### PR TITLE
Add `cap-evolve run --resume` to continue interrupted runs (#42)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to cap-evolve are documented here. The format follows
 
 ## [Unreleased]
 ### Added
+- **`cap-evolve run --resume`** — continue an interrupted run (pod eviction, crash,
+  timeout) from its last completed state instead of starting over. Reopens the run dir
+  (`--run-ts`, else the latest under the base) via `RunDir.create(exist_ok=True)` so it
+  no longer fails with `FileExistsError`; skips the baseline when it already ran; picks
+  the loop up at iteration N+1 from the current best (spend, journal, git history, and
+  the test seal are all preserved); and skips a re-finalize when the test seal is already
+  burned. Explicit budget flags (`--max-iterations`, …) **extend** a resumed run. Works
+  across every algorithm — `hill-climb`/`skillopt` already resumed from rollouts, and
+  **`gepa` now reconstructs its full pool/lineage/frontier** from the run dir (a tiny
+  `gepa_state.json` checkpoint + rollouts) so its Pareto search continues where it stopped.
 - **Six more coding agents as optimizers** — `cursor` (Cursor `cursor-agent`),
   `droid` (Factory Droid), `copilot` (GitHub Copilot CLI), `kimi` (Moonshot Kimi),
   `pi` (earendil-works Pi), and `antigravity` (Google `agy`, a configurable wrapper).

--- a/RUN.md
+++ b/RUN.md
@@ -60,6 +60,10 @@ snapshot or record-as-rejected → repeat until budget is spent. Diagnosis of
 traces is provided by the **`diagnose`** skill, which the algorithm calls to turn
 failures into an actionable learning signal.
 
+> **Interrupted?** Pass `--resume` (below) to continue from the last completed
+> state — the run dir is a durable checkpoint, so baseline and every accepted
+> iteration are reused instead of recomputed.
+
 ## 5. Finalize & report
 Load **`finalize`**: score the best candidate on TEST **exactly once** (the run
 dir seals it), then **`report`** for a human-readable summary and the best

--- a/core/README.md
+++ b/core/README.md
@@ -23,6 +23,8 @@ pip install ./core
 ```bash
 cap-evolve run   --spec .capevolve/project/capevolve.yaml \
             --project .capevolve/project
+cap-evolve run   --spec .capevolve/project/capevolve.yaml \
+            --project .capevolve/project --run-ts full --resume  # continue an interrupted run
 cap-evolve check --spec .capevolve/project/capevolve.yaml   # validate adapter
 cap-evolve report                                        # regenerate dashboard
 ```

--- a/core/cap_evolve/cli.py
+++ b/core/cap_evolve/cli.py
@@ -10,6 +10,7 @@ Subcommands:
     cap-evolve splits  --ids ... [--seed N] [--ratios a,b,c]
     cap-evolve check   [project_dir]
     cap-evolve run     --spec .capevolve/project/capevolve.yaml   (sequences phase skills)
+                       [--resume [--run-ts TS]]  resume an interrupted run in place
 
 ``run`` is intentionally minimal in Phase 0 and grows as phase skills land; it
 already resolves the manifest and validates the spec so the wiring is testable.
@@ -106,6 +107,11 @@ def _cmd_run(argv):
     p.add_argument("--dry-run", action="store_true",
                    help="print a pre-run cost estimate (call counts + $ range) and exit")
     p.add_argument("--run-ts", default=None)
+    p.add_argument("--resume", action="store_true",
+                   help="continue an interrupted run from its last completed state instead "
+                        "of starting fresh: reopens the run dir (--run-ts, else the latest "
+                        "under the base), skips the baseline if done, and picks the loop up "
+                        "at iteration N+1 from the current best. Explicit budget flags extend it.")
     p.add_argument("--reuse-baseline", default=None,
                    help="prior run dir: reuse its baseline (split/baseline/seed/val-rollouts) "
                         "and skip the baseline eval")
@@ -247,6 +253,20 @@ def _cmd_run(argv):
                           "report": chk.to_dict()}))
         return 1
 
+    # Resume: reopen an existing run instead of creating a fresh one. Resolve which run
+    # to reopen — the explicit --run-ts, else the latest run_* under the base — and feed
+    # its ts to baseline so RunDir.create(exist_ok=True) reopens it in place.
+    from .rundir import RunDir as _RunDir
+    resume_ts = args.run_ts
+    if args.resume and not resume_ts:
+        try:
+            latest = _RunDir.latest(proj_abs.parent)
+            resume_ts = latest.root.name[len("run_"):]
+        except FileNotFoundError:
+            print(json.dumps({"step": "resume", "error": (
+                f"--resume: no run_* found under {proj_abs.parent}; pass --run-ts to name one")}))
+            return 1
+
     # 1) baseline (creates the run dir; capture its relative path)
     base_cmd = [py, skill_run("baseline"), "--base", base, "--project", project,
                 "--capability", cap_path, "--seed", str(spec.get("split_seed", 0)),
@@ -261,13 +281,24 @@ def _cmd_run(argv):
     # baseline eval (algorithm starts at iter 1 on the reused baseline).
     if spec.get("reuse_baseline"):
         base_cmd += ["--reuse-baseline", str(spec["reuse_baseline"])]
-    if args.run_ts:
-        base_cmd += ["--run-ts", args.run_ts]
+    if resume_ts:
+        base_cmd += ["--run-ts", resume_ts]
+    if args.resume:
+        base_cmd += ["--resume"]
     proc = run(base_cmd)
     if proc.returncode != 0:
         print(json.dumps({"step": "baseline", "error": proc.stderr[-1500:]}))
         return 1
     run_dir = json.loads(proc.stdout)["run_dir"]
+
+    # Resume: explicit budget flags EXTEND the reopened run (e.g. bump max_iterations to
+    # keep climbing past the original cap). Without an override the frozen budget stands.
+    if args.resume:
+        overrides = {k: getattr(args, k) for k in
+                     ("max_iterations", "max_metric_calls", "max_usd", "max_optimizer_usd", "stall")
+                     if getattr(args, k) is not None}
+        if overrides:
+            _RunDir.open(workdir / run_dir).update_budget(**overrides)
 
     # Record the intake phase's spend + summary into the run, if the intake phase
     # wrote <project>/intake.json. Best-effort: a missing/malformed file is ignored so
@@ -306,6 +337,11 @@ def _cmd_run(argv):
                "--gate-mode", str(spec.get("gate_mode", "auto")),
                "--k-se", str(spec.get("gate_k_se", 1.0)),
                "--store", str(spec.get("store", "git"))]
