### PR TITLE
feat(optimizers): add 6 coding agents for obra/superpowers parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to cap-evolve are documented here. The format follows
 
 ## [Unreleased]
 ### Added
+- **Six more coding agents as optimizers** — `cursor` (Cursor `cursor-agent`),
+  `droid` (Factory Droid), `copilot` (GitHub Copilot CLI), `kimi` (Moonshot Kimi),
+  `pi` (earendil-works Pi), and `antigravity` (Google `agy`, a configurable wrapper).
+  This brings cap-evolve's supported coding-agent set to parity with
+  [obra/superpowers](https://github.com/obra/superpowers). Each is **one row** in
+  `skills/optimizers/registry.yaml` (verified headless command, except `antigravity`
+  which reads `CAPEVOLVE_ANTIGRAVITY_CMD` because its auth is Google-Sign-In-only and
+  its non-interactive approve flag is unconfirmed) plus a per-CLI
+  `run-optimizer/references/<name>.md`. `install.sh --host` learns each one's skills
+  dir. No core/runner changes — the registry-driven `run-optimizer` already generalizes.
 - **Per-iteration optimizer dollar cap** (`optimizer_usd_per_iter` in `capevolve.yaml`):
   threaded through `run-optimizer --usd-budget` into a new registry `usd_budget_flag`,
   enforced natively by the optimizer CLI where supported (claude-code →

--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ you want intake to ask):
 - objective:  maximize mean reward on the VAL split
 
 # 5. OPTIMIZER  (proposes the edits) + MODEL + CREDENTIALS
-- optimizer:   <claude-code | codex | gemini-cli | opencode | openclaw | ibm-bob | generic | mock>
+- optimizer:   <claude-code | codex | gemini-cli | opencode | cursor | droid | copilot | kimi | pi | antigravity | openclaw | ibm-bob | generic | mock>
 - model:       <backend-specific model id>
 - credentials: <e.g. ANTHROPIC_API_KEY or a logged-in Claude Code session; BOBSHELL_API_KEY for ibm-bob>
 
@@ -371,7 +371,7 @@ Start from the closest example and edit its `adapter.py`:
 
 ```yaml
 capabilities:    [system-prompt, tools]   # any of: system-prompt | tools | mcp-tool | skill-package
-optimizer_skill: claude-code              # ← swap: codex | gemini-cli | opencode | openclaw | ibm-bob | generic | mock
+optimizer_skill: claude-code              # ← swap: codex | gemini-cli | opencode | cursor | droid | copilot | kimi | pi | antigravity | openclaw | ibm-bob | generic | mock
 algorithm_skill: hill-climb               # hill-climb (--focus all|cyclic|hardest-first) | gepa | skillopt
 num_trials: 4
 store: git                                # versions every iteration
@@ -501,7 +501,7 @@ variants collapsed into one `hill-climb` skill with `--focus`.
 | phases       | `intake` · `implement-and-check` · `baseline` · `evaluate` · `diagnose` · `gate` · `finalize` · `report` |
 | capabilities | `system-prompt` · `skill-package` · `tools` · `mcp-tool` |
 | algorithms   | `hill-climb` (`--focus all\|cyclic\|hardest-first`) · `gepa` · `skillopt` |
-| optimizers   | `run-optimizer` + `optimizers/registry.yaml` (`claude-code`, `codex`, `gemini-cli`, `opencode`, `openclaw`, `ibm-bob`, `generic`, `mock`) |
+| optimizers   | `run-optimizer` + `optimizers/registry.yaml` (`claude-code`, `codex`, `gemini-cli`, `opencode`, `cursor`, `droid`, `copilot`, `kimi`, `pi`, `antigravity`, `openclaw`, `ibm-bob`, `generic`, `mock`) |
 
 `gepa` (real GEPA — reflective Pareto search, two-stage minibatch-then-full-val
 economy; arXiv:2507.19457) and `skillopt` (epochs × mini-batches with a decaying

--- a/RUN.md
+++ b/RUN.md
@@ -16,7 +16,7 @@ pip install ./core                              # the honest-eval substrate (or 
 The plugin's hooks (PreToolUse / Stop / SubagentStop / SessionStart) enforce the
 sealed-test and green-check rules automatically; they no-op outside a run dir.
 
-**Any host (host-agnostic — Codex / Gemini / opencode / openclaw / IBM Bob / bare):**
+**Any host (host-agnostic — Codex / Gemini / opencode / Cursor / Factory Droid / Copilot CLI / Kimi / Pi / Antigravity / openclaw / IBM Bob / bare):**
 ```
 ./install.sh                     # copy skills into this host's skills dir
 pip install ./core               # or: export CAPEVOLVE_CORE="$PWD/core"

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -21,8 +21,9 @@ prioritizes what makes cap-evolve best-in-class and widely adopted.
   (a thin precursor).
 - Capabilities: system-prompt, skill-package, tools, mcp-tool (action-policy / mutation-lock); capabilities chosen as a LIST.
 - Optimizers: one **`run-optimizer`** skill + `optimizers/registry.yaml`
-  (claude-code, codex, gemini-cli, opencode, openclaw, ibm-bob, generic, mock) —
-  verified headless commands; adding one is a single YAML row.
+  (claude-code, codex, gemini-cli, opencode, cursor, droid, copilot, kimi, pi,
+  antigravity, openclaw, ibm-bob, generic, mock — the agent set matches
+  obra/superpowers) — verified headless commands; adding one is a single YAML row.
 - Honest-eval upgrades: paired significance gate (default), seal-on-success test,
   structured `Rollout.error` infra signal, per-trial seed for real pass^k variance.
 - Rich **self-contained** `dashboard.html` + `cap-evolve report --terminal` ANSI report.

--- a/docs/specs/2026-06-24-multi-agent-support-design.md
+++ b/docs/specs/2026-06-24-multi-agent-support-design.md
@@ -1,0 +1,106 @@
+# Design: multi-agent support parity with obra/superpowers
+
+**Date:** 2026-06-24
+**Status:** Approved (design); implementation pending
+
+## Goal
+
+Bring cap-evolve's supported coding-agent set up to parity with
+[obra/superpowers](https://github.com/obra/superpowers). Superpowers supports 11
+harnesses; cap-evolve already covers the overlapping ones (Claude Code, Codex,
+Gemini CLI, opencode). This adds the **6 agents cap-evolve lacks**:
+
+- **Cursor** (`cursor-agent` CLI)
+- **Factory Droid** (`droid` CLI)
+- **GitHub Copilot CLI** (`copilot` CLI)
+- **Kimi** (`kimi` CLI, Moonshot AI)
+- **Pi** (`pi` CLI, earendil-works)
+- **Antigravity** (`agy` CLI, Google)
+
+Support is added across **both layers** that "supporting an agent" means in
+cap-evolve:
+
+- **(a) Optimizer / edit-proposer** — the agent can DRIVE the optimization loop
+  (a `registry.yaml` row + verified headless command).
+- **(b) Install host** — cap-evolve's skills can be INSTALLED into that agent's
+  skills dir (`install.sh --host <name>`).
+
+## Architecture fit
+
+The current (top-level) tree already abstracts every optimizer behind one
+`run-optimizer` runner driven by `skills/optimizers/registry.yaml`. The generic
+`scripts/run.py` already:
+
+- expands `{workdir}`, `{prompt}`, `{prompt_text}`, `{model}`, `{self_dir}`,
+  and `${ENV}` placeholders,
+- drops the `-m`/`--model` flag group when no model is set,
+- appends `json_flag` / `budget_flag` / `usd_budget_flag` on demand,
+- checks the CLI is on `PATH` and reports which auth env vars are present.
+
+**Therefore no Python changes are required.** Each new agent is **one YAML row +
+one prose reference file**, plus enumeration updates in docs/installer.
+
+## 1. Registry rows (`skills/optimizers/registry.yaml`)
+
+Verified headless commands (researched against official docs/repos):
+
+| key | command_template | auth env | json_flag | pattern |
+|---|---|---|---|---|
+| `cursor` | `cursor-agent -p {prompt_text} --force --model {model}` | `CURSOR_API_KEY` | `--output-format json` | verified |
+| `droid` | `droid exec --auto low -m {model} {prompt_text}` | `FACTORY_API_KEY` | `--output-format json` | verified |
+| `copilot` | `copilot -p {prompt_text} --allow-all-tools --model {model}` | `COPILOT_GITHUB_TOKEN,GH_TOKEN,GITHUB_TOKEN` | `""` | verified |
+| `kimi` | `kimi -p {prompt_text} -m {model}` | `MOONSHOT_API_KEY,KIMI_API_KEY` | `""` | verified cmd; auth env unverified |
+| `pi` | `pi -p {prompt_text} --model {model}` | `ANTHROPIC_API_KEY,OPENAI_API_KEY` | `""` | verified; no approve flag by design |
+| `antigravity` | `${CAPEVOLVE_ANTIGRAVITY_CMD}` | `CAPEVOLVE_ANTIGRAVITY_CMD` | `""` | configurable wrapper (like `openclaw`) |
+
+Common fields: `budget_flag: ""`, `usd_budget_flag: ""`, `offline: "false"`.
+`instructions_file: AGENTS.md` for the agents that read it (cursor/droid/copilot/
+kimi). `skills_dir` is set only where native skill discovery is documented;
+otherwise omitted and explained in prose (honest about what is unverified).
+
+### Why Antigravity is a configurable wrapper
+
+`agy -p` is a real headless print mode, but research could not confirm (1) a
+CI-usable API-key env var — auth is Google Sign-In / OS keyring — nor (2) the exact
+non-interactive auto-approve flag. Rather than ship an unverified command, it
+mirrors the `openclaw` escape-hatch: the user sets the full command via
+`CAPEVOLVE_ANTIGRAVITY_CMD` (recommended best-guess documented in its reference).
+
+## 2. Reference prose (`skills/optimizers/run-optimizer/references/<name>.md`)
+
+One file per agent (`cursor.md`, `droid.md`, `copilot.md`, `kimi.md`, `pi.md`,
+`antigravity.md`), modeled on the existing `codex.md`: install, auth, the headless
+invocation, JSON/cost notes, native-skills/instructions conventions, and explicit
+caveats (Kimi auth, Pi no-prompts, Antigravity OAuth-only).
+
+## 3. Cross-cutting enumeration + installer updates
+
+Every place that lists the optimizer set (found via grep):
+
+- `skills/optimizers/run-optimizer/SKILL.md` — description (line ~3) + known
+  optimizers list (lines ~42–43).
+- `README.md` — inline lists (~329, ~374) + feature-matrix optimizers row (~504)
+  + install/hosts prose.
+- `install.sh` — `--host` detection: add `antigravity`, `droid`/`factory`,
+  `copilot`, `kimi`, `pi` skills-dir cases (`cursor` already present).
+- `templates/project/capevolve.yaml`, `templates/project/PROJECT.md` — optimizer
+  enumeration comments.
+- `skills/phases/intake/inputs/INPUTS.md` — optimizer enumeration.
+- `RUN.md`, `llms.txt` — optimizer enumerations.
+- `CHANGELOG.md` — `[Unreleased] / Added` entry.
+
+## 4. Verification
+
+- `python skills/optimizers/run-optimizer/scripts/run.py --list` lists all 14
+  optimizers (8 existing + 6 new).
+- For each new name, run with `--name <agent>` against a throwaway workdir with the
+  CLI absent → expect the clean `"<cli>" not on PATH` JSON with install + auth hint
+  (proves the row resolves and the command builds).
+- `mock` end-to-end stays green; `run-optimizer/scripts/check.py` passes.
+
+## Out of scope (YAGNI)
+
+- No Python changes (the registry-driven runner already generalizes).
+- No per-agent skill folders (the registry replaced those).
+- No live API calls to the 6 CLIs (cannot verify creds in this environment).
+- The deleted nested `cap-evolve/` tree is not touched.

--- a/install.sh
+++ b/install.sh
@@ -35,15 +35,23 @@ detect_dest() {
     # Per-host skill dirs verified against current docs (2026). Codex uses
     # .agents/skills (NOT ~/.codex); opencode reads .claude/skills natively;
     # Gemini bundles skills inside extensions; IBM Bob has no SKILL.md concept.
+    # cursor/droid/copilot/kimi/pi/antigravity dirs follow each tool's dotdir
+    # convention (best-guess) — override with --dest or $CAPEVOLVE_SKILLS_DIR if
+    # your build differs. See skills/optimizers/run-optimizer/references/<host>.md.
     case "$HOST" in
-      claude|claude-code) echo "$HOME/.claude/skills"; return;;
-      codex)              echo "$HOME/.agents/skills"; return;;
-      gemini|gemini-cli)  echo "$HOME/.gemini/extensions/cap-evolve/skills"; return;;
-      opencode)           echo "$HOME/.config/opencode/skills"; return;;
-      openclaw)           echo "$HOME/.openclaw/workspace/skills"; return;;
-      cursor)             echo "$PWD/.cursor/skills"; return;;
-      bob|ibm-bob)        echo "$HOME/.bob/skills"; return;;
-      *)                  echo "$HOME/.config/$HOST/skills"; return;;
+      claude|claude-code)          echo "$HOME/.claude/skills"; return;;
+      codex)                       echo "$HOME/.agents/skills"; return;;
+      gemini|gemini-cli)           echo "$HOME/.gemini/extensions/cap-evolve/skills"; return;;
+      opencode)                    echo "$HOME/.config/opencode/skills"; return;;
+      openclaw)                    echo "$HOME/.openclaw/workspace/skills"; return;;
+      cursor)                      echo "$PWD/.cursor/skills"; return;;
+      droid|factory|factory-droid) echo "$HOME/.factory/skills"; return;;
+      copilot|github-copilot)      echo "$HOME/.copilot/skills"; return;;
+      kimi|kimi-code)              echo "$HOME/.kimi/skills"; return;;
+      pi)                          echo "$HOME/.pi/skills"; return;;
+      antigravity|agy)             echo "$HOME/.antigravity/skills"; return;;
+      bob|ibm-bob)                 echo "$HOME/.bob/skills"; return;;
+      *)                           echo "$HOME/.config/$HOST/skills"; return;;
     esac
   fi
   if [[ -d "./.claude/skills" ]]; then echo "./.claude/skills"; return; fi

