### PR TITLE
feat: benchmark CI run-history page on GitHub Pages

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -39,6 +39,11 @@ jobs:
   bench:
     name: ${{ matrix.bench }}
     runs-on: [self-hosted, ibm-vpc]
+    # Repo default token is read-only; the "Comment results on the PR" step needs write.
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
     # Fork guard: never run PR code from a fork on the self-hosted runner.
     if: >-
       github.event_name == 'workflow_dispatch' ||

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -77,6 +77,35 @@ jobs:
         if: steps.gate.outputs.run == 'true'
         run: bash ci/benchmarks/lib/run_suite.sh "${{ matrix.bench }}" "$GITHUB_WORKSPACE/ci/benchmarks/.work/suite_${{ matrix.bench }}"
 
+      - name: Write run metadata
+        if: steps.gate.outputs.run == 'true' && always()
+        run: |
+          out="$GITHUB_WORKSPACE/ci/benchmarks/.work/suite_${{ matrix.bench }}"
+          mkdir -p "$out"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            source="PR #${{ github.event.pull_request.number }}"; pr="${{ github.event.pull_request.number }}"
+          else
+            source="manual (${{ github.ref_name }})"; pr="null"
+          fi
+          cat > "$out/runmeta.json" <<JSON
+          {
+            "run_id": ${{ github.run_id }},
+            "run_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+            "bench": "${{ matrix.bench }}",
+            "event": "${{ github.event_name }}",
+            "source": "$source",
+            "pr": $pr,
+            "branch": "${{ github.head_ref || github.ref_name }}",
+            "sha": "${{ github.event.pull_request.head.sha || github.sha }}",
+            "date": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+            "iterations": ${ITERATIONS:-1},
+            "agent_model": "aws/gpt-oss-120b",
+            "optimizer_model": "claude-opus-4-8",
+            "conclusion": "${{ job.status }}"
+          }
+          JSON
+          cat "$out/runmeta.json"
+
       - name: Upload artifacts (metrics + optimized capabilities)
         if: steps.gate.outputs.run == 'true' && always()
         uses: actions/upload-artifact@v4
@@ -104,3 +133,60 @@ jobs:
             } else {
               await github.rest.issues.createComment({owner, repo, issue_number, body});
             }
