### PR TITLE
site(#38): primary vs shown-only metrics on the honest-eval tile

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -142,8 +142,9 @@ bash examples/toy_calc/run.sh</code></pre>
         <div class="diff-tile-title">Honest evaluation</div>
         <p class="diff-tile-desc">
           Test split sealed until finalize, scored exactly once; every accepted iteration
-          passes a paired-significance gate on val; every published number ships with its
-          run artifact.
+          passes a paired-significance gate on val — on the primary metric only, with any
+          shown-only secondaries (cost, latency, sub-checks) displayed but never gating;
+          every published number ships with its run artifact.
         </p>
         <span class="diff-tile-link">Splits, gates, sealing →</span>
       </a>


### PR DESCRIPTION
Documents the **primary vs shown-only metrics** feature (#38, PR #49) on the GitHub Pages site.

`site/` lives only on `main` (added after PR #49's branch point), so the site copy ships separately from #49 rather than bloating that PR or breaking its clean merge.

**Change:** one clause on the home page's "Honest evaluation" tile (`site/index.html`) — the paired-significance gate runs on the **primary metric only**, and shown-only secondaries (cost, latency, sub-checks) are displayed but never gate. Mirrors the prose docs added in #49 (`docs/ADAPTER_CONTRACT.md`, `docs/HONEST_EVAL.md`, `docs/OPTIMIZE_YOUR_OWN.md`, `RUN.md`).

Relates to #38. Merge after (or alongside) #49.