--- a/llms.txt
+++ b/llms.txt
@@ -37,7 +37,8 @@ except at finalize; gate acceptance on val with a paired significance gate.
 - algorithms: hill-climb (--focus all|cyclic|hardest-first), gepa, skillopt
   (gepa & skillopt are the sample-efficient flagships)
 - optimizers: run-optimizer + optimizers/registry.yaml (claude-code, codex, gemini-cli,
-  opencode, openclaw, ibm-bob, generic, mock — one runner resolves the name)
+  opencode, cursor, droid, copilot, kimi, pi, antigravity, openclaw, ibm-bob, generic,
+  mock — one runner resolves the name; the agent set matches obra/superpowers)
 - orchestrate: orchestrate, using-cap-evolve (session-start router)
 
 ## Examples

--- a/skills/optimizers/registry.yaml
+++ b/skills/optimizers/registry.yaml
@@ -124,3 +124,62 @@ ibm-bob:
   offline: "false"
   skills_dir: ".bob/skills"
   instructions_file: "AGENTS.md"
+
+cursor:
+  command_template: "cursor-agent -p {prompt_text} --force --model {model}"
+  env_keys: "CURSOR_API_KEY"
+  install_url: "https://cursor.com/docs/cli"
+  auth_notes: "cursor-agent login, or CURSOR_API_KEY."
+  json_flag: "--output-format json"
+  budget_flag: ""
+  offline: "false"
+  skills_dir: ".cursor/skills"
+  instructions_file: "AGENTS.md"
+
+droid:
+  command_template: "droid exec --auto low -m {model} {prompt_text}"
+  env_keys: "FACTORY_API_KEY"
+  install_url: "https://docs.factory.ai/cli"
+  auth_notes: "droid login, or FACTORY_API_KEY."
+  json_flag: "--output-format json"
+  budget_flag: ""
+  offline: "false"
+  instructions_file: "AGENTS.md"
+
+copilot:
+  command_template: "copilot -p {prompt_text} --allow-all-tools --model {model}"
+  env_keys: "COPILOT_GITHUB_TOKEN,GH_TOKEN,GITHUB_TOKEN"
+  install_url: "https://github.com/github/copilot-cli  (npm i -g @github/copilot)"
+  auth_notes: "copilot /login, or COPILOT_GITHUB_TOKEN / GH_TOKEN."
+  json_flag: ""
+  budget_flag: ""
+  offline: "false"
+  instructions_file: "AGENTS.md"
+
+kimi:
+  command_template: "kimi -p {prompt_text} -m {model}"
+  env_keys: "MOONSHOT_API_KEY,KIMI_API_KEY"
+  install_url: "https://github.com/MoonshotAI/kimi-code"
+  auth_notes: "kimi login (Kimi OAuth / Moonshot key). API-key env var unverified — login is the safe path."
+  json_flag: ""
+  budget_flag: ""
+  offline: "false"
+  instructions_file: "AGENTS.md"
+
+pi:
+  command_template: "pi -p {prompt_text} --model {model}"
+  env_keys: "ANTHROPIC_API_KEY,OPENAI_API_KEY"
+  install_url: "https://github.com/earendil-works/pi"
+  auth_notes: "Provider-native keys (ANTHROPIC_API_KEY / OPENAI_API_KEY) or pi /login. No edit prompts by design."
+  json_flag: ""
+  budget_flag: ""
+  offline: "false"
+
+antigravity:
+  command_template: "${CAPEVOLVE_ANTIGRAVITY_CMD}"
+  env_keys: "CAPEVOLVE_ANTIGRAVITY_CMD"
+  install_url: "https://antigravity.google/docs/cli-overview"
+  auth_notes: "Google Sign-In (OAuth/keyring); no documented CI API-key. Headless `agy -p` exists — set the full command via CAPEVOLVE_ANTIGRAVITY_CMD."
+  json_flag: ""
+  budget_flag: ""
+  offline: "false"