+    # Resume: every deterministic algorithm accepts --resume (continue from the current
+    # best in the run dir instead of re-reading baseline.json). agent mode already
+    # short-circuited above, so we never reach here for it.
+    if args.resume:
+        alg_cmd += ["--resume"]
     if algorithm_focus is not None:
         alg_cmd += ["--focus", algorithm_focus]
     # Surface the selected capability skills to the optimizer prompt so it knows the
@@ -367,8 +403,17 @@ def _cmd_run(argv):
     # 3) finalize  4) report
     last = proc.stdout
     report_extra = ["--dashboard-mode", dash_mode, "--dashboard-port", str(dash_port)]
-    for step, extra in (("finalize", ["--n-trials", str(spec.get("num_trials", 1))]),
-                        ("report", report_extra)):
+    # Resume seal guard: if a prior finalize already burned the test seal, re-running
+    # finalize would raise TestSealError. Skip it and just regenerate the report so the
+    # honest test number stays scored exactly once.
+    steps = [("finalize", ["--n-trials", str(spec.get("num_trials", 1))]), ("report", report_extra)]
+    if args.resume:
+        try:
+            if _RunDir.open(workdir / run_dir).read_splits().test_used:
+                steps = [("report", report_extra)]
+        except (FileNotFoundError, KeyError):
+            pass
+    for step, extra in steps:
         cmd = [py, skill_run(step), "--run-dir", run_dir]
         if step == "finalize":
             cmd += ["--project", project]

--- a/core/cap_evolve/gepa.py
+++ b/core/cap_evolve/gepa.py
@@ -59,6 +59,7 @@ from .harness import (
     _live,
     _paired_deltas,
     evaluate_candidate,
+    split_result_from_rollouts,
 )
 from .loop import SplitResult, aggregate_scores
 from .rundir import RunDir
@@ -393,6 +394,51 @@ def _build_merge(ancestor_dir: Path, a_dir: Path, b_dir: Path, dst: Path) -> dic
                           and any(v == "a" for v in origin.values())}
 
 
