### PR TITLE
fix: use python3 for mock optimizer command (closes #61)

### DIFF
--- a/skills/optimizers/registry.yaml
+++ b/skills/optimizers/registry.yaml
@@ -52,7 +52,7 @@
 # Per-CLI install/auth/flag prose lives in references/<name>.md.
 
 mock:
-  command_template: "python {self_dir}/_mock_apply.py --workdir {workdir} --prompt {prompt}"
+  command_template: "python3 {self_dir}/_mock_apply.py --workdir {workdir} --prompt {prompt}"
   env_keys: ""
   install_url: ""
   auth_notes: "No auth — deterministic, zero-API. Driven by mock_script.json."


### PR DESCRIPTION
## Summary

- `skills/optimizers/registry.yaml`: change the `mock` row's `command_template` from `python` to `python3`
- Consistent with `examples/toy_calc/run.sh`, which already uses `python3`

Closes #61.

## Why

The mock row is marked `offline: "true"`, so `run-optimizer` deliberately skips the `shutil.which(exe)` PATH check (`scripts/run.py:288`). On any machine without a `python` symlink (modern macOS, many Linux distros), `subprocess.run(["python", ...])` on line 298 raises `FileNotFoundError`. The exception is uncaught; the harness logs it to `events.jsonl` under `optimizer_error` and reports exit code 1 — but stdout never sees it. Every optimizer iteration crashes silently, no candidate ever beats the seed, and `toy_calc` finishes with `test_reward: 0.0` — the exact opposite of what the demo is meant to show.

## Test plan

- [x] `which python` returns nothing on the test machine (macOS 24.6, Python 3.14 via Homebrew)
- [x] Before fix: `bash examples/toy_calc/run.sh` → `test_reward: 0.0`, `test_delta: 0.0`, `best_id: seed`
- [x] After fix: `bash examples/toy_calc/run.sh` → `test_reward: 1.0`, `test_delta: 1.0`, `best_id: cand_0001`

## Follow-up (not in this PR)

Independent of the interpreter fix, `subprocess.run(cmd, ...)` at `run-optimizer/scripts/run.py:298` should catch `FileNotFoundError` and emit a structured error like the `shutil.which` branch above it. The offline path currently has no such guard, so any future missing-executable in an offline registry row will produce the same silent failure. Happy to file a separate PR after this one lands if the approach seems right.