### PR TITLE
fix: correct Qwen 14B held-out split labels from 30/10/10 to train=val=30, test=20

### DIFF
--- a/docs/RESULTS.md
+++ b/docs/RESULTS.md
@@ -124,6 +124,56 @@ run head-to-head, and improved the single-trial held-out test +37.5%. A genuine,
 here needs a stronger runner model or tool-level edits (which drove most of the lift in the
 no-holdout run).
 
+---
+
+## τ²-Bench airline — Qwen 2.5 14B (tools only, held-out)
+
+Same benchmark, capability, split, and algorithm as the held-out run above, with a
+self-hosted open model (**Qwen 2.5 14B-Instruct** via vLLM on OpenShift) replacing the
+Claude runner.
+
+- **Capability:** airline **policy + tools** (`[system-prompt, tools]`).
+- **Optimizer:** `claude-code` @ `claude-sonnet-4-6` (Vertex AI).
+- **Runner + user simulator:** `Qwen/Qwen2.5-14B-Instruct` via vLLM on OpenShift.
+- **Tasks / trials:** all **50** airline tasks · **5** trials each.
+- **Split:** **train=val=30, test=20** — **held-out**.
+- **Algorithm / gate:** `hill-climb --focus all`, **10** iterations, paired significance gate `k_se 0.3`.
+
+| split | baseline | optimized | Δ |
+|---|---|---|---|
+| **val** (30 tasks) | **0.200** (20.0%) | **0.387** (38.7%) | **+0.187 / +93.5% relative** |
+| **sealed test** (20 tasks, scored once) | **0.170** (17.0%) | **0.240** (24.0%) | **+0.070 / +41.2% relative** |
+
+3 of 10 iterations accepted. The optimizer added code-level enforcement of cancellation
+rules, input validation guards, and pre-flight status checks — hardening tool
+implementations rather than rewriting policy prose.
+
+---
+
+## τ²-Bench airline — Qwen 2.5 14B, all capabilities (held-out)
+
+Same model and split as above, with all three capability types optimized jointly.
+
+- **Capability:** `[skill-package, system-prompt, tools]`.
+- **Optimizer:** `claude-code` @ `claude-sonnet-4-6` (Vertex AI).
+- **Runner + user simulator:** `Qwen/Qwen2.5-14B-Instruct` via vLLM on OpenShift.
+- **Tasks / trials:** all **50** airline tasks · **5** trials each.
+- **Split:** **train=val=30, test=20** — **held-out**.
+- **Algorithm / gate:** `hill-climb --focus all`, **10** iterations, paired significance gate `k_se 0.3`.
+
+| split | baseline | optimized | Δ |
+|---|---|---|---|
+| **val** (30 tasks) | **0.273** (27.3%) | **0.520** (52.0%) | **+0.247 / +90.5% relative** |
+| **sealed test** (20 tasks, scored once) | **0.120** (12.0%) | **0.270** (27.0%) | **+0.150 / +125.0% relative** |
+
+3 of 10 iterations accepted, 7 rejected. The optimizer edited tool code, policy rules,
+and skill prose jointly — combining code-level guards with policy clarifications and
+structured methodology in SKILL.md.
+
+**Best held-out test gain across all Qwen 14B runs (+125%).** On a self-hosted 14B model,
+`[skill-package, system-prompt, tools]` with `hill-climb` outperformed the tools-only run
+(+41.2%) when paired with hill-climb's conservative gating.
+
 ## SkillsBench — skill-package optimization (held-out, committed)
 
 Artifact: [`examples/skillsbench/run_full/`](../examples/skillsbench/run_full/)

--- a/site/results.html
+++ b/site/results.html
@@ -242,7 +242,7 @@
           <li><strong>Optimizer:</strong> <code>claude-code</code> @ <code>claude-sonnet-4-6</code> (Vertex AI).</li>
           <li><strong>Runner + user simulator:</strong> <code>Qwen/Qwen2.5-14B-Instruct</code> via vLLM on OpenShift.</li>
           <li><strong>Tasks / trials:</strong> 50 airline tasks · <strong>5</strong> trials each.</li>
-          <li><strong>Split:</strong> 30 train / 10 val / 10 test — <strong>held-out</strong>.</li>
+          <li><strong>Split:</strong> train=val=30, test=20 — <strong>held-out</strong>.</li>
           <li><strong>Algorithm / gate:</strong> <code>hill-climb --focus all</code>, <strong>10</strong> iterations, paired significance gate <code>k_se 0.3</code>.</li>
         </ul>
 
