### PR TITLE
Primary vs shown-only metrics + inspect-first intake + GitHub key

### DIFF
--- a/RUN.md
+++ b/RUN.md
@@ -68,6 +68,7 @@ artifact.
 ## The rules (enforced by cap_evolve, restated here for bare hosts)
 - Train/val/test are split once with a seed; **test is scored only at finalize**.
 - Acceptance is gated on **val**, never on the data the optimizer edited against.
+- Only the **primary** metric (the scalar reward) gates; shown-only secondaries (e.g. `cost_usd`, `db_match`) are displayed but never affect accept/reject.
 - Multi-trial scoring reports mean + stderr; pass^k is reported when trials > 1.
 - Rejected approaches are remembered and never re-proposed.
 

--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -126,6 +126,37 @@ def _live(adapter, candidate_dir: Path):
 
 # ---- evaluation -----------------------------------------------------------
 
+def _aggregate_metrics(per_trial_metrics: list, reduced_reward: float) -> list:
+    """Reduce per-trial metric catalogs into one display catalog for the reduced Score.
+
+    Secondary metrics are averaged across the trials that report them; the primary
+    metric's value is pinned to ``reduced_reward`` so it stays consistent with the
+    gate scalar (and satisfies Score's primary-value==reward invariant). Metric
+    identity is by ``name``; ``primary``/``direction`` come from the first trial that
+    names the metric. Returns [] when no trial reported any metric.
+    """
+    from .stats import mean as _mean
+    order: list[str] = []
+    vals: dict[str, list[float]] = {}
+    meta: dict[str, dict] = {}
+    for cat in per_trial_metrics or []:
+        for m in cat or []:
+            name = m.get("name")
+            if name is None:
+                continue
+            if name not in vals:
+                order.append(name)
+                vals[name] = []
+                meta[name] = {"primary": bool(m.get("primary")), "direction": m.get("direction")}
+            vals[name].append(float(m.get("value", 0.0)))
+    out = []
+    for name in order:
+        value = reduced_reward if meta[name]["primary"] else _mean(vals[name])
+        out.append({"name": name, "value": value,
+                    "primary": meta[name]["primary"], "direction": meta[name]["direction"]})
+    return out
+
+
 def evaluate_candidate(
     adapter,
     candidate_dir: Path,
@@ -173,6 +204,7 @@ def evaluate_candidate(
     # collect per-task trial rewards (+ last rollout/score) across trials
     per_task_trials: dict[str, list[float]] = {t.id: [] for t in tasks}
     per_task_feedback: dict[str, str] = {t.id: "" for t in tasks}
+    per_task_metrics: dict[str, list] = {t.id: [] for t in tasks}  # per-trial metric catalogs
     per_task_errored: dict[str, bool] = {t.id: False for t in tasks}  # any trial an infra error?
     per_task_errored_trials: dict[str, int] = {t.id: 0 for t in tasks}  # how many trials errored
     task_by_id = {t.id: t for t in tasks}
@@ -199,6 +231,7 @@ def evaluate_candidate(
             sc = adapter.score(task, rollout)
             per_task_trials[tid].append(sc.reward)
             per_task_feedback[tid] = sc.feedback or per_task_feedback[tid]
+            per_task_metrics[tid].append(sc.metrics)
             (out_dir / f"{tid}__{tag}__t{k}.json").write_text(
                 json.dumps({"input": task.input, "rollout": rollout.to_dict(),
                             "score": sc.to_dict()}, default=str),
@@ -250,6 +283,7 @@ def evaluate_candidate(
             raw={"errored": per_task_errored[tid],
                  "errored_trials": per_task_errored_trials[tid],
                  "n_trials": n_trials},
+            metrics=_aggregate_metrics(per_task_metrics[tid], mean(tr)),
         ))
 
     elapsed = time.time() - t0
@@ -274,6 +308,7 @@ def split_result_from_rollouts(run_dir: RunDir, tag: str, split: str = "val", ks
     by_task: dict[str, list[float]] = {}
     feedback: dict[str, str] = {}
     raw: dict[str, dict] = {}
+    metrics_by_task: dict[str, list] = {}
     if vdir.exists():
         for f in sorted(vdir.glob(f"*__{tag}__t*.json")):
             rec = _json.loads(f.read_text(encoding="utf-8"))
@@ -281,6 +316,7 @@ def split_result_from_rollouts(run_dir: RunDir, tag: str, split: str = "val", ks
             tid = sc.get("task_id") or f.name.split("__")[0]
             by_task.setdefault(tid, []).append(float(sc.get("reward", 0.0)))
             feedback[tid] = sc.get("feedback", feedback.get(tid, ""))
+            metrics_by_task.setdefault(tid, []).append(sc.get("metrics") or [])
             # carry the structured infra flag + trial counts forward across resume.
             # Each rollout file is one trial, so count an errored trial here and tally
             # the total trials seen — letting _is_infra_ignore reconstruct the
@@ -291,7 +327,8 @@ def split_result_from_rollouts(run_dir: RunDir, tag: str, split: str = "val", ks
                 r0["errored"] = True
                 r0["errored_trials"] = int(r0.get("errored_trials", 0)) + 1
     scores = [Score(task_id=t, reward=mean(r), feedback=feedback.get(t, ""),
-                    n=len(r), stderr=stderr(r), trial_rewards=r, raw=raw.get(t, {}))
+                    n=len(r), stderr=stderr(r), trial_rewards=r, raw=raw.get(t, {}),
+                    metrics=_aggregate_metrics(metrics_by_task.get(t, []), mean(r)))
               for t, r in by_task.items()]
     return aggregate_scores(split, scores, ks=ks)
 

--- a/core/cap_evolve/types.py
+++ b/core/cap_evolve/types.py
@@ -93,10 +93,31 @@ class Score:
     stderr: float = 0.0
     trial_rewards: list = field(default_factory=list)
     raw: dict = field(default_factory=dict)
+    metrics: list = field(default_factory=list)  # shown-only catalog; see _validate_metrics
 
     def __post_init__(self) -> None:
         self.reward = _clamp01(self.reward)
         self.trial_rewards = [_clamp01(r) for r in self.trial_rewards]
+        self._validate_metrics()
+
+    def _validate_metrics(self) -> None:
+        if not self.metrics:
+            return
+        primaries = [m for m in self.metrics if m.get("primary") is True]
+        if len(primaries) != 1:
+            raise ValueError(f"exactly one metric must be primary, got {len(primaries)}")
+        for m in self.metrics:
+            if m.get("direction") not in ("higher", "lower"):
+                raise ValueError(f"metric {m.get('name')!r} needs direction higher|lower")
+        pv = float(primaries[0]["value"])
+        if abs(pv - self.reward) > 1e-9:
+            raise ValueError(f"primary metric value {pv} must equal reward {self.reward}")
+
+    def primary_metric(self):
+        for m in self.metrics:
+            if m.get("primary") is True:
+                return m
+        return None
 
     def to_dict(self) -> dict:
         return asdict(self)
@@ -111,6 +132,7 @@ class Score:
             stderr=float(d.get("stderr") or 0.0),
             trial_rewards=list(d.get("trial_rewards") or []),
             raw=dict(d.get("raw") or {}),
+            metrics=list(d.get("metrics") or []),
         )
 
 

--- a/core/cap_evolve/types.py
+++ b/core/cap_evolve/types.py
@@ -101,15 +101,33 @@ class Score:
         self._validate_metrics()
 
     def _validate_metrics(self) -> None:
+        # Fully validate every entry: a malformed catalog that slips through here
+        # crashes later in harness._aggregate_metrics (float(value), name as dict key).
         if not self.metrics:
             return
-        primaries = [m for m in self.metrics if m.get("primary") is True]
-        if len(primaries) != 1:
-            raise ValueError(f"exactly one metric must be primary, got {len(primaries)}")
+        seen: set = set()
+        n_primary = 0
         for m in self.metrics:
+            if not isinstance(m, dict):
+                raise ValueError(f"metric entry must be a dict, got {type(m).__name__}")
+            name = m.get("name")
+            if not isinstance(name, str) or not name.strip():
+                raise ValueError(f"metric name must be a non-empty string, got {name!r}")
+            if name in seen:
+                raise ValueError(f"duplicate metric name {name!r}")
+            seen.add(name)
+            primary = m.get("primary")
+            if not isinstance(primary, bool):
+                raise ValueError(f"metric {name!r} 'primary' must be a bool, got {primary!r}")
+            n_primary += primary
             if m.get("direction") not in ("higher", "lower"):
-                raise ValueError(f"metric {m.get('name')!r} needs direction higher|lower")
-        pv = float(primaries[0]["value"])
+                raise ValueError(f"metric {name!r} needs direction higher|lower")
+            value = m.get("value")
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise ValueError(f"metric {name!r} value must be numeric, got {value!r}")
+        if n_primary != 1:
+            raise ValueError(f"exactly one metric must be primary, got {n_primary}")
+        pv = float(next(m["value"] for m in self.metrics if m["primary"]))
         if abs(pv - self.reward) > 1e-9:
             raise ValueError(f"primary metric value {pv} must equal reward {self.reward}")
 

--- a/core/tests/test_metrics.py
+++ b/core/tests/test_metrics.py
@@ -1,0 +1,48 @@
+"""Shown-only secondary metrics ride alongside the gating primary reward."""
+import pytest
+from cap_evolve.types import Score
+
+
+def _score(**kw):
+    return Score(task_id="t1", reward=0.8, **kw)
+
+
+def test_empty_metrics_is_allowed_and_roundtrips():
+    s = _score()
+    assert s.metrics == []
+    assert s.primary_metric() is None
+    assert Score.from_dict(s.to_dict()).metrics == []
+
+
+def test_primary_metric_returned():
+    s = _score(metrics=[
+        {"name": "acc", "value": 0.8, "primary": True, "direction": "higher"},
+        {"name": "latency_ms", "value": 120.0, "primary": False, "direction": "lower"},
+    ])
+    assert s.primary_metric()["name"] == "acc"
+    assert [m["name"] for m in s.metrics if not m["primary"]] == ["latency_ms"]
+
+
+def test_roundtrip_preserves_metrics():
+    s = _score(metrics=[{"name": "acc", "value": 0.8, "primary": True, "direction": "higher"}])
+    assert Score.from_dict(s.to_dict()).metrics == s.metrics
+
+
+def test_exactly_one_primary_required():
+    with pytest.raises(ValueError):
+        _score(metrics=[
+            {"name": "a", "value": 0.8, "primary": True, "direction": "higher"},
+            {"name": "b", "value": 0.8, "primary": True, "direction": "higher"},
+        ])
+    with pytest.raises(ValueError):
+        _score(metrics=[{"name": "a", "value": 0.8, "primary": False, "direction": "higher"}])
+
+
+def test_direction_must_be_higher_or_lower():
+    with pytest.raises(ValueError):
+        _score(metrics=[{"name": "a", "value": 0.8, "primary": True, "direction": "sideways"}])
+
+
+def test_primary_value_must_match_reward():
+    with pytest.raises(ValueError):
+        _score(metrics=[{"name": "a", "value": 0.5, "primary": True, "direction": "higher"}])

--- a/core/tests/test_metrics.py
+++ b/core/tests/test_metrics.py
@@ -46,3 +46,47 @@ def test_direction_must_be_higher_or_lower():
 def test_primary_value_must_match_reward():
     with pytest.raises(ValueError):
         _score(metrics=[{"name": "a", "value": 0.5, "primary": True, "direction": "higher"}])
+
+
+def _ok_primary():
+    return {"name": "acc", "value": 0.8, "primary": True, "direction": "higher"}
+
+
+def test_secondary_value_must_be_numeric():
+    # non-numeric value would crash later in _aggregate_metrics (float(m["value"]))
+    with pytest.raises(ValueError):
+        _score(metrics=[_ok_primary(),
+                        {"name": "note", "value": "fast", "primary": False, "direction": "lower"}])
+
+
+def test_bool_value_rejected():
+    # bool is a subclass of int but is not a metric value
+    with pytest.raises(ValueError):
+        _score(metrics=[_ok_primary(),
+                        {"name": "ok", "value": True, "primary": False, "direction": "higher"}])
+
+
+def test_name_must_be_nonempty_string():
+    with pytest.raises(ValueError):
+        _score(metrics=[_ok_primary(),
+                        {"name": "", "value": 1.0, "primary": False, "direction": "lower"}])
+    with pytest.raises(ValueError):
+        _score(metrics=[_ok_primary(),
+                        {"name": None, "value": 1.0, "primary": False, "direction": "lower"}])
+
+
+def test_duplicate_names_rejected():
+    # names are used as dict keys during aggregation; duplicates silently collide
+    with pytest.raises(ValueError):
+        _score(metrics=[_ok_primary(),
+                        {"name": "acc", "value": 1.0, "primary": False, "direction": "higher"}])
+
+
+def test_primary_must_be_bool():
+    with pytest.raises(ValueError):
+        _score(metrics=[{"name": "a", "value": 0.8, "primary": 1, "direction": "higher"}])
+
+
+def test_non_dict_entry_rejected():
+    with pytest.raises(ValueError):
+        _score(metrics=[_ok_primary(), ["not", "a", "dict"]])

--- a/core/tests/test_metrics_results.py
+++ b/core/tests/test_metrics_results.py
@@ -1,0 +1,37 @@
+"""Secondary metrics survive aggregation/serialization for display."""
+from cap_evolve.loop import aggregate_scores
+from cap_evolve.types import Score
+
+
+def test_score_dict_includes_secondaries():
+    s = Score(task_id="t1", reward=0.8, metrics=[
+        {"name": "acc", "value": 0.8, "primary": True, "direction": "higher"},
+        {"name": "latency_ms", "value": 120.0, "primary": False, "direction": "lower"},
+    ])
+    d = s.to_dict()
+    assert d["metrics"][1]["name"] == "latency_ms"
+    # display-only: reward (the gate scalar) is unchanged by the presence of secondaries
+    assert d["reward"] == 0.8
+
+
+def test_aggregate_scores_preserves_metrics():
+    # Guard: the aggregation site (loop.aggregate_scores) emits per-task rows via
+    # Score.to_dict(), so the shown-only `metrics` catalog reaches the results JSON
+    # verbatim. Display-only: the aggregate gate scalar `reward` is unaffected.
+    scores = [
+        Score(task_id="t1", reward=0.8, metrics=[
+            {"name": "acc", "value": 0.8, "primary": True, "direction": "higher"},
+            {"name": "latency_ms", "value": 120.0, "primary": False, "direction": "lower"},
+        ]),
+        Score(task_id="t2", reward=0.4, metrics=[
+            {"name": "acc", "value": 0.4, "primary": True, "direction": "higher"},
+            {"name": "latency_ms", "value": 90.0, "primary": False, "direction": "lower"},
+        ]),
+    ]
+    result = aggregate_scores("val", scores)
+    per_task = result.to_dict()["per_task"]
+    assert per_task[0]["metrics"][1]["name"] == "latency_ms"
+    assert per_task[1]["metrics"][1]["value"] == 90.0
+    # gate scalar reward on each row is the primary value, unchanged
+    assert per_task[0]["reward"] == 0.8
+    assert per_task[1]["reward"] == 0.4

--- a/core/tests/test_metrics_results.py
+++ b/core/tests/test_metrics_results.py
@@ -1,5 +1,9 @@
 """Secondary metrics survive aggregation/serialization for display."""
+import json
+
 from cap_evolve.loop import aggregate_scores
+from cap_evolve.harness import _aggregate_metrics, split_result_from_rollouts
+from cap_evolve.rundir import RunDir
 from cap_evolve.types import Score
 
 
@@ -35,3 +39,59 @@ def test_aggregate_scores_preserves_metrics():
     # gate scalar reward on each row is the primary value, unchanged
     assert per_task[0]["reward"] == 0.8
     assert per_task[1]["reward"] == 0.4
+
+
+def test_aggregate_metrics_pins_primary_to_reward():
+    per_trial = [
+        [{"name": "acc", "value": 1.0, "primary": True, "direction": "higher"},
+         {"name": "latency_ms", "value": 100.0, "primary": False, "direction": "lower"}],
+        [{"name": "acc", "value": 0.0, "primary": True, "direction": "higher"},
+         {"name": "latency_ms", "value": 200.0, "primary": False, "direction": "lower"}],
+    ]
+    out = _aggregate_metrics(per_trial, reduced_reward=0.5)
+    by = {m["name"]: m for m in out}
+    assert by["acc"]["value"] == 0.5          # primary pinned to reduced reward
+    assert by["acc"]["primary"] is True
+    assert by["latency_ms"]["value"] == 150.0  # secondary averaged
+    assert by["latency_ms"]["direction"] == "lower"
+
+
+def test_aggregate_metrics_empty():
+    assert _aggregate_metrics([[], []], 0.7) == []
+
+
+def test_reduced_score_carries_metrics():
+    per_trial = [[{"name": "acc", "value": 1.0, "primary": True, "direction": "higher"}],
+                 [{"name": "acc", "value": 0.0, "primary": True, "direction": "higher"}]]
+    reward = 0.5
+    s = Score(task_id="t1", reward=reward, trial_rewards=[1.0, 0.0],
+              metrics=_aggregate_metrics(per_trial, reward))
+    assert s.primary_metric()["value"] == 0.5   # no ValueError raised
+    assert s.to_dict()["metrics"][0]["name"] == "acc"
+
+
+def test_split_result_from_rollouts_carries_metrics(tmp_path):
+    # Reduction path the dashboard uses: two persisted trials for one task, each
+    # with a primary metric whose value differs per trial. The reconstructed
+    # per-task Score must carry metrics with the primary pinned to the mean reward.
+    run_dir = RunDir.create(tmp_path)
+    val_dir = run_dir.rollouts / "val"
+    val_dir.mkdir(parents=True, exist_ok=True)
+    trials = [
+        (1.0, [{"name": "acc", "value": 1.0, "primary": True, "direction": "higher"},
+               {"name": "latency_ms", "value": 100.0, "primary": False, "direction": "lower"}]),
+        (0.0, [{"name": "acc", "value": 0.0, "primary": True, "direction": "higher"},
+               {"name": "latency_ms", "value": 200.0, "primary": False, "direction": "lower"}]),
+    ]
+    for k, (reward, metrics) in enumerate(trials):
+        score = Score(task_id="t1", reward=reward, trial_rewards=[reward], metrics=metrics)
+        (val_dir / f"t1__cand__t{k}.json").write_text(
+            json.dumps({"input": {}, "rollout": {}, "score": score.to_dict()}, default=str),
+            encoding="utf-8",
+        )
+    result = split_result_from_rollouts(run_dir, tag="cand", split="val")
+    row = result.to_dict()["per_task"][0]
+    by = {m["name"]: m for m in row["metrics"]}
+    assert by["acc"]["value"] == 0.5          # primary pinned to mean reward
+    assert by["acc"]["primary"] is True
+    assert by["latency_ms"]["value"] == 150.0  # secondary averaged

--- a/docs/ADAPTER_CONTRACT.md
+++ b/docs/ADAPTER_CONTRACT.md
@@ -29,6 +29,14 @@ class Adapter(CapabilityAdapter):
   `feedback`. The feedback is the learning signal (gepa's "Actionable Side
   Information"); describe *why* generally, and **never leak the gold answer**. Must be
   deterministic on a fixed rollout (enforced by the gate).
+  You may also return a `metrics` catalog of shown-only secondaries alongside the
+  reward — each entry is `{name, value, primary, direction}` with `direction` in
+  `higher | lower`. Exactly one entry has `primary: true` and its `value` must equal
+  `reward` (the scalar the gate uses); every other entry is display-only and **never
+  affects accept/reject**. Secondaries flow through the rollout/results JSON for the
+  dashboard. Example (tau2 airline): primary `reward` plus shown-only `db_match`
+  (higher) and `cost_usd` (lower). See `examples/tau2_airline/adapters/adapter.py`
+  `_shown_metrics()`. Leave `metrics` empty to keep the plain scalar-reward behavior.
 
 ## Optional hooks (working defaults provided)
 
@@ -70,6 +78,10 @@ cap-evolve check .capevolve/project   # must print {"ok": true}
 implemented, `tasks` is non-empty and stable, and `score` is deterministic. This is
 mandatory before any budget is spent — a half-wired adapter can only produce a
 dishonest number.
+
+The gate reads only the **primary** metric (the scalar `reward`). Any shown-only
+secondaries a `score()` returns are carried through for display but can never move an
+accept/reject decision or the sealed number.
 
 ## Everything else is provided
 

--- a/docs/HONEST_EVAL.md
+++ b/docs/HONEST_EVAL.md
@@ -19,7 +19,10 @@ construction*, and the rules below are enforced in code, not just documented.
    any split but `val` (`TrainGateError`) and, by default, accepts a candidate
    only when the improvement exceeds `k · SE` — so noise is not mistaken for
    progress (`mode="significant"`). Other modes (`strict`, `threshold`,
-   `simplicity_tiebreak`) exist but never relax the val-only rule.
+   `simplicity_tiebreak`) exist but never relax the val-only rule. The gate reads
+   only the **primary** metric (the scalar `reward`); any shown-only secondary
+   metrics a scorer emits (`Score.metrics`) are for display and cannot move the
+   decision.
 
 4. **Variance is measured, not assumed.** With `num_trials > 1`, each task gets a
    mean and stderr; `combined_stderr` mixes between-task and within-task error;

--- a/docs/OPTIMIZE_YOUR_OWN.md
+++ b/docs/OPTIMIZE_YOUR_OWN.md
@@ -80,6 +80,11 @@ you want intake to ask):
 - source:     <the benchmark's own verifier  OR  your score() function in adapter.py>
 - feedback:   must be GENERAL and gold-SAFE — it is the learning signal; never leak the gold answer
 - objective:  maximize mean reward on the VAL split
+- metrics_display:   <optional names to also SHOW, e.g. [accuracy, latency_ms]; empty = just the primary reward>
+- metric_primary:    <which name GATES accept/reject; blank = the reward scalar itself>
+- metric_directions: <parallel to metrics_display: higher | lower per metric>
+                      # secondaries are display-only (dashboard/results JSON); ONLY the primary (= reward) gates.
+                      # your score() returns them via Score.metrics — see docs/ADAPTER_CONTRACT.md
 
 # 5. OPTIMIZER  (proposes the edits) + MODEL + CREDENTIALS
 - optimizer:   <claude-code | codex | gemini-cli | opencode | cursor | droid | copilot | kimi | pi | antigravity | openclaw | ibm-bob | generic | mock>

--- a/examples/tau2_airline/adapters/adapter.py
+++ b/examples/tau2_airline/adapters/adapter.py
@@ -33,6 +33,23 @@ from cap_evolve import CapabilityAdapter, Rollout, Score, Task
 DOMAIN = "airline"
 
 
+def _shown_metrics(reward: float, reward_info: dict, rollout) -> list:
+    """Shown-only secondary metrics for display; the GATE still uses reward (primary).
+
+    Always emits the primary ``reward`` (== Score.reward) plus at least one shown-only
+    secondary (``cost_usd``), and ``db_match`` when tau2 reports the DB check. These ride
+    through the results JSON for the dashboard and never affect accept/reject.
+    """
+    metrics = [{"name": "reward", "value": float(reward), "primary": True, "direction": "higher"}]
+    db_check = (reward_info or {}).get("db_check") or {}
+    if "db_match" in db_check:
+        metrics.append({"name": "db_match", "value": 1.0 if db_check.get("db_match") else 0.0,
+                        "primary": False, "direction": "higher"})
+    metrics.append({"name": "cost_usd", "value": float(getattr(rollout, "cost_usd", 0.0) or 0.0),
+                    "primary": False, "direction": "lower"})
+    return metrics
+
+
 # ---------------------------------------------------------------------------
 # Candidate building helpers (pure; no network)
 # ---------------------------------------------------------------------------
@@ -379,6 +396,7 @@ class Adapter(CapabilityAdapter):
                     f"({rollout.error}). This is uncontrollable noise, not an agent "
                     "policy/tool failure; do not optimize against it."
                 ),
+                metrics=_shown_metrics(0.0, {}, rollout),
             )
 
         reward = float(meta.get("tau2_reward", 0.0) or 0.0)
@@ -391,7 +409,10 @@ class Adapter(CapabilityAdapter):
         ctx["trace"] = rollout.trace or rollout.output or meta.get("trace") or []
 
         feedback = self._build_feedback(reward, reward_info, ctx)
-        return Score(task_id=task.id, reward=reward, feedback=feedback)
+        return Score(
+            task_id=task.id, reward=reward, feedback=feedback,
+            metrics=_shown_metrics(reward, reward_info, rollout),
+        )
 
     # ---- gold-safe rollout introspection (for argument-level feedback) ----
     #

--- a/skills/phases/intake/SKILL.md
+++ b/skills/phases/intake/SKILL.md
@@ -43,7 +43,7 @@ inputs. The metric / GitHub / stop-condition questions below feed directly into 
 - For each shown metric, is higher or lower better? → `metric_directions` (parallel to `metrics_display`).
 
 ### GitHub integration
-- `gh auth status` = authed? Offer: mirror weaknesses as issues + ship winner as PR (`Closes #n`) → `github_integration: true`; else offer `gh auth login` or skip → `false`. GitHub is mirror-only; the run dir stays authoritative.
+- `gh auth status` = authed? Offer: mirror the algorithm's work items as issues + ship winner as PR (`Closes #n`) → `github_integration: true`; else offer `gh auth login` or skip → `false`. WHAT gets mirrored is algorithm-specific (the `algorithm_skill` defines it — e.g. evo-graph → weaknesses). GitHub is mirror-only; the run dir stays authoritative.
 
 ### Stop condition (agent mode)
 - Free-text halt rule re-read each round → `stop_condition`. Deterministic mode leaves it blank and uses budget knobs.

--- a/skills/phases/intake/SKILL.md
+++ b/skills/phases/intake/SKILL.md
@@ -26,6 +26,28 @@ Downstream, `implement-and-check` consumes `project`; `baseline` consumes
 `project` + `tasks`. If intake under-delivers either token, the hard gate in
 `implement-and-check` fails loudly rather than silently optimizing against a stub.
 
+## Step 0 — Inspect before asking
+Before any question, inspect the target so you can PROPOSE defaults instead of asking blind:
+1. Look at the repo/benchmark/agent: entrypoint, how one eval runs, where traces/scores live.
+2. Detect candidate metrics (what the scorer emits), a natural train/val/test split, and cost caps.
+3. Run `gh auth status` to know whether GitHub is available.
+
+Then ask the FEWEST questions — present detected metrics/splits/caps as multiple-choice
+defaults with a free-text escape, keeping the ask-user-if-missing discipline for NEEDED
+inputs. The metric / GitHub / stop-condition questions below feed directly into the
+`capevolve.yaml` spec keys, so ask them here (after inspecting, before scaffolding).
+
+### Metrics
+- Which metrics should the dashboard show? (detected: `<list>`) — multiple choice + free text → `metrics_display`.
+- Which ONE gates accept/reject? — single choice → `metric_primary`. (This is the only metric the gate uses.)
+- For each shown metric, is higher or lower better? → `metric_directions` (parallel to `metrics_display`).
+
+### GitHub integration
+- `gh auth status` = authed? Offer: mirror weaknesses as issues + ship winner as PR (`Closes #n`) → `github_integration: true`; else offer `gh auth login` or skip → `false`. GitHub is mirror-only; the run dir stays authoritative.
+
+### Stop condition (agent mode)
+- Free-text halt rule re-read each round → `stop_condition`. Deterministic mode leaves it blank and uses budget knobs.
+
 ## What it does
 1. **Interview** (driven by this SKILL.md): pick the capability skill (*what* is
    optimized), the optimizer (*which* coding agent proposes edits), the algorithm

--- a/skills/phases/intake/inputs/INPUTS.md
+++ b/skills/phases/intake/inputs/INPUTS.md
@@ -157,6 +157,12 @@ path, how to obtain it, and the alternatives. Never invent a NEEDED input.
   also: significant|strict|threshold|simplicity_tiebreak), `gate_k_se` (default 1.0; the
   examples use 0.2). Add `--no-regression` to forbid breaking passing tasks.
 
