### PR TITLE
feat: num_trials=10 + parallel trials (all benchmarks, both tiers)

### DIFF
--- a/ci/benchmarks/lib/run_task.sh
+++ b/ci/benchmarks/lib/run_task.sh
@@ -56,6 +56,7 @@ LITELLM_PROXY_API_KEY=$ANTHROPIC_AUTH_TOKEN
 MAX_TOKENS=8000
 TEMPERATURE=0.0
 ENV
+    export TAU2_MAX_CONCURRENCY=10        # run_trials pool bound (parallel trials)
     ;;
   swebench)
     cp "$TPL/swe_bench/adapter.py" "$PROJ/adapters/"
@@ -68,9 +69,10 @@ LITELLM_PROXY_API_KEY=$ANTHROPIC_AUTH_TOKEN
 MAX_TOKENS=8000
 TEMPERATURE=0.0
 SWEBENCH_INSTANCE_IDS=$TASK_ID
-SWEBENCH_MAX_WORKERS=1
+SWEBENCH_MAX_WORKERS=10
 SWEBENCH_NAMESPACE=${SWEBENCH_NAMESPACE:-swebench}
 ENV
+    export SWEBENCH_MAX_WORKERS=10        # run_trials generation pool (read at adapter import)
     ;;
   skillsbench)
     cp "$TPL/skillsbench/adapter.py" "$PROJ/adapters/"
@@ -88,10 +90,11 @@ ANTHROPIC_BASE_URL=$ANTHROPIC_BASE_URL
 ANTHROPIC_AUTH_TOKEN=$ANTHROPIC_AUTH_TOKEN
 SKILLSBENCH_MODEL=$AGENT_MODEL
 SKILLSBENCH_TASKS_DIR=$SB_SRC/tasks
-SKILLSBENCH_CONCURRENCY=1
+SKILLSBENCH_CONCURRENCY=10
 ENV
     export SKILLSBENCH_MODEL="$AGENT_MODEL"        # read at adapter import
     export SKILLSBENCH_TASKS_DIR="$SB_SRC/tasks"   # local tasks (avoid remote SHA resolution)
+    export SKILLSBENCH_CONCURRENCY=10              # run_trials pool bound (parallel trials)
     ;;
   *) echo "unknown bench: $BENCH" >&2; exit 2;;
 esac
@@ -109,7 +112,7 @@ algorithm_skill:    hill-climb
 algorithm_focus:    all
 dataset_source:     adapter
 split_ids_file:     "inputs/split_ids.json"
-num_trials:         1
+num_trials:         10
 gate_mode:          paired
 gate_k_se:          1.0
 max_iterations:     $ITER

--- a/core/cap_evolve/__init__.py
+++ b/core/cap_evolve/__init__.py
@@ -21,6 +21,7 @@ from .rundir import Budget, RunDir, Spent
 from .selection import PICKERS, STRATEGIES, pick, validate_strategy
 from .splits import Splits, TestSealError, make_splits
 from .stats import aggregate, bootstrap_ci, combined_stderr, mean, pass_at_k, pass_k, stderr
+from .trials import run_trials_pool
 from .types import Candidate, Rollout, Score, Task
 
 __version__ = "0.1.0"