+
+  # Collect each run's per-(run x bench) record onto the benchmark-history branch (single
+  # writer → no push races) and regenerate benchmarks.json for the Pages history page.
+  # Runs on a GitHub-hosted runner (JSON + git only; no VPC access needed).
+  aggregate:
+    name: aggregate history
+    needs: [bench]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4              # for ci/benchmarks/lib/record.py
+
+      - name: Download all benchmark artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: _artifacts
+          pattern: benchmarks-*
+
+      - name: Build records
+        run: |
+          mkdir -p _new_records
+          for d in _artifacts/benchmarks-*; do
+            [ -d "$d" ] || continue
+            bench="$(basename "$d" | sed 's/^benchmarks-//')"
+            suite="$d/suite_$bench"
+            rm="$suite/runmeta.json"; metrics="$suite/metrics.jsonl"
+            [ -f "$rm" ] || { echo "no runmeta for $bench, skipping"; continue; }
+            rid="$(python3 -c "import json;print(json.load(open('$rm'))['run_id'])")"
+            python3 ci/benchmarks/lib/record.py build "$metrics" --runmeta "$rm" \
+              > "_new_records/${rid}__${bench}.json"
+            echo "built _new_records/${rid}__${bench}.json"
+          done
+          ls -la _new_records || true
+
+      - name: Push to benchmark-history (single writer, with rebase-retry)
+        run: |
+          [ -n "$(ls -A _new_records 2>/dev/null)" ] || { echo "no records to push"; exit 0; }
+          git config --global user.name "skillberry-bot"
+          git config --global user.email "actions@github.com"
+          for attempt in 1 2 3 4 5; do
+            rm -rf _hist
+            git clone --depth 1 --branch benchmark-history \
+              "https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git" _hist || {
+                echo "branch missing — bootstrap it per ci/benchmarks/README.md"; exit 1; }
+            mkdir -p _hist/records
+            cp _new_records/*.json _hist/records/
+            python3 ci/benchmarks/lib/record.py aggregate _hist/records \
+              --now "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --out _hist
+            cd _hist
+            git add records benchmarks.json meta.json
+            git commit -m "bench: record run ${{ github.run_id }}" || { echo "nothing to commit"; exit 0; }
+            if git push origin benchmark-history; then echo "pushed"; exit 0; fi
+            echo "push race, retrying ($attempt)"; cd ..; sleep 3
+          done
+          echo "failed to push after retries"; exit 1

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -29,9 +29,9 @@ on:
         default: all
         options: [all, tau2, swebench, skillsbench]
       iterations:
-        description: "Optimizer iterations per task (default 1; raise to give the optimizer more budget)"
+        description: "Optimizer iterations per task (default 3; raise to give the optimizer more budget)"
         type: string
-        default: "1"
+        default: "3"
   pull_request:
     types: [labeled]
 
@@ -60,7 +60,7 @@ jobs:
     env:
       ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
       ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
-      ITERATIONS: ${{ github.event.inputs.iterations || '1' }}
+      ITERATIONS: ${{ github.event.inputs.iterations || '3' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -103,7 +103,7 @@ jobs:
             "branch": "${{ github.head_ref || github.ref_name }}",
             "sha": "${{ github.event.pull_request.head.sha || github.sha }}",
             "date": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
-            "iterations": ${ITERATIONS:-1},
+            "iterations": ${ITERATIONS:-3},
             "agent_model": "aws/gpt-oss-120b",
             "optimizer_model": "claude-opus-4-8",
             "conclusion": "${{ job.status }}"

--- a/ci/benchmarks/README.md
+++ b/ci/benchmarks/README.md
@@ -101,3 +101,20 @@ bash ci/benchmarks/lib/select_tasks.sh <bench> full <zero-baseline ids...>
 bash ci/benchmarks/lib/freeze_baseline.sh <bench> <task_id>
 # 3. update <bench>/tasks.json and re-measure (RESULTS.md)
 ```
+
+## Benchmark history page
+
+Every run appends a per-`(run×bench)` record to the **`benchmark-history`** orphan branch
+(`records/<run_id>__<bench>.json`) and regenerates `benchmarks.json` + `meta.json` there
+(single-writer `aggregate` job → no races). The Pages page `site/benchmarks.html` fetches
+`benchmarks.json` at load and renders a sortable/filterable table (rollup rows expand to
+per-task detail). Bootstrap the branch once:
+
+```bash
+git switch --orphan benchmark-history
+mkdir -p records && : > records/.gitkeep
+echo '[]' > benchmarks.json
+echo '{"count":0,"runs":0,"updated":null}' > meta.json
+git add records/.gitkeep benchmarks.json meta.json
+git commit -m "chore: init benchmark-history branch" && git push origin benchmark-history
+```

--- a/ci/benchmarks/README.md
+++ b/ci/benchmarks/README.md
@@ -16,7 +16,7 @@ regression, not a leaderboard.
 > budget to explore. The `flip`/`hard` tagging + agent-per-task are kept in the harness for
 > future use with a different model or a non-binary scorer.
 
-- **Agent:** `aws/gpt-oss-120b` (all benchmarks) · **Optimizer:** Claude Code @ `claude-opus-4-8` · **1 iteration** (default; configurable via the `iterations` workflow input or `ITERATIONS` env).
+- **Agent:** `aws/gpt-oss-120b` (all benchmarks) · **Optimizer:** Claude Code @ `claude-opus-4-8` · **3 iterations** (default; configurable via the `iterations` workflow input or `ITERATIONS` env).
 - **Baselines are frozen** (committed under `<bench>/<task>/baseline/`) and reused via
   `cap-evolve run --reuse-baseline` — the baseline agent is **never re-run**; CI only
   optimizes + evaluates.

--- a/ci/benchmarks/lib/record.py
+++ b/ci/benchmarks/lib/record.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Build & aggregate benchmark-history records for the CI history page.
+
+  record.py build <metrics.jsonl> --runmeta <runmeta.json>   # -> record JSON on stdout
+  record.py aggregate <records_dir> --now <iso> --out <dir>  # -> benchmarks.json + meta.json
+
+One record per (run x benchmark): the run metadata (from runmeta.json) merged with the
+per-task rows (from the suite's metrics.jsonl) plus a suite rollup. The aggregate step
+concatenates all committed records into benchmarks.json (newest first) for the Pages page.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+SCHEMA = 1
+
+
+def _num(x) -> bool:
+    return isinstance(x, (int, float)) and not isinstance(x, bool)
+
+
+def rollup(tasks: list[dict]) -> dict | None:
+    """Suite rollup matching metrics.py table(): mean rewards, flip count, n, optimizer $."""
+    rb = [t["reward_baseline"] for t in tasks if _num(t.get("reward_baseline"))]
+    ro = [t["reward_opt"] for t in tasks if _num(t.get("reward_opt"))]
+    if not (rb and ro):
+        return None
+    return {
+        "reward_base": round(sum(rb) / len(rb), 6),
+        "reward_opt": round(sum(ro) / len(ro), 6),
+        "flips": sum(1 for t in tasks if t.get("flipped")),
+        "n": len(tasks),
+        "optimizer_usd": round(sum(t.get("optimizer_usd") or 0 for t in tasks), 6),
+    }
+
+
+def build_record(metrics_jsonl: Path, runmeta: dict) -> dict:
+    tasks: list[dict] = []
+    if metrics_jsonl.exists():
+        for line in metrics_jsonl.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line:
+                tasks.append(json.loads(line))
+    rec = dict(runmeta)
+    rec["schema"] = SCHEMA
+    rec["tasks"] = tasks
+    rec["suite"] = rollup(tasks) if runmeta.get("conclusion") == "success" else None
+    return rec
+
+
+def aggregate(records_dir: Path, now: str) -> tuple[list[dict], dict]:
+    recs = [json.loads(p.read_text(encoding="utf-8")) for p in sorted(records_dir.glob("*.json"))]
+    recs.sort(key=lambda r: (r.get("date", ""), r.get("run_id", 0)), reverse=True)
+    meta = {"count": len(recs), "runs": len({r.get("run_id") for r in recs}), "updated": now}
+    return recs, meta
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    b = sub.add_parser("build")
+    b.add_argument("metrics")
+    b.add_argument("--runmeta", required=True)
+    a = sub.add_parser("aggregate")
+    a.add_argument("records_dir")
+    a.add_argument("--now", required=True)
+    a.add_argument("--out", required=True)
+    ns = ap.parse_args(argv[1:])
+
+    if ns.cmd == "build":
+        runmeta = json.loads(Path(ns.runmeta).read_text(encoding="utf-8"))
+        print(json.dumps(build_record(Path(ns.metrics), runmeta)))
+        return 0
+    if ns.cmd == "aggregate":
+        recs, meta = aggregate(Path(ns.records_dir), ns.now)
+        out = Path(ns.out)
+        out.mkdir(parents=True, exist_ok=True)
+        (out / "benchmarks.json").write_text(json.dumps(recs, indent=2), encoding="utf-8")
+        (out / "meta.json").write_text(json.dumps(meta, indent=2), encoding="utf-8")
+        return 0
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/ci/benchmarks/lib/run_suite.sh
+++ b/ci/benchmarks/lib/run_suite.sh
@@ -62,7 +62,7 @@ done <<< "$ids_tags"
 {
   echo "## Benchmark suite — $BENCH"
   echo
-  echo "Agent \`aws/gpt-oss-120b\` · optimizer Claude Code \`claude-opus-4-8\` · ${ITERATIONS:-1} iteration(s) · baselines frozen (reused)."
+  echo "Agent \`aws/gpt-oss-120b\` · optimizer Claude Code \`claude-opus-4-8\` · ${ITERATIONS:-3} iteration(s) · baselines frozen (reused)."
   echo
   "$PY" "$LIB_DIR/metrics.py" table "$OUT/metrics.jsonl"
 } > "$OUT/report.md"

--- a/ci/benchmarks/lib/run_task.sh
+++ b/ci/benchmarks/lib/run_task.sh
@@ -24,7 +24,7 @@ FROZEN="${4:-}"
 
 LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO="$(cd "$LIB_DIR/../../.." && pwd)"
-ITER="${ITERATIONS:-1}"                                   # optimizer iterations (CI-configurable; default 1)
+ITER="${ITERATIONS:-3}"                                   # optimizer iterations (CI-configurable; default 3)
 AGENT_MODEL="${AGENT_MODEL:-aws/gpt-oss-120b}"            # bare gateway model for the AGENT under test
 #   hard tasks use aws/gpt-oss-120b; flip tasks may use a stronger model (e.g. aws/claude-sonnet-5)
 PY="${CAPEVOLVE_PY:-$REPO/.venv-e2e/bin/python}"          # venv with core+litellm(+swebench/datasets)

--- a/ci/benchmarks/lib/test_record.py
+++ b/ci/benchmarks/lib/test_record.py
@@ -1,0 +1,60 @@
+import json
+from pathlib import Path
+
+import record  # same dir; run pytest from ci/benchmarks/lib
+
+TASK_OK = {
+    "bench": "tau2", "task": "35",
+    "reward_baseline": 0.0, "reward_opt": 1.0, "reward_delta": 1.0, "flipped": True,
+    "latency_baseline_s": 10.0, "latency_opt_s": 11.0,
+    "cost_baseline_usd": 0.0, "cost_opt_runner_usd": 0.0,
+    "optimizer_usd": 0.05, "optimizer_tokens": 0, "optimizer_seconds": 0, "iterations": 1,
+}
+TASK2 = {**TASK_OK, "task": "37", "reward_baseline": 0.0, "reward_opt": 0.0,
+         "flipped": False, "optimizer_usd": 0.03}
+
+
+def _write_jsonl(p: Path, rows):
+    p.write_text("\n".join(json.dumps(r) for r in rows), encoding="utf-8")
+
+
+def test_rollup_math():
+    r = record.rollup([TASK_OK, TASK2])
+    assert r == {"reward_base": 0.0, "reward_opt": 0.5, "flips": 1, "n": 2, "optimizer_usd": 0.08}
+
+
+def test_rollup_empty_is_none():
+    assert record.rollup([]) is None
+
+
+def test_build_success(tmp_path):
+    m = tmp_path / "metrics.jsonl"; _write_jsonl(m, [TASK_OK, TASK2])
+    meta = {"run_id": 1, "bench": "tau2", "conclusion": "success", "date": "2026-07-23T00:00:00Z"}
+    rec = record.build_record(m, meta)
+    assert rec["schema"] == 1
+    assert rec["run_id"] == 1 and rec["bench"] == "tau2"
+    assert len(rec["tasks"]) == 2
+    assert rec["suite"]["flips"] == 1 and rec["suite"]["n"] == 2
+
+
+def test_build_failed_run_has_null_suite(tmp_path):
+    m = tmp_path / "metrics.jsonl"; _write_jsonl(m, [TASK_OK])
+    meta = {"run_id": 2, "bench": "tau2", "conclusion": "failure", "date": "d"}
+    rec = record.build_record(m, meta)
+    assert rec["suite"] is None
+    assert len(rec["tasks"]) == 1
+
+
+def test_build_missing_metrics(tmp_path):
+    meta = {"run_id": 3, "bench": "swebench", "conclusion": "success", "date": "d"}
+    rec = record.build_record(tmp_path / "nope.jsonl", meta)
+    assert rec["tasks"] == [] and rec["suite"] is None
+
+
+def test_aggregate_sorts_and_counts(tmp_path):
+    d = tmp_path / "records"; d.mkdir()
+    (d / "1__tau2.json").write_text(json.dumps({"run_id": 1, "bench": "tau2", "date": "2026-07-20T00:00:00Z"}))
+    (d / "2__tau2.json").write_text(json.dumps({"run_id": 2, "bench": "tau2", "date": "2026-07-22T00:00:00Z"}))
+    recs, meta = record.aggregate(d, now="2026-07-23T09:00:00Z")
+    assert [r["run_id"] for r in recs] == [2, 1]  # newest first
+    assert meta == {"count": 2, "runs": 2, "updated": "2026-07-23T09:00:00Z"}

--- a/docs/superpowers/plans/2026-07-23-benchmark-history-page.md
+++ b/docs/superpowers/plans/2026-07-23-benchmark-history-page.md
@@ -239,7 +239,7 @@ In `.github/workflows/benchmarks.yml`, inside the `bench` job, **after** the "Ru
             "branch": "${{ github.head_ref || github.ref_name }}",
             "sha": "${{ github.event.pull_request.head.sha || github.sha }}",
             "date": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
-            "iterations": ${ITERATIONS:-1},
+            "iterations": ${ITERATIONS:-3},
             "agent_model": "aws/gpt-oss-120b",
             "optimizer_model": "claude-opus-4-8",
             "conclusion": "${{ job.status }}"

--- a/docs/superpowers/plans/2026-07-23-benchmark-history-page.md
+++ b/docs/superpowers/plans/2026-07-23-benchmark-history-page.md
@@ -1,0 +1,562 @@
+# Benchmark CI History Page Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish a durable, sortable/filterable HTML table of every `ci/benchmarks` execution (PR + manual runs) on the GitHub Pages site.
+
+**Architecture:** Each benchmark job writes a small `runmeta.json` alongside its existing `metrics.jsonl` (both captured in the uploaded artifact). A single `aggregate` job (`needs: [bench]`, `if: always()`) turns each into one per-`(run×bench)` record via `record.py`, pushes the records to a `benchmark-history` orphan branch, and regenerates `benchmarks.json` + `meta.json`. A static `site/benchmarks.html` fetches that JSON at load and renders rollup rows that expand to per-task detail.
+
+**Tech Stack:** Python 3.12 stdlib (no new deps), GitHub Actions, vanilla HTML/CSS/JS (no build step, matches existing `site/`), pytest for unit tests.
+
+## Global Constraints
+
+- No new Python dependencies — stdlib only (`json`, `pathlib`, `argparse`).
+- No JS framework / build step — one plain `site/benchmarks.js`, reuse `site/style.css` + existing `.nav`/`.page-*` classes.
+- Data model: one record per `(run × benchmark)`, `schema: 1`, exactly as in the design spec `docs/superpowers/specs/2026-07-23-benchmark-ci-history-page-design.md`.
+- Suite rollup math must match `ci/benchmarks/lib/metrics.py` `table()`: `reward_base`=mean of numeric `reward_baseline`, `reward_opt`=mean of numeric `reward_opt`, `flips`=count of `flipped`, `n`=len(tasks), `optimizer_usd`=sum of `optimizer_usd`.
+- `suite` is `null` unless the job `conclusion == "success"` and metrics exist.
+- History branch name: `benchmark-history`. Raw URL the page fetches: `https://raw.githubusercontent.com/skillberry-ai/cap-evolve/benchmark-history/benchmarks.json`.
+- Run `python3` (repo venv `.venv` or `.venv-e2e`); tests via `python3 -m pytest`.
+
+---
+
+### Task 1: `record.py` — build one record + aggregate records
+
+**Files:**
+- Create: `ci/benchmarks/lib/record.py`
+- Test: `ci/benchmarks/lib/test_record.py`
+
+**Interfaces:**
+- Produces:
+  - `build_record(metrics_jsonl: pathlib.Path, runmeta: dict) -> dict` — returns a record dict with keys `schema, tasks, suite` merged over `runmeta`.
+  - `rollup(tasks: list[dict]) -> dict | None` — the suite rollup, or `None` if no numeric rewards.
+  - `aggregate(records_dir: pathlib.Path, now: str) -> tuple[list[dict], dict]` — `(records_newest_first, meta)`.
+  - CLI: `record.py build <metrics.jsonl> --runmeta <runmeta.json>` → prints record JSON to stdout; `record.py aggregate <records_dir> --now <iso> --out <dir>` → writes `<dir>/benchmarks.json` + `<dir>/meta.json`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# ci/benchmarks/lib/test_record.py
+import json
+from pathlib import Path
+import record  # same dir; run pytest from ci/benchmarks/lib
+
+TASK_OK = {
+    "bench": "tau2", "task": "35",
+    "reward_baseline": 0.0, "reward_opt": 1.0, "reward_delta": 1.0, "flipped": True,
+    "latency_baseline_s": 10.0, "latency_opt_s": 11.0,
+    "cost_baseline_usd": 0.0, "cost_opt_runner_usd": 0.0,
+    "optimizer_usd": 0.05, "optimizer_tokens": 0, "optimizer_seconds": 0, "iterations": 1,
+}
+TASK2 = {**TASK_OK, "task": "37", "reward_baseline": 0.0, "reward_opt": 0.0,
+         "flipped": False, "optimizer_usd": 0.03}
+
+def _write_jsonl(p: Path, rows):
+    p.write_text("\n".join(json.dumps(r) for r in rows), encoding="utf-8")
+
+def test_rollup_math():
+    r = record.rollup([TASK_OK, TASK2])
+    assert r == {"reward_base": 0.0, "reward_opt": 0.5, "flips": 1, "n": 2, "optimizer_usd": 0.08}
+
+def test_rollup_empty_is_none():
+    assert record.rollup([]) is None
+
+def test_build_success(tmp_path):
+    m = tmp_path / "metrics.jsonl"; _write_jsonl(m, [TASK_OK, TASK2])
+    meta = {"run_id": 1, "bench": "tau2", "conclusion": "success", "date": "2026-07-23T00:00:00Z"}
+    rec = record.build_record(m, meta)
+    assert rec["schema"] == 1
+    assert rec["run_id"] == 1 and rec["bench"] == "tau2"
+    assert len(rec["tasks"]) == 2
+    assert rec["suite"]["flips"] == 1 and rec["suite"]["n"] == 2
+
+def test_build_failed_run_has_null_suite(tmp_path):
+    m = tmp_path / "metrics.jsonl"; _write_jsonl(m, [TASK_OK])
+    meta = {"run_id": 2, "bench": "tau2", "conclusion": "failure", "date": "d"}
+    rec = record.build_record(m, meta)
+    assert rec["suite"] is None
+    assert len(rec["tasks"]) == 1
+
+def test_build_missing_metrics(tmp_path):
+    meta = {"run_id": 3, "bench": "swebench", "conclusion": "success", "date": "d"}
+    rec = record.build_record(tmp_path / "nope.jsonl", meta)
+    assert rec["tasks"] == [] and rec["suite"] is None
+
+def test_aggregate_sorts_and_counts(tmp_path):
+    d = tmp_path / "records"; d.mkdir()
+    (d / "1__tau2.json").write_text(json.dumps({"run_id": 1, "bench": "tau2", "date": "2026-07-20T00:00:00Z"}))
+    (d / "2__tau2.json").write_text(json.dumps({"run_id": 2, "bench": "tau2", "date": "2026-07-22T00:00:00Z"}))
+    recs, meta = record.aggregate(d, now="2026-07-23T09:00:00Z")
+    assert [r["run_id"] for r in recs] == [2, 1]  # newest first
+    assert meta == {"count": 2, "runs": 2, "updated": "2026-07-23T09:00:00Z"}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd ci/benchmarks/lib && python3 -m pytest test_record.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'record'`.
+
+- [ ] **Step 3: Write `record.py`**
+
+```python
+#!/usr/bin/env python3
+"""Build & aggregate benchmark-history records for the CI history page.
+
+  record.py build <metrics.jsonl> --runmeta <runmeta.json>   # -> record JSON on stdout
+  record.py aggregate <records_dir> --now <iso> --out <dir>  # -> benchmarks.json + meta.json
+"""
+from __future__ import annotations
+import argparse, json, sys
+from pathlib import Path
+
+SCHEMA = 1
+
+
+def _num(x) -> bool:
+    return isinstance(x, (int, float)) and not isinstance(x, bool)
+
+
+def rollup(tasks: list[dict]) -> dict | None:
+    rb = [t["reward_baseline"] for t in tasks if _num(t.get("reward_baseline"))]
+    ro = [t["reward_opt"] for t in tasks if _num(t.get("reward_opt"))]
+    if not (rb and ro):
+        return None
+    return {
+        "reward_base": round(sum(rb) / len(rb), 6),
+        "reward_opt": round(sum(ro) / len(ro), 6),
+        "flips": sum(1 for t in tasks if t.get("flipped")),
+        "n": len(tasks),
+        "optimizer_usd": round(sum(t.get("optimizer_usd") or 0 for t in tasks), 6),
+    }
+
+
+def build_record(metrics_jsonl: Path, runmeta: dict) -> dict:
+    tasks: list[dict] = []
+    if metrics_jsonl.exists():
+        for line in metrics_jsonl.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line:
+                tasks.append(json.loads(line))
+    rec = dict(runmeta)
+    rec["schema"] = SCHEMA
+    rec["tasks"] = tasks
+    rec["suite"] = rollup(tasks) if runmeta.get("conclusion") == "success" else None
+    return rec
+
+
+def aggregate(records_dir: Path, now: str) -> tuple[list[dict], dict]:
+    recs = [json.loads(p.read_text(encoding="utf-8")) for p in sorted(records_dir.glob("*.json"))]
+    recs.sort(key=lambda r: (r.get("date", ""), r.get("run_id", 0)), reverse=True)
+    meta = {"count": len(recs), "runs": len({r.get("run_id") for r in recs}), "updated": now}
+    return recs, meta
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser()
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    b = sub.add_parser("build"); b.add_argument("metrics"); b.add_argument("--runmeta", required=True)
+    a = sub.add_parser("aggregate"); a.add_argument("records_dir"); a.add_argument("--now", required=True); a.add_argument("--out", required=True)
+    ns = ap.parse_args(argv[1:])
+    if ns.cmd == "build":
+        runmeta = json.loads(Path(ns.runmeta).read_text(encoding="utf-8"))
+        print(json.dumps(build_record(Path(ns.metrics), runmeta)))
+        return 0
+    if ns.cmd == "aggregate":
+        recs, meta = aggregate(Path(ns.records_dir), ns.now)
+        out = Path(ns.out); out.mkdir(parents=True, exist_ok=True)
+        (out / "benchmarks.json").write_text(json.dumps(recs, indent=2), encoding="utf-8")
+        (out / "meta.json").write_text(json.dumps(meta, indent=2), encoding="utf-8")
+        return 0
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd ci/benchmarks/lib && python3 -m pytest test_record.py -v`
+Expected: PASS (6 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ci/benchmarks/lib/record.py ci/benchmarks/lib/test_record.py
+git commit -m "feat(bench): record.py — build + aggregate benchmark-history records"
+```
+
+---
+
+### Task 2: Emit `runmeta.json` per bench job + `aggregate` job in the workflow
+
+**Files:**
+- Modify: `.github/workflows/benchmarks.yml` (add a runmeta step to the `bench` job; add a new `aggregate` job)
+- Modify: `ci/benchmarks/README.md` (document the `benchmark-history` branch + one-time bootstrap)
+
+**Interfaces:**
+- Consumes: `ci/benchmarks/lib/record.py` (`build`, `aggregate` CLI) from Task 1; the existing `run_suite.sh` output dir `ci/benchmarks/.work/suite_<bench>/` containing `metrics.jsonl`.
+- Produces: on the `benchmark-history` branch, `records/<run_id>__<bench>.json`, `benchmarks.json`, `meta.json`.
+
+- [ ] **Step 1: Bootstrap the orphan branch (one-time, manual)**
+
+Run locally (documented in README, done once by a maintainer):
+
+```bash
+git switch --orphan benchmark-history
+mkdir -p records
+echo '[]' > benchmarks.json
+echo '{"count":0,"runs":0,"updated":null}' > meta.json
+git add records benchmarks.json meta.json 2>/dev/null; : > records/.gitkeep; git add records/.gitkeep benchmarks.json meta.json
+git commit -m "chore: init benchmark-history branch"
+git push origin benchmark-history
+git switch feat/benchmark-history-page
+```
+
+- [ ] **Step 2: Add a `runmeta.json` step to the `bench` job**
+
+In `.github/workflows/benchmarks.yml`, inside the `bench` job, **after** the "Run suite" step, add (this step runs even on failure so failed runs are still recorded):
+
+```yaml
+      - name: Write run metadata
+        if: steps.gate.outputs.run == 'true' && always()
+        run: |
+          out="$GITHUB_WORKSPACE/ci/benchmarks/.work/suite_${{ matrix.bench }}"
+          mkdir -p "$out"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            source="PR #${{ github.event.pull_request.number }}"; pr="${{ github.event.pull_request.number }}"
+          else
+            source="manual (${{ github.ref_name }})"; pr="null"
+          fi
+          cat > "$out/runmeta.json" <<JSON
+          {
+            "run_id": ${{ github.run_id }},
+            "run_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+            "bench": "${{ matrix.bench }}",
+            "event": "${{ github.event_name }}",
+            "source": "$source",
+            "pr": $pr,
+            "branch": "${{ github.head_ref || github.ref_name }}",
+            "sha": "${{ github.event.pull_request.head.sha || github.sha }}",
+            "date": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+            "iterations": ${ITERATIONS:-1},
+            "agent_model": "aws/gpt-oss-120b",
+            "optimizer_model": "claude-opus-4-8",
+            "conclusion": "${{ job.status }}"
+          }
+          JSON
+          cat "$out/runmeta.json"
+```
+
+Note: `${{ job.status }}` at this late `always()` step reflects success/failure of prior steps. The `upload-artifact` step already globs `ci/benchmarks/.work/suite_<bench>/**`, so `runmeta.json` and `metrics.jsonl` are both included.
+
+- [ ] **Step 3: Add the `aggregate` job**
+
+Append to `.github/workflows/benchmarks.yml` under `jobs:` (sibling of `bench`):
+
+```yaml
+  aggregate:
+    name: aggregate history
+    needs: [bench]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4              # for ci/benchmarks/lib/record.py
+
+      - name: Download all benchmark artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: _artifacts
+          pattern: benchmarks-*
+
+      - name: Build records
+        run: |
+          mkdir -p _new_records
+          for d in _artifacts/benchmarks-*; do
+            [ -d "$d" ] || continue
+            bench="$(basename "$d" | sed 's/^benchmarks-//')"
+            suite="$d/suite_$bench"
+            rm="$suite/runmeta.json"; metrics="$suite/metrics.jsonl"
+            [ -f "$rm" ] || { echo "no runmeta for $bench, skipping"; continue; }
+            rid="$(python3 -c "import json,sys;print(json.load(open('$rm'))['run_id'])")"
+            python3 ci/benchmarks/lib/record.py build "$metrics" --runmeta "$rm" \
+              > "_new_records/${rid}__${bench}.json"
+            echo "built _new_records/${rid}__${bench}.json"
+          done
+          ls -la _new_records || true
+
+      - name: Push to benchmark-history (single writer, with rebase-retry)
+        run: |
+          [ -n "$(ls -A _new_records 2>/dev/null)" ] || { echo "no records to push"; exit 0; }
+          git config --global user.name "skillberry-bot"
+          git config --global user.email "actions@github.com"
+          for attempt in 1 2 3 4 5; do
+            rm -rf _hist
+            git clone --depth 1 --branch benchmark-history \
+              "https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git" _hist || {
+                echo "branch missing — bootstrap it per ci/benchmarks/README.md"; exit 1; }
+            mkdir -p _hist/records
+            cp _new_records/*.json _hist/records/
+            python3 ci/benchmarks/lib/record.py aggregate _hist/records \
+              --now "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --out _hist
+            cd _hist
+            git add records benchmarks.json meta.json
+            git commit -m "bench: record run ${{ github.run_id }}" || { echo "nothing to commit"; exit 0; }
+            if git push origin benchmark-history; then echo "pushed"; exit 0; fi
+            echo "push race, retrying ($attempt)"; cd ..; sleep 3
+          done
+          echo "failed to push after retries"; exit 1
+```
+
+- [ ] **Step 4: Document the branch in the README**
+
+Add to `ci/benchmarks/README.md` under a new `## Benchmark history page` section:
+
+```markdown
+## Benchmark history page
+
+Every run appends a per-`(run×bench)` record to the **`benchmark-history`** orphan branch
+(`records/<run_id>__<bench>.json`) and regenerates `benchmarks.json` + `meta.json` there
+(single-writer `aggregate` job → no races). The Pages page `site/benchmarks.html` fetches
+`benchmarks.json` at load. Bootstrap the branch once:
+
+    git switch --orphan benchmark-history
+    mkdir -p records && : > records/.gitkeep
+    echo '[]' > benchmarks.json
+    echo '{"count":0,"runs":0,"updated":null}' > meta.json
+    git add records/.gitkeep benchmarks.json meta.json
+    git commit -m "chore: init benchmark-history branch" && git push origin benchmark-history
+```
+
+- [ ] **Step 5: Validate locally (workflow can't be unit-tested)**
+
+Simulate the aggregate logic against a fixture that mimics a downloaded artifact:
+
+Run:
+```bash
+cd /tmp && rm -rf aggchk && mkdir -p aggchk/records
+printf '%s\n' '{"bench":"tau2","task":"35","reward_baseline":0.0,"reward_opt":0.0,"flipped":false,"optimizer_usd":0.02}' > aggchk/metrics.jsonl
+printf '%s' '{"run_id":999,"bench":"tau2","conclusion":"success","date":"2026-07-23T10:00:00Z"}' > aggchk/runmeta.json
+python3 "$OLDPWD/ci/benchmarks/lib/record.py" build aggchk/metrics.jsonl --runmeta aggchk/runmeta.json > aggchk/records/999__tau2.json
+python3 "$OLDPWD/ci/benchmarks/lib/record.py" aggregate aggchk/records --now 2026-07-23T10:01:00Z --out aggchk
+cat aggchk/benchmarks.json aggchk/meta.json
+```
+Expected: `benchmarks.json` is a 1-element array whose record has `suite.n == 1`; `meta.json` shows `count: 1, runs: 1`.
+
+Also lint the YAML:
+Run: `python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/benchmarks.yml'))" && echo "YAML OK"`
+Expected: `YAML OK`. (If PyYAML is absent, `pip install pyyaml` in the venv or skip — GitHub validates on push.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .github/workflows/benchmarks.yml ci/benchmarks/README.md
+git commit -m "feat(bench): aggregate job pushes run records to benchmark-history branch"
+```
+
+---
+
+### Task 3: `site/benchmarks.html` + `site/benchmarks.js` + nav link
+
+**Files:**
+- Create: `site/benchmarks.html`
+- Create: `site/benchmarks.js`
+- Modify: `site/index.html`, `site/results.html`, `site/getting-started.html`, `site/architecture.html`, `site/agent-orchestration.html`, `site/optimize-your-own.html`, `site/adapter-templates.html` (add the nav link to each page's `.nav-links`)
+- Create: `site/benchmarks.fixture.json` (local eyeball fixture; not deployed data)
+
+**Interfaces:**
+- Consumes: the record schema from Task 1 (`benchmarks.json` = array of records; each has `source, pr, run_url, bench, date, iterations, conclusion, suite{reward_base,reward_opt,flips,n,optimizer_usd}, tasks[]`).
+- Produces: a deployed page at `/benchmarks.html`.
+
+- [ ] **Step 1: Create `site/benchmarks.html`**
+
+Mirror the `<head>`/nav/footer of `site/results.html` (same `style.css`, Inter font, `.nav`). Body:
+
+```html
+<main class="page doc">
+  <h1>Benchmark runs</h1>
+  <p class="lead">Every <code>ci/benchmarks</code> execution (PR &amp; manual). Rollup rows expand to per-task detail.
+    <span id="updated" class="muted"></span></p>
+
+  <div class="filters">
+    <label>Benchmark <select id="f-bench"><option value="">all</option><option>tau2</option><option>swebench</option><option>skillsbench</option></select></label>
+    <label>Source <select id="f-source"><option value="">all</option><option value="pr">PR</option><option value="manual">manual</option></select></label>
+    <label>Result <select id="f-conc"><option value="">all</option><option>success</option><option>failure</option><option>cancelled</option></select></label>
+    <label>Search <input id="f-q" type="search" placeholder="branch or task…"></label>
+  </div>
+
+  <table id="runs">
+    <thead><tr>
+      <th data-k="date">Date</th><th data-k="source">Source</th><th data-k="bench">Bench</th>
+      <th data-k="iterations">Iters</th><th data-k="reward">Reward base→opt</th>
+      <th data-k="flips">Flips</th><th data-k="optimizer_usd">Optimizer $</th><th data-k="conclusion">Result</th>
+    </tr></thead>
+    <tbody id="rows"></tbody>
+  </table>
+  <p id="empty" class="muted" hidden>No runs recorded yet.</p>
+  <p id="error" class="muted" hidden>Couldn't load benchmark history.</p>
+</main>
+<script src="benchmarks.js"></script>
+```
+
+- [ ] **Step 2: Create `site/benchmarks.js`**
+
+```javascript
+const RAW = "https://raw.githubusercontent.com/skillberry-ai/cap-evolve/benchmark-history";
+let RECORDS = [], sortKey = "date", sortDir = -1;
+
+const $ = (s) => document.querySelector(s);
+const fmt = (v, d = 3) => (typeof v === "number" ? v.toFixed(d) : "—");
+
+async function load() {
+  try {
+    const [recs, meta] = await Promise.all([
+      fetch(`${RAW}/benchmarks.json?t=${Date.now()}`).then((r) => r.json()),
+      fetch(`${RAW}/meta.json?t=${Date.now()}`).then((r) => r.json()).catch(() => null),
+    ]);
+    RECORDS = Array.isArray(recs) ? recs : [];
+    if (meta && meta.updated) $("#updated").textContent = `· last updated ${new Date(meta.updated).toLocaleString()}`;
+    render();
+  } catch (e) {
+    $("#error").hidden = false;
+  }
+}
+
+function passes(r) {
+  const b = $("#f-bench").value, s = $("#f-source").value, c = $("#f-conc").value, q = $("#f-q").value.toLowerCase();
+  if (b && r.bench !== b) return false;
+  if (s === "pr" && r.event !== "pull_request") return false;
+  if (s === "manual" && r.event === "pull_request") return false;
+  if (c && r.conclusion !== c) return false;
+  if (q) {
+    const hay = `${r.branch || ""} ${(r.tasks || []).map((t) => t.task).join(" ")}`.toLowerCase();
+    if (!hay.includes(q)) return false;
+  }
+  return true;
+}
+
+function sortVal(r, k) {
+  if (k === "reward") return r.suite ? r.suite.reward_opt : -1;
+  if (k === "flips") return r.suite ? r.suite.flips : -1;
+  if (k === "optimizer_usd") return r.suite ? r.suite.optimizer_usd : -1;
+  return r[k] ?? "";
+}
+
+function render() {
+  const rows = RECORDS.filter(passes).sort((a, b) => {
+    const x = sortVal(a, sortKey), y = sortVal(b, sortKey);
+    return (x < y ? -1 : x > y ? 1 : 0) * sortDir;
+  });
+  const tb = $("#rows"); tb.innerHTML = "";
+  $("#empty").hidden = rows.length > 0;
+  for (const r of rows) {
+    const tr = document.createElement("tr");
+    tr.className = "run-row";
+    const reward = r.suite ? `${fmt(r.suite.reward_base)} → ${fmt(r.suite.reward_opt)}` : "—";
+    const flips = r.suite ? `${r.suite.flips}/${r.suite.n}` : "—";
+    const usd = r.suite ? `$${fmt(r.suite.optimizer_usd, 4)}` : "—";
+    const src = r.pr ? `<a href="https://github.com/skillberry-ai/cap-evolve/pull/${r.pr}">${r.source}</a>` : r.source;
+    const badge = `<span class="badge ${r.conclusion}">${r.conclusion}</span>`;
+    tr.innerHTML = `<td><a href="${r.run_url}">${(r.date || "").replace("T", " ").replace("Z", "")}</a></td>
+      <td>${src}</td><td>${r.bench}</td><td>${r.iterations ?? "—"}</td>
+      <td>${reward}</td><td>${flips}</td><td>${usd}</td><td>${badge}</td>`;
+    tb.appendChild(tr);
+    const detail = document.createElement("tr");
+    detail.className = "detail-row"; detail.hidden = true;
+    detail.innerHTML = `<td colspan="8">${taskTable(r.tasks || [])}</td>`;
+    tb.appendChild(detail);
+    tr.addEventListener("click", (e) => { if (e.target.tagName !== "A") detail.hidden = !detail.hidden; });
+  }
+}
+
+function taskTable(tasks) {
+  if (!tasks.length) return `<em class="muted">no per-task metrics</em>`;
+  const head = `<tr><th>task</th><th>reward base→opt</th><th>flip</th><th>latency (s)</th><th>runner $</th><th>opt $</th><th>iters</th></tr>`;
+  const body = tasks.map((t) => `<tr><td><code>${t.task}</code></td>
+    <td>${fmt(t.reward_baseline)} → ${fmt(t.reward_opt)}</td>
+    <td>${t.flipped ? "✅" : "—"}</td>
+    <td>${fmt(t.latency_baseline_s, 1)} → ${fmt(t.latency_opt_s, 1)}</td>
+    <td>$${fmt(t.cost_opt_runner_usd, 4)}</td><td>$${fmt(t.optimizer_usd, 4)}</td>
+    <td>${t.iterations ?? "—"}</td></tr>`).join("");
+  return `<table class="detail">${head}${body}</table>`;
+}
+
+document.querySelectorAll("#runs thead th").forEach((th) =>
+  th.addEventListener("click", () => {
+    const k = th.dataset.k; if (!k) return;
+    sortDir = sortKey === k ? -sortDir : -1; sortKey = k; render();
+  })
+);
+["f-bench", "f-source", "f-conc", "f-q"].forEach((id) => $("#" + id).addEventListener("input", render));
+load();
+```
+
+- [ ] **Step 3: Add table/badge/filter styles**
+
+Append to `site/style.css`:
+
+```css
+.filters { display: flex; flex-wrap: wrap; gap: 1rem; margin: 1rem 0; }
+.filters label { display: flex; flex-direction: column; font-size: .8rem; color: #555; gap: .25rem; }
+.run-row { cursor: pointer; }
+.run-row:hover { background: #f6f8fa; }
+.detail-row > td { background: #fafbfc; padding: .5rem 1rem; }
+table.detail { width: 100%; font-size: .85rem; }
+.badge { padding: .1rem .5rem; border-radius: 999px; font-size: .75rem; font-weight: 600; }
+.badge.success { background: #d5f5e3; color: #1e7a46; }
+.badge.failure { background: #fbdcdc; color: #a12; }
+.badge.cancelled { background: #eee; color: #666; }
+.muted { color: #777; font-weight: 400; }
+```
+
+- [ ] **Step 4: Add the nav link to every page**
+
+In each `site/*.html`, inside `<div class="nav-links">`, add after the Results link:
+
+```html
+      <a href="benchmarks.html">Benchmark runs</a>
+```
+On `benchmarks.html` itself give it `class="active"`.
+
+- [ ] **Step 5: Eyeball with a local fixture**
+
+Create `site/benchmarks.fixture.json` with two records (one `success` with 2 tasks, one `failure` with `suite: null`), temporarily point `RAW` fetch at `./benchmarks.fixture.json`, then:
+
+Run: `cd site && python3 -m http.server 8099`
+Open: `http://localhost:8099/benchmarks.html`
+Verify: rows render, clicking a row expands the per-task table, sort headers reorder, filters narrow the list, the failed run shows a red badge with no metrics. Then revert `RAW` to the live URL and delete/keep the fixture (keep it — it's a test aid, not deployed data).
+
+Expected: all interactions work; empty/error states show when data is absent.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add site/benchmarks.html site/benchmarks.js site/style.css site/benchmarks.fixture.json site/*.html
+git commit -m "feat(site): benchmark runs history page (sortable/filterable, expandable rows)"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- Forward-only, per-(run×bench) records → Task 1 (`build_record`) + Task 2 (runmeta + aggregate). ✓
+- Rollup + expandable per-task rows → Task 3 (`render` + `taskTable`). ✓
+- Approach 1: history branch, single aggregator, client fetch → Task 2 (aggregate job, orphan branch) + Task 3 (`RAW` fetch + cache-buster). ✓
+- PR + manual runs labelled; failures visible → Task 2 runmeta `source`/`conclusion`, `if: always()`; Task 3 badge + null-suite handling. ✓
+- Sort/filter (bench, source, conclusion, search) → Task 3 filters. ✓
+- No new deps / no build step / reuse style → Global Constraints + Task 3. ✓
+- README bootstrap of orphan branch → Task 2 Step 1 + Step 4. ✓
+- meta.json "last updated" → Task 1 `aggregate` + Task 3 `#updated`. ✓
+- Error handling (missing metrics, failed job, empty history, fetch failure) → Task 1 `build_record` guards, Task 3 `#empty`/`#error`. ✓
+
+**2. Placeholder scan:** No TBD/TODO; every code step shows full code; every run step shows the command + expected output. ✓
+
+**3. Type consistency:** `rollup`/`build_record`/`aggregate` signatures identical across Task 1 definition and Task 2 CLI usage. `benchmarks.json` = array of records; `meta.json` = `{count,runs,updated}` — consumed exactly by Task 3 `load()`. Record fields used in JS (`source, pr, run_url, bench, date, iterations, conclusion, suite.*, tasks[].*`) all match Task 1 output + `metrics.py` task shape. ✓
+
+## Notes / risks flagged during planning
+
+- The `aggregate` job pushes with `GITHUB_TOKEN` (`contents: write`). If branch/org policy blocks it, the maintainer will relax it (admin available). Fork PRs are already blocked by the existing fork guard, so the token has write access on same-repo runs.
+- `${{ job.status }}` in the runmeta step reflects the job outcome at that late `always()` step (post-Run-suite). Cancelled jobs may skip the step; those simply won't produce a record (acceptable — no data to show).

--- a/docs/superpowers/specs/2026-07-23-benchmark-ci-history-page-design.md
+++ b/docs/superpowers/specs/2026-07-23-benchmark-ci-history-page-design.md
@@ -1,0 +1,170 @@
+# Benchmark CI History Page — Design
+
+**Date:** 2026-07-23
+**Status:** Approved design, pre-implementation
+**Branch:** `feat/benchmark-history-page`
+
+## Problem
+
+The `ci/benchmarks` suite (tau2 · swebench · skillsbench) runs on demand — on PRs via the
+`benchmark-test` label and manually via `workflow_dispatch`. Today each run's results are
+**ephemeral**: they exist only as (a) a sticky PR comment, (b) an Actions artifact that
+expires (~90 days), and (c) transient files on the self-hosted runner. There is **no durable,
+aggregated record** of benchmark executions over time, and nothing on the public site
+(`https://skillberry-ai.github.io/cap-evolve/`) that shows the running history.
+
+## Goal
+
+Collect the results of **every** CI benchmark execution — PR runs and manual (`workflow_dispatch`)
+runs, whole-suite or single-benchmark — into a durable store, and publish them on the GitHub
+Pages site as a **sortable, filterable HTML table** with per-benchmark rollup rows that expand
+to per-task detail.
+
+## Scope decisions (confirmed with maintainer)
+
+- **Forward-only** collection. No historical backfill (past PR runs were mostly `skipped`, and
+  artifacts expire). The page starts sparse and grows as runs happen.
+- **Row granularity: both** — per-`(run × benchmark)` rollup rows that **expand** to show the
+  per-task detail rows.
+- **Persistence + delivery: Approach 1** — a dedicated `benchmark-history` orphan branch written
+  by a single aggregator job; the static page fetches the aggregated JSON at runtime from
+  `raw.githubusercontent.com`. Keeps `main` history clean; the page is always fresh with no
+  redeploy.
+
+## Non-goals
+
+- No backfill of expired/`skipped` past runs.
+- No new server or database; no build step / JS framework (the site is static HTML/CSS today).
+- Not a replacement for the curated `site/results.html` (canonical, hand-verified numbers) or
+  the separate `dashboard/` app. This is a **raw log of CI executions**, a distinct page.
+- No change to *what* the benchmark suite measures or how it scores.
+
+## Data model
+
+One record per **(run × benchmark)**, so partial suites and manual runs slot in naturally.
+
+```jsonc
+{
+  "schema": 1,
+  "run_id": 30013033262,
+  "run_url": "https://github.com/skillberry-ai/cap-evolve/actions/runs/30013033262",
+  "bench": "tau2",                     // tau2 | swebench | skillsbench
+  "event": "pull_request",             // pull_request | workflow_dispatch
+  "source": "PR #55",                  // human label: "PR #55" or "manual (main)"
+  "pr": 55,                            // null for manual runs
+  "branch": "feature/skill-tool-optimization-knowledge",
+  "sha": "abc1234",
+  "date": "2026-07-23T13:50:51Z",      // run createdAt (UTC ISO-8601)
+  "iterations": 1,
+  "agent_model": "aws/gpt-oss-120b",
+  "optimizer_model": "claude-opus-4-8",
+  "conclusion": "success",             // success | failure | cancelled — surfaces failed jobs
+  "suite": {                           // rollup (null when conclusion != success / no metrics)
+    "reward_base": 0.0, "reward_opt": 0.0,
+    "flips": 0, "n": 2, "optimizer_usd": 0.12
+  },
+  "tasks": [                           // one object per task; exactly the metrics.py `extract` shape
+    { "bench": "tau2", "task": "35", "reward_baseline": 0.0, "reward_opt": 0.0,
+      "reward_delta": 0.0, "flipped": false,
+      "latency_baseline_s": 12.3, "latency_opt_s": 13.1,
+      "cost_baseline_usd": 0.0, "cost_opt_runner_usd": 0.0,
+      "optimizer_usd": 0.06, "optimizer_tokens": 0, "optimizer_seconds": 0, "iterations": 1 }
+  ]
+}
+```
+
+Aggregated artifacts on the `benchmark-history` branch:
+
+- `records/<run_id>__<bench>.json` — one file per record (immutable; unique name → no write races).
+- `benchmarks.json` — array of all records (what the page fetches).
+- `meta.json` — `{ "updated": "<ISO>", "count": <n>, "runs": <n_runs> }` for a "last updated" line.
+
+## Components (each single-purpose, independently testable)
+
+1. **`ci/benchmarks/lib/record.py`**
+   - `build_record(metrics_jsonl_path, meta: dict) -> dict` — pure function: reads a suite's
+     `metrics.jsonl`, computes the `suite` rollup (reuse the same math as `metrics.py table`),
+     merges run metadata, returns one record dict. No I/O beyond reading the given file.
+   - `main()` CLI: `record.py build <metrics.jsonl> --bench B --meta meta.json > record.json`,
+     reading run metadata from a small JSON (so the workflow passes `$GITHUB_*` values in).
+   - Unit tests: rollup math, partial suite, failed-run (no metrics) → `suite: null`,
+     manual-vs-PR `source` labelling.
+
+2. **`aggregate` job** in `.github/workflows/benchmarks.yml`
+   - `needs: [bench]`, `if: always()` (so it records failed bench jobs too),
+     `runs-on: ubuntu-latest` (GitHub-hosted is fine — it only shuffles JSON + git, no VPC).
+   - Downloads the 3 `benchmarks-<bench>` artifacts (each already contains `metrics.jsonl`;
+     add the per-job `conclusion` via the jobs API or matrix outputs).
+   - For each present bench: `record.py build …` → `records/<run_id>__<bench>.json`.
+   - Checks out the orphan `benchmark-history` branch (create if missing), writes the record
+     files, regenerates `benchmarks.json` (glob `records/*.json`) + `meta.json`, commits, and
+     **pushes once** (single writer → no races between the matrix jobs).
+   - Uses the default `GITHUB_TOKEN` with `permissions: contents: write` scoped to the job.
+
+3. **`benchmark-history` orphan branch** — data only, no source tree. Created once (bootstrap
+   documented in `ci/benchmarks/README.md`).
+
+4. **`site/benchmarks.html` + `site/benchmarks.js`** — vanilla JS, reusing the existing nav +
+   `style.css`. Adds a "Benchmark runs" nav link. On load, fetches
+   `https://raw.githubusercontent.com/skillberry-ai/cap-evolve/benchmark-history/benchmarks.json`
+   (public repo → CORS-OK) with a `?t=<timestamp>` cache-buster (raw.githubusercontent has a
+   ~5 min CDN cache), renders the table, wires client-side sort/filter/expand. Shows the
+   `meta.json` "last updated" line and a graceful empty/error state.
+
+## Page UX
+
+- **Rollup rows** (one per run×bench): source (PR link or "manual"), date, bench, iters,
+  mean reward `base→opt`, flips `x/n`, optimizer `$`, conclusion badge (green success /
+  red failure / grey cancelled). Click to **expand** the per-task detail table.
+- **Sort:** click any column header (date default, newest first).
+- **Filter:** benchmark (tau2/swebench/skillsbench), source (PR / manual), conclusion, date
+  range, and a free-text search over branch + task id.
+- Failed/cancelled runs appear as rows with a red/grey badge and no metrics — so infra failures
+  are visible in the log, not silently dropped.
+- Pure client-side (data volume is small); no dependencies beyond the one `benchmarks.js` file.
+
+## Data flow
+
+```
+bench job (self-hosted)  →  metrics.jsonl + artifact
+        │
+        ▼
+aggregate job (ubuntu, needs:[bench], if:always)
+   record.py → records/<run_id>__<bench>.json
+   regenerate benchmarks.json + meta.json
+   commit + push (single writer) → benchmark-history branch
+        │
+        ▼
+site/benchmarks.html  (fetches benchmarks.json at load) → sort / filter / expand
+```
+
+New benchmark data needs **no Pages redeploy**; the page HTML deploys once via the existing
+`pages.yml` when `site/**` changes.
+
+## Error handling
+
+- **Failed/cancelled bench job:** aggregator still writes a record (`conclusion` set, `suite: null`);
+  the page shows it as a failed run. `if: always()` on the aggregate job ensures this.
+- **Missing/empty `metrics.jsonl`:** `record.py` yields `suite: null, tasks: []` rather than crashing.
+- **Concurrent runs:** single aggregate writer per run; distinct `records/*` filenames; the push
+  uses a fetch+rebase-retry loop to tolerate a second run's aggregate landing between fetch and push.
+- **Page fetch failure / empty history:** the page renders an explicit "no runs yet" / "couldn't
+  load" state instead of a blank table.
+- **Orphan branch missing:** aggregator bootstraps it (`git checkout --orphan`) on first run.
+
+## Testing
+
+- Unit: `record.py` rollup math, partial suite, failed-run, PR-vs-manual `source`
+  (mirrors existing `ci/benchmarks/lib` test style).
+- Fixture: a sample `metrics.jsonl` → expected `record.json` (golden file).
+- Aggregation: `benchmarks.json` regeneration from a `records/` fixture dir (idempotent; stable order).
+- Page: a tiny local fixture `benchmarks.json` to eyeball sort/filter/expand + empty/error states
+  before wiring the live URL.
+- Workflow: dry-run the `aggregate` job logic locally against downloaded artifacts before merge.
+
+## Rollout
+
+1. Land page + `record.py` + `aggregate` job on this branch; bootstrap the `benchmark-history`
+   branch (empty `benchmarks.json`).
+2. Merge to `main`; `pages.yml` deploys `benchmarks.html`.
+3. Next labelled/dispatched benchmark run populates the history; verify the page updates.

--- a/site/adapter-templates.html
+++ b/site/adapter-templates.html
@@ -28,6 +28,7 @@
     <div class="nav-links">
       <a href="getting-started.html">Getting started</a>
       <a href="results.html">Results</a>
+      <a href="benchmarks.html">Benchmark runs</a>
       <a href="architecture.html">Architecture</a>
       <a href="agent-orchestration.html">Agent mode</a>
       <a href="optimize-your-own.html">Optimize your own</a>

--- a/site/agent-orchestration.html
+++ b/site/agent-orchestration.html
@@ -28,6 +28,7 @@
     <div class="nav-links">
       <a href="getting-started.html">Getting started</a>
       <a href="results.html">Results</a>
+      <a href="benchmarks.html">Benchmark runs</a>
       <a href="architecture.html">Architecture</a>
       <a href="agent-orchestration.html" class="active">Agent mode</a>
       <a href="optimize-your-own.html">Optimize your own</a>

--- a/site/architecture.html
+++ b/site/architecture.html
@@ -28,6 +28,7 @@
     <div class="nav-links">
       <a href="getting-started.html">Getting started</a>
       <a href="results.html">Results</a>
+      <a href="benchmarks.html">Benchmark runs</a>
       <a href="architecture.html" class="active">Architecture</a>
       <a href="agent-orchestration.html">Agent mode</a>
       <a href="optimize-your-own.html">Optimize your own</a>

--- a/site/benchmarks.fixture.json
+++ b/site/benchmarks.fixture.json
@@ -1,0 +1,15 @@
+[
+  {"schema":1,"run_id":123,"run_url":"https://github.com/skillberry-ai/cap-evolve/actions/runs/123",
+   "bench":"tau2","event":"pull_request","source":"PR #55","pr":55,
+   "branch":"feature/skill-tool-optimization-knowledge","sha":"abc1234","date":"2026-07-23T13:50:51Z",
+   "iterations":1,"agent_model":"aws/gpt-oss-120b","optimizer_model":"claude-opus-4-8","conclusion":"success",
+   "suite":{"reward_base":0.0,"reward_opt":0.5,"flips":1,"n":2,"optimizer_usd":0.12},
+   "tasks":[
+     {"task":"35","reward_baseline":0.0,"reward_opt":1.0,"flipped":true,"latency_baseline_s":10.0,"latency_opt_s":11.0,"cost_opt_runner_usd":0.0,"optimizer_usd":0.06,"iterations":1},
+     {"task":"37","reward_baseline":0.0,"reward_opt":0.0,"flipped":false,"latency_baseline_s":9.0,"latency_opt_s":9.5,"cost_opt_runner_usd":0.0,"optimizer_usd":0.06,"iterations":1}]},
+  {"schema":1,"run_id":124,"run_url":"https://github.com/skillberry-ai/cap-evolve/actions/runs/124",
+   "bench":"swebench","event":"workflow_dispatch","source":"manual (main)","pr":null,
+   "branch":"main","sha":"def5678","date":"2026-07-22T09:00:00Z",
+   "iterations":1,"agent_model":"aws/gpt-oss-120b","optimizer_model":"claude-opus-4-8","conclusion":"failure",
+   "suite":null,"tasks":[]}
+]

--- a/site/benchmarks.html
+++ b/site/benchmarks.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Benchmark runs — cap-evolve</title>
+  <meta name="description" content="Every ci/benchmarks execution (tau2 · swebench · skillsbench), on PRs and manual runs — a sortable, filterable log of reward, flips, latency and cost vs the frozen baseline.">
+  <link rel="canonical" href="https://skillberry-ai.github.io/cap-evolve/benchmarks.html">
+  <meta property="og:type" content="article">
+  <meta property="og:site_name" content="cap-evolve">
+  <meta property="og:title" content="Benchmark runs — cap-evolve">
+  <meta property="og:description" content="A sortable, filterable log of every ci/benchmarks execution (PR + manual runs), with per-task detail.">
+  <meta property="og:url" content="https://skillberry-ai.github.io/cap-evolve/benchmarks.html">
+  <meta property="og:image" content="https://skillberry-ai.github.io/cap-evolve/assets/dashboard.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Benchmark runs — cap-evolve">
+  <meta name="twitter:description" content="A sortable, filterable log of every ci/benchmarks execution (PR + manual runs), with per-task detail.">
+  <meta name="twitter:image" content="https://skillberry-ai.github.io/cap-evolve/assets/dashboard.png">
+  <link rel="preconnect" href="https://rsms.me/">
+  <link rel="stylesheet" href="https://rsms.me/inter/inter.css">
+  <link rel="stylesheet" href="style.css?v=20260721-2">
+</head>
+<body>
+
+<nav class="nav">
+  <div class="nav-inner">
+    <a class="nav-brand" href="./"><img src="assets/logo.png" alt="" class="nav-brand-logo" aria-hidden="true">cap-evolve</a>
+    <div class="nav-links">
+      <a href="getting-started.html">Getting started</a>
+      <a href="results.html">Results</a>
+      <a href="benchmarks.html" class="active">Benchmark runs</a>
+      <a href="architecture.html">Architecture</a>
+      <a href="agent-orchestration.html">Agent mode</a>
+      <a href="optimize-your-own.html">Optimize your own</a>
+      <a href="adapter-templates.html">Adapter templates</a>
+      <a class="gh" href="https://github.com/skillberry-ai/cap-evolve">GitHub</a>
+    </div>
+  </div>
+</nav>
+
+<main class="page doc">
+
+  <h1>Benchmark runs</h1>
+  <p class="lead">
+    Every <code>ci/benchmarks</code> execution (tau2 · swebench · skillsbench), on PRs and manual
+    runs. Each row is one benchmark in one run vs the frozen baseline; click to expand its
+    per-task detail. <span id="updated" class="muted"></span>
+  </p>
+  <p>
+    See the hand-verified canonical numbers on the <a href="results.html">Results</a> page; this
+    is the raw CI log. Failed/cancelled runs are shown too, so infra breakage is visible.
+  </p>
+
+  <div class="filters">
+    <label>Benchmark
+      <select id="f-bench"><option value="">all</option><option>tau2</option><option>swebench</option><option>skillsbench</option></select>
+    </label>
+    <label>Source
+      <select id="f-source"><option value="">all</option><option value="pr">PR</option><option value="manual">manual</option></select>
+    </label>
+    <label>Result
+      <select id="f-conc"><option value="">all</option><option>success</option><option>failure</option><option>cancelled</option></select>
+    </label>
+    <label>Search
+      <input id="f-q" type="search" placeholder="branch or task…">
+    </label>
+  </div>
+
+  <table id="runs">
+    <thead><tr>
+      <th data-k="date">Date</th>
+      <th data-k="source">Source</th>
+      <th data-k="bench">Bench</th>
+      <th data-k="iterations">Iters</th>
+      <th data-k="reward">Reward base→opt</th>
+      <th data-k="flips">Flips</th>
+      <th data-k="optimizer_usd">Optimizer $</th>
+      <th data-k="conclusion">Result</th>
+    </tr></thead>
+    <tbody id="rows"></tbody>
+  </table>
+  <p id="empty" class="muted" hidden>No runs recorded yet — trigger the suite (add the
+    <code>benchmark-test</code> label to a PR, or Actions → Benchmarks).</p>
+  <p id="error" class="muted" hidden>Couldn't load benchmark history.</p>
+
+</main>
+
+<footer class="footer">
+  <div class="footer-inner">
+    <div>
+      Apache-2.0 · beta (0.x) · <em>Optimize agentic capabilities — with agents</em>
+    </div>
+    <div class="footer-affil">
+      <span>Made at</span>
+      <span class="footer-affil-logos">
+        <img src="assets/ibm-logo.svg" alt="IBM" class="logo-ibm">
+        <img src="assets/redhat-logo.svg" alt="Red Hat" class="logo-redhat">
+      </span>
+    </div>
+    <div>
+      <a href="https://github.com/skillberry-ai/cap-evolve">github.com/skillberry-ai/cap-evolve</a>
+    </div>
+  </div>
+</footer>
+
+<script src="benchmarks.js"></script>
+</body>
+</html>

--- a/site/benchmarks.js
+++ b/site/benchmarks.js
@@ -1,0 +1,105 @@
+const RAW = "https://raw.githubusercontent.com/skillberry-ai/cap-evolve/benchmark-history";
+let RECORDS = [], sortKey = "date", sortDir = -1;
+
+const $ = (s) => document.querySelector(s);
+const fmt = (v, d = 3) => (typeof v === "number" ? v.toFixed(d) : "—");
+
+async function load() {
+  try {
+    const [recs, meta] = await Promise.all([
+      fetch(`${RAW}/benchmarks.json?t=${Date.now()}`).then((r) => r.json()),
+      fetch(`${RAW}/meta.json?t=${Date.now()}`).then((r) => r.json()).catch(() => null),
+    ]);
+    RECORDS = Array.isArray(recs) ? recs : [];
+    if (meta && meta.updated) {
+      $("#updated").textContent = `· last updated ${new Date(meta.updated).toLocaleString()}`;
+    }
+    render();
+  } catch (e) {
+    $("#error").hidden = false;
+  }
+}
+
+function passes(r) {
+  const b = $("#f-bench").value, s = $("#f-source").value, c = $("#f-conc").value;
+  const q = $("#f-q").value.toLowerCase();
+  if (b && r.bench !== b) return false;
+  if (s === "pr" && r.event !== "pull_request") return false;
+  if (s === "manual" && r.event === "pull_request") return false;
+  if (c && r.conclusion !== c) return false;
+  if (q) {
+    const hay = `${r.branch || ""} ${(r.tasks || []).map((t) => t.task).join(" ")}`.toLowerCase();
+    if (!hay.includes(q)) return false;
+  }
+  return true;
+}
+
+function sortVal(r, k) {
+  if (k === "reward") return r.suite ? r.suite.reward_opt : -1;
+  if (k === "flips") return r.suite ? r.suite.flips : -1;
+  if (k === "optimizer_usd") return r.suite ? r.suite.optimizer_usd : -1;
+  return r[k] ?? "";
+}
+
+function render() {
+  const rows = RECORDS.filter(passes).sort((a, b) => {
+    const x = sortVal(a, sortKey), y = sortVal(b, sortKey);
+    return (x < y ? -1 : x > y ? 1 : 0) * sortDir;
+  });
+  const tb = $("#rows");
+  tb.innerHTML = "";
+  $("#empty").hidden = rows.length > 0;
+  for (const r of rows) {
+    const tr = document.createElement("tr");
+    tr.className = "run-row";
+    const reward = r.suite ? `${fmt(r.suite.reward_base)} → ${fmt(r.suite.reward_opt)}` : "—";
+    const flips = r.suite ? `${r.suite.flips}/${r.suite.n}` : "—";
+    const usd = r.suite ? `$${fmt(r.suite.optimizer_usd, 4)}` : "—";
+    const src = r.pr
+      ? `<a href="https://github.com/skillberry-ai/cap-evolve/pull/${r.pr}">${r.source}</a>`
+      : (r.source || "—");
+    const badge = `<span class="badge ${r.conclusion}">${r.conclusion}</span>`;
+    const date = (r.date || "").replace("T", " ").replace("Z", "");
+    tr.innerHTML = `<td><a href="${r.run_url}">${date}</a></td>
+      <td>${src}</td><td>${r.bench}</td><td>${r.iterations ?? "—"}</td>
+      <td>${reward}</td><td>${flips}</td><td>${usd}</td><td>${badge}</td>`;
+    tb.appendChild(tr);
+
+    const detail = document.createElement("tr");
+    detail.className = "detail-row";
+    detail.hidden = true;
+    detail.innerHTML = `<td colspan="8">${taskTable(r.tasks || [])}</td>`;
+    tb.appendChild(detail);
+
+    tr.addEventListener("click", (e) => {
+      if (e.target.tagName !== "A") detail.hidden = !detail.hidden;
+    });
+  }
+}
+
+function taskTable(tasks) {
+  if (!tasks.length) return `<em class="muted">no per-task metrics</em>`;
+  const head = `<tr><th>task</th><th>reward base→opt</th><th>flip</th><th>latency (s)</th>` +
+    `<th>runner $</th><th>opt $</th><th>iters</th></tr>`;
+  const body = tasks.map((t) => `<tr><td><code>${t.task}</code></td>
+    <td>${fmt(t.reward_baseline)} → ${fmt(t.reward_opt)}</td>
+    <td>${t.flipped ? "✅" : "—"}</td>
+    <td>${fmt(t.latency_baseline_s, 1)} → ${fmt(t.latency_opt_s, 1)}</td>
+    <td>$${fmt(t.cost_opt_runner_usd, 4)}</td><td>$${fmt(t.optimizer_usd, 4)}</td>
+    <td>${t.iterations ?? "—"}</td></tr>`).join("");
+  return `<table class="detail">${head}${body}</table>`;
+}
+
+document.querySelectorAll("#runs thead th").forEach((th) =>
+  th.addEventListener("click", () => {
+    const k = th.dataset.k;
+    if (!k) return;
+    sortDir = sortKey === k ? -sortDir : -1;
+    sortKey = k;
+    render();
+  })
+);
+["f-bench", "f-source", "f-conc", "f-q"].forEach((id) =>
+  $("#" + id).addEventListener("input", render)
+);
+load();

--- a/site/benchmarks.js
+++ b/site/benchmarks.js
@@ -3,6 +3,8 @@ let RECORDS = [], sortKey = "date", sortDir = -1;
 
 const $ = (s) => document.querySelector(s);
 const fmt = (v, d = 3) => (typeof v === "number" ? v.toFixed(d) : "—");
+const esc = (v) => String(v ?? "").replace(/[&<>"']/g, (c) =>
+  ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
 
 async function load() {
   try {
@@ -56,12 +58,12 @@ function render() {
     const flips = r.suite ? `${r.suite.flips}/${r.suite.n}` : "—";
     const usd = r.suite ? `$${fmt(r.suite.optimizer_usd, 4)}` : "—";
     const src = r.pr
-      ? `<a href="https://github.com/skillberry-ai/cap-evolve/pull/${r.pr}">${r.source}</a>`
-      : (r.source || "—");
-    const badge = `<span class="badge ${r.conclusion}">${r.conclusion}</span>`;
-    const date = (r.date || "").replace("T", " ").replace("Z", "");
-    tr.innerHTML = `<td><a href="${r.run_url}">${date}</a></td>
-      <td>${src}</td><td>${r.bench}</td><td>${r.iterations ?? "—"}</td>
+      ? `<a href="https://github.com/skillberry-ai/cap-evolve/pull/${encodeURIComponent(r.pr)}">${esc(r.source)}</a>`
+      : esc(r.source || "—");
+    const badge = `<span class="badge ${esc(r.conclusion)}">${esc(r.conclusion)}</span>`;
+    const date = esc((r.date || "").replace("T", " ").replace("Z", ""));
+    tr.innerHTML = `<td><a href="${esc(r.run_url)}">${date}</a></td>
+      <td>${src}</td><td>${esc(r.bench)}</td><td>${r.iterations ?? "—"}</td>
       <td>${reward}</td><td>${flips}</td><td>${usd}</td><td>${badge}</td>`;
     tb.appendChild(tr);
 
@@ -81,7 +83,7 @@ function taskTable(tasks) {
   if (!tasks.length) return `<em class="muted">no per-task metrics</em>`;
   const head = `<tr><th>task</th><th>reward base→opt</th><th>flip</th><th>latency (s)</th>` +
     `<th>runner $</th><th>opt $</th><th>iters</th></tr>`;
-  const body = tasks.map((t) => `<tr><td><code>${t.task}</code></td>
+  const body = tasks.map((t) => `<tr><td><code>${esc(t.task)}</code></td>
     <td>${fmt(t.reward_baseline)} → ${fmt(t.reward_opt)}</td>
     <td>${t.flipped ? "✅" : "—"}</td>
     <td>${fmt(t.latency_baseline_s, 1)} → ${fmt(t.latency_opt_s, 1)}</td>

--- a/site/getting-started.html
+++ b/site/getting-started.html
@@ -28,6 +28,7 @@
     <div class="nav-links">
       <a href="getting-started.html" class="active">Getting started</a>
       <a href="results.html">Results</a>
+      <a href="benchmarks.html">Benchmark runs</a>
       <a href="architecture.html">Architecture</a>
       <a href="agent-orchestration.html">Agent mode</a>
       <a href="optimize-your-own.html">Optimize your own</a>

--- a/site/index.html
+++ b/site/index.html
@@ -29,6 +29,7 @@
     <div class="nav-links">
       <a href="getting-started.html">Getting started</a>
       <a href="results.html">Results</a>
+      <a href="benchmarks.html">Benchmark runs</a>
       <a href="architecture.html">Architecture</a>
       <a href="agent-orchestration.html">Agent mode</a>
       <a href="optimize-your-own.html">Optimize your own</a>

--- a/site/optimize-your-own.html
+++ b/site/optimize-your-own.html
@@ -28,6 +28,7 @@
     <div class="nav-links">
       <a href="getting-started.html">Getting started</a>
       <a href="results.html">Results</a>
+      <a href="benchmarks.html">Benchmark runs</a>
       <a href="architecture.html">Architecture</a>
       <a href="agent-orchestration.html">Agent mode</a>
       <a href="optimize-your-own.html" class="active">Optimize your own</a>

--- a/site/results.html
+++ b/site/results.html
@@ -28,6 +28,7 @@
     <div class="nav-links">
       <a href="getting-started.html">Getting started</a>
       <a href="results.html" class="active">Results</a>
+      <a href="benchmarks.html">Benchmark runs</a>
       <a href="architecture.html">Architecture</a>
       <a href="agent-orchestration.html">Agent mode</a>
       <a href="optimize-your-own.html">Optimize your own</a>

--- a/site/style.css
+++ b/site/style.css
@@ -707,13 +707,13 @@ table code {
 
 /* Benchmark runs history page */
 .filters { display: flex; flex-wrap: wrap; gap: 1rem; margin: 1rem 0; }
