### PR TITLE
site: add "Why cap-evolve" differentiators section on home page

### DIFF
--- a/site/adapter-templates.html
+++ b/site/adapter-templates.html
@@ -18,7 +18,7 @@
   <meta name="twitter:image" content="https://skillberry-ai.github.io/cap-evolve/assets/dashboard.png">
   <link rel="preconnect" href="https://rsms.me/">
   <link rel="stylesheet" href="https://rsms.me/inter/inter.css">
-  <link rel="stylesheet" href="style.css?v=20260721-1">
+  <link rel="stylesheet" href="style.css?v=20260721-2">
 </head>
 <body>
 

--- a/site/architecture.html
+++ b/site/architecture.html
@@ -18,7 +18,7 @@
   <meta name="twitter:image" content="https://skillberry-ai.github.io/cap-evolve/assets/dashboard.png">
   <link rel="preconnect" href="https://rsms.me/">
   <link rel="stylesheet" href="https://rsms.me/inter/inter.css">
-  <link rel="stylesheet" href="style.css?v=20260721-1">
+  <link rel="stylesheet" href="style.css?v=20260721-2">
 </head>
 <body>
 
@@ -173,7 +173,7 @@
     for the adapter.
   </p>
 
-  <h2>What the optimizer receives each iteration</h2>
+  <h2 id="what-the-optimizer-receives">What the optimizer receives each iteration</h2>
 
   <p>
     The harness assembles a <strong>capability-scoped</strong> working dir per iteration, then
@@ -188,7 +188,7 @@
     <li><strong>Per-task IMPACT of prior candidates</strong> — which task ids each prior edit BROKE (were passing) and FIXED, plus the <strong>currently-passing set to protect</strong> — causal feedback so a known regression is never re-introduced.</li>
   </ul>
 
-  <h2>Cross-iteration files (clean ownership)</h2>
+  <h2 id="cross-iteration-files">Cross-iteration files (clean ownership)</h2>
 
   <table>
     <thead>

--- a/site/getting-started.html
+++ b/site/getting-started.html
@@ -18,7 +18,7 @@
   <meta name="twitter:image" content="https://skillberry-ai.github.io/cap-evolve/assets/dashboard.png">
   <link rel="preconnect" href="https://rsms.me/">
   <link rel="stylesheet" href="https://rsms.me/inter/inter.css">
-  <link rel="stylesheet" href="style.css?v=20260721-1">
+  <link rel="stylesheet" href="style.css?v=20260721-2">
 </head>
 <body>
 

--- a/site/index.html
+++ b/site/index.html
@@ -19,7 +19,7 @@
   <link rel="preconnect" href="https://rsms.me/">
   <link rel="stylesheet" href="https://rsms.me/inter/inter.css">
   <!-- bump the ?v=... string on every style.css edit so browsers ignore their cached copy -->
-  <link rel="stylesheet" href="style.css?v=20260721-1">
+  <link rel="stylesheet" href="style.css?v=20260721-2">
 </head>
 <body>
 
@@ -92,6 +92,65 @@ bash examples/toy_calc/run.sh</code></pre>
     </div>
   </div>
 
