### PR TITLE
fix: auto-detect dashboard frontend dist directory

### DIFF
--- a/dashboard/backend/capevolve_dashboard/asgi.py
+++ b/dashboard/backend/capevolve_dashboard/asgi.py
@@ -6,8 +6,8 @@ from .app import create_app
 
 _base = Path(os.environ.get("CAPEVOLVE_BASE_DIR", ".capevolve"))
 _static = os.environ.get("CAPEVOLVE_STATIC_DIR")
-if not _static:
-    _auto = Path(__file__).resolve().parent.parent.parent / "frontend" / "dist"
+if _static is None:
+    _auto = Path(__file__).resolve().parents[2] / "frontend" / "dist"
     if _auto.is_dir():
         _static = str(_auto)
 app = create_app(_base, static_dir=Path(_static) if _static else None)

--- a/dashboard/backend/capevolve_dashboard/asgi.py
+++ b/dashboard/backend/capevolve_dashboard/asgi.py
@@ -6,4 +6,8 @@ from .app import create_app
 
 _base = Path(os.environ.get("CAPEVOLVE_BASE_DIR", ".capevolve"))
 _static = os.environ.get("CAPEVOLVE_STATIC_DIR")
+if not _static:
+    _auto = Path(__file__).resolve().parent.parent.parent / "frontend" / "dist"
+    if _auto.is_dir():
+        _static = str(_auto)
 app = create_app(_base, static_dir=Path(_static) if _static else None)


### PR DESCRIPTION
When CAPEVOLVE_STATIC_DIR is not set, the dashboard server now auto-detects the frontend build at ../frontend/dist relative to the backend package. Previously, --dashboard auto would start the server but serve 404 at / unless the env var was manually set.