### PR TITLE
fix: repair quickstart command — add toy_calc run.sh (closes #3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ depends on its system prompt; full setup in [examples/toy_calc](examples/toy_cal
 git clone <repo> AgentCapTune && cd AgentCapTune
 pip install ./core                         # the honest-eval substrate (CLI: acapo)
 ./install.sh                               # place skills into your agent host
-python3 -m agent_capo.cli run --spec .agentcapo/project/acapo.yaml --project .agentcapo/project
+bash examples/toy_calc/run.sh              # scaffold a tmp project dir and run
 ```
 ```jsonc
 {

--- a/examples/toy_calc/run.sh
+++ b/examples/toy_calc/run.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Run the toy_calc example end-to-end (zero-API, deterministic).
+# Usage: cd <repo-root> && bash examples/toy_calc/run.sh
+set -euo pipefail
+
+REPO="$(cd "$(dirname "$0")/../.." && pwd)"
+export AGENT_CAPO_CORE="$REPO/core"
+export PYTHONPATH="$REPO/core"
+export ACAPO_SKILLS_DIR="$REPO/skills"
+export ACAPO_TOY_DATA="$REPO/examples/toy_calc"
+export ACAPO_MOCK_SCRIPT="$REPO/examples/toy_calc/mock_script.json"
+
+D="$(mktemp -d -t toy_calc.XXXXXX)"
+mkdir -p "$D/.agentcapo/project/adapters"
+cp "$REPO/examples/toy_calc/adapter.py"   "$D/.agentcapo/project/adapters/"
+cp -R "$REPO/examples/toy_calc/capability" "$D/seed_capability"
+cp "$REPO/templates/project/acapo.yaml"   "$D/.agentcapo/project/acapo.yaml"
+
+echo "Working directory: $D"
+python3 -m agent_capo.cli run \
+  --spec    "$D/.agentcapo/project/acapo.yaml" \
+  --project "$D/.agentcapo/project" \
+  --run-ts  demo


### PR DESCRIPTION
Closes #3.

## Summary

- The README quickstart ran `python3 -m agent_capo.cli run --spec .agentcapo/project/acapo.yaml` immediately after `git clone`, but that path doesn't exist in a fresh checkout — users hit a `FileNotFoundError` before any optimization logic runs.
- Add `examples/toy_calc/run.sh`: a self-contained script that scaffolds a temp working directory with the correct structure (adapter, capability dir, `acapo.yaml`) and the required env vars, then invokes the CLI.
- Update the README quickstart to call `bash examples/toy_calc/run.sh` instead.

## Testing

Ran `bash examples/toy_calc/run.sh` from a clean environment:
- `baseline_val: 0.0` → `test_reward: 1.0` ✓

Signed-off-by: Eran Raichstein <eranra@il.ibm.com>