### PR TITLE
fix(bench): fix finalize candidate label, drop flips, add trials col, format durations

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -135,6 +135,7 @@ jobs:
             "sha": "${{ github.event.pull_request.head.sha || github.sha }}",
             "date": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
             "iterations": ${ITERATIONS:-3},
+            "trials": ${NUM_TRIALS:-10},
             "agent_model": "aws/gpt-oss-120b",
             "optimizer_model": "claude-opus-4-8",
             "conclusion": "${{ job.status }}"

--- a/ci/benchmarks/README.md
+++ b/ci/benchmarks/README.md
@@ -6,15 +6,12 @@ set of **hard** tasks (baseline reward 0) and reports **reward / latency / cost*
 from a single run, plus the optimizer's capability diffs — a reproducible end-to-end
 pipeline + metrics regression, not a leaderboard.
 
-> **On flips (0→1 after optimization).** We searched extensively for tasks that would flip
-> 0→1 after optimization — ~55 task-runs across `aws/gpt-oss-120b` (1 and 3 iterations) and
-> `aws/claude-sonnet-5` (1 iteration), on all three benchmarks — and found **none**. These
-> benchmarks are **binary-scored**; a task a model fails at baseline is capability-bound, and a
-> few optimization iterations on the prompt/policy/skill don't carry a hard failure to a pass.
-> The suite therefore ships **hard-only**: it proves the loop runs and reports honest metrics
-> (reward stays 0, non-regression), and the `iterations` knob lets you give the optimizer more
-> budget to explore. The `flip`/`hard` tagging + agent-per-task are kept in the harness for
-> future use with a different model or a non-binary scorer.
+> **Hard-only suite.** Every curated task has baseline reward 0. These benchmarks are
+> binary-scored, and a task a model fails at baseline is capability-bound — a few
+> optimization iterations on the prompt/policy/skill rarely carry a hard failure to a
+> pass. So this suite mainly proves the pipeline runs end-to-end and reports honest
+> non-regression metrics; the `iterations` knob gives the optimizer more budget to
+> explore if you want to push harder.
 
 - **Agent:** `aws/gpt-oss-120b` (all benchmarks) · **Optimizer:** Claude Code @ `claude-opus-4-8` · **3 iterations** (default; configurable via the `iterations` workflow input or `ITERATIONS` env).
 - **One project, one run:** all of a tier's tasks are optimized TOGETHER in a single
@@ -31,7 +28,7 @@ ci/benchmarks/
   lib/
     run_suite.sh      # run a whole benchmark's tasks.json + emit metrics + capabilities
     metrics.py         # per-task + suite reward report (Markdown + jsonl)
-    assert_run.py      # completion + non-regression (+ optional flip) gate
+    assert_run.py      # completion + non-regression gate
     ci_setup.sh         # idempotent runner venv + deps/clones (cached outside the checkout)
     measure_2x.sh       # run the suite twice (reproducibility) + assemble RESULTS.md
     results_md.py       # RESULTS.md assembly from a measure_2x.sh run