+- **metrics (display)**: which numbers to surface and which one GATES.
+  - `metric_primary`: the single metric that decides accept/reject (= the scalar reward). Blank = use the reward directly.
+  - `metrics_display` + `metric_directions`: extra SHOWN-ONLY metrics and each one's direction (`higher`|`lower`). These never affect the gate — display only.
+- **github_integration** (default `false`): if `true`, intake runs `gh auth status`; when authed, cap-evolve may mirror weaknesses as issues and ship the winner as a PR (`Closes #n`). GitHub is NEVER the source of truth — the run dir is. If unauthed, intake offers `gh auth login` or skip.
+- **stop_condition** (default empty): agent-mode free-text halt rule, re-read each round. Deterministic mode ignores it and uses the budget knobs.
+
 - **baseline traces** (optional): prior rollouts to seed diagnosis. Default: none
   (the baseline phase produces them on the first val eval).
 

--- a/skills/phases/intake/inputs/INPUTS.md
+++ b/skills/phases/intake/inputs/INPUTS.md
@@ -160,7 +160,7 @@ path, how to obtain it, and the alternatives. Never invent a NEEDED input.
 - **metrics (display)**: which numbers to surface and which one GATES.
   - `metric_primary`: the single metric that decides accept/reject (= the scalar reward). Blank = use the reward directly.
   - `metrics_display` + `metric_directions`: extra SHOWN-ONLY metrics and each one's direction (`higher`|`lower`). These never affect the gate — display only.
