### PR TITLE
feat(site): benchmarks table — drop flips, add Eval $ + model columns

### DIFF
--- a/ci/benchmarks/lib/metrics.py
+++ b/ci/benchmarks/lib/metrics.py
@@ -59,6 +59,12 @@ def extract(run_dir: str, bench: str = "", task: str = "") -> dict:
         "latency_opt_s": latency_opt_s,
         "cost_baseline_usd": cost_baseline_usd,
         "cost_opt_runner_usd": cost_opt_runner_usd,
+        # total RUNNER (evaluation) spend across ALL rollouts (baseline + every
+        # optimize iteration + finalize) — the cost of running the benchmark itself,
+        # distinct from the optimizer's own spend. 0 when the runner/gateway does not
+        # surface usage (tau2/skillsbench via the gateway); non-zero for swebench (litellm).
+        "eval_usd": spent.get("usd"),
+        "eval_tokens": spent.get("runner_tokens"),
         "optimizer_usd": spent.get("optimizer_usd"),
         "optimizer_tokens": spent.get("optimizer_tokens"),
         "optimizer_seconds": spent.get("optimizer_seconds"),

--- a/ci/benchmarks/lib/record.py
+++ b/ci/benchmarks/lib/record.py
@@ -23,7 +23,7 @@ def _num(x) -> bool:
 
 
 def rollup(tasks: list[dict]) -> dict | None:
-    """Suite rollup matching metrics.py table(): mean rewards, flip count, n, optimizer $."""
+    """Suite rollup: mean rewards, n, total eval (runner) $, total optimizer $."""
     rb = [t["reward_baseline"] for t in tasks if _num(t.get("reward_baseline"))]
     ro = [t["reward_opt"] for t in tasks if _num(t.get("reward_opt"))]
     if not (rb and ro):
@@ -31,8 +31,10 @@ def rollup(tasks: list[dict]) -> dict | None:
     return {
         "reward_base": round(sum(rb) / len(rb), 6),
         "reward_opt": round(sum(ro) / len(ro), 6),
-        "flips": sum(1 for t in tasks if t.get("flipped")),
         "n": len(tasks),
+        # total runner/evaluation cost of running the benchmark (sum over tasks; each
+        # task's eval_usd is that run's spent.usd — 0 when the gateway hides usage)
+        "eval_usd": round(sum(t.get("eval_usd") or 0 for t in tasks), 6),
         "optimizer_usd": round(sum(t.get("optimizer_usd") or 0 for t in tasks), 6),
     }
 

--- a/ci/benchmarks/lib/test_record.py
+++ b/ci/benchmarks/lib/test_record.py
@@ -8,10 +8,11 @@ TASK_OK = {
     "reward_baseline": 0.0, "reward_opt": 1.0, "reward_delta": 1.0, "flipped": True,
     "latency_baseline_s": 10.0, "latency_opt_s": 11.0,
     "cost_baseline_usd": 0.0, "cost_opt_runner_usd": 0.0,
+    "eval_usd": 0.10, "eval_tokens": 1000,
     "optimizer_usd": 0.05, "optimizer_tokens": 0, "optimizer_seconds": 0, "iterations": 1,
 }
 TASK2 = {**TASK_OK, "task": "37", "reward_baseline": 0.0, "reward_opt": 0.0,
-         "flipped": False, "optimizer_usd": 0.03}
+         "flipped": False, "eval_usd": 0.05, "optimizer_usd": 0.03}
 
 
 def _write_jsonl(p: Path, rows):
@@ -20,7 +21,8 @@ def _write_jsonl(p: Path, rows):
 
 def test_rollup_math():
     r = record.rollup([TASK_OK, TASK2])
-    assert r == {"reward_base": 0.0, "reward_opt": 0.5, "flips": 1, "n": 2, "optimizer_usd": 0.08}
+    assert r == {"reward_base": 0.0, "reward_opt": 0.5, "n": 2,
+                 "eval_usd": 0.15, "optimizer_usd": 0.08}
 
 
 def test_rollup_empty_is_none():
@@ -34,7 +36,8 @@ def test_build_success(tmp_path):
     assert rec["schema"] == 1
     assert rec["run_id"] == 1 and rec["bench"] == "tau2"
     assert len(rec["tasks"]) == 2
