### PR TITLE
feat(bench): per-benchmark smoke labels + first-class test tier

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -37,7 +37,7 @@ on:
 
 jobs:
   bench:
-    name: ${{ matrix.bench }}
+    name: ${{ matrix.tier }} / ${{ matrix.bench }}
     runs-on: [self-hosted, ibm-vpc]
     # Repo default token is read-only; the "Comment results on the PR" step needs write.
     permissions:
@@ -45,34 +45,45 @@ jobs:
       pull-requests: write
       issues: write
     # Fork guard: never run PR code from a fork on the self-hosted runner.
+    # PR trigger: any label containing 'benchmark-smoke' (the all-label or a per-bench one).
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name == github.repository &&
-        contains(github.event.pull_request.labels.*.name, 'benchmark-test'))
+        contains(join(github.event.pull_request.labels.*.name, ','), 'benchmark-smoke'))
     strategy:
       fail-fast: false
       matrix:
+        # tier is a first-class dimension: smoke now, full later (same workflow + page).
+        tier: [smoke]
         bench: [tau2, swebench, skillsbench]
     concurrency:
-      group: benchmarks-${{ matrix.bench }}-${{ github.ref }}
+      group: benchmarks-${{ matrix.tier }}-${{ matrix.bench }}-${{ github.ref }}
       cancel-in-progress: true
     env:
       ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
       ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
       ITERATIONS: ${{ github.event.inputs.iterations || '3' }}
+      TIER: ${{ matrix.tier }}
     steps:
       - uses: actions/checkout@v4
 
-      - name: Gate (skip unselected benchmark on manual dispatch)
+      - name: Gate (decide whether this tier/bench runs)
         id: gate
+        env:
+          # exact-match label checks (evaluated by Actions, not the shell)
+          HAS_ALL: ${{ contains(github.event.pull_request.labels.*.name, 'benchmark-smoke') }}
+          HAS_THIS: ${{ contains(github.event.pull_request.labels.*.name, format('benchmark-smoke-{0}', matrix.bench)) }}
         run: |
-          sel="${{ github.event.inputs.benchmark || 'all' }}"
-          if [ "$sel" != "all" ] && [ "$sel" != "${{ matrix.bench }}" ]; then
-            echo "run=false" >> "$GITHUB_OUTPUT"
+          run=false
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            sel="${{ github.event.inputs.benchmark || 'all' }}"
+            if [ "$sel" = "all" ] || [ "$sel" = "${{ matrix.bench }}" ]; then run=true; fi
           else
-            echo "run=true" >> "$GITHUB_OUTPUT"
+            # pull_request: benchmark-smoke (all) OR benchmark-smoke-<bench>
+            if [ "$HAS_ALL" = "true" ] || [ "$HAS_THIS" = "true" ]; then run=true; fi
           fi
+          echo "run=$run" >> "$GITHUB_OUTPUT"
 
       - name: Setup runner env
         if: steps.gate.outputs.run == 'true'
@@ -97,6 +108,7 @@ jobs:
             "run_id": ${{ github.run_id }},
             "run_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
             "bench": "${{ matrix.bench }}",
+            "tier": "${{ matrix.tier }}",
             "event": "${{ github.event_name }}",
             "source": "$source",
             "pr": $pr,

--- a/ci/benchmarks/README.md
+++ b/ci/benchmarks/README.md
@@ -69,9 +69,18 @@ repo → Settings → Actions → Runners with the `ibm-vpc` label.
 
 ## Trigger the suite
 
+The suite runs a **smoke** tier today (2 hard tasks per benchmark). `tier` is a first-class
+dimension in the workflow (`smoke` now; `full` can be added later to the same workflow and the
+same history page). Runs surface the tier everywhere: the PR checks read **`smoke / <bench>`**,
+the report header reads **`## Smoke suite — <bench>`**, and the history page has a **Type** column.
+
 - **Manually:** Actions → **Benchmarks** → Run workflow → pick `all` or one benchmark.
-- **On a PR:** add the **`benchmark-test`** label (the tau2 pipeline regression is the
-  **`integration-test`** label / **Integration tests** workflow).
+- **On a PR — labels:**
+  - **`benchmark-smoke`** → run all three smoke benchmarks.
+  - **`benchmark-smoke-tau2`** / **`benchmark-smoke-swebench`** / **`benchmark-smoke-skillsbench`** →
+    run just that one (combine labels to run a subset).
+
+  (The tau2 pipeline regression is the **`integration-test`** label / **Integration tests** workflow.)
 
 Repo secrets required: `ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN`.
 

