### PR TITLE
fix: complete Acapo -> cap-evolve rebranding in templates and hooks (…

### DIFF
--- a/plugins/cap-evolve/hooks/_hooklib.py
+++ b/plugins/cap-evolve/hooks/_hooklib.py
@@ -67,7 +67,7 @@ def find_run_dir(start: Path) -> Path | None:
     here = Path(start).resolve()
     candidates: list[Path] = []
     for parent in [here, *here.parents]:
-        for base_name in (".capevolve", ".agentcapo"):
+        for base_name in (".capevolve"):
             base = parent / base_name
             if base.is_dir():
                 runs = sorted(
@@ -83,8 +83,8 @@ def find_run_dir(start: Path) -> Path | None:
 
 
 def project_dir_for(run_dir: Path) -> Path | None:
-    """The ``.capevolve/project`` (or ``.agentcapo/project``) sibling of a run dir."""
-    base = run_dir.parent  # .capevolve/ or .agentcapo/
+    """The ``.capevolve/project`` sibling of a run dir."""
+    base = run_dir.parent  # .capevolve/
     for name in ("project",):
         proj = base / name
         if (proj / "adapters" / "adapter.py").exists():

--- a/plugins/cap-evolve/hooks/inject_router.py
+++ b/plugins/cap-evolve/hooks/inject_router.py
@@ -48,7 +48,7 @@ def _looks_like_capevolve(cwd: Path) -> bool:
     if H.find_run_dir(cwd) is not None:
         return True
     for parent in [cwd, *cwd.parents]:
-        for base in (".capevolve", ".agentcapo"):
+        for base in (".capevolve"):
             if (parent / base / "project").is_dir():
                 return True
         # repo checkout (dev) — RUN.md + skills/ present

--- a/templates/project/PROJECT.md
+++ b/templates/project/PROJECT.md
@@ -1,4 +1,4 @@
-# Acapo project — <target name>
+# cap-evolve project — <target name>
 
 Filled by the `intake` skill. Records the decisions behind this run so anyone
 (human or agent) can understand and reproduce it.


### PR DESCRIPTION
…#105)

## What & why
<!-- What does this change and why? Link any issue. -->

## Checklist
- [ ] `python -m pytest core/tests -q` passes
- [ ] `python skills/_registry/build_manifest.py skills` is clean (no errors)
- [ ] Any new/changed skill's `scripts/check.py` is green
- [ ] Honesty invariants untouched (gate on val, test sealed) — or explained
- [ ] Docs updated (README/skill SKILL.md) if behavior changed