-    assert rec["suite"]["flips"] == 1 and rec["suite"]["n"] == 2
+    assert rec["suite"]["n"] == 2 and rec["suite"]["eval_usd"] == 0.15
+    assert "flips" not in rec["suite"]
 
 
 def test_build_failed_run_has_null_suite(tmp_path):

--- a/site/benchmarks.fixture.json
+++ b/site/benchmarks.fixture.json
@@ -1,20 +1,93 @@
 [
-  {"schema":1,"run_id":123,"run_url":"https://github.com/skillberry-ai/cap-evolve/actions/runs/123",
-   "bench":"tau2","tier":"smoke","event":"pull_request","source":"PR #55","pr":55,
-   "branch":"feature/x","sha":"abc1234","date":"2026-07-24T13:50:51Z","iterations":3,
-   "agent_model":"aws/gpt-oss-120b","optimizer_model":"claude-opus-4-8","conclusion":"success",
-   "suite":{"reward_base":0.0,"reward_opt":0.5,"flips":1,"n":2,"optimizer_usd":0.12},
-   "tasks":[
-     {"task":"35","reward_baseline":0.0,"reward_opt":1.0,"flipped":true,"latency_baseline_s":10.0,"latency_opt_s":11.0,"cost_opt_runner_usd":0.0,"optimizer_usd":0.06,"iterations":3},
-     {"task":"37","reward_baseline":0.0,"reward_opt":0.0,"flipped":false,"latency_baseline_s":9.0,"latency_opt_s":9.5,"cost_opt_runner_usd":0.0,"optimizer_usd":0.06,"iterations":3}]},
-  {"schema":1,"run_id":124,"run_url":"https://github.com/skillberry-ai/cap-evolve/actions/runs/124",
-   "bench":"swebench","tier":"full","event":"workflow_dispatch","source":"manual (main)","pr":null,
-   "branch":"main","sha":"def5678","date":"2026-07-23T09:00:00Z","iterations":5,
-   "agent_model":"aws/gpt-oss-120b","optimizer_model":"claude-opus-4-8","conclusion":"success",
-   "suite":{"reward_base":0.2,"reward_opt":0.4,"flips":0,"n":10,"optimizer_usd":1.10},"tasks":[]},
-  {"schema":1,"run_id":100,"run_url":"https://github.com/skillberry-ai/cap-evolve/actions/runs/100",
-   "bench":"skillsbench","event":"workflow_dispatch","source":"manual (main)","pr":null,
-   "branch":"main","sha":"0000000","date":"2026-07-20T00:00:00Z","iterations":3,
-   "agent_model":"aws/gpt-oss-120b","optimizer_model":"claude-opus-4-8","conclusion":"failure",
-   "suite":null,"tasks":[]}
+  {
+    "schema": 1,
+    "run_id": 123,
+    "run_url": "https://github.com/skillberry-ai/cap-evolve/actions/runs/123",
+    "bench": "tau2",
+    "tier": "smoke",
+    "event": "pull_request",
+    "source": "PR #55",
+    "pr": 55,
+    "branch": "feature/x",
+    "sha": "abc1234",
+    "date": "2026-07-24T13:50:51Z",
+    "iterations": 3,
+    "agent_model": "aws/gpt-oss-120b",
+    "optimizer_model": "claude-opus-4-8",
+    "conclusion": "success",
+    "suite": {
+      "reward_base": 0.0,
+      "reward_opt": 0.5,
+      "n": 2,
+      "optimizer_usd": 0.12,
+      "eval_usd": 0.0
+    },
+    "tasks": [
+      {
+        "task": "35",
+        "reward_baseline": 0.0,
+        "reward_opt": 1.0,
+        "flipped": true,
+        "latency_baseline_s": 10.0,
+        "latency_opt_s": 11.0,
+        "cost_opt_runner_usd": 0.0,
+        "optimizer_usd": 0.06,
+        "iterations": 3
+      },
+      {
+        "task": "37",
+        "reward_baseline": 0.0,
+        "reward_opt": 0.0,
+        "flipped": false,
+        "latency_baseline_s": 9.0,
+        "latency_opt_s": 9.5,
+        "cost_opt_runner_usd": 0.0,
+        "optimizer_usd": 0.06,
+        "iterations": 3
+      }
+    ]
+  },
+  {
+    "schema": 1,
+    "run_id": 124,
+    "run_url": "https://github.com/skillberry-ai/cap-evolve/actions/runs/124",
+    "bench": "swebench",
+    "tier": "full",
+    "event": "workflow_dispatch",
+    "source": "manual (main)",
+    "pr": null,
+    "branch": "main",
+    "sha": "def5678",
+    "date": "2026-07-23T09:00:00Z",
+    "iterations": 5,
+    "agent_model": "aws/gpt-oss-120b",
+    "optimizer_model": "claude-opus-4-8",
+    "conclusion": "success",
+    "suite": {
+      "reward_base": 0.2,
+      "reward_opt": 0.4,
+      "n": 10,
+      "optimizer_usd": 1.1,
+      "eval_usd": 0.0123
+    },
+    "tasks": []
+  },
+  {
+    "schema": 1,
+    "run_id": 100,
+    "run_url": "https://github.com/skillberry-ai/cap-evolve/actions/runs/100",
+    "bench": "skillsbench",
+    "event": "workflow_dispatch",
+    "source": "manual (main)",
+    "pr": null,
+    "branch": "main",
+    "sha": "0000000",
+    "date": "2026-07-20T00:00:00Z",
+    "iterations": 3,
+    "agent_model": "aws/gpt-oss-120b",
+    "optimizer_model": "claude-opus-4-8",
+    "conclusion": "failure",
+    "suite": null,
+    "tasks": []
+  }
 ]