--- a/ci/benchmarks/lib/run_suite.sh
+++ b/ci/benchmarks/lib/run_suite.sh
@@ -59,8 +59,9 @@ PY
 done <<< "$ids_tags"
 
 # render the report
+KIND="${TIER:-smoke}"
 {
-  echo "## Benchmark suite — $BENCH"
+  echo "## ${KIND^} suite — $BENCH"
   echo
   echo "Agent \`aws/gpt-oss-120b\` · optimizer Claude Code \`claude-opus-4-8\` · ${ITERATIONS:-3} iteration(s) · baselines frozen (reused)."
   echo

--- a/ci/benchmarks/lib/test_record.py
+++ b/ci/benchmarks/lib/test_record.py
@@ -58,3 +58,14 @@ def test_aggregate_sorts_and_counts(tmp_path):
     recs, meta = record.aggregate(d, now="2026-07-23T09:00:00Z")
     assert [r["run_id"] for r in recs] == [2, 1]  # newest first
     assert meta == {"count": 2, "runs": 2, "updated": "2026-07-23T09:00:00Z"}
+
+
+def test_build_preserves_tier(tmp_path):
+    m = tmp_path / "metrics.jsonl"; _write_jsonl(m, [TASK_OK])
+    rec = record.build_record(m, {"run_id": 9, "bench": "tau2", "tier": "smoke",
+                                   "conclusion": "success", "date": "d"})
+    assert rec["tier"] == "smoke"
+    # tier absent -> not fabricated (the page defaults missing tier to "smoke" at render)
+    rec2 = record.build_record(m, {"run_id": 9, "bench": "tau2",
+                                    "conclusion": "success", "date": "d"})
+    assert "tier" not in rec2

--- a/docs/superpowers/specs/2026-07-24-smoke-labels-and-tiering-design.md
+++ b/docs/superpowers/specs/2026-07-24-smoke-labels-and-tiering-design.md
@@ -1,0 +1,94 @@
+# Smoke labels + test tiering — Design
+
+**Date:** 2026-07-24
+**Status:** Approved design, pre-implementation
+**Branch:** `feat/smoke-labels-and-tiering`
+
+## Problem
+
+Two gaps in the `ci/benchmarks` workflow:
+1. On a PR, the single `benchmark-test` label runs **all three** benchmarks — no way to run just one.
+2. The suite is a **smoke** regression (2 hard tasks per benchmark), but nothing in the labels,
+   checks, report, or history page says so — it reads like the full benchmark.
+
+Additionally, **full** (non-smoke) tests will later be added to the **same** `Benchmarks`
+workflow and the **same** history page. So "smoke" must be a *tier*, not the identity of the
+workflow/page.
+
+## Goals
+
+- Per-benchmark PR selection via labels.
+- Mark smoke runs as smoke **everywhere they surface**, while keeping the workflow named
+  `Benchmarks` and the history page shared across tiers.
+- Leave clean seams so a future `full` tier drops in with minimal change.
+
+## Decisions (confirmed)
+
+- **Labels:** rename `benchmark-test` → **`benchmark-smoke`** (all); add
+  **`benchmark-smoke-tau2` / `-swebench` / `-skillsbench`** (per-bench, combinable).
+  Future full tier mirrors as `benchmark-full*`.
+- **Tier is a first-class dimension:** `smoke` now, `full` later — not a global rename.
+- Workflow name stays **`Benchmarks`**; history page title/nav stay **`Benchmarks`**.
+
+## Design
+
+### Labels (repo state, via `gh`)
+- `gh label edit benchmark-test --name benchmark-smoke` (in-place → migrates PR #55's label).
+- `gh label create benchmark-smoke-{tau2,swebench,skillsbench}`.
+
+### `.github/workflows/benchmarks.yml`
+- `name: Benchmarks` unchanged.
+- Matrix gains a tier dimension (only smoke today):
+  ```yaml
+  matrix:
+    tier: [smoke]
+    bench: [tau2, swebench, skillsbench]
+  ```
+- Job name → `${{ matrix.tier }} / ${{ matrix.bench }}` → PR checks read **`smoke / tau2`**.
+- `concurrency.group` includes tier.
+- Job-level `if` (PR path): run when any label contains the tier prefix —
+  `contains(join(github.event.pull_request.labels.*.name, ','), 'benchmark-smoke')`
+  (matches both `benchmark-smoke` and `benchmark-smoke-<bench>`).
+- Per-matrix `Gate` step sets `run`:
+  - `workflow_dispatch`: existing `inputs.benchmark` (all / one), unchanged.
+  - `pull_request`: run if labels contain `benchmark-smoke` **or**
+    `format('benchmark-smoke-{0}', matrix.bench)`.
+- `Write run metadata` step adds `"tier": "${{ matrix.tier }}"` to `runmeta.json`.
+- `TIER: ${{ matrix.tier }}` in job env, passed to `run_suite.sh`.
+
+### `ci/benchmarks/lib/run_suite.sh`
+- Report header tier-driven: `## ${TIER^} suite — $BENCH` → `## Smoke suite — tau2`
+  (falls back to `smoke` if `TIER` unset).
+
+### `ci/benchmarks/lib/record.py`
+- No code change: `build_record` already merges `runmeta` verbatim, so `tier` flows into the
+  record. Add a unit test asserting `tier` passthrough + a default when absent.
+
+### `site/benchmarks.html` + `benchmarks.js`
+- Title / nav / H1 stay **"Benchmarks"** (shared across tiers).
+- Add a **"Type"** column (renders `r.tier || 'smoke'`) and a **tier filter**
+  (all / smoke / full).
+- Update the empty-state hint: `benchmark-test` → `benchmark-smoke`.
+- Lead copy notes runs are smoke or full.
+
+### `ci/benchmarks/README.md`
+- Trigger section: `benchmark-smoke` (all) + per-bench labels; note the smoke tier and that
+  full is a future tier in the same workflow.
+
+## Not building now (YAGNI — full's shape is unspecified)
+- The `full` task sets / `tasks.json` wiring and `benchmark-full*` labels. Only the seams
+  (tier matrix, tier field, tier-driven names, Type column/filter) are added so full is a
+  small later change.
+
+## Backward compatibility
+- Records already pushed (pre-tier) have no `tier`; the page defaults missing → `smoke`
+  (correct, since all historical runs are smoke).
+- Sticky-comment marker `<!-- benchmarks:<bench> -->` unchanged (no orphaned comments).
+- Renaming the matrix/check name to `smoke / <bench>` changes PR check names; if any branch
+  protection requires the old names, update it (admin available).
+
+## Testing
+- `record.py` unit test: `tier` passthrough + default.
+- YAML lint; extract + run the gate logic mentally / dry-run against label combos.
+- Page: fixture with a smoke + a (hypothetical) full record → Type column + tier filter render;
+  missing-tier record shows "smoke".

--- a/site/benchmarks.fixture.json
+++ b/site/benchmarks.fixture.json
@@ -1,15 +1,20 @@
 [
   {"schema":1,"run_id":123,"run_url":"https://github.com/skillberry-ai/cap-evolve/actions/runs/123",
-   "bench":"tau2","event":"pull_request","source":"PR #55","pr":55,
-   "branch":"feature/skill-tool-optimization-knowledge","sha":"abc1234","date":"2026-07-23T13:50:51Z",
-   "iterations":1,"agent_model":"aws/gpt-oss-120b","optimizer_model":"claude-opus-4-8","conclusion":"success",
+   "bench":"tau2","tier":"smoke","event":"pull_request","source":"PR #55","pr":55,
+   "branch":"feature/x","sha":"abc1234","date":"2026-07-24T13:50:51Z","iterations":3,
+   "agent_model":"aws/gpt-oss-120b","optimizer_model":"claude-opus-4-8","conclusion":"success",
    "suite":{"reward_base":0.0,"reward_opt":0.5,"flips":1,"n":2,"optimizer_usd":0.12},
    "tasks":[
-     {"task":"35","reward_baseline":0.0,"reward_opt":1.0,"flipped":true,"latency_baseline_s":10.0,"latency_opt_s":11.0,"cost_opt_runner_usd":0.0,"optimizer_usd":0.06,"iterations":1},
-     {"task":"37","reward_baseline":0.0,"reward_opt":0.0,"flipped":false,"latency_baseline_s":9.0,"latency_opt_s":9.5,"cost_opt_runner_usd":0.0,"optimizer_usd":0.06,"iterations":1}]},
+     {"task":"35","reward_baseline":0.0,"reward_opt":1.0,"flipped":true,"latency_baseline_s":10.0,"latency_opt_s":11.0,"cost_opt_runner_usd":0.0,"optimizer_usd":0.06,"iterations":3},
+     {"task":"37","reward_baseline":0.0,"reward_opt":0.0,"flipped":false,"latency_baseline_s":9.0,"latency_opt_s":9.5,"cost_opt_runner_usd":0.0,"optimizer_usd":0.06,"iterations":3}]},
   {"schema":1,"run_id":124,"run_url":"https://github.com/skillberry-ai/cap-evolve/actions/runs/124",
-   "bench":"swebench","event":"workflow_dispatch","source":"manual (main)","pr":null,
-   "branch":"main","sha":"def5678","date":"2026-07-22T09:00:00Z",
-   "iterations":1,"agent_model":"aws/gpt-oss-120b","optimizer_model":"claude-opus-4-8","conclusion":"failure",
+   "bench":"swebench","tier":"full","event":"workflow_dispatch","source":"manual (main)","pr":null,
+   "branch":"main","sha":"def5678","date":"2026-07-23T09:00:00Z","iterations":5,
+   "agent_model":"aws/gpt-oss-120b","optimizer_model":"claude-opus-4-8","conclusion":"success",
+   "suite":{"reward_base":0.2,"reward_opt":0.4,"flips":0,"n":10,"optimizer_usd":1.10},"tasks":[]},
+  {"schema":1,"run_id":100,"run_url":"https://github.com/skillberry-ai/cap-evolve/actions/runs/100",
+   "bench":"skillsbench","event":"workflow_dispatch","source":"manual (main)","pr":null,
+   "branch":"main","sha":"0000000","date":"2026-07-20T00:00:00Z","iterations":3,
+   "agent_model":"aws/gpt-oss-120b","optimizer_model":"claude-opus-4-8","conclusion":"failure",
    "suite":null,"tasks":[]}
 ]

