### PR TITLE
feat(bench): persist CapEvolve UI snapshots on benchmark-history + manual prune

### DIFF
--- a/.github/workflows/benchmark-history-prune.yml
+++ b/.github/workflows/benchmark-history-prune.yml
@@ -1,0 +1,68 @@
+name: Prune benchmark-history
+
+# Manual-only deletion. benchmark-history keeps every record + UI snapshot
+# forever by default (see docs/superpowers/specs/2026-07-29-persist-capevolve-ui-ci-benchmarks-design.md).
+# Run this on demand to delete anything older than N days once the branch grows too large.
+# Note: this deletes files in a new commit — it does not rewrite git history, so it
+# does not reclaim .git object storage. It only changes what benchmark-history currently
+# serves (records/, runs/, benchmarks.json, meta.json).
+
+on:
+  workflow_dispatch:
+    inputs:
+      days:
+        description: "Delete records (and their UI snapshots) older than this many days"
+        type: string
+        default: "30"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: benchmark-history-write
+  cancel-in-progress: false
+
+jobs:
+  prune:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4              # for ci/benchmarks/lib/record.py
+
+      - name: Prune records + UI snapshots older than cutoff
+        env:
+          DAYS: ${{ github.event.inputs.days || '30' }}
+        run: |
+          git config --global user.name "skillberry-bot"
+          git config --global user.email "actions@github.com"
+          for attempt in 1 2 3 4 5; do
+            rm -rf _hist
+            git clone --depth 1 --branch benchmark-history \
+              "https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git" _hist || {
+                echo "branch missing — bootstrap it per ci/benchmarks/README.md"; exit 1; }
+            cutoff="$(date -u -d "-${DAYS} days" +%Y-%m-%dT%H:%M:%SZ)"
+            echo "pruning records older than $cutoff"
+            deleted=0
+            for f in _hist/records/*.json; do
+              [ -f "$f" ] || continue
+              date_val="$(python3 -c "import json;print(json.load(open('$f')).get('date',''))")"
+              if [[ -n "$date_val" && "$date_val" < "$cutoff" ]]; then
+                slug="$(basename "$f" .json)"
+                echo "deleting $slug (date=$date_val)"
+                rm -f "$f"
+                rm -rf "_hist/runs/$slug"
+                deleted=$((deleted+1))
+              fi
+            done
+            echo "deleted $deleted record(s)"
+            echo "### Prune summary" >> "$GITHUB_STEP_SUMMARY"
+            echo "cutoff: $cutoff (older than ${DAYS}d) — deleted $deleted record(s)" >> "$GITHUB_STEP_SUMMARY"
+            python3 ci/benchmarks/lib/record.py aggregate _hist/records \
+              --now "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --out _hist
+            cd _hist
+            git add records benchmarks.json meta.json
+            [ -d runs ] && git add runs
+            git commit -m "bench: prune records older than ${DAYS}d ($deleted deleted)" || { echo "nothing to commit"; exit 0; }
+            if git push origin benchmark-history; then echo "pushed"; exit 0; fi
+            echo "push race, retrying ($attempt)"; cd ..; sleep 3
+          done
+          echo "failed to push after retries"; exit 1

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -214,6 +214,19 @@ jobs:
         if: steps.gate.outputs.run == 'true'
         run: bash ci/benchmarks/lib/run_suite.sh "${{ matrix.bench }}" "$GITHUB_WORKSPACE/ci/benchmarks/.work/suite_${{ matrix.tier }}_${{ matrix.bench }}"
 
+      - name: Export CapEvolve UI snapshot
+        if: steps.gate.outputs.run == 'true' && always()
+        run: |
+          run_dir="$GITHUB_WORKSPACE/ci/benchmarks/.work/suite_${{ matrix.tier }}_${{ matrix.bench }}_proj/.capevolve/run_suite"
+          out="$GITHUB_WORKSPACE/ci/benchmarks/.work/suite_${{ matrix.tier }}_${{ matrix.bench }}"
+          if [ -f "$run_dir/events.jsonl" ]; then
+            PYTHONPATH="$GITHUB_WORKSPACE/dashboard/backend" "$CAPEVOLVE_PY" -m capevolve_dashboard.export_static \
+              --base "$(dirname "$run_dir")" --run-id run_suite --out "$out/ui/data" \
+              || echo "::warning::UI export failed for ${{ matrix.tier }}/${{ matrix.bench }} (best-effort, continuing)"
+          else
+            echo "no run dir at $run_dir (job likely failed/cancelled before producing one) — skipping UI export"
+          fi
+
       - name: Write run metadata
         if: steps.gate.outputs.run == 'true' && always()
         run: |

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -296,6 +296,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    concurrency:
+      group: benchmark-history-write
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4              # for ci/benchmarks/lib/record.py
 
@@ -305,14 +308,36 @@ jobs:
           path: _artifacts
           pattern: benchmarks-*
 
-      - name: Build records
+      - name: Check for UI snapshots
+        id: uicheck
         run: |
-          mkdir -p _new_records
+          if find _artifacts -type d -path '*/ui/data' 2>/dev/null | grep -q .; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Node.js 22
+        if: steps.uicheck.outputs.found == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Build static dashboard shell
+        if: steps.uicheck.outputs.found == 'true'
+        working-directory: dashboard/frontend
+        run: |
+          npm ci
+          VITE_STATIC=1 npx vite build --outDir "$RUNNER_TEMP/ui_shell"
+
+      - name: Build records + assemble UI snapshots
+        run: |
           # upload-artifact stores files flat at the artifact root (the least-common-ancestor
           # of ci/benchmarks/.work/suite_<tier>_<bench>/** is that dir), so runmeta.json/
-          # metrics.jsonl live directly under _artifacts/benchmarks-<tier>-<bench>/. The dir
+          # metrics.jsonl/ui/ live directly under _artifacts/benchmarks-<tier>-<bench>/. The dir
           # suffix is the <tier>-<bench> slug — use it verbatim to keep record files unique
           # per (run, tier, bench) so smoke and full of the same bench never collide.
+          mkdir -p _new_records _hist_runs
           have=0; built=0
           for d in _artifacts/benchmarks-*; do
             [ -d "$d" ] || continue
@@ -321,7 +346,15 @@ jobs:
             [ -f "$rm" ] || { echo "::warning::no runmeta for $slug, skipping"; continue; }
             have=$((have+1))
             rid="$(python3 -c "import json;print(json.load(open('$rm'))['run_id'])")"
-            python3 ci/benchmarks/lib/record.py build "$metrics" --runmeta "$rm" --steps "$steps" \
+            has_ui_flag=""
+            if [ -d "$d/ui/data" ] && [ -n "$(ls -A "$d/ui/data" 2>/dev/null)" ]; then
+              dest="_hist_runs/${rid}__${slug}/ui"
+              mkdir -p "$dest"
+              cp -R "$RUNNER_TEMP/ui_shell/." "$dest/"
+              cp -R "$d/ui/data" "$dest/data"
+              has_ui_flag="--has-ui"
+            fi
+            python3 ci/benchmarks/lib/record.py build "$metrics" --runmeta "$rm" --steps "$steps" $has_ui_flag \
               > "_new_records/${rid}__${slug}.json" && built=$((built+1))
             echo "built _new_records/${rid}__${slug}.json"
           done