--- a/site/benchmarks.html
+++ b/site/benchmarks.html
@@ -105,8 +105,10 @@
       <th data-k="tier">Type</th>
       <th data-k="iterations">Iters</th>
       <th data-k="reward">Reward base→opt</th>
-      <th data-k="flips">Flips</th>
+      <th data-k="eval_usd">Eval $</th>
       <th data-k="optimizer_usd">Optimizer $</th>
+      <th data-k="agent_model">Agent model</th>
+      <th data-k="optimizer_model">Optimizer model</th>
       <th data-k="conclusion">Result</th>
     </tr></thead>
     <tbody id="rows"></tbody>
@@ -136,7 +138,7 @@
   </div>
 </footer>
 
-<script src="benchmarks.js?v=20260724b"></script>
+<script src="benchmarks.js?v=20260724c"></script>
 <script src="js/site.js?v=20260724" defer></script>
 </body>
 </html>

--- a/site/benchmarks.html
+++ b/site/benchmarks.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Benchmark runs — cap-evolve</title>
-  <meta name="description" content="Every ci/benchmarks execution (tau2 · swebench · skillsbench), on PRs and manual runs — a sortable, filterable log of reward, flips, latency and cost vs the frozen baseline.">
+  <meta name="description" content="Every ci/benchmarks execution (tau2 · swebench · skillsbench), on PRs and manual runs — a sortable, filterable log of reward, eval/optimizer cost, and models vs the frozen baseline.">
   <link rel="canonical" href="https://skillberry-ai.github.io/cap-evolve/benchmarks.html">
   <meta property="og:type" content="article">
   <meta property="og:site_name" content="cap-evolve">

