### PR TITLE
fix(site): update hero headline + restore IBM/Red Hat logo colours in dark mode

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -53,7 +53,7 @@
   <section class="hero">
     <img src="assets/logo-300.png" alt="cap-evolve" class="hero-logo">
     <span class="eyebrow"><span class="eyebrow-dot"></span>Reflective optimization for agents</span>
-    <h1>Make your agent <span class="grad">measurably better</span></h1>
+    <h1>Make your agent <span class="grad">reliably better — and prove it</span></h1>
     <p class="tagline">Optimize agentic capabilities — with agents.</p>
     <p class="description">
       <strong>cap-evolve improves an AI agent's prompts, tools, and skills by learning

--- a/site/style.css
+++ b/site/style.css
@@ -298,9 +298,7 @@ body::before {
 .hero-affil-logos { display: inline-flex; align-items: center; gap: 1.2rem; }
 .hero-affil-logos img { display: block; }
 .hero-affil-logos .logo-ibm, .hero-affil-logos .logo-redhat { height: 24px; width: auto; }
-/* IBM/Red Hat marks are dark-on-transparent; lift them on the dark theme */
-:root:not([data-theme="light"]) .logo-ibm,
-:root:not([data-theme="light"]) .logo-redhat { filter: brightness(0) invert(1); opacity: 0.85; }
+/* IBM/Red Hat marks: keep full colour in both light and dark themes */
 
 /* ─────────────────────── quickstart CTA panel ─────────────────────── */
 


### PR DESCRIPTION
## Summary

Two small site fixes on the `index.html` home page.

### 1 · Hero headline copy change

| Before | After |
|--------|-------|
| *Make your agent **measurably better*** | *Make your agent **reliably better — and prove it*** |

File: `site/index.html` line 56.

### 2 · IBM / Red Hat logos in colour for dark mode

The logos were previously forced to white/monochrome in dark mode via:

```css
:root:not([data-theme="light"]) .logo-ibm,
:root:not([data-theme="light"]) .logo-redhat { filter: brightness(0) invert(1); opacity: 0.85; }
```

That rule has been removed so the coloured SVG assets render as-is in both light and dark themes (both the hero block and the footer logos).

File: `site/style.css` lines 301-303.

### Checklist
- [x] Copy updated
- [x] Logo colour filter removed
- [x] No other styles affected