@@ -251,8 +251,8 @@
             <tr><th>split</th><th>baseline</th><th>optimized</th><th>Δ</th></tr>
           </thead>
           <tbody>
-            <tr><td><strong>val</strong> (10 tasks)</td><td class="num"><strong>0.200</strong> (20.0%)</td><td class="num"><strong>0.387</strong> (38.7%)</td><td class="gain">+0.187 / +93.5% relative</td></tr>
-            <tr><td><strong>sealed test</strong> (10 tasks, scored once)</td><td class="num"><strong>0.170</strong> (17.0%)</td><td class="num"><strong>0.240</strong> (24.0%)</td><td class="gain">+0.070 / +41.2% relative</td></tr>
+            <tr><td><strong>val</strong> (30 tasks)</td><td class="num"><strong>0.200</strong> (20.0%)</td><td class="num"><strong>0.387</strong> (38.7%)</td><td class="gain">+0.187 / +93.5% relative</td></tr>
+            <tr><td><strong>sealed test</strong> (20 tasks, scored once)</td><td class="num"><strong>0.170</strong> (17.0%)</td><td class="num"><strong>0.240</strong> (24.0%)</td><td class="gain">+0.070 / +41.2% relative</td></tr>
           </tbody>
         </table>
 
@@ -275,7 +275,7 @@
           <li><strong>Optimizer:</strong> <code>claude-code</code> @ <code>claude-sonnet-4-6</code> (Vertex AI).</li>
           <li><strong>Runner + user simulator:</strong> <code>Qwen/Qwen2.5-14B-Instruct</code> via vLLM on OpenShift.</li>
           <li><strong>Tasks / trials:</strong> 50 airline tasks · <strong>5</strong> trials each.</li>
-          <li><strong>Split:</strong> 30 train / 10 val / 10 test — <strong>held-out</strong>.</li>
+          <li><strong>Split:</strong> train=val=30, test=20 — <strong>held-out</strong>.</li>
           <li><strong>Algorithm / gate:</strong> <code>hill-climb --focus all</code>, <strong>10</strong> iterations, paired significance gate <code>k_se 0.3</code>.</li>
         </ul>
 
@@ -284,8 +284,8 @@
             <tr><th>split</th><th>baseline</th><th>optimized</th><th>Δ</th></tr>
           </thead>
           <tbody>
-            <tr><td><strong>val</strong> (10 tasks)</td><td class="num"><strong>0.273</strong> (27.3%)</td><td class="num"><strong>0.520</strong> (52.0%)</td><td class="gain">+0.247 / +90.5% relative</td></tr>
-            <tr><td><strong>sealed test</strong> (10 tasks, scored once)</td><td class="num"><strong>0.120</strong> (12.0%)</td><td class="num"><strong>0.270</strong> (27.0%)</td><td class="gain">+0.150 / +125.0% relative</td></tr>
+            <tr><td><strong>val</strong> (30 tasks)</td><td class="num"><strong>0.273</strong> (27.3%)</td><td class="num"><strong>0.520</strong> (52.0%)</td><td class="gain">+0.247 / +90.5% relative</td></tr>
+            <tr><td><strong>sealed test</strong> (20 tasks, scored once)</td><td class="num"><strong>0.120</strong> (12.0%)</td><td class="num"><strong>0.270</strong> (27.0%)</td><td class="gain">+0.150 / +125.0% relative</td></tr>
           </tbody>
         </table>
 


### PR DESCRIPTION
## Summary

Follows up on #148 / #146 — applies the same split correction to both Qwen 2.5 14B result sections.

The Qwen runs used the same split as the other held-out runs: **train=val=30, test=20** — not 30 train / 10 val / 10 test.

## Changes

### `site/results.html`
Both the `#qwen-tools` (tools-only) and `#qwen-all` (all-capabilities) sections:
- Split bullet: `30 train / 10 val / 10 test` → `train=val=30, test=20`
- val row task count: `(10 tasks)` → `(30 tasks)`
- sealed test row task count: `(10 tasks, scored once)` → `(20 tasks, scored once)`

### `docs/RESULTS.md`
The Qwen sections were missing from the markdown docs entirely. Added both:
- **τ²-Bench airline — Qwen 2.5 14B (tools only, held-out)** — split train=val=30, test=20, val 30 tasks, test 20 tasks
- **τ²-Bench airline — Qwen 2.5 14B, all capabilities (held-out)** — same split

Reward values and gain figures are unchanged — only the split description and task counts are corrected.

Relates to #146