### PR TITLE
fix(bench): harden benchmark CI — optimizer CLI check, gateway-budget preflight, stdin, infra reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to cap-evolve are documented here. The format follows
 [Semantic Versioning](https://semver.org/) (currently `0.x` — anything may change).
 
 ## [Unreleased]
+### Fixed
+- **Benchmark CI robustness (skillberry-1 self-hosted runner).** Three fixes so a broken
+  runner or gateway is *loud*, not a silent all-0.000 "success": (1) `ci_setup.sh` now
+  installs + hard-verifies the `claude-code` optimizer CLI — when it was missing the
+  optimizer failed every iteration (`cli_present:false`) and every task reported
+  `best=seed`/0.000; (2) `ci_setup.sh` adds a **model-gateway budget preflight** — one
+  tiny gpt-oss call that aborts with a clear error on `429 budget_exceeded` (the shared
+  LiteLLM gateway hitting its spend cap 429s both the agent and the optimizer, killing
+  every rollout with `INFRASTRUCTURE_ERROR`); (3) `run_suite.sh` iterates the task list on
+  FD 3 (+ `run_task </dev/null`) so the optimizer subprocess reading stdin can no longer
+  DRAIN the here-string and cut the suite off after one task. `metrics.py` now detects an
+  infra-dominated eval (majority trials errored + reward≈0) and renders it as
+  `⚠️ infra-error`, excluding it from the suite mean/flip counts so a gateway outage no
+  longer looks like a capability regression.
+
 ### Added
 - **`cap-evolve run --resume`** — continue an interrupted run (pod eviction, crash,
   timeout) from its last completed state instead of starting over. Reopens the run dir

--- a/ci/benchmarks/lib/ci_setup.sh
+++ b/ci/benchmarks/lib/ci_setup.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 # ci_setup.sh — idempotently prepare the self-hosted runner for ONE benchmark.
 # Creates a cached py3.12 venv + benchmark deps/clones OUTSIDE the checkout (so they
-# survive between jobs), and exports CAPEVOLVE_PY / SKILLSBENCH_SRC / PATH to $GITHUB_ENV.
+# survive between jobs), ensures the claude-code optimizer CLI is installed, preflights
+# the model-gateway budget (fail fast on 429 budget_exceeded rather than score all-0.000),
+# and exports CAPEVOLVE_PY / SKILLSBENCH_SRC / PATH to $GITHUB_ENV.
 #
 #   ci_setup.sh <bench>
 set -euo pipefail
@@ -31,6 +33,45 @@ case "$BENCH" in
 esac
 
 "$CAPEVOLVE_PY" -c "import cap_evolve; print('cap_evolve OK')"
+
+# Ensure the claude-code optimizer CLI (the EDIT PROPOSER) is present. If a runner is
+# reprovisioned/rebooted the global npm install can vanish; without `claude` the benchmark
+# SILENTLY degrades — the optimizer fails every iteration with `cli_present:false`, no edit
+# is proposed, and every task reports best=seed / reward 0.000 as if it had "optimized".
+# Install idempotently into a user-writable prefix ($HOME/.local/bin is already on PATH and
+# exported below), then HARD-FAIL if it is still unavailable so a broken runner is loud.
+if ! command -v claude >/dev/null 2>&1; then
+  command -v npm >/dev/null || { echo "::error:: npm required to install the claude-code optimizer"; exit 1; }
+  echo "claude CLI missing — installing @anthropic-ai/claude-code into $HOME/.local"
+  npm install -g --prefix "$HOME/.local" @anthropic-ai/claude-code
+fi
+export PATH="$HOME/.local/bin:$PATH"
+command -v claude >/dev/null || {
+  echo "::error:: claude-code optimizer CLI still unavailable after install — aborting."
+  echo "::error:: (running anyway would silently yield best=seed / reward 0.000 on every task.)"
+  exit 1
+}
+echo "claude-code optimizer: $(command -v claude) ($(claude --version 2>/dev/null | head -1))"
+
+# Gateway budget preflight. The agent (gpt-oss) AND the optimizer (opus) share one
+# LiteLLM gateway; when it hits its spend cap it returns 429 budget_exceeded and every
+# rollout dies with INFRASTRUCTURE_ERROR → the whole suite silently scores 0.000 (looks
+# identical to a real regression). Probe once and FAIL FAST rather than burn hours. Only
+# hard-fails on the budget case; other transient errors are non-blocking.
+if [ -n "${ANTHROPIC_BASE_URL:-}" ] && [ -n "${ANTHROPIC_AUTH_TOKEN:-}" ] && command -v curl >/dev/null; then
+  probe=/tmp/capevolve_budget_probe.$$.json
+  code="$(curl -sS -m 30 -o "$probe" -w '%{http_code}' \
+    "$ANTHROPIC_BASE_URL/chat/completions" \
+    -H "Authorization: Bearer $ANTHROPIC_AUTH_TOKEN" -H 'Content-Type: application/json' \
+    -d '{"model":"aws/gpt-oss-120b","messages":[{"role":"user","content":"ping"}],"max_tokens":1}' 2>/dev/null || echo 000)"
+  if [ "$code" = "429" ] && grep -qi 'budget' "$probe" 2>/dev/null; then
+    echo "::error:: model gateway is OVER BUDGET (HTTP 429 budget_exceeded) — aborting."
+    echo "::error:: every rollout would score 0.000 as INFRASTRUCTURE_ERROR. Raise/reset the gateway budget."
+    head -c 300 "$probe" 2>/dev/null; echo; rm -f "$probe"; exit 1
+  fi
+  rm -f "$probe"
+  echo "gateway budget preflight: HTTP $code (not budget-blocked)"
+fi
 
 # Export for later workflow steps (no-op locally).
 if [ -n "${GITHUB_ENV:-}" ]; then

--- a/ci/benchmarks/lib/metrics.py
+++ b/ci/benchmarks/lib/metrics.py
@@ -28,6 +28,36 @@ def _load(p: Path) -> dict:
         return {}
 
 
+def _infra_dominated(agg: dict) -> bool:
+    """True if this eval's reward≈0 is due to INFRASTRUCTURE errors, not capability.
+
+    Mirrors the core's ``_is_infra_ignore``: a task counts as infra only when a
+    MAJORITY of its trials errored AND its mean reward ≈ 0 (a partly-passing task is
+    controllable and protected). The eval is infra-DOMINATED when a majority of its
+    tasks are infra — e.g. a gateway 429 budget_exceeded kills every rollout, so the
+    whole eval reads 0.000. Distinguishing this from a real regression keeps a billing
+    outage from looking like a capability drop in the report.
+    """
+    per = agg.get("per_task") or []
+    if not per:
+        return False
+    eps = 1e-9
+    infra = 0
+    for pt in per:
+        raw = pt.get("raw") or {}
+        if not raw.get("errored"):
+            continue
+        if float(pt.get("reward", 0) or 0) > eps:
+            continue  # partially passed → controllable, not infra
+        et, nt = raw.get("errored_trials"), (raw.get("n_trials") or pt.get("n"))
+        if et is not None and nt:
+            if int(et) * 2 > int(nt):
+                infra += 1
+        else:
+            infra += 1  # no per-trial counts: any-trial-errored + mean≈0
+    return infra > 0 and infra * 2 >= len(per)
+
+
 def extract(run_dir: str, bench: str = "", task: str = "") -> dict:
     rd = Path(run_dir)
     baseline = _load(rd / "baseline.json")
@@ -45,6 +75,12 @@ def extract(run_dir: str, bench: str = "", task: str = "") -> dict:
     latency_opt_s = test.get("seconds")
     cost_opt_runner_usd = test.get("cost_usd")
 
+    # Infra-error detection: a gateway outage (e.g. 429 budget_exceeded) makes every
+    # rollout die with INFRASTRUCTURE_ERROR and the eval read 0.000 — NOT a real
+    # regression. Flag it so the table/rollup can exclude it instead of counting it.
+    opt_infra = _infra_dominated(test)
+    baseline_infra = _infra_dominated(bval)
+
     def _d(a, b):
         return round(a - b, 6) if isinstance(a, (int, float)) and isinstance(b, (int, float)) else None
 
@@ -53,8 +89,12 @@ def extract(run_dir: str, bench: str = "", task: str = "") -> dict:
         "task": task,
         "reward_baseline": reward_baseline,
         "reward_opt": reward_opt,
-        "reward_delta": _d(reward_opt, reward_baseline),
-        "flipped": bool(reward_baseline == 0 and (reward_opt or 0) > 0),
+        "reward_delta": None if (opt_infra or baseline_infra) else _d(reward_opt, reward_baseline),
+        # a flip only counts on real evals — never credit/penalize an infra-errored one
+        "flipped": bool(reward_baseline == 0 and (reward_opt or 0) > 0
+                        and not opt_infra and not baseline_infra),
+        "opt_infra": opt_infra,
+        "baseline_infra": baseline_infra,
         "latency_baseline_s": latency_baseline_s,
         "latency_opt_s": latency_opt_s,
         "cost_baseline_usd": cost_baseline_usd,
@@ -87,24 +127,38 @@ def table(rows: list[dict]) -> str:
     sep = "|---|---|---|:--:|---|---|---|:--:|"
     out = [hdr, sep]
     for r in rows:
-        reward = f"{_fmt(r['reward_baseline'])} → {_fmt(r['reward_opt'])}"
-        flip = "✅" if r.get("flipped") else ("—" if (r.get("reward_opt") or 0) == 0 else "")
+        infra = r.get("opt_infra") or r.get("baseline_infra")
+        if infra:
+            # Gateway/infra outage — reward≈0 is noise, not a result. Say so explicitly.
+            reward = f"{_fmt(r['reward_baseline'])} → ⚠️ infra-error"
+            flip = "⚠️"
+        else:
+            reward = f"{_fmt(r['reward_baseline'])} → {_fmt(r['reward_opt'])}"
+            flip = "✅" if r.get("flipped") else ("—" if (r.get("reward_opt") or 0) == 0 else "")
         lat = f"{_fmt(r['latency_baseline_s'])} → {_fmt(r['latency_opt_s'])}"
         cost = f"{_fmt(r['cost_baseline_usd'],'$')} → {_fmt(r['cost_opt_runner_usd'],'$')}"
         out.append(
             f"| {r['bench']} | `{r['task']}` | {reward} | {flip} | {lat} | {cost} | "
             f"{_fmt(r['optimizer_usd'],'$')} | {_fmt(r['iterations'])} |"
         )
-    # suite rollup
-    rew_b = [r['reward_baseline'] for r in rows if isinstance(r['reward_baseline'], (int, float))]
-    rew_o = [r['reward_opt'] for r in rows if isinstance(r['reward_opt'], (int, float))]
-    flips = sum(1 for r in rows if r.get("flipped"))
+    # suite rollup — EXCLUDE infra-errored evals from the mean + flip counts so a
+    # gateway outage can't masquerade as a regression (or a win).
+    real = [r for r in rows if not (r.get("opt_infra") or r.get("baseline_infra"))]
+    infra_n = len(rows) - len(real)
+    rew_b = [r['reward_baseline'] for r in real if isinstance(r['reward_baseline'], (int, float))]
+    rew_o = [r['reward_opt'] for r in real if isinstance(r['reward_opt'], (int, float))]
+    flips = sum(1 for r in real if r.get("flipped"))
     opt_usd = sum(r['optimizer_usd'] or 0 for r in rows)
     if rew_b and rew_o:
         out.append("")
+        suffix = f" · {infra_n} infra-errored (excluded)" if infra_n else ""
         out.append(f"**Suite:** mean reward {sum(rew_b)/len(rew_b):.3f} → "
-                   f"{sum(rew_o)/len(rew_o):.3f} · flips {flips}/{len(rows)} · "
-                   f"optimizer ${opt_usd:.4f}")
+                   f"{sum(rew_o)/len(rew_o):.3f} · flips {flips}/{len(real)} · "
+                   f"optimizer ${opt_usd:.4f}{suffix}")
+    elif infra_n:
+        out.append("")
+        out.append(f"**Suite:** ⚠️ all {infra_n} eval(s) infra-errored (gateway/runtime "
+                   "outage) — no valid optimized result. Check the model gateway (budget/429).")
     return "\n".join(out)
 
 