@@ -344,10 +377,15 @@ jobs:
                 echo "branch missing — bootstrap it per ci/benchmarks/README.md"; exit 1; }
             mkdir -p _hist/records
             cp _new_records/*.json _hist/records/
+            if [ -d _hist_runs ] && [ -n "$(ls -A _hist_runs 2>/dev/null)" ]; then
+              mkdir -p _hist/runs
+              cp -R _hist_runs/. _hist/runs/
+            fi
             python3 ci/benchmarks/lib/record.py aggregate _hist/records \
               --now "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --out _hist
             cd _hist
             git add records benchmarks.json meta.json
+            [ -d runs ] && git add runs
             git commit -m "bench: record run ${{ github.run_id }}" || { echo "nothing to commit"; exit 0; }
             if git push origin benchmark-history; then echo "pushed"; exit 0; fi
             echo "push race, retrying ($attempt)"; cd ..; sleep 3

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -5,9 +5,12 @@ name: Deploy GitHub Pages
 # Triggers:
 #   - push to main that touches site/ or this workflow → auto-deploy
 #   - manual dispatch → deploy on demand
+#   - the Benchmarks workflow completing → redeploy so a new run's CapEvolve UI
+#     snapshot (benchmark-history's runs/**) becomes browsable
 #
-# What it does: uploads site/ verbatim as the Pages artifact and hands it to
-# the official Pages deploy action. No build step (static HTML/CSS/PNG only).
+# What it does: uploads site/ (plus benchmark-history's runs/** folded in under
+# site/benchmark-ui/runs/**) as the Pages artifact and hands it to the official
+# Pages deploy action. No build step for site/ itself (static HTML/CSS/PNG only).
 
 on:
   push:
@@ -16,6 +19,9 @@ on:
       - "site/**"
       - ".github/workflows/pages.yml"
   workflow_dispatch:
+  workflow_run:
+    workflows: ["Benchmarks"]
+    types: [completed]
 
 permissions:
   contents: read
@@ -32,13 +38,29 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      # Explicit ref: main — workflow_run's default checkout otherwise resolves to
+      # the SHA of the triggering Benchmarks run, which can be a PR branch. Pages
+      # must always deploy main's site/, regardless of what triggered this build.
       - uses: actions/checkout@v4
+        with:
+          ref: main
 
       - name: Verify site/ exists
         run: |
           test -d site || { echo "no site/ directory"; exit 1; }
           test -f site/index.html || { echo "no site/index.html"; exit 1; }
           ls -la site/
+
+      - name: Fold in benchmark-history UI snapshots
+        run: |
+          rm -rf _bench_history
+          git clone --depth 1 --branch benchmark-history \
+            "https://github.com/${{ github.repository }}.git" _bench_history || {
+              echo "benchmark-history branch not found — deploying without UI snapshots"; exit 0; }
+          mkdir -p site/benchmark-ui
+          if [ -d _bench_history/runs ]; then
+            cp -R _bench_history/runs site/benchmark-ui/runs
+          fi
 
       - name: Configure Pages
         uses: actions/configure-pages@v5

--- a/ci/benchmarks/README.md
+++ b/ci/benchmarks/README.md
@@ -159,3 +159,19 @@ echo '{"count":0,"runs":0,"updated":null}' > meta.json
 git add records/.gitkeep benchmarks.json meta.json
 git commit -m "chore: init benchmark-history branch" && git push origin benchmark-history
 ```
+
+### Per-run CapEvolve UI snapshots
+
+Each `bench` job also best-effort-exports its raw `.capevolve` run directory as a static
+CapEvolve dashboard snapshot (`export_static.py` + a `VITE_STATIC=1` Vite build), assembled
+by the `aggregate` job into `runs/<run_id>__<tier>-<bench>/ui/` on `benchmark-history`
+alongside its record, which gets `"has_ui": true`. `pages.yml` redeploys on every Benchmarks
+completion and folds `benchmark-history`'s `runs/**` into the deployed site under
+`benchmark-ui/runs/**`, so `benchmarks.html` can link "Open UI" straight to a specific run's
+dashboard. Records/snapshots are **kept forever by default** — there is no automatic expiry.
+
+To reclaim space, run **Actions → "Prune benchmark-history" → Run workflow** with a `days`
+input (default `30`) — it deletes any record (and its paired UI snapshot) older than that
+many days, directly on `benchmark-history`. This only removes files from the branch's current
+tree; it does not rewrite git history, so it doesn't reclaim `.git` object storage — that's
+an accepted tradeoff for keeping "keep forever unless a human explicitly prunes" simple.

--- a/ci/benchmarks/lib/record.py
+++ b/ci/benchmarks/lib/record.py
@@ -50,7 +50,12 @@ def rollup(tasks: list[dict], steps: list[dict] | None = None) -> dict | None:
     }
 
 
-def build_record(metrics_jsonl: Path, runmeta: dict, steps_jsonl: Path | None = None) -> dict:
+def build_record(
+    metrics_jsonl: Path,
+    runmeta: dict,
+    steps_jsonl: Path | None = None,
+    has_ui: bool = False,
+) -> dict:
     tasks: list[dict] = []
     if metrics_jsonl.exists():
         for line in metrics_jsonl.read_text(encoding="utf-8").splitlines():
@@ -68,6 +73,7 @@ def build_record(metrics_jsonl: Path, runmeta: dict, steps_jsonl: Path | None = 
     rec["tasks"] = tasks
     rec["steps"] = steps
     rec["suite"] = rollup(tasks, steps) if runmeta.get("conclusion") == "success" else None
+    rec["has_ui"] = has_ui
     return rec
 
 
@@ -85,6 +91,7 @@ def main(argv: list[str]) -> int:
     b.add_argument("metrics")
     b.add_argument("--runmeta", required=True)
     b.add_argument("--steps", default=None)
+    b.add_argument("--has-ui", action="store_true")
     a = sub.add_parser("aggregate")
     a.add_argument("records_dir")
     a.add_argument("--now", required=True)
@@ -94,7 +101,7 @@ def main(argv: list[str]) -> int:
     if ns.cmd == "build":
         runmeta = json.loads(Path(ns.runmeta).read_text(encoding="utf-8"))
         steps_path = Path(ns.steps) if ns.steps else None
-        print(json.dumps(build_record(Path(ns.metrics), runmeta, steps_path)))
+        print(json.dumps(build_record(Path(ns.metrics), runmeta, steps_path, has_ui=ns.has_ui)))
         return 0
     if ns.cmd == "aggregate":
         recs, meta = aggregate(Path(ns.records_dir), ns.now)

--- a/ci/benchmarks/lib/test_record.py
+++ b/ci/benchmarks/lib/test_record.py
@@ -106,3 +106,17 @@ def test_build_preserves_tier(tmp_path):
     rec2 = record.build_record(m, {"run_id": 9, "bench": "tau2",
                                     "conclusion": "success", "date": "d"})
     assert "tier" not in rec2
+
+
+def test_build_has_ui_true(tmp_path):
+    m = tmp_path / "metrics.jsonl"; _write_jsonl(m, [TASK_OK])
+    meta = {"run_id": 10, "bench": "tau2", "conclusion": "success", "date": "d"}
+    rec = record.build_record(m, meta, has_ui=True)
+    assert rec["has_ui"] is True
+
+
+def test_build_has_ui_defaults_false(tmp_path):
+    m = tmp_path / "metrics.jsonl"; _write_jsonl(m, [TASK_OK])
+    meta = {"run_id": 11, "bench": "tau2", "conclusion": "success", "date": "d"}
+    rec = record.build_record(m, meta)
+    assert rec["has_ui"] is False

--- a/docs/superpowers/plans/2026-07-29-persist-capevolve-ui-ci-benchmarks.md
+++ b/docs/superpowers/plans/2026-07-29-persist-capevolve-ui-ci-benchmarks.md
@@ -1,0 +1,658 @@
+# Persist CapEvolve UI for CI Benchmark Runs — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persist a browsable static CapEvolve dashboard snapshot for every CI benchmark run (success/failure/cancelled) onto the existing `benchmark-history` branch, and link to it from `site/benchmarks.html`, with no automatic expiry and a manually-triggered prune workflow.
+
+**Architecture:** The self-hosted `bench` job (per matrix cell) best-effort-exports the run's raw `.capevolve` directory to static JSON via the existing `export_static.py`, riding along in the artifact it already uploads. The `aggregate` job (ubuntu-latest) builds the Vite static shell once, assembles each artifact's `ui/data/` into `runs/<run_id>__<tier>-<bench>/ui/` on `benchmark-history`, and stamps `has_ui: true` on the matching record. `pages.yml` gains a `workflow_run` trigger that folds `benchmark-history`'s `runs/**` into the Pages deploy under `benchmark-ui/runs/**`. `benchmarks.js` renders an "Open UI" link for any record with `has_ui: true`. A new `benchmark-history-prune.yml` workflow (`workflow_dispatch` only) lets a maintainer delete records + paired UI snapshots older than N days (default 30) — this is the *only* deletion path; nothing is automatic.
+
+**Tech Stack:** GitHub Actions (`workflow_dispatch`, `pull_request`, `workflow_run`), Python 3 (`ci/benchmarks/lib/record.py`, `pytest`), Node 22 / Vite (`dashboard/frontend`, `VITE_STATIC=1`), vanilla JS (`site/benchmarks.js`), git orphan branch (`benchmark-history`).
+
+## Global Constraints
+
+- No automatic retention/expiry of any kind — records and UI snapshots on `benchmark-history` are kept forever by default.
+- Deletion only happens via the new manual `workflow_dispatch` prune workflow, with a `days` input defaulting to `"30"`.
+- Everything lives on the single existing `benchmark-history` branch — no new branch.
+- No changes to the live `dashboard/` app itself — reuse `export_static.py` and the `VITE_STATIC=1` Vite build exactly as they exist today.
+- The `bench` job's export step must be best-effort (`if: always()`, never fails the job) since it must still attempt to run on a cancelled job.
+- Don't modify `ci/benchmarks/lib/ci_setup.sh` — run `export_static.py` via `PYTHONPATH="$GITHUB_WORKSPACE/dashboard/backend"` against the already-cached `$CAPEVOLVE_PY` venv instead of installing `dashboard/backend`'s FastAPI/uvicorn deps.
+- Design doc of record: `docs/superpowers/specs/2026-07-29-persist-capevolve-ui-ci-benchmarks-design.md`. Follow it exactly; this plan is its task breakdown.
+
+---
+
+### Task 1: `record.py` — add `has_ui` field + CLI flag
+
+**Files:**
+- Modify: `ci/benchmarks/lib/record.py:53-71` (`build_record`), `ci/benchmarks/lib/record.py:81-98` (`main`/CLI)
+- Test: `ci/benchmarks/lib/test_record.py`
+
+**Interfaces:**
+- Produces: `build_record(metrics_jsonl: Path, runmeta: dict, steps_jsonl: Path | None = None, has_ui: bool = False) -> dict` — return dict gains `rec["has_ui"]` (bool). CLI `build` subcommand gains `--has-ui` (`store_true`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `ci/benchmarks/lib/test_record.py` (after `test_build_preserves_tier`):
+
+```python
+def test_build_has_ui_true(tmp_path):
+    m = tmp_path / "metrics.jsonl"; _write_jsonl(m, [TASK_OK])
+    meta = {"run_id": 10, "bench": "tau2", "conclusion": "success", "date": "d"}
+    rec = record.build_record(m, meta, has_ui=True)
+    assert rec["has_ui"] is True
+
+
+def test_build_has_ui_defaults_false(tmp_path):
+    m = tmp_path / "metrics.jsonl"; _write_jsonl(m, [TASK_OK])
+    meta = {"run_id": 11, "bench": "tau2", "conclusion": "success", "date": "d"}
+    rec = record.build_record(m, meta)
+    assert rec["has_ui"] is False
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd ci/benchmarks/lib && python3 -m pytest test_record.py -k has_ui -v`
+Expected: FAIL — `KeyError: 'has_ui'` (the field doesn't exist yet) or `TypeError: build_record() got an unexpected keyword argument 'has_ui'`.
+
+- [ ] **Step 3: Implement `has_ui` in `build_record`**
+
+In `ci/benchmarks/lib/record.py`, change the `build_record` signature and body (line 53-71):
+
+```python
+def build_record(
+    metrics_jsonl: Path,
+    runmeta: dict,
+    steps_jsonl: Path | None = None,
+    has_ui: bool = False,
+) -> dict:
+    tasks: list[dict] = []
+    if metrics_jsonl.exists():
+        for line in metrics_jsonl.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line:
+                tasks.append(json.loads(line))
+    steps: list[dict] = []
+    if steps_jsonl and steps_jsonl.exists():
+        for line in steps_jsonl.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line:
+                steps.append(json.loads(line))
+    rec = dict(runmeta)
+    rec["schema"] = SCHEMA
+    rec["tasks"] = tasks
+    rec["steps"] = steps
+    rec["suite"] = rollup(tasks, steps) if runmeta.get("conclusion") == "success" else None
+    rec["has_ui"] = has_ui
+    return rec
+```
+
+- [ ] **Step 4: Add the `--has-ui` CLI flag**
+
+In `ci/benchmarks/lib/record.py`, in `main()` (line 81-98), add the flag to the `build` subparser and pass it through:
+
+```python
+    b = sub.add_parser("build")
+    b.add_argument("metrics")
+    b.add_argument("--runmeta", required=True)
+    b.add_argument("--steps", default=None)
+    b.add_argument("--has-ui", action="store_true")
+```
+
+and change the `build` branch's call:
+
+```python
+    if ns.cmd == "build":
+        runmeta = json.loads(Path(ns.runmeta).read_text(encoding="utf-8"))
+        steps_path = Path(ns.steps) if ns.steps else None
+        print(json.dumps(build_record(Path(ns.metrics), runmeta, steps_path, has_ui=ns.has_ui)))
+        return 0
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd ci/benchmarks/lib && python3 -m pytest test_record.py -v`
+Expected: all tests PASS, including the 2 new ones and all pre-existing ones (`test_build_success` etc. — confirm the new optional `has_ui` param with a default doesn't break any 3-positional-arg call site).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ci/benchmarks/lib/record.py ci/benchmarks/lib/test_record.py
+git commit -m "feat(bench): add has_ui field to benchmark-history records"
+```
+
+---
+
+### Task 2: `benchmarks.yml` — export the CapEvolve UI snapshot in the `bench` job
+
+**Files:**
+- Modify: `.github/workflows/benchmarks.yml:213-216` (insert a new step between "Run suite" and "Write run metadata")
+
+**Interfaces:**
+- Consumes: `export_static.py`'s existing CLI (`--base`, `--run-id`, `--out`) — unmodified. `$CAPEVOLVE_PY` env var, already exported to `$GITHUB_ENV` by `ci_setup.sh`.
+- Produces: `ci/benchmarks/.work/suite_<tier>_<bench>/ui/data/*.json` inside the job's existing `out` dir — rides along in the artifact `actions/upload-artifact@v4` already uploads (path `ci/benchmarks/.work/suite_${{ matrix.tier }}_${{ matrix.bench }}/**`, unchanged). Task 3 (`aggregate` job) looks for a `ui/data/` subdirectory inside each downloaded artifact.
+
+- [ ] **Step 1: Insert the export step**
+
+In `.github/workflows/benchmarks.yml`, insert this new step immediately after the "Run suite" step (line 215) and before "Write run metadata" (line 217):
+
+```yaml
+      - name: Export CapEvolve UI snapshot
+        if: steps.gate.outputs.run == 'true' && always()
+        run: |
+          run_dir="$GITHUB_WORKSPACE/ci/benchmarks/.work/suite_${{ matrix.tier }}_${{ matrix.bench }}_proj/.capevolve/run_suite"
+          out="$GITHUB_WORKSPACE/ci/benchmarks/.work/suite_${{ matrix.tier }}_${{ matrix.bench }}"
+          if [ -f "$run_dir/events.jsonl" ]; then
+            PYTHONPATH="$GITHUB_WORKSPACE/dashboard/backend" "$CAPEVOLVE_PY" -m capevolve_dashboard.export_static \
+              --base "$(dirname "$run_dir")" --run-id run_suite --out "$out/ui/data" \
+              || echo "::warning::UI export failed for ${{ matrix.tier }}/${{ matrix.bench }} (best-effort, continuing)"
+          else
+            echo "no run dir at $run_dir (job likely failed/cancelled before producing one) — skipping UI export"
+          fi
+```
+
+- [ ] **Step 2: Validate YAML syntax**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/benchmarks.yml')); print('ok')"`
+Expected: `ok` (no `yaml.scanner.ScannerError`/`yaml.parser.ParserError`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/benchmarks.yml
+git commit -m "feat(bench): export CapEvolve UI snapshot in the bench job"
+```
+
+---
+
+### Task 3: `benchmarks.yml` — assemble UI snapshots + `has_ui` in the `aggregate` job
+
+**Files:**
+- Modify: `.github/workflows/benchmarks.yml:279-343` (whole `aggregate` job)
+
+**Interfaces:**
+- Consumes: `record.py build --has-ui` (Task 1). Each artifact's optional `ui/data/` dir (Task 2). `dashboard/frontend`'s existing `npm ci` / `VITE_STATIC=1 npx vite build` convention (mirrors `.github/workflows/ci.yml`'s `build-dashboard` job).
+- Produces: `_hist/runs/<run_id>__<tier>-<bench>/ui/` pushed to `benchmark-history` alongside `records/`. `concurrency: group: benchmark-history-write` — Task 4's prune workflow uses the same group name so the two never race.
+
+- [ ] **Step 1: Replace the `aggregate` job**
+
+In `.github/workflows/benchmarks.yml`, replace the entire `aggregate` job (lines 279-343) with:
+
+```yaml
+  aggregate:
+    name: aggregate history
+    needs: [bench]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    concurrency:
+      group: benchmark-history-write
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4              # for ci/benchmarks/lib/record.py
+
+      - name: Download all benchmark artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: _artifacts
+          pattern: benchmarks-*
+
+      - name: Check for UI snapshots
+        id: uicheck
+        run: |
+          if find _artifacts -type d -path '*/ui/data' 2>/dev/null | grep -q .; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Node.js 22
+        if: steps.uicheck.outputs.found == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Build static dashboard shell
+        if: steps.uicheck.outputs.found == 'true'
+        working-directory: dashboard/frontend
+        run: |
+          npm ci
+          VITE_STATIC=1 npx vite build --outDir "$RUNNER_TEMP/ui_shell"
+
+      - name: Build records + assemble UI snapshots
+        run: |
+          # upload-artifact stores files flat at the artifact root (the least-common-ancestor
+          # of ci/benchmarks/.work/suite_<tier>_<bench>/** is that dir), so runmeta.json/
+          # metrics.jsonl/ui/ live directly under _artifacts/benchmarks-<tier>-<bench>/. The dir
+          # suffix is the <tier>-<bench> slug — use it verbatim to keep record files unique
+          # per (run, tier, bench) so smoke and full of the same bench never collide.
+          mkdir -p _new_records _hist_runs
+          have=0; built=0
+          for d in _artifacts/benchmarks-*; do
+            [ -d "$d" ] || continue
+            slug="$(basename "$d" | sed 's/^benchmarks-//')"   # e.g. smoke-tau2 / full-tau2
+            rm="$d/runmeta.json"; metrics="$d/metrics.jsonl"; steps="$d/steps.jsonl"
+            [ -f "$rm" ] || { echo "::warning::no runmeta for $slug, skipping"; continue; }
+            have=$((have+1))
+            rid="$(python3 -c "import json;print(json.load(open('$rm'))['run_id'])")"
+            has_ui_flag=""
+            if [ -d "$d/ui/data" ] && [ -n "$(ls -A "$d/ui/data" 2>/dev/null)" ]; then
+              dest="_hist_runs/${rid}__${slug}/ui"
+              mkdir -p "$dest"
+              cp -R "$RUNNER_TEMP/ui_shell/." "$dest/"
+              cp -R "$d/ui/data" "$dest/data"
+              has_ui_flag="--has-ui"
+            fi
+            python3 ci/benchmarks/lib/record.py build "$metrics" --runmeta "$rm" --steps "$steps" $has_ui_flag \
+              > "_new_records/${rid}__${slug}.json" && built=$((built+1))
+            echo "built _new_records/${rid}__${slug}.json"
+          done
+          ls -la _new_records || true
+          # Guard: if artifacts with runmeta exist but produced no records, fail loudly
+          # instead of silently exiting 0 (which previously masked a path bug).
+          if [ "$have" -gt 0 ] && [ "$built" -lt "$have" ]; then
+            echo "::error::found $have runmeta artifact(s) but built only $built record(s)"; exit 1
+          fi
+
+      - name: Push to benchmark-history (single writer, with rebase-retry)
+        run: |
+          [ -n "$(ls -A _new_records 2>/dev/null)" ] || { echo "no records to push"; exit 0; }
+          git config --global user.name "skillberry-bot"
+          git config --global user.email "actions@github.com"
+          for attempt in 1 2 3 4 5; do
+            rm -rf _hist
+            git clone --depth 1 --branch benchmark-history \
+              "https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git" _hist || {
+                echo "branch missing — bootstrap it per ci/benchmarks/README.md"; exit 1; }
+            mkdir -p _hist/records
+            cp _new_records/*.json _hist/records/
+            if [ -d _hist_runs ] && [ -n "$(ls -A _hist_runs 2>/dev/null)" ]; then
+              mkdir -p _hist/runs
+              cp -R _hist_runs/. _hist/runs/
+            fi
+            python3 ci/benchmarks/lib/record.py aggregate _hist/records \
+              --now "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --out _hist
+            cd _hist
+            git add records benchmarks.json meta.json
+            [ -d runs ] && git add runs
+            git commit -m "bench: record run ${{ github.run_id }}" || { echo "nothing to commit"; exit 0; }
+            if git push origin benchmark-history; then echo "pushed"; exit 0; fi
+            echo "push race, retrying ($attempt)"; cd ..; sleep 3
+          done
+          echo "failed to push after retries"; exit 1
+```
+
+- [ ] **Step 2: Validate YAML syntax**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/benchmarks.yml')); print('ok')"`
+Expected: `ok`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/benchmarks.yml
+git commit -m "feat(bench): assemble UI snapshots and stamp has_ui in the aggregate job"
+```
+
+---
+
+### Task 4: New manual prune workflow — `.github/workflows/benchmark-history-prune.yml`
+
+**Files:**
+- Create: `.github/workflows/benchmark-history-prune.yml`
+
+**Interfaces:**
+- Consumes: `ci/benchmarks/lib/record.py aggregate` (unchanged CLI). Same `benchmark-history-write` concurrency group as Task 3, so this and the `aggregate` job never race.
+
+- [ ] **Step 1: Create the workflow file**
+
+```yaml
+name: Prune benchmark-history
+
+# Manual-only deletion. benchmark-history keeps every record + UI snapshot
+# forever by default (see docs/superpowers/specs/2026-07-29-persist-capevolve-ui-ci-benchmarks-design.md).
+# Run this on demand to delete anything older than N days once the branch grows too large.
+# Note: this deletes files in a new commit — it does not rewrite git history, so it
+# does not reclaim .git object storage. It only changes what benchmark-history currently
+# serves (records/, runs/, benchmarks.json, meta.json).
+
+on:
+  workflow_dispatch:
+    inputs:
+      days:
+        description: "Delete records (and their UI snapshots) older than this many days"
+        type: string
+        default: "30"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: benchmark-history-write
+  cancel-in-progress: false
+
+jobs:
+  prune:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4              # for ci/benchmarks/lib/record.py
+
+      - name: Prune records + UI snapshots older than cutoff
+        env:
+          DAYS: ${{ github.event.inputs.days || '30' }}
+        run: |
+          git config --global user.name "skillberry-bot"
+          git config --global user.email "actions@github.com"
+          for attempt in 1 2 3 4 5; do
+            rm -rf _hist
+            git clone --depth 1 --branch benchmark-history \
+              "https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git" _hist || {
+                echo "branch missing — bootstrap it per ci/benchmarks/README.md"; exit 1; }
+            cutoff="$(date -u -d "-${DAYS} days" +%Y-%m-%dT%H:%M:%SZ)"
+            echo "pruning records older than $cutoff"
+            deleted=0
+            for f in _hist/records/*.json; do
+              [ -f "$f" ] || continue
+              date_val="$(python3 -c "import json;print(json.load(open('$f')).get('date',''))")"
+              if [[ -n "$date_val" && "$date_val" < "$cutoff" ]]; then
+                slug="$(basename "$f" .json)"
+                echo "deleting $slug (date=$date_val)"
+                rm -f "$f"
+                rm -rf "_hist/runs/$slug"
+                deleted=$((deleted+1))
+              fi
+            done
+            echo "deleted $deleted record(s)"
+            echo "### Prune summary" >> "$GITHUB_STEP_SUMMARY"
+            echo "cutoff: $cutoff (older than ${DAYS}d) — deleted $deleted record(s)" >> "$GITHUB_STEP_SUMMARY"
+            python3 ci/benchmarks/lib/record.py aggregate _hist/records \
+              --now "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --out _hist
+            cd _hist
+            git add records benchmarks.json meta.json
+            [ -d runs ] && git add runs
+            git commit -m "bench: prune records older than ${DAYS}d ($deleted deleted)" || { echo "nothing to commit"; exit 0; }
+            if git push origin benchmark-history; then echo "pushed"; exit 0; fi
+            echo "push race, retrying ($attempt)"; cd ..; sleep 3
+          done
+          echo "failed to push after retries"; exit 1
+```
+
+- [ ] **Step 2: Validate YAML syntax**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/benchmark-history-prune.yml')); print('ok')"`
+Expected: `ok`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/benchmark-history-prune.yml
+git commit -m "feat(bench): add manual workflow to prune old benchmark-history records+UI"
+```
+
+---
+
+### Task 5: `pages.yml` — fold `benchmark-history`'s `runs/` into the Pages deploy
+
+**Files:**
+- Modify: `.github/workflows/pages.yml` (whole file)
+
+**Interfaces:**
+- Consumes: `benchmark-history`'s `runs/**` (public, unauthenticated clone — same branch the `RAW` fetch in `benchmarks.js` already reads).
+- Produces: deployed Pages tree gains `benchmark-ui/runs/<run_id>__<tier>-<bench>/ui/index.html` — the exact path Task 6's "Open UI" link points to.
+
+- [ ] **Step 1: Replace the whole file**
+
+```yaml
+name: Deploy GitHub Pages
+
+# Publish the cap-evolve site from site/ to GitHub Pages.
+#
+# Triggers:
+#   - push to main that touches site/ or this workflow → auto-deploy
+#   - manual dispatch → deploy on demand
+#   - the Benchmarks workflow completing → redeploy so a new run's CapEvolve UI
+#     snapshot (benchmark-history's runs/**) becomes browsable
+#
+# What it does: uploads site/ (plus benchmark-history's runs/** folded in under
+# site/benchmark-ui/runs/**) as the Pages artifact and hands it to the official
+# Pages deploy action. No build step for site/ itself (static HTML/CSS/PNG only).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "site/**"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+  workflow_run:
+    workflows: ["Benchmarks"]
+    types: [completed]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Only one Pages deployment at a time; cancel any in-progress deploy when a
+# newer commit lands.
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # Explicit ref: main — workflow_run's default checkout otherwise resolves to
+      # the SHA of the triggering Benchmarks run, which can be a PR branch. Pages
+      # must always deploy main's site/, regardless of what triggered this build.
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Verify site/ exists
+        run: |
+          test -d site || { echo "no site/ directory"; exit 1; }
+          test -f site/index.html || { echo "no site/index.html"; exit 1; }
+          ls -la site/
+
+      - name: Fold in benchmark-history UI snapshots
+        run: |
+          rm -rf _bench_history
+          git clone --depth 1 --branch benchmark-history \
+            "https://github.com/${{ github.repository }}.git" _bench_history || {
+              echo "benchmark-history branch not found — deploying without UI snapshots"; exit 0; }
+          mkdir -p site/benchmark-ui
+          if [ -d _bench_history/runs ]; then
+            cp -R _bench_history/runs site/benchmark-ui/runs
+          fi
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site/
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+```
+
+- [ ] **Step 2: Validate YAML syntax**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/pages.yml')); print('ok')"`
+Expected: `ok`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/pages.yml
+git commit -m "feat(pages): redeploy on Benchmarks completion and fold in benchmark-history UI snapshots"
+```
+
+---
+
+### Task 6: `benchmarks.html` / `benchmarks.js` / fixture — the "Open UI" link
+
+**Files:**
+- Modify: `site/benchmarks.html:102-119` (table header), `site/benchmarks.html:145` (cache-bust version)
+- Modify: `site/benchmarks.js:91-122` (`render()`)
+- Modify: `site/benchmarks.fixture.json:2-43` (first example record)
+
+**Interfaces:**
+- Consumes: `r.has_ui` (bool, Task 1/3), `r.run_id`, `r.tier`, `r.bench` — all already present on every record.
+- Produces: an `<a>` link to `./benchmark-ui/runs/<run_id>__<tier>-<bench>/ui/index.html#/runs/run_suite`, matching the path Task 5 assembles.
+
+- [ ] **Step 1: Add the "UI" column header**
+
+In `site/benchmarks.html`, in the `<thead><tr>` block (lines 103-117), add a new `<th>` right after the `conclusion` column:
+
+```html
+      <th data-k="conclusion">Result</th>
+      <th>UI</th>
+    </tr></thead>
+```
+
+(replacing the existing `<th data-k="conclusion">Result</th>\n    </tr></thead>` at lines 116-117).
+
+- [ ] **Step 2: Bump the script cache-bust version**
+
+In `site/benchmarks.html` line 145, change:
+
+```html
+<script src="benchmarks.js?v=20260728a"></script>
+```
+
+to:
+
+```html
+<script src="benchmarks.js?v=20260729a"></script>
+```
+
+- [ ] **Step 3: Render the "Open UI" link in `render()`**
+
+In `site/benchmarks.js`, in the per-row loop (lines 91-122), add a computed `ui` variable alongside the other computed cell values (after the `latency` line, before `src`):
+
+```javascript
+    const ui = r.has_ui
+      ? `<a href="./benchmark-ui/runs/${encodeURIComponent(r.run_id)}__${esc(r.tier || "smoke")}-${encodeURIComponent(r.bench)}/ui/index.html#/runs/run_suite" target="_blank" rel="noopener">Open UI</a>`
+      : `<span class="muted">—</span>`;
+```
+
+then append a `<td>${ui}</td>` cell to `tr.innerHTML` right after the `<td>${badge}</td>` cell (line 110):
+
+```javascript
+    tr.innerHTML = `<td><a href="${esc(r.run_url)}">${date}</a></td>
+      <td>${src}</td><td>${esc(r.bench)}</td><td>${tier}</td><td>${r.iterations ?? "—"}</td>
+      <td>${r.trials ?? "—"}</td>
+      <td>${reward}</td><td>${evalUsd}</td><td>${optUsd}</td><td>${latency}</td>
+      <td><code>${esc(r.agent_model || "—")}</code></td><td><code>${esc(r.optimizer_model || "—")}</code></td>
+      <td>${badge}</td><td>${ui}</td>`;
+```
+
+and bump the detail row's `colspan` from `13` to `14` (line 116):
+
+```javascript
+    detail.innerHTML = `<td colspan="14">${taskTable(r.tasks || [])}${stepsTable(r.steps || [])}</td>`;
+```
+
+- [ ] **Step 4: Add a `has_ui` example to the fixture**
+
+In `site/benchmarks.fixture.json`, add `"has_ui": true,` to the first record (run_id 123) right after its `"conclusion": "success",` line (line 18):
+
+```json
+    "conclusion": "success",
+    "has_ui": true,
+```
+
+- [ ] **Step 5: Manually verify rendering**
+
+Run: `cd site && python3 -m http.server 8123` then open `http://localhost:8123/benchmarks.html` in a browser. Since the page fetches the live `benchmark-history` branch (not the fixture) by default, temporarily point `RAW` in `benchmarks.js` at the fixture to check rendering — or simply eyeball the table: confirm a new "UI" column header renders, and that expanding a row (click) still shows the correct detail table without a layout break (colspan mismatch would show a jagged detail row). Revert any temporary `RAW` edit before committing.
+Expected: table renders with the new "UI" column; rows with `has_ui: true` show an "Open UI" link, others show "—"; detail rows span the full width cleanly.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add site/benchmarks.html site/benchmarks.js site/benchmarks.fixture.json
+git commit -m "feat(site): render Open UI link on benchmark-history rows with has_ui"
+```
+
+---
+
+### Task 7: Document the new pieces in `ci/benchmarks/README.md`
+
+**Files:**
+- Modify: `ci/benchmarks/README.md:146-161` ("Benchmark history page" section)
+
+**Interfaces:** None (documentation only).
+
+- [ ] **Step 1: Extend the "Benchmark history page" section**
+
+In `ci/benchmarks/README.md`, replace the "Benchmark history page" section (lines 146-161) with:
+
+```markdown
+## Benchmark history page
+
+Every run appends a per-`(run×bench)` record to the **`benchmark-history`** orphan branch
+(`records/<run_id>__<tier>-<bench>.json`) and regenerates `benchmarks.json` + `meta.json` there
+(single-writer `aggregate` job → no races). The Pages page `site/benchmarks.html` fetches
+`benchmarks.json` at load and renders a sortable/filterable table (rollup rows expand to
+per-task detail). Bootstrap the branch once:
+
+```bash
+git switch --orphan benchmark-history
+mkdir -p records && : > records/.gitkeep
+echo '[]' > benchmarks.json
+echo '{"count":0,"runs":0,"updated":null}' > meta.json
+git add records/.gitkeep benchmarks.json meta.json
+git commit -m "chore: init benchmark-history branch" && git push origin benchmark-history
+```
+
+### Per-run CapEvolve UI snapshots
+
+Each `bench` job also best-effort-exports its raw `.capevolve` run directory as a static
+CapEvolve dashboard snapshot (`export_static.py` + a `VITE_STATIC=1` Vite build), assembled
+by the `aggregate` job into `runs/<run_id>__<tier>-<bench>/ui/` on `benchmark-history`
+alongside its record, which gets `"has_ui": true`. `pages.yml` redeploys on every Benchmarks
+completion and folds `benchmark-history`'s `runs/**` into the deployed site under
+`benchmark-ui/runs/**`, so `benchmarks.html` can link "Open UI" straight to a specific run's
+dashboard. Records/snapshots are **kept forever by default** — there is no automatic expiry.
+
+To reclaim space, run **Actions → "Prune benchmark-history" → Run workflow** with a `days`
+input (default `30`) — it deletes any record (and its paired UI snapshot) older than that
+many days, directly on `benchmark-history`. This only removes files from the branch's current
+tree; it does not rewrite git history, so it doesn't reclaim `.git` object storage — that's
+an accepted tradeoff for keeping "keep forever unless a human explicitly prunes" simple.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add ci/benchmarks/README.md
+git commit -m "docs(bench): document per-run UI snapshots and the manual prune workflow"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Data model (`has_ui` field, `runs/<slug>/ui/`) — Task 1, 3. ✅
+- Bench-job export step, best-effort/`always()` — Task 2. ✅
+- Aggregate-job shell build + assemble + push, `concurrency` group — Task 3. ✅
+- Manual prune workflow (`days` input, default 30, deletes records+runs, same concurrency group) — Task 4. ✅
+- `pages.yml` `workflow_run` trigger + combined artifact — Task 5. ✅
+- `benchmarks.html`/`benchmarks.js` "Open UI" link — Task 6. ✅
+- Testing section: `record.py` unit tests (Task 1), fixture + manual render check (Task 6). The design doc's suggestion to exercise `export_static.py` via a real smoke-tier CI run and to dry-run the prune workflow against a scratch branch are operational verifications to perform after this PR merges and runs once in CI — not unit-testable inline; noted here rather than fabricated as a task.
+
+**Placeholder scan:** No TBD/TODO; every step has literal file content, exact paths, and runnable commands.
+
+**Type/signature consistency:** `build_record(..., has_ui: bool = False)` (Task 1) is called identically in Task 3's `record.py build ... $has_ui_flag` (CLI, not the Python function) and in Task 1's own tests — consistent. `r.has_ui` (JS, Task 6) matches the JSON key `has_ui` set by Task 1/3. The UI path `runs/<run_id>__<tier>-<bench>/ui/` is identical across Task 3 (`_hist_runs/${rid}__${slug}/ui`, where `slug = <tier>-<bench>`) and Task 6's link construction — verified the slug order matches (`basename` strips the `benchmarks-` prefix from an artifact named `benchmarks-<tier>-<bench>`, leaving `<tier>-<bench>`).

--- a/docs/superpowers/specs/2026-07-29-persist-capevolve-ui-ci-benchmarks-design.md
+++ b/docs/superpowers/specs/2026-07-29-persist-capevolve-ui-ci-benchmarks-design.md
@@ -1,0 +1,156 @@
+# Persist the CapEvolve UI for CI benchmark runs — Design
+
+**Date:** 2026-07-29
+**Status:** Approved design, pre-implementation
+
+## Problem
+
+`ci/benchmarks` (`.github/workflows/benchmarks.yml`) runs each benchmark/tier as a matrix job on
+a self-hosted runner, producing a real CapEvolve run directory (`.capevolve/run_suite/` —
+`events.jsonl`, `candidates/`, embedded git history, etc.). Today that run directory is
+ephemeral: only the reduced `metrics.jsonl` / `report.md` / `runmeta.json` are uploaded as a GH
+Actions artifact, and the raw run directory (everything the CapEvolve dashboard needs) is
+discarded when the job ends. There is no way to open the dashboard for a specific CI run after
+the fact — from the public benchmark history page
+(`https://skillberry-ai.github.io/cap-evolve/benchmarks.html`) or otherwise.
+
+## Goal
+
+When a CI benchmark job completes (or is cancelled), persist a browsable snapshot of the
+CapEvolve dashboard for that specific run, and link to it from `benchmarks.html`.
+
+## Non-goals
+
+- No changes to the live dashboard (`dashboard/`) itself beyond what already exists
+  (`VITE_STATIC=1` build + `export_static.py` — both already shipped and demonstrated in
+  `examples/tau2_airline/run_full/ui/`).
+- No automatic retention/expiry. Snapshots are kept forever by default, matching
+  `benchmark-history`'s existing "keep all" philosophy for records.
+- No new server, database, or hosting provider — everything goes through the existing
+  `benchmark-history` orphan branch and the existing GitHub Pages deployment.
+
+## Design
+
+### Data model — extend `benchmark-history`, don't add a new branch
+
+Everything lives on the existing `benchmark-history` orphan branch, kept forever by default
+(same as records today):
+
+- `records/<run_id>__<tier>-<bench>.json` — unchanged, **plus a new `has_ui: bool` field** set
+  at build time, so consumers know whether a snapshot exists without a separate manifest file.
+- **New:** `runs/<run_id>__<tier>-<bench>/ui/` — a self-contained static CapEvolve dashboard
+  export (shared Vite shell + that run's `data/*.json`), using the exact same slug as its record.
+
+Kept-forever by default is a deliberate choice: it matches how `records/` already behaves, and
+it avoids the complexity of squashing branch history (deleting a file in a new commit does not
+reclaim the blob from git history, so any automatic pruning would need periodic history rewrites
+to actually bound repo size — out of scope here; see "Manual pruning workflow" below instead).
+
+### 1. Per-matrix `bench` job (self-hosted runner) — export the run
+
+After `run_suite.sh` produces `<proj>/.capevolve/run_suite/`, add one best-effort step
+(`if: always()`, so it still attempts to run when the job is cancelled) that runs:
+
+```bash
+python -m capevolve_dashboard.export_static \
+  --base "<proj>/.capevolve" --run-id run_suite --out "$out_dir/ui/data"
+```
+
+guarded by a check that the run directory actually exists (a job that fails before producing any
+run dir has nothing to export — skip silently, don't fail the job). This writes into the job's
+*existing* `out_dir`, so it rides along in the artifact `actions/upload-artifact@v4` already
+uploads — no new artifact is created.
+
+Caveat: GitHub Actions gives a cancelled job only a short grace period before killing the
+runner, so on cancellation this step is best-effort and may not always complete in time. This is
+an accepted limitation, not a bug to fix here.
+
+### 2. `aggregate` job (ubuntu-latest) — build the shell, assemble, push
+
+The existing `aggregate` job (which already downloads artifacts and builds `records/*.json`)
+gains:
+
+1. **Build the static frontend shell once per aggregate run** (Node 22, mirroring `ci.yml`'s
+   `actions/setup-node@v4` usage):
+   ```bash
+   cd dashboard/frontend && npm ci && VITE_STATIC=1 npx vite build --outDir "$RUNNER_TEMP/ui_shell"
+   ```
+   Vite's content-hashed filenames mean an unchanged frontend produces byte-identical output
+   across runs, so this doesn't bloat the branch — git already dedupes identical blobs.
+2. **Assemble each run's snapshot**: for every downloaded artifact that has a `ui/data/`
+   directory, copy `$RUNNER_TEMP/ui_shell/*` + that artifact's `ui/data/` into
+   `_hist/runs/<run_id>__<tier>-<bench>/ui/`.
+3. **Set `has_ui: true`** on the corresponding record when its snapshot was assembled (`false`,
+   or omitted, otherwise — e.g. historical records that predate this feature, or a job whose
+   export step didn't run/failed).
+4. **Push to `benchmark-history`** using the existing rebase-retry loop, unchanged — this stays
+   an append-only branch; no squashing.
+
+Add a `concurrency: group: benchmark-history-write` to the `aggregate` job (and to the manual
+prune workflow below) so the two can never race writing to the same branch.
+
+### 3. Manual prune workflow (new) — `.github/workflows/benchmark-history-prune.yml`
+
+Since there's no automatic retention, a maintainer needs a deliberate way to reclaim space:
+
+- Trigger: `workflow_dispatch` only, with input `days` (string, default `"30"`).
+- `runs-on: ubuntu-latest`, `permissions: contents: write`, same `concurrency` group as above.
+- Clones `benchmark-history`, computes a cutoff (`now - days`), and for every
+  `records/<slug>.json` whose `date` is older than the cutoff: deletes the record file **and**
+  its `runs/<slug>/ui/` directory (if present).
+- Regenerates `benchmarks.json` / `meta.json` via the existing `record.py aggregate`, commits
+  (message includes the cutoff and count deleted), and pushes with the same rebase-retry pattern
+  used elsewhere.
+- Logs what it deleted (slugs + dates) in the job summary so the action is auditable.
+- This only removes files from the current tree (simple deletion commit) — it does not rewrite
+  history to reclaim git object storage. That's an accepted limitation matching the "no
+  automatic retention" decision; the point of this workflow is maintainer control over what's
+  currently served, not minimizing `.git` size.
+
+### 4. `pages.yml` — fold `benchmark-history`'s `runs/` into the Pages deploy
+
+Unlike `benchmarks.json`/`meta.json` (fetched client-side at runtime, no redeploy needed), the
+dashboard's `index.html`/JS must be served through GitHub Pages itself (raw.githubusercontent.com
+serves `.html` as `text/plain`, which browsers won't render). So a Pages redeploy is required
+whenever a new run's snapshot should become browsable.
+
+- Add a `workflow_run: workflows: ["Benchmarks"], types: [completed]` trigger (in addition to the
+  existing push-to-`main`-touching-`site/**` and `workflow_dispatch` triggers).
+- The build job additionally checks out `benchmark-history` and copies its `runs/**` into the
+  assembled artifact tree, alongside `site/**`, so the final deployed layout is:
+  ```
+  <pages-root>/                (from site/**)
+  <pages-root>/benchmark-ui/runs/<slug>/ui/...   (from benchmark-history's runs/**)
+  ```
+- `upload-pages-artifact` uploads this combined tree; `deploy-pages` is otherwise unchanged.
+- The existing `concurrency: group: "pages", cancel-in-progress: true` already serializes
+  deploys, so an extra trigger source doesn't introduce new races.
+
+### 5. `benchmarks.html` / `benchmarks.js` — the "Open UI" link
+
+For every row whose record has `has_ui: true`, render an "Open UI" link/button pointing to:
+
+```
+./benchmark-ui/runs/<run_id>__<tier>-<bench>/ui/index.html#/runs/run_suite
+```
+
+(relative to the deployed Pages root, matching the path `pages.yml` assembles above). Rows
+without `has_ui` (older records, or jobs where export failed/was skipped) simply show no link —
+no broken-link handling needed since the field is authoritative at write time.
+
+## Testing
+
+- `record.py`: unit-test that `build` sets `has_ui` correctly (true when a matching `ui/data/`
+  input is present, false/absent otherwise), and that `aggregate` passes `has_ui` through
+  unchanged into `benchmarks.json`.
+- `export_static.py` invocation in the `bench` job: exercise via the existing smoke-tier
+  benchmark run (cheap, already part of normal CI usage) rather than a new dedicated test —
+  confirm `ui/data/*.json` appears in the uploaded artifact and the assembled `runs/<slug>/ui/`
+  renders correctly when opened locally.
+- `benchmarks.js`: extend `site/benchmarks.fixture.json` with a `has_ui: true` example row and
+  confirm the "Open UI" link renders with the expected href.
+- New prune workflow: dry-run against a scratch copy of `benchmark-history` (or a throwaway test
+  branch) before relying on it against the real branch; verify it deletes only records older
+  than the cutoff and correctly removes their paired `runs/` directories.
+- `pages.yml`: verify via `workflow_dispatch` that the combined artifact tree contains both
+  `site/**` and `benchmark-ui/runs/**` before merging.

--- a/site/benchmarks.fixture.json
+++ b/site/benchmarks.fixture.json
@@ -16,6 +16,7 @@
     "agent_model": "aws/gpt-oss-120b",
     "optimizer_model": "claude-opus-4-8",
     "conclusion": "success",
+    "has_ui": true,
     "suite": {
       "reward_base": 0.0,
       "reward_opt": 0.5,

--- a/site/benchmarks.html
+++ b/site/benchmarks.html
@@ -114,6 +114,7 @@
       <th data-k="agent_model">Agent model</th>
       <th data-k="optimizer_model">Optimizer model</th>
       <th data-k="conclusion">Result</th>
+      <th>UI</th>
     </tr></thead>
     <tbody id="rows"></tbody>
   </table>
@@ -142,7 +143,7 @@
   </div>
 </footer>
 
-<script src="benchmarks.js?v=20260728a"></script>
+<script src="benchmarks.js?v=20260729a"></script>
 <script src="js/site.js?v=20260724" defer></script>
 </body>
 </html>

--- a/site/benchmarks.js
+++ b/site/benchmarks.js
@@ -96,6 +96,9 @@ function render() {
     const optUsd = r.suite ? `$${fmt(r.suite.optimizer_usd, 4)}` : "—";
     const latency = r.suite && (r.suite.eval_seconds != null || r.suite.optimizer_seconds != null)
       ? fmtDuration((r.suite.eval_seconds ?? 0) + (r.suite.optimizer_seconds ?? 0)) : "—";
+    const ui = r.has_ui
+      ? `<a href="./benchmark-ui/runs/${encodeURIComponent(r.run_id)}__${esc(r.tier || "smoke")}-${encodeURIComponent(r.bench)}/ui/index.html#/runs/run_suite" target="_blank" rel="noopener">Open UI</a>`
+      : `<span class="muted">—</span>`;
     const src = r.pr
       ? `<a href="https://github.com/skillberry-ai/cap-evolve/pull/${encodeURIComponent(r.pr)}">${esc(r.source)}</a>`
       : esc(r.source || "—");
@@ -107,13 +110,13 @@ function render() {
       <td>${r.trials ?? "—"}</td>
       <td>${reward}</td><td>${evalUsd}</td><td>${optUsd}</td><td>${latency}</td>
       <td><code>${esc(r.agent_model || "—")}</code></td><td><code>${esc(r.optimizer_model || "—")}</code></td>
-      <td>${badge}</td>`;
+      <td>${badge}</td><td>${ui}</td>`;
     tb.appendChild(tr);
 
     const detail = document.createElement("tr");
     detail.className = "detail-row";
     detail.hidden = true;
-    detail.innerHTML = `<td colspan="13">${taskTable(r.tasks || [])}${stepsTable(r.steps || [])}</td>`;
+    detail.innerHTML = `<td colspan="14">${taskTable(r.tasks || [])}${stepsTable(r.steps || [])}</td>`;
     tb.appendChild(detail);
 
     tr.addEventListener("click", (e) => {


### PR DESCRIPTION
## Summary
- Every CI benchmark run (success/failure/cancelled) now best-effort-exports a static CapEvolve dashboard snapshot of its `.capevolve` run directory, which the `aggregate` job assembles onto the `benchmark-history` branch under `runs/<run_id>__<tier>-<bench>/ui/` alongside the existing `records/*.json` (now with a new `has_ui` field).
- `site/benchmarks.html` gains a "UI" column that links to the snapshot ("Open UI") when `has_ui` is true.
- `pages.yml` now also triggers on `Benchmarks` workflow completion and folds `benchmark-history`'s `runs/**` into the deployed site under `benchmark-ui/runs/**`.
- Records and UI snapshots are kept **forever by default** — no automatic expiry. A new manually-triggered workflow (`benchmark-history-prune.yml`, `workflow_dispatch`, `days` input, default 30) lets a maintainer delete records + UI snapshots older than N days on request.
- `aggregate` and the new prune workflow share a `benchmark-history-write` concurrency group so they never race writing to the branch.

## Test plan
- [x] `ci/benchmarks/lib` pytest suite: 11/11 passing, including new `test_build_has_ui_true` / `test_build_has_ui_defaults_false`.
- [x] All three workflow YAMLs (`benchmarks.yml`, `benchmark-history-prune.yml`, `pages.yml`) validated with `yaml.safe_load`.
- [x] `site/benchmarks.js` / `site/benchmarks.fixture.json` validated with `node --check` / JSON parse; "Open UI" link slug format verified to exactly match the server-side `runs/<run_id>__<tier>-<bench>/ui/` path assembled in the `aggregate` job.
- [ ] End-to-end verification on a real CI run (self-hosted `ibm-vpc` runner) — export step, aggregate assembly, Pages fold-in, and the prune workflow haven't been exercised against a live run yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)