-- **github_integration** (default `false`): if `true`, intake runs `gh auth status`; when authed, cap-evolve may mirror weaknesses as issues and ship the winner as a PR (`Closes #n`). GitHub is NEVER the source of truth — the run dir is. If unauthed, intake offers `gh auth login` or skip.
+- **github_integration** (default `false`): if `true`, intake runs `gh auth status`; when authed, cap-evolve may mirror the algorithm's work items as issues and ship the winner as a PR (`Closes #n`). WHAT gets mirrored is algorithm-specific — the chosen `algorithm_skill` defines it (e.g. evo-graph mirrors *weaknesses*; a candidate-based algorithm might mirror candidates/iterations). GitHub is NEVER the source of truth — the run dir is. If unauthed, intake offers `gh auth login` or skip.
 - **stop_condition** (default empty): agent-mode free-text halt rule, re-read each round. Deterministic mode ignores it and uses the budget knobs.
 
 - **baseline traces** (optional): prior rollouts to seed diagnosis. Default: none

--- a/templates/project/capevolve.yaml
+++ b/templates/project/capevolve.yaml
@@ -59,7 +59,7 @@ metric_primary: ""           # which name gates accept/reject (defaults to the r
 metric_directions: []        # parallel to metrics_display: higher | lower for each
 
 # --- integrations / stop ----------------------------------------------------