--- a/ci/benchmarks/lib/run_suite.sh
+++ b/ci/benchmarks/lib/run_suite.sh
@@ -27,14 +27,18 @@ for t in json.load(open(sys.argv[1])):
 PY
 )"
 
-while IFS=$'\t' read -r id tag agent; do
+# NOTE: iterate on FD 3 (not stdin). The optimizer subprocess (claude -p …) reads stdin;
+# if the loop fed `read` from stdin, claude would DRAIN the here-string and the loop would
+# exit after the first task (silently ran 1/N tasks once claude-code actually ran). FD 3
+# keeps the task list isolated; run_task also gets </dev/null below.
+while IFS=$'\t' read -r id tag agent <&3; do
   [ -n "$id" ] || continue
   frozen="$BASE/$(echo "$id" | tr '/ ' '__')/baseline"
   # A tier may be partially populated (e.g. full mid-freeze): run only tasks whose frozen
   # baseline exists; skip the rest with a warning instead of failing the whole suite.
   [ -f "$frozen/baseline.json" ] || { echo "::warning::no frozen baseline for $BENCH/$TIER $id — skipping"; continue; }
   echo "::group::$BENCH $id ($tag, agent=$agent)"
-  out="$(AGENT_MODEL="$agent" bash "$LIB_DIR/run_task.sh" "$BENCH" "$id" optimize "$frozen" 2>&1)" || true
+  out="$(AGENT_MODEL="$agent" bash "$LIB_DIR/run_task.sh" "$BENCH" "$id" optimize "$frozen" </dev/null 2>&1)" || true
   echo "$out"
   run_dir="$(printf '%s' "$out" | sed -n 's/^RUN_DIR=//p' | tail -1)"
   echo "::endgroup::"
