### PR TITLE
fix(site): show custom From/To only for Time=Custom; cache-bust benchmarks.js

### DIFF
--- a/site/benchmarks.html
+++ b/site/benchmarks.html
@@ -136,7 +136,7 @@
   </div>
 </footer>
 
-<script src="benchmarks.js"></script>
+<script src="benchmarks.js?v=20260724b"></script>
 <script src="js/site.js?v=20260724" defer></script>
 </body>
 </html>

--- a/site/style.css
+++ b/site/style.css
@@ -601,6 +601,7 @@ html.js .reveal-3 { transition-delay: 0.16s; }
 
 .filters { display: flex; flex-wrap: wrap; gap: 1rem; margin: 1.5rem 0; }
 .filters label { display: flex; flex-direction: column; font-size: 0.78rem; color: var(--muted); gap: 0.25rem; }
+.filters label[hidden] { display: none; }   /* custom From/To hidden unless Time = Custom (beats display:flex above) */
 .filters select, .filters input {
   font: inherit; font-size: 0.88rem; padding: 0.4rem 0.6rem;
   background: var(--bg-soft); color: var(--ink);


### PR DESCRIPTION
Closes #85.

## Summary
Two small fixes to the benchmark history page's time filter:

1. **Custom From/To leaked into every preset.** `.filters label { display: flex }` overrode the `hidden` attribute on the custom-range labels, so From/To showed for `Last 1 hour`/`24 hours`/etc. Added `.filters label[hidden] { display: none; }` (higher specificity) — the datetime inputs now appear **only when Time = Custom…**.
2. **Stale `benchmarks.js`.** The script tag had no `?v=` cache-buster (unlike `style.css`), so after the time-filter shipped, browsers kept running the cached pre-filter JS — changing Time appeared to do nothing until a hard refresh. Added `?v=20260724b`.

## Testing
- `hidden` attr present on `#f-from-wrap`/`#f-to-wrap`; new CSS rule (specificity 0,2,1) beats `.filters label` (0,1,1) so it wins by both specificity and order.
- Confirmed live that Time filtering works after a hard refresh (the reporter verified) — this cache-bust makes that the default going forward.

Signed-off-by: Eran Raichstein <eranra@il.ibm.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)