### PR TITLE
fix(bench): include tier in artifact/suite/record/comment names

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -104,12 +104,12 @@ jobs:
 
       - name: Run suite
         if: steps.gate.outputs.run == 'true'
-        run: bash ci/benchmarks/lib/run_suite.sh "${{ matrix.bench }}" "$GITHUB_WORKSPACE/ci/benchmarks/.work/suite_${{ matrix.bench }}"
+        run: bash ci/benchmarks/lib/run_suite.sh "${{ matrix.bench }}" "$GITHUB_WORKSPACE/ci/benchmarks/.work/suite_${{ matrix.tier }}_${{ matrix.bench }}"
 
       - name: Write run metadata
         if: steps.gate.outputs.run == 'true' && always()
         run: |
-          out="$GITHUB_WORKSPACE/ci/benchmarks/.work/suite_${{ matrix.bench }}"
+          out="$GITHUB_WORKSPACE/ci/benchmarks/.work/suite_${{ matrix.tier }}_${{ matrix.bench }}"
           mkdir -p "$out"
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             source="PR #${{ github.event.pull_request.number }}"; pr="${{ github.event.pull_request.number }}"
@@ -140,8 +140,8 @@ jobs:
         if: steps.gate.outputs.run == 'true' && always()
         uses: actions/upload-artifact@v4
         with:
-          name: benchmarks-${{ matrix.bench }}
-          path: ci/benchmarks/.work/suite_${{ matrix.bench }}/**
+          name: benchmarks-${{ matrix.tier }}-${{ matrix.bench }}
+          path: ci/benchmarks/.work/suite_${{ matrix.tier }}_${{ matrix.bench }}/**
           if-no-files-found: warn
 
       - name: Comment results on the PR
@@ -150,12 +150,12 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const path = `ci/benchmarks/.work/suite_${{ matrix.bench }}/report.md`;
+            const path = `ci/benchmarks/.work/suite_${{ matrix.tier }}_${{ matrix.bench }}/report.md`;
             if (!fs.existsSync(path)) return;
-            const body = `<!-- benchmarks:${{ matrix.bench }} -->\n` + fs.readFileSync(path, 'utf8');
+            const body = `<!-- benchmarks:${{ matrix.tier }}-${{ matrix.bench }} -->\n` + fs.readFileSync(path, 'utf8');
             const {owner, repo} = context.repo;
             const issue_number = context.issue.number;
-            const marker = `<!-- benchmarks:${{ matrix.bench }} -->`;
+            const marker = `<!-- benchmarks:${{ matrix.tier }}-${{ matrix.bench }} -->`;
             const {data: comments} = await github.rest.issues.listComments({owner, repo, issue_number});
             const existing = comments.find(c => c.body && c.body.includes(marker));
             if (existing) {
@@ -187,19 +187,21 @@ jobs:
         run: |
           mkdir -p _new_records
           # upload-artifact stores files flat at the artifact root (the least-common-ancestor
-          # of ci/benchmarks/.work/suite_<bench>/** is that dir), so runmeta.json/metrics.jsonl
-          # live directly under _artifacts/benchmarks-<bench>/ — NOT a suite_<bench>/ subdir.
+          # of ci/benchmarks/.work/suite_<tier>_<bench>/** is that dir), so runmeta.json/
+          # metrics.jsonl live directly under _artifacts/benchmarks-<tier>-<bench>/. The dir
+          # suffix is the <tier>-<bench> slug — use it verbatim to keep record files unique
+          # per (run, tier, bench) so smoke and full of the same bench never collide.
           have=0; built=0
           for d in _artifacts/benchmarks-*; do
             [ -d "$d" ] || continue
-            bench="$(basename "$d" | sed 's/^benchmarks-//')"
+            slug="$(basename "$d" | sed 's/^benchmarks-//')"   # e.g. smoke-tau2 / full-tau2
             rm="$d/runmeta.json"; metrics="$d/metrics.jsonl"
-            [ -f "$rm" ] || { echo "::warning::no runmeta for $bench, skipping"; continue; }
+            [ -f "$rm" ] || { echo "::warning::no runmeta for $slug, skipping"; continue; }
             have=$((have+1))
             rid="$(python3 -c "import json;print(json.load(open('$rm'))['run_id'])")"
             python3 ci/benchmarks/lib/record.py build "$metrics" --runmeta "$rm" \
-              > "_new_records/${rid}__${bench}.json" && built=$((built+1))
-            echo "built _new_records/${rid}__${bench}.json"
+              > "_new_records/${rid}__${slug}.json" && built=$((built+1))
+            echo "built _new_records/${rid}__${slug}.json"
           done
           ls -la _new_records || true
           # Guard: if artifacts with runmeta exist but produced no records, fail loudly


### PR DESCRIPTION
Closes #95.

## Summary
The tier dimension (added in #90) was missing from four names, so running **both tiers of one bench** together — a `tier=all` dispatch, or a PR carrying both `benchmark-smoke-<b>` and `benchmark-full-<b>` — would collide:
- **artifact** `benchmarks-<bench>` → duplicate name (upload-artifact v4 errors)
- **suite work dir** `suite_<bench>` → cross-tier overwrite
- **aggregate record** `<run_id>__<bench>.json` → one tier overwrites the other
- **PR comment marker** `<!-- benchmarks:<bench> -->` → one tier's comment clobbers the other

Add `<tier>` to all four: `benchmarks-<tier>-<bench>`, `suite_<tier>_<bench>`, `<run_id>__<tier>-<bench>.json`, `<!-- benchmarks:<tier>-<bench> -->`.

## Impact
- **Single-tier dispatches** (what's been run so far) are unaffected in behaviour.
- **Multi-tier runs** now stay isolated (distinct artifacts, records, comments).
- Old history records (pre-fix, `<run_id>__<bench>.json`) remain valid — the aggregate globs `records/*.json` and rebuilds `benchmarks.json` regardless of filename; new records just carry the tier slug.

## Testing
`benchmarks.yml` YAML-lints; all four names verified tiered.

Signed-off-by: Eran Raichstein <eranra@il.ibm.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)