+# ---- resume: persist + reconstruct the search state -----------------------
+
+def _persist_gepa_state(run_dir: RunDir, *, lineage: dict, accepts: int,
+                        merges_done: int, comp_cursor: int, n_steps: int) -> None:
+    """Checkpoint the reconstructable search state after each step.
+
+    Only the lineage + counters are stored — each accepted candidate's val is
+    re-read for free from its persisted rollouts on resume, so the file stays tiny.
+    Atomic write (a torn checkpoint would mislead resume).
+    """
+    from .rundir import _atomic_write
+    _atomic_write(run_dir.root / "gepa_state.json", json.dumps({
+        "lineage": lineage, "accepts": accepts, "merges_done": merges_done,
+        "comp_cursor": comp_cursor, "steps": n_steps}, indent=2))
+
+
+def _reconstruct_gepa(run_dir: RunDir, seed_val: SplitResult):
+    """Rebuild (pool, lineage, accepts, merges_done, comp_cursor, step_offset).
+
+    Seeds the pool from ``seed`` and re-adds every accepted candidate recorded in
+    ``gepa_state.json``, reconstructing each one's val ``SplitResult`` from its
+    persisted rollouts (no re-eval). A candidate whose snapshot is missing (a torn
+    accept) is skipped so the frontier stays consistent. No ``gepa_state.json`` (an
+    older run, or a crash before the first checkpoint) → seed-only pool, i.e. exactly
+    today's fresh behavior.
+    """
+    seed_dir = run_dir.candidate_dir("seed")
+    pool: list[dict] = [_entry("seed", seed_dir, seed_val, parent=None)]
+    lineage: dict[str, str | None] = {"seed": None}
+    state_path = run_dir.root / "gepa_state.json"
+    if not state_path.exists():
+        return pool, lineage, 0, 0, 0, 0
+    st = json.loads(state_path.read_text(encoding="utf-8"))
+    for cid, parent in (st.get("lineage") or {}).items():
+        if cid == "seed":
+            continue
+        cdir = run_dir.candidate_dir(cid)
+        if not cdir.exists():
+            continue
+        pool.append(_entry(cid, cdir, split_result_from_rollouts(run_dir, cid, "val"), parent=parent))
+        lineage[cid] = parent
+    return (pool, lineage, int(st.get("accepts") or 0), int(st.get("merges_done") or 0),
+            int(st.get("comp_cursor") or 0), int(st.get("steps") or 0))
+
+
 # ---- the GEPA loop ---------------------------------------------------------
 
 def gepa_loop(
@@ -413,6 +459,7 @@ def gepa_loop(
     no_regression: bool = False,
     seed: int = 0,
     store=None,
+    resume: bool = False,
 ) -> dict:
     """Run GEPA's sample-efficient reflective Pareto loop.
 
@@ -443,15 +490,21 @@ def gepa_loop(
                       component_selector=component_selector,
                       selection_strategy=selection_strategy)
 
-    seed_dir = run_dir.candidate_dir("seed")
-    pool: list[dict] = [_entry("seed", seed_dir, seed_val, parent=None)]
-    lineage: dict[str, str | None] = {"seed": None}
+    # Fresh vs resume: on resume rebuild the pool/lineage/counters from the run dir so
+    # the Pareto search continues where it stopped; otherwise seed-only (a fresh run).
+    if resume:
+        pool, lineage, accepts, merges_done, comp_cursor, step_offset = _reconstruct_gepa(
+            run_dir, seed_val)
+        run_dir.log_event("gepa_resume", pool=len(pool), accepts=accepts,
+                          merges_done=merges_done, step_offset=step_offset)
+    else:
+        seed_dir = run_dir.candidate_dir("seed")
+        pool = [_entry("seed", seed_dir, seed_val, parent=None)]
+        lineage = {"seed": None}
+        accepts = merges_done = comp_cursor = step_offset = 0
     train_ids = list(run_dir.read_splits().train) or list(run_dir.read_splits().val)
 
     steps: list[dict] = []
-    accepts = 0
-    merges_done = 0
-    comp_cursor = 0  # round-robin pointer over the parent's components
 
     def _budget_left() -> tuple[bool, str]:
         exhausted, why = run_dir.budget_exhausted()
@@ -459,14 +512,23 @@ def gepa_loop(
             return False, why
         if max_metric_calls and run_dir.spent.metric_calls >= max_metric_calls:
             return False, f"max_metric_calls reached ({run_dir.spent.metric_calls}/{max_metric_calls})"
-        if max_iterations and len(steps) >= max_iterations:
-            return False, f"max_iterations reached ({len(steps)}/{max_iterations})"
+        if max_iterations and step_offset + len(steps) >= max_iterations:
+            return False, f"max_iterations reached ({step_offset + len(steps)}/{max_iterations})"
         return True, ""
+
+    def _save() -> None:
+        _persist_gepa_state(run_dir, lineage=lineage, accepts=accepts,
+                            merges_done=merges_done, comp_cursor=comp_cursor,
+                            n_steps=step_offset + len(steps))
 
     while True:
         ok, why = _budget_left()
         if not ok:
             break
+
+        # Global step index across resumes: names candidates/tags/commits so a resumed
+        # run never collides with the ids already on disk (step_offset = prior steps).
+        n = step_offset + len(steps)
 
         # 2. select a parent from the per-instance frontier (frequency-weighted).
         sel_seed = rng.randrange(2 ** 31)
@@ -485,10 +547,10 @@ def gepa_loop(
 
         # 4. eval parent on the minibatch (cheap, cached, traced).
         parent_mb = _eval_minibatch(adapter, parent_dir, mb, run_dir=run_dir,
-                                    cache=cache, tag=f"mb_p_{len(steps):04d}", seed=seed)
+                                    cache=cache, tag=f"mb_p_{n:04d}", seed=seed)
 
         # 5. build the reflective dataset + component focus, then optimize a child.
-        cid = f"gepa_{len(steps) + 1:04d}"
+        cid = f"gepa_{n + 1:04d}"
         workdir = run_dir.root / "work" / cid
         if workdir.exists():
             shutil.rmtree(workdir)
@@ -522,7 +584,7 @@ def gepa_loop(
 
         # 6. eval child on the SAME minibatch; cheap LOCAL gate sum(child)>sum(parent).
         child_mb = _eval_minibatch(adapter, workdir, mb, run_dir=run_dir,
-                                   cache=cache, tag=f"mb_c_{len(steps):04d}", seed=seed)
+                                   cache=cache, tag=f"mb_c_{n:04d}", seed=seed)
         local_pass = _sum_reward(child_mb) > _sum_reward(parent_mb)
         run_dir.log_event("gepa_local_gate", candidate=cid, parent=parent["id"],
                           child_sum=_sum_reward(child_mb), parent_sum=_sum_reward(parent_mb),
@@ -542,9 +604,10 @@ def gepa_loop(
                               f"{parent_mb.reward:.3f})",
                          "local minibatch gate: sum(child) <= sum(parent)", child_mb.reward)
             if store is not None:
-                store.commit(f"iter {len(steps)+1}: reject(local) {cid}", accepted=False)
+                store.commit(f"iter {n+1}: reject(local) {cid}", accepted=False)
             steps.append(step)
             run_dir.record_spend_warnings()
+            _save()
             continue
 
         # 7. local gate PASSED → pay for full val + the honest significance gate.
@@ -569,11 +632,11 @@ def gepa_loop(
             history.add(cid, summary, cand_val.reward)
             accepts += 1
             if store is not None:
-                store.commit(f"iter {len(steps)+1}: ACCEPT {summary}", tag="best", accepted=True)
+                store.commit(f"iter {n+1}: ACCEPT {summary}", tag="best", accepted=True)
         else:
             rejected.add(cid, summary, decision_dict.get("reason", "val gate"), cand_val.reward)
             if store is not None:
-                store.commit(f"iter {len(steps)+1}: reject(val) {summary}", accepted=False)
+                store.commit(f"iter {n+1}: reject(val) {summary}", accepted=False)
         steps.append(step)
         run_dir.record_spend_warnings()
 
@@ -584,14 +647,16 @@ def gepa_loop(
                 mb_size=minibatch_size, rng=rng, n_trials=n_trials,
                 gate_kwargs=gate_kwargs, no_regression=no_regression,
                 store=store, history=history, rejected=rejected, train_ids=train_ids,
-                idx=len(steps), seed=seed,
+                idx=step_offset + len(steps), seed=seed,
             )
             if merge_step is not None:
                 steps.append(merge_step)
                 merges_done += 1
                 if merge_step.get("accepted"):
                     accepts += 1
+        _save()
 
+    _save()
     best = max(pool, key=lambda c: c["val"])
     run_dir.set_best(best["id"])
     _, why2 = run_dir.budget_exhausted()
@@ -601,7 +666,7 @@ def gepa_loop(
         "best_val": best["val"],
         "frontier_size": len(selection.pareto_frontier(pool)),
         "pool_size": len(pool),
-        "iterations": len(steps),
+        "iterations": step_offset + len(steps),
         "accepts": accepts,
         "merges": merges_done,
         "metric_calls": run_dir.spent.metric_calls,

--- a/core/cap_evolve/rundir.py
+++ b/core/cap_evolve/rundir.py
@@ -170,11 +170,23 @@ class RunDir:
 
     # ---- creation / loading -------------------------------------------------
     @classmethod
-    def create(cls, base: Path, *, ts: str | None = None, budget: Budget | None = None) -> "RunDir":
+    def create(cls, base: Path, *, ts: str | None = None, budget: Budget | None = None,
+               exist_ok: bool = False) -> "RunDir":
+        """Create (or, with ``exist_ok``, resume) the run dir under ``base``.
+
+        ``exist_ok=True`` is the ``--resume`` path: if ``run_<ts>`` already has a
+        ``state.json``, reopen it UNCHANGED — preserving ``best_id``/``budget``/``spent``
+        so the loop keeps counting from prior progress instead of resetting. If the dir
+        exists but has no ``state.json`` (a torn/partial create), initialize a fresh
+        state into it. ``exist_ok=False`` (default) keeps the old strict behavior: a
+        colliding ``run_<ts>`` raises ``FileExistsError``.
+        """
         base = Path(base)
         ts = ts or time.strftime("%Y%m%d_%H%M%S")
         root = base / f"run_{ts}"
-        root.mkdir(parents=True, exist_ok=False)
+        if exist_ok and (root / "state.json").exists():
+            return cls.open(root)  # resume: preserve existing state, never reset
+        root.mkdir(parents=True, exist_ok=exist_ok)
         rd = cls(root)
         rd.candidates.mkdir(parents=True, exist_ok=True)
         rd.rollouts.mkdir(parents=True, exist_ok=True)
@@ -253,6 +265,24 @@ class RunDir:
             st["spent"] = sp.to_dict()
             self._write_state(st)
             return sp
+
+    def update_budget(self, **overrides) -> Budget:
+        """Overwrite selected budget fields (locked RMW). Used to EXTEND a resumed run.
+
+        Only keys explicitly passed are changed (e.g. ``max_iterations=30`` to keep
+        climbing past the original cap); everything else — and all ``spent`` — is
+        preserved. Unknown keys are ignored so a stray CLI flag can't corrupt state.
+        """
+        allowed = {"max_iterations", "max_metric_calls", "max_usd", "stall", "max_optimizer_usd"}
+        with _file_lock(self._state_lock):
+            st = self._read_state()
+            b = Budget.from_dict(st.get("budget")).to_dict()
+            for k, v in overrides.items():
+                if k in allowed and v is not None:
+                    b[k] = v
+            st["budget"] = b
+            self._write_state(st)
+            return Budget.from_dict(b)
 
     def budget_exhausted(self) -> tuple[bool, str]:
         b, s = self.budget, self.spent

--- a/core/tests/test_resume.py
+++ b/core/tests/test_resume.py
@@ -1,0 +1,188 @@
+"""Resume tests — offline, deterministic, zero API.
+
+Covers the pieces that make ``cap-evolve run --resume`` correct:
+  * ``RunDir.create(exist_ok=True)`` reopens a run WITHOUT resetting state.json
+    (best_id/budget/spent preserved), and still initializes a torn/empty dir.
+  * ``RunDir.update_budget`` extends only the fields passed (to keep climbing past
+    the original cap on resume), leaving spend untouched.
+  * gepa persists ``gepa_state.json`` and, on ``resume``, reconstructs its
+    pool/lineage/counters from the run dir so the Pareto search continues and new
+    candidate ids never collide with the ones already on disk.
+  * baseline's ``--resume`` fast-path reopens an existing run and skips the eval.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+CORE = REPO / "core"
+EXAMPLE = REPO / "examples" / "toy_calc"
+MOCK_RUN = REPO / "skills" / "optimizers" / "run-optimizer" / "scripts" / "run.py"
+BASELINE_RUN = REPO / "skills" / "phases" / "baseline" / "scripts" / "run.py"
+
+sys.path.insert(0, str(CORE))
+sys.path.insert(0, str(EXAMPLE))
+
+
+@pytest.fixture(autouse=True)
+def _env():
+    old = dict(os.environ)
+    os.environ["CAPEVOLVE_CORE"] = str(CORE)
+    os.environ["CAPEVOLVE_TOY_DATA"] = str(EXAMPLE)
+    os.environ["CAPEVOLVE_MOCK_SCRIPT"] = str(EXAMPLE / "mock_script.json")
+    yield
+    os.environ.clear()
+    os.environ.update(old)
+
+
+def _toy_adapter():
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("toy_calc_adapter", EXAMPLE / "adapter.py")
+    toy = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(toy)
+    return toy.Adapter()
+
+
+def _mock_optimizer():
+    from cap_evolve import harness
+    return harness.optimizer_from_command(
+        ["python3", str(MOCK_RUN), "--name", "mock", "--workdir", "{workdir}", "--prompt", "{prompt}"])
+
+
+# ---- RunDir.create(exist_ok) + update_budget ------------------------------
+
+def test_create_exist_ok_preserves_state(tmp_path):
+    from cap_evolve import Budget, RunDir
+    base = tmp_path / ".capevolve"
+    rd = RunDir.create(base, ts="r1", budget=Budget(max_iterations=5))
+    rd.set_best("cand_0003")
+    rd.update_spent(iterations=3, usd=1.25, accepted=True)
+
+    # Reopen with exist_ok — must NOT reset best/budget/spent.
+    rd2 = RunDir.create(base, ts="r1", budget=Budget(max_iterations=99), exist_ok=True)
+    assert rd2.root == rd.root
+    assert rd2.best_id == "cand_0003"
+    assert rd2.spent.iterations == 3
+    assert rd2.spent.usd == pytest.approx(1.25)
+    assert rd2.budget.max_iterations == 5  # original budget kept, not the new 99
+
+
+def test_create_strict_default_raises_on_collision(tmp_path):
+    from cap_evolve import RunDir
+    base = tmp_path / ".capevolve"
+    RunDir.create(base, ts="r2")
+    with pytest.raises(FileExistsError):
+        RunDir.create(base, ts="r2")  # exist_ok defaults False
+
+
+def test_create_exist_ok_initializes_torn_dir(tmp_path):
+    from cap_evolve import RunDir
+    base = tmp_path / ".capevolve"
+    (base / "run_r3").mkdir(parents=True)  # dir exists but no state.json (torn create)
+    rd = RunDir.create(base, ts="r3", exist_ok=True)
+    assert rd.state_path.exists()
+    assert rd.best_id is None
+
+
+def test_update_budget_extends_only_passed(tmp_path):
+    from cap_evolve import Budget, RunDir
+    base = tmp_path / ".capevolve"
+    rd = RunDir.create(base, ts="r4", budget=Budget(max_iterations=5, max_usd=2.0))
+    rd.update_spent(iterations=2)
+    rd.update_budget(max_iterations=20, bogus_key=123)  # unknown key ignored
+    assert rd.budget.max_iterations == 20
+    assert rd.budget.max_usd == pytest.approx(2.0)  # untouched
+    assert rd.spent.iterations == 2                 # spend untouched
+
+
+# ---- gepa resume: persist + reconstruct -----------------------------------
+
+def _gepa_run(tmp_path, ts, *, resume=False, **kw):
+    from cap_evolve import Budget, RunDir, gepa, harness
+    adapter = _toy_adapter()
+    run_dir = RunDir.create(tmp_path / ".capevolve", ts=ts,
+                            budget=Budget(max_iterations=kw.pop("max_iterations", 6)),
+                            exist_ok=resume)
+    if not resume:
+        seed = tmp_path / f"seed_{ts}"
+        shutil.copytree(EXAMPLE / "capability", seed)
+        harness.ensure_splits(adapter, run_dir, seed=0)
+        base = harness.baseline(adapter, seed, run_dir=run_dir)
+    else:
+        base = harness.split_result_from_rollouts(run_dir, "seed", "val")
+    res = gepa.gepa_loop(adapter, run_dir=run_dir, optimizer=_mock_optimizer(),
+                         seed_val=base, minibatch_size=3, max_merges=0, seed=0,
+                         gate_kwargs={"mode": "significant", "k_se": 1.0},
+                         resume=resume, **kw)
+    return run_dir, res
+
+
+def test_gepa_persists_state_and_reconstructs(tmp_path):
+    from cap_evolve import gepa
+    run_dir, res = _gepa_run(tmp_path, "gr1", max_metric_calls=400, max_iterations=6)
+    assert res["accepts"] >= 1 and res["best_val"] == 1.0
+
+    # gepa_state.json checkpoint was written and matches the run.
+    state = json.loads((run_dir.root / "gepa_state.json").read_text())
+    assert state["steps"] == res["iterations"]
+    accepted_ids = [c for c in state["lineage"] if c != "seed"]
+    assert accepted_ids  # at least one accepted candidate recorded
+
+    # Reconstruction rebuilds the pool (seed + accepted) with faithful lineage.
+    pool, lineage, accepts, merges, cursor, offset = gepa._reconstruct_gepa(
+        run_dir, gepa.split_result_from_rollouts(run_dir, "seed", "val"))
+    assert {c["id"] for c in pool} >= {"seed", *accepted_ids}
+    assert lineage["seed"] is None
+    assert offset == res["iterations"] and accepts == res["accepts"]
+
+
+def test_gepa_resume_continues_without_collision(tmp_path):
+    run_dir, res1 = _gepa_run(tmp_path, "gr2", max_metric_calls=200, max_iterations=3)
+    pool1 = res1["pool_size"]
+    ids_before = {p.name for p in run_dir.candidates.iterdir()}
+
+    # Resume the SAME run dir: frontier retained, best kept, ids continue past prior.
+    run_dir2, res2 = _gepa_run(tmp_path, "gr2", resume=True, max_metric_calls=400, max_iterations=6)
+    assert run_dir2.root == run_dir.root
+    assert res2["pool_size"] >= pool1           # accepted candidates were reloaded
+    assert res2["best_val"] == 1.0
+    assert res2["iterations"] >= res1["iterations"]  # total steps span both sessions
+    new_ids = {p.name for p in run_dir2.candidates.iterdir()} - ids_before
+    # any freshly-created gepa candidate must not reuse an id that already existed
+    assert not (new_ids & ids_before)
+    assert run_dir2.read_splits().test_used is False
+
+
+# ---- baseline --resume fast-path ------------------------------------------
+
+def test_baseline_resume_skips_eval(tmp_path):
+    # Build a real project layout (adapters/adapter.py + seed capability), as run.sh does.
+    project = tmp_path / ".capevolve" / "project"
+    (project / "adapters").mkdir(parents=True)
+    shutil.copy(EXAMPLE / "adapter.py", project / "adapters" / "adapter.py")
+    seed = tmp_path / "seed_capability"
+    shutil.copytree(EXAMPLE / "capability", seed)
+    base = tmp_path / ".capevolve"
+    common = ["--base", str(base), "--project", str(project),
+              "--capability", str(seed), "--run-ts", "b1"]
+    env = {**os.environ, "PYTHONPATH": str(CORE)}
+    r1 = subprocess.run([sys.executable, str(BASELINE_RUN), *common],
+                        capture_output=True, text=True, env=env)
+    assert r1.returncode == 0, r1.stderr
+    first = json.loads(r1.stdout)
+    assert not first.get("resumed")
+
+    # Second invocation with --resume must reopen and skip the eval.
+    r2 = subprocess.run([sys.executable, str(BASELINE_RUN), *common, "--resume"],
+                        capture_output=True, text=True, env=env)
+    assert r2.returncode == 0, r2.stderr
+    second = json.loads(r2.stdout)
+    assert second["resumed"] is True
+    assert second["run_dir"] == first["run_dir"]
+    assert second["baseline_val"] == first["baseline_val"]

--- a/docs/AGENT_ORCHESTRATION.md
+++ b/docs/AGENT_ORCHESTRATION.md
@@ -72,6 +72,14 @@ cap-evolve run --spec .capevolve/project/capevolve.yaml --project .capevolve/pro
 # -> prints {"mode":"agent","run_dir":".capevolve/run_myrun","algorithm":"agent-optimize", ...}
 ```
 
+If a run is interrupted, add `--resume` (with the same `--run-ts`) to reopen the run dir
+and hand the agent back the existing `run_dir` + current best instead of re-running the
+baseline:
+
+```bash
+cap-evolve run --spec .capevolve/project/capevolve.yaml --project .capevolve/project --run-ts myrun --resume
+```
+
 The agent then drives the loop against `run_dir`, using the phase scripts directly:
 
 ```bash

--- a/docs/OPTIMIZE_YOUR_OWN.md
+++ b/docs/OPTIMIZE_YOUR_OWN.md
@@ -120,6 +120,14 @@ cap-evolve run   --spec .capevolve/project/capevolve.yaml --project .capevolve/p
 open .capevolve/run_*/dashboard.html
 ```
 
+Interrupted (crash, timeout, pod eviction)? Re-run the same command with `--resume`
+(and `--run-ts <ts>` to name the run, else the latest is reused) to continue from the
+last completed state — baseline and every accepted iteration are reused, not recomputed:
+
+```bash
+cap-evolve run --spec .capevolve/project/capevolve.yaml --project .capevolve/project --run-ts full --resume
+```
+
 Start from the closest example and edit its `adapter.py`:
 
 | You want to optimize… | Copy | `capabilities:` |

--- a/docs/REPRODUCE_tau2.md
+++ b/docs/REPRODUCE_tau2.md
@@ -109,6 +109,11 @@ cap-evolve estimate --spec .../capevolve.yaml   # pre-run cost preview (spends n
 cap-evolve run --spec .../capevolve.yaml --project ... --run-ts full --dashboard auto
 ```
 
+> **Long run interrupted?** This run takes hours and interruptions (pod eviction, disk
+> pressure, credential expiry) happen. Re-run the exact command with `--resume` appended —
+> it reopens `run_full`, skips the already-scored baseline, and continues from the last
+> accepted iteration, so you don't repay the baseline eval or the accepted-iteration cost.
+
 - **Cost preview** — `cap-evolve estimate` prints the call counts (`val × trials ×
   iterations` runner calls, `iterations` optimizer calls) and a calibrated `$` range.
 - **Baseline** — score the seed policy + tools on val.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -50,6 +50,16 @@ knob (`TAU2_MAX_CONCURRENCY`).
 **`TestSealError` / "test already scored"** — the sealed test split is scored exactly once
 per run, by design. Start a fresh run dir to finalize again. See [`HONEST_EVAL.md`](HONEST_EVAL.md).
 
+**Run interrupted (crash, timeout, pod eviction) — how do I continue it?** Re-run the same
+`cap-evolve run` command with `--resume` (and `--run-ts <ts>` to name the run; without it the
+latest run under the base is reused). It reopens the run dir instead of failing with
+`FileExistsError`, skips the baseline if it already ran, and picks the loop up at iteration
+N+1 from the current best — completed rollouts, accepted candidates, optimizer spend, and the
+git history are all preserved. If the interrupted run had already finalized (test seal burned),
+resume skips finalize and just regenerates the report, so the held-out number is never scored
+twice. To keep climbing past the original budget, pass a larger `--max-iterations` (or other
+budget flag) alongside `--resume` — explicit budget flags extend the resumed run.
+
 **A gain was rejected by the gate** — expected when the val improvement is within noise
 (Δ ≤ k·SE). Lower `k_se`, add trials (`num_trials`) to shrink SE, or accept that the edit
 didn't beat baseline significantly. On a small held-out val the gate will correctly refuse

--- a/site/optimize-your-own.html
+++ b/site/optimize-your-own.html
@@ -157,6 +157,7 @@ you want intake to ask):
 cap-evolve check .capevolve/project                              # hard gate — must print {"ok": true}
 cap-evolve estimate --spec .capevolve/project/capevolve.yaml     # dry-run cost preview (spends nothing)
 cap-evolve run   --spec .capevolve/project/capevolve.yaml --project .capevolve/project