-github_integration: false    # mirror-only: mirror weaknesses as issues + ship winner as PR (Closes #n)
+github_integration: false    # mirror-only: mirror the algorithm's work items as issues + ship winner as PR (Closes #n); WHAT is mirrored is algorithm-specific (evo-graph=weaknesses)
 stop_condition: ""           # agent-mode free-text halt rule, re-read each round (e.g. "stop when val acc >= 0.9 or 5 rounds")
 
 # --- acceptance gate --------------------------------------------------------

--- a/templates/project/capevolve.yaml
+++ b/templates/project/capevolve.yaml
@@ -51,6 +51,17 @@ split_ids_file: ""
 # --- scoring ----------------------------------------------------------------
 num_trials: 1
 
+# --- metrics (display) ------------------------------------------------------
+# The GATE always uses the PRIMARY metric only (= the scalar reward). Secondaries
+# are shown in the dashboard/results but never affect accept/reject.
+metrics_display: []          # names to show, e.g. [accuracy, latency_ms]; empty = just the primary reward
+metric_primary: ""           # which name gates accept/reject (defaults to the reward if blank)
+metric_directions: []        # parallel to metrics_display: higher | lower for each
+
+# --- integrations / stop ----------------------------------------------------
+github_integration: false    # mirror-only: mirror weaknesses as issues + ship winner as PR (Closes #n)
+stop_condition: ""           # agent-mode free-text halt rule, re-read each round (e.g. "stop when val acc >= 0.9 or 5 rounds")
+
 # --- acceptance gate --------------------------------------------------------
 gate_mode: paired                        # paired (recommended: per-task paired SE, same tasks both sides — banks real 1-task gains) | significant | strict | threshold | simplicity_tiebreak
 gate_k_se: 1.0