--- a/skills/optimizers/run-optimizer/SKILL.md
+++ b/skills/optimizers/run-optimizer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: run-optimizer
-description: Drives any shell-invokable coding agent (Claude Code, Codex, Gemini CLI, opencode, OpenClaw, IBM Bob, or a fully custom command) as the edit proposer in a cap-evolve run, resolving the named optimizer from optimizers/registry.yaml. Use this as the optimizer for every run; pick the concrete agent with --name (or optimizer_skill in the spec). Use --name mock for a deterministic, zero-API proposer in tests and CI.
+description: Drives any shell-invokable coding agent (Claude Code, Codex, Gemini CLI, opencode, Cursor, Factory Droid, GitHub Copilot CLI, Kimi, Pi, Antigravity, OpenClaw, IBM Bob, or a fully custom command) as the edit proposer in a cap-evolve run, resolving the named optimizer from optimizers/registry.yaml. Use this as the optimizer for every run; pick the concrete agent with --name (or optimizer_skill in the spec). Use --name mock for a deterministic, zero-API proposer in tests and CI.
 component: optimizer
 argument-hint: "--name NAME --workdir DIR --prompt FILE [--model ID]"
 allowed-tools: Read, Write, Bash
@@ -35,17 +35,23 @@ new skill directory.
 | `{prompt_text}` | the *contents* of `INSTRUCTIONS.md` (for CLIs that take the prompt inline) |
 | `{model}` | the resolved model id; an empty `{model}` drops itself and a preceding `-m`/`--model` |
 | `{self_dir}` | the runner's own scripts dir (used by the `mock` row) |
