### PR TITLE
ci: gate self-hosted PR jobs on trusted author, not same-repo origin

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -49,13 +49,15 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
-    # Fork guard: never run PR code from a fork on the self-hosted runner.
+    # Trust guard: run PR code from ANY repo (same-repo or a fork) on the self-hosted
+    # runner only when the PR author is a known collaborator — never for outside/
+    # first-time contributors, who could otherwise run arbitrary code with secrets.
     # PR trigger: any label containing 'benchmark-smoke' or 'benchmark-full'
     # (an all-label or a per-bench one). The per-matrix gate decides the exact tier×bench.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' &&
-        github.event.pull_request.head.repo.full_name == github.repository &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association) &&
         (contains(join(github.event.pull_request.labels.*.name, ','), 'benchmark-smoke') ||
          contains(join(github.event.pull_request.labels.*.name, ','), 'benchmark-full')))
     strategy:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -27,10 +27,13 @@ jobs:
   tau2:
     name: tau2 (task 9)
     runs-on: [self-hosted, ibm-vpc]
+    # Trust guard: run PR code from ANY repo (same-repo or a fork) on the self-hosted
+    # runner only when the PR author is a known collaborator — never for outside/
+    # first-time contributors, who could otherwise run arbitrary code with secrets.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' &&
-        github.event.pull_request.head.repo.full_name == github.repository &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association) &&
         contains(github.event.pull_request.labels.*.name, 'integration-test'))
     concurrency:
       group: itest-tau2-${{ github.ref }}


### PR DESCRIPTION
## Summary
- `integration-tests.yml` and `benchmarks.yml` run on a self-hosted runner with secrets (`ANTHROPIC_BASE_URL`/`ANTHROPIC_AUTH_TOKEN`) and internal VPC network access. Both were gated with `github.event.pull_request.head.repo.full_name == github.repository`, which blocks **every** PR opened from a fork — including PRs from trusted collaborators/org members who work from a fork instead of a same-repo branch.
- Replaces that same-repo check with `contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)` in both workflows, so trust is based on **who** opened the PR rather than **which repo** the branch lives in.
- Outside/first-time contributors are still blocked from running arbitrary code with secrets on the self-hosted runner — this is a targeting change, not a removal of the security boundary.

## Test plan
- [x] Both workflow files parse as valid YAML (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] `actionlint` not available locally to run against these files — verify in CI review
- [ ] Confirm on a real fork PR from a trusted collaborator that the `integration-test` / `benchmark-smoke` labels now trigger the jobs as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)