### PR TITLE
fix(site): bump style.css ?v so #86's From/To hide rule ships

### DIFF
--- a/site/adapter-templates.html
+++ b/site/adapter-templates.html
@@ -24,7 +24,7 @@
   <!-- dark-first: default dark, honor an explicit saved choice. Applied pre-paint (no FOUC) + enables JS-gated reveal -->
   <script>(function(){try{document.documentElement.setAttribute('data-theme',localStorage.getItem('capevolve-theme')||'dark');}catch(e){document.documentElement.setAttribute('data-theme','dark');}document.documentElement.classList.add('js');})();</script>
   <!-- bump the ?v=... string on every style.css edit so browsers ignore their cached copy -->
-  <link rel="stylesheet" href="style.css?v=20260724">
+  <link rel="stylesheet" href="style.css?v=20260724b">
 </head>
 <body>
 

--- a/site/agent-orchestration.html
+++ b/site/agent-orchestration.html
@@ -24,7 +24,7 @@
   <!-- dark-first: default dark, honor an explicit saved choice. Applied pre-paint (no FOUC) + enables JS-gated reveal -->
   <script>(function(){try{document.documentElement.setAttribute('data-theme',localStorage.getItem('capevolve-theme')||'dark');}catch(e){document.documentElement.setAttribute('data-theme','dark');}document.documentElement.classList.add('js');})();</script>
   <!-- bump the ?v=... string on every style.css edit so browsers ignore their cached copy -->
-  <link rel="stylesheet" href="style.css?v=20260724">
+  <link rel="stylesheet" href="style.css?v=20260724b">
 </head>
 <body>
 

--- a/site/architecture.html
+++ b/site/architecture.html
@@ -24,7 +24,7 @@
   <!-- dark-first: default dark, honor an explicit saved choice. Applied pre-paint (no FOUC) + enables JS-gated reveal -->
   <script>(function(){try{document.documentElement.setAttribute('data-theme',localStorage.getItem('capevolve-theme')||'dark');}catch(e){document.documentElement.setAttribute('data-theme','dark');}document.documentElement.classList.add('js');})();</script>
   <!-- bump the ?v=... string on every style.css edit so browsers ignore their cached copy -->
-  <link rel="stylesheet" href="style.css?v=20260724">
+  <link rel="stylesheet" href="style.css?v=20260724b">
 </head>
 <body>
 

--- a/site/benchmarks.html
+++ b/site/benchmarks.html
@@ -24,7 +24,7 @@
   <!-- dark-first: default dark, honor an explicit saved choice. Applied pre-paint (no FOUC) + enables JS-gated reveal -->
   <script>(function(){try{document.documentElement.setAttribute('data-theme',localStorage.getItem('capevolve-theme')||'dark');}catch(e){document.documentElement.setAttribute('data-theme','dark');}document.documentElement.classList.add('js');})();</script>
   <!-- bump the ?v=... string on every style.css edit so browsers ignore their cached copy -->
-  <link rel="stylesheet" href="style.css?v=20260724">
+  <link rel="stylesheet" href="style.css?v=20260724b">
 </head>
 <body>
 

--- a/site/getting-started.html
+++ b/site/getting-started.html
@@ -24,7 +24,7 @@
   <!-- dark-first: default dark, honor an explicit saved choice. Applied pre-paint (no FOUC) + enables JS-gated reveal -->
   <script>(function(){try{document.documentElement.setAttribute('data-theme',localStorage.getItem('capevolve-theme')||'dark');}catch(e){document.documentElement.setAttribute('data-theme','dark');}document.documentElement.classList.add('js');})();</script>
   <!-- bump the ?v=... string on every style.css edit so browsers ignore their cached copy -->
-  <link rel="stylesheet" href="style.css?v=20260724">
+  <link rel="stylesheet" href="style.css?v=20260724b">
 </head>
 <body>
 

--- a/site/index.html
+++ b/site/index.html
@@ -24,7 +24,7 @@
   <!-- dark-first: default dark, honor an explicit saved choice. Applied pre-paint (no FOUC) + enables JS-gated reveal -->
   <script>(function(){try{document.documentElement.setAttribute('data-theme',localStorage.getItem('capevolve-theme')||'dark');}catch(e){document.documentElement.setAttribute('data-theme','dark');}document.documentElement.classList.add('js');})();</script>
   <!-- bump the ?v=... string on every style.css edit so browsers ignore their cached copy -->
-  <link rel="stylesheet" href="style.css?v=20260724">
+  <link rel="stylesheet" href="style.css?v=20260724b">
 </head>
 <body>
 

--- a/site/optimize-your-own.html
+++ b/site/optimize-your-own.html
@@ -24,7 +24,7 @@
   <!-- dark-first: default dark, honor an explicit saved choice. Applied pre-paint (no FOUC) + enables JS-gated reveal -->
   <script>(function(){try{document.documentElement.setAttribute('data-theme',localStorage.getItem('capevolve-theme')||'dark');}catch(e){document.documentElement.setAttribute('data-theme','dark');}document.documentElement.classList.add('js');})();</script>
   <!-- bump the ?v=... string on every style.css edit so browsers ignore their cached copy -->
-  <link rel="stylesheet" href="style.css?v=20260724">
+  <link rel="stylesheet" href="style.css?v=20260724b">
 </head>
 <body>
 

--- a/site/results.html
+++ b/site/results.html
@@ -24,7 +24,7 @@
   <!-- dark-first: default dark, honor an explicit saved choice. Applied pre-paint (no FOUC) + enables JS-gated reveal -->
   <script>(function(){try{document.documentElement.setAttribute('data-theme',localStorage.getItem('capevolve-theme')||'dark');}catch(e){document.documentElement.setAttribute('data-theme','dark');}document.documentElement.classList.add('js');})();</script>
   <!-- bump the ?v=... string on every style.css edit so browsers ignore their cached copy -->
-  <link rel="stylesheet" href="style.css?v=20260724">
+  <link rel="stylesheet" href="style.css?v=20260724b">
 </head>
 <body>
 

--- a/site/run-end-to-end.html
+++ b/site/run-end-to-end.html
@@ -24,7 +24,7 @@
   <!-- dark-first: default dark, honor an explicit saved choice. Applied pre-paint (no FOUC) + enables JS-gated reveal -->
   <script>(function(){try{document.documentElement.setAttribute('data-theme',localStorage.getItem('capevolve-theme')||'dark');}catch(e){document.documentElement.setAttribute('data-theme','dark');}document.documentElement.classList.add('js');})();</script>
   <!-- bump the ?v=... string on every style.css edit so browsers ignore their cached copy -->
-  <link rel="stylesheet" href="style.css?v=20260724">
+  <link rel="stylesheet" href="style.css?v=20260724b">
 </head>
 <body>
 


### PR DESCRIPTION
Closes #87.

## Summary
#86 added `.filters label[hidden] { display: none; }` to `style.css` but didn't bump the `?v=` on the `<link>` tags, so browsers kept serving the **cached** CSS and the custom From/To inputs still appeared for preset time ranges. Bump `style.css?v=20260724` → `?v=20260724b` across all 9 pages.

After Pages redeploys, a normal load fetches the fresh CSS and From/To are hidden unless Time = Custom.

Signed-off-by: Eran Raichstein <eranra@il.ibm.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)