### PR TITLE
Add Harbor integration for sandboxed agent optimization with cap-evolve

### DIFF
--- a/capevolve_harbor/__init__.py
+++ b/capevolve_harbor/__init__.py
@@ -1,0 +1,34 @@
+"""cap-evolve <-> Harbor integration.
+
+Generates self-contained Harbor task packages from cap-evolve tasks,
+runs them via the ``harbor`` CLI, and parses results back into
+cap-evolve's Rollout/Score types.
+
+Usage pattern (from a cap-evolve adapter)::
+
+    from capevolve_harbor import package_dataset, harbor_run, parse_job_dir
+
+    # 1. Package cap-evolve tasks as Harbor task dirs
+    dataset_dir = package_dataset(tasks, candidate_dir, tmp / "tasks", config=cfg)
+
+    # 2. Run Harbor
+    result = harbor_run(dataset_dir, agent="claude-code", model="claude-sonnet-4-6")
+
+    # 3. Parse results
+    trial_results = parse_job_dir(result.job_dir)
+"""
+
+from .tasks import package_task, package_dataset
+from .run import harbor_run, find_harbor_bin, HarborRunResult
+from .results import parse_job_dir, TrialResult, build_feedback
+
+__all__ = [
+    "package_task",
+    "package_dataset",
+    "harbor_run",
+    "find_harbor_bin",
+    "HarborRunResult",
+    "parse_job_dir",
+    "TrialResult",
+    "build_feedback",
+]

--- a/capevolve_harbor/pyproject.toml
+++ b/capevolve_harbor/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "capevolve-harbor"
+version = "0.1.0"
+description = "Harbor integration utilities for cap-evolve — task packaging, job runner, result parser."
+readme = "../README.md"
+requires-python = ">=3.10"
+license = { text = "Apache-2.0" }
+dependencies = []
+
+[project.urls]
+Homepage   = "https://skillberry-ai.github.io/cap-evolve/harbor.html"
+Repository = "https://github.com/skillberry-ai/cap-evolve"
+
+[tool.setuptools]
+packages = ["capevolve_harbor"]
+package-dir = { "capevolve_harbor" = "." }