+cap-evolve run   --spec .capevolve/project/capevolve.yaml --project .capevolve/project --run-ts full --resume  # continue an interrupted run
 open .capevolve/run_*/dashboard.html</code></pre>
 
   <p>Start from the closest example and edit its <code>adapter.py</code>:</p>

--- a/skills/algorithms/gepa/SKILL.md
+++ b/skills/algorithms/gepa/SKILL.md
@@ -2,7 +2,7 @@
 name: gepa
 description: Runs the real GEPA optimization loop (arXiv:2507.19457) — sample-efficient reflective Pareto search. Use when rollouts are expensive and the scorer gives informative per-task feedback, and you want the most quality per evaluation. Each iteration samples a parent from a per-instance Pareto frontier, evaluates it on a cheap minibatch of train tasks with full traces, builds a reflective dataset over the failures, asks the optimizer for one targeted component edit, re-checks the child on the same minibatch (a cheap local gate), and only on pass pays for a full-val eval behind the honest significance gate. Adds round-robin component focus and a system-aware merge across complementary lineages. Prefer over hill-climb when feedback is rich and budget is tight; use hill-climb for the first baseline run or feedback-poor binary tasks.
 component: algorithm
-argument-hint: "--run-dir DIR --project DIR --optimizer 'CMD {workdir} {prompt}' [--max-metric-calls N --minibatch-size 4 --component-selector round_robin|all --max-merges 2]"
+argument-hint: "--run-dir DIR --project DIR --optimizer 'CMD {workdir} {prompt}' [--max-metric-calls N --minibatch-size 4 --component-selector round_robin|all --max-merges 2 --resume]"
 allowed-tools: Read, Write, Bash
 provides: [candidate]
 needs: [scores, traces, reflective_dataset, candidate]