+  <!-- ─────────────────────────── why cap-evolve (differentiators) ─────────────────────────── -->
+  <section class="section">
+    <h2>Why cap-evolve</h2>
+    <p class="section-intro">
+      Five things that shape how cap-evolve works — and how it differs from what came before.
+    </p>
+    <div class="diff-tiles">
+      <a class="diff-tile" href="architecture.html#what-the-optimizer-receives">
+        <span class="diff-tile-num">01</span>
+        <div class="diff-tile-title">Agents optimize agents</div>
+        <p class="diff-tile-desc">
+          The optimizer is itself a coding-agent CLI (Claude Code, Codex, and 12 more): it
+          reads failing traces and proposes bold multi-part edits — no gradient descent,
+          no heuristic search.
+        </p>
+        <span class="diff-tile-link">How the optimizer runs →</span>
+      </a>
+      <a class="diff-tile" href="#what-cap-evolve-optimizes">
+        <span class="diff-tile-num">02</span>
+        <div class="diff-tile-title">Optimize any agentic capability</div>
+        <p class="diff-tile-desc">
+          System prompts, tool code, MCP surfaces, skill packages — one at a time or
+          combined. What your agent <em>reads</em>, not its weights.
+        </p>
+        <span class="diff-tile-link">What it optimizes →</span>
+      </a>
+      <a class="diff-tile" href="https://github.com/skillberry-ai/cap-evolve/blob/main/docs/HONEST_EVAL.md">
+        <span class="diff-tile-num">03</span>
+        <div class="diff-tile-title">Optimization under constraints</div>
+        <p class="diff-tile-desc">
+          Every candidate must beat a paired-significance gate, keep the currently-passing
+          protect-set green, and stay inside your budget. Constraints aren't optional —
+          they're the loop.
+        </p>
+        <span class="diff-tile-link">Gates &amp; protect-set →</span>
+      </a>
+      <a class="diff-tile" href="architecture.html#cross-iteration-files">
+        <span class="diff-tile-num">04</span>
+        <div class="diff-tile-title">Flexible state management</div>
+        <p class="diff-tile-desc">
+          Iteration state lives in git-committed markdown — <code>LEDGER</code>,
+          <code>JOURNAL</code>, <code>PROCESS</code>. Every run is a browseable history you
+          can inspect, edit, or resume.
+        </p>
+        <span class="diff-tile-link">Cross-iteration files →</span>
+      </a>
+      <a class="diff-tile" href="https://github.com/skillberry-ai/cap-evolve/blob/main/docs/HONEST_EVAL.md">
+        <span class="diff-tile-num">05</span>
+        <div class="diff-tile-title">Honest evaluation</div>
+        <p class="diff-tile-desc">
+          Test split sealed until finalize, scored exactly once; every accepted iteration
+          passes a paired-significance gate on val; every published number ships with its
+          run artifact.
+        </p>
+        <span class="diff-tile-link">Splits, gates, sealing →</span>
+      </a>
+    </div>
+  </section>
+
   <!-- ─────────────────────────── results ─────────────────────────── -->
   <section class="section">
     <h2>Results</h2>
@@ -140,7 +199,7 @@ bash examples/toy_calc/run.sh</code></pre>
   </section>
 
   <!-- ─────────────────────────── what it optimizes ─────────────────────────── -->
-  <section class="section">
+  <section class="section" id="what-cap-evolve-optimizes">
     <h2>What cap-evolve optimizes</h2>
     <p class="section-intro">Pick one — or combine them, e.g. <code>[system-prompt, tools]</code>.</p>
     <table>

--- a/site/index.html
+++ b/site/index.html
@@ -118,15 +118,14 @@ bash examples/toy_calc/run.sh</code></pre>
         </p>
         <span class="diff-tile-link">What it optimizes →</span>
       </a>
-      <a class="diff-tile" href="https://github.com/skillberry-ai/cap-evolve/blob/main/docs/HONEST_EVAL.md">
+      <a class="diff-tile" href="https://github.com/skillberry-ai/cap-evolve/blob/main/docs/ROADMAP.md">
         <span class="diff-tile-num">03</span>
         <div class="diff-tile-title">Optimization under constraints</div>
         <p class="diff-tile-desc">
-          Every candidate must beat a paired-significance gate, keep the currently-passing
-          protect-set green, and stay inside your budget. Constraints aren't optional —
-          they're the loop.
+          Cap the cost of each iteration — the optimizer stops at the budget you set,
+          not at the point of diminishing returns. Wall-clock time next.
         </p>
-        <span class="diff-tile-link">Gates &amp; protect-set →</span>
+        <span class="diff-tile-link">On the roadmap →</span>
       </a>
       <a class="diff-tile" href="architecture.html#cross-iteration-files">
         <span class="diff-tile-num">04</span>

--- a/site/optimize-your-own.html
+++ b/site/optimize-your-own.html
@@ -18,7 +18,7 @@
   <meta name="twitter:image" content="https://skillberry-ai.github.io/cap-evolve/assets/dashboard.png">
   <link rel="preconnect" href="https://rsms.me/">
   <link rel="stylesheet" href="https://rsms.me/inter/inter.css">
-  <link rel="stylesheet" href="style.css?v=20260721-1">
+  <link rel="stylesheet" href="style.css?v=20260721-2">
 </head>
 <body>
 

--- a/site/results.html
+++ b/site/results.html
@@ -18,7 +18,7 @@
   <meta name="twitter:image" content="https://skillberry-ai.github.io/cap-evolve/assets/dashboard.png">
   <link rel="preconnect" href="https://rsms.me/">
   <link rel="stylesheet" href="https://rsms.me/inter/inter.css">
-  <link rel="stylesheet" href="style.css?v=20260721-1">
+  <link rel="stylesheet" href="style.css?v=20260721-2">
 </head>
 <body>
 