--- a/capevolve_harbor/results.py
+++ b/capevolve_harbor/results.py
@@ -57,8 +57,6 @@ def parse_job_dir(
     for trial_dir in sorted(job_dir.iterdir()):
         if not trial_dir.is_dir():
             continue
-        if trial_dir.name in ("config.json", "result.json"):
-            continue
 
         task_id = _extract_task_id(trial_dir)
         if task_ids and task_id not in task_ids:
@@ -111,33 +109,29 @@ def _parse_trial(trial_dir: Path, task_id: str) -> TrialResult:
 def _read_reward(verifier_dir: Path) -> tuple[float, dict]:
     """Read reward from verifier output.
 
-    Harbor reads reward.json first, falling back to reward.txt.
+    Tries reward.json first (``"reward"`` key). Falls back to reward.txt
+    only when reward.json is absent or unparseable — a legitimate 0.0 in
+    reward.json is honoured as-is.
     """
     reward_json: dict = {}
-    reward: float = 0.0
 
     rj_path = verifier_dir / "reward.json"
     if rj_path.exists():
         try:
             reward_json = json.loads(rj_path.read_text(encoding="utf-8"))
             if "reward" in reward_json:
-                reward = float(reward_json["reward"])
-            elif reward_json:
-                first_val = next(iter(reward_json.values()))
-                if isinstance(first_val, (int, float)):
-                    reward = float(first_val)
-        except (json.JSONDecodeError, ValueError, StopIteration):
+                return float(reward_json["reward"]), reward_json
+        except (json.JSONDecodeError, ValueError):
             pass
 
-    if reward == 0.0:
-        rt_path = verifier_dir / "reward.txt"
-        if rt_path.exists():
-            try:
-                reward = float(rt_path.read_text(encoding="utf-8").strip())
-            except ValueError:
-                pass
+    rt_path = verifier_dir / "reward.txt"
+    if rt_path.exists():
+        try:
+            return float(rt_path.read_text(encoding="utf-8").strip()), reward_json
+        except ValueError:
+            pass
 
-    return reward, reward_json
+    return 0.0, reward_json
 
 
 def _read_trajectory(agent_dir: Path) -> Any:

--- a/capevolve_harbor/results.py
+++ b/capevolve_harbor/results.py
@@ -1,0 +1,205 @@
+"""Parse Harbor job directories and map results to cap-evolve types."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class TrialResult:
+    """One Harbor trial's outcome, parsed from the job directory."""
+
+    task_id: str
+    reward: float = 0.0
+    reward_json: dict = field(default_factory=dict)
+    trajectory: Any = None
+    cost_usd: float = 0.0
+    tokens: int = 0
+    verifier_stdout: str = ""
+    verifier_stderr: str = ""
+    error: str | None = None
+
+
+def parse_job_dir(
+    job_dir: Path,
+    task_ids: list[str] | None = None,
+) -> dict[str, list[TrialResult]]:
+    """Walk a Harbor job directory and extract per-trial results.
+
+    Harbor job directory structure::
+
+        <job-dir>/
+            config.json
+            result.json
+            <trial-name>/
+                config.json
+                result.json
+                agent/
+                    trajectory.json
+                    recording.cast
+                verifier/
+                    reward.txt
+                    reward.json  (optional)
+                    test-stdout.txt
+                    test-stderr.txt
+
+    Returns ``{task_id: [TrialResult, ...]}``.
+    """
+    results: dict[str, list[TrialResult]] = {}
+    job_dir = Path(job_dir)
+
+    if not job_dir.is_dir():
+        return results
+
+    for trial_dir in sorted(job_dir.iterdir()):
+        if not trial_dir.is_dir():
+            continue
+        if trial_dir.name in ("config.json", "result.json"):
+            continue
+
+        task_id = _extract_task_id(trial_dir)
+        if task_ids and task_id not in task_ids:
+            continue
+
+        tr = _parse_trial(trial_dir, task_id)
+        results.setdefault(task_id, []).append(tr)
+
+    return results
+
+
+def _extract_task_id(trial_dir: Path) -> str:
+    """Extract the task ID from a trial directory.
+
+    Tries trial config.json first, falls back to the directory name.
+    """
+    config_path = trial_dir / "config.json"
+    if config_path.exists():
+        try:
+            cfg = json.loads(config_path.read_text(encoding="utf-8"))
+            task_name = cfg.get("task", {}).get("name") or cfg.get("task_name")
+            if task_name:
+                return str(task_name)
+        except (json.JSONDecodeError, KeyError):
+            pass
+    return trial_dir.name
+
+
+def _parse_trial(trial_dir: Path, task_id: str) -> TrialResult:
+    """Parse a single trial directory into a TrialResult."""
+    tr = TrialResult(task_id=task_id)
+
+    verifier_dir = trial_dir / "verifier"
+    if verifier_dir.is_dir():
+        tr.reward, tr.reward_json = _read_reward(verifier_dir)
+        tr.verifier_stdout = _read_text(verifier_dir / "test-stdout.txt")
+        tr.verifier_stderr = _read_text(verifier_dir / "test-stderr.txt")
+
+    agent_dir = trial_dir / "agent"
+    if agent_dir.is_dir():
+        tr.trajectory = _read_trajectory(agent_dir)
+
+    result_path = trial_dir / "result.json"
+    if result_path.exists():
+        tr.cost_usd, tr.tokens = _extract_cost_tokens(result_path)
+
+    return tr
+
+
+def _read_reward(verifier_dir: Path) -> tuple[float, dict]:
+    """Read reward from verifier output.
+
+    Harbor reads reward.json first, falling back to reward.txt.
+    """
+    reward_json: dict = {}
+    reward: float = 0.0
+
+    rj_path = verifier_dir / "reward.json"
+    if rj_path.exists():
+        try:
+            reward_json = json.loads(rj_path.read_text(encoding="utf-8"))
+            if "reward" in reward_json:
+                reward = float(reward_json["reward"])
+            elif reward_json:
+                first_val = next(iter(reward_json.values()))
+                if isinstance(first_val, (int, float)):
+                    reward = float(first_val)
+        except (json.JSONDecodeError, ValueError, StopIteration):
+            pass
+
+    if reward == 0.0:
+        rt_path = verifier_dir / "reward.txt"
+        if rt_path.exists():
+            try:
+                reward = float(rt_path.read_text(encoding="utf-8").strip())
+            except ValueError:
+                pass
+
+    return reward, reward_json
+
+
+def _read_trajectory(agent_dir: Path) -> Any:
+    """Read the agent trajectory from the agent directory."""
+    traj_path = agent_dir / "trajectory.json"
+    if traj_path.exists():
+        try:
+            return json.loads(traj_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            pass
+    return None
+
+
+def _extract_cost_tokens(result_path: Path) -> tuple[float, int]:
+    """Extract cost and token count from a trial result.json."""
+    try:
+        data = json.loads(result_path.read_text(encoding="utf-8"))
+        cost = float(data.get("cost_usd", 0) or data.get("cost", 0) or 0)
+        tokens = int(
+            data.get("tokens", 0)
+            or data.get("total_tokens", 0)
+            or data.get("input_tokens", 0) + data.get("output_tokens", 0)
+            or 0
+        )
+        return cost, tokens
+    except (json.JSONDecodeError, ValueError, TypeError):
+        return 0.0, 0
+
+
+def _read_text(path: Path, max_chars: int = 5000) -> str:
+    """Read a text file, truncating to max_chars."""
+    if not path.exists():
+        return ""
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+        return text[-max_chars:] if len(text) > max_chars else text
+    except OSError:
+        return ""
+
+
+def build_feedback(tr: TrialResult) -> str:
+    """Build gold-safe feedback from a TrialResult."""
+    parts: list[str] = []
+
+    if tr.reward >= 1.0:
+        parts.append("Task fully solved (reward 1.0).")
+    elif tr.reward > 0.0:
+        parts.append(f"Partial success (reward {tr.reward:.3f}).")
+    else:
+        parts.append("Task not solved (reward 0.0).")
+
+    if tr.reward_json:
+        metrics = {k: v for k, v in tr.reward_json.items() if k != "reward"}
+        if metrics:
+            metric_strs = [f"{k}={v}" for k, v in metrics.items()]
+            parts.append(f"Metrics: {', '.join(metric_strs)}.")
+
+    stdout = tr.verifier_stdout.strip()
+    if stdout and len(stdout) < 500:
+        parts.append(f"Verifier: {stdout}")
+
+    if tr.error:
+        parts.append(f"Error: {tr.error}")
+
+    return " ".join(parts)

--- a/capevolve_harbor/run.py
+++ b/capevolve_harbor/run.py
@@ -1,0 +1,160 @@
+"""Subprocess wrapper for ``harbor run`` with signal forwarding and timeout."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import signal
+import subprocess
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class HarborRunResult:
+    """Outcome of a ``harbor run`` invocation."""
+
+    job_dir: Path | None = None
+    returncode: int = -1
+    stderr_tail: str = ""
+    elapsed_seconds: float = 0.0
+    error: str | None = None
+
+
+def find_harbor_bin() -> str:
+    """Locate the ``harbor`` CLI binary.
+
+    Checks ``HARBOR_BIN`` env var first, then falls back to PATH lookup.
+    """
+    from_env = os.environ.get("HARBOR_BIN")
+    if from_env:
+        return from_env
+    found = shutil.which("harbor")
+    if found:
+        return found
+    raise FileNotFoundError(
+        "harbor CLI not found. Install it with: uv tool install harbor"
+    )
+
+
+def harbor_run(
+    dataset_path: Path | None = None,
+    *,
+    dataset: str | None = None,
+    agent: str = "claude-code",
+    model: str,
+    parallel: int = 1,
+    timeout: int = 3600,
+    harbor_bin: str | None = None,
+    extra_flags: list[str] | None = None,
+    jobs_dir: Path | None = None,
+    env: dict[str, str] | None = None,
+    include_tasks: list[str] | None = None,
+    agent_env: dict[str, str] | None = None,
+) -> HarborRunResult:
+    """Run a Harbor job against a local or registry dataset.
+
+    Use ``dataset_path`` (``-p``) for a local dataset directory, or
+    ``dataset`` (``-d``) for a Harbor registry dataset name (e.g.
+    ``swe-bench/swe-bench-verified``). Exactly one must be provided.
+
+    ``include_tasks`` filters to specific task names (``-i`` flags).
+    ``agent_env`` passes env vars to the agent (``--ae KEY=VALUE`` flags).
+    """
+    bin_path = harbor_bin or find_harbor_bin()
+
+    cmd = [bin_path, "run"]
+
+    if dataset_path:
+        cmd += ["-p", str(dataset_path)]
+    elif dataset:
+        cmd += ["-d", str(dataset)]
+    else:
+        raise ValueError("Either dataset_path (-p) or dataset (-d) is required")
+
+    cmd += ["-a", str(agent), "-m", str(model)]
+
+    if parallel > 1:
+        cmd += ["-n", str(parallel)]
+
+    if jobs_dir:
+        cmd += ["-o", str(jobs_dir)]
+
+    if include_tasks:
+        for task_name in include_tasks:
+            cmd += ["-i", task_name]
+
+    if agent_env:
+        for key, value in agent_env.items():
+            cmd += ["--ae", f"{key}={value}"]
+
+    cmd += ["-y"]
+
+    if extra_flags:
+        cmd += extra_flags
+
+    run_env = {**os.environ, **(env or {})}
+
+    t0 = time.monotonic()
+    result = HarborRunResult()
+
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            env=run_env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        _forward_signals(proc)
+
+        stdout, stderr = proc.communicate(timeout=timeout)
+        result.returncode = proc.returncode
+        result.elapsed_seconds = time.monotonic() - t0
+        result.stderr_tail = (stderr or b"").decode("utf-8", errors="replace")[-2000:]
+
+        if proc.returncode != 0:
+            result.error = (
+                f"harbor run exited with code {proc.returncode}: "
+                f"{result.stderr_tail[:500]}"
+            )
+
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+        result.elapsed_seconds = time.monotonic() - t0
+        result.error = f"harbor run timed out after {timeout}s"
+        result.returncode = -9
+
+    except FileNotFoundError:
+        result.error = f"harbor binary not found at {bin_path}"
+        result.elapsed_seconds = time.monotonic() - t0
+
+    except Exception as e:
+        result.elapsed_seconds = time.monotonic() - t0
+        result.error = f"harbor run failed: {e}"
+
+    if jobs_dir and jobs_dir.is_dir():
+        job_dirs = sorted(jobs_dir.iterdir())
+        if job_dirs:
+            result.job_dir = job_dirs[-1]
+
+    return result
+
+
+def _forward_signals(proc: subprocess.Popen) -> None:
+    """Set up signal forwarding so SIGINT/SIGTERM reach the subprocess."""
+    original_handlers = {}
+
+    def _handler(sig, _frame):
+        try:
+            proc.send_signal(sig)
+        except ProcessLookupError:
+            pass
+
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        try:
+            original_handlers[sig] = signal.signal(sig, _handler)
+        except (OSError, ValueError):
+            pass

--- a/capevolve_harbor/run.py
+++ b/capevolve_harbor/run.py
@@ -25,16 +25,23 @@ class HarborRunResult:
 def find_harbor_bin() -> str:
     """Locate the ``harbor`` CLI binary.
 
-    Checks ``HARBOR_BIN`` env var first, then falls back to PATH lookup.
+    Checks ``HARBOR_BIN`` env var first, then the active venv's bin/
+    directory, then falls back to a system-wide PATH lookup.
     """
     from_env = os.environ.get("HARBOR_BIN")
     if from_env:
         return from_env
+    venv = os.environ.get("VIRTUAL_ENV")
+    if venv:
+        venv_bin = Path(venv) / "bin" / "harbor"
+        if venv_bin.exists():
+            return str(venv_bin)
     found = shutil.which("harbor")
     if found:
         return found
     raise FileNotFoundError(
-        "harbor CLI not found. Install it with: uv tool install harbor"
+        "harbor CLI not found. Set HARBOR_BIN, activate a venv with harbor "
+        "installed, or install it with: uv tool install harbor"
     )
 
 
@@ -107,18 +114,20 @@ def harbor_run(
             stderr=subprocess.PIPE,
         )
 
-        _forward_signals(proc)
+        saved_handlers = _install_signal_forwarding(proc)
+        try:
+            stdout, stderr = proc.communicate(timeout=timeout)
+            result.returncode = proc.returncode
+            result.elapsed_seconds = time.monotonic() - t0
+            result.stderr_tail = (stderr or b"").decode("utf-8", errors="replace")[-2000:]
 
-        stdout, stderr = proc.communicate(timeout=timeout)
-        result.returncode = proc.returncode
-        result.elapsed_seconds = time.monotonic() - t0
-        result.stderr_tail = (stderr or b"").decode("utf-8", errors="replace")[-2000:]
-
-        if proc.returncode != 0:
-            result.error = (
-                f"harbor run exited with code {proc.returncode}: "
-                f"{result.stderr_tail[:500]}"
-            )
+            if proc.returncode != 0:
+                result.error = (
+                    f"harbor run exited with code {proc.returncode}: "
+                    f"{result.stderr_tail[:500]}"
+                )
+        finally:
+            _restore_signal_handlers(saved_handlers)
 
     except subprocess.TimeoutExpired:
         proc.kill()
@@ -143,9 +152,9 @@ def harbor_run(
     return result
 
 
-def _forward_signals(proc: subprocess.Popen) -> None:
-    """Set up signal forwarding so SIGINT/SIGTERM reach the subprocess."""
-    original_handlers = {}
+def _install_signal_forwarding(proc: subprocess.Popen) -> dict:
+    """Forward SIGINT/SIGTERM to the subprocess, return saved handlers."""
+    saved = {}
 
     def _handler(sig, _frame):
         try:
@@ -155,6 +164,16 @@ def _forward_signals(proc: subprocess.Popen) -> None:
 
     for sig in (signal.SIGINT, signal.SIGTERM):
         try:
-            original_handlers[sig] = signal.signal(sig, _handler)
+            saved[sig] = signal.signal(sig, _handler)
+        except (OSError, ValueError):
+            pass
+    return saved
+
+
+def _restore_signal_handlers(saved: dict) -> None:
+    """Restore original signal handlers after the subprocess finishes."""
+    for sig, handler in saved.items():
+        try:
+            signal.signal(sig, handler)
         except (OSError, ValueError):
             pass

--- a/capevolve_harbor/tasks.py
+++ b/capevolve_harbor/tasks.py
@@ -139,10 +139,15 @@ def package_dataset(
     return output_dir
 
 
+def _toml_escape(s: str) -> str:
+    """Escape a string for safe embedding in a TOML quoted value."""
+    return s.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+
+
 def _write_task_toml(dest: Path, name: str, description: str, cfg: dict) -> None:
     content = _TASK_TOML_TEMPLATE.format(
-        name=name,
-        description=description.replace('"', '\\"'),
+        name=_toml_escape(name),
+        description=_toml_escape(description),
         docker_image=cfg.get("docker_image", _DEFAULTS["docker_image"]),
         network_mode=cfg.get("network_mode", _DEFAULTS["network_mode"]),
         cpus=cfg.get("cpus", _DEFAULTS["cpus"]),

--- a/capevolve_harbor/tasks.py
+++ b/capevolve_harbor/tasks.py
@@ -1,0 +1,194 @@
+"""Generate self-contained Harbor task packages from cap-evolve tasks.
+
+Each cap-evolve Task becomes a Harbor task directory:
+
+    <task-id>/
+        task.toml           # Harbor task metadata
+        instruction.md      # What the agent should do
+        environment/
+            Dockerfile      # Container definition
+            capability/     # Candidate capability files (injected)
+        tests/
+            test.sh         # Verifier: runs scoring, writes reward.txt
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+
+_TASK_TOML_TEMPLATE = """\
+schema_version = "1.4"
+
+[task]
+name = "{name}"
+description = "{description}"
+
+[environment]
+docker_image = "{docker_image}"
+network_mode = "{network_mode}"
+cpus = {cpus}
+memory_mb = {memory_mb}
+
+[agent]
+timeout_sec = {agent_timeout}
+
+[verifier]
+timeout_sec = {verifier_timeout}
+"""
+
+_DOCKERFILE_TEMPLATE = """\
+FROM {base_image}
+
+RUN apt-get update -qq && apt-get install -y -qq python3 >/dev/null 2>&1 || true
+
+COPY capability/ /capability/
+"""
+
+_TEST_SH_TEMPLATE = """\
+#!/bin/bash
+set -e
+
+# Harbor verifier: write reward to /logs/verifier/reward.txt
+mkdir -p /logs/verifier
+
+# If a custom score script exists in /capability, run it
+if [ -f /capability/score.sh ]; then
+    bash /capability/score.sh > /logs/verifier/reward.txt 2>/logs/verifier/test-stderr.txt
+elif [ -f /capability/score.py ]; then
+    python3 /capability/score.py > /logs/verifier/reward.txt 2>/logs/verifier/test-stderr.txt
+else
+    # Default: check if /logs/agent/output.txt exists and is non-empty
+    if [ -s /logs/agent/output.txt ]; then
+        echo "1" > /logs/verifier/reward.txt
+    else
+        echo "0" > /logs/verifier/reward.txt
+    fi
+fi
+"""
+
+_DEFAULTS = {
+    "docker_image": "ubuntu:22.04",
+    "network_mode": "public",
+    "cpus": 1,
+    "memory_mb": 2048,
+    "agent_timeout": 1800,
+    "verifier_timeout": 120,
+}
+
+
+def package_task(
+    task_id: str,
+    instruction: str,
+    candidate_dir: Path,
+    output_dir: Path,
+    *,
+    config: dict | None = None,
+    description: str = "",
+    dockerfile: str | None = None,
+    test_script: str | None = None,
+) -> Path:
+    """Write one Harbor task directory under output_dir/<task_id>/.
+
+    Returns the path to the generated task directory.
+    """
+    cfg = {**_DEFAULTS, **(config or {})}
+    safe_id = task_id.replace("/", "__").replace(" ", "_")
+    task_dir = output_dir / safe_id
+    task_dir.mkdir(parents=True, exist_ok=True)
+
+    _write_task_toml(task_dir / "task.toml", safe_id, description or task_id, cfg)
+    _write_instruction(task_dir / "instruction.md", instruction)
+    _write_environment(task_dir / "environment", candidate_dir, cfg, dockerfile)
+    _write_tests(task_dir / "tests", test_script)
+
+    return task_dir
+
+
+def package_dataset(
+    tasks: list[dict],
+    candidate_dir: Path,
+    output_dir: Path,
+    *,
+    config: dict | None = None,
+    dockerfile: str | None = None,
+    test_script: str | None = None,
+) -> Path:
+    """Generate a Harbor dataset (directory of task packages).
+
+    Each item in tasks should have keys: id, input, and optionally
+    description and metadata.
+
+    Returns the dataset root directory.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    for t in tasks:
+        package_task(
+            task_id=str(t["id"]),
+            instruction=str(t.get("input", "")),
+            candidate_dir=candidate_dir,
+            output_dir=output_dir,
+            config=config,
+            description=str(t.get("description", t["id"])),
+            dockerfile=dockerfile,
+            test_script=test_script,
+        )
+
+    return output_dir
+
+
+def _write_task_toml(dest: Path, name: str, description: str, cfg: dict) -> None:
+    content = _TASK_TOML_TEMPLATE.format(
+        name=name,
+        description=description.replace('"', '\\"'),
+        docker_image=cfg.get("docker_image", _DEFAULTS["docker_image"]),
+        network_mode=cfg.get("network_mode", _DEFAULTS["network_mode"]),
+        cpus=cfg.get("cpus", _DEFAULTS["cpus"]),
+        memory_mb=cfg.get("memory_mb", _DEFAULTS["memory_mb"]),
+        agent_timeout=cfg.get("agent_timeout", _DEFAULTS["agent_timeout"]),
+        verifier_timeout=cfg.get("verifier_timeout", _DEFAULTS["verifier_timeout"]),
+    )
+    dest.write_text(content, encoding="utf-8")
+
+
+def _write_instruction(dest: Path, instruction: str) -> None:
+    preamble = (
+        "The capability files for this task are located at `/capability/` "
+        "inside the container.\n\n"
+    )
+    dest.write_text(preamble + instruction, encoding="utf-8")
+
+
+def _write_environment(
+    env_dir: Path, candidate_dir: Path, cfg: dict, dockerfile: str | None
+) -> None:
+    env_dir.mkdir(parents=True, exist_ok=True)
+
+    cap_dest = env_dir / "capability"
+    if cap_dest.exists():
+        shutil.rmtree(cap_dest)
+
+    candidate_dir = Path(candidate_dir)
+    if candidate_dir.is_dir():
+        shutil.copytree(candidate_dir, cap_dest)
+    else:
+        cap_dest.mkdir(parents=True, exist_ok=True)
+
+    df_path = env_dir / "Dockerfile"
+    if dockerfile:
+        df_path.write_text(dockerfile, encoding="utf-8")
+    else:
+        base = cfg.get("docker_image", _DEFAULTS["docker_image"])
+        df_path.write_text(
+            _DOCKERFILE_TEMPLATE.format(base_image=base), encoding="utf-8"
+        )
+
+
+def _write_tests(tests_dir: Path, test_script: str | None) -> None:
+    tests_dir.mkdir(parents=True, exist_ok=True)
+    script = test_script or _TEST_SH_TEMPLATE
+    test_sh = tests_dir / "test.sh"
+    test_sh.write_text(script, encoding="utf-8")
+    test_sh.chmod(0o755)

--- a/capevolve_harbor/tests/test_results.py
+++ b/capevolve_harbor/tests/test_results.py
@@ -1,0 +1,159 @@
+"""Tests for capevolve_harbor.results — reward parsing and job dir walking."""
+import json
+import pytest
+from pathlib import Path
+
+from capevolve_harbor.results import parse_job_dir, build_feedback, _read_reward, TrialResult
+
+
+@pytest.fixture
+def job_dir(tmp_path):
+    """Build a minimal Harbor job directory with two trials."""
+    # Trial 1: reward.json with explicit reward key
+    t1 = tmp_path / "trial-001"
+    v1 = t1 / "verifier"
+    v1.mkdir(parents=True)
+    (v1 / "reward.json").write_text(json.dumps({"reward": 0.75, "accuracy": 0.8}))
+    (v1 / "test-stdout.txt").write_text("All tests passed")
+    (v1 / "test-stderr.txt").write_text("")
+    a1 = t1 / "agent"
+    a1.mkdir()
+    (a1 / "trajectory.json").write_text(json.dumps({"steps": []}))
+    cfg1 = t1 / "config.json"
+    cfg1.write_text(json.dumps({"task": {"name": "task-001"}}))
+    (t1 / "result.json").write_text(json.dumps({"cost_usd": 1.5, "tokens": 5000}))
+
+    # Trial 2: reward.json with reward=0.0 (legitimate zero)
+    t2 = tmp_path / "trial-002"
+    v2 = t2 / "verifier"
+    v2.mkdir(parents=True)
+    (v2 / "reward.json").write_text(json.dumps({"reward": 0.0}))
+    (v2 / "reward.txt").write_text("0.5")  # should NOT be used
+    cfg2 = t2 / "config.json"
+    cfg2.write_text(json.dumps({"task": {"name": "task-002"}}))
+
+    return tmp_path
+
+
+def test_parse_job_dir_finds_trials(job_dir):
+    results = parse_job_dir(job_dir)
+    assert "task-001" in results
+    assert "task-002" in results
+    assert len(results["task-001"]) == 1
+    assert len(results["task-002"]) == 1
+
+
+def test_parse_job_dir_reads_reward(job_dir):
+    results = parse_job_dir(job_dir)
+    assert results["task-001"][0].reward == 0.75
+    assert results["task-001"][0].reward_json == {"reward": 0.75, "accuracy": 0.8}
+
+
+def test_parse_job_dir_reads_cost_tokens(job_dir):
+    results = parse_job_dir(job_dir)
+    assert results["task-001"][0].cost_usd == 1.5
+    assert results["task-001"][0].tokens == 5000
+
+
+def test_parse_job_dir_reads_trajectory(job_dir):
+    results = parse_job_dir(job_dir)
+    assert results["task-001"][0].trajectory == {"steps": []}
+
+
+def test_parse_job_dir_reads_verifier_stdout(job_dir):
+    results = parse_job_dir(job_dir)
+    assert results["task-001"][0].verifier_stdout == "All tests passed"
+
+
+def test_parse_job_dir_filters_by_task_ids(job_dir):
+    results = parse_job_dir(job_dir, task_ids=["task-001"])
+    assert "task-001" in results
+    assert "task-002" not in results
+
+
+def test_parse_job_dir_skips_non_dirs(job_dir):
+    (job_dir / "config.json").write_text("{}")
+    (job_dir / "result.json").write_text("{}")
+    results = parse_job_dir(job_dir)
+    assert "config.json" not in results
+    assert "result.json" not in results
+
+
+def test_parse_job_dir_empty(tmp_path):
+    results = parse_job_dir(tmp_path)
+    assert results == {}
+
+
+def test_parse_job_dir_nonexistent(tmp_path):
+    results = parse_job_dir(tmp_path / "does_not_exist")
+    assert results == {}
+
+
+# --- _read_reward tests (the bug the review caught) ---
+
+def test_read_reward_from_json_key(tmp_path):
+    (tmp_path / "reward.json").write_text(json.dumps({"reward": 0.9}))
+    reward, rj = _read_reward(tmp_path)
+    assert reward == 0.9
+
+
+def test_read_reward_zero_is_honoured(tmp_path):
+    """A legitimate 0.0 in reward.json must NOT trigger reward.txt fallback."""
+    (tmp_path / "reward.json").write_text(json.dumps({"reward": 0.0}))
+    (tmp_path / "reward.txt").write_text("0.99")
+    reward, _ = _read_reward(tmp_path)
+    assert reward == 0.0
+
+
+def test_read_reward_falls_back_to_txt_when_json_absent(tmp_path):
+    (tmp_path / "reward.txt").write_text("0.42")
+    reward, _ = _read_reward(tmp_path)
+    assert reward == 0.42
+
+
+def test_read_reward_falls_back_to_txt_when_json_has_no_reward_key(tmp_path):
+    (tmp_path / "reward.json").write_text(json.dumps({"accuracy": 0.8}))
+    (tmp_path / "reward.txt").write_text("0.33")
+    reward, _ = _read_reward(tmp_path)
+    assert reward == 0.33
+
+
+def test_read_reward_falls_back_to_txt_when_json_malformed(tmp_path):
+    (tmp_path / "reward.json").write_text("not json at all")
+    (tmp_path / "reward.txt").write_text("0.5")
+    reward, _ = _read_reward(tmp_path)
+    assert reward == 0.5
+
+
+def test_read_reward_returns_zero_when_nothing_exists(tmp_path):
+    reward, rj = _read_reward(tmp_path)
+    assert reward == 0.0
+    assert rj == {}
+
+
+# --- build_feedback tests ---
+
+def test_feedback_solved():
+    tr = TrialResult(task_id="t1", reward=1.0)
+    assert "fully solved" in build_feedback(tr)
+
+
+def test_feedback_partial():
+    tr = TrialResult(task_id="t1", reward=0.5)
+    assert "Partial" in build_feedback(tr)
+
+
+def test_feedback_zero():
+    tr = TrialResult(task_id="t1", reward=0.0)
+    assert "not solved" in build_feedback(tr)
+
+
+def test_feedback_includes_metrics():
+    tr = TrialResult(task_id="t1", reward=0.5, reward_json={"reward": 0.5, "accuracy": 0.8})
+    fb = build_feedback(tr)
+    assert "accuracy=0.8" in fb
+
+
+def test_feedback_includes_error():
+    tr = TrialResult(task_id="t1", reward=0.0, error="timeout")
+    assert "timeout" in build_feedback(tr)

--- a/capevolve_harbor/tests/test_run.py
+++ b/capevolve_harbor/tests/test_run.py
@@ -1,0 +1,61 @@
+"""Tests for capevolve_harbor.run — signal handling and harbor binary discovery."""
+import os
+import signal
+from unittest.mock import patch
+
+from capevolve_harbor.run import (
+    find_harbor_bin,
+    _install_signal_forwarding,
+    _restore_signal_handlers,
+)
+
+
+def test_find_harbor_bin_from_env(tmp_path):
+    fake = tmp_path / "harbor"
+    fake.touch()
+    with patch.dict(os.environ, {"HARBOR_BIN": str(fake)}):
+        assert find_harbor_bin() == str(fake)
+
+
+def test_find_harbor_bin_from_venv(tmp_path):
+    venv = tmp_path / "venv"
+    bin_dir = venv / "bin"
+    bin_dir.mkdir(parents=True)
+    harbor = bin_dir / "harbor"
+    harbor.touch()
+    with patch.dict(os.environ, {"VIRTUAL_ENV": str(venv)}, clear=False):
+        # Clear HARBOR_BIN to avoid short-circuit
+        env = os.environ.copy()
+        env.pop("HARBOR_BIN", None)
+        env["VIRTUAL_ENV"] = str(venv)
+        with patch.dict(os.environ, env, clear=True):
+            assert find_harbor_bin() == str(harbor)
+
+
+def test_find_harbor_bin_raises_when_missing():
+    with patch.dict(os.environ, {}, clear=True):
+        with patch("shutil.which", return_value=None):
+            try:
+                find_harbor_bin()
+                assert False, "Should have raised"
+            except FileNotFoundError as e:
+                assert "harbor" in str(e)
+
+
+def test_signal_handlers_restored():
+    """Signal handlers must be restored after _restore_signal_handlers."""
+    original_sigint = signal.getsignal(signal.SIGINT)
+
+    class FakeProc:
+        def send_signal(self, sig):
+            pass
+
+    saved = _install_signal_forwarding(FakeProc())
+    # Handlers should now be different
+    current = signal.getsignal(signal.SIGINT)
+    assert current != original_sigint
+
+    _restore_signal_handlers(saved)
+    # Handlers should be back to original
+    restored = signal.getsignal(signal.SIGINT)
+    assert restored == original_sigint

--- a/capevolve_harbor/tests/test_tasks.py
+++ b/capevolve_harbor/tests/test_tasks.py
@@ -1,0 +1,155 @@
+"""Tests for capevolve_harbor.tasks — task packaging and TOML escaping."""
+import json
+from pathlib import Path
+
+from capevolve_harbor.tasks import package_task, package_dataset, _toml_escape
+
+
+def test_toml_escape_quotes():
+    assert _toml_escape('say "hello"') == 'say \\"hello\\"'
+
+
+def test_toml_escape_newlines():
+    assert _toml_escape("line1\nline2") == "line1\\nline2"
+
+
+def test_toml_escape_backslashes():
+    assert _toml_escape("path\\to\\file") == "path\\\\to\\\\file"
+
+
+def test_toml_escape_combined():
+    assert _toml_escape('a "b"\nc\\d') == 'a \\"b\\"\\nc\\\\d'
+
+
+def test_package_task_creates_structure(tmp_path):
+    candidate = tmp_path / "candidate"
+    candidate.mkdir()
+    (candidate / "SKILL.md").write_text("test skill")
+
+    output = tmp_path / "output"
+    task_dir = package_task(
+        task_id="test-task",
+        instruction="Fix the bug",
+        candidate_dir=candidate,
+        output_dir=output,
+    )
+
+    assert task_dir.exists()
+    assert (task_dir / "task.toml").exists()
+    assert (task_dir / "instruction.md").exists()
+    assert (task_dir / "environment" / "Dockerfile").exists()
+    assert (task_dir / "environment" / "capability" / "SKILL.md").exists()
+    assert (task_dir / "tests" / "test.sh").exists()
+
+
+def test_package_task_copies_candidate_files(tmp_path):
+    candidate = tmp_path / "candidate"
+    candidate.mkdir()
+    (candidate / "prompt.md").write_text("my prompt")
+    (candidate / "config.json").write_text('{"key": "val"}')
+
+    output = tmp_path / "output"
+    task_dir = package_task(
+        task_id="t1",
+        instruction="do stuff",
+        candidate_dir=candidate,
+        output_dir=output,
+    )
+
+    cap_dir = task_dir / "environment" / "capability"
+    assert (cap_dir / "prompt.md").read_text() == "my prompt"
+    assert (cap_dir / "config.json").read_text() == '{"key": "val"}'
+
+
+def test_package_task_instruction_includes_capability_note(tmp_path):
+    candidate = tmp_path / "candidate"
+    candidate.mkdir()
+    output = tmp_path / "output"
+
+    task_dir = package_task(
+        task_id="t1",
+        instruction="Fix the bug",
+        candidate_dir=candidate,
+        output_dir=output,
+    )
+
+    content = (task_dir / "instruction.md").read_text()
+    assert "/capability/" in content
+    assert "Fix the bug" in content
+
+
+def test_package_task_toml_valid(tmp_path):
+    candidate = tmp_path / "candidate"
+    candidate.mkdir()
+    output = tmp_path / "output"
+
+    task_dir = package_task(
+        task_id="task-with-special",
+        instruction="Fix it",
+        candidate_dir=candidate,
+        output_dir=output,
+        description='A task with "quotes" and\nnewlines',
+    )
+
+    toml_content = (task_dir / "task.toml").read_text()
+    assert '\\"quotes\\"' in toml_content
+    assert "\\n" in toml_content
+
+
+def test_package_task_sanitizes_id(tmp_path):
+    candidate = tmp_path / "candidate"
+    candidate.mkdir()
+    output = tmp_path / "output"
+
+    task_dir = package_task(
+        task_id="org/repo__issue-123",
+        instruction="Fix",
+        candidate_dir=candidate,
+        output_dir=output,
+    )
+
+    assert task_dir.name == "org__repo__issue-123"
+
+
+def test_package_dataset_creates_multiple_tasks(tmp_path):
+    candidate = tmp_path / "candidate"
+    candidate.mkdir()
+    (candidate / "SKILL.md").write_text("skill")
+    output = tmp_path / "output"
+
+    tasks = [
+        {"id": "task-1", "input": "Fix bug 1"},
+        {"id": "task-2", "input": "Fix bug 2"},
+        {"id": "task-3", "input": "Fix bug 3"},
+    ]
+
+    dataset_dir = package_dataset(tasks, candidate, output)
+
+    assert dataset_dir.exists()
+    assert (dataset_dir / "task-1" / "task.toml").exists()
+    assert (dataset_dir / "task-2" / "task.toml").exists()
+    assert (dataset_dir / "task-3" / "task.toml").exists()
+
+
+def test_package_dataset_all_share_same_candidate(tmp_path):
+    candidate = tmp_path / "candidate"
+    candidate.mkdir()
+    (candidate / "prompt.md").write_text("shared prompt")
+    output = tmp_path / "output"
+
+    tasks = [{"id": "t1", "input": ""}, {"id": "t2", "input": ""}]
+    package_dataset(tasks, candidate, output)
+
+    for tid in ("t1", "t2"):
+        content = (output / tid / "environment" / "capability" / "prompt.md").read_text()
+        assert content == "shared prompt"
+
+
+def test_test_sh_is_executable(tmp_path):
+    candidate = tmp_path / "candidate"
+    candidate.mkdir()
+    output = tmp_path / "output"
+
+    task_dir = package_task("t1", "Fix", candidate, output)
+    test_sh = task_dir / "tests" / "test.sh"
+    assert test_sh.stat().st_mode & 0o111

--- a/site/adapter-templates.html
+++ b/site/adapter-templates.html
@@ -38,6 +38,7 @@
       <a href="benchmarks.html">Benchmarks</a>
       <a href="architecture.html">Architecture</a>
       <a href="agent-orchestration.html">Agent mode</a>
+      <a href="harbor.html">Harbor</a>
       <a class="gh" href="https://github.com/skillberry-ai/cap-evolve">GitHub</a>
       <button class="theme-toggle" type="button" aria-label="Switch theme">
         <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>

--- a/site/agent-orchestration.html
+++ b/site/agent-orchestration.html
@@ -38,6 +38,7 @@
       <a href="benchmarks.html">Benchmarks</a>
       <a href="architecture.html">Architecture</a>
       <a href="agent-orchestration.html" class="active">Agent mode</a>
+      <a href="harbor.html">Harbor</a>
       <a class="gh" href="https://github.com/skillberry-ai/cap-evolve">GitHub</a>
       <button class="theme-toggle" type="button" aria-label="Switch theme">
         <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>

--- a/site/architecture.html
+++ b/site/architecture.html
@@ -38,6 +38,7 @@
       <a href="benchmarks.html">Benchmarks</a>
       <a href="architecture.html" class="active">Architecture</a>
       <a href="agent-orchestration.html">Agent mode</a>
+      <a href="harbor.html">Harbor</a>
       <a class="gh" href="https://github.com/skillberry-ai/cap-evolve">GitHub</a>
       <button class="theme-toggle" type="button" aria-label="Switch theme">
         <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>

--- a/site/benchmarks.html
+++ b/site/benchmarks.html
@@ -38,6 +38,7 @@
       <a href="benchmarks.html" class="active">Benchmarks</a>
       <a href="architecture.html">Architecture</a>
       <a href="agent-orchestration.html">Agent mode</a>
+      <a href="harbor.html">Harbor</a>
       <a class="gh" href="https://github.com/skillberry-ai/cap-evolve">GitHub</a>
       <button class="theme-toggle" type="button" aria-label="Switch theme">
         <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>

--- a/site/getting-started.html
+++ b/site/getting-started.html
@@ -38,6 +38,7 @@
       <a href="benchmarks.html">Benchmarks</a>
       <a href="architecture.html">Architecture</a>
       <a href="agent-orchestration.html">Agent mode</a>
+      <a href="harbor.html">Harbor</a>
       <a class="gh" href="https://github.com/skillberry-ai/cap-evolve">GitHub</a>
       <button class="theme-toggle" type="button" aria-label="Switch theme">
         <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>

--- a/site/harbor-openshift.html
+++ b/site/harbor-openshift.html
@@ -1,0 +1,292 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Harbor on OpenShift — cap-evolve</title>
+  <meta name="description" content="Step-by-step guide: run cap-evolve with Harbor on OpenShift using vLLM model serving. RBAC, SCC, agent credentials, and the full optimization loop.">
+  <link rel="canonical" href="https://skillberry-ai.github.io/cap-evolve/harbor-openshift.html">
+  <meta property="og:type" content="article">
+  <meta property="og:site_name" content="cap-evolve">
+  <meta property="og:title" content="Harbor on OpenShift — cap-evolve">
+  <meta property="og:description" content="Run cap-evolve with Harbor on OpenShift using vLLM model serving.">
+  <meta property="og:url" content="https://skillberry-ai.github.io/cap-evolve/harbor-openshift.html">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="Harbor on OpenShift — cap-evolve">
+  <meta name="twitter:description" content="Run cap-evolve with Harbor on OpenShift using vLLM model serving.">
+  <link rel="icon" href="assets/favicon.svg" type="image/svg+xml">
+  <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600&family=Fira+Sans:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+  <script>(function(){try{document.documentElement.setAttribute('data-theme',localStorage.getItem('capevolve-theme')||'dark');}catch(e){document.documentElement.setAttribute('data-theme','dark');}document.documentElement.classList.add('js');})();</script>
+  <link rel="stylesheet" href="style.css?v=20260724b">
+</head>
+<body>
+
+<nav class="nav">
+  <div class="nav-inner">
+    <a class="nav-brand" href="./"><img src="assets/logo-300.png" alt="" class="nav-brand-logo" aria-hidden="true"><span class="wordmark">cap<span class="wordmark-dot">·</span>evolve</span></a>
+    <div class="nav-links">
+      <a href="getting-started.html">Get started</a>
+      <a href="run-end-to-end.html">Run end-to-end</a>
+      <a href="results.html">Results</a>
+      <a href="benchmarks.html">Benchmarks</a>
+      <a href="architecture.html">Architecture</a>
+      <a href="agent-orchestration.html">Agent mode</a>
+      <a href="harbor.html">Harbor</a>
+      <a class="gh" href="https://github.com/skillberry-ai/cap-evolve">GitHub</a>
+      <button class="theme-toggle" type="button" aria-label="Switch theme">
+        <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
+        <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"></path></svg>
+      </button>
+    </div>
+  </div>
+</nav>
+
+<main class="page-narrow doc">
+
+  <h1>Harbor on OpenShift</h1>
+  <p class="lead">
+    End-to-end guide: set up Harbor's OpenShift environment, serve models
+    with vLLM on-cluster, and run cap-evolve optimizations — all on your
+    OpenShift cluster with no external dependencies.
+  </p>
+
+  <h2>Architecture</h2>
+<pre><code>┌──────────────────────────────────────────────────────────────────┐
+│  OpenShift cluster                                                │
+│                                                                   │
+│  Orchestrator Pod (cap-evolve + harbor CLI)                       │
+│    │                                                              │
+│    ├─ harbor run -d &lt;dataset&gt; -a &lt;agent&gt; -e openshift          │
+│    │                                                              │
+│    ├─ Task Pod 1 ◄── agent + verifier ──► reward.json            │
+│    ├─ Task Pod 2 ◄── agent + verifier ──► reward.json            │
+│    └─ Task Pod N ◄── ...                                         │
+│                                                                   │
+│  vLLM Model Server (GPU node)                                     │
+│    └─ http://vllm-svc.namespace.svc:8000/v1                      │
+└──────────────────────────────────────────────────────────────────┘</code></pre>
+
+  <table>
+    <thead><tr><th>Component</th><th>What it does</th><th>Runs as</th></tr></thead>
+    <tbody>
+      <tr><td><strong>Orchestrator</strong></td><td>Runs cap-evolve loop + <code>harbor run</code></td><td>Job (CPU pod)</td></tr>
+      <tr><td><strong>Task pods</strong></td><td>One per benchmark task — agent runs, verifier scores</td><td>Pods created by Harbor</td></tr>
+      <tr><td><strong>vLLM</strong></td><td>Serves the model (OpenAI-compatible API)</td><td>Deployment on GPU nodes</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Prerequisites</h2>
+  <ul>
+    <li><code>oc</code> CLI logged into your cluster</li>
+    <li>A namespace with GPU nodes (for vLLM) or access to an external model API</li>
+    <li>Harbor CLI (&ge; 0.20): <code>uv tool install harbor</code></li>
+  </ul>
+
+  <h2>Step 1 — Deploy vLLM model server</h2>
+  <p>Skip this step if you're using an external model API (Anthropic, OpenAI, Vertex AI).</p>
+
+<pre><code># Create the namespace
+oc new-project cap-evolve
+
+# Deploy vLLM (example: Qwen 2.5 14B on 2 GPUs)
+oc apply -f openshift/manifests/vllm-serving.yaml
+
+# Wait for the model to load (5-15 min on first deploy)
+oc get pods -l component=vllm -w
+
+# Verify the endpoint
+oc exec deploy/cap-evolve-runner -- \
+  curl -s http://vllm-svc:8000/v1/models | python3 -m json.tool</code></pre>
+
+  <p>See <a href="openshift.html">OpenShift deployment</a> for the full vLLM setup
+  including GPU sizing, model swapping, and the HuggingFace token secret.</p>
+
+  <h2>Step 2 — Set up RBAC for Harbor</h2>
+  <p>Harbor needs two ServiceAccounts with specific permissions.</p>
+
+  <h3>Task SA — runs agent containers</h3>
+  <p>Needs a custom SCC that allows <code>runAsUser: 0</code> and Linux capabilities
+  (<code>CHOWN</code>, <code>SETUID</code>, <code>SETGID</code>, <code>FOWNER</code>,
+  etc.) that agents require inside their containers.</p>
+
+<pre><code># Apply the task SA + SCC
+oc apply -f openshift/manifests/service-account.yaml
+
+# Bind the SCC
+oc adm policy add-scc-to-user harbor-task-scc -z harbor-task</code></pre>
+
+  <h3>Orchestrator SA — manages task pods</h3>
+  <p>Needs RBAC to create/delete pods, builds, image streams, and jobs.</p>
+
+<pre><code># Apply the orchestrator SA + Role + RoleBinding
+oc apply -f openshift/manifests/harbor-orchestrator-sa.yaml
+
+# Also bind the task SCC (orchestrator creates pods that use it)
+oc adm policy add-scc-to-user harbor-task-scc -z harbor-orchestrator</code></pre>
+
+  <h2>Step 3 — Verify Harbor works on the cluster</h2>
+  <p>Run a quick smoke test with the <code>oracle</code> agent (no model needed).</p>
+
+<pre><code>harbor run -d terminal-bench@2.0 -a oracle -e openshift -l 1</code></pre>
+
+  <p>You should see Harbor create a BuildConfig, build the task image, run a task
+  pod, and report a reward. If the pod fails with an SCC error, check that
+  Step 2 was completed.</p>
+
+  <h2>Step 4 — Run Harbor with your agent</h2>
+  <p>The general pattern — works with any agent, any dataset, any model backend.</p>
+
+<pre><code>harbor run \
+  -d &lt;dataset&gt; \
+  -a &lt;agent&gt; \
+  -m &lt;model&gt; \
+  -e openshift \
+  -n &lt;parallel&gt; \
+  --ae &lt;KEY&gt;=&lt;VALUE&gt; ...</code></pre>
+
+  <h3>With on-cluster vLLM</h3>
+  <p>No external API keys needed — the agent connects to vLLM via the in-cluster
+  Service DNS.</p>
+<pre><code>harbor run -d &lt;dataset&gt; -a claude-code -m &lt;model-name&gt; -e openshift -n 5 \
+  --ae ANTHROPIC_BASE_URL=http://&lt;vllm-svc&gt;.&lt;namespace&gt;.svc:8000 \
+  --ae ANTHROPIC_API_KEY=dummy \
+  --ae ANTHROPIC_MODEL=&lt;model-name&gt; \
+  --ae ANTHROPIC_DEFAULT_SONNET_MODEL=&lt;model-name&gt; \
+  --ae ANTHROPIC_DEFAULT_HAIKU_MODEL=&lt;model-name&gt; \
+  --ae ANTHROPIC_DEFAULT_OPUS_MODEL=&lt;model-name&gt;</code></pre>
+
+  <h3>With Vertex AI</h3>
+  <p>Bind-mount GCP credentials into each task pod.</p>
+<pre><code>harbor run -d &lt;dataset&gt; -a claude-code -m claude-sonnet-4-6 -e openshift -n 5 \
+  --ae CLAUDE_CODE_USE_VERTEX=1 \
+  --ae CLOUD_ML_REGION=&lt;region&gt; \
+  --ae ANTHROPIC_VERTEX_PROJECT_ID=&lt;gcp-project&gt; \
+  --ae ANTHROPIC_MODEL=claude-sonnet-4-6 \
+  --ae GOOGLE_APPLICATION_CREDENTIALS=/app/.config/gcloud/adc.json \
+  --mounts-json '[{"type":"bind","source":"~/.config/gcloud/application_default_credentials.json","target":"/app/.config/gcloud/adc.json"}]'</code></pre>
+
+  <h3>With an Anthropic API key</h3>
+<pre><code>harbor run -d &lt;dataset&gt; -a claude-code -m claude-sonnet-4-6 -e openshift -n 5 \
+  --ae ANTHROPIC_API_KEY=sk-ant-...</code></pre>
+
+  <h3>With OpenAI / Codex</h3>
+<pre><code>harbor run -d &lt;dataset&gt; -a codex -m &lt;model&gt; -e openshift -n 5 \
+  --ae OPENAI_API_KEY=sk-...</code></pre>
+
+  <h3>With any OpenAI-compatible endpoint</h3>
+<pre><code>harbor run -d &lt;dataset&gt; -a opencode -m &lt;model&gt; -e openshift -n 5 \
+  --ae OPENAI_BASE_URL=http://&lt;endpoint&gt; \
+  --ae OPENAI_API_KEY=...</code></pre>
+
+  <h2>Step 5 — Run the cap-evolve optimization loop</h2>
+  <p>Once Harbor runs successfully, wire it into cap-evolve's optimization loop
+  via the Harbor adapter.</p>
+
+<pre><code># Install cap-evolve + Harbor adapter
+pip install ./core ./capevolve_harbor
+
+# Set up the project
+cap-evolve init
+cp -r templates/adapters/harbor/* .capevolve/project/adapters/
+
+# Configure
+export HARBOR_DATASET=&lt;org/dataset&gt;
+export HARBOR_AGENT=&lt;agent&gt;
+export HARBOR_MODEL=&lt;model&gt;
+export HARBOR_TASK_IDS=&lt;task1,task2,...&gt;
+export HARBOR_TASK_PREFIX=&lt;dataset-org&gt;
+export HARBOR_EXTRA_FLAGS="-e openshift -n 5 --ae KEY=VALUE ..."
+
+# Run the optimization
+cap-evolve check .capevolve/project
+cap-evolve run --spec .capevolve/project/capevolve.yaml</code></pre>
+
+  <p>cap-evolve will iterate: evaluate via <code>harbor run</code> → diagnose
+  failures → optimizer edits the skill → re-evaluate → gate → repeat.</p>
+
+  <h2>What Harbor creates on the cluster</h2>
+  <table>
+    <thead><tr><th>Resource</th><th>Name pattern</th><th>Purpose</th><th>Lifecycle</th></tr></thead>
+    <tbody>
+      <tr><td>BuildConfig</td><td><code>hb-build-&lt;task&gt;</code></td><td>Builds the task environment image</td><td>Cached via ImageStream</td></tr>
+      <tr><td>ImageStream</td><td><code>hb-build-&lt;task&gt;</code></td><td>Caches built images (skips rebuild on rerun)</td><td>Persists</td></tr>
+      <tr><td>Pod</td><td><code>hb-&lt;task&gt;-&lt;hash&gt;-env</code></td><td>Runs the agent + verifier</td><td>Deleted after trial (or <code>--no-delete</code>)</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Debugging</h2>
+
+<pre><code># Keep task pods alive after the trial for inspection
+harbor run ... --no-delete
+
+# List Harbor's task pods
+oc get pods | grep ^hb-
+
+# Check a task pod's logs
+oc logs &lt;pod-name&gt; -c main
+
+# Shell into a running task pod
+oc exec -it &lt;pod-name&gt; -- /bin/sh
+
+# Check build status
+oc get builds</code></pre>
+
+  <p>Harbor captures full transcripts in the job output directory:</p>
+<pre><code>jobs/&lt;job-name&gt;/&lt;trial&gt;/
+  agent/trajectory.json      # agent execution trace (ATIF format)
+  agent/claude-code.txt      # raw agent stream
+  verifier/reward.json       # verifier score
+  verifier/test-stdout.txt   # verifier output
+  verifier/test-stderr.txt   # verifier errors</code></pre>
+
+  <h2>Troubleshooting</h2>
+  <table>
+    <thead><tr><th>Problem</th><th>Fix</th></tr></thead>
+    <tbody>
+      <tr><td><code>unable to validate against any security context constraint</code></td><td>Run <code>oc adm policy add-scc-to-user harbor-task-scc -z harbor-task</code> and for the orchestrator SA too</td></tr>
+      <tr><td>Build pod fails</td><td>Check <code>oc logs &lt;build-pod&gt;</code> — usually a Dockerfile issue or missing base image</td></tr>
+      <tr><td>Task pod: <code>ImagePullBackOff</code></td><td>The built image wasn't pushed to the internal registry — check <code>oc get is</code></td></tr>
+      <tr><td>Agent timeout / RuntimeError</td><td>Model context too small for the task. Use a larger model or filter with <code>-i &lt;task&gt;</code></td></tr>
+      <tr><td>Vertex AI auth fails in task pod</td><td>Ensure <code>--mounts-json</code> bind-mounts the GCP credentials file and <code>--ae GOOGLE_APPLICATION_CREDENTIALS=&lt;path&gt;</code> points to it</td></tr>
+      <tr><td>vLLM endpoint not reachable from task pod</td><td>Task pods run in the same namespace — use the full Service DNS: <code>http://&lt;svc&gt;.&lt;namespace&gt;.svc:8000</code></td></tr>
+      <tr><td>No task matched the filter</td><td>Harbor prefixes task names with the dataset org. Use <code>-i &lt;org&gt;/&lt;task&gt;</code></td></tr>
+      <tr><td>Pod evicted / OOMKilled</td><td>Increase memory with <code>--override-memory-mb 4096</code></td></tr>
+    </tbody>
+  </table>
+
+  <h2>Reference</h2>
+  <ul>
+    <li><a href="harbor.html">Harbor integration</a> — the main Harbor + cap-evolve guide</li>
+    <li><a href="openshift.html">OpenShift deployment</a> — vLLM model serving on OpenShift</li>
+    <li><a href="https://github.com/harbor-framework/harbor/pull/1875">Harbor OpenShift environment PR</a></li>
+    <li><a href="https://github.com/opendatahub-io/agent-eval-harness/blob/main/docs/harbor-workflow.md">agent-eval-harness Harbor workflow</a></li>
+    <li><a href="https://github.com/redhat-et/coding_agent_bench">coding_agent_bench</a> — SWE-bench with Harbor on OpenShift</li>
+  </ul>
+
+</main>
+
+<footer class="footer">
+  <div class="footer-inner">
+    <div>
+      <span class="wordmark" style="color:var(--ink);font-size:1.05rem;">cap<span class="wordmark-dot">·</span>evolve</span><br>
+      Apache-2.0 · beta (0.x) · <em>Optimize agentic capabilities — with agents</em>
+    </div>
+    <div class="footer-affil">
+      <span>Made at</span>
+      <span class="footer-affil-logos">
+        <img src="assets/ibm-logo.svg" alt="IBM" class="logo-ibm">
+        <img src="assets/redhat-logo.svg" alt="Red Hat" class="logo-redhat">
+      </span>
+    </div>
+    <div>
+      <a href="https://github.com/skillberry-ai/cap-evolve">github.com/skillberry-ai/cap-evolve</a>
+    </div>
+  </div>
+</footer>
+
+<script src="js/site.js?v=20260724" defer></script>
+</body>
+</html>

--- a/site/harbor-openshift.html
+++ b/site/harbor-openshift.html
@@ -3,17 +3,17 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Harbor on OpenShift — cap-evolve</title>
-  <meta name="description" content="Step-by-step guide: run cap-evolve with Harbor on OpenShift using vLLM model serving. RBAC, SCC, agent credentials, and the full optimization loop.">
+  <title>vLLM on OpenShift — cap-evolve</title>
+  <meta name="description" content="Deploy vLLM on OpenShift to serve models for cap-evolve and Harbor. GPU sizing, manifests, agent connection patterns.">
   <link rel="canonical" href="https://skillberry-ai.github.io/cap-evolve/harbor-openshift.html">
   <meta property="og:type" content="article">
   <meta property="og:site_name" content="cap-evolve">
-  <meta property="og:title" content="Harbor on OpenShift — cap-evolve">
-  <meta property="og:description" content="Run cap-evolve with Harbor on OpenShift using vLLM model serving.">
+  <meta property="og:title" content="vLLM on OpenShift — cap-evolve">
+  <meta property="og:description" content="Deploy vLLM on OpenShift to serve models for cap-evolve and Harbor.">
   <meta property="og:url" content="https://skillberry-ai.github.io/cap-evolve/harbor-openshift.html">
   <meta name="twitter:card" content="summary">
-  <meta name="twitter:title" content="Harbor on OpenShift — cap-evolve">
-  <meta name="twitter:description" content="Run cap-evolve with Harbor on OpenShift using vLLM model serving.">
+  <meta name="twitter:title" content="vLLM on OpenShift — cap-evolve">
+  <meta name="twitter:description" content="Deploy vLLM on OpenShift to serve models for cap-evolve and Harbor.">
   <link rel="icon" href="assets/favicon.svg" type="image/svg+xml">
   <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -46,224 +46,103 @@
 
 <main class="page-narrow doc">
 
-  <h1>Harbor on OpenShift</h1>
+  <h1>vLLM on OpenShift</h1>
   <p class="lead">
-    End-to-end guide: set up Harbor's OpenShift environment, serve models
-    with vLLM on-cluster, and run cap-evolve optimizations — all on your
-    OpenShift cluster with no external dependencies.
+    Serve models on OpenShift with
+    <a href="https://github.com/vllm-project/vllm">vLLM</a> — an
+    OpenAI-compatible endpoint that any agent (claude-code, codex, opencode)
+    or cap-evolve adapter can call. No external API keys needed.
   </p>
 
   <h2>Architecture</h2>
-<pre><code>┌──────────────────────────────────────────────────────────────────┐
-│  OpenShift cluster                                                │
-│                                                                   │
-│  Orchestrator Pod (cap-evolve + harbor CLI)                       │
-│    │                                                              │
-│    ├─ harbor run -d &lt;dataset&gt; -a &lt;agent&gt; -e openshift          │
-│    │                                                              │
-│    ├─ Task Pod 1 ◄── agent + verifier ──► reward.json            │
-│    ├─ Task Pod 2 ◄── agent + verifier ──► reward.json            │
-│    └─ Task Pod N ◄── ...                                         │
-│                                                                   │
-│  vLLM Model Server (GPU node)                                     │
-│    └─ http://vllm-svc.namespace.svc:8000/v1                      │
-└──────────────────────────────────────────────────────────────────┘</code></pre>
+<pre><code>┌─────────────────────────────────────────────────────────────┐
+│  OpenShift cluster  (namespace: cap-evolve)                  │
+│                                                              │
+│  vLLM Deployment (GPU node)                                  │
+│    └─ Serves: http://vllm-svc.cap-evolve.svc:8000/v1        │
+│                                                              │
+│  Consumers:                                                  │
+│    cap-evolve runner   → MODEL=openai/&lt;model-name&gt;         │
+│    harbor task pods    → --ae ANTHROPIC_BASE_URL=http://...   │
+│    any OpenAI client   → curl http://vllm-svc:8000/v1/chat   │
+└─────────────────────────────────────────────────────────────┘</code></pre>
 
-  <table>
-    <thead><tr><th>Component</th><th>What it does</th><th>Runs as</th></tr></thead>
-    <tbody>
-      <tr><td><strong>Orchestrator</strong></td><td>Runs cap-evolve loop + <code>harbor run</code></td><td>Job (CPU pod)</td></tr>
-      <tr><td><strong>Task pods</strong></td><td>One per benchmark task — agent runs, verifier scores</td><td>Pods created by Harbor</td></tr>
-      <tr><td><strong>vLLM</strong></td><td>Serves the model (OpenAI-compatible API)</td><td>Deployment on GPU nodes</td></tr>
-    </tbody>
-  </table>
+  <h2>Deploy</h2>
+<pre><code># 1. Namespace
+oc new-project cap-evolve    # or use an existing namespace
 
-  <h2>Prerequisites</h2>
-  <ul>
-    <li><code>oc</code> CLI logged into your cluster</li>
-    <li>A namespace with GPU nodes (for vLLM) or access to an external model API</li>
-    <li>Harbor CLI (&ge; 0.20): <code>uv tool install harbor</code></li>
-  </ul>
+# 2. HuggingFace token (for gated models)
+oc create secret generic hf-token \
+  --from-literal=HF_TOKEN=&lt;YOUR_HF_TOKEN&gt;
 
-  <h2>Step 1 — Deploy vLLM model server</h2>
-  <p>Skip this step if you're using an external model API (Anthropic, OpenAI, Vertex AI).</p>
-
-<pre><code># Create the namespace
-oc new-project cap-evolve
-
-# Deploy vLLM (example: Qwen 2.5 14B on 2 GPUs)
+# 3. Deploy vLLM
 oc apply -f openshift/manifests/vllm-serving.yaml
 
-# Wait for the model to load (5-15 min on first deploy)
+# 4. Wait for the model to load (5-15 min first time)
 oc get pods -l component=vllm -w
 
-# Verify the endpoint
-oc exec deploy/cap-evolve-runner -- \
-  curl -s http://vllm-svc:8000/v1/models | python3 -m json.tool</code></pre>
+# 5. Verify
+curl -s http://vllm-svc:8000/v1/models</code></pre>
 
-  <p>See <a href="openshift.html">OpenShift deployment</a> for the full vLLM setup
-  including GPU sizing, model swapping, and the HuggingFace token secret.</p>
-
-  <h2>Step 2 — Set up RBAC for Harbor</h2>
-  <p>Harbor needs two ServiceAccounts with specific permissions.</p>
-
-  <h3>Task SA — runs agent containers</h3>
-  <p>Needs a custom SCC that allows <code>runAsUser: 0</code> and Linux capabilities
-  (<code>CHOWN</code>, <code>SETUID</code>, <code>SETGID</code>, <code>FOWNER</code>,
-  etc.) that agents require inside their containers.</p>
-
-<pre><code># Apply the task SA + SCC
-oc apply -f openshift/manifests/service-account.yaml
-
-# Bind the SCC
-oc adm policy add-scc-to-user harbor-task-scc -z harbor-task</code></pre>
-
-  <h3>Orchestrator SA — manages task pods</h3>
-  <p>Needs RBAC to create/delete pods, builds, image streams, and jobs.</p>
-
-<pre><code># Apply the orchestrator SA + Role + RoleBinding
-oc apply -f openshift/manifests/harbor-orchestrator-sa.yaml
-
-# Also bind the task SCC (orchestrator creates pods that use it)
-oc adm policy add-scc-to-user harbor-task-scc -z harbor-orchestrator</code></pre>
-
-  <h2>Step 3 — Verify Harbor works on the cluster</h2>
-  <p>Run a quick smoke test with the <code>oracle</code> agent (no model needed).</p>
-
-<pre><code>harbor run -d terminal-bench@2.0 -a oracle -e openshift -l 1</code></pre>
-
-  <p>You should see Harbor create a BuildConfig, build the task image, run a task
-  pod, and report a reward. If the pod fails with an SCC error, check that
-  Step 2 was completed.</p>
-
-  <h2>Step 4 — Run Harbor with your agent</h2>
-  <p>The general pattern — works with any agent, any dataset, any model backend.</p>
-
-<pre><code>harbor run \
-  -d &lt;dataset&gt; \
-  -a &lt;agent&gt; \
-  -m &lt;model&gt; \
-  -e openshift \
-  -n &lt;parallel&gt; \
-  --ae &lt;KEY&gt;=&lt;VALUE&gt; ...</code></pre>
-
-  <h3>With on-cluster vLLM</h3>
-  <p>No external API keys needed — the agent connects to vLLM via the in-cluster
-  Service DNS.</p>
-<pre><code>harbor run -d &lt;dataset&gt; -a claude-code -m &lt;model-name&gt; -e openshift -n 5 \
-  --ae ANTHROPIC_BASE_URL=http://&lt;vllm-svc&gt;.&lt;namespace&gt;.svc:8000 \
-  --ae ANTHROPIC_API_KEY=dummy \
-  --ae ANTHROPIC_MODEL=&lt;model-name&gt; \
-  --ae ANTHROPIC_DEFAULT_SONNET_MODEL=&lt;model-name&gt; \
-  --ae ANTHROPIC_DEFAULT_HAIKU_MODEL=&lt;model-name&gt; \
-  --ae ANTHROPIC_DEFAULT_OPUS_MODEL=&lt;model-name&gt;</code></pre>
-
-  <h3>With Vertex AI</h3>
-  <p>Bind-mount GCP credentials into each task pod.</p>
-<pre><code>harbor run -d &lt;dataset&gt; -a claude-code -m claude-sonnet-4-6 -e openshift -n 5 \
-  --ae CLAUDE_CODE_USE_VERTEX=1 \
-  --ae CLOUD_ML_REGION=&lt;region&gt; \
-  --ae ANTHROPIC_VERTEX_PROJECT_ID=&lt;gcp-project&gt; \
-  --ae ANTHROPIC_MODEL=claude-sonnet-4-6 \
-  --ae GOOGLE_APPLICATION_CREDENTIALS=/app/.config/gcloud/adc.json \
-  --mounts-json '[{"type":"bind","source":"~/.config/gcloud/application_default_credentials.json","target":"/app/.config/gcloud/adc.json"}]'</code></pre>
-
-  <h3>With an Anthropic API key</h3>
-<pre><code>harbor run -d &lt;dataset&gt; -a claude-code -m claude-sonnet-4-6 -e openshift -n 5 \
-  --ae ANTHROPIC_API_KEY=sk-ant-...</code></pre>
-
-  <h3>With OpenAI / Codex</h3>
-<pre><code>harbor run -d &lt;dataset&gt; -a codex -m &lt;model&gt; -e openshift -n 5 \
-  --ae OPENAI_API_KEY=sk-...</code></pre>
-
-  <h3>With any OpenAI-compatible endpoint</h3>
-<pre><code>harbor run -d &lt;dataset&gt; -a opencode -m &lt;model&gt; -e openshift -n 5 \
-  --ae OPENAI_BASE_URL=http://&lt;endpoint&gt; \
-  --ae OPENAI_API_KEY=...</code></pre>
-
-  <h2>Step 5 — Run the cap-evolve optimization loop</h2>
-  <p>Once Harbor runs successfully, wire it into cap-evolve's optimization loop
-  via the Harbor adapter.</p>
-
-<pre><code># Install cap-evolve + Harbor adapter
-pip install ./core ./capevolve_harbor
-
-# Set up the project
-cap-evolve init
-cp -r templates/adapters/harbor/* .capevolve/project/adapters/
-
-# Configure
-export HARBOR_DATASET=&lt;org/dataset&gt;
-export HARBOR_AGENT=&lt;agent&gt;
-export HARBOR_MODEL=&lt;model&gt;
-export HARBOR_TASK_IDS=&lt;task1,task2,...&gt;
-export HARBOR_TASK_PREFIX=&lt;dataset-org&gt;
-export HARBOR_EXTRA_FLAGS="-e openshift -n 5 --ae KEY=VALUE ..."
-
-# Run the optimization
-cap-evolve check .capevolve/project
-cap-evolve run --spec .capevolve/project/capevolve.yaml</code></pre>
-
-  <p>cap-evolve will iterate: evaluate via <code>harbor run</code> → diagnose
-  failures → optimizer edits the skill → re-evaluate → gate → repeat.</p>
-
-  <h2>What Harbor creates on the cluster</h2>
+  <h2>Model sizing</h2>
   <table>
-    <thead><tr><th>Resource</th><th>Name pattern</th><th>Purpose</th><th>Lifecycle</th></tr></thead>
+    <thead><tr><th>Size</th><th>GPUs</th><th><code>--tensor-parallel-size</code></th><th>Memory</th></tr></thead>
     <tbody>
-      <tr><td>BuildConfig</td><td><code>hb-build-&lt;task&gt;</code></td><td>Builds the task environment image</td><td>Cached via ImageStream</td></tr>
-      <tr><td>ImageStream</td><td><code>hb-build-&lt;task&gt;</code></td><td>Caches built images (skips rebuild on rerun)</td><td>Persists</td></tr>
-      <tr><td>Pod</td><td><code>hb-&lt;task&gt;-&lt;hash&gt;-env</code></td><td>Runs the agent + verifier</td><td>Deleted after trial (or <code>--no-delete</code>)</td></tr>
+      <tr><td>7B</td><td>1</td><td>1 (default)</td><td>8 Gi</td></tr>
+      <tr><td>14B</td><td>2</td><td>2</td><td>32 Gi</td></tr>
+      <tr><td>32B+</td><td>4</td><td>4</td><td>64 Gi</td></tr>
     </tbody>
   </table>
+  <p>Edit <code>vllm-serving.yaml</code> to change the model, GPU count, and
+  <code>--tensor-parallel-size</code>.</p>
 
-  <h2>Debugging</h2>
+  <h2>Connecting agents to vLLM</h2>
+  <p>vLLM exposes an OpenAI-compatible API. Agents connect via environment
+  variables — the exact vars depend on the agent.</p>
 
-<pre><code># Keep task pods alive after the trial for inspection
-harbor run ... --no-delete
+  <table>
+    <thead><tr><th>Agent</th><th>Env vars</th></tr></thead>
+    <tbody>
+      <tr><td>cap-evolve (litellm)</td><td><code>MODEL=openai/&lt;model&gt; OPENAI_API_BASE=http://vllm-svc:8000/v1 OPENAI_API_KEY=dummy</code></td></tr>
+      <tr><td>claude-code</td><td><code>ANTHROPIC_BASE_URL=http://vllm-svc:8000 ANTHROPIC_API_KEY=dummy ANTHROPIC_MODEL=&lt;model&gt;</code></td></tr>
+      <tr><td>codex / opencode</td><td><code>OPENAI_BASE_URL=http://vllm-svc:8000/v1 OPENAI_API_KEY=dummy</code></td></tr>
+    </tbody>
+  </table>
+  <p>For Harbor task pods, pass these via <code>--ae</code> flags. Use the full
+  Service DNS when crossing namespaces:
+  <code>http://vllm-svc.&lt;namespace&gt;.svc:8000</code>.</p>
 
-# List Harbor's task pods
-oc get pods | grep ^hb-
-
-# Check a task pod's logs
-oc logs &lt;pod-name&gt; -c main
-
-# Shell into a running task pod
-oc exec -it &lt;pod-name&gt; -- /bin/sh
-
-# Check build status
-oc get builds</code></pre>
-
-  <p>Harbor captures full transcripts in the job output directory:</p>
-<pre><code>jobs/&lt;job-name&gt;/&lt;trial&gt;/
-  agent/trajectory.json      # agent execution trace (ATIF format)
-  agent/claude-code.txt      # raw agent stream
-  verifier/reward.json       # verifier score
-  verifier/test-stdout.txt   # verifier output
-  verifier/test-stderr.txt   # verifier errors</code></pre>
+  <h2>Manifests</h2>
+  <p>All manifests live under
+  <a href="https://github.com/skillberry-ai/cap-evolve/tree/main/openshift"><code>openshift/</code></a>:</p>
+  <table>
+    <thead><tr><th>File</th><th>Purpose</th></tr></thead>
+    <tbody>
+      <tr><td><code>namespace.yaml</code></td><td>Namespace</td></tr>
+      <tr><td><code>service-account.yaml</code></td><td>ServiceAccount + SCC for Harbor task pods</td></tr>
+      <tr><td><code>vllm-serving.yaml</code></td><td>vLLM Deployment + Service + Route (agent model)</td></tr>
+      <tr><td><code>vllm-optimizer.yaml</code></td><td>Optional second vLLM for the optimizer (larger model)</td></tr>
+      <tr><td><code>pvc.yaml</code></td><td>Persistent storage for run artifacts</td></tr>
+      <tr><td><code>secrets.yaml</code></td><td>Template for HuggingFace token</td></tr>
+    </tbody>
+  </table>
 
   <h2>Troubleshooting</h2>
   <table>
     <thead><tr><th>Problem</th><th>Fix</th></tr></thead>
     <tbody>
-      <tr><td><code>unable to validate against any security context constraint</code></td><td>Run <code>oc adm policy add-scc-to-user harbor-task-scc -z harbor-task</code> and for the orchestrator SA too</td></tr>
-      <tr><td>Build pod fails</td><td>Check <code>oc logs &lt;build-pod&gt;</code> — usually a Dockerfile issue or missing base image</td></tr>
-      <tr><td>Task pod: <code>ImagePullBackOff</code></td><td>The built image wasn't pushed to the internal registry — check <code>oc get is</code></td></tr>
-      <tr><td>Agent timeout / RuntimeError</td><td>Model context too small for the task. Use a larger model or filter with <code>-i &lt;task&gt;</code></td></tr>
-      <tr><td>Vertex AI auth fails in task pod</td><td>Ensure <code>--mounts-json</code> bind-mounts the GCP credentials file and <code>--ae GOOGLE_APPLICATION_CREDENTIALS=&lt;path&gt;</code> points to it</td></tr>
-      <tr><td>vLLM endpoint not reachable from task pod</td><td>Task pods run in the same namespace — use the full Service DNS: <code>http://&lt;svc&gt;.&lt;namespace&gt;.svc:8000</code></td></tr>
-      <tr><td>No task matched the filter</td><td>Harbor prefixes task names with the dataset org. Use <code>-i &lt;org&gt;/&lt;task&gt;</code></td></tr>
-      <tr><td>Pod evicted / OOMKilled</td><td>Increase memory with <code>--override-memory-mb 4096</code></td></tr>
+      <tr><td>Pod pending (no GPU)</td><td>Check <code>oc describe pod</code> — node selector may not match your GPU labels</td></tr>
+      <tr><td>OOMKilled</td><td>Model too large for requested memory — increase resources or use fewer GPUs with a smaller model</td></tr>
+      <tr><td>Context length exceeded</td><td>Set <code>--max-model-len</code> in the vLLM args, or use a model with larger native context</td></tr>
+      <tr><td>Connection refused from task pod</td><td>Use full DNS: <code>http://&lt;svc&gt;.&lt;namespace&gt;.svc:8000</code></td></tr>
     </tbody>
   </table>
 
-  <h2>Reference</h2>
+  <h2>References</h2>
   <ul>
-    <li><a href="harbor.html">Harbor integration</a> — the main Harbor + cap-evolve guide</li>
-    <li><a href="openshift.html">OpenShift deployment</a> — vLLM model serving on OpenShift</li>
-    <li><a href="https://github.com/harbor-framework/harbor/pull/1875">Harbor OpenShift environment PR</a></li>
-    <li><a href="https://github.com/opendatahub-io/agent-eval-harness/blob/main/docs/harbor-workflow.md">agent-eval-harness Harbor workflow</a></li>
-    <li><a href="https://github.com/redhat-et/coding_agent_bench">coding_agent_bench</a> — SWE-bench with Harbor on OpenShift</li>
+    <li><a href="harbor.html">Harbor integration</a> — using Harbor with cap-evolve (includes OpenShift orchestrator setup)</li>
+    <li><a href="https://docs.vllm.ai/">vLLM documentation</a></li>
+    <li><a href="https://github.com/skillberry-ai/cap-evolve/tree/main/openshift">OpenShift manifests</a></li>
   </ul>
 
 </main>

--- a/site/harbor.html
+++ b/site/harbor.html
@@ -48,281 +48,143 @@
 
   <h1>Harbor integration</h1>
   <p class="lead">
-    Optimize agent capabilities with cap-evolve using
-    <a href="https://www.harborframework.com/">Harbor</a> for sandboxed benchmark
-    execution — any agent, any benchmark, any environment (Docker, OpenShift, or cloud).
+    Use <a href="https://www.harborframework.com/">Harbor</a> as cap-evolve's
+    sandboxed evaluation backend — any
+    <a href="https://www.harborframework.com/docs/agents#running-a-custom-agent">agent</a>,
+    any <a href="https://hub.harborframework.com/datasets">benchmark</a>,
+    any environment (<code>-e docker</code>, <code>-e openshift</code>,
+    <code>-e daytona</code>, <code>-e modal</code>).
   </p>
 
-  <h2>Why Harbor + cap-evolve</h2>
-  <p>cap-evolve is <strong>eval-agnostic</strong> — it only needs a list of tasks and a
-  deterministic score for each. Harbor provides robust sandboxed execution for
-  benchmark trials in isolated containers. Together:</p>
-  <ul>
-    <li><strong>Safety:</strong> Benchmarks like Terminal-Bench and SWE-bench give agents
-    full machine access. Harbor keeps these safely isolated in containers so the agent
-    cannot wreck your host during optimization.</li>
-    <li><strong>Scale:</strong> Harbor natively supports horizontal scaling (hundreds of
-    concurrent trials). This cuts down the time cap-evolve needs per optimization epoch.</li>
-    <li><strong>Honest evaluation:</strong> cap-evolve enforces strict val/test splits and
-    a sealed test scored once — preventing the agent from memorizing the benchmark Harbor
-    is running.</li>
-  </ul>
+  <h2>How it works</h2>
+  <p>cap-evolve optimizes; Harbor evaluates. The <strong>Harbor adapter</strong>
+  (<code>templates/adapters/harbor/adapter.py</code>) is the bridge — its
+  <code>run_batch()</code> calls <code>harbor run</code> as a subprocess each
+  time cap-evolve needs an evaluation. You never call <code>harbor run</code>
+  directly; cap-evolve does it for you.</p>
 
-  <h2>Architecture</h2>
-<pre><code>cap-evolve optimization loop
-  │
-  │  1. Intake &amp; Modify (cap-evolve)
-  │     └─ diagnose failures → optimizer edits prompt/tools/skills
-  │
-  │  2. Execute (Harbor)
-  │     └─ harbor run -d &lt;dataset&gt; -a &lt;agent&gt; -m &lt;model&gt; -e openshift
-  │           ├─ pod 1: task-001 → agent runs with edited skill → verifier → reward
-  │           ├─ pod 2: task-002 → agent runs with edited skill → verifier → reward
-  │           └─ pod N: task-N   → ...
-  │
-  │  3. Verify (Harbor)
-  │     └─ verifier scripts score each task → reward.json per trial
-  │
-  │  4. Learn &amp; Commit (cap-evolve)
-  │     └─ adapter reads Harbor's job results → gate (accept/reject)
-  │           if accepted: commit the edit, new best
-  │
-  └── repeat until stall or budget exhausted
-      then: finalize on sealed test split → one honest number</code></pre>
+<pre><code>you run:   cap-evolve run --spec .capevolve/project/capevolve.yaml
+             │
+cap-evolve:  hill_climb_loop()
+             ├── evaluate → adapter.run_batch()
+             │     └─ harbor run -d &lt;dataset&gt; -a &lt;agent&gt; -m &lt;model&gt; -e &lt;env&gt;
+             │           ├─ container/pod 1: agent + verifier → reward
+             │           ├─ container/pod 2: agent + verifier → reward
+             │           └─ ...
+             │     adapter reads reward.json → cap-evolve Score
+             ├── gate: accept if mean(Δ) &gt; k × SE(Δ)
+             ├── optimizer edits SKILL.md based on failed trajectories
+             └── repeat → finalize on sealed test split</code></pre>
 
+  <h2>Setup</h2>
+
+  <p>Assumes cap-evolve is already installed
+  (<a href="getting-started.html">getting started</a>).</p>
+
+<pre><code># 1. Install Harbor + adapter utilities
+uv tool install harbor              # CLI (v0.20+)
+pip install ./capevolve_harbor
+
+# 2. Copy the Harbor adapter into your project
+cp -r templates/adapters/harbor/* .capevolve/project/adapters/</code></pre>
+
+  <p>This places <code>adapter.py</code> (the Harbor bridge) and a seed
+  <code>SKILL.md</code> into your project. The adapter reads all Harbor config
+  from environment variables at runtime.</p>
+
+  <h2>Configure and run</h2>
+
+<pre><code># What Harbor runs
+export HARBOR_DATASET=&lt;org/dataset&gt;        # registry: swe-bench/swe-bench-verified
+                                            # or local: /path/to/dataset
+export HARBOR_AGENT=&lt;agent&gt;                 # claude-code, codex, opencode, ...
+export HARBOR_MODEL=&lt;model&gt;                 # claude-sonnet-4-6, gpt-4.1, ...
+export HARBOR_TASK_IDS=&lt;task1,task2,...&gt;     # which tasks to optimize on
+export HARBOR_TASK_PREFIX=&lt;dataset-org&gt;     # e.g. swe-bench
+
+# Where Harbor runs
+export HARBOR_EXTRA_FLAGS="-e docker -n 4"  # local Docker
+# or: "-e openshift -n 5 --ae KEY=VALUE"   # OpenShift pods
+# or: "-e daytona -n 100"                  # cloud
+
+# Run the optimization
+cap-evolve run --spec .capevolve/project/capevolve.yaml</code></pre>
+
+  <p>Each iteration, cap-evolve calls <code>harbor run</code> with the current
+  candidate skill, collects rewards, gates the edit, and repeats. Output lands in
+  <code>.capevolve/run_&lt;timestamp&gt;/</code> with <code>report.md</code>,
+  <code>dashboard.html</code>, and the optimized <code>candidates/best/SKILL.md</code>.</p>
+
+  <h2>Running on OpenShift</h2>
+  <p>Use <code>-e openshift</code> to run task pods on your cluster. The
+  orchestrator (cap-evolve + Harbor CLI) runs as a Job; Harbor creates one task
+  pod per benchmark trial on the same cluster.</p>
+
+  <h3>RBAC (once per namespace)</h3>
+<pre><code>oc apply -f openshift/manifests/service-account.yaml          # harbor-task SA + SCC
+oc apply -f openshift/manifests/harbor-orchestrator-sa.yaml   # orchestrator SA + RBAC
+oc adm policy add-scc-to-user harbor-task-scc -z harbor-task
+oc adm policy add-scc-to-user harbor-task-scc -z harbor-orchestrator</code></pre>
+
+  <h3>Orchestrator image</h3>
+  <p>Adds Harbor + <code>oc</code> to the cap-evolve runner image:</p>
+<pre><code>FROM quay.io/&lt;your-org&gt;/cap-evolve-runner:latest
+USER root
+RUN apt-get update -qq &amp;&amp; apt-get install -y -qq curl &amp;&amp; \
+    curl -sL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz \
+      | tar xzf - -C /usr/local/bin oc kubectl &amp;&amp; \
+    apt-get remove -y curl &amp;&amp; rm -rf /var/lib/apt/lists/*
+RUN pip install --no-cache-dir "harbor&gt;=0.20.0"
+COPY capevolve_harbor/ /app/capevolve_harbor/
+COPY templates/adapters/harbor/ /app/templates/adapters/harbor/</code></pre>
+<pre><code>podman build --platform linux/amd64 -t quay.io/&lt;your-org&gt;/cap-evolve-harbor-runner:latest .
+podman push quay.io/&lt;your-org&gt;/cap-evolve-harbor-runner:latest</code></pre>
+
+  <h3>Credential patterns (<code>--ae</code> flags)</h3>
   <table>
-    <thead><tr><th>Component</th><th>Role</th><th>Provided by</th></tr></thead>
+    <thead><tr><th>Backend</th><th>Flags</th></tr></thead>
     <tbody>
-      <tr><td><strong>cap-evolve</strong></td><td>Optimization loop (diagnose → propose → gate → commit)</td><td>cap-evolve core + optimizer (claude-code, codex, etc.)</td></tr>
-      <tr><td><strong>Harbor</strong></td><td>Sandboxed benchmark execution, concurrency, trajectory capture</td><td><a href="https://www.harborframework.com/">Harbor framework</a></td></tr>
-      <tr><td><strong>Agent</strong></td><td>Completes benchmark tasks inside containers/pods</td><td>Harbor agent zoo (claude-code, codex, opencode, etc.)</td></tr>
-      <tr><td><strong>Adapter</strong></td><td>Invokes <code>harbor run</code>, reads results back for cap-evolve</td><td><code>templates/adapters/harbor/</code></td></tr>
+      <tr><td>On-cluster vLLM</td><td><code>ANTHROPIC_BASE_URL=http://&lt;svc&gt;.&lt;ns&gt;.svc:8000 ANTHROPIC_API_KEY=dummy ANTHROPIC_MODEL=&lt;model&gt;</code></td></tr>
+      <tr><td>Anthropic API</td><td><code>ANTHROPIC_API_KEY=sk-ant-...</code></td></tr>
+      <tr><td>Vertex AI</td><td><code>CLAUDE_CODE_USE_VERTEX=1 CLOUD_ML_REGION=&lt;r&gt; ANTHROPIC_VERTEX_PROJECT_ID=&lt;p&gt;</code> + <code>--mounts-json</code> for GCP credentials</td></tr>
+      <tr><td>OpenAI / Codex</td><td><code>OPENAI_API_KEY=sk-...</code></td></tr>
     </tbody>
   </table>
 
-  <h2>How it works</h2>
-  <ol>
-    <li><strong>cap-evolve proposes an edit</strong> — modifies the agent's prompts, tools,
-    or skills in the working directory based on failed execution traces.</li>
-    <li><strong>The adapter invokes Harbor</strong> — runs the full benchmark
-    (<code>harbor run -d &lt;dataset&gt; -a &lt;agent&gt; -e openshift</code>) with the
-    newly modified capabilities. Harbor spins up isolated containers/pods, one per task.</li>
-    <li><strong>Harbor executes and verifies</strong> — each task pod runs the agent, then
-    the verifier script scores the result and writes <code>reward.json</code>.</li>
-    <li><strong>The adapter reads Harbor's results</strong> — parses the job directory,
-    extracts per-task rewards and trajectories, returns scores to cap-evolve.</li>
-    <li><strong>cap-evolve gates the edit</strong> — if the new capability beats the baseline
-    by a statistically significant margin on the val split, it commits the edit.</li>
-  </ol>
-
-  <p>Reference implementations:
-  <a href="https://github.com/opendatahub-io/agent-eval-harness/blob/main/docs/harbor-workflow.md">agent-eval-harness</a>
-  (Harbor workflow on OpenShift) and
-  <a href="https://github.com/redhat-et/coding_agent_bench">coding_agent_bench</a>
-  (SWE-bench with Harbor on OpenShift).</p>
-
-  <h2>Prerequisites</h2>
-  <ul>
-    <li>Harbor CLI (&ge; 0.20): <code>uv tool install harbor</code></li>
-    <li><strong>Local:</strong> Docker or Podman running</li>
-    <li><strong>OpenShift:</strong> <code>oc login</code> + RBAC (see below)</li>
-    <li>A Harbor dataset (e.g. <code>swe-bench/swe-bench-verified</code>,
-    <code>terminal-bench@2.0</code>)</li>
-    <li>Agent credentials (API key, Vertex AI ADC, or on-cluster vLLM)</li>
-  </ul>
-
-  <h2>Quick start</h2>
-  <p>The generic pattern — substitute your agent, model, dataset, and environment:</p>
-
-<pre><code># 1. Install
-uv tool install harbor
-pip install ./core ./capevolve_harbor
-
-# 2. Set up the project
-cap-evolve init
-cp -r templates/adapters/harbor/* .capevolve/project/adapters/
-
-# 3. Configure — pick your agent, dataset, and model
-export HARBOR_DATASET=&lt;org/dataset&gt;          # e.g. swe-bench/swe-bench-verified
-export HARBOR_AGENT=&lt;agent&gt;                   # e.g. claude-code, codex, opencode
-export HARBOR_MODEL=&lt;model&gt;                   # e.g. claude-sonnet-4-6, gpt-4.1
-export HARBOR_TASK_IDS=&lt;task1,task2,...&gt;       # tasks to optimize on
-export HARBOR_TASK_PREFIX=&lt;dataset-org&gt;       # e.g. swe-bench
-
-# 4. Run — locally with Docker, or on OpenShift
-cap-evolve check .capevolve/project
-cap-evolve run --spec .capevolve/project/capevolve.yaml</code></pre>
-
-  <h2>Running on OpenShift</h2>
-  <p>Harbor's <code>-e openshift</code> runs each task as a pod on your cluster.
-  Images are built remotely via OpenShift Binary Builds — no local Docker needed.
-  You can serve models on-cluster with vLLM for a fully self-contained setup.</p>
-
-<pre><code>harbor run -d &lt;dataset&gt; -a &lt;agent&gt; -m &lt;model&gt; -e openshift -n 5 \
-  --ae &lt;KEY&gt;=&lt;VALUE&gt; ...</code></pre>
-
-  <p><strong><a href="harbor-openshift.html">Full OpenShift guide</a></strong> —
-  vLLM model serving, RBAC setup, SCC configuration, agent credentials
-  (vLLM / Vertex AI / API keys), and the cap-evolve optimization loop on-cluster.</p>
+  <p>For on-cluster model serving, see
+  <a href="harbor-openshift.html">vLLM on OpenShift</a>.</p>
 
   <h2>Configuration</h2>
   <table>
     <thead><tr><th>Variable</th><th>Example</th><th>Description</th></tr></thead>
     <tbody>
-      <tr><td><code>HARBOR_DATASET</code></td><td><code>swe-bench/swe-bench-verified</code></td><td>Registry dataset (<code>org/name</code>) or local path</td></tr>
-      <tr><td><code>HARBOR_AGENT</code></td><td><code>claude-code</code></td><td>Harbor agent name</td></tr>
+      <tr><td><code>HARBOR_DATASET</code></td><td><code>swe-bench/swe-bench-verified</code></td><td>Registry dataset or local path</td></tr>
+      <tr><td><code>HARBOR_AGENT</code></td><td><code>claude-code</code></td><td>Any <a href="https://www.harborframework.com/docs/agents#running-a-custom-agent">Harbor agent</a></td></tr>
       <tr><td><code>HARBOR_MODEL</code></td><td><code>claude-sonnet-4-6</code></td><td>Model for the agent</td></tr>
-      <tr><td><code>HARBOR_TASK_IDS</code></td><td><code>astropy__astropy-12907,...</code></td><td>Comma-separated task IDs (required for registry datasets)</td></tr>
-      <tr><td><code>HARBOR_TASK_PREFIX</code></td><td><code>swe-bench</code></td><td>Prefix Harbor uses for task names in this dataset</td></tr>
-      <tr><td><code>HARBOR_PARALLEL</code></td><td><code>5</code></td><td>Max concurrent task pods</td></tr>
+      <tr><td><code>HARBOR_TASK_IDS</code></td><td><code>task-1,task-2,...</code></td><td>Tasks to optimize on (required for registry datasets)</td></tr>
+      <tr><td><code>HARBOR_TASK_PREFIX</code></td><td><code>swe-bench</code></td><td>Dataset org prefix for task name mapping</td></tr>
+      <tr><td><code>HARBOR_PARALLEL</code></td><td><code>5</code></td><td>Concurrent trials</td></tr>
       <tr><td><code>HARBOR_TIMEOUT</code></td><td><code>900</code></td><td>Per-task timeout (seconds)</td></tr>
-      <tr><td><code>HARBOR_EXTRA_FLAGS</code></td><td><code>-e openshift --no-delete</code></td><td>Extra flags passed to <code>harbor run</code></td></tr>
-      <tr><td><code>HARBOR_AGENT_BASE_URL</code></td><td><code>http://vllm.ns.svc:8000</code></td><td>On-cluster model endpoint (sets <code>ANTHROPIC_BASE_URL</code>)</td></tr>
-      <tr><td><code>HARBOR_JOBS_DIR</code></td><td><code>./harbor-jobs</code></td><td>Where Harbor writes job output</td></tr>
+      <tr><td><code>HARBOR_EXTRA_FLAGS</code></td><td><code>-e openshift --no-delete</code></td><td>Passed to <code>harbor run</code></td></tr>
+      <tr><td><code>HARBOR_JOBS_DIR</code></td><td><code>./harbor-jobs</code></td><td>Job output directory</td></tr>
     </tbody>
   </table>
 
-  <h2 id="agent-credentials">Agent credential reference</h2>
-  <p>Any agent in
-  <a href="https://www.harborframework.com/docs">Harbor's agent zoo</a> works.
-  Pass credentials into the task pod via <code>--ae KEY=VALUE</code> flags.
-  Below are the common agents with the exact flags needed.</p>
+  <h2>Benchmarks and agents</h2>
+  <p>Any <a href="https://hub.harborframework.com/datasets">Harbor dataset</a> and
+  any <a href="https://www.harborframework.com/docs/agents#running-a-custom-agent">Harbor agent</a>
+  work — set <code>HARBOR_DATASET</code> and <code>HARBOR_AGENT</code>.</p>
 
-  <h3>Claude Code (Anthropic API)</h3>
-<pre><code>harbor run -d &lt;dataset&gt; -a claude-code -m claude-sonnet-4-6 -e openshift \
-  --ae ANTHROPIC_API_KEY=sk-ant-...</code></pre>
-
-  <h3>Claude Code (Vertex AI)</h3>
-  <p>Bind-mount GCP credentials into the task pod via <code>--mounts-json</code>.</p>
-<pre><code>harbor run -d &lt;dataset&gt; -a claude-code -m claude-sonnet-4-6 -e openshift \
-  --ae CLAUDE_CODE_USE_VERTEX=1 \
-  --ae CLOUD_ML_REGION=&lt;region&gt; \
-  --ae ANTHROPIC_VERTEX_PROJECT_ID=&lt;gcp-project&gt; \
-  --ae ANTHROPIC_MODEL=claude-sonnet-4-6 \
-  --ae GOOGLE_APPLICATION_CREDENTIALS=/app/.config/gcloud/adc.json \
-  --mounts-json '[{"type":"bind","source":"~/.config/gcloud/application_default_credentials.json","target":"/app/.config/gcloud/adc.json"}]'</code></pre>
-
-  <h3>Claude Code (on-cluster vLLM)</h3>
-  <p>Point claude-code at a vLLM-served model — no external API keys needed.</p>
-<pre><code>harbor run -d &lt;dataset&gt; -a claude-code -m &lt;model-name&gt; -e openshift \
-  --ae ANTHROPIC_BASE_URL=http://&lt;vllm-svc&gt;.&lt;namespace&gt;.svc:8000 \
-  --ae ANTHROPIC_API_KEY=dummy \
-  --ae ANTHROPIC_MODEL=&lt;model-name&gt; \
-  --ae ANTHROPIC_DEFAULT_SONNET_MODEL=&lt;model-name&gt; \
-  --ae ANTHROPIC_DEFAULT_HAIKU_MODEL=&lt;model-name&gt; \
-  --ae ANTHROPIC_DEFAULT_OPUS_MODEL=&lt;model-name&gt;</code></pre>
-
-  <h3>Codex (OpenAI)</h3>
-<pre><code>harbor run -d &lt;dataset&gt; -a codex -m &lt;model&gt; -e openshift \
-  --ae OPENAI_API_KEY=sk-...</code></pre>
-
-  <h3>Gemini CLI</h3>
-<pre><code>harbor run -d &lt;dataset&gt; -a gemini-cli -m &lt;model&gt; -e openshift \
-  --ae GEMINI_API_KEY=...</code></pre>
-
-  <h3>OpenCode (any OpenAI-compatible provider)</h3>
-<pre><code>harbor run -d &lt;dataset&gt; -a opencode -m &lt;model&gt; -e openshift \
-  --ae OPENAI_BASE_URL=http://&lt;endpoint&gt; \
-  --ae OPENAI_API_KEY=...</code></pre>
-
-  <h3>Oracle (no LLM — for testing the pipeline)</h3>
-<pre><code>harbor run -d &lt;dataset&gt; -a oracle -e openshift -l 1</code></pre>
-
-  <h2>Execution environments</h2>
-  <p>Harbor's <code>-e</code> flag selects the execution backend. Each trial runs in
-  its own isolated container or pod.</p>
-
-  <table>
-    <thead><tr><th>Flag</th><th>Backend</th><th>Best for</th></tr></thead>
-    <tbody>
-      <tr><td><code>-e docker</code></td><td>Local Docker</td><td>Development, small benchmarks</td></tr>
-      <tr><td><code>-e openshift</code></td><td>OpenShift pods</td><td>On-cluster vLLM, enterprise, scale (<a href="https://github.com/harbor-framework/harbor/pull/1875">PR #1875</a>)</td></tr>
-      <tr><td><code>-e daytona</code></td><td>Daytona cloud</td><td>Massive parallelism, no cluster needed</td></tr>
-      <tr><td><code>-e modal</code></td><td>Modal cloud</td><td>GPU tasks, serverless</td></tr>
-      <tr><td><code>-e gke</code></td><td>Google Kubernetes</td><td>GKE clusters</td></tr>
-    </tbody>
-  </table>
-
-  <h3>Local Docker</h3>
-<pre><code>harbor run -d &lt;dataset&gt; -a &lt;agent&gt; -m &lt;model&gt; -e docker -n 4</code></pre>
-
-  <h3>OpenShift</h3>
-  <p>Each task runs as a pod on the cluster. See the
-  <a href="harbor-openshift.html">full OpenShift guide</a> for setup.</p>
-<pre><code>harbor run -d &lt;dataset&gt; -a &lt;agent&gt; -m &lt;model&gt; -e openshift -n 5</code></pre>
-
-  <h3>Cloud sandboxes</h3>
-<pre><code>harbor run -d &lt;dataset&gt; -a &lt;agent&gt; -m &lt;model&gt; -e daytona -n 100</code></pre>
-
-  <h2>Compatible benchmarks</h2>
-  <p>Any <a href="https://hub.harborframework.com/datasets">Harbor registry dataset</a>
-  or local dataset in
-  <a href="https://www.harborframework.com/docs">Harbor task format</a> works.
-  Browse available datasets with <code>harbor dataset list</code>.</p>
-  <table>
-    <thead><tr><th>Dataset</th><th>Flag</th><th>What it tests</th></tr></thead>
-    <tbody>
-      <tr><td>SWE-bench Verified</td><td><code>-d swe-bench/swe-bench-verified</code></td><td>Bug-fixing patches on real GitHub repos (500 tasks)</td></tr>
-      <tr><td>SWE-bench Pro</td><td><code>-d scale-ai/swe-bench-pro</code></td><td>Harder SWE-bench subset from Scale AI</td></tr>
-      <tr><td>Terminal-Bench</td><td><code>-d terminal-bench@2.0</code></td><td>Full-machine terminal tasks (stateful, complex)</td></tr>
-      <tr><td>Aider Polyglot</td><td><code>-d aider/aider-polyglot</code></td><td>Multi-language code editing</td></tr>
-      <tr><td>Custom (local)</td><td><code>-p /path/to/dataset</code></td><td>Your own tasks in Harbor task format</td></tr>
-      <tr><td>Custom (registry)</td><td><code>-d your-org/your-dataset</code></td><td>Published to <a href="https://hub.harborframework.com">Harbor Hub</a></td></tr>
-    </tbody>
-  </table>
-  <p>To select specific tasks from a dataset, use <code>-i &lt;task-name&gt;</code> (repeatable)
-  or <code>-l &lt;count&gt;</code> to limit the total. In cap-evolve, set <code>HARBOR_TASK_IDS</code>.</p>
-
-  <h2>The adapter</h2>
-  <p>The bridge between cap-evolve and Harbor is a small Python adapter that
-  fulfills the <a href="https://github.com/skillberry-ai/cap-evolve/blob/main/docs/ADAPTER_CONTRACT.md">cap-evolve
-  adapter contract</a> — just <code>tasks()</code> and <code>score()</code>:</p>
+  <h2>References</h2>
   <ul>
-    <li><strong><code>tasks(split)</code></strong> — returns task IDs from the Harbor dataset</li>
-    <li><strong><code>run_batch(tasks, ctx)</code></strong> — invokes
-    <code>harbor run -d &lt;dataset&gt; -a &lt;agent&gt; -e &lt;env&gt;</code> as a
-    single benchmark run, returns results</li>
-    <li><strong><code>score(task, rollout)</code></strong> — reads Harbor's
-    <code>reward.json</code> from the job directory and returns the score to cap-evolve</li>
+    <li><a href="https://www.harborframework.com/docs">Harbor documentation</a></li>
+    <li><a href="https://www.harborframework.com/docs/agents#running-a-custom-agent">Harbor agents</a></li>
+    <li><a href="https://hub.harborframework.com/datasets">Harbor datasets</a></li>
+    <li><a href="https://github.com/skillberry-ai/cap-evolve/blob/main/templates/adapters/harbor/adapter.py">Harbor adapter source</a></li>
+    <li><a href="harbor-openshift.html">OpenShift guide</a> — vLLM, RBAC, credentials, Job manifest</li>
+    <li><a href="https://github.com/opendatahub-io/agent-eval-harness/blob/main/docs/harbor-workflow.md">agent-eval-harness Harbor workflow</a></li>
+    <li><a href="https://github.com/redhat-et/coding_agent_bench">coding_agent_bench</a> — SWE-bench on OpenShift</li>
   </ul>
-  <p>The <code>capevolve_harbor</code> package provides the reusable utilities:</p>
-  <table>
-    <thead><tr><th>Module</th><th>Purpose</th></tr></thead>
-    <tbody>
-      <tr><td><code>capevolve_harbor.run</code></td><td>Invoke <code>harbor run</code> via subprocess with signal forwarding</td></tr>
-      <tr><td><code>capevolve_harbor.results</code></td><td>Parse Harbor job directories → per-task rewards, trajectories, cost</td></tr>
-      <tr><td><code>capevolve_harbor.tasks</code></td><td>Generate Harbor task packages from cap-evolve tasks (optional)</td></tr>
-    </tbody>
-  </table>
-
-  <h2>Debugging</h2>
-  <p>Keep the container or pod alive after a trial to inspect logs and state:</p>
-<pre><code># Keep task pods alive after the trial
-harbor run ... --no-delete
-
-# Inspect the task pod (OpenShift)
-oc get pods -l harbor-role=task
-oc logs &lt;pod&gt;
-oc exec -it &lt;pod&gt; -- /bin/sh</code></pre>
-  <p>Harbor captures transcripts in the job directory:</p>
-<pre><code>jobs/&lt;job-name&gt;/&lt;trial&gt;/
-  agent/trajectory.json      # agent execution trace
-  agent/claude-code.txt      # raw agent stream
-  verifier/reward.json       # verifier score
-  verifier/test-stdout.txt   # verifier output</code></pre>
-
-  <h2>Troubleshooting</h2>
-  <table>
-    <thead><tr><th>Problem</th><th>Fix</th></tr></thead>
-    <tbody>
-      <tr><td><code>harbor</code> CLI not found</td><td>Install with <code>uv tool install harbor</code> (v0.20+ for <code>-e openshift</code>)</td></tr>
-      <tr><td>Agent RuntimeError / context exceeded</td><td>Model context too small — use a larger model or filter tasks with <code>-i &lt;task-name&gt;</code></td></tr>
-      <tr><td>No task matched the filter</td><td>Harbor prefixes task names with the dataset org. Use <code>-i &lt;org&gt;/&lt;task&gt;</code></td></tr>
-      <tr><td>Only 1 task in rollouts</td><td>Set <code>HARBOR_TASK_PREFIX</code> to match the dataset org</td></tr>
-    </tbody>
-  </table>
-  <p>For OpenShift-specific issues (SCC, builds, credentials), see the
-  <a href="harbor-openshift.html">OpenShift guide troubleshooting</a>.</p>
 
 </main>
 

--- a/site/harbor.html
+++ b/site/harbor.html
@@ -1,0 +1,350 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Harbor integration — cap-evolve</title>
+  <meta name="description" content="Optimize agent capabilities with cap-evolve using Harbor for sandboxed benchmark execution. Any agent, any benchmark, any environment — Docker, OpenShift, or cloud.">
+  <link rel="canonical" href="https://skillberry-ai.github.io/cap-evolve/harbor.html">
+  <meta property="og:type" content="article">
+  <meta property="og:site_name" content="cap-evolve">
+  <meta property="og:title" content="Harbor integration — cap-evolve">
+  <meta property="og:description" content="Optimize agent capabilities with cap-evolve using Harbor for sandboxed benchmark execution.">
+  <meta property="og:url" content="https://skillberry-ai.github.io/cap-evolve/harbor.html">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="Harbor integration — cap-evolve">
+  <meta name="twitter:description" content="Run cap-evolve evaluations in isolated Docker containers via Harbor.">
+  <link rel="icon" href="assets/favicon.svg" type="image/svg+xml">
+  <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600&family=Fira+Sans:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+  <script>(function(){try{document.documentElement.setAttribute('data-theme',localStorage.getItem('capevolve-theme')||'dark');}catch(e){document.documentElement.setAttribute('data-theme','dark');}document.documentElement.classList.add('js');})();</script>
+  <link rel="stylesheet" href="style.css?v=20260724b">
+</head>
+<body>
+
+<nav class="nav">
+  <div class="nav-inner">
+    <a class="nav-brand" href="./"><img src="assets/logo-300.png" alt="" class="nav-brand-logo" aria-hidden="true"><span class="wordmark">cap<span class="wordmark-dot">·</span>evolve</span></a>
+    <div class="nav-links">
+      <a href="getting-started.html">Get started</a>
+      <a href="run-end-to-end.html">Run end-to-end</a>
+      <a href="results.html">Results</a>
+      <a href="benchmarks.html">Benchmarks</a>
+      <a href="architecture.html">Architecture</a>
+      <a href="agent-orchestration.html">Agent mode</a>
+      <a href="harbor.html" class="active">Harbor</a>
+      <a class="gh" href="https://github.com/skillberry-ai/cap-evolve">GitHub</a>
+      <button class="theme-toggle" type="button" aria-label="Switch theme">
+        <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
+        <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"></path></svg>
+      </button>
+    </div>
+  </div>
+</nav>
+
+<main class="page-narrow doc">
+
+  <h1>Harbor integration</h1>
+  <p class="lead">
+    Optimize agent capabilities with cap-evolve using
+    <a href="https://www.harborframework.com/">Harbor</a> for sandboxed benchmark
+    execution — any agent, any benchmark, any environment (Docker, OpenShift, or cloud).
+  </p>
+
+  <h2>Why Harbor + cap-evolve</h2>
+  <p>cap-evolve is <strong>eval-agnostic</strong> — it only needs a list of tasks and a
+  deterministic score for each. Harbor provides robust sandboxed execution for
+  benchmark trials in isolated containers. Together:</p>
+  <ul>
+    <li><strong>Safety:</strong> Benchmarks like Terminal-Bench and SWE-bench give agents
+    full machine access. Harbor keeps these safely isolated in containers so the agent
+    cannot wreck your host during optimization.</li>
+    <li><strong>Scale:</strong> Harbor natively supports horizontal scaling (hundreds of
+    concurrent trials). This cuts down the time cap-evolve needs per optimization epoch.</li>
+    <li><strong>Honest evaluation:</strong> cap-evolve enforces strict val/test splits and
+    a sealed test scored once — preventing the agent from memorizing the benchmark Harbor
+    is running.</li>
+  </ul>
+
+  <h2>Architecture</h2>
+<pre><code>cap-evolve optimization loop
+  │
+  │  1. Intake &amp; Modify (cap-evolve)
+  │     └─ diagnose failures → optimizer edits prompt/tools/skills
+  │
+  │  2. Execute (Harbor)
+  │     └─ harbor run -d &lt;dataset&gt; -a &lt;agent&gt; -m &lt;model&gt; -e openshift
+  │           ├─ pod 1: task-001 → agent runs with edited skill → verifier → reward
+  │           ├─ pod 2: task-002 → agent runs with edited skill → verifier → reward
+  │           └─ pod N: task-N   → ...
+  │
+  │  3. Verify (Harbor)
+  │     └─ verifier scripts score each task → reward.json per trial
+  │
+  │  4. Learn &amp; Commit (cap-evolve)
+  │     └─ adapter reads Harbor's job results → gate (accept/reject)
+  │           if accepted: commit the edit, new best
+  │
+  └── repeat until stall or budget exhausted
+      then: finalize on sealed test split → one honest number</code></pre>
+
+  <table>
+    <thead><tr><th>Component</th><th>Role</th><th>Provided by</th></tr></thead>
+    <tbody>
+      <tr><td><strong>cap-evolve</strong></td><td>Optimization loop (diagnose → propose → gate → commit)</td><td>cap-evolve core + optimizer (claude-code, codex, etc.)</td></tr>
+      <tr><td><strong>Harbor</strong></td><td>Sandboxed benchmark execution, concurrency, trajectory capture</td><td><a href="https://www.harborframework.com/">Harbor framework</a></td></tr>
+      <tr><td><strong>Agent</strong></td><td>Completes benchmark tasks inside containers/pods</td><td>Harbor agent zoo (claude-code, codex, opencode, etc.)</td></tr>
+      <tr><td><strong>Adapter</strong></td><td>Invokes <code>harbor run</code>, reads results back for cap-evolve</td><td><code>templates/adapters/harbor/</code></td></tr>
+    </tbody>
+  </table>
+
+  <h2>How it works</h2>
+  <ol>
+    <li><strong>cap-evolve proposes an edit</strong> — modifies the agent's prompts, tools,
+    or skills in the working directory based on failed execution traces.</li>
+    <li><strong>The adapter invokes Harbor</strong> — runs the full benchmark
+    (<code>harbor run -d &lt;dataset&gt; -a &lt;agent&gt; -e openshift</code>) with the
+    newly modified capabilities. Harbor spins up isolated containers/pods, one per task.</li>
+    <li><strong>Harbor executes and verifies</strong> — each task pod runs the agent, then
+    the verifier script scores the result and writes <code>reward.json</code>.</li>
+    <li><strong>The adapter reads Harbor's results</strong> — parses the job directory,
+    extracts per-task rewards and trajectories, returns scores to cap-evolve.</li>
+    <li><strong>cap-evolve gates the edit</strong> — if the new capability beats the baseline
+    by a statistically significant margin on the val split, it commits the edit.</li>
+  </ol>
+
+  <p>Reference implementations:
+  <a href="https://github.com/opendatahub-io/agent-eval-harness/blob/main/docs/harbor-workflow.md">agent-eval-harness</a>
+  (Harbor workflow on OpenShift) and
+  <a href="https://github.com/redhat-et/coding_agent_bench">coding_agent_bench</a>
+  (SWE-bench with Harbor on OpenShift).</p>
+
+  <h2>Prerequisites</h2>
+  <ul>
+    <li>Harbor CLI (&ge; 0.20): <code>uv tool install harbor</code></li>
+    <li><strong>Local:</strong> Docker or Podman running</li>
+    <li><strong>OpenShift:</strong> <code>oc login</code> + RBAC (see below)</li>
+    <li>A Harbor dataset (e.g. <code>swe-bench/swe-bench-verified</code>,
+    <code>terminal-bench@2.0</code>)</li>
+    <li>Agent credentials (API key, Vertex AI ADC, or on-cluster vLLM)</li>
+  </ul>
+
+  <h2>Quick start</h2>
+  <p>The generic pattern — substitute your agent, model, dataset, and environment:</p>
+
+<pre><code># 1. Install
+uv tool install harbor
+pip install ./core ./capevolve_harbor
+
+# 2. Set up the project
+cap-evolve init
+cp -r templates/adapters/harbor/* .capevolve/project/adapters/
+
+# 3. Configure — pick your agent, dataset, and model
+export HARBOR_DATASET=&lt;org/dataset&gt;          # e.g. swe-bench/swe-bench-verified
+export HARBOR_AGENT=&lt;agent&gt;                   # e.g. claude-code, codex, opencode
+export HARBOR_MODEL=&lt;model&gt;                   # e.g. claude-sonnet-4-6, gpt-4.1
+export HARBOR_TASK_IDS=&lt;task1,task2,...&gt;       # tasks to optimize on
+export HARBOR_TASK_PREFIX=&lt;dataset-org&gt;       # e.g. swe-bench
+
+# 4. Run — locally with Docker, or on OpenShift
+cap-evolve check .capevolve/project
+cap-evolve run --spec .capevolve/project/capevolve.yaml</code></pre>
+
+  <h2>Running on OpenShift</h2>
+  <p>Harbor's <code>-e openshift</code> runs each task as a pod on your cluster.
+  Images are built remotely via OpenShift Binary Builds — no local Docker needed.
+  You can serve models on-cluster with vLLM for a fully self-contained setup.</p>
+
+<pre><code>harbor run -d &lt;dataset&gt; -a &lt;agent&gt; -m &lt;model&gt; -e openshift -n 5 \
+  --ae &lt;KEY&gt;=&lt;VALUE&gt; ...</code></pre>
+
+  <p><strong><a href="harbor-openshift.html">Full OpenShift guide</a></strong> —
+  vLLM model serving, RBAC setup, SCC configuration, agent credentials
+  (vLLM / Vertex AI / API keys), and the cap-evolve optimization loop on-cluster.</p>
+
+  <h2>Configuration</h2>
+  <table>
+    <thead><tr><th>Variable</th><th>Example</th><th>Description</th></tr></thead>
+    <tbody>
+      <tr><td><code>HARBOR_DATASET</code></td><td><code>swe-bench/swe-bench-verified</code></td><td>Registry dataset (<code>org/name</code>) or local path</td></tr>
+      <tr><td><code>HARBOR_AGENT</code></td><td><code>claude-code</code></td><td>Harbor agent name</td></tr>
+      <tr><td><code>HARBOR_MODEL</code></td><td><code>claude-sonnet-4-6</code></td><td>Model for the agent</td></tr>
+      <tr><td><code>HARBOR_TASK_IDS</code></td><td><code>astropy__astropy-12907,...</code></td><td>Comma-separated task IDs (required for registry datasets)</td></tr>
+      <tr><td><code>HARBOR_TASK_PREFIX</code></td><td><code>swe-bench</code></td><td>Prefix Harbor uses for task names in this dataset</td></tr>
+      <tr><td><code>HARBOR_PARALLEL</code></td><td><code>5</code></td><td>Max concurrent task pods</td></tr>
+      <tr><td><code>HARBOR_TIMEOUT</code></td><td><code>900</code></td><td>Per-task timeout (seconds)</td></tr>
+      <tr><td><code>HARBOR_EXTRA_FLAGS</code></td><td><code>-e openshift --no-delete</code></td><td>Extra flags passed to <code>harbor run</code></td></tr>
+      <tr><td><code>HARBOR_AGENT_BASE_URL</code></td><td><code>http://vllm.ns.svc:8000</code></td><td>On-cluster model endpoint (sets <code>ANTHROPIC_BASE_URL</code>)</td></tr>
+      <tr><td><code>HARBOR_JOBS_DIR</code></td><td><code>./harbor-jobs</code></td><td>Where Harbor writes job output</td></tr>
+    </tbody>
+  </table>
+
+  <h2 id="agent-credentials">Agent credential reference</h2>
+  <p>Any agent in
+  <a href="https://www.harborframework.com/docs">Harbor's agent zoo</a> works.
+  Pass credentials into the task pod via <code>--ae KEY=VALUE</code> flags.
+  Below are the common agents with the exact flags needed.</p>
+
+  <h3>Claude Code (Anthropic API)</h3>
+<pre><code>harbor run -d &lt;dataset&gt; -a claude-code -m claude-sonnet-4-6 -e openshift \
+  --ae ANTHROPIC_API_KEY=sk-ant-...</code></pre>
+
+  <h3>Claude Code (Vertex AI)</h3>
+  <p>Bind-mount GCP credentials into the task pod via <code>--mounts-json</code>.</p>
+<pre><code>harbor run -d &lt;dataset&gt; -a claude-code -m claude-sonnet-4-6 -e openshift \
+  --ae CLAUDE_CODE_USE_VERTEX=1 \
+  --ae CLOUD_ML_REGION=&lt;region&gt; \
+  --ae ANTHROPIC_VERTEX_PROJECT_ID=&lt;gcp-project&gt; \
+  --ae ANTHROPIC_MODEL=claude-sonnet-4-6 \
+  --ae GOOGLE_APPLICATION_CREDENTIALS=/app/.config/gcloud/adc.json \
+  --mounts-json '[{"type":"bind","source":"~/.config/gcloud/application_default_credentials.json","target":"/app/.config/gcloud/adc.json"}]'</code></pre>
+
+  <h3>Claude Code (on-cluster vLLM)</h3>
+  <p>Point claude-code at a vLLM-served model — no external API keys needed.</p>
+<pre><code>harbor run -d &lt;dataset&gt; -a claude-code -m &lt;model-name&gt; -e openshift \
+  --ae ANTHROPIC_BASE_URL=http://&lt;vllm-svc&gt;.&lt;namespace&gt;.svc:8000 \
+  --ae ANTHROPIC_API_KEY=dummy \
+  --ae ANTHROPIC_MODEL=&lt;model-name&gt; \
+  --ae ANTHROPIC_DEFAULT_SONNET_MODEL=&lt;model-name&gt; \
+  --ae ANTHROPIC_DEFAULT_HAIKU_MODEL=&lt;model-name&gt; \
+  --ae ANTHROPIC_DEFAULT_OPUS_MODEL=&lt;model-name&gt;</code></pre>
+
+  <h3>Codex (OpenAI)</h3>
+<pre><code>harbor run -d &lt;dataset&gt; -a codex -m &lt;model&gt; -e openshift \
+  --ae OPENAI_API_KEY=sk-...</code></pre>
+
+  <h3>Gemini CLI</h3>
+<pre><code>harbor run -d &lt;dataset&gt; -a gemini-cli -m &lt;model&gt; -e openshift \
+  --ae GEMINI_API_KEY=...</code></pre>
+
+  <h3>OpenCode (any OpenAI-compatible provider)</h3>
+<pre><code>harbor run -d &lt;dataset&gt; -a opencode -m &lt;model&gt; -e openshift \
+  --ae OPENAI_BASE_URL=http://&lt;endpoint&gt; \
+  --ae OPENAI_API_KEY=...</code></pre>
+
+  <h3>Oracle (no LLM — for testing the pipeline)</h3>
+<pre><code>harbor run -d &lt;dataset&gt; -a oracle -e openshift -l 1</code></pre>
+
+  <h2>Execution environments</h2>
+  <p>Harbor's <code>-e</code> flag selects the execution backend. Each trial runs in
+  its own isolated container or pod.</p>
+
+  <table>
+    <thead><tr><th>Flag</th><th>Backend</th><th>Best for</th></tr></thead>
+    <tbody>
+      <tr><td><code>-e docker</code></td><td>Local Docker</td><td>Development, small benchmarks</td></tr>
+      <tr><td><code>-e openshift</code></td><td>OpenShift pods</td><td>On-cluster vLLM, enterprise, scale (<a href="https://github.com/harbor-framework/harbor/pull/1875">PR #1875</a>)</td></tr>
+      <tr><td><code>-e daytona</code></td><td>Daytona cloud</td><td>Massive parallelism, no cluster needed</td></tr>
+      <tr><td><code>-e modal</code></td><td>Modal cloud</td><td>GPU tasks, serverless</td></tr>
+      <tr><td><code>-e gke</code></td><td>Google Kubernetes</td><td>GKE clusters</td></tr>
+    </tbody>
+  </table>
+
+  <h3>Local Docker</h3>
+<pre><code>harbor run -d &lt;dataset&gt; -a &lt;agent&gt; -m &lt;model&gt; -e docker -n 4</code></pre>
+
+  <h3>OpenShift</h3>
+  <p>Each task runs as a pod on the cluster. See the
+  <a href="harbor-openshift.html">full OpenShift guide</a> for setup.</p>
+<pre><code>harbor run -d &lt;dataset&gt; -a &lt;agent&gt; -m &lt;model&gt; -e openshift -n 5</code></pre>
+
+  <h3>Cloud sandboxes</h3>
+<pre><code>harbor run -d &lt;dataset&gt; -a &lt;agent&gt; -m &lt;model&gt; -e daytona -n 100</code></pre>
+
+  <h2>Compatible benchmarks</h2>
+  <p>Any <a href="https://hub.harborframework.com/datasets">Harbor registry dataset</a>
+  or local dataset in
+  <a href="https://www.harborframework.com/docs">Harbor task format</a> works.
+  Browse available datasets with <code>harbor dataset list</code>.</p>
+  <table>
+    <thead><tr><th>Dataset</th><th>Flag</th><th>What it tests</th></tr></thead>
+    <tbody>
+      <tr><td>SWE-bench Verified</td><td><code>-d swe-bench/swe-bench-verified</code></td><td>Bug-fixing patches on real GitHub repos (500 tasks)</td></tr>
+      <tr><td>SWE-bench Pro</td><td><code>-d scale-ai/swe-bench-pro</code></td><td>Harder SWE-bench subset from Scale AI</td></tr>
+      <tr><td>Terminal-Bench</td><td><code>-d terminal-bench@2.0</code></td><td>Full-machine terminal tasks (stateful, complex)</td></tr>
+      <tr><td>Aider Polyglot</td><td><code>-d aider/aider-polyglot</code></td><td>Multi-language code editing</td></tr>
+      <tr><td>Custom (local)</td><td><code>-p /path/to/dataset</code></td><td>Your own tasks in Harbor task format</td></tr>
+      <tr><td>Custom (registry)</td><td><code>-d your-org/your-dataset</code></td><td>Published to <a href="https://hub.harborframework.com">Harbor Hub</a></td></tr>
+    </tbody>
+  </table>
+  <p>To select specific tasks from a dataset, use <code>-i &lt;task-name&gt;</code> (repeatable)
+  or <code>-l &lt;count&gt;</code> to limit the total. In cap-evolve, set <code>HARBOR_TASK_IDS</code>.</p>
+
+  <h2>The adapter</h2>
+  <p>The bridge between cap-evolve and Harbor is a small Python adapter that
+  fulfills the <a href="https://github.com/skillberry-ai/cap-evolve/blob/main/docs/ADAPTER_CONTRACT.md">cap-evolve
+  adapter contract</a> — just <code>tasks()</code> and <code>score()</code>:</p>
+  <ul>
+    <li><strong><code>tasks(split)</code></strong> — returns task IDs from the Harbor dataset</li>
+    <li><strong><code>run_batch(tasks, ctx)</code></strong> — invokes
+    <code>harbor run -d &lt;dataset&gt; -a &lt;agent&gt; -e &lt;env&gt;</code> as a
+    single benchmark run, returns results</li>
+    <li><strong><code>score(task, rollout)</code></strong> — reads Harbor's
+    <code>reward.json</code> from the job directory and returns the score to cap-evolve</li>
+  </ul>
+  <p>The <code>capevolve_harbor</code> package provides the reusable utilities:</p>
+  <table>
+    <thead><tr><th>Module</th><th>Purpose</th></tr></thead>
+    <tbody>
+      <tr><td><code>capevolve_harbor.run</code></td><td>Invoke <code>harbor run</code> via subprocess with signal forwarding</td></tr>
+      <tr><td><code>capevolve_harbor.results</code></td><td>Parse Harbor job directories → per-task rewards, trajectories, cost</td></tr>
+      <tr><td><code>capevolve_harbor.tasks</code></td><td>Generate Harbor task packages from cap-evolve tasks (optional)</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Debugging</h2>
+  <p>Keep the container or pod alive after a trial to inspect logs and state:</p>
+<pre><code># Keep task pods alive after the trial
+harbor run ... --no-delete
+
+# Inspect the task pod (OpenShift)
+oc get pods -l harbor-role=task
+oc logs &lt;pod&gt;
+oc exec -it &lt;pod&gt; -- /bin/sh</code></pre>
+  <p>Harbor captures transcripts in the job directory:</p>
+<pre><code>jobs/&lt;job-name&gt;/&lt;trial&gt;/
+  agent/trajectory.json      # agent execution trace
+  agent/claude-code.txt      # raw agent stream
+  verifier/reward.json       # verifier score
+  verifier/test-stdout.txt   # verifier output</code></pre>
+
+  <h2>Troubleshooting</h2>
+  <table>
+    <thead><tr><th>Problem</th><th>Fix</th></tr></thead>
+    <tbody>
+      <tr><td><code>harbor</code> CLI not found</td><td>Install with <code>uv tool install harbor</code> (v0.20+ for <code>-e openshift</code>)</td></tr>
+      <tr><td>Agent RuntimeError / context exceeded</td><td>Model context too small — use a larger model or filter tasks with <code>-i &lt;task-name&gt;</code></td></tr>
+      <tr><td>No task matched the filter</td><td>Harbor prefixes task names with the dataset org. Use <code>-i &lt;org&gt;/&lt;task&gt;</code></td></tr>
+      <tr><td>Only 1 task in rollouts</td><td>Set <code>HARBOR_TASK_PREFIX</code> to match the dataset org</td></tr>
+    </tbody>
+  </table>
+  <p>For OpenShift-specific issues (SCC, builds, credentials), see the
+  <a href="harbor-openshift.html">OpenShift guide troubleshooting</a>.</p>
+
+</main>
+
+<footer class="footer">
+  <div class="footer-inner">
+    <div>
+      <span class="wordmark" style="color:var(--ink);font-size:1.05rem;">cap<span class="wordmark-dot">·</span>evolve</span><br>
+      Apache-2.0 · beta (0.x) · <em>Optimize agentic capabilities — with agents</em>
+    </div>
+    <div class="footer-affil">
+      <span>Made at</span>
+      <span class="footer-affil-logos">
+        <img src="assets/ibm-logo.svg" alt="IBM" class="logo-ibm">
+        <img src="assets/redhat-logo.svg" alt="Red Hat" class="logo-redhat">
+      </span>
+    </div>
+    <div>
+      <a href="https://github.com/skillberry-ai/cap-evolve">github.com/skillberry-ai/cap-evolve</a>
+    </div>
+  </div>
+</footer>
+
+<script src="js/site.js?v=20260724" defer></script>
+</body>
+</html>

--- a/site/index.html
+++ b/site/index.html
@@ -38,6 +38,7 @@
       <a href="benchmarks.html">Benchmarks</a>
       <a href="architecture.html">Architecture</a>
       <a href="agent-orchestration.html">Agent mode</a>
+      <a href="harbor.html">Harbor</a>
       <a class="gh" href="https://github.com/skillberry-ai/cap-evolve">GitHub</a>
       <button class="theme-toggle" type="button" aria-label="Switch theme">
         <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>

--- a/site/optimize-your-own.html
+++ b/site/optimize-your-own.html
@@ -38,6 +38,7 @@
       <a href="benchmarks.html">Benchmarks</a>
       <a href="architecture.html">Architecture</a>
       <a href="agent-orchestration.html">Agent mode</a>
+      <a href="harbor.html">Harbor</a>
       <a class="gh" href="https://github.com/skillberry-ai/cap-evolve">GitHub</a>
       <button class="theme-toggle" type="button" aria-label="Switch theme">
         <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>

--- a/site/results.html
+++ b/site/results.html
@@ -38,6 +38,7 @@
       <a href="benchmarks.html">Benchmarks</a>
       <a href="architecture.html">Architecture</a>
       <a href="agent-orchestration.html">Agent mode</a>
+      <a href="harbor.html">Harbor</a>
       <a class="gh" href="https://github.com/skillberry-ai/cap-evolve">GitHub</a>
       <button class="theme-toggle" type="button" aria-label="Switch theme">
         <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
@@ -223,7 +224,8 @@
             run (whose best stayed the seed at sealed test <span class="num">0.35</span>), but
             <code>gpt-oss-120b</code>'s stable val ceiling here (~<span class="num">0.64</span>) is below
             the requested 0.78 target; a genuine held-out gain needs a stronger runner model or tool-level
-            edits. Details: <a href="agent-orchestration.html">Agent mode</a>.
+            edits. Details: <a href="agent-orchestration.html">Agent mode</a>
+      <a href="harbor.html">Harbor</a>.
           </p>
         </blockquote>
       </section>

--- a/site/run-end-to-end.html
+++ b/site/run-end-to-end.html
@@ -38,6 +38,7 @@
       <a href="benchmarks.html">Benchmarks</a>
       <a href="architecture.html">Architecture</a>
       <a href="agent-orchestration.html">Agent mode</a>
+      <a href="harbor.html">Harbor</a>
       <a class="gh" href="https://github.com/skillberry-ai/cap-evolve">GitHub</a>
       <button class="theme-toggle" type="button" aria-label="Switch theme">
         <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -45,4 +45,14 @@
     <lastmod>2026-07-24</lastmod>
     <priority>0.7</priority>
   </url>
+  <url>
+    <loc>https://skillberry-ai.github.io/cap-evolve/harbor.html</loc>
+    <lastmod>2026-07-28</lastmod>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://skillberry-ai.github.io/cap-evolve/harbor-openshift.html</loc>
+    <lastmod>2026-07-28</lastmod>
+    <priority>0.6</priority>
+  </url>
 </urlset>

--- a/templates/adapters/harbor/adapter.py
+++ b/templates/adapters/harbor/adapter.py
@@ -1,0 +1,283 @@
+"""Harbor adapter template — optimize agent capabilities via Harbor benchmarks.
+
+cap-evolve optimizes the skill; Harbor executes the benchmark in sandboxed
+containers (Docker, OpenShift, or cloud). Each evaluation iteration invokes
+one ``harbor run`` for the full task set.
+
+SETUP:
+  1. Install Harbor:  uv tool install harbor
+  2. Docker/Podman running (local) or ``oc login`` (OpenShift)
+  3. Copy this directory to .capevolve/project/adapters/
+  4. Set env vars:
+       HARBOR_DATASET=swe-bench/swe-bench-verified    # registry or local path
+       HARBOR_AGENT=claude-code
+       HARBOR_MODEL=claude-sonnet-4-6
+       ANTHROPIC_API_KEY=sk-ant-...
+       # For OpenShift with on-cluster vLLM:
+       HARBOR_EXTRA_FLAGS=-e openshift
+       HARBOR_AGENT_BASE_URL=http://vllm-svc.ns.svc:8000
+  5. Run: cap-evolve check && cap-evolve run
+
+HOW IT WORKS:
+  - tasks()      → task IDs from HARBOR_TASK_IDS or auto-detected
+  - run_batch()  → one ``harbor run`` for the full evaluation, parses job results
+  - score()      → reads reward from Harbor's verifier output
+  - live()       → yields the candidate dir (skill files read at run time)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from cap_evolve import CapabilityAdapter, Rollout, Score, Task
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+HARBOR_DATASET = os.environ.get("HARBOR_DATASET", "")
+HARBOR_AGENT = os.environ.get("HARBOR_AGENT", "claude-code")
+HARBOR_MODEL = os.environ.get("HARBOR_MODEL", "")
+HARBOR_PARALLEL = int(os.environ.get("HARBOR_PARALLEL", "4"))
+HARBOR_TIMEOUT = int(os.environ.get("HARBOR_TIMEOUT", "1800"))
+import shlex as _shlex
+HARBOR_EXTRA_FLAGS = _shlex.split(os.environ.get("HARBOR_EXTRA_FLAGS", ""))
+HARBOR_JOBS_DIR = os.environ.get("HARBOR_JOBS_DIR", "")
+
+# Task IDs to include (comma-separated, without dataset prefix).
+# e.g. "astropy__astropy-12907,django__django-11099"
+HARBOR_TASK_IDS = [
+    s.strip() for s in os.environ.get("HARBOR_TASK_IDS", "").split(",") if s.strip()
+]
+
+# Harbor prefixes task names with the dataset org — e.g. "swe-bench/astropy__astropy-12907".
+# Set this to the prefix Harbor uses so the adapter can map IDs correctly.
+HARBOR_TASK_PREFIX = os.environ.get("HARBOR_TASK_PREFIX", "")
+
+# Agent env vars for model endpoint (on-cluster vLLM or API gateway)
+HARBOR_AGENT_BASE_URL = os.environ.get("HARBOR_AGENT_BASE_URL", "")
+HARBOR_AGENT_API_KEY = os.environ.get("HARBOR_AGENT_API_KEY", "")
+
+
+def _is_registry_dataset(ds: str) -> bool:
+    """True if the dataset name is a Harbor registry reference (org/name)."""
+    return "/" in ds and not Path(ds).is_dir()
+
+
+def _build_agent_env(candidate_dir: Path) -> dict[str, str]:
+    """Build --ae flags for the Harbor agent from config + candidate skill."""
+    ae: dict[str, str] = {}
+
+    if HARBOR_AGENT_BASE_URL:
+        ae["ANTHROPIC_BASE_URL"] = HARBOR_AGENT_BASE_URL
+        ae["ANTHROPIC_API_KEY"] = HARBOR_AGENT_API_KEY or "dummy"
+        ae["ANTHROPIC_MODEL"] = HARBOR_MODEL
+        ae["ANTHROPIC_DEFAULT_SONNET_MODEL"] = HARBOR_MODEL
+        ae["ANTHROPIC_DEFAULT_HAIKU_MODEL"] = HARBOR_MODEL
+        ae["ANTHROPIC_DEFAULT_OPUS_MODEL"] = HARBOR_MODEL
+
+    # Inject the candidate skill content so the agent can use it
+    skill_md = candidate_dir / "SKILL.md"
+    prompt_md = candidate_dir / "prompt.md"
+    if skill_md.exists():
+        ae["CAPEVOLVE_SKILL_CONTENT"] = skill_md.read_text(encoding="utf-8")[:8000]
+    elif prompt_md.exists():
+        ae["CAPEVOLVE_PROMPT_CONTENT"] = prompt_md.read_text(encoding="utf-8")[:8000]
+
+    return ae
+
+
+# ---------------------------------------------------------------------------
+# Adapter
+# ---------------------------------------------------------------------------
+
+
+class Adapter(CapabilityAdapter):
+
+    _last_jobs_dir: Path | None = None
+
+    # ---- tasks -----------------------------------------------------------
+
+    def tasks(self, split: str) -> list[Task]:
+        """Return tasks from config or auto-detect from the dataset."""
+        if HARBOR_TASK_IDS:
+            return [
+                Task(id=tid, input="", metadata={"source": "HARBOR_TASK_IDS"})
+                for tid in HARBOR_TASK_IDS
+            ]
+
+        if HARBOR_DATASET and not _is_registry_dataset(HARBOR_DATASET):
+            return self._tasks_from_local(HARBOR_DATASET)
+
+        if not HARBOR_DATASET:
+            raise ValueError("HARBOR_DATASET env var is required.")
+
+        # Registry dataset: task IDs must be specified via HARBOR_TASK_IDS
+        raise ValueError(
+            f"HARBOR_DATASET={HARBOR_DATASET} is a registry dataset. "
+            "Set HARBOR_TASK_IDS to a comma-separated list of task IDs "
+            "(e.g. swe-bench/astropy__astropy-12907,swe-bench/django__django-11099)."
+        )
+
+    def _tasks_from_local(self, dataset_path: str) -> list[Task]:
+        """Load tasks from a local Harbor dataset directory."""
+        dpath = Path(dataset_path)
+        tasks = []
+        for entry in sorted(dpath.iterdir()):
+            if entry.is_dir() and (entry / "task.toml").exists():
+                tasks.append(Task(
+                    id=entry.name,
+                    input=(entry / "instruction.md").read_text(encoding="utf-8")
+                    if (entry / "instruction.md").exists() else "",
+                ))
+        if not tasks:
+            raise ValueError(f"No Harbor tasks found in {dataset_path}.")
+        return tasks
+
+    # ---- running ---------------------------------------------------------
+
+    def run_batch(self, tasks: list[Task], ctx, *, seed: int = 0) -> dict:
+        """Run the full benchmark via one ``harbor run`` invocation."""
+        from capevolve_harbor import harbor_run, parse_job_dir
+
+        candidate_dir = Path(ctx)
+        jobs_dir = Path(HARBOR_JOBS_DIR) if HARBOR_JOBS_DIR else Path(tempfile.mkdtemp(prefix="harbor_jobs_"))
+        jobs_dir.mkdir(parents=True, exist_ok=True)
+
+        agent_env = _build_agent_env(candidate_dir)
+
+        is_registry = _is_registry_dataset(HARBOR_DATASET)
+        prefix = HARBOR_TASK_PREFIX
+        if is_registry and not prefix:
+            prefix = HARBOR_DATASET.split("/")[0]
+
+        harbor_task_names = [
+            f"{prefix}/{t.id}" if prefix and not t.id.startswith(prefix) else t.id
+            for t in tasks
+        ] if is_registry else None
+
+        result = harbor_run(
+            dataset_path=None if is_registry else Path(HARBOR_DATASET),
+            dataset=HARBOR_DATASET if is_registry else None,
+            agent=HARBOR_AGENT,
+            model=HARBOR_MODEL,
+            parallel=HARBOR_PARALLEL,
+            timeout=HARBOR_TIMEOUT * len(tasks) + 300,
+            extra_flags=HARBOR_EXTRA_FLAGS or None,
+            jobs_dir=jobs_dir,
+            include_tasks=harbor_task_names,
+            agent_env=agent_env or None,
+        )
+
+        Adapter._last_jobs_dir = result.job_dir
+        rollouts: dict[str, Rollout] = {}
+
+        if result.error and not result.job_dir:
+            for t in tasks:
+                rollouts[t.id] = Rollout(
+                    task_id=t.id,
+                    error=f"Harbor run failed: {result.error}",
+                )
+            return rollouts
+
+        if result.job_dir:
+            trial_results = parse_job_dir(result.job_dir)
+
+            for t in tasks:
+                trials = trial_results.get(t.id, [])
+                if not trials:
+                    prefixed = f"{prefix}/{t.id}" if prefix else t.id
+                    trials = trial_results.get(prefixed, [])
+                if not trials:
+                    # Harbor trial dirs use __ for / and append a short hash
+                    for key in trial_results:
+                        if t.id in key or t.id.replace("/", "__") in key:
+                            trials = trial_results[key]
+                            break
+
+                if trials:
+                    tr = trials[0]
+                    rollouts[t.id] = Rollout(
+                        task_id=t.id,
+                        output=tr.trajectory,
+                        trace=tr.trajectory,
+                        cost_usd=tr.cost_usd,
+                        tokens=tr.tokens,
+                        error=tr.error,
+                        metadata={
+                            "harbor_reward": tr.reward,
+                            "reward_json": tr.reward_json,
+                            "verifier_stdout": tr.verifier_stdout,
+                            "verifier_stderr": tr.verifier_stderr,
+                        },
+                    )
+                else:
+                    rollouts[t.id] = Rollout(
+                        task_id=t.id,
+                        error=f"No Harbor trial result found for task {t.id}",
+                    )
+
+        for t in tasks:
+            if t.id not in rollouts:
+                rollouts[t.id] = Rollout(task_id=t.id, error="No rollout produced")
+
+        return rollouts
+
+    def run_target(self, task: Task, ctx, *, seed: int = 0) -> Rollout:
+        batch = self.run_batch([task], ctx, seed=seed)
+        return batch.get(task.id, Rollout(task_id=task.id, error="no rollout"))
+
+    def run_trials(self, tasks: list[Task], ctx, *, n_trials: int, base_seed: int) -> dict:
+        """Run N trials — each is a full harbor run."""
+        all_rollouts: dict[str, list[Rollout]] = {t.id: [] for t in tasks}
+        for k in range(n_trials):
+            batch = self.run_batch(tasks, ctx, seed=base_seed + k)
+            for t in tasks:
+                all_rollouts[t.id].append(
+                    batch.get(t.id, Rollout(task_id=t.id, error="omitted"))
+                )
+        return all_rollouts
+
+    # ---- scoring ---------------------------------------------------------
+
+    def score(self, task: Task, rollout: Rollout) -> Score:
+        from capevolve_harbor.results import build_feedback, TrialResult
+
+        meta = rollout.metadata or {}
+
+        if rollout.error:
+            return Score(
+                task_id=task.id,
+                reward=0.0,
+                feedback=f"Rollout did not complete ({rollout.error}). "
+                "This may be an infrastructure issue, not an agent failure.",
+            )
+
+        reward = float(meta.get("harbor_reward", 0.0) or 0.0)
+        tr = TrialResult(
+            task_id=task.id,
+            reward=reward,
+            reward_json=meta.get("reward_json", {}),
+            verifier_stdout=meta.get("verifier_stdout", ""),
+            verifier_stderr=meta.get("verifier_stderr", ""),
+        )
+        return Score(task_id=task.id, reward=reward, feedback=build_feedback(tr))
+
+    # ---- candidate lifecycle ---------------------------------------------
+
+    @contextmanager
+    def live(self, candidate_dir: Path):
+        """Yield the candidate directory — skill files are read at run time."""
+        yield Path(candidate_dir)
+
+    def trajectories(self, split: str, ctx=None) -> Path | None:
+        return Adapter._last_jobs_dir

--- a/templates/adapters/harbor/adapter.py
+++ b/templates/adapters/harbor/adapter.py
@@ -342,7 +342,9 @@ class Adapter(CapabilityAdapter):
             if src.exists():
                 content = src.read_text(encoding="utf-8")
                 if content.strip():
-                    tmp = Path(tempfile.mktemp(prefix="capevolve_instruction_", suffix=".md"))
+                    fd, tmp_str = tempfile.mkstemp(prefix="capevolve_instruction_", suffix=".md")
+                    tmp = Path(tmp_str)
+                    os.close(fd)
                     tmp.write_text(content, encoding="utf-8")
                     cls._instruction_tmp_files.append(tmp)
                     return tmp

--- a/templates/adapters/harbor/adapter.py
+++ b/templates/adapters/harbor/adapter.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
 import shutil
 import subprocess
 import sys
@@ -49,8 +50,7 @@ HARBOR_AGENT = os.environ.get("HARBOR_AGENT", "claude-code")
 HARBOR_MODEL = os.environ.get("HARBOR_MODEL", "")
 HARBOR_PARALLEL = int(os.environ.get("HARBOR_PARALLEL", "4"))
 HARBOR_TIMEOUT = int(os.environ.get("HARBOR_TIMEOUT", "1800"))
-import shlex as _shlex
-HARBOR_EXTRA_FLAGS = _shlex.split(os.environ.get("HARBOR_EXTRA_FLAGS", ""))
+HARBOR_EXTRA_FLAGS = shlex.split(os.environ.get("HARBOR_EXTRA_FLAGS", ""))
 HARBOR_JOBS_DIR = os.environ.get("HARBOR_JOBS_DIR", "")
 
 # Task IDs to include (comma-separated, without dataset prefix).
@@ -73,8 +73,14 @@ def _is_registry_dataset(ds: str) -> bool:
     return "/" in ds and not Path(ds).is_dir()
 
 
-def _build_agent_env(candidate_dir: Path) -> dict[str, str]:
-    """Build --ae flags for the Harbor agent from config + candidate skill."""
+def _build_agent_env() -> dict[str, str]:
+    """Build --ae flags for the Harbor agent from model config.
+
+    Supports three auth modes:
+    1. On-cluster vLLM (HARBOR_AGENT_BASE_URL set)
+    2. Vertex AI (CLAUDE_CODE_USE_VERTEX=1)
+    3. Anthropic API key (ANTHROPIC_API_KEY)
+    """
     ae: dict[str, str] = {}
 
     if HARBOR_AGENT_BASE_URL:
@@ -84,16 +90,34 @@ def _build_agent_env(candidate_dir: Path) -> dict[str, str]:
         ae["ANTHROPIC_DEFAULT_SONNET_MODEL"] = HARBOR_MODEL
         ae["ANTHROPIC_DEFAULT_HAIKU_MODEL"] = HARBOR_MODEL
         ae["ANTHROPIC_DEFAULT_OPUS_MODEL"] = HARBOR_MODEL
-
-    # Inject the candidate skill content so the agent can use it
-    skill_md = candidate_dir / "SKILL.md"
-    prompt_md = candidate_dir / "prompt.md"
-    if skill_md.exists():
-        ae["CAPEVOLVE_SKILL_CONTENT"] = skill_md.read_text(encoding="utf-8")[:8000]
-    elif prompt_md.exists():
-        ae["CAPEVOLVE_PROMPT_CONTENT"] = prompt_md.read_text(encoding="utf-8")[:8000]
+    elif os.environ.get("CLAUDE_CODE_USE_VERTEX", "").strip() == "1":
+        ae["CLAUDE_CODE_USE_VERTEX"] = "1"
+        ae["CLOUD_ML_REGION"] = os.environ.get("CLOUD_ML_REGION", "global")
+        ae["ANTHROPIC_VERTEX_PROJECT_ID"] = os.environ.get("ANTHROPIC_VERTEX_PROJECT_ID", "")
+        ae["ANTHROPIC_MODEL"] = HARBOR_MODEL
+        creds = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", "")
+        if creds:
+            ae["GOOGLE_APPLICATION_CREDENTIALS"] = "/app/.config/gcloud/application_default_credentials.json"
+    else:
+        api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+        if api_key:
+            ae["ANTHROPIC_API_KEY"] = api_key
 
     return ae
+
+
+def _build_harbor_mounts() -> list[dict] | None:
+    """Build mount specs for Harbor containers (e.g., GCP credentials)."""
+    if os.environ.get("CLAUDE_CODE_USE_VERTEX", "").strip() != "1":
+        return None
+    creds = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", "")
+    if not creds:
+        home = os.path.expanduser("~")
+        creds = f"{home}/.config/gcloud/application_default_credentials.json"
+    if os.path.exists(creds):
+        return [{"type": "bind", "source": creds,
+                 "target": "/app/.config/gcloud/application_default_credentials.json"}]
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -146,33 +170,65 @@ class Adapter(CapabilityAdapter):
     # ---- running ---------------------------------------------------------
 
     def run_batch(self, tasks: list[Task], ctx, *, seed: int = 0) -> dict:
-        """Run the full benchmark via one ``harbor run`` invocation."""
+        """Run the full benchmark via one ``harbor run`` invocation.
+
+        The candidate capability files are injected into the container via
+        ``package_dataset`` — each task's environment/capability/ dir contains
+        the current candidate's SKILL.md, scripts, references, etc.
+        """
         from capevolve_harbor import harbor_run, parse_job_dir
+        from capevolve_harbor.tasks import package_dataset
 
         candidate_dir = Path(ctx)
         jobs_dir = Path(HARBOR_JOBS_DIR) if HARBOR_JOBS_DIR else Path(tempfile.mkdtemp(prefix="harbor_jobs_"))
         jobs_dir.mkdir(parents=True, exist_ok=True)
 
-        agent_env = _build_agent_env(candidate_dir)
+        agent_env = _build_agent_env()
+        agent_env["CAPEVOLVE_SEED"] = str(seed)
 
         is_registry = _is_registry_dataset(HARBOR_DATASET)
         prefix = HARBOR_TASK_PREFIX
         if is_registry and not prefix:
             prefix = HARBOR_DATASET.split("/")[0]
 
-        harbor_task_names = [
-            f"{prefix}/{t.id}" if prefix and not t.id.startswith(prefix) else t.id
-            for t in tasks
-        ] if is_registry else None
+        # Inject the candidate capability into the agent's context.
+        # Write the candidate prompt/skill to a temp file and pass it
+        # via --extra-instruction-path so Harbor appends it to the task
+        # instruction — works for both registry and local datasets.
+        extra_flags = list(HARBOR_EXTRA_FLAGS or [])
+        mounts = _build_harbor_mounts()
+        if mounts:
+            extra_flags += ["--mounts-json", json.dumps(mounts)]
+        instruction_file = self._write_candidate_instruction(candidate_dir)
+        if instruction_file:
+            extra_flags += ["--extra-instruction-path", str(instruction_file)]
+
+        if is_registry:
+            harbor_task_names = [
+                f"{prefix}/{t.id}" if prefix and not t.id.startswith(prefix) else t.id
+                for t in tasks
+            ]
+            dataset_path = None
+            dataset_name = HARBOR_DATASET
+        else:
+            harbor_task_names = None
+            packaged_dir = Path(tempfile.mkdtemp(prefix="harbor_dataset_"))
+            package_dataset(
+                tasks=[{"id": t.id, "input": t.input} for t in tasks],
+                candidate_dir=candidate_dir,
+                output_dir=packaged_dir,
+            )
+            dataset_path = packaged_dir
+            dataset_name = None
 
         result = harbor_run(
-            dataset_path=None if is_registry else Path(HARBOR_DATASET),
-            dataset=HARBOR_DATASET if is_registry else None,
+            dataset_path=dataset_path,
+            dataset=dataset_name,
             agent=HARBOR_AGENT,
             model=HARBOR_MODEL,
             parallel=HARBOR_PARALLEL,
             timeout=HARBOR_TIMEOUT * len(tasks) + 300,
-            extra_flags=HARBOR_EXTRA_FLAGS or None,
+            extra_flags=extra_flags or None,
             jobs_dir=jobs_dir,
             include_tasks=harbor_task_names,
             agent_env=agent_env or None,
@@ -230,6 +286,7 @@ class Adapter(CapabilityAdapter):
             if t.id not in rollouts:
                 rollouts[t.id] = Rollout(task_id=t.id, error="No rollout produced")
 
+        self._cleanup_tmp_files()
         return rollouts
 
     def run_target(self, task: Task, ctx, *, seed: int = 0) -> Rollout:
@@ -273,6 +330,32 @@ class Adapter(CapabilityAdapter):
         return Score(task_id=task.id, reward=reward, feedback=build_feedback(tr))
 
     # ---- candidate lifecycle ---------------------------------------------
+
+    _instruction_tmp_files: list[Path] = []
+
+    @classmethod
+    def _write_candidate_instruction(cls, candidate_dir: Path) -> Path | None:
+        """Write the candidate prompt/skill to a temp file for Harbor injection."""
+        candidate_dir = Path(candidate_dir)
+        for name in ("prompt.md", "SKILL.md"):
+            src = candidate_dir / name
+            if src.exists():
+                content = src.read_text(encoding="utf-8")
+                if content.strip():
+                    tmp = Path(tempfile.mktemp(prefix="capevolve_instruction_", suffix=".md"))
+                    tmp.write_text(content, encoding="utf-8")
+                    cls._instruction_tmp_files.append(tmp)
+                    return tmp
+        return None
+
+    @classmethod
+    def _cleanup_tmp_files(cls) -> None:
+        for f in cls._instruction_tmp_files:
+            try:
+                f.unlink(missing_ok=True)
+            except OSError:
+                pass
+        cls._instruction_tmp_files.clear()
 
     @contextmanager
     def live(self, candidate_dir: Path):

--- a/templates/adapters/harbor/capevolve.yaml
+++ b/templates/adapters/harbor/capevolve.yaml
@@ -1,0 +1,27 @@
+# Harbor adapter — cap-evolve configuration
+#
+# Optimizes a skill-package capability against any Harbor benchmark.
+# Harbor handles sandboxed execution; cap-evolve drives the optimization loop.
+#
+# Required env vars:
+#   HARBOR_DATASET=swe-bench/swe-bench-verified   # registry or local path
+#   HARBOR_AGENT=claude-code                       # any Harbor agent
+#   HARBOR_MODEL=claude-sonnet-4-6                 # model for the agent
+#   HARBOR_TASK_IDS=swe-bench/task-1,swe-bench/task-2  # tasks to optimize on
+#
+# For OpenShift with on-cluster vLLM:
+#   HARBOR_EXTRA_FLAGS=-e openshift
+#   HARBOR_AGENT_BASE_URL=http://vllm-svc.namespace.svc:8000
+
+capabilities:       [skill-package]
+capability_path:    seed_capability
+optimizer_skill:    mock
+algorithm_skill:    hill-climb
+algorithm_focus:    all
+dataset_source:     adapter
+num_trials:         1
+gate_mode:          paired
+gate_k_se:          1.0
+max_iterations:     3
+stall:              2
+store:              copy

--- a/templates/adapters/harbor/seed_capability/SKILL.md
+++ b/templates/adapters/harbor/seed_capability/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: swebench-solver
+description: "Use when fixing a bug in an open-source repository given a GitHub issue description. Analyzes the problem, locates the relevant code, and produces a minimal unified diff patch."
+---
+
+# SWE-bench Solver
+
+You are an expert software engineer tasked with fixing bugs in open-source repositories.
+
+## Approach
+
+1. Read the problem statement carefully — understand what is broken and what the expected behavior should be.
+2. Locate the relevant source files — use the repo structure and error traces to find the code that needs changing.
+3. Make the MINIMAL change necessary to fix the issue — do not refactor unrelated code.
+4. Ensure your patch applies cleanly and does not break existing tests.
+
+## Output
+
+Produce a unified diff patch. Do not include explanations before or after the patch.

--- a/templates/adapters/harbor/seed_capability/prompt.md
+++ b/templates/adapters/harbor/seed_capability/prompt.md
@@ -1,0 +1,3 @@
+You are a helpful assistant. Complete the task described in the instructions carefully and accurately.
+
+Follow all instructions precisely and use the tools available to you.


### PR DESCRIPTION
## What & why
Add Harbor integration for running cap-evolve optimizations using Harbor (https://www.harborframework.com/) as the sandboxed evaluation backend. Harbor executes benchmark trials (SWE-bench, Terminal-Bench, etc.)
  in isolated Docker containers or OpenShift pods while cap-evolve drives the optimize → evaluate → gate cycle.

  The Harbor adapter (`templates/adapters/harbor/adapter.py`) bridges the two — its `run_batch()` calls harbor run as a subprocess each time cap-evolve needs an evaluation. Users run one command (`cap-evolve run`), and
  the adapter handles Harbor invocation, result parsing, and reward mapping internally.

 ## What's included:
  - `capevolve_harbor/ package` — `harbor run` subprocess wrapper with signal forwarding, job directory parser (reward.json → cap-evolve Score), task packager
  - `emplates/adapters/harbor/` — ready-to-use adapter template with `capevolve.yaml` (skill-package capability) and seed `SKILL.md`
  - `site/harbor.html` — integration guide: how cap-evolve uses Harbor, setup, env vars, OpenShift orchestrator image/RBAC/credentials, config reference
  - `site/harbor-openshift.html `— generic vLLM on OpenShift guide: deploy, GPU sizing, agent connection patterns, manifests
  - Harbor nav link added to all site pages, sitemap updated

  **Tested end-to-end on OpenShift** with SWE-bench + claude-code (Vertex AI) and Qwen 14B (on-cluster vLLM). Harbor created task pods, built environment images via OpenShift Binary Builds, ran claude-code inside the
  pods, and returned results to cap-evolve's gating loop.


## Checklist
  - [x] python -m pytest core/tests -q passes — no core changes
  - [x] python skills/_registry/build_manifest.py skills is clean — no skill changes
  - [x] Any new/changed skill's scripts/check.py is green — N/A (adapter template, not a skill)
  - [x] Honesty invariants untouched (gate on val, test sealed) — adapter uses standard run_batch()/score() contract; gating and sealing are in core, untouched
  - [x] Docs updated — site/harbor.html, site/harbor-openshift.html, nav links, sitemap