@@ -83,6 +83,11 @@ to recombine) rather than producing a degenerate child.
 - `--gate-mode` / `--k-se`: the val acceptance bar (paired significance by default).
 - `--no-regression`: reject a child that breaks any previously-passing val task.
 - `--seed`: seeds the parent-sampling + minibatch RNG (logged for reproducibility).
+- `--resume`: reconstruct the pool/lineage/frontier from the run dir (a
+  `gepa_state.json` checkpoint + each accepted candidate's rollouts) and continue the
+  Pareto search where it stopped, instead of restarting from the seed. Preserved spend
+  keeps the budget honest; the parent-sampling RNG stream restarts (selection is
+  stochastic by design, so the resumed run is not byte-identical).
 
 ## How to run
 

--- a/skills/algorithms/gepa/scripts/run.py
+++ b/skills/algorithms/gepa/scripts/run.py
@@ -51,6 +51,9 @@ def main(argv=None) -> int:
     p.add_argument("--store-commit-cmd", default=None)
     p.add_argument("--no-regression", action="store_true",
                    help="reject candidates that break a previously-passing val task")
+    p.add_argument("--resume", action="store_true",
+                   help="reconstruct the pool/frontier from the run dir and continue the "
+                        "search instead of restarting from the seed")
     args = p.parse_args(argv)
 
     run_dir = RunDir.open(Path(args.run_dir))
@@ -70,6 +73,7 @@ def main(argv=None) -> int:
         gate_kwargs=({"k_se": args.k_se} if args.gate_mode == "auto"
                      else {"mode": args.gate_mode, "k_se": args.k_se}),
         no_regression=args.no_regression, seed=args.seed, store=store,
+        resume=args.resume,
     )
     print(json.dumps(result, indent=2))
     return 0