--- a/site/benchmarks.html
+++ b/site/benchmarks.html
@@ -53,7 +53,8 @@
     <h1>Benchmark runs</h1>
     <p class="lead">
       Every <code>ci/benchmarks</code> execution (tau2 · swebench · skillsbench), on PRs and manual
-      runs. Each row is one benchmark in one run vs the frozen baseline; click to expand its
+      runs. Each row is one benchmark in one run vs the frozen baseline; the <strong>Type</strong>
+      column marks the tier (<code>smoke</code> or <code>full</code>). Click a row to expand its
       per-task detail. <span id="updated" class="muted"></span>
     </p>
     <p>
@@ -65,6 +66,9 @@
   <div class="filters">
     <label>Benchmark
       <select id="f-bench"><option value="">all</option><option>tau2</option><option>swebench</option><option>skillsbench</option></select>
+    </label>
+    <label>Type
+      <select id="f-tier"><option value="">all</option><option>smoke</option><option>full</option></select>
     </label>
     <label>Source
       <select id="f-source"><option value="">all</option><option value="pr">PR</option><option value="manual">manual</option></select>
@@ -82,6 +86,7 @@
       <th data-k="date">Date</th>
       <th data-k="source">Source</th>
       <th data-k="bench">Bench</th>
+      <th data-k="tier">Type</th>
       <th data-k="iterations">Iters</th>
       <th data-k="reward">Reward base→opt</th>
       <th data-k="flips">Flips</th>