-| `${VAR}` | environment expansion (the `generic`/`openclaw` escape hatches read their command from env) |
+| `${VAR}` | environment expansion (the `generic`/`openclaw`/`antigravity` escape hatches read their command from env) |
 
 ## Choosing an optimizer (`--name` / `optimizer_skill`)
 
-`mock`, `generic`, `claude-code`, `codex`, `gemini-cli`, `opencode`, `openclaw`,
-`ibm-bob`. Per-CLI install / auth / flag details are in `references/<name>.md`.
+`mock`, `generic`, `claude-code`, `codex`, `gemini-cli`, `opencode`, `cursor`,
+`droid` (Factory Droid), `copilot` (GitHub Copilot CLI), `kimi`, `pi`,
+`antigravity`, `openclaw`, `ibm-bob`. Per-CLI install / auth / flag details are in
+`references/<name>.md`.
 
 - **`mock`** is fully offline (runs a shipped JSON-driven editor, never a network
   CLI), so the end-to-end proof slice costs nothing and never flakes.
-- **`generic`** / **`openclaw`** read their command from `CAPEVOLVE_OPTIMIZER_CMD`
-  / `CAPEVOLVE_OPENCLAW_CMD` — the escape hatch that makes "any optimizer" literal.
+- **`generic`** / **`openclaw`** / **`antigravity`** read their command from
+  `CAPEVOLVE_OPTIMIZER_CMD` / `CAPEVOLVE_OPENCLAW_CMD` / `CAPEVOLVE_ANTIGRAVITY_CMD`
+  — the escape hatch that makes "any optimizer" literal. (`antigravity` is a wrapper
+  because its auth is Google-Sign-In-only and its headless approve flag is unconfirmed.)
+- **`cursor`**, **`droid`**, **`copilot`**, **`kimi`**, **`pi`** are verified
+  headless commands; matches the agent set supported by obra/superpowers.
 
 ## Standalone use
 