### PR DESCRIPTION
🎥 **Demo video (evo-graph UI *inside* the cap-evolve dashboard):** https://drive.google.com/file/d/1oWCM4cLAgPJds2xMHOwGKbXIBi_a-D1O/view

---

# PR: Primary vs shown-only metrics + inspect-first intake + GitHub key

Closes #38

## What this does

Lets a run declare **one gating primary metric** plus **shown-only secondary metrics**, and adds the `github_integration` and `stop_condition` spec keys. Intake now inspects the repo/benchmark before asking, and asks the fewest questions.

The acceptance gate is unchanged — it still compares the scalar `reward`, which is now formalized as the primary metric's value. Secondary metrics ride through the results JSON for **display only** and never affect accept/reject.

## Changes

- **`Score` gains a shown-only `metrics` catalog** (`core/cap_evolve/types.py`): each entry `{name, value, primary, direction}`, exactly one `primary: true`, `direction ∈ {higher, lower}`, and the primary's `value` must equal `reward`. Adds `Score.primary_metric()`.
- **Secondaries survive the real results path** (`core/cap_evolve/harness.py`): the per-trial → per-task reduction and the resume/reconstruct path now aggregate secondary metrics across trials (mean) and pin the primary to the reduced reward — so the invariant holds with `n_trials > 1`.
- **New spec keys** (`templates/project/capevolve.yaml`): `metrics_display`, `metric_primary`, `metric_directions`, `github_integration`, `stop_condition`.
- **Intake** (`skills/phases/intake/SKILL.md`, `inputs/INPUTS.md`): inspect-first onboarding; asks metric display-set/primary/directions, `github_integration` (with `gh auth status` flow), and `stop_condition`. GitHub is **mirror-only** (run dir is source of truth), and *what* gets mirrored is algorithm-specific (not hardcoded to any one algorithm's vocabulary).

## Guarantees held

- `gate.py` is byte-for-byte unchanged; the gate uses only the primary metric.
- Rewards stay clamped to `[0,1]`; primary metric value == reward.
- Pure stdlib in `core/cap_evolve/`.
- `capevolve.yaml` stays flat (zero-dependency reader compatible).

## Tests

- New `core/tests/test_metrics.py` (Score catalog + validation) and `core/tests/test_metrics_results.py` (aggregation + on-disk resume path).
- Full suite: **114 passed**.

## Not in scope (follow-up issues)

- GitHub mirroring *behavior* (issue/PR creation) — lands with the algorithm that emits work items (#40).
- Dashboard *rendering* of secondaries — #39/#41.