@@ -90,8 +95,8 @@
     </tr></thead>
     <tbody id="rows"></tbody>
   </table>
-  <p id="empty" class="muted" hidden>No runs recorded yet — trigger the suite (add the
-    <code>benchmark-test</code> label to a PR, or Actions → Benchmarks).</p>
+  <p id="empty" class="muted" hidden>No runs recorded yet — trigger the suite (add a
+    <code>benchmark-smoke</code> label to a PR, or Actions → Benchmarks).</p>
   <p id="error" class="muted" hidden>Couldn't load benchmark history.</p>
 
 </main>

--- a/site/benchmarks.js
+++ b/site/benchmarks.js
@@ -24,8 +24,10 @@ async function load() {
 
 function passes(r) {
   const b = $("#f-bench").value, s = $("#f-source").value, c = $("#f-conc").value;
+  const t = $("#f-tier").value;
   const q = $("#f-q").value.toLowerCase();
   if (b && r.bench !== b) return false;
+  if (t && (r.tier || "smoke") !== t) return false;
   if (s === "pr" && r.event !== "pull_request") return false;
   if (s === "manual" && r.event === "pull_request") return false;
   if (c && r.conclusion !== c) return false;
@@ -40,6 +42,7 @@ function sortVal(r, k) {
   if (k === "reward") return r.suite ? r.suite.reward_opt : -1;
   if (k === "flips") return r.suite ? r.suite.flips : -1;
   if (k === "optimizer_usd") return r.suite ? r.suite.optimizer_usd : -1;
+  if (k === "tier") return r.tier || "smoke";
   return r[k] ?? "";
 }
 
@@ -62,15 +65,16 @@ function render() {
       : esc(r.source || "—");
     const badge = `<span class="badge ${esc(r.conclusion)}">${esc(r.conclusion)}</span>`;
     const date = esc((r.date || "").replace("T", " ").replace("Z", ""));
+    const tier = esc(r.tier || "smoke");
     tr.innerHTML = `<td><a href="${esc(r.run_url)}">${date}</a></td>
-      <td>${src}</td><td>${esc(r.bench)}</td><td>${r.iterations ?? "—"}</td>
+      <td>${src}</td><td>${esc(r.bench)}</td><td>${tier}</td><td>${r.iterations ?? "—"}</td>
       <td>${reward}</td><td>${flips}</td><td>${usd}</td><td>${badge}</td>`;
     tb.appendChild(tr);
 
     const detail = document.createElement("tr");
     detail.className = "detail-row";
     detail.hidden = true;
-    detail.innerHTML = `<td colspan="8">${taskTable(r.tasks || [])}</td>`;
+    detail.innerHTML = `<td colspan="9">${taskTable(r.tasks || [])}</td>`;
     tb.appendChild(detail);
 
     tr.addEventListener("click", (e) => {
@@ -101,7 +105,7 @@ document.querySelectorAll("#runs thead th").forEach((th) =>
     render();
   })
 );
-["f-bench", "f-source", "f-conc", "f-q"].forEach((id) =>
+["f-bench", "f-tier", "f-source", "f-conc", "f-q"].forEach((id) =>
   $("#" + id).addEventListener("input", render)
 );
 load();


### PR DESCRIPTION
Closes #79.

## Summary
Adds per-benchmark PR selection and makes **tier** (smoke now, full later) a first-class dimension — while keeping the workflow named **Benchmarks** and the history page shared across tiers.

### Labels
- Renamed `benchmark-test` → **`benchmark-smoke`** (all three).
- Added **`benchmark-smoke-tau2` / `-swebench` / `-skillsbench`** (per-bench, combinable).

### Workflow (`benchmarks.yml`) — name stays `Benchmarks`
- Matrix gains `tier: [smoke]`; job/check name → **`smoke / <bench>`**.
- Job `if` (PR): any label containing `benchmark-smoke`.
- Per-matrix gate: run a bench when `benchmark-smoke` (all) **or** `benchmark-smoke-<bench>` is present; `workflow_dispatch` selection unchanged.
- `runmeta.json` + each record carry `tier`; `TIER` env passed to the suite.

### Results surface 'smoke'
- Report header tier-driven: **`## Smoke suite — <bench>`** (`run_suite.sh`).
- History page keeps title **Benchmarks**; adds a **Type** column + tier filter (missing tier renders as `smoke`).

### Docs / tests
- `ci/benchmarks/README.md` trigger section rewritten for the new labels + tier framing.
- `record.py` tier passthrough test (7 passing); fixture extended with smoke/full/missing-tier records.

## Not built now (YAGNI — full's shape unspecified)
The actual `full` task sets and `benchmark-full*` labels. Only the seams (tier matrix, tier field, tier-driven names, Type column/filter) are added so full drops in with a small change.

## Testing
- `python3 -m pytest ci/benchmarks/lib/test_record.py` → 7 passed.
- `benchmarks.yml` YAML-lints (matrix `{tier:[smoke],bench:[…]}`, name `${{ matrix.tier }} / ${{ matrix.bench }}`); `run_suite.sh` passes `bash -n` (header → `## Smoke suite — tau2`); `benchmarks.js` passes `node --check`.
- DOM-stub render test: smoke/full/missing-tier fixture → Type cells correct, missing tier → 'smoke', detail `colspan=9`.
- Labels created/renamed on the repo.

Signed-off-by: Eran Raichstein <eranra@il.ibm.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)