### PR TITLE
chore(site): sitemap, robots.txt, and canonical/OG/Twitter meta for SEO

### DIFF
--- a/site/adapter-templates.html
+++ b/site/adapter-templates.html
@@ -5,6 +5,17 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Adapter templates — cap-evolve</title>
   <meta name="description" content="Copy-and-run cap-evolve adapter templates — JSONL, HuggingFace, tau2-bench, SWE-bench, SkillsBench — that work with any litellm provider. Onboarding a benchmark is config, not code.">
+  <link rel="canonical" href="https://skillberry-ai.github.io/cap-evolve/adapter-templates.html">
+  <meta property="og:type" content="article">
+  <meta property="og:site_name" content="cap-evolve">
+  <meta property="og:title" content="Adapter templates — cap-evolve">
+  <meta property="og:description" content="Copy-and-run cap-evolve adapter templates — JSONL, HuggingFace, tau2-bench, SWE-bench, SkillsBench — that work with any litellm provider. Onboarding a benchmark is config, not code.">
+  <meta property="og:url" content="https://skillberry-ai.github.io/cap-evolve/adapter-templates.html">
+  <meta property="og:image" content="https://skillberry-ai.github.io/cap-evolve/assets/dashboard.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Adapter templates — cap-evolve">
+  <meta name="twitter:description" content="Copy-and-run cap-evolve adapter templates — JSONL, HuggingFace, tau2-bench, SWE-bench, SkillsBench — that work with any litellm provider. Onboarding a benchmark is config, not code.">
+  <meta name="twitter:image" content="https://skillberry-ai.github.io/cap-evolve/assets/dashboard.png">
   <link rel="preconnect" href="https://rsms.me/">
   <link rel="stylesheet" href="https://rsms.me/inter/inter.css">
   <link rel="stylesheet" href="style.css?v=20260720-1">

--- a/site/architecture.html
+++ b/site/architecture.html
@@ -5,6 +5,17 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Architecture — cap-evolve</title>
   <meta name="description" content="The cap-evolve pipeline (intake → check → baseline → algorithm → finalize → report), the optimizer context assembled each iteration, and the skill library.">
+  <link rel="canonical" href="https://skillberry-ai.github.io/cap-evolve/architecture.html">
+  <meta property="og:type" content="article">
+  <meta property="og:site_name" content="cap-evolve">
+  <meta property="og:title" content="Architecture — cap-evolve">
+  <meta property="og:description" content="The cap-evolve pipeline (intake → check → baseline → algorithm → finalize → report), the optimizer context assembled each iteration, and the skill library.">
+  <meta property="og:url" content="https://skillberry-ai.github.io/cap-evolve/architecture.html">
+  <meta property="og:image" content="https://skillberry-ai.github.io/cap-evolve/assets/dashboard.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Architecture — cap-evolve">
+  <meta name="twitter:description" content="The cap-evolve pipeline (intake → check → baseline → algorithm → finalize → report), the optimizer context assembled each iteration, and the skill library.">
+  <meta name="twitter:image" content="https://skillberry-ai.github.io/cap-evolve/assets/dashboard.png">
   <link rel="preconnect" href="https://rsms.me/">
   <link rel="stylesheet" href="https://rsms.me/inter/inter.css">
   <link rel="stylesheet" href="style.css?v=20260720-1">

--- a/site/getting-started.html
+++ b/site/getting-started.html
@@ -5,6 +5,17 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Getting started — cap-evolve</title>
   <meta name="description" content="Your first successful cap-evolve run, in two minutes, with no API key. Clone, install the core, run the toy_calc example, open the dashboard.">