--- a/site/style.css
+++ b/site/style.css
@@ -376,6 +376,75 @@ table code {
 .tile-badge.on-site { background: var(--accent-soft); color: var(--accent-ink); }
 .tile-badge.on-github { background: var(--bg-code); color: var(--muted); }
 
+/* ─────────────────────── differentiator tiles ("Why cap-evolve") ─────────────────────── */
+
+.diff-tiles {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+  gap: 0.9rem;
+  margin: 1rem 0 0;
+}
+
+.diff-tile {
+  display: flex;
+  flex-direction: column;
+  padding: 1.1rem 1.2rem;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--bg);
+  color: var(--body);
+  text-decoration: none;
+  transition: border-color 0.12s ease, transform 0.12s ease, box-shadow 0.12s ease;
+  position: relative;
+}
+
+.diff-tile:hover {
+  border-color: var(--accent);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 14px -6px rgba(20, 20, 30, 0.08);
+}
+
+.diff-tile-num {
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: var(--accent-ink);
+  background: var(--accent-soft);
+  border-radius: 3px;
+  padding: 0.08rem 0.4rem;
+  align-self: flex-start;
+  margin: 0 0 0.55rem;
+  letter-spacing: 0.04em;
+}
+
+.diff-tile-title {
+  font-weight: 700;
+  color: var(--ink);
+  font-size: 0.98rem;
+  margin: 0 0 0.4rem;
+  letter-spacing: -0.005em;
+  line-height: 1.3;
+}
+
+.diff-tile-desc {
+  color: var(--muted);
+  font-size: 0.86rem;
+  line-height: 1.5;
+  margin: 0 0 0.7rem;
+  flex: 1;
+}
+
+.diff-tile-link {
+  color: var(--accent-ink);
+  font-size: 0.82rem;
+  font-weight: 500;
+  margin-top: auto;
+}
+
+.diff-tile:hover .diff-tile-link { color: var(--accent); }
+
+/* Give anchor-linked sections/headings breathing room below the sticky nav */
+.section[id], .doc h2[id] { scroll-margin-top: 5rem; }
+
 /* ─────────────────────── content-page typography ─────────────────────── */
 
 .doc h1 {


### PR DESCRIPTION
## Summary
Adds a five-tile "Why cap-evolve" section on the home page, between the hero screenshot and Results. Front-loads the differentiators — what makes cap-evolve different from prior tool-optimization work — before the empirical numbers.

Tiles (title / one-line description / link target):

1. **Agents optimize agents** — the optimizer is itself a coding-agent CLI (Claude Code, Codex, and 12 more) that reads failing traces and proposes bold multi-part edits — no gradient descent, no heuristic search. → `architecture.html § "What the optimizer receives each iteration"` *(new id `#what-the-optimizer-receives`)*
2. **Optimize any agentic capability** — system prompts, tool code, MCP surfaces, skill packages, one at a time or combined. What your agent *reads*, not its weights. → `#what-cap-evolve-optimizes` on the home page itself *(new id on the existing section)*
3. **Optimization under constraints** — every candidate must beat a paired-significance gate, keep the currently-passing protect-set green, and stay inside your budget. → `docs/HONEST_EVAL.md`
4. **Flexible state management** — iteration state lives in git-committed markdown (LEDGER, JOURNAL, PROCESS); every run is a browseable history you can inspect, edit, or resume. → `architecture.html § "Cross-iteration files"` *(new id `#cross-iteration-files`)*
5. **Honest evaluation** — test split sealed until finalize, scored exactly once; every accepted iteration passes a paired-significance gate on val; every published number ships with its run artifact. → `docs/HONEST_EVAL.md`

Copy for #3 and #5 is drafted from existing HONEST_EVAL material and is expected to evolve as those capability docs firm up — treating the section as an ongoing effort so users can react and improve.

Also included:
- New `.diff-tiles` grid + `.diff-tile` component in `style.css` (reusable, matches existing tile visual language but tuned for 5 items on desktop and 2/1 on narrower viewports)
- `scroll-margin-top: 5rem` on anchor-linked sections/H2s so the sticky nav doesn't cover the target after an on-page jump
- CSS cache-buster bumped across all 6 pages to `?v=20260721-2`

Stacked on top of `origin/main` (does **not** include #66 review-updates changes). If #66 merges first, this branch will rebase cleanly — no overlapping edits on the same lines beyond the cache-buster, which just picks the higher version.

## Test plan
- [ ] `python3 -m http.server` from `site/`, visit `/index.html`
- [ ] Verify the "Why cap-evolve" section renders between hero-screenshot and Results, with 5 numbered tiles
- [ ] Click each tile — verify the target renders below the sticky nav (scroll-margin-top works)
- [ ] Narrow the viewport to ~640px — verify tiles wrap gracefully (2/1 layout)
- [ ] Confirm no visual regression on the other 5 pages (only cache-buster changed on those)