@@ -61,7 +65,7 @@ PY
     git --no-pager diff --no-index "$seed_dir" "$opt_dir" > "$dst/capability.diff" 2>/dev/null || true
     [ -d "$opt_dir" ] && cp -R "$opt_dir"/. "$dst/optimized_capability/" 2>/dev/null || true
   fi
-done <<< "$ids_tags"
+done 3<<< "$ids_tags"
 
 # render the report
 KIND="${TIER:-smoke}"


### PR DESCRIPTION
## Summary
Consolidates the benchmark-infra fixes surfaced while debugging PR #58's tau2 smoke. The theme: **a broken runner or an out-of-budget gateway must fail LOUD**, not silently report an all-0.000 "success" that looks like a capability regression.

Debugging that smoke run turned up three distinct latent bugs, each masked by the previous one:

| symptom | root cause | fix |
|---|---|---|
| all tasks 0.000 | `claude` CLI missing on runner → optimizer `cli_present:false` every iter → `best=seed` | ci_setup installs + **hard-verifies** claude-code |
| suite ran 1/N tasks | optimizer's `claude -p` reads stdin → **drains** `run_suite`'s `while read <<<` here-string | iterate on **FD 3** + `run_task </dev/null` |
| all tasks 0.000 again | shared LiteLLM gateway hit its spend cap → `429 budget_exceeded` → every rollout `INFRASTRUCTURE_ERROR` | **gateway-budget preflight** in ci_setup (fail fast) + `metrics.py` renders `⚠️ infra-error`, excluded from mean/flip |

## Changes
- **`ci_setup.sh`** — install + hard-verify the `claude-code` optimizer CLI; add a one-call **gateway-budget preflight** that aborts on `429 budget_exceeded` (only the budget case hard-fails; other transient errors are non-blocking).
- **`run_suite.sh`** — iterate the task list on FD 3 and run `run_task </dev/null` so a stdin-reading subprocess can't cut the suite short. (Verified with a local repro: buggy → 1 iteration; fixed → all.)
- **`metrics.py`** — `_infra_dominated()` detects a majority-errored, reward≈0 eval and renders `⚠️ infra-error`, excluding it from the suite mean and flip counts (a gateway outage no longer masquerades as a regression). All-infra suites get an explicit "check the gateway (budget/429)" line.

## Testing
- Shell syntax checks pass.
- metrics.py unit test: infra row → `reward_delta=None`, excluded from mean; real row counted; all-infra suite flagged.

## Notes
- Honesty core (gate, splits, sealed test) untouched — this only affects runner setup + human-facing reporting.
- Overlaps with the ci_setup/run_suite fixes already on PR #58 and #145; merging here lands them on `main` so both feature PRs inherit them on rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)