### PR TITLE
fix(core): surface optimizer CLI's real error in optimizer_error event

### DIFF
--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -264,8 +264,35 @@ def optimizer_from_command(cmd_template: list[str]) -> OptimizerFn:
         env = dict(os.environ)
         proc = subprocess.run(cmd, capture_output=True, text=True, env=env)
         if proc.returncode != 0:
-            raise RuntimeError(f"optimizer failed ({proc.returncode}): {proc.stderr[:2000]}")
+            raise RuntimeError(
+                f"optimizer failed ({proc.returncode}): {_optimizer_failure_detail(proc)}")
     return _run
+
+
+def _optimizer_failure_detail(proc: "subprocess.CompletedProcess") -> str:
+    """Best-effort human-readable reason a failed optimizer subprocess gives.
+
+    The optimizer runner (``run-optimizer``) reports the underlying agent CLI's
+    real output as a JSON object on **stdout** (``stderr_tail``/``stdout_tail``),
+    while its own stderr is usually empty. Prefer that detail so the
+    ``optimizer_error`` event (and the dashboard) explains *why* it failed
+    instead of an empty ``failed (1):``.
+    """
+    detail = (proc.stderr or "").strip()
+    out = (proc.stdout or "").strip()
+    if out:
+        try:
+            import json as _json
+            info = _json.loads(out.splitlines()[-1])
+            tail = str(info.get("stderr_tail") or info.get("stdout_tail") or "").strip()
+            if tail:
+                detail = f"{detail} {tail}".strip() if detail else tail
+            elif not detail:
+                detail = out[-2000:]
+        except Exception:  # noqa: BLE001 — stdout wasn't the runner's JSON
+            if not detail:
+                detail = out[-2000:]
+    return (detail or "no output from optimizer")[:2000]
 
 
 # ---- one propose -> gate step ---------------------------------------------

--- a/core/tests/test_optimizer_error_detail.py
+++ b/core/tests/test_optimizer_error_detail.py
@@ -1,0 +1,44 @@
+"""A failed optimizer must surface WHY it failed: run-optimizer reports the agent
+CLI's real output as JSON on stdout (stderr_tail/stdout_tail), and the harness
+must lift that into the error (and thus the optimizer_error event/dashboard)."""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+CORE = REPO / "core"
+sys.path.insert(0, str(CORE))
+
+from cap_evolve.harness import _optimizer_failure_detail  # noqa: E402
+
+
+def _proc(returncode=1, stdout="", stderr=""):
+    return subprocess.CompletedProcess(args=["x"], returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def test_lifts_stderr_tail_from_runner_json():
+    out = json.dumps({"optimizer": "claude-code", "returncode": 1,
+                      "stderr_tail": "anthropic: overloaded_error 529", "stdout_tail": ""})
+    assert "overloaded_error 529" in _optimizer_failure_detail(_proc(stdout=out))
+
+
+def test_falls_back_to_stdout_tail():
+    out = json.dumps({"returncode": 1, "stderr_tail": "", "stdout_tail": "model refused to edit"})
+    assert "model refused to edit" in _optimizer_failure_detail(_proc(stdout=out))
+
+
+def test_prefers_real_stderr_and_appends_tail():
+    out = json.dumps({"stderr_tail": "CLI tail"})
+    d = _optimizer_failure_detail(_proc(stdout=out, stderr="proc stderr"))
+    assert "proc stderr" in d and "CLI tail" in d
+
+
+def test_non_json_stdout_is_used_raw():
+    assert "boom traceback" in _optimizer_failure_detail(_proc(stdout="boom traceback"))
+
+
+def test_empty_everything_is_explained_not_blank():
+    d = _optimizer_failure_detail(_proc(stdout="", stderr=""))
+    assert d and d != ""  # never a bare "failed (1): "


### PR DESCRIPTION
A failed optimizer showed only 'optimizer failed (1): ' because harness used the runner subprocess's stderr (empty) — run-optimizer reports the agent CLI's real output as JSON on stdout (stderr_tail/stdout_tail). Lift that into the RuntimeError so the optimizer_error event (and the dashboard) explains WHY it failed. 5 tests.

## What & why
<!-- What does this change and why? Link any issue. -->

## Checklist
- [ ] `python -m pytest core/tests -q` passes
- [ ] `python skills/_registry/build_manifest.py skills` is clean (no errors)
- [ ] Any new/changed skill's `scripts/check.py` is green
- [ ] Honesty invariants untouched (gate on val, test sealed) — or explained
- [ ] Docs updated (README/skill SKILL.md) if behavior changed