+  <link rel="canonical" href="https://skillberry-ai.github.io/cap-evolve/getting-started.html">
+  <meta property="og:type" content="article">
+  <meta property="og:site_name" content="cap-evolve">
+  <meta property="og:title" content="Getting started — cap-evolve">
+  <meta property="og:description" content="Your first successful cap-evolve run, in two minutes, with no API key. Clone, install the core, run the toy_calc example, open the dashboard.">
+  <meta property="og:url" content="https://skillberry-ai.github.io/cap-evolve/getting-started.html">
+  <meta property="og:image" content="https://skillberry-ai.github.io/cap-evolve/assets/dashboard.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Getting started — cap-evolve">
+  <meta name="twitter:description" content="Your first successful cap-evolve run, in two minutes, with no API key. Clone, install the core, run the toy_calc example, open the dashboard.">
+  <meta name="twitter:image" content="https://skillberry-ai.github.io/cap-evolve/assets/dashboard.png">
   <link rel="preconnect" href="https://rsms.me/">
   <link rel="stylesheet" href="https://rsms.me/inter/inter.css">
   <link rel="stylesheet" href="style.css?v=20260720-1">

--- a/site/index.html
+++ b/site/index.html
@@ -5,6 +5,17 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>cap-evolve — Optimize agentic capabilities — with agents</title>
   <meta name="description" content="cap-evolve improves an AI agent's prompts, tools, and skills by learning from failed evaluation traces. Bring your agent and eval; cap-evolve runs the loop and reports one honest number.">
+  <link rel="canonical" href="https://skillberry-ai.github.io/cap-evolve/">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="cap-evolve">
+  <meta property="og:title" content="cap-evolve — Optimize agentic capabilities — with agents">
+  <meta property="og:description" content="cap-evolve improves an AI agent's prompts, tools, and skills by learning from failed evaluation traces. Bring your agent and eval; cap-evolve runs the loop and reports one honest number.">
+  <meta property="og:url" content="https://skillberry-ai.github.io/cap-evolve/">
+  <meta property="og:image" content="https://skillberry-ai.github.io/cap-evolve/assets/dashboard.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="cap-evolve — Optimize agentic capabilities — with agents">
+  <meta name="twitter:description" content="cap-evolve improves an AI agent's prompts, tools, and skills by learning from failed evaluation traces. Bring your agent and eval; cap-evolve runs the loop and reports one honest number.">
+  <meta name="twitter:image" content="https://skillberry-ai.github.io/cap-evolve/assets/dashboard.png">
   <link rel="preconnect" href="https://rsms.me/">
   <link rel="stylesheet" href="https://rsms.me/inter/inter.css">
   <!-- bump the ?v=... string on every style.css edit so browsers ignore their cached copy -->

--- a/site/optimize-your-own.html
+++ b/site/optimize-your-own.html
@@ -5,6 +5,17 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Optimize your own agent — cap-evolve</title>
   <meta name="description" content="Wire one small adapter — three methods — to optimize your own capability against your benchmark. Two ways: let your coding agent build it, or drive the cap-evolve CLI yourself.">
+  <link rel="canonical" href="https://skillberry-ai.github.io/cap-evolve/optimize-your-own.html">
+  <meta property="og:type" content="article">
+  <meta property="og:site_name" content="cap-evolve">
+  <meta property="og:title" content="Optimize your own agent — cap-evolve">
+  <meta property="og:description" content="Wire one small adapter — three methods — to optimize your own capability against your benchmark. Two ways: let your coding agent build it, or drive the cap-evolve CLI yourself.">
+  <meta property="og:url" content="https://skillberry-ai.github.io/cap-evolve/optimize-your-own.html">
+  <meta property="og:image" content="https://skillberry-ai.github.io/cap-evolve/assets/dashboard.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Optimize your own agent — cap-evolve">
+  <meta name="twitter:description" content="Wire one small adapter — three methods — to optimize your own capability against your benchmark. Two ways: let your coding agent build it, or drive the cap-evolve CLI yourself.">
+  <meta name="twitter:image" content="https://skillberry-ai.github.io/cap-evolve/assets/dashboard.png">
   <link rel="preconnect" href="https://rsms.me/">
   <link rel="stylesheet" href="https://rsms.me/inter/inter.css">
   <link rel="stylesheet" href="style.css?v=20260720-1">