--- a/skills/phases/baseline/scripts/run.py
+++ b/skills/phases/baseline/scripts/run.py
@@ -39,13 +39,30 @@ def main(argv=None) -> int:
     p.add_argument("--max-optimizer-usd", type=float, default=0.0,
                    help="0 = off; separate cap on optimizer spend alone")
     p.add_argument("--run-ts", default=None, help="fixed timestamp for reproducible run dirs")
+    p.add_argument("--resume", action="store_true",
+                   help="reopen an existing run dir instead of failing; skip the baseline "
+                        "eval when it already ran (baseline.json present)")
     args = p.parse_args(argv)
 
     Path(args.base).mkdir(parents=True, exist_ok=True)
     budget = Budget(max_iterations=args.max_iterations, stall=args.stall,
                     max_metric_calls=args.max_metric_calls, max_usd=args.max_usd,
                     max_optimizer_usd=args.max_optimizer_usd)
-    run_dir = RunDir.create(Path(args.base), ts=args.run_ts, budget=budget)
+    run_dir = RunDir.create(Path(args.base), ts=args.run_ts, budget=budget, exist_ok=args.resume)
+
+    # Resume fast-path: baseline already ran → the split is frozen, the seed is scored,
+    # best_id is set. Re-print the recorded baseline and skip the (expensive) eval so the
+    # algorithm resumes straight from the current best. state.json is left untouched.
+    if args.resume and (run_dir.root / "baseline.json").exists():
+        splits = run_dir.read_splits()
+        recorded = json.loads((run_dir.root / "baseline.json").read_text(encoding="utf-8"))
+        print(json.dumps({
+            "run_dir": str(run_dir.root),
+            "splits": {"train": len(splits.train), "val": len(splits.val), "test": len(splits.test)},
+            "baseline_val": recorded.get("val", {}),
+            "resumed": True,
+        }, indent=2))
+        return 0
 
     adapter = load_adapter(Path(args.project))
 


