### PR TITLE
fix: add core/README.md and fix readme path in pyproject.toml

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -1,0 +1,35 @@
+# agent-capo-core
+
+[![python](https://img.shields.io/badge/python-3.10%2B-blue)](https://pypi.org/project/agent-capo-core/)
+[![license](https://img.shields.io/badge/license-MIT-informational)](../LICENSE)
+[![deps](https://img.shields.io/badge/runtime%20deps-0%20(stdlib)-success)](#)
+
+Tiny stdlib-only honest-evaluation substrate for the
+[AgentCapTune](https://github.com/skillberry-ai/agent-capo) skills library.
+
+Provides the `acapo` CLI and the four-phase eval loop (baseline → optimize → gate → finalize).
+Zero runtime dependencies — pure Python 3.10+ stdlib.
+
+## Install
+
+```bash
+pip install agent-capo-core        # from PyPI (once published)
+# or, from the repo:
+pip install ./core
+```
+
+## Usage
+
+```bash
+acapo run   --spec .agentcapo/project/acapo.yaml \
+            --project .agentcapo/project
+acapo check --spec .agentcapo/project/acapo.yaml   # validate adapter
+acapo report                                        # regenerate dashboard
+```
+
+See the [AgentCapTune repository](https://github.com/skillberry-ai/agent-capo) for full
+documentation, examples, and the skills library.
+
+## License
+
+MIT.

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "agent-capo-core"
 version = "0.1.0"
 description = "Tiny stdlib-only honest-evaluation substrate for the agent-capo skills library."
-readme = "../README.md"
+readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "MIT" }
 # Zero hard runtime dependencies — pure stdlib by design.


### PR DESCRIPTION
Closes #1.

## Summary

- `core/pyproject.toml` had `readme = "../README.md"`, pointing outside the package source tree. setuptools ≥61 enforces that readme files must be inside the package being built, so `pip install ./core` failed with `DistutilsOptionError`.
- Added `core/README.md` with package-specific content for `agent-capo-core`.
- Changed `pyproject.toml` to reference `"README.md"` (local to `core/`).

## Testing

`pip install ./core` now completes successfully (`Successfully installed agent-capo-core-0.1.0`).

Signed-off-by: Eran Raichstein <eranra@il.ibm.com>