### PR TITLE
docs: pin venv to a specific interpreter (python3.11) in setup snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ rises — **no model is called**.
 git clone https://github.com/skillberry-ai/cap-evolve.git
 cd cap-evolve
 
-python3 -m venv .venv && source .venv/bin/activate
+python3.11 -m venv .venv && source .venv/bin/activate   # pin a specific 3.10+ interpreter
 pip install ./core                 # package: cap-evolve-core · CLI: cap-evolve · zero runtime deps
 
 bash examples/toy_calc/run.sh

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -15,7 +15,7 @@ cd cap-evolve
 ## 2. Create a clean environment and install the core
 
 ```bash
-python3 -m venv .venv && source .venv/bin/activate
+python3.11 -m venv .venv && source .venv/bin/activate   # pin a specific 3.10+ interpreter
 pip install ./core          # package: cap-evolve-core, CLI: cap-evolve (zero runtime deps)
 cap-evolve version          # verify
 ```

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -6,7 +6,7 @@ add-ons depending on how you want to drive it. Requires **Python 3.10+** and **g
 ```bash
 git clone https://github.com/skillberry-ai/cap-evolve.git
 cd cap-evolve
-python3 -m venv .venv && source .venv/bin/activate   # recommended: isolated env
+python3.11 -m venv .venv && source .venv/bin/activate   # recommended: isolated env (pin a specific 3.10+ interpreter)
 ```
 
 ## Required — the core (honest-eval substrate + CLI)


### PR DESCRIPTION
## What

Change the documented environment setup from a bare `python3 -m venv .venv` to a pinned `python3.11 -m venv .venv` in the three user-facing setup snippets:

- `README.md`
- `docs/INSTALL.md`
- `docs/GETTING_STARTED.md`

## Why

`python3` resolves to whatever the machine's default is — often an older or unsupported interpreter. Pinning to `python3.11` gives users a reproducible, known-good environment and matches the Python version the repo's CI runs on. 3.11 still satisfies the documented "Python 3.10+" requirement.

Docs-only; no code changes.