--- a/site/results.html
+++ b/site/results.html
@@ -5,6 +5,17 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Results — cap-evolve</title>
   <meta name="description" content="Full benchmark results for cap-evolve — toy_calc, τ²-bench airline (fit-metric + held-out), SkillsBench. Every number cross-checked against committed run artifacts.">
+  <link rel="canonical" href="https://skillberry-ai.github.io/cap-evolve/results.html">
+  <meta property="og:type" content="article">
+  <meta property="og:site_name" content="cap-evolve">
+  <meta property="og:title" content="Results — cap-evolve">
+  <meta property="og:description" content="Full benchmark results for cap-evolve — toy_calc, τ²-bench airline (fit-metric + held-out), SkillsBench. Every number cross-checked against committed run artifacts.">
+  <meta property="og:url" content="https://skillberry-ai.github.io/cap-evolve/results.html">
+  <meta property="og:image" content="https://skillberry-ai.github.io/cap-evolve/assets/dashboard.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Results — cap-evolve">
+  <meta name="twitter:description" content="Full benchmark results for cap-evolve — toy_calc, τ²-bench airline (fit-metric + held-out), SkillsBench. Every number cross-checked against committed run artifacts.">
+  <meta name="twitter:image" content="https://skillberry-ai.github.io/cap-evolve/assets/dashboard.png">
   <link rel="preconnect" href="https://rsms.me/">
   <link rel="stylesheet" href="https://rsms.me/inter/inter.css">
   <link rel="stylesheet" href="style.css?v=20260720-1">

--- a/site/robots.txt
+++ b/site/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://skillberry-ai.github.io/cap-evolve/sitemap.xml

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://skillberry-ai.github.io/cap-evolve/</loc>
+    <lastmod>2026-07-21</lastmod>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://skillberry-ai.github.io/cap-evolve/getting-started.html</loc>
+    <lastmod>2026-07-21</lastmod>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://skillberry-ai.github.io/cap-evolve/optimize-your-own.html</loc>
+    <lastmod>2026-07-21</lastmod>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://skillberry-ai.github.io/cap-evolve/results.html</loc>
+    <lastmod>2026-07-21</lastmod>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://skillberry-ai.github.io/cap-evolve/architecture.html</loc>
+    <lastmod>2026-07-21</lastmod>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://skillberry-ai.github.io/cap-evolve/adapter-templates.html</loc>
+    <lastmod>2026-07-21</lastmod>
+    <priority>0.7</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
Closes #63.

## Summary
Improves Google and social discoverability of the GitHub Pages docs site. Static files only — deployed verbatim by the existing `pages.yml` workflow (no build step changed).

- **`site/sitemap.xml`** — lists all 6 pages with priorities; ready to submit to Google Search Console.
- **`site/robots.txt`** — allows all crawlers and points to the sitemap.
- **Per-page meta** on all 6 HTML pages — `rel=canonical` (consolidates duplicate URLs) plus Open Graph and Twitter Card tags (`summary_large_image`, using `assets/dashboard.png`) so links shared on X/LinkedIn/Slack render rich cards.

## Companion change (already applied, repo setting)
Added 15 GitHub **topics** (llm, ai-agents, agent-optimization, prompt-optimization, mcp, model-context-protocol, agent-skills, evals, gepa, dspy, …) to improve GitHub search + topic-page discovery.

## Follow-ups (not code — for the maintainer)
- Register the site in Google Search Console and submit `sitemap.xml`.
- Submit to relevant Awesome lists (awesome-ai-agents, awesome-mcp, awesome-llm) for backlinks.

## Testing
- `sitemap.xml` validated as well-formed XML.
- Verified each page carries 11 new SEO tags (1 canonical + 6 OG + 4 Twitter).

Signed-off-by: Eran Raichstein <eranra@il.ibm.com>