### PR TITLE
feat(adapter): add score_batch hook, batch SWE-bench Docker evaluation per trial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,16 @@ All notable changes to cap-evolve are documented here. The format follows
   every other benchmark's smoke tier. `select_candidates.py` and its output
   (`utils/smoke_candidates.json`) live under `utils/` — not read by CI, only for
   re-picking tasks later.
+- **Adapter-native batch scoring (`score_batch`).** New optional adapter hook,
+  `score_batch(tasks, rollouts) -> {task_id: Score}` — the scoring-side counterpart to
+  `run_batch`/`run_trials` (see `docs/ADAPTER_CONTRACT.md`). The harness calls it once
+  per trial instead of looping `score()` per task; any task id it omits falls back to a
+  single `score()` call, so a partial implementation can never silently drop a score.
+  The SWE-bench adapter now implements it, batching a trial's instances into **one**
+  `swebench.harness.run_evaluation` call with a comma-separated `--instance_ids` list —
+  previously every trial ran one Docker-harness subprocess per instance with nothing for
+  `--max_workers` to parallelize over, so `SWEBENCH_MAX_WORKERS=10` (already set in CI)
+  was a no-op. Adapters that don't implement `score_batch` are unaffected.
 - **Consuming-LLM profiles.** Declare the runtime/consuming model via `target_model`
   (a concrete model id or a capability tier: `frontier|strong|mid|weak`) in
   `capevolve.yaml`. The optimizer prompt (new `{{TARGET_READER}}` block) and the