--- a/skills/optimizers/run-optimizer/references/antigravity.md
+++ b/skills/optimizers/run-optimizer/references/antigravity.md
@@ -1,0 +1,32 @@
+# antigravity optimizer
+
+Google Antigravity's agent CLI (`agy`) as the edit proposer. Antigravity ships a
+full GUI/IDE *and* a CLI that share one agent engine; the CLI has a real headless
+print mode. Two facts make a fixed command unsafe to ship, so this row is a
+**configurable wrapper** (like `openclaw`): you set the full command via env.
+
+```bash
+# best-guess for current builds — verify with `agy --help` before relying on it:
+export CAPEVOLVE_ANTIGRAVITY_CMD='agy -p {prompt_text} --model <id>'
+```
+
+The `{workdir}`, `{prompt}`, `{prompt_text}`, and `{model}` placeholders are
+substituted into whatever you set; the command runs with `cwd=<workdir>`.
+
+- **Install:** `curl -fsSL https://antigravity.google/cli/install.sh | bash`
+  (docs: https://antigravity.google/docs/cli-overview)
+- **Auth — the catch:** Antigravity authenticates via **Google Sign-In / OS keyring**.
+  There is **no documented CI-usable API-key env var**, so fully-unattended runs are not
+  guaranteed; sign in interactively first (`agy` will print an auth URL over SSH).
+- **Auto-approve — the second catch:** `agy -p` is genuinely headless and a
+  `proceed-in-sandbox` permission mode auto-approves commands inside the sandbox, but the
+  exact non-interactive flag/value to *set* that mode (and any `--cwd`) is not spelled out
+  in the public docs. Confirm against your installed build and bake the right flags into
+  `CAPEVOLVE_ANTIGRAVITY_CMD`.
+
+## Native skills, instructions, and subagents
+
+Antigravity supports plugins (`agy plugin install <repo>`). The registry leaves
+`skills_dir`/`instructions_file` blank pending verification, so cap-evolve relies on its
+guaranteed channel: the capability + diagnose skills under `./guidance/` plus an explicit
+pointer in the `./INSTRUCTIONS.md` prompt.

--- a/skills/optimizers/run-optimizer/references/copilot.md
+++ b/skills/optimizers/run-optimizer/references/copilot.md
@@ -1,0 +1,29 @@
+# copilot optimizer
+
+GitHub Copilot CLI — the standalone `copilot` (2025) — as the edit proposer.
+
+    copilot -p "<instructions>" --allow-all-tools [--model <model>]
+
+run with `cwd=<workdir>`. `-p`/`--prompt` runs a single prompt and exits;
+`--allow-all-tools` auto-approves all tools (scope it instead with
+`--allow-tool='write'` for edits, `--deny-tool` takes precedence). The working
+directory is the cwd (no documented `--cwd`); `--cloud` would run cloud-hosted.
+
+**Use the standalone `copilot`, not the old `gh copilot` extension** — the latter
+only suggests/explains shell commands and cannot edit files.
+
+- **Install:** `npm install -g @github/copilot`
+  (docs: https://docs.github.com/en/copilot/concepts/agents/about-copilot-cli)
+- **Auth (precedence):** `copilot /login`, or `COPILOT_GITHUB_TOKEN` → `GH_TOKEN` →
+  `GITHUB_TOKEN` (a fine-grained PAT with the "Copilot Requests" permission).
+- **JSON / cost:** no structured cost output documented, so `json_flag` is blank;
+  the optimizer runs prose-fed.
+
+## Native skills, instructions, and subagents
+
+- **Always-on instructions:** the registry sets `instructions_file: AGENTS.md`
+  (Copilot CLI honors `AGENTS.md`; it also reads `.github/copilot-instructions.md`).
+  cap-evolve writes its pointer into `AGENTS.md`.
+- **Native skills:** left blank — Copilot's plugin install (`copilot plugin ...`) is not a
+  simple in-repo `SKILL.md` dir, so cap-evolve relies on its guaranteed channel (skills
+  under `./guidance/` + the `./INSTRUCTIONS.md` pointer).

--- a/skills/optimizers/run-optimizer/references/cursor.md
+++ b/skills/optimizers/run-optimizer/references/cursor.md
@@ -1,0 +1,28 @@
+# cursor optimizer
+
+Cursor's headless agent CLI (`cursor-agent`, NOT the IDE) as the edit proposer.
+
+    cursor-agent -p "<instructions>" --force [--model <model>]
+
+run with `cwd=<workdir>`. `-p`/`--print` runs non-interactively and exits;
+`--force` (alias `--yolo`) auto-approves edits and shell unless explicitly denied.
+`--workspace <path>` is available but unnecessary here — the runner already sets
+cwd to the candidate dir, so relative edits land there.
+
+- **Install:** `curl https://cursor.com/install -fsS | bash`
+  (docs: https://cursor.com/docs/cli)
+- **Auth:** `cursor-agent login`, or `CURSOR_API_KEY` (`--api-key` also accepted).
+- **JSON / cost:** `--output-format json` emits a structured result; the runner
+  appends it (and best-effort parses `total_cost_usd`/`usage`) when called with
+  `--json`. If the installed version omits cost, the loop continues without a figure.
+
+## Native skills, instructions, and subagents
+
+- **Always-on instructions:** Cursor reads `AGENTS.md` at the workspace root, so the
+  registry sets `instructions_file: AGENTS.md` and cap-evolve writes its pointer there
+  (to `./INSTRUCTIONS.md`, the native skills dir, `./guidance/`, `./MEMORY.md`/`./STATE.md`).
+- **Native skills:** `skills_dir: .cursor/skills` is set on the optimistic, install.sh-aligned
+  assumption that `cursor-agent` discovers `SKILL.md` packages there. This is **not strongly
+  documented** for the headless CLI — verify against your installed build; cap-evolve's
+  guaranteed channel (skills under `./guidance/` + the `./INSTRUCTIONS.md` pointer) works
+  regardless.

--- a/skills/optimizers/run-optimizer/references/droid.md
+++ b/skills/optimizers/run-optimizer/references/droid.md
@@ -1,0 +1,27 @@
+# droid optimizer
+
+Factory Droid's headless mode (`droid exec`) as the edit proposer.
+
+    droid exec --auto low [-m <model>] "<instructions>"
+
+run with `cwd=<workdir>`. `droid exec` is the non-interactive CI/CD subcommand;
+the prompt is the positional arg (also accepts `-f/--file` or stdin). `--auto low`
+permits file create/edit while blocking system changes (`medium` adds installs/
+builds/local commits, `high` adds push; the default with no flag is read-only).
+`--cwd <path>` exists but is unnecessary — the runner sets cwd to the candidate dir.
+
+- **Install:** `curl -fsSL https://app.factory.ai/cli | sh` · `brew install --cask droid`
+  · `npm install -g droid` (docs: https://docs.factory.ai/cli)
+- **Auth:** `droid login`, or `FACTORY_API_KEY` (`export FACTORY_API_KEY=fk-...`).
+- **JSON / cost:** `-o/--output-format json`; the runner appends it (best-effort
+  cost parse) when called with `--json`.
+
+## Native skills, instructions, and subagents
+
+- **Always-on instructions:** Droid reads `AGENTS.md`, so the registry sets
+  `instructions_file: AGENTS.md` and cap-evolve writes its pointer there.
+- **Native skills:** left blank in the registry — Factory's plugin/skill discovery for
+  `droid exec` is installed via `droid plugin` rather than a simple in-repo `SKILL.md`
+  dir, so cap-evolve relies on its guaranteed channel (skills under `./guidance/` + the
+  `./INSTRUCTIONS.md` pointer). Set `skills_dir` if your build documents an auto-discovered
+  path.

--- a/skills/optimizers/run-optimizer/references/kimi.md
+++ b/skills/optimizers/run-optimizer/references/kimi.md
@@ -1,0 +1,30 @@
+# kimi optimizer
+
+Moonshot AI's Kimi coding CLI (`kimi`, the Node-based `kimi-code`) as the edit
+proposer.
+
+    kimi -p "<instructions>" [-m <model>]
+
+run with `cwd=<workdir>`. `-p`/`--prompt <prompt>` runs a single prompt
+non-interactively, streams to stdout, and does not open the TUI; under `-p` tool
+calls run on the auto permission policy (no human approval), so **`-p` cannot be
+combined with `--yolo`/`--auto`/`--plan`** — it already auto-approves. Working
+directory is the cwd (no documented `--cwd`).
+
+- **Install:** `curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash` ·
+  `brew install kimi-code` (repo: https://github.com/MoonshotAI/kimi-code).
+  Note: the older Python `MoonshotAI/kimi-cli` is being wound down in favor of `kimi-code`.
+- **Auth:** `kimi login` (Kimi OAuth or a Moonshot API key) is the safe path.
+  ⚠️ A model-auth env var (`MOONSHOT_API_KEY`/`KIMI_API_KEY`) is listed in the
+  registry as a convenience but is **unverified** against current docs — prefer
+  `kimi login` for unattended runs until confirmed.
+- **JSON / cost:** `--output-format text|stream-json` exists (only with `-p`), but no
+  documented `total_cost_usd`, so `json_flag` is blank and the optimizer runs prose-fed.
+
+## Native skills, instructions, and subagents
+
+- **Always-on instructions:** the registry sets `instructions_file: AGENTS.md`; cap-evolve
+  writes its pointer there.
+- **Native skills:** left blank — Kimi installs plugins via `/plugins`, not a simple
+  in-repo `SKILL.md` dir, so cap-evolve relies on its guaranteed channel (skills under
+  `./guidance/` + the `./INSTRUCTIONS.md` pointer).

--- a/skills/optimizers/run-optimizer/references/pi.md
+++ b/skills/optimizers/run-optimizer/references/pi.md
@@ -1,0 +1,29 @@
+# pi optimizer
+
+The Pi coding agent (`pi`, `@earendil-works/pi-coding-agent`) as the edit proposer.
+
+    pi -p "<instructions>" [--model <pattern>]
+
+run with `cwd=<workdir>`. `-p`/`--print` prints the response and exits (the prompt
+is positional, also accepts stdin). Pi has **no permission popups by design** — in
+non-interactive mode it applies edits without confirmation, so there is no
+`--yolo`/`--auto` flag to add. `--model <pattern>` selects the model (e.g.
+`sonnet:high`, which implies the provider); `--provider <name>` is available if you
+need to pin it. Sessions are keyed by cwd (no `--cwd`); `--mode json`/`--mode rpc`
+give structured/process integration.
+
+- **Install:** `npm install -g --ignore-scripts @earendil-works/pi-coding-agent` ·
+  or `curl -fsSL https://pi.dev/install.sh | sh` (repo: https://github.com/earendil-works/pi)
+- **Auth:** provider-native — `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, etc., or `pi /login`.
+  (`PI_API_KEY` is not a thing.)
+- **JSON / cost:** no documented `total_cost_usd`, so `json_flag` is blank and the
+  optimizer runs prose-fed.
+
+## Native skills, instructions, and subagents
+
+- **Native skills:** Pi has **native skills** (`pi install git:...`; local dev `pi -e <dir>`)
+  and loads them without a compatibility `Skill` tool. cap-evolve does not assume a fixed
+  in-repo skills dir, so the registry leaves `skills_dir`/`instructions_file` blank and
+  relies on its guaranteed channel (skills under `./guidance/` + the `./INSTRUCTIONS.md`
+  pointer). If you package the capability/diagnose skills for Pi natively, point Pi at them
+  per its docs.


### PR DESCRIPTION
Closes #21.

## Summary
Adds **Cursor, Factory Droid, GitHub Copilot CLI, Kimi, Pi, and Antigravity** as edit-proposer optimizers, bringing cap-evolve's supported coding-agent set to parity with [obra/superpowers](https://github.com/obra/superpowers) (8 → 14 optimizers). Support spans both layers: drivable as the optimizer **and** installable as a host (`install.sh --host`).

## Design decisions
- `run-optimizer` already abstracts every optimizer behind one runner + `optimizers/registry.yaml`, so **no core/runner code changed** — each agent is one YAML row + one `references/<name>.md`.
- `cursor`, `droid`, `copilot`, `kimi`, `pi` use **verified headless commands** (researched against official docs).
- `antigravity` is a **configurable wrapper** (`CAPEVOLVE_ANTIGRAVITY_CMD`, like `openclaw`) because its auth is Google-Sign-In-only (no documented CI API key) and its non-interactive approve flag is unconfirmed.
- Honesty caveats documented in each reference (Kimi auth env unverified → steer to `kimi login`; Pi has no approve flag by design; `skills_dir` set only where native discovery is documented; new host dirs flagged as best-guess conventions).

## Files
- `skills/optimizers/registry.yaml` — 6 rows
- `skills/optimizers/run-optimizer/references/{cursor,droid,copilot,kimi,pi,antigravity}.md`
- `skills/optimizers/run-optimizer/SKILL.md`, `install.sh`
- `README.md`, `llms.txt`, `RUN.md`, `docs/ROADMAP.md`, `CHANGELOG.md`
- `docs/specs/2026-06-24-multi-agent-support-design.md` (design spec)

## Testing
- `run-optimizer --list` → 14 optimizers; `run-optimizer/scripts/check.py` green (enumerates all rows + per-CLI presence).
- Each new row builds a clean command (CLI-absent → install/auth JSON); the `antigravity` wrapper expands `{prompt_text}`/`{model}` and runs.
- `install.sh --host {cursor,droid,copilot,kimi,pi,antigravity}` routes to the correct skills dir and copies skills; `bash -n install.sh` clean.
- No live API calls to the 6 CLIs (creds not available in this environment).

Signed-off-by: Eran Raichstein <eranra@il.ibm.com>