--- a/site/benchmarks.js
+++ b/site/benchmarks.js
@@ -56,7 +56,7 @@ function passes(r) {
 
 function sortVal(r, k) {
   if (k === "reward") return r.suite ? r.suite.reward_opt : -1;
-  if (k === "flips") return r.suite ? r.suite.flips : -1;
+  if (k === "eval_usd") return r.suite ? (r.suite.eval_usd ?? -1) : -1;
   if (k === "optimizer_usd") return r.suite ? r.suite.optimizer_usd : -1;
   if (k === "tier") return r.tier || "smoke";
   return r[k] ?? "";
@@ -83,8 +83,8 @@ function render() {
     const tr = document.createElement("tr");
     tr.className = "run-row";
     const reward = r.suite ? `${fmt(r.suite.reward_base)} → ${fmt(r.suite.reward_opt)}` : "—";
-    const flips = r.suite ? `${r.suite.flips}/${r.suite.n}` : "—";
-    const usd = r.suite ? `$${fmt(r.suite.optimizer_usd, 4)}` : "—";
+    const evalUsd = r.suite && r.suite.eval_usd != null ? `$${fmt(r.suite.eval_usd, 4)}` : "—";
+    const optUsd = r.suite ? `$${fmt(r.suite.optimizer_usd, 4)}` : "—";
     const src = r.pr
       ? `<a href="https://github.com/skillberry-ai/cap-evolve/pull/${encodeURIComponent(r.pr)}">${esc(r.source)}</a>`
       : esc(r.source || "—");
@@ -93,13 +93,15 @@ function render() {
     const tier = esc(r.tier || "smoke");
     tr.innerHTML = `<td><a href="${esc(r.run_url)}">${date}</a></td>
       <td>${src}</td><td>${esc(r.bench)}</td><td>${tier}</td><td>${r.iterations ?? "—"}</td>
-      <td>${reward}</td><td>${flips}</td><td>${usd}</td><td>${badge}</td>`;
+      <td>${reward}</td><td>${evalUsd}</td><td>${optUsd}</td>
+      <td><code>${esc(r.agent_model || "—")}</code></td><td><code>${esc(r.optimizer_model || "—")}</code></td>
+      <td>${badge}</td>`;
     tb.appendChild(tr);
 
     const detail = document.createElement("tr");
     detail.className = "detail-row";
     detail.hidden = true;
-    detail.innerHTML = `<td colspan="9">${taskTable(r.tasks || [])}</td>`;
+    detail.innerHTML = `<td colspan="11">${taskTable(r.tasks || [])}</td>`;
     tb.appendChild(detail);
 
     tr.addEventListener("click", (e) => {
@@ -110,11 +112,10 @@ function render() {
 
 function taskTable(tasks) {
   if (!tasks.length) return `<em class="muted">no per-task metrics</em>`;
-  const head = `<tr><th>task</th><th>reward base→opt</th><th>flip</th><th>latency (s)</th>` +
+  const head = `<tr><th>task</th><th>reward base→opt</th><th>latency (s)</th>` +
     `<th>runner $</th><th>opt $</th><th>iters</th></tr>`;
   const body = tasks.map((t) => `<tr><td><code>${esc(t.task)}</code></td>
     <td>${fmt(t.reward_baseline)} → ${fmt(t.reward_opt)}</td>
-    <td>${t.flipped ? "✅" : "—"}</td>
     <td>${fmt(t.latency_baseline_s, 1)} → ${fmt(t.latency_opt_s, 1)}</td>
     <td>$${fmt(t.cost_opt_runner_usd, 4)}</td><td>$${fmt(t.optimizer_usd, 4)}</td>
     <td>${t.iterations ?? "—"}</td></tr>`).join("");


### PR DESCRIPTION
Closes #97.

## Summary
Improvements to the /benchmarks.html table.

### Remove flips
Dropped the **Flips** column (and the per-task flip in the expanded detail), and removed `flips` from `record.py`'s suite rollup. **Kept** `metrics.py`'s per-task `flipped` — it still feeds the PR-comment report (`flips X/n`) and `select_tasks --expect-flip`, so this is web-table-only.

### Add 'Eval $' (cost of the benchmark run, ≠ optimizer)
New column sourced from **`spent.usd`** — the *complete* runner/evaluation spend (baseline + **every** optimize iteration + finalize), whereas the page previously only ever read baseline+finalize cost. `metrics.py` now records `eval_usd`/`eval_tokens`; the rollup sums them.
- **0** for tau2/skillsbench (the IBM gateway returns no per-call usage — confirmed: frozen baselines show `cost_usd:0, tokens:0`), **non-zero** for swebench (litellm). This matches the dashboard, which reads the same `cost_usd` source; its non-zero screenshots come from cost-surfacing runs.

### Add model columns
**Agent model** + **Optimizer model** (already carried per-run in `runmeta.json` → the record). Two columns, monospace.

Detail colspan 9→11; `benchmarks.js` cache-buster bumped to `?v=20260724c`.

## Testing
- `ci/benchmarks/lib/test_record.py` — 7 passing (rollup now asserts `eval_usd`, no `flips`).
- `benchmarks.js` passes `node --check`; DOM-stub render test confirms Eval $ (swebench $0.0123), both model cells, no flips, detail `colspan=11`, and no 'flip' header in the per-task table.

Signed-off-by: Eran Raichstein <eranra@il.ibm.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)