--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -200,6 +200,7 @@ def evaluate_candidate(
     from .stats import mean, stderr
     has_batch = hasattr(adapter, "run_batch")
     has_run_trials = hasattr(adapter, "run_trials")
+    has_score_batch = hasattr(adapter, "score_batch")
 
     # collect per-task trial rewards (+ last rollout/score) across trials
     per_task_trials: dict[str, list[float]] = {t.id: [] for t in tasks}
@@ -215,20 +216,36 @@ def evaluate_candidate(
         """Score + persist one trial's rollouts. The single source of truth for
         per-trial scoring/persistence/accumulation — called identically by the
         per-trial loop and the adapter.run_trials batch branch, so pass^k/SE and the
-        on-disk t{k}.json files are byte-for-byte equivalent regardless of path."""
+        on-disk t{k}.json files are byte-for-byte equivalent regardless of path.
+
+        If the adapter exposes ``score_batch(tasks, rollouts) -> {task_id: Score}``,
+        the whole trial is scored in ONE call (e.g. one Docker harness invocation for
+        swebench) instead of one ``adapter.score()`` call per task. Any task id the
+        batch omits falls back to a single ``adapter.score()`` call, so a partial
+        implementation can never silently drop a score."""
+        filled = {
+            tid: (rollouts_for_k.get(tid) or Rollout(task_id=tid, error="omitted from batch result"))
+            for tid in task_by_id
+        }
+        if has_score_batch:
+            sb = adapter.score_batch(list(task_by_id.values()), filled) or {}
+            scores_by_id = sb if isinstance(sb, dict) else {t.id: s for t, s in zip(task_by_id.values(), sb)}
+        else:
+            scores_by_id = {}
+
         for tid, task in task_by_id.items():
-            rollout = rollouts_for_k.get(tid)
-            if rollout is None:
-                # A trial omitted this task (an error/timeout inside the runner).
-                # Record it as a failed rollout (reward 0) — do NOT serially re-run
-                # it here, which would add a slow tail to every batch evaluation.
-                rollout = Rollout(task_id=tid, error="omitted from batch result")
+            # A trial may have omitted this task (an error/timeout inside the runner) —
+            # `filled` already turned that into a failed rollout above. Do NOT serially
+            # re-run it here, which would add a slow tail to every batch evaluation.
+            rollout = filled[tid]
             if getattr(rollout, "error", None):
                 per_task_errored[tid] = True
                 per_task_errored_trials[tid] += 1
             run_acc["cost"] += float(getattr(rollout, "cost_usd", 0.0) or 0.0)
             run_acc["tokens"] += int(getattr(rollout, "tokens", 0) or 0)
-            sc = adapter.score(task, rollout)
+            sc = scores_by_id.get(tid)
+            if sc is None:  # not in has_score_batch mode, or the batch omitted this id
+                sc = adapter.score(task, rollout)
             per_task_trials[tid].append(sc.reward)
             per_task_feedback[tid] = sc.feedback or per_task_feedback[tid]
             per_task_metrics[tid].append(sc.metrics)

--- a/core/tests/test_w1_engine.py
+++ b/core/tests/test_w1_engine.py
@@ -58,6 +58,79 @@ def test_per_trial_seed_is_threaded(tmp_path):
     assert res.per_task[0]["stderr"] > 0.0
 
 
+# ---- score_batch hook (adapter-native batch scoring) ----------------------
+
+class _ScoreBatchAdapter:
+    """Two tasks per trial; ``score_batch`` scores them in ONE call and records
+    the id-sets it was invoked with, to prove the harness batches per-trial
+    rather than calling per task. Can omit one task id from its result to
+    exercise the harness's per-task ``score()`` fallback."""
+
+    def __init__(self, omit_task_id=None):
+        self.omit_task_id = omit_task_id
+        self.batch_calls = []          # one sorted id-list per score_batch call
+        self.single_score_calls = []   # task ids scored via the singular fallback
+
+    def tasks(self, split):
+        from cap_evolve import Task
+        return [Task(id="t0"), Task(id="t1")]
+
+    def run_target(self, task, ctx, *, seed=0):
+        from cap_evolve import Rollout
+        return Rollout(task_id=task.id, output="ok")
+
+    def score(self, task, rollout):
+        from cap_evolve import Score
+        self.single_score_calls.append(task.id)
+        return Score(task_id=task.id, reward=0.5, feedback="single")
+
+    def score_batch(self, tasks, rollouts):
+        from cap_evolve import Score
+        self.batch_calls.append(sorted(t.id for t in tasks))
+        out = {}
+        for t in tasks:
+            if t.id == self.omit_task_id:
+                continue  # let the harness's per-task fallback handle this one
+            out[t.id] = Score(task_id=t.id, reward=1.0, feedback="batched")
+        return out
+
+    def apply(self, candidate_dir, edits=None):
+        return None
+
+
+def test_score_batch_called_once_per_trial_with_all_tasks(tmp_path):
+    from cap_evolve import RunDir, harness
+    from cap_evolve.splits import Splits
+    adapter = _ScoreBatchAdapter()
+    rd = RunDir.create(tmp_path / ".capevolve", ts="sb")
+    rd.write_splits(Splits(train=[], val=["t0", "t1"], test=[], seed=0))
+    cand = tmp_path / "c"; cand.mkdir()
+    rd.snapshot("sb", cand)
+    res = harness.evaluate_candidate(adapter, rd.candidate_dir("sb"), run_dir=rd,
+                                     split="val", n_trials=2, tag="sb")
+    # one score_batch call per trial, each covering BOTH tasks -- not one per task
+    assert adapter.batch_calls == [["t0", "t1"], ["t0", "t1"]]
+    assert adapter.single_score_calls == []  # never falls back when the batch covers everything
+    assert all(row["reward"] == 1.0 for row in res.per_task)
+
+
+def test_score_batch_omission_falls_back_to_single_score(tmp_path):
+    from cap_evolve import RunDir, harness
+    from cap_evolve.splits import Splits
+    adapter = _ScoreBatchAdapter(omit_task_id="t1")
+    rd = RunDir.create(tmp_path / ".capevolve", ts="sbfb")
+    rd.write_splits(Splits(train=[], val=["t0", "t1"], test=[], seed=0))
+    cand = tmp_path / "c"; cand.mkdir()
+    rd.snapshot("sbfb", cand)
+    res = harness.evaluate_candidate(adapter, rd.candidate_dir("sbfb"), run_dir=rd,
+                                     split="val", n_trials=1, tag="sbfb")
+    # t1 was omitted from the batch result -> the harness scored it singly instead
+    assert adapter.single_score_calls == ["t1"]
+    rewards = {row["task_id"]: row["reward"] for row in res.per_task}
+    assert rewards["t0"] == 1.0   # from the batch
+    assert rewards["t1"] == 0.5   # from the single-score fallback
+
+
 # ---- seal-on-success ------------------------------------------------------
 
 class _CrashingAdapter:

--- a/docs/ADAPTER_CONTRACT.md
+++ b/docs/ADAPTER_CONTRACT.md
@@ -55,10 +55,17 @@ with `hasattr` (`core/cap_evolve/harness.py`) and uses them when present:
 ```python
 def run_batch(self, tasks, ctx, *, seed=0) -> ...                                  # drive a benchmark's OWN batch runner INSTEAD of run_target (as tau2 does)
 def run_trials(self, tasks, ctx, *, n_trials, base_seed) -> {id: [Rollout, ...]}   # batched fast path: ALL trials in ONE run
+def score_batch(self, tasks, rollouts) -> {id: Score}                             # batched fast path: score a WHOLE trial in ONE call (e.g. one Docker harness invocation, as swebench does)
 ```
 
 `run_trials` collapses N sequential eval passes into one concurrent run; per-trial
 persistence and pass^k / SE are byte-for-byte unchanged, so resume keeps working.
+`score_batch` is the scoring-side counterpart: the harness calls it once per trial with
+that trial's `{task_id: Rollout}` instead of looping `score()` per task — the point is a
+benchmark whose real evaluation cost is in an external harness (e.g. a Docker build per
+instance) can batch that harness call and let it parallelize internally. Any task id the
+batch omits falls back to a single `score()` call, so a partial implementation can never
+silently drop a score.
 
 ## Why this shape (three abstract, not prior work's three or SkillOpt's five)
 

--- a/templates/adapters/swe_bench/adapter.py
+++ b/templates/adapters/swe_bench/adapter.py
@@ -285,40 +285,12 @@ Do not include any explanation before or after the patch.
         Runs the patch in a Docker container against the instance's test suite.
         Returns binary reward: 1.0 if all tests pass, 0.0 otherwise.
         """
-        if rollout.error:
-            return Score(
-                task_id=task.id,
-                reward=0.0,
-                feedback=(
-                    f"Rollout failed: {rollout.error}. Infrastructure error, "
-                    "not a prompt defect; do not optimize against it."
-                ),
-            )
-
-        patch = rollout.output or ""
-        if not patch.strip():
-            return Score(
-                task_id=task.id,
-                reward=0.0,
-                feedback="Empty patch produced. The prompt must instruct the model "
-                "to output a valid unified diff.",
-            )
-
-        # A non-diff can never resolve an instance — reject cheaply without paying
-        # for a Docker build. This also keeps `cap-evolve check`'s scorer probe
-        # (a synthetic non-diff rollout) offline and fast.
-        if not _looks_like_diff(patch):
-            return Score(
-                task_id=task.id,
-                reward=0.0,
-                feedback="Output is not a valid unified diff (no diff/---/@@ markers). "
-                "The prompt must instruct the model to output ONLY a unified diff.",
-            )
-
-        instance_id = task.id
+        pre = _cheap_score_precheck(task.id, rollout)
+        if pre is not None:
+            return pre
 
         try:
-            reward, feedback = self._evaluate_patch(instance_id, patch)
+            reward, feedback = self._evaluate_patch(task.id, rollout.output or "")
         except Exception as e:  # noqa: BLE001
             return Score(
                 task_id=task.id,
@@ -328,37 +300,82 @@ Do not include any explanation before or after the patch.
 
         return Score(task_id=task.id, reward=reward, feedback=feedback)
 
+    def score_batch(self, tasks: list[Task], rollouts: dict) -> dict:
+        """Score a WHOLE trial's rollouts with ONE swebench harness invocation.
+
+        A single-instance call (the ``score()`` path) has nothing for
+        ``--max_workers`` to parallelize over; batching every instance in this
+        trial into one ``run_evaluation`` call with multiple ``--instance_ids``
+        lets the harness build/run those Docker containers concurrently. Cheap
+        local checks (error/empty/non-diff) still run per-rollout first, so they
+        never occupy a Docker slot — same as ``score()``.
+        """
+        out: dict[str, Score] = {}
+        batchable: list[tuple[str, str]] = []
+        for task in tasks:
+            rollout = rollouts.get(task.id) or Rollout(task_id=task.id, error="omitted from batch result")
+            pre = _cheap_score_precheck(task.id, rollout)
+            if pre is not None:
+                out[task.id] = pre
+                continue
+            batchable.append((task.id, rollout.output or ""))
+
+        if batchable:
+            try:
+                results = self._evaluate_patches_batch(batchable)
+            except Exception as e:  # noqa: BLE001
+                results = {
+                    iid: (0.0, f"Evaluation harness error: {e}. Check Docker is running.")
+                    for iid, _ in batchable
+                }
+            for iid, (reward, feedback) in results.items():
+                out[iid] = Score(task_id=iid, reward=reward, feedback=feedback)
+
+        return out
+
     def _evaluate_patch(self, instance_id: str, patch: str) -> tuple[float, str]:
         """Run the swebench Docker harness for one instance + patch.
 
-        Uses the current ``swebench.harness.run_evaluation`` CLI
-        (``--dataset_name/--predictions_path/--max_workers/--run_id``) and reads
-        the ``<model>.<run_id>.json`` report it writes (``resolved_ids``).
-        Returns ``(reward, feedback)``.
+        Thin wrapper over ``_evaluate_patches_batch`` with a single pair, so the
+        harness-invocation/report-parsing logic exists in exactly one place.
         """
-        run_id = f"capevolve_{instance_id}"
+        return self._evaluate_patches_batch([(instance_id, patch)])[instance_id]
+
+    def _evaluate_patches_batch(self, pairs: list[tuple[str, str]]) -> dict:
+        """Run the swebench Docker harness for MULTIPLE (instance_id, patch) pairs
+        in ONE subprocess call.
+
+        Uses the current ``swebench.harness.run_evaluation`` CLI
+        (``--dataset_name/--predictions_path/--max_workers/--run_id``), passing
+        ALL instance ids as one comma-separated ``--instance_ids`` list so
+        ``--max_workers`` actually parallelizes Docker evaluation across them —
+        a single-id call has nothing to parallelize. Reads the
+        ``<model>.<run_id>.json`` report it writes (``resolved_ids``) and returns
+        ``{instance_id: (reward, feedback)}`` with one entry per input pair.
+        """
+        if not pairs:
+            return {}
+
+        run_id = f"capevolve_batch_{pairs[0][0]}_{len(pairs)}"
         with tempfile.TemporaryDirectory(prefix="swebench_eval_") as tmpdir:
             tmp = Path(tmpdir)
             predictions_path = tmp / "predictions.jsonl"
-            predictions_path.write_text(
-                json.dumps(
-                    {
+            with predictions_path.open("w", encoding="utf-8") as f:
+                for instance_id, patch in pairs:
+                    f.write(json.dumps({
                         "instance_id": instance_id,
                         "model_patch": patch,
                         "model_name_or_path": model_config.MODEL,
-                    }
-                )
-                + "\n",
-                encoding="utf-8",
-            )
+                    }) + "\n")
 
+            instance_ids_csv = ",".join(iid for iid, _ in pairs)
             cmd = [
                 sys.executable,
                 "-m",
                 "swebench.harness.run_evaluation",
                 "--dataset_name", DATASET,
                 "--split", SPLIT,
-                "--instance_ids", instance_id,
+                "--instance_ids", instance_ids_csv,
                 "--predictions_path", str(predictions_path),
                 "--max_workers", str(MAX_WORKERS),
                 "--timeout", str(TIMEOUT),
@@ -373,33 +390,25 @@ Do not include any explanation before or after the patch.
                     timeout=TIMEOUT + 600, cwd=tmpdir,
                 )
             except subprocess.TimeoutExpired:
-                return 0.0, (
+                msg = (
                     f"Evaluation timed out. Docker image builds can be slow on the "
                     f"first run; raise SWEBENCH_TIMEOUT (currently {TIMEOUT}s)."
                 )
+                return {iid: (0.0, msg) for iid, _ in pairs}
 
-            # The harness writes <model_name_or_path sanitized>.<run_id>.json to cwd.
-            reports = list(tmp.glob(f"*{run_id}.json")) + list(tmp.glob("*.json"))
-            for rf in reports:
-                try:
-                    report = json.loads(rf.read_text(encoding="utf-8"))
-                except Exception:  # not the report file — skip
-                    continue
-                resolved_ids = report.get("resolved_ids", [])
-                if instance_id in resolved_ids:
-                    return 1.0, "Instance resolved — the patch makes the tests pass."
-                if report.get("completed_ids") or report.get("submitted_instances"):
-                    return 0.0, (
-                        "Instance NOT resolved: the patch applied/ran but did not make "
-                        "the failing tests pass. Guide the model toward a correct, "
-                        "minimal fix for the described issue."
-                    )
+            report = _parse_swebench_report(tmp, run_id)
+            if report is None:
+                stderr_tail = (proc.stderr or "")[-800:]
+                msg = (
+                    f"No evaluation report produced (harness exit {proc.returncode}). "
+                    f"Check Docker is running and the image built. stderr: {stderr_tail}"
+                )
+                return {iid: (0.0, msg) for iid, _ in pairs}
 
-            stderr_tail = (proc.stderr or "")[-800:]
-            return 0.0, (
-                f"No evaluation report produced (harness exit {proc.returncode}). "
-                f"Check Docker is running and the image built. stderr: {stderr_tail}"
-            )
+            return {
+                iid: _score_from_report(iid, report, proc.returncode)
+                for iid, _ in pairs
+            }
 
 
 # ---------------------------------------------------------------------------
@@ -410,6 +419,79 @@ Do not include any explanation before or after the patch.
 def _looks_like_diff(text: str) -> bool:
     """True if ``text`` contains unified-diff markers (cheap, no Docker)."""
     return any(m in text for m in ("diff --git", "\n--- ", "--- ", "@@ ")) or text.startswith("--- ")
+
+
+def _cheap_score_precheck(instance_id: str, rollout: Rollout) -> Score | None:
+    """Local, Docker-free checks shared by ``score()`` and ``score_batch()``.
+
+    Returns a terminal ``Score`` for an infra-error/empty/non-diff rollout so it
+    never occupies a Docker slot, or ``None`` when the patch is diff-shaped and
+    should proceed to the harness. This also keeps `cap-evolve check`'s scorer
+    probe (a synthetic non-diff rollout) offline and fast.
+    """
+    if rollout.error:
+        return Score(
+            task_id=instance_id,
+            reward=0.0,
+            feedback=(
+                f"Rollout failed: {rollout.error}. Infrastructure error, "
+                "not a prompt defect; do not optimize against it."
+            ),
+        )
+
+    patch = rollout.output or ""
+    if not patch.strip():
+        return Score(
+            task_id=instance_id,
+            reward=0.0,
+            feedback="Empty patch produced. The prompt must instruct the model "
+            "to output a valid unified diff.",
+        )
+
+    if not _looks_like_diff(patch):
+        return Score(
+            task_id=instance_id,
+            reward=0.0,
+            feedback="Output is not a valid unified diff (no diff/---/@@ markers). "
+            "The prompt must instruct the model to output ONLY a unified diff.",
+        )
+
+    return None
+
+
+def _parse_swebench_report(tmp: Path, run_id: str) -> dict | None:
+    """Load the swebench harness's report JSON for ``run_id`` from ``tmp``, if any.
+
+    The harness writes ``<model_name_or_path sanitized>.<run_id>.json`` to cwd;
+    fall back to any ``*.json`` in ``tmp`` in case the naming doesn't match.
+    """
+    reports = list(tmp.glob(f"*{run_id}.json")) + list(tmp.glob("*.json"))
+    for rf in reports:
+        try:
+            return json.loads(rf.read_text(encoding="utf-8"))
+        except Exception:  # not the report file — skip
+            continue
+    return None
+
+
+def _score_from_report(instance_id: str, report: dict, harness_exit: int) -> tuple[float, str]:
+    """Read ``instance_id``'s outcome out of a (possibly multi-instance) report."""
+    resolved_ids = report.get("resolved_ids", [])
+    if instance_id in resolved_ids:
+        return 1.0, "Instance resolved — the patch makes the tests pass."
+
+    ran_ids = set(report.get("completed_ids") or []) | set(report.get("submitted_instances") or [])
+    if instance_id in ran_ids:
+        return 0.0, (
+            "Instance NOT resolved: the patch applied/ran but did not make "
+            "the failing tests pass. Guide the model toward a correct, "
+            "minimal fix for the described issue."
+        )
+
+    return 0.0, (
+        f"No evaluation report produced (harness exit {harness_exit}). "
+        f"Check Docker is running and the image built."
+    )
 
 
 def _extract_patch(text: str) -> str:
@@ -474,3 +556,23 @@ if __name__ == "__main__":
     assert not _looks_like_diff("__probe_output__")  # check probe stays offline
     assert not _looks_like_diff("I could not find the bug.")
     print("swe_bench extract/diff self-check: OK")
+
+    # Cheap precheck: error/empty/non-diff never reach Docker; a real diff passes through.
+    assert _cheap_score_precheck("i1", Rollout(task_id="i1", error="boom")) is not None
+    assert _cheap_score_precheck("i1", Rollout(task_id="i1", output="")) is not None
+    assert _cheap_score_precheck("i1", Rollout(task_id="i1", output="not a diff")) is not None
+    assert _cheap_score_precheck("i1", Rollout(task_id="i1", output="--- a/f.py\n+++ b/f.py\n@@ -1 +1 @@")) is None
+
+    # Batch report parsing (no subprocess/Docker): a multi-instance report resolves
+    # one instance, runs-but-fails a second, and never mentions a third.
+    fake_report = {
+        "resolved_ids": ["repo__a-1"],
+        "completed_ids": ["repo__a-1", "repo__b-2"],
+    }
+    assert _score_from_report("repo__a-1", fake_report, 0) == (
+        1.0, "Instance resolved — the patch makes the tests pass.")
+    reward, feedback = _score_from_report("repo__b-2", fake_report, 0)
+    assert reward == 0.0 and "NOT resolved" in feedback
+    reward, feedback = _score_from_report("repo__c-3", fake_report, 1)
+    assert reward == 0.0 and "No evaluation report" in feedback
+    print("swe_bench batch-scoring self-check: OK")


### PR DESCRIPTION
## Summary
- Adds an optional `score_batch(tasks, rollouts) -> {task_id: Score}` adapter hook — the scoring-side counterpart to the existing `run_batch`/`run_trials` generation-side hooks. The harness calls it once per trial instead of looping `adapter.score()` per task; any task id it omits falls back to a single `score()` call, so a partial implementation can never silently drop a score. Adapters without `score_batch` are byte-for-byte unaffected.
- Implements it in the SWE-bench adapter: a trial's instances are now batched into **one** `swebench.harness.run_evaluation` call with a comma-separated `--instance_ids` list, instead of one Docker-harness subprocess per instance. This is what actually lets `SWEBENCH_MAX_WORKERS=10` (already set in CI) parallelize Docker evaluation — previously there was nothing for `--max_workers` to parallelize over.
- Follow-up flagged in `docs/superpowers/specs/2026-07-24-parallel-trials-design.md` ("swebench ... the harness still scores (Docker eval) each rollout sequentially").

## Test plan
- [x] `python3 -m py_compile core/cap_evolve/harness.py templates/adapters/swe_bench/adapter.py`
- [x] `PYTHONPATH=core:templates/adapters python3 templates/adapters/swe_bench/adapter.py` (offline self-check, no Docker)
- [x] `cd core && python3 -m pytest tests/test_w1_engine.py -q` — 24/24 passing, including two new tests: `score_batch` called once per trial with all tasks, and omission falling back to single `score()`
- [ ] Functional Docker-level verification on the next swebench CI run on skillberry-1 (not run locally — expensive, out of scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)