@@ -97,8 +94,8 @@ Just add task ids to `<bench>/full/tasks.json` (same shape as `<bench>/smoke/tas
 [{"id": "<task_id>", "tag": "full", "agent": "aws/gpt-oss-120b"}]
 ```
 No baseline-freezing step — `run_suite.sh` computes the baseline fresh, in the same run, for
-whatever ids are listed. Pick ids with baseline reward 0 (a hard task; see the flips note
-above) by running `run_suite.sh` against a candidate list and checking the report.
+whatever ids are listed. Pick ids with baseline reward 0 (a hard task) by running
+`run_suite.sh` against a candidate list and checking the report.
 
 Repo secrets required: `ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN`.
 
@@ -111,8 +108,10 @@ Repo secrets required: `ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN`.
 
 ## Metrics
 
-Per task: `reward (base→opt)`, `flip`, `latency base→opt (s)`, `runner cost base→opt`,
-`optimizer $`, `iters`. **Latency** is wall-time and hardware-dependent (baseline and
+Per task: `reward (base→opt)`, `Δ` — that's it. Latency/cost are never per-task in a
+whole-suite run (every task is scored in the same eval call); instead they're reported
+per **suite iteration** (baseline → each hill-climb step → finalize): `optimizer $`/time
+and `eval $`/time. **Latency** is wall-time and hardware-dependent (baseline and
 optimized are both measured on the same run's runner host; treat cross-host/cross-run
 comparisons as indicative only). **Cost/tokens** are hardware-independent, but the
 tau2/skillsbench runners do not surface usage (reads 0); swebench (litellm) does.

--- a/ci/benchmarks/lib/assert_run.py
+++ b/ci/benchmarks/lib/assert_run.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python3
 """Assert a cap-evolve run dir completed and did not regress on the sealed test.
 
-  assert_run.py <run_dir> [--min-iterations N] [--expect-flip]
+  assert_run.py <run_dir> [--min-iterations N]
 
 - completed: baseline.json + final.json present
 - iteration_ran: state.json spent.iterations >= N (default 1)
 - no_regression: final test reward >= baseline val reward
-- --expect-flip: additionally require final test reward > baseline (0 -> >0)
 Exit 0 on pass, 1 on failure (prints why).
 """
 from __future__ import annotations
@@ -19,7 +18,6 @@ def main(argv: list[str]) -> int:
         print(__doc__); return 2
     rd = Path(argv[1])
     min_it = 1
-    expect_flip = "--expect-flip" in argv
     if "--min-iterations" in argv:
         min_it = int(argv[argv.index("--min-iterations") + 1])
 
@@ -35,8 +33,6 @@ def main(argv: list[str]) -> int:
         print(f"FAIL: only {it} optimizer iteration(s), need >= {min_it}"); return 1
     if fin + 1e-9 < base:
         print(f"FAIL: regression — test {fin} < baseline {base}"); return 1
-    if expect_flip and not (fin > base):
-        print(f"FAIL: expected a flip but test {fin} <= baseline {base}"); return 1
     print(f"OK: baseline={base} test={fin} iterations={it}")
     return 0
 

--- a/ci/benchmarks/lib/metrics.py
+++ b/ci/benchmarks/lib/metrics.py
@@ -14,10 +14,10 @@ same task set scored before/after), not a generalization/held-out claim.
 Latency/cost are NOT meaningful per task in a whole-suite optimization (every task is
 scored in the same eval call) — they're reported per SUITE ITERATION instead, read from
 the run's events.jsonl (one "step" event per hill-climb iteration, plus the baseline
-and finalize evaluate events). Latency is wall-time seconds; it is hardware-dependent (a
-local run vs a self-hosted CI run are not directly comparable). Cost/tokens are
-hardware-independent but some runners (tau2, skillsbench) do not surface usage, so cost
-may read 0 there.
+and finalize evaluate events). Latency is wall-time, shown as minutes+seconds; it is
+hardware-dependent (a local run vs a self-hosted CI run are not directly comparable).
+Cost/tokens are hardware-independent but some runners (tau2, skillsbench) do not
+surface usage, so cost may read 0 there.
 """
 from __future__ import annotations
 
@@ -41,6 +41,15 @@ def _fmt(v, unit=""):
     return f"{v}{unit}"
 
 
+def _fmt_duration(v) -> str:
+    """Wall-time seconds as minutes+seconds (e.g. 14m48s), or plain seconds under a minute."""
+    if v is None:
+        return "—"
+    total = int(round(float(v)))
+    m, s = divmod(total, 60)
+    return f"{m}m{s:02d}s" if m else f"{s}s"
+
+
 def _infra_task(pt: dict) -> bool:
     """True if this task's reward≈0 is an infrastructure error (majority trials errored
     with mean≈0), not a real capability result — so it can be flagged, not counted as 0."""
@@ -55,14 +64,16 @@ def _infra_task(pt: dict) -> bool:
     return True
 
 
-def iteration_rows(run_dir: str) -> list[dict]:
+def iteration_rows(run_dir: str, best_id: str | None = None) -> list[dict]:
     """Per-iteration latency/cost timeline for ONE run, built from events.jsonl.
 
     Phases, in the order they occur: ``baseline`` (seed val eval) -> ``iterate`` (one
     row per hill-climb "step", accepted or rejected) -> ``finalize`` (best-on-test eval)
     -> ``finalize_baseline`` (optional seed-on-test eval, only logged when the best
     candidate isn't the seed). No optimizer call happens outside "iterate" rows, so
-    their optimizer_usd/optimizer_seconds are 0.0.
+    their optimizer_usd/optimizer_seconds are 0.0. ``best_id`` labels the ``finalize``
+    row's candidate (the "evaluate" event itself only carries a fixed tag, not the
+    actual candidate id — the caller already knows it from state.json).
     """
     events_path = Path(run_dir) / "events.jsonl"
     rows: list[dict] = []
@@ -98,7 +109,7 @@ def iteration_rows(run_dir: str) -> list[dict]:
             })
         elif kind == "evaluate" and ev.get("tag") == "FINAL" and ev.get("split") == "test":
             rows.append({
-                "phase": "finalize", "iter": None, "candidate": None, "accepted": None,
+                "phase": "finalize", "iter": None, "candidate": best_id, "accepted": None,
                 "reward": ev.get("reward"),
                 "optimizer_usd": 0.0, "optimizer_seconds": 0.0,
                 "eval_usd": ev.get("cost_usd"), "eval_seconds": ev.get("seconds"),
@@ -145,7 +156,6 @@ def suite_report(run_dir: str, bench: str, tier: str, agent: str, iters, jsonl_p
             "bench": bench, "tier": tier, "task": tid,
             "reward_baseline": rb, "reward_opt": ro,
             "reward_delta": (round(ro - rb, 6) if isinstance(rb, (int, float)) and isinstance(ro, (int, float)) and not infra else None),
-            "flipped": bool(rb == 0 and (ro or 0) > 0 and not infra),
             "opt_infra": infra,
             "run_dir": str(rd),
         })
@@ -154,7 +164,7 @@ def suite_report(run_dir: str, bench: str, tier: str, agent: str, iters, jsonl_p
             for r in rows:
                 f.write(json.dumps(r) + "\n")
 
-    steps = iteration_rows(str(rd))
+    steps = iteration_rows(str(rd), best_id=best_id)
     if steps_jsonl_path:
         with open(steps_jsonl_path, "w", encoding="utf-8") as f:
             for s in steps:
@@ -178,7 +188,7 @@ def suite_report(run_dir: str, bench: str, tier: str, agent: str, iters, jsonl_p
         real.append(r)
         d = r["reward_delta"]
         dtxt = (f"{d:+.3f}" if isinstance(d, (int, float)) else "—")
-        note = "✅" if r["flipped"] else ("↓" if isinstance(d, (int, float)) and d < 0 else "")
+        note = "↓" if isinstance(d, (int, float)) and d < 0 else ""
         out.append(f"| {bench} | `{r['task']}` | {_fmt(r['reward_baseline'])} → {_fmt(r['reward_opt'])} | {dtxt} | {note} |")
 
     # Suite headline = the run's aggregate reward (baseline val → optimized test).
@@ -204,22 +214,22 @@ def suite_report(run_dir: str, bench: str, tier: str, agent: str, iters, jsonl_p
     if not steps:
         out.append("(no iteration events found — run may have failed before logging any.)")
     else:
-        out.append("| phase | iter | candidate | accepted | reward | optimizer $ | optimizer (s) | eval $ | eval (s) |")
+        out.append("| phase | iter | candidate | accepted | reward | optimizer $ | optimizer time | eval $ | eval time |")
         out.append("|---|:--:|---|:--:|---|---|---|---|---|")
         opt_usd_t = opt_s_t = eval_usd_t = eval_s_t = 0.0
         for s in steps:
             acc = "—" if s["accepted"] is None else ("✅" if s["accepted"] else "❌")
             out.append(f"| {s['phase']} | {s['iter'] if s['iter'] is not None else '—'} | "
                        f"`{s['candidate']}` | {acc} | {_fmt(s['reward'])} | "
-                       f"{_fmt(s['optimizer_usd'], '$')} | {_fmt(s['optimizer_seconds'], 's')} | "
-                       f"{_fmt(s['eval_usd'], '$')} | {_fmt(s['eval_seconds'], 's')} |")
+                       f"{_fmt(s['optimizer_usd'], '$')} | {_fmt_duration(s['optimizer_seconds'])} | "
+                       f"{_fmt(s['eval_usd'], '$')} | {_fmt_duration(s['eval_seconds'])} |")
             opt_usd_t += s["optimizer_usd"] or 0
             opt_s_t += s["optimizer_seconds"] or 0
             eval_usd_t += s["eval_usd"] or 0
             eval_s_t += s["eval_seconds"] or 0
         out.append("")
-        out.append(f"**Totals:** optimizer ${opt_usd_t:.4f} over {opt_s_t:.1f}s · "
-                   f"eval ${eval_usd_t:.4f} over {eval_s_t:.1f}s")
+        out.append(f"**Totals:** optimizer ${opt_usd_t:.4f} over {_fmt_duration(opt_s_t)} · "
+                   f"eval ${eval_usd_t:.4f} over {_fmt_duration(eval_s_t)}")
     return "\n".join(out)
 
 

--- a/ci/benchmarks/lib/results_md.py
+++ b/ci/benchmarks/lib/results_md.py
@@ -48,6 +48,15 @@ def fnum(v, unit=""):
     return (f"${v:.4f}" if unit == "$" else f"{v:.2f}{unit}")
 
 
+def fduration(v):
+    """Wall-time seconds as minutes+seconds (e.g. 14m48s), matching metrics.py."""
+    if v is None:
+        return "—"
+    total = int(round(v))
+    m, s = divmod(total, 60)
+    return f"{m}m{s:02d}s" if m else f"{s}s"
+
+
 def main(argv):
     measure, out = Path(argv[1]), Path(argv[2])
     runs = load_runs(measure)
@@ -59,8 +68,8 @@ def main(argv):
         (
             "Agent `aws/gpt-oss-120b` · optimizer Claude Code `claude-opus-4-8` · 1 iteration · "
             "baseline computed fresh each run (no reuse across runs). Measured twice on "
-            "skillberry-1 (self-hosted, IBM VPC). All tasks are **hard** (baseline reward 0; no "
-            "natural 0→1 flip exists at this budget — see README). Latency is wall-time and "
+            "skillberry-1 (self-hosted, IBM VPC). All tasks are **hard** (baseline reward 0) — "
+            "see README. Latency is wall-time and "
             "host-dependent; cost/tokens are host-independent (tau2/skillsbench runners report 0)."
         ),
         "",
@@ -80,16 +89,16 @@ def main(argv):
         "",
         "## Per-suite latency/cost (summed over baseline + every iteration + finalize)",
         "",
-        "| bench | optimizer $ r1/r2 | optimizer (s) r1/r2 | eval $ r1/r2 | eval (s) r1/r2 |",
+        "| bench | optimizer $ r1/r2 | optimizer time r1/r2 | eval $ r1/r2 | eval time r1/r2 |",
         "|---|---|---|---|---|",
     ]
     for bench in benches:
         t1 = totals.get((bench, "run1"), {})
         t2 = totals.get((bench, "run2"), {})
         opt_usd = f"{fnum(t1.get('optimizer_usd'),'$')}/{fnum(t2.get('optimizer_usd'),'$')}"
-        opt_s = f"{fnum(t1.get('optimizer_seconds'))}/{fnum(t2.get('optimizer_seconds'))}"
+        opt_s = f"{fduration(t1.get('optimizer_seconds'))}/{fduration(t2.get('optimizer_seconds'))}"
         eval_usd = f"{fnum(t1.get('eval_usd'),'$')}/{fnum(t2.get('eval_usd'),'$')}"
-        eval_s = f"{fnum(t1.get('eval_seconds'))}/{fnum(t2.get('eval_seconds'))}"
+        eval_s = f"{fduration(t1.get('eval_seconds'))}/{fduration(t2.get('eval_seconds'))}"
         lines.append(f"| {bench} | {opt_usd} | {opt_s} | {eval_usd} | {eval_s} |")
 
     lines.append("")

--- a/ci/benchmarks/lib/test_record.py
+++ b/ci/benchmarks/lib/test_record.py
@@ -7,10 +7,10 @@ import record  # same dir; run pytest from ci/benchmarks/lib
 # per-task (every task in a suite run is scored in the same eval call).
 TASK_OK = {
     "bench": "tau2", "task": "35",
-    "reward_baseline": 0.0, "reward_opt": 1.0, "reward_delta": 1.0, "flipped": True,
+    "reward_baseline": 0.0, "reward_opt": 1.0, "reward_delta": 1.0,
     "opt_infra": False, "run_dir": "/work/run_suite",
 }
-TASK2 = {**TASK_OK, "task": "37", "reward_baseline": 0.0, "reward_opt": 0.0, "flipped": False}
+TASK2 = {**TASK_OK, "task": "37", "reward_baseline": 0.0, "reward_opt": 0.0}
 
 # Real steps rows: one per suite-run iteration (baseline / each hill-climb step / finalize).
 STEPS = [

--- a/site/benchmarks.fixture.json
+++ b/site/benchmarks.fixture.json
@@ -12,6 +12,7 @@
     "sha": "abc1234",
     "date": "2026-07-24T13:50:51Z",
     "iterations": 3,
+    "trials": 10,
     "agent_model": "aws/gpt-oss-120b",
     "optimizer_model": "claude-opus-4-8",
     "conclusion": "success",
@@ -25,8 +26,8 @@
       "eval_seconds": 120.0
     },
     "tasks": [
-      { "task": "35", "reward_baseline": 0.0, "reward_opt": 1.0, "flipped": true },
-      { "task": "37", "reward_baseline": 0.0, "reward_opt": 0.0, "flipped": false }
+      { "task": "35", "reward_baseline": 0.0, "reward_opt": 1.0 },
+      { "task": "37", "reward_baseline": 0.0, "reward_opt": 0.0 }
     ],
     "steps": [
       { "phase": "baseline", "iter": null, "candidate": "seed", "accepted": null,
@@ -35,7 +36,7 @@
       { "phase": "iterate", "iter": 1, "candidate": "cand_0001", "accepted": true,
         "reward": 0.5, "optimizer_usd": 0.05, "optimizer_seconds": 12.0,
         "eval_usd": 0.05, "eval_seconds": 40.0 },
-      { "phase": "finalize", "iter": null, "candidate": null, "accepted": null,
+      { "phase": "finalize", "iter": null, "candidate": "cand_0001", "accepted": null,
         "reward": 0.5, "optimizer_usd": 0.0, "optimizer_seconds": 0.0,
         "eval_usd": 0.05, "eval_seconds": 40.0 }
     ]
@@ -53,6 +54,7 @@
     "sha": "def5678",
     "date": "2026-07-23T09:00:00Z",
     "iterations": 5,
+    "trials": 10,
     "agent_model": "aws/gpt-oss-120b",
     "optimizer_model": "claude-opus-4-8",
     "conclusion": "success",
@@ -80,6 +82,7 @@
     "sha": "0000000",
     "date": "2026-07-20T00:00:00Z",
     "iterations": 3,
+    "trials": 10,
     "agent_model": "aws/gpt-oss-120b",
     "optimizer_model": "claude-opus-4-8",
     "conclusion": "failure",

--- a/site/benchmarks.html
+++ b/site/benchmarks.html
@@ -106,10 +106,11 @@
       <th data-k="bench">Bench</th>
       <th data-k="tier">Type</th>
       <th data-k="iterations">Iters</th>
+      <th data-k="trials">Trials</th>
       <th data-k="reward">Reward base→opt</th>
       <th data-k="eval_usd">Eval $</th>
       <th data-k="optimizer_usd">Optimizer $</th>
-      <th data-k="latency_s">Latency (s)</th>
+      <th data-k="latency_s">Latency</th>
       <th data-k="agent_model">Agent model</th>
       <th data-k="optimizer_model">Optimizer model</th>
       <th data-k="conclusion">Result</th>
@@ -141,7 +142,7 @@
   </div>
 </footer>
 
-<script src="benchmarks.js?v=20260727a"></script>
+<script src="benchmarks.js?v=20260728a"></script>
 <script src="js/site.js?v=20260724" defer></script>
 </body>
 </html>

--- a/site/benchmarks.js
+++ b/site/benchmarks.js
@@ -3,6 +3,13 @@ let RECORDS = [], sortKey = "date", sortDir = -1;
 
 const $ = (s) => document.querySelector(s);
 const fmt = (v, d = 3) => (typeof v === "number" ? v.toFixed(d) : "—");
+// Wall-time seconds as minutes+seconds (e.g. 14m48s), matching metrics.py's _fmt_duration.
+const fmtDuration = (v) => {
+  if (typeof v !== "number") return "—";
+  const total = Math.round(v);
+  const m = Math.floor(total / 60), s = total % 60;
+  return m ? `${m}m${String(s).padStart(2, "0")}s` : `${s}s`;
+};
 const esc = (v) => String(v ?? "").replace(/[&<>"']/g, (c) =>
   ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
 
@@ -88,7 +95,7 @@ function render() {
     const evalUsd = r.suite && r.suite.eval_usd != null ? `$${fmt(r.suite.eval_usd, 4)}` : "—";
     const optUsd = r.suite ? `$${fmt(r.suite.optimizer_usd, 4)}` : "—";
     const latency = r.suite && (r.suite.eval_seconds != null || r.suite.optimizer_seconds != null)
-      ? fmt((r.suite.eval_seconds ?? 0) + (r.suite.optimizer_seconds ?? 0), 1) : "—";
+      ? fmtDuration((r.suite.eval_seconds ?? 0) + (r.suite.optimizer_seconds ?? 0)) : "—";
     const src = r.pr
       ? `<a href="https://github.com/skillberry-ai/cap-evolve/pull/${encodeURIComponent(r.pr)}">${esc(r.source)}</a>`
       : esc(r.source || "—");
@@ -97,6 +104,7 @@ function render() {
     const tier = esc(r.tier || "smoke");
     tr.innerHTML = `<td><a href="${esc(r.run_url)}">${date}</a></td>
       <td>${src}</td><td>${esc(r.bench)}</td><td>${tier}</td><td>${r.iterations ?? "—"}</td>
+      <td>${r.trials ?? "—"}</td>
       <td>${reward}</td><td>${evalUsd}</td><td>${optUsd}</td><td>${latency}</td>
       <td><code>${esc(r.agent_model || "—")}</code></td><td><code>${esc(r.optimizer_model || "—")}</code></td>
       <td>${badge}</td>`;
@@ -105,7 +113,7 @@ function render() {
     const detail = document.createElement("tr");
     detail.className = "detail-row";
     detail.hidden = true;
-    detail.innerHTML = `<td colspan="12">${taskTable(r.tasks || [])}${stepsTable(r.steps || [])}</td>`;
+    detail.innerHTML = `<td colspan="13">${taskTable(r.tasks || [])}${stepsTable(r.steps || [])}</td>`;
     tb.appendChild(detail);
 
     tr.addEventListener("click", (e) => {
@@ -118,23 +126,22 @@ function taskTable(tasks) {
   if (!tasks.length) return `<em class="muted">no per-task metrics</em>`;
   // Latency/cost are never per-task in a whole-suite optimization (every task is
   // scored together in the same eval call) — see stepsTable() for that.
-  const head = `<tr><th>task</th><th>reward base→opt</th><th>flip</th></tr>`;
+  const head = `<tr><th>task</th><th>reward base→opt</th></tr>`;
   const body = tasks.map((t) => `<tr><td><code>${esc(t.task)}</code></td>
-    <td>${fmt(t.reward_baseline)} → ${fmt(t.reward_opt)}</td>
-    <td>${t.flipped ? "✅" : ""}</td></tr>`).join("");
+    <td>${fmt(t.reward_baseline)} → ${fmt(t.reward_opt)}</td></tr>`).join("");
   return `<table class="detail">${head}${body}</table>`;
 }
 
 function stepsTable(steps) {
   if (!steps.length) return `<em class="muted">no per-iteration metrics</em>`;
   const head = `<tr><th>phase</th><th>iter</th><th>candidate</th><th>accepted</th>` +
-    `<th>reward</th><th>optimizer $</th><th>optimizer (s)</th><th>eval $</th><th>eval (s)</th></tr>`;
+    `<th>reward</th><th>optimizer $</th><th>optimizer time</th><th>eval $</th><th>eval time</th></tr>`;
   const body = steps.map((s) => `<tr><td>${esc(s.phase)}</td><td>${s.iter ?? "—"}</td>
     <td><code>${esc(s.candidate)}</code></td>
     <td>${s.accepted == null ? "—" : (s.accepted ? "✅" : "❌")}</td>
     <td>${fmt(s.reward)}</td>
-    <td>$${fmt(s.optimizer_usd, 4)}</td><td>${fmt(s.optimizer_seconds, 1)}</td>
-    <td>$${fmt(s.eval_usd, 4)}</td><td>${fmt(s.eval_seconds, 1)}</td></tr>`).join("");
+    <td>$${fmt(s.optimizer_usd, 4)}</td><td>${fmtDuration(s.optimizer_seconds)}</td>
+    <td>$${fmt(s.eval_usd, 4)}</td><td>${fmtDuration(s.eval_seconds)}</td></tr>`).join("");
   return `<table class="detail">${head}${body}</table>`;
 }
 


### PR DESCRIPTION
Closes #157.

## Summary

- **Finalize candidate fix**: the Iterations table's `finalize` row showed
  `candidate` as the literal `None` instead of the real best_id. The underlying
  `"evaluate"` event only carries a fixed tag (`"FINAL"`), not the candidate's
  actual id, so `iteration_rows()` now takes `best_id` (already loaded from
  `state.json` by its caller, `suite_report()`) and labels the row correctly
  (e.g. `cand_0001`).
- **Removed the "flip" (0→1) concept** everywhere it was calculated or
  displayed — it's confusing and only meaningful with very few trials per
  task; per-task reward (base→opt) already carries the signal that matters.
  Removed from: `metrics.py`'s per-task rows and table ("flipped" field, ✅
  note), `assert_run.py`'s `--expect-flip` flag (unused by any caller),
  `test_record.py` fixtures, `site/benchmarks.js`'s per-task "flip" column,
  and `site/benchmarks.fixture.json`. Reworded README/`results_md.py` prose
  that leaned on flip framing.
- **Trials column**: `benchmarks.yml` now captures `NUM_TRIALS` into
  `runmeta.json` as `"trials"` (mirrors the existing `"iterations"` field),
  which flows through `record.py`'s verbatim pass-through into the history
  records. `site/benchmarks.html` gained a **Trials** column next to **Iters**.
- **Duration formatting**: wall-time is now shown as minutes+seconds (e.g.
  `14m48s`) instead of raw seconds — in the Iterations table + Totals line
  (`metrics.py`), the per-iteration detail table + main-table **Latency**
  column (`site/benchmarks.js`), and `results_md.py`'s per-suite latency/cost
  table.

**Not included** (deliberately out of scope — see PR discussion): the
tau2/skillsbench `eval $` = `$0.00` issue. Traced it to
`templates/adapters/tau2_bench/adapter.py:242` — cost comes from the tau2-bench
library's own `SimulationRun.agent_cost`/`user_cost`, which itself depends on
litellm recognizing the model for pricing; `aws/gpt-oss-120b` via the custom
RITS/gateway route isn't in litellm's pricing table, so it's 0 upstream before
it ever reaches our adapter (also `tokens=0` is hardcoded there). Needs
inspecting the `tau2` package on skillberry-1 before proposing a real fix —
tracked separately.

## Testing

- `python3 -m py_compile` on every edited Python file; `node --check` on
  `benchmarks.js`; both edited JSON files parse; `benchmarks.yml` YAML parses.
- `ci/benchmarks/lib/test_record.py` — 9/9 passing (fixtures updated to the
  real per-task row shape, no `flipped` field).
- End-to-end synthetic-run smoke test: a fabricated `events.jsonl` (seed
  baseline, one accepted iteration, finalize, finalize_baseline) fed through
  `metrics.py suite` and `record.py build` — confirmed the `finalize` row now
  shows `cand_0001` (not `None`), no `flipped` key anywhere, durations render
  as `14m48s`-style, and `"trials": 10` appears in the built record.
- Not run against the real gateway from this environment; the next
  `workflow_dispatch` will exercise it for real.

Signed-off-by: Eran Raichstein <eranra@il.ibm.com>