### PR DESCRIPTION
## What & why

Closes #42. When a run is interrupted (pod eviction, crash, timeout) it could not be resumed — re-running with the same `--run-ts` failed at `RunDir.create()` with `FileExistsError`, forcing a fresh run that throws away the completed baseline, accepted iterations, optimizer $ spend, and the journal/ledger context.

The run dir is already a durable checkpoint (`state.json` carries `best_id`/`budget`/`spent`; rollouts, candidate snapshots and git history persist), and `hill-climb`/`skillopt` already had a `--resume` that reads the current best from rollouts. This PR wires resume through the top-level `cap-evolve run` orchestrator and closes the remaining gaps.

## Changes

- **`RunDir.create(exist_ok=True)`** — reopen an existing run **unchanged** (preserve `best_id`/`budget`/`spent`) instead of raising; initialize fresh state only for a torn/empty dir. Correctness rests on *never resetting `state.json` on reopen* — the loop then continues from `spent.iterations` automatically. Adds `RunDir.update_budget` to **extend** a resumed run.
- **`baseline --resume`** — reopen the run dir and skip the eval when `baseline.json` already exists (`ensure_splits` is already idempotent).
- **`cap-evolve run --resume`** — resolve the run (`--run-ts`, else `RunDir.latest`), thread `--resume` to every algorithm, let explicit budget flags extend the run, and **skip a re-finalize when the test seal is already burned** so the held-out number is still scored exactly once.
- **`gepa` — full frontier reconstruction.** Persist a tiny `gepa_state.json` checkpoint each step and, on `--resume`, rebuild `pool`/`lineage`/counters from it + each accepted candidate's rollouts so the Pareto search continues where it stopped (new candidate ids continue past those on disk). Missing checkpoint ⇒ seed-only pool (today's behavior; backward compatible).

