### PR TITLE
fix: correct tau2 held-out split label from 30/10/10 to 30(=val)/20

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ models, task/trial counts, commits, and costs: **[docs/RESULTS.md](docs/RESULTS.
 |---|---|---|---|
 | **toy_calc** (zero-API) | sealed test | `0.0 → 1.0` | deterministic proof |
 | **τ²-bench airline** (policy + tools) | val — *fit metric* | `0.536 → 0.712` | **+0.176 / +32.8%** |
-| **τ²-bench airline**, held-out 30/10/10 | sealed **test** | `30.0 → 47.5` | **+17.5 pp / +58.3%** |
+| **τ²-bench airline**, held-out 30(=val)/20 | sealed **test** | `30.0 → 47.5` | **+17.5 pp / +58.3%** |
 | **SkillsBench** (skill package) | sealed **test** (held-out) | `0.556 → 0.667` | **+0.111 / +20.0%** |
 
 *Not an apples-to-apples leaderboard.* For how the held-out τ²-bench result sits next to

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -58,7 +58,7 @@ claims.
 | **EvoTool** (arXiv:2603.04900) | **original τ-Bench** airline, GPT-4.1 | ReAct 35.9 → **39.1** (+3.2) | **~+8.9%** |
 | **EvoTool** | original τ-Bench airline, Qwen3-8B | ReAct 14.4 → **15.7** (+1.3) | **~+9.0%** |
 | Evolutionary Context Search | τ²-Bench | reported **+23.3%** | +23.3% |
-| **cap-evolve** (this repo) | **τ²-Bench** airline, held-out 30/10/10 | sealed test 30.0 → **47.5** (+17.5 pp) | **+58.3%** |
+| **cap-evolve** (this repo) | **τ²-Bench** airline, held-out 30(=val)/20 | sealed test 30.0 → **47.5** (+17.5 pp) | **+58.3%** |
 
 Notes and honest caveats:
 - **EvoTool evaluates the *original* τ-Bench** (Yao et al., 2024), while cap-evolve and

--- a/docs/RESULTS.md
+++ b/docs/RESULTS.md
@@ -59,15 +59,15 @@ lines), not just prompt tweaks — five trajectory-verified before→after edits
 
 ---
 
-## τ²-Bench airline — held-out 30/10/10 run
+## τ²-Bench airline — held-out 30(=val)/20 run
 
 Same benchmark and capability, run with a real holdout split (`split_ids.json`,
-30 train / 10 val / 10 test) so the test number is a genuine generalization result.
+train=val=30, test=20) so the test number is a genuine generalization result.
 
 | split | baseline | optimized | Δ |
 |---|---|---|---|
-| **val** (10 tasks) | **56.7** | **70.0** | **+13.3 pp / +23.5% relative** |
-| **sealed test** (10 tasks, scored once) | **30.0** | **47.5** | **+17.5 pp / +58.3% relative** |
+| **val** (30 tasks) | **56.7** | **70.0** | **+13.3 pp / +23.5% relative** |
+| **sealed test** (20 tasks, scored once) | **30.0** | **47.5** | **+17.5 pp / +58.3% relative** |
 
 > The held-out `run_full` artifact for this run is committed separately. Until it lands,
 > treat these figures as the reported held-out result; the reproducible artifact-backed

--- a/site/results.html
+++ b/site/results.html
@@ -155,11 +155,11 @@
       </section>
 
       <section class="reveal">
-        <h2 id="tau2-heldout">τ²-bench airline — held-out 30/10/10 run</h2>
+        <h2 id="tau2-heldout">τ²-bench airline — held-out 30(=val)/20 run</h2>
 
         <p>
           Same benchmark and capability, run with a real holdout split
-          (<code>split_ids.json</code>, 30 train / 10 val / 10 test) so the test number is a genuine
+          (<code>split_ids.json</code>, train=val=30, test=20) so the test number is a genuine
           generalization result.
         </p>
 
@@ -168,8 +168,8 @@
             <tr><th>split</th><th>baseline</th><th>optimized</th><th>Δ</th></tr>
           </thead>
           <tbody>
-            <tr><td><strong>val</strong> (10 tasks)</td><td class="num"><strong>0.567</strong> (56.7%)</td><td class="num"><strong>0.700</strong> (70.0%)</td><td class="gain">+13.3 pp / +23.5% relative</td></tr>
-            <tr><td><strong>sealed test</strong> (10 tasks, scored once)</td><td class="num"><strong>0.300</strong> (30.0%)</td><td class="num"><strong>0.475</strong> (47.5%)</td><td class="gain">+17.5 pp / +58.3% relative</td></tr>
+            <tr><td><strong>val</strong> (30 tasks)</td><td class="num"><strong>0.567</strong> (56.7%)</td><td class="num"><strong>0.700</strong> (70.0%)</td><td class="gain">+13.3 pp / +23.5% relative</td></tr>
+            <tr><td><strong>sealed test</strong> (20 tasks, scored once)</td><td class="num"><strong>0.300</strong> (30.0%)</td><td class="num"><strong>0.475</strong> (47.5%)</td><td class="gain">+17.5 pp / +58.3% relative</td></tr>
           </tbody>
         </table>
 
@@ -394,7 +394,7 @@
 
             <!-- Row 2: τ²-bench airline held-out test — 30.0 → 47.5 -->
             <text class="row-label" x="170" y="136" text-anchor="end">τ²-bench airline</text>
-            <text class="row-sub"   x="170" y="149" text-anchor="end">held-out test (10 tasks)</text>
+            <text class="row-sub"   x="170" y="149" text-anchor="end">held-out test (20 tasks)</text>
             <line class="connector" x1="318" y1="142" x2="383" y2="142"/>
             <circle class="dot-base" cx="312" cy="142" r="6"/>
             <circle class="dot-opt"  cx="389" cy="142" r="6"/>
@@ -438,7 +438,7 @@
       <div class="toc-title">On this page</div>
       <a href="#toy-calc">toy_calc</a>
       <a href="#tau2-fit">τ²-bench — fit metric</a>
-      <a href="#tau2-heldout">τ²-bench — held-out 30/10/10</a>
+      <a href="#tau2-heldout">τ²-bench — held-out 30(=val)/20</a>
       <a href="#tau2-agent">τ²-bench — agent mode</a>
       <a href="#qwen-tools">τ²-bench — Qwen 14B</a>
       <a href="#qwen-all">Qwen 14B — all capabilities</a>


### PR DESCRIPTION
## Summary

Fixes #146.

The τ²-bench airline held-out run used **train=val=30 and test=20**, not 30 train / 10 val / 10 test as was incorrectly documented.

## Changes

| File | Change |
|---|---|
| `README.md` | Split column: `held-out 30/10/10` → `held-out 30(=val)/20` |
| `docs/RESULTS.md` | Section heading, split description, and task counts in the table (val: 10→30 tasks, test: 10→20 tasks) |
| `docs/COMPARISON.md` | Benchmark column: `held-out 30/10/10` → `held-out 30(=val)/20` |
| `site/results.html` | Section heading, split description text, table rows (val: 10→30 tasks, test: 10→20 tasks), SVG chart subtitle, and nav link |

The reward values (30.0 → 47.5, +17.5 pp / +58.3%) are unchanged — only the split description and task counts are corrected.