### PR TITLE
fix(ci): tau2 integration test to 1 iter/1 trial; smoke pinned 3, full defaults to 10/10

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -34,9 +34,9 @@ on:
         default: smoke
         options: [all, smoke, full]
       iterations:
-        description: "Optimizer iterations per task for the FULL tier (default 3; raise to give the optimizer more budget). Smoke always runs 3, regardless of this input."
+        description: "Optimizer iterations per task for the FULL tier (default 10; raise to give the optimizer more budget). Smoke always runs 3, regardless of this input."
         type: string
-        default: "3"
+        default: "10"
   pull_request:
     types: [labeled]
 
@@ -72,8 +72,12 @@ jobs:
       ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
       ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
       # Smoke always runs a fixed 3 iterations (cheap, fast regression) — decoupled
-      # from the `iterations` input, which only controls the (expensive) full tier.
-      ITERATIONS: ${{ matrix.tier == 'smoke' && '3' || github.event.inputs.iterations || '3' }}
+      # from the `iterations` input, which only controls the (expensive) full tier
+      # (default 10 there — see the `iterations` input above).
+      ITERATIONS: ${{ matrix.tier == 'smoke' && '3' || github.event.inputs.iterations || '10' }}
+      # 10 trials/eval for both tiers (run_suite.sh's own default — pinned explicitly
+      # here so it can't silently drift if that default ever changes).
+      NUM_TRIALS: "10"
       TIER: ${{ matrix.tier }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -34,7 +34,7 @@ on:
         default: smoke
         options: [all, smoke, full]
       iterations:
-        description: "Optimizer iterations per task (default 3; raise to give the optimizer more budget)"
+        description: "Optimizer iterations per task for the FULL tier (default 3; raise to give the optimizer more budget). Smoke always runs 3, regardless of this input."
         type: string
         default: "3"
   pull_request:
@@ -71,7 +71,9 @@ jobs:
     env:
       ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
       ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
-      ITERATIONS: ${{ github.event.inputs.iterations || '3' }}
+      # Smoke always runs a fixed 3 iterations (cheap, fast regression) — decoupled
+      # from the `iterations` input, which only controls the (expensive) full tier.
+      ITERATIONS: ${{ matrix.tier == 'smoke' && '3' || github.event.inputs.iterations || '3' }}
       TIER: ${{ matrix.tier }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -3,7 +3,7 @@
 # ============================================================================
 #
 # The general pipeline regression on a real benchmark: agent aws/gpt-oss-120b,
-# optimizer Claude Code @ claude-opus-4-8, 3 iterations, via the adapter template.
+# optimizer Claude Code @ claude-opus-4-8, 1 iteration, via the adapter template.
 # Runs the same run_suite.sh path benchmarks.yml uses, scoped to a single-task
 # "integration" tier (ci/benchmarks/tau2/integration/tasks.json = [task 9]).
 # Passes when the run COMPLETES and the sealed test does not regress vs baseline
@@ -45,6 +45,7 @@ jobs:
       - name: Run tau2 task-9 end-to-end (agent gpt-oss-120b, optimizer claude-opus-4-8)
         env:
           TIER: integration
+          ITERATIONS: "1"
         run: |
           set -euo pipefail
           out="$(bash ci/benchmarks/lib/run_suite.sh tau2 "$GITHUB_WORKSPACE/ci/benchmarks/.work/suite_integration_tau2")"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -3,7 +3,7 @@
 # ============================================================================
 #
 # The general pipeline regression on a real benchmark: agent aws/gpt-oss-120b,
-# optimizer Claude Code @ claude-opus-4-8, 1 iteration, via the adapter template.
+# optimizer Claude Code @ claude-opus-4-8, 1 iteration, 1 trial, via the adapter template.
 # Runs the same run_suite.sh path benchmarks.yml uses, scoped to a single-task
 # "integration" tier (ci/benchmarks/tau2/integration/tasks.json = [task 9]).
 # Passes when the run COMPLETES and the sealed test does not regress vs baseline
@@ -46,6 +46,7 @@ jobs:
         env:
           TIER: integration
           ITERATIONS: "1"
+          NUM_TRIALS: "1"
         run: |
           set -euo pipefail
           out="$(bash ci/benchmarks/lib/run_suite.sh tau2 "$GITHUB_WORKSPACE/ci/benchmarks/.work/suite_integration_tau2")"


### PR DESCRIPTION
Closes #153.

## Summary
- `integration-tests.yml`'s tau2 task-9 check was running `run_suite.sh`'s defaults
  of 3 optimizer iterations and 10 trials per eval. It's a pipeline-completes/
  non-regression smoke check on a single task, not a capability-improvement
  measurement or a statistical benchmark, so set `ITERATIONS: "1"` and
  `NUM_TRIALS: "1"` explicitly in the step's env instead of relying on those
  defaults. Updated the workflow's header comment to match.
- `benchmarks.yml`: the `iterations` workflow_dispatch input previously drove BOTH
  the smoke and full tier matrix cells via one shared `ITERATIONS` env value, so
  raising it to give a full-tier run more optimizer budget also inflated every
  smoke run in that same dispatch.
  - **Smoke** is now pinned to always run **3 iterations**, regardless of the
    `iterations` input.
  - **Full** now defaults to **10 iterations** (the `iterations` input's own
    default changed from 3 → 10, since it now exclusively controls full) and is
    still raisable per-dispatch for more optimizer budget.
  - **Trials**: pinned `NUM_TRIALS: "10"` explicitly for both tiers (this matches
    `run_suite.sh`'s own existing default — pinning it in the workflow just makes
    it explicit so it can't silently drift if that script's default ever changes).

## Testing
- `python3 -c "import yaml; yaml.safe_load(...)"` — both edited workflow files parse.
- Not run against the real gateway from this environment; the next
  `workflow_dispatch` or labeled-PR run will exercise these for real.

Signed-off-by: Eran Raichstein <eranra@il.ibm.com>