Deliberately left as-is (heuristic, not correctness): hill-climb's cyclic focus cursor and skillopt's LR-schedule position reset on resume; a candidate that crashed mid-eval is re-proposed from `best` rather than resumed mid-rollout.

## Verification

- **Full core suite green (150 passed)**, incl. new `core/tests/test_resume.py`: `RunDir` exist_ok/update_budget, gepa persist+reconstruct+resume-without-collision, and the baseline skip fast-path.
- **toy_calc CLI e2e** — interrupted after baseline (`iters 0`, `best seed`) → `cap-evolve run --resume` → ran to completion (`iters 3`, `best cand_0001`, test sealed once). Verified both the explicit `--run-ts` and the latest-fallback paths.
- **tau2-bench via a litellm proxy** — real baseline scored on task 37, then `--resume` correctly **skipped baseline** (`metric_calls` only advanced for the candidate + finalize evals), ran a **real optimizer iteration**, honestly rejected the candidate on val, and **finalized once** (`test_used=True`).

## Docs

CHANGELOG, `RUN.md`, `docs/{OPTIMIZE_YOUR_OWN,AGENT_ORCHESTRATION,REPRODUCE_tau2,TROUBLESHOOTING}.md`, `skills/algorithms/gepa/SKILL.md`, `core/README.md`, and the optimize-your-own site page (GitHub Pages deploys automatically on push to `main` touching `site/**`).