-.filters label { display: flex; flex-direction: column; font-size: .8rem; color: #555; gap: .25rem; }
+.filters label { display: flex; flex-direction: column; font-size: .8rem; color: var(--muted); gap: .25rem; }
 .run-row { cursor: pointer; }
-.run-row:hover { background: #f6f8fa; }
-.detail-row > td { background: #fafbfc; padding: .5rem 1rem; }
+.run-row:hover { background: var(--bg-soft); }
+.detail-row > td { background: var(--bg-soft); padding: .5rem 1rem; }
 table.detail { width: 100%; font-size: .85rem; }
 .badge { padding: .1rem .5rem; border-radius: 999px; font-size: .75rem; font-weight: 600; }
-.badge.success { background: #d5f5e3; color: #1e7a46; }
+.badge.success { background: var(--success-soft); color: var(--success); }
 .badge.failure { background: #fbdcdc; color: #a12; }
-.badge.cancelled { background: #eee; color: #666; }
-.muted { color: #777; font-weight: 400; }
+.badge.cancelled { background: var(--bg-code); color: var(--muted); }
+.muted { color: var(--muted); font-weight: 400; }

--- a/site/style.css
+++ b/site/style.css
@@ -704,3 +704,16 @@ table code {
   table th, table td { padding: 0.55rem 0.5rem; }
   .footer-inner { flex-direction: column; }
 }
+
+/* Benchmark runs history page */
+.filters { display: flex; flex-wrap: wrap; gap: 1rem; margin: 1rem 0; }
+.filters label { display: flex; flex-direction: column; font-size: .8rem; color: #555; gap: .25rem; }
+.run-row { cursor: pointer; }
+.run-row:hover { background: #f6f8fa; }
+.detail-row > td { background: #fafbfc; padding: .5rem 1rem; }
+table.detail { width: 100%; font-size: .85rem; }
+.badge { padding: .1rem .5rem; border-radius: 999px; font-size: .75rem; font-weight: 600; }
+.badge.success { background: #d5f5e3; color: #1e7a46; }
+.badge.failure { background: #fbdcdc; color: #a12; }
+.badge.cancelled { background: #eee; color: #666; }
+.muted { color: #777; font-weight: 400; }


### PR DESCRIPTION
Closes #74.

## Summary
Adds a durable, forward-only log of every `ci/benchmarks` execution (PR + manual runs, whole-suite or single) and publishes it as a sortable/filterable page at `/benchmarks.html`.

- **`ci/benchmarks/lib/record.py`** (+ tests) — pure `build_record`/`rollup`/`aggregate`; turns a suite's `metrics.jsonl` + run metadata into one per-`(run×bench)` record and concatenates records into `benchmarks.json`.
- **`benchmarks.yml`** — each bench job writes `runmeta.json` into its artifact; a new single-writer `aggregate` job (`needs: [bench]`, `if: always()`) pushes per-run records + a regenerated `benchmarks.json`/`meta.json` to a **`benchmark-history`** orphan branch (clone + rebase-retry → no races). Runs on `ubuntu-latest` (JSON + git only).
- **`site/benchmarks.html` + `benchmarks.js`** — vanilla, no-build; fetches `benchmarks.json` from the history branch (cache-busted), renders rollup rows that expand to per-task detail; sort on any column; filter by bench/source/result + text search. Nav link added to all pages. Failed/cancelled runs show as red/grey badge rows so infra breakage stays visible.

## Design decisions
- **Approach 1** (per the design doc): data on a dedicated `benchmark-history` orphan branch, client-side fetch — keeps `main` history clean and the page fresh with no redeploy.
- **Forward-only**: no backfill (past PR runs were mostly `skipped`; artifacts expire).
- One record per `(run×bench)` so partial suites and manual runs slot in naturally.

## Testing
- `python3 -m pytest ci/benchmarks/lib/test_record.py` — 6 passing (rollup math, success/failure/partial, aggregate sort+counts).
- Aggregate CLI validated end-to-end on a fixture; `benchmarks.yml` YAML-linted (jobs `bench`, `aggregate`).
- Page render/filter/sort/expand + empty/error states exercised against `site/benchmarks.fixture.json` via a DOM stub; `benchmarks.js` passes `node --check`.

## Notes
- The `benchmark-history` orphan branch is already bootstrapped (empty `benchmarks.json`). Once merged, Pages redeploys and `/benchmarks.html` shows "no runs yet" until the next benchmark run's `aggregate` job populates it.
- The `aggregate` job pushes with `GITHUB_TOKEN` (`contents: write`); if branch/org policy blocks it, relax that policy. Fork PRs are already blocked by the existing fork guard.

Signed-off-by: Eran Raichstein <eranra@il.ibm.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)