### PR TITLE
ci(skillsbench): align smoke tier with tau2/swebench (2→10 tasks, tag repr)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,15 @@ All notable changes to cap-evolve are documented here. The format follows
   every other benchmark's smoke tier. `select_candidates.py` and its output
   (`utils/smoke_candidates.json`) live under `utils/` — not read by CI, only for
   re-picking tasks later.
+- **SkillsBench smoke tier aligned with tau2/swebench.** `ci/benchmarks/skillsbench/smoke/tasks.json`
+  grows from 2 tasks (tag `hard`) to all 10 tasks the adapter's `TASK_IDS` allowlist
+  supports (tag `repr`, matching tau2's count and the tau2/swebench tag convention) —
+  the same pool already used and baselined in `docs/REPRODUCE_skillsbench.md` (baseline
+  pass rate 0.333, not 0). `ci/benchmarks/README.md`'s "Hard-only suite" framing is
+  reworded to "Calibrated-headroom suite" to match this and swebench's own
+  `select_candidates.py` selection goal (nonzero but not saturated at baseline), rather
+  than the stricter "every curated task has baseline reward 0" claim neither benchmark
+  actually satisfies.
 - **Adapter-native batch scoring (`score_batch`).** New optional adapter hook,
   `score_batch(tasks, rollouts) -> {task_id: Score}` — the scoring-side counterpart to
   `run_batch`/`run_trials` (see `docs/ADAPTER_CONTRACT.md`). The harness calls it once

--- a/ci/benchmarks/README.md
+++ b/ci/benchmarks/README.md
@@ -2,16 +2,18 @@
 
 Triggerable, real-model optimization regression over **tau2 · swebench · skillsbench**,
 built on the [adapter templates](../../templates/adapters/). Each benchmark runs a curated
-set of **hard** tasks (baseline reward 0) and reports **reward / latency / cost** base→opt
-from a single run, plus the optimizer's capability diffs — a reproducible end-to-end
-pipeline + metrics regression, not a leaderboard.
+set of **representative** tasks (calibrated for headroom — nonzero but not saturated at
+baseline) and reports **reward / latency / cost** base→opt from a single run, plus the
+optimizer's capability diffs — a reproducible end-to-end pipeline + metrics regression,
+not a leaderboard.
 
-> **Hard-only suite.** Every curated task has baseline reward 0. These benchmarks are
-> binary-scored, and a task a model fails at baseline is capability-bound — a few
-> optimization iterations on the prompt/policy/skill rarely carry a hard failure to a
-> pass. So this suite mainly proves the pipeline runs end-to-end and reports honest
-> non-regression metrics; the `iterations` knob gives the optimizer more budget to
-> explore if you want to push harder.
+> **Calibrated-headroom suite.** Curated tasks are picked to have room to improve at
+> baseline — solvable often enough to be meaningful, not so saturated that optimization
+> has nothing to move. These benchmarks are binary-scored, so a few optimization
+> iterations on the prompt/policy/skill can plausibly flip some but not all trials. This
+> suite mainly proves the pipeline runs end-to-end and reports honest non-regression
+> metrics; the `iterations` knob gives the optimizer more budget to explore if you want
+> to push harder.
 
 - **Agent:** `aws/gpt-oss-120b` (all benchmarks) · **Optimizer:** Claude Code @ `claude-opus-4-8` · **3 iterations** (default; configurable via the `iterations` workflow input or `ITERATIONS` env).
 - **One project, one run:** all of a tier's tasks are optimized TOGETHER in a single
@@ -66,7 +68,7 @@ repo → Settings → Actions → Runners with the `ibm-vpc` label.
 ## Trigger the suite
 
 Runs come in two **tiers** (a first-class dimension in the workflow, same workflow + history page):
-- **`smoke`** — a few hard tasks per benchmark (fast regression; the default).
+- **`smoke`** — a few representative tasks per benchmark (fast regression; the default).
 - **`full`** — the whole/representative benchmark per bench (thorough; expensive). Its tasks
   live under `ci/benchmarks/<bench>/full/tasks.json`; a bench with an empty list simply runs
   zero tasks until populated (see below). `tau2/full/tasks.json` is already populated (50
@@ -94,7 +96,7 @@ Just add task ids to `<bench>/full/tasks.json` (same shape as `<bench>/smoke/tas
 [{"id": "<task_id>", "tag": "full", "agent": "aws/gpt-oss-120b"}]
 ```
 No baseline-freezing step — `run_suite.sh` computes the baseline fresh, in the same run, for
-whatever ids are listed. Pick ids with baseline reward 0 (a hard task) by running
+whatever ids are listed. Pick ids with headroom (baseline not already saturated) by running
 `run_suite.sh` against a candidate list and checking the report.
 
 Repo secrets required: `ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN`.

--- a/ci/benchmarks/skillsbench/smoke/tasks.json
+++ b/ci/benchmarks/skillsbench/smoke/tasks.json
@@ -1,4 +1,12 @@
 [
-  {"id": "offer-letter-generator", "tag": "hard", "agent": "aws/gpt-oss-120b"},
-  {"id": "exceltable-in-ppt", "tag": "hard", "agent": "aws/gpt-oss-120b"}
+  {"id": "offer-letter-generator", "tag": "repr", "agent": "aws/gpt-oss-120b"},
+  {"id": "exceltable-in-ppt", "tag": "repr", "agent": "aws/gpt-oss-120b"},
+  {"id": "xlsx-recover-data", "tag": "repr", "agent": "aws/gpt-oss-120b"},
+  {"id": "sales-pivot-analysis", "tag": "repr", "agent": "aws/gpt-oss-120b"},
+  {"id": "invoice-fraud-detection", "tag": "repr", "agent": "aws/gpt-oss-120b"},
+  {"id": "weighted-gdp-calc", "tag": "repr", "agent": "aws/gpt-oss-120b"},
+  {"id": "financial-modeling-qa", "tag": "repr", "agent": "aws/gpt-oss-120b"},
+  {"id": "pdf-excel-diff", "tag": "repr", "agent": "aws/gpt-oss-120b"},
+  {"id": "pptx-reference-formatting", "tag": "repr", "agent": "aws/gpt-oss-120b"},
+  {"id": "reserves-at-risk-calc", "tag": "repr", "agent": "aws/gpt-oss-120b"}
 ]


### PR DESCRIPTION
## Summary
- SkillsBench's smoke tier had only 2 tasks tagged `hard`, inconsistent with tau2 (10 tasks, tag `repr`) and swebench (5 tasks, tag `repr`). Expands it to the full 10-task pool already supported by `templates/adapters/skillsbench/adapter.py`'s `TASK_IDS` allowlist — the same pool already used and empirically baselined in `docs/REPRODUCE_skillsbench.md` (baseline pass rate 0.333, optimized 0.714 val / 0.667 test) — and switches the tag to `repr` to match tau2/swebench convention.
- No new task ids are introduced (all 10 are already in the adapter's allowlist), so no adapter/`run_suite.sh` changes are needed and there's no new "unknown SkillsBench task id" risk.
- Rewords `ci/benchmarks/README.md`'s "Hard-only suite / baseline reward 0" framing to "Calibrated-headroom suite", since that claim was already inaccurate: swebench's own `select_candidates.py` explicitly targets tasks with a nonzero-but-not-saturated baseline, and skillsbench's documented baseline is 0.333, not 0.
- Adds a `CHANGELOG.md` bullet documenting the change.

## Test plan
- [x] `python3 -m json.tool ci/benchmarks/skillsbench/smoke/tasks.json` — valid JSON
- [x] Verified the 10 chosen ids are an exact set-match against `TASK_IDS` in `templates/adapters/skillsbench/adapter.py`
- [ ] Next `smoke / skillsbench` CI run on the `ibm-vpc` self-hosted runner (skillberry-1) exercises the new 10-task list end-to-end (requires VPC gateway/Docker access not available from this dev environment)