@@ -53,6 +54,7 @@ __all__ = [
     "pass_at_k",
     "pass_k",
     "stderr",
+    "run_trials_pool",
     "Candidate",
     "Rollout",
     "Score",

--- a/core/cap_evolve/trials.py
+++ b/core/cap_evolve/trials.py
@@ -1,0 +1,61 @@
+"""Concurrent multi-trial helper for adapters.
+
+The harness (``harness._run_and_score``) has a fast path: if an adapter exposes
+``run_trials(tasks, ctx, *, n_trials, base_seed) -> {task_id: [rollout_t0, ...]}``
+it asks for the whole ``task × trial`` grid in one call instead of looping trials
+sequentially. This helper builds that return value by running each ``(task, trial)``
+rollout through the adapter's existing per-rollout function, concurrently, bounded
+by ``max_workers``.
+
+Seed contract (see ``adapter.py``): trial ``k`` runs with ``seed = base_seed + k`` so
+distinct trials are independent draws (honest pass^k + significance gate). Scoring is
+NOT done here — the harness scores each returned rollout, so this only parallelizes
+rollout *generation*.
+"""
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from typing import Callable
+
+from .types import Rollout, Task
+
+
+def run_trials_pool(
+    run_one: Callable[[Task, int], Rollout],
+    tasks: list[Task],
+    *,
+    n_trials: int,
+    base_seed: int,
+    max_workers: int = 1,
+) -> dict[str, list[Rollout]]:
+    """Run the ``task × trial`` grid concurrently and return trial-ordered rollouts.
+
+    ``run_one(task, seed) -> Rollout`` produces ONE rollout. Returns
+    ``{task_id: [rollout_t0, ..., rollout_t{n-1}]}`` (length ``n_trials`` per task,
+    trial order preserved). An exception in ``run_one`` becomes an error ``Rollout``
+    for that ``(task, trial)`` so one bad trial can't sink the batch. ``max_workers``
+    bounds concurrency; ``1`` runs sequentially (identical result, no threads).
+    """
+    n_trials = max(0, int(n_trials))
+    max_workers = max(1, int(max_workers))
+    results: dict[str, list[Rollout]] = {t.id: [None] * n_trials for t in tasks}  # type: ignore[list-item]
+    jobs = [(t, k) for t in tasks for k in range(n_trials)]
+
+    def _one(job):
+        task, k = job
+        try:
+            return task.id, k, run_one(task, base_seed + k)
+        except Exception as e:  # infra error, not a scored failure
+            return task.id, k, Rollout(task_id=task.id, error=f"trial {k} raised: {e}")
+
+    if not jobs:
+        return results
+    if max_workers == 1:
+        for job in jobs:
+            tid, k, rollout = _one(job)
+            results[tid][k] = rollout
+    else:
+        with ThreadPoolExecutor(max_workers=max_workers) as ex:
+            for tid, k, rollout in ex.map(_one, jobs):
+                results[tid][k] = rollout
+    return results

--- a/core/tests/test_trials.py
+++ b/core/tests/test_trials.py
@@ -1,0 +1,44 @@
+"""Tests for the concurrent multi-trial helper (cap_evolve.run_trials_pool)."""
+from cap_evolve import run_trials_pool
+from cap_evolve.types import Rollout, Task
+
+
+def _tasks(ids):
+    return [Task(id=i) for i in ids]
+
+
+def test_shape_and_per_trial_seed_order():
+    def run_one(task, seed):
+        return Rollout(task_id=task.id, output=f"{task.id}:{seed}")
+
+    out = run_trials_pool(run_one, _tasks(["a", "b"]), n_trials=3, base_seed=100, max_workers=1)
+    assert set(out) == {"a", "b"}
+    # trial-ordered; trial k uses seed = base_seed + k
+    assert [r.output for r in out["a"]] == ["a:100", "a:101", "a:102"]
+    assert [r.output for r in out["b"]] == ["b:100", "b:101", "b:102"]
+
+
+def test_concurrent_matches_sequential():
+    def run_one(task, seed):
+        return Rollout(task_id=task.id, output=str(seed))
+
+    seq = run_trials_pool(run_one, _tasks(["x"]), n_trials=5, base_seed=0, max_workers=1)
+    par = run_trials_pool(run_one, _tasks(["x"]), n_trials=5, base_seed=0, max_workers=4)
+    assert [r.output for r in seq["x"]] == [r.output for r in par["x"]] == ["0", "1", "2", "3", "4"]
+
+
+def test_exception_becomes_error_rollout():
+    def run_one(task, seed):
+        if seed == 1:
+            raise RuntimeError("boom")
+        return Rollout(task_id=task.id, output="ok")
+
+    out = run_trials_pool(run_one, _tasks(["a"]), n_trials=3, base_seed=0, max_workers=2)
+    assert out["a"][1].error and "boom" in out["a"][1].error   # the failing trial
+    assert out["a"][0].error is None and out["a"][2].error is None  # neighbours unaffected
+
+
+def test_zero_trials_is_empty_lists():
+    out = run_trials_pool(lambda t, s: Rollout(task_id=t.id), _tasks(["a", "b"]),
+                          n_trials=0, base_seed=0, max_workers=4)
+    assert out == {"a": [], "b": []}

--- a/docs/superpowers/specs/2026-07-24-parallel-trials-design.md
+++ b/docs/superpowers/specs/2026-07-24-parallel-trials-design.md
@@ -1,0 +1,61 @@
+# Parallel multi-trial evaluation — Design
+
+**Date:** 2026-07-24
+**Status:** Approved design, pre-implementation
+**Branch:** `feat/parallel-trials`
+
+## Goal
+
+Default **`num_trials = 10`** for all benchmarks and both tiers (smoke + full), and make
+those trials **run in parallel** (concurrency 10) rather than sequentially.
+
+## Why it's not just a config knob
+
+The harness (`harness._run_and_score`) only parallelizes trials if the adapter implements
+**`run_trials(tasks, ctx, *, n_trials, base_seed) -> {task_id: [rollout_t0, …]}`**; otherwise it
+loops `for k in range(n_trials)` **sequentially**. The CI template adapters
+(`templates/adapters/{tau2_bench,swe_bench,skillsbench}`) did **not** implement it, and CI uses a
+single-task split — so 10 trials would run serially and the existing concurrency knobs
+(`TAU2_MAX_CONCURRENCY`, `SWEBENCH_MAX_WORKERS`, `SKILLSBENCH_CONCURRENCY`), which parallelize
+*tasks within a trial*, had nothing to parallelize.
+
+## Design
+
+### Shared helper (core) — tested once
+`core/cap_evolve/trials.py::run_trials_pool(run_one, tasks, *, n_trials, base_seed, max_workers)`
+runs the whole `task × trial` grid concurrently over the adapter's existing `run_target`,
+returning trial-ordered `{task_id: [rollout_t0, …]}`. Trial `k` uses `seed = base_seed + k`
+(independent draws). Exceptions become error rollouts; `max_workers=1` runs sequentially with an
+identical result. Exported from `cap_evolve`.
+
+### Thin `run_trials` in each template adapter (delegate to the helper)
+- **tau2** — pool bound = `TAU2_MAX_CONCURRENCY`.
+- **swebench** — pool bound = `SWEBENCH_MAX_WORKERS`. Parallelizes patch **generation** only;
+  the harness still scores (Docker eval) each rollout sequentially in `_persist_trial`.
+- **skillsbench** — pool bound = `SKILLSBENCH_CONCURRENCY`. Concurrent `bench eval run`
+  subprocesses stay isolated by the per-seed jobs dir + a unique temp skills dir.
+
+No change to the base `CapabilityAdapter` → **no blast radius** for other adapters/users; the 3
+CI adapters opt in.
+
+### Config (`ci/benchmarks/lib/run_task.sh`)
+- `num_trials: 1 → 10` (applies to baseline, optimize val, and finalize test evals; all benches,
+  both tiers — `run_task.sh` has no tier branching).
+- Export **`TAU2_MAX_CONCURRENCY=10`**, **`SWEBENCH_MAX_WORKERS=10`**, **`SKILLSBENCH_CONCURRENCY=10`**
+  (exported so they reach `os.environ`, matching the existing `export SKILLSBENCH_MODEL` pattern for
+  import-time reads).
+
+## Known follow-up (flagged, NOT in this PR)
+
+Existing frozen baselines — the 6 smoke tasks and the tau2 **full** baselines being frozen now —
+were captured at **`num_trials=1`**. With eval at 10 trials, base→opt comparisons mix a 1-trial
+baseline mean with a 10-trial candidate mean (no baseline variance estimate). For a fully honest
+comparison the baselines should be **re-frozen at `num_trials=10`** on the runner (`freeze_baseline`
+picks up the new `num_trials`). Deferred per the chosen scope ("Full: config + run_trials + conc=10",
+not "+ re-freeze").
+
+## Testing
+- `run_trials_pool` unit tests (shape, per-trial seed order, concurrent==sequential, exception →
+  error rollout, zero trials).
+- Adapters compile; `run_task.sh` lints; `num_trials: 10` + the three exports present.
+- Functional (real models / Docker) verification happens on the next benchmark run on skillberry-1.

--- a/templates/adapters/skillsbench/adapter.py
+++ b/templates/adapters/skillsbench/adapter.py
@@ -149,6 +149,20 @@ class Adapter(CapabilityAdapter):
 
     # ---- running ---------------------------------------------------------
 
+    def run_trials(self, tasks: list[Task], ctx, *, n_trials: int, base_seed: int) -> dict:
+        """Run the whole task×trial grid concurrently (bounded by SKILLSBENCH_CONCURRENCY).
+
+        Each trial runs through run_target with a distinct seed = base_seed + k; the
+        per-seed jobs dir + a unique temp skills dir keep concurrent bench runs isolated.
+        """
+        from cap_evolve import run_trials_pool
+
+        max_workers = int(os.environ.get("SKILLSBENCH_CONCURRENCY", "7"))
+        return run_trials_pool(
+            lambda task, seed: self.run_target(task, ctx, seed=seed),
+            tasks, n_trials=n_trials, base_seed=base_seed, max_workers=max_workers,
+        )
+
     def run_target(self, task: Task, ctx, *, seed: int = 0) -> Rollout:
         """Run ONE SkillsBench task — a thin wrapper over run_batch."""
         return self.run_batch([task], ctx, seed=seed).get(

--- a/templates/adapters/swe_bench/adapter.py
+++ b/templates/adapters/swe_bench/adapter.py
@@ -131,6 +131,19 @@ class Adapter(CapabilityAdapter):
 
     # ---- running ---------------------------------------------------------
 
+    def run_trials(self, tasks: list[Task], ctx, *, n_trials: int, base_seed: int) -> dict:
+        """Generate all task×trial patches concurrently (bounded by SWEBENCH_MAX_WORKERS).
+
+        Parallelizes patch GENERATION only — the harness scores (Docker eval) each
+        returned rollout sequentially. Each trial k uses seed = base_seed + k.
+        """
+        from cap_evolve import run_trials_pool
+
+        return run_trials_pool(
+            lambda task, seed: self.run_target(task, ctx, seed=seed),
+            tasks, n_trials=n_trials, base_seed=base_seed, max_workers=MAX_WORKERS,
+        )
+
     def run_target(self, task: Task, ctx, *, seed: int = 0) -> Rollout:
         """Generate a patch for one SWE-bench instance using litellm.
 

--- a/templates/adapters/tau2_bench/adapter.py
+++ b/templates/adapters/tau2_bench/adapter.py
@@ -250,6 +250,21 @@ class Adapter(CapabilityAdapter):
             },
         )
 
+    def run_trials(self, tasks: list[Task], ctx, *, n_trials: int, base_seed: int) -> dict:
+        """Run the whole task×trial grid concurrently (bounded by TAU2_MAX_CONCURRENCY).
+
+        The harness uses this fast path (instead of looping trials sequentially) to
+        run all num_trials in parallel. Delegates to the shared pool over run_target;
+        each trial k uses seed = base_seed + k (independent draws).
+        """
+        from cap_evolve import run_trials_pool
+
+        max_workers = int(os.environ.get("TAU2_MAX_CONCURRENCY", "100"))
+        return run_trials_pool(
+            lambda task, seed: self.run_target(task, ctx, seed=seed),
+            tasks, n_trials=n_trials, base_seed=base_seed, max_workers=max_workers,
+        )
+
     def run_target(self, task: Task, ctx, *, seed: int = 0) -> Rollout:
         """Run a single task by delegating to run_batch."""
         batch = self.run_batch([task], ctx, seed=seed)


### PR DESCRIPTION
Closes #89.

## Summary
Default **10 trials/task** for all benchmarks and both tiers, running **in parallel** (concurrency 10).

**Why not just config:** the harness only parallelizes trials when an adapter implements `run_trials`; otherwise it loops `for k in range(n_trials)` sequentially, and the CI template adapters didn't implement it (and CI uses single-task splits, so the existing per-task concurrency knobs had nothing to parallelize).

- **core** — `cap_evolve.run_trials_pool(run_one, tasks, *, n_trials, base_seed, max_workers)`: runs the `task × trial` grid concurrently over the adapter's `run_target`, returns trial-ordered `{task_id: [rollout_t0, …]}`; trial `k` uses `seed = base_seed + k`; exceptions → error rollouts; `max_workers=1` is identical to sequential. Exported + unit-tested (4 tests).
- **adapters** — tau2/swebench/skillsbench get a thin `run_trials` delegating to the helper, bounded by each adapter's own concurrency env (`TAU2_MAX_CONCURRENCY` / `SWEBENCH_MAX_WORKERS` / `SKILLSBENCH_CONCURRENCY`). No base-class change → no blast radius for other adapters. (swebench parallelizes patch *generation*; Docker scoring stays sequential in the harness.)
- **run_task.sh** — `num_trials: 1 → 10`; export the three concurrency vars = 10.

## Testing
- `run_trials_pool` unit tests: shape, per-trial seed order, concurrent==sequential, exception→error rollout, zero trials — 4 passing.
- All three adapters + core compile; `run_task.sh` passes `bash -n`; `num_trials: 10` + exports present.
- Functional (real models / Docker) verification via the next benchmark run on skillberry-1.

## Follow-up (flagged, not in this PR)
Existing frozen baselines (6 smoke + the tau2 **full** ones) were captured at `num_trials=1`; with 10-trial eval, base→opt mixes a 1-trial baseline with 10-trial candidates. For a fully honest comparison, **re-freeze baselines at num_trials=10** on the runner. Deferred per the chosen scope.

Signed-off-by: Eran Raichstein <eranra@il.ibm.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)