### PR TITLE
fix(harness): recover optimizer cost on non-zero optimizer exit

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -173,7 +173,10 @@ jobs:
       NUM_TRIALS: ${{ github.event.inputs.trials || '10' }}
       AGENT_MODEL: ${{ github.event.inputs.agent_model || 'aws/gpt-oss-120b' }}
       OPTIMIZER_MODEL: ${{ github.event.inputs.optimizer_model || 'aws/claude-opus-4-8' }}
-      OPTIMIZER_USD_PER_ITER: ${{ github.event.inputs.optimizer_usd_per_iter || '0' }}
+      # Smoke defaults to a $50/iteration cap (fast regression, generous headroom);
+      # full stays unlimited by default. An explicit `optimizer_usd_per_iter`
+      # dispatch input overrides this for whichever tier(s) run in that dispatch.
+      OPTIMIZER_USD_PER_ITER: ${{ github.event.inputs.optimizer_usd_per_iter || (matrix.tier == 'smoke' && '50' || '0') }}
       OPTIMIZER_MAX_TURNS: ${{ github.event.inputs.optimizer_max_turns || '80' }}
       GATE_K_SE: ${{ github.event.inputs.gate_k_se || '1.0' }}
       ALGORITHM_FOCUS: ${{ github.event.inputs.algorithm_focus || 'all' }}

--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -449,8 +449,15 @@ def optimizer_from_command(cmd_template: list[str]) -> OptimizerFn:
         env = dict(os.environ)
         proc = subprocess.run(cmd, capture_output=True, text=True, env=env)
         if proc.returncode != 0:
-            raise RuntimeError(
+            err = RuntimeError(
                 f"optimizer failed ({proc.returncode}): {_optimizer_failure_detail(proc)}")
+            # run-optimizer prints its cost payload *before* returning its own exit
+            # code, which mirrors the underlying CLI's (e.g. non-zero on hitting
+            # --max-budget-usd though the CLI still reports real total_cost_usd) —
+            # attach whatever cost it already computed so the caller can still
+            # count real spend against the budget instead of discarding it.
+            err.cost = _parse_optimizer_cost(proc.stdout)  # type: ignore[attr-defined]
+            raise err
         # Capture optimizer spend (cost_usd/tokens) from run-optimizer's JSON payload
         # so it counts against the budget and shows in the dashboard. Returns None
         # when the agent CLI emitted no structured cost (spend stays unmeasured).
@@ -1262,6 +1269,13 @@ def run_step(
         # and the gate simply rejects it (a wasted iteration, not a crash).
         optimizer_error = str(e)
         run_dir.log_event("optimizer_error", candidate=cid, error=optimizer_error[:500])
+        # The optimizer may have already spent real money before failing (e.g. it
+        # hit its own --usd-budget/--max-turns cap mid-session) — recover that cost
+        # instead of letting it disappear as an unmeasured $0.
+        recovered_cost = getattr(e, "cost", None)
+        if isinstance(recovered_cost, dict):
+            opt_cost_usd = float(recovered_cost.get("cost_usd") or 0.0)
+            opt_tokens = int(recovered_cost.get("tokens") or 0)
     optimizer_seconds = time.time() - _opt_t0
     run_dir.update_spent(optimizer_seconds=optimizer_seconds, optimizer_usd=opt_cost_usd,
                          optimizer_tokens=opt_tokens)

--- a/core/tests/test_budget_cost.py
+++ b/core/tests/test_budget_cost.py
@@ -5,8 +5,8 @@ import json
 
 from cap_evolve import RunDir
 from cap_evolve.rundir import Budget, Spent
-from cap_evolve.harness import _parse_optimizer_cost
-from cap_evolve import cli, pricing
+from cap_evolve.harness import _parse_optimizer_cost, optimizer_from_command
+from cap_evolve import cli, pricing, harness
 
 
 # ---- Spent / Budget round-trip + total ------------------------------------
@@ -71,6 +71,33 @@ def test_parse_optimizer_cost_from_runner_payload():
 def test_parse_optimizer_cost_absent():
     assert _parse_optimizer_cost("just some prose, no json") is None
     assert _parse_optimizer_cost(json.dumps({"cost": {"total_cost_usd": None, "tokens": None}})) is None
+
+
+# ---- optimizer cost must survive a non-zero optimizer exit ----------------
+
+def test_optimizer_from_command_recovers_cost_on_nonzero_exit(tmp_path, monkeypatch):
+    """run-optimizer computes real cost from the CLI's JSON *before* returning its
+    own exit code, which mirrors the underlying CLI's (e.g. non-zero on hitting
+    --max-budget-usd). That already-computed cost must not be thrown away just
+    because the optimizer process failed."""
+    payload = json.dumps({"optimizer": "claude-code", "returncode": 1,
+                          "cost": {"total_cost_usd": 0.0591, "tokens": 500}})
+
+    class FakeProc:
+        returncode = 1
+        stdout = payload
+        stderr = ""
+
+    monkeypatch.setattr(harness.subprocess, "run", lambda *a, **k: FakeProc())
+
+    opt = optimizer_from_command(["fake", "--workdir", "{workdir}", "--prompt", "{prompt}"])
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    try:
+        opt(workdir, "do something")
+        assert False, "expected RuntimeError"
+    except RuntimeError as e:
+        assert getattr(e, "cost", None) == {"cost_usd": 0.0591, "tokens": 500}
 
 
 # ---- pricing table is real (not zeros) + estimate math --------------------


### PR DESCRIPTION
## Summary
- `optimizer_from_command()` raised `RuntimeError` on any non-zero exit from the optimizer subprocess *before* parsing cost from its stdout. When the underlying CLI hits its own `--max-budget-usd`/`--max-turns` cap it exits non-zero but still reports real `total_cost_usd`, which `run-optimizer` had already parsed and printed — that cost was silently discarded, showing as `$0.00` optimizer spend in the dashboard/reports despite real spend and `optimizer_seconds`.
- Fix: attach the parsed cost to the raised exception (`err.cost`) and recover it in the candidate-creation except-block. Failure handling/gating is unchanged — only the cost-loss is fixed.
- Also bumps the smoke tier's default per-iteration optimizer budget to **$50** in `.github/workflows/benchmarks.yml` (full tier stays unlimited/`0` by default; an explicit `optimizer_usd_per_iter` dispatch input still overrides either tier).

## Test plan
- [x] Added `test_optimizer_from_command_recovers_cost_on_nonzero_exit` (written first, confirmed failing against the old code, then passing after the fix)
- [x] Full `core` test suite passes (179/179)
- [x] `.github/workflows/benchmarks.yml` YAML validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)