### PR TITLE
fix(bench): friendly live-run wait state, rate-limit-safe polling, elapsed timer

### DIFF
--- a/dashboard/frontend/src/lib/api.ts
+++ b/dashboard/frontend/src/lib/api.ts
@@ -64,11 +64,27 @@ export function applyDataBaseOverride(search: string = window.location.search): 
   }
 }
 
+/** True when this page load is viewing a `?dataBase=`-overridden (live) data source,
+ * as opposed to the default bundled static export or the live backend. Callers use this
+ * to distinguish "this run's data just doesn't exist yet" (live, still exporting its
+ * first snapshot) from a genuinely missing/broken run. */
+export function isLiveOverride(): boolean {
+  return Boolean((window as unknown as { __CAPEVOLVE_DATA_BASE__?: string }).__CAPEVOLVE_DATA_BASE__)
+}
+
+/** Thrown by getJSON() for a 404 while `isLiveOverride()` is true — the poller hasn't
+ * pushed this run's first snapshot yet, not a real error. */
+export class LivePendingError extends Error {}
+
 async function getJSON<T>(url: string, signal?: AbortSignal): Promise<T> {
   const target = STATIC_MODE ? `${dataBase()}/${staticSlug(url)}.json` : url
   const res = await fetch(target, { signal })
   if (!res.ok) {
-    throw new Error(`${res.status} ${res.statusText} for ${target}`)
+    const message = `${res.status} ${res.statusText} for ${target}`
+    if (res.status === 404 && isLiveOverride()) {
+      throw new LivePendingError(message)
+    }
+    throw new Error(message)
   }
   return (await res.json()) as T
 }

--- a/dashboard/frontend/src/routes/RunDeepDive.tsx
+++ b/dashboard/frontend/src/routes/RunDeepDive.tsx
@@ -2,7 +2,7 @@ import { useCallback, useRef } from 'react'
 import { Link, useParams } from 'react-router-dom'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { ArrowLeft } from 'lucide-react'
-import { api } from '../lib/api'
+import { api, LivePendingError } from '../lib/api'
 import { useRunStream } from '../lib/useRunStream'
 import { AppShell } from '../components/AppShell'
 import { Card } from '../components/ui/Card'
@@ -43,7 +43,14 @@ export function RunDeepDive() {
     queryKey: ['run', id],
     queryFn: ({ signal }) => api.run(id!, signal),
     enabled: !!id,
+    // A live-view run whose first snapshot hasn't landed yet 404s, not fails: settle
+    // into isError immediately (no retry backoff) so the friendly message below shows
+    // right away, then let refetchInterval poll every 10s until the poller's first
+    // push lands and the fetch succeeds.
+    retry: (failureCount, err) => (err instanceof LivePendingError ? false : failureCount < 3),
+    refetchInterval: (query) => (query.state.error instanceof LivePendingError ? 10_000 : false),
   })
+  const isLivePending = error instanceof LivePendingError
 
   // SSE: on each live event, debounce-refetch the authoritative reduced run.
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -88,7 +95,16 @@ export function RunDeepDive() {
           </div>
         )}
 
-        {isError && (
+        {isError && isLivePending && (
+          <Card className="border-accent/40">
+            <div className="p-4 text-sm text-muted">
+              Hold on — this run just started. Live data will show up here in a few minutes,
+              once the first snapshot is exported.
+            </div>
+          </Card>
+        )}
+
+        {isError && !isLivePending && (
           <Card className="border-rejected/40">
             <div className="p-4 text-sm text-rejected">Couldn’t load run: {(error as Error)?.message}</div>
           </Card>

--- a/dashboard/frontend/src/test/RunDeepDive.test.tsx
+++ b/dashboard/frontend/src/test/RunDeepDive.test.tsx
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { RunDeepDive } from '../routes/RunDeepDive'
+import { LivePendingError } from '../lib/api'
+
+vi.mock('../lib/api', async () => {
+  const actual = await vi.importActual<typeof import('../lib/api')>('../lib/api')
+  return { ...actual, api: { ...actual.api, run: vi.fn() } }
+})
+
+afterEach(() => vi.restoreAllMocks())
+
+function renderRunDeepDive() {
+  const qc = new QueryClient()
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={['/runs/run_suite']}>
+        <Routes>
+          <Route path="/runs/:id" element={<RunDeepDive />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+describe('RunDeepDive error states', () => {
+  it('shows a friendly pending message for a live run with no snapshot yet, instead of a raw 404', async () => {
+    const { api } = await import('../lib/api')
+    vi.mocked(api.run).mockRejectedValue(new LivePendingError('404 Not Found for data/runs_run_suite.json'))
+    renderRunDeepDive()
+    expect(await screen.findByText(/Hold on/)).toBeInTheDocument()
+    expect(screen.queryByText(/Couldn.t load run/)).not.toBeInTheDocument()
+  })
+
+  it(
+    'shows the generic error message for a real (non-live-pending) failure',
+    async () => {
+      const { api } = await import('../lib/api')
+      vi.mocked(api.run).mockRejectedValue(new Error('500 Internal Server Error for /api/runs/run_suite'))
+      renderRunDeepDive()
+      await waitFor(() => expect(screen.getByText(/Couldn.t load run/)).toBeInTheDocument(), { timeout: 10_000 })
+      expect(screen.queryByText(/Hold on/)).not.toBeInTheDocument()
+    },
+    15_000,
+  )
+})

--- a/dashboard/frontend/src/test/data-base.test.ts
+++ b/dashboard/frontend/src/test/data-base.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { applyDataBaseOverride } from '../lib/api'
+import { applyDataBaseOverride, isLiveOverride } from '../lib/api'
 
 type WindowOverride = { __CAPEVOLVE_DATA_BASE__?: string; __CAPEVOLVE_STATIC__?: unknown }
 
@@ -21,6 +21,17 @@ describe('applyDataBaseOverride', () => {
   it('leaves the override unset when there is no dataBase param', () => {
     applyDataBaseOverride('?foo=bar')
     expect((window as unknown as WindowOverride).__CAPEVOLVE_DATA_BASE__).toBeUndefined()
+  })
+})
+
+describe('isLiveOverride', () => {
+  it('is true once a dataBase override is set', () => {
+    applyDataBaseOverride('?dataBase=https%3A%2F%2Fexample.test%2Flive%2Fdata')
+    expect(isLiveOverride()).toBe(true)
+  })
+
+  it('is false with no override set', () => {
+    expect(isLiveOverride()).toBe(false)
   })
 })
 
@@ -62,5 +73,26 @@ describe('getJSON static-mode base', () => {
     const { api } = await import('../lib/api')
     await api.runs()
     expect(calls[0]).toBe('data/runs.json')
+  })
+
+  it('throws LivePendingError (not a plain Error) for a 404 while a dataBase override is set', async () => {
+    (window as unknown as WindowOverride).__CAPEVOLVE_STATIC__ = true
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: false, status: 404, statusText: 'Not Found' }) as Response),
+    )
+    const { api, applyDataBaseOverride: apply, LivePendingError: LivePendingErrorCtor } = await import('../lib/api')
+    apply('?dataBase=https%3A%2F%2Fexample.test%2Flive%2Fdata')
+    await expect(api.run('run_suite')).rejects.toBeInstanceOf(LivePendingErrorCtor)
+  })
+
+  it('throws a plain Error (not LivePendingError) for a 404 with no override set', async () => {
+    (window as unknown as WindowOverride).__CAPEVOLVE_STATIC__ = true
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: false, status: 404, statusText: 'Not Found' }) as Response),
+    )
+    const { api, LivePendingError: LivePendingErrorCtor } = await import('../lib/api')
+    await expect(api.run('run_suite')).rejects.not.toBeInstanceOf(LivePendingErrorCtor)
   })
 })

--- a/site/benchmarks.html
+++ b/site/benchmarks.html
@@ -24,7 +24,7 @@
   <!-- dark-first: default dark, honor an explicit saved choice. Applied pre-paint (no FOUC) + enables JS-gated reveal -->
   <script>(function(){try{document.documentElement.setAttribute('data-theme',localStorage.getItem('capevolve-theme')||'dark');}catch(e){document.documentElement.setAttribute('data-theme','dark');}document.documentElement.classList.add('js');})();</script>
   <!-- bump the ?v=... string on every style.css edit so browsers ignore their cached copy -->
-  <link rel="stylesheet" href="style.css?v=20260729b">
+  <link rel="stylesheet" href="style.css?v=20260729c">
 </head>
 <body>
 
@@ -148,7 +148,7 @@
   </div>
 </footer>
 
-<script src="benchmarks.js?v=20260729b"></script>
+<script src="benchmarks.js?v=20260729c"></script>
 <script src="js/site.js?v=20260724" defer></script>
 </body>
 </html>

--- a/site/benchmarks.js
+++ b/site/benchmarks.js
@@ -14,6 +14,13 @@ const fmtDuration = (v) => {
 };
 const esc = (v) => String(v ?? "").replace(/[&<>"']/g, (c) =>
   ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
+// Elapsed time since a job started, e.g. "3m07s" or "1h05m" (no seconds once past an hour).
+const fmtElapsed = (ms) => {
+  const total = Math.max(0, Math.floor(ms / 1000));
+  const h = Math.floor(total / 3600), m = Math.floor((total % 3600) / 60), s = total % 60;
+  if (h) return `${h}h${String(m).padStart(2, "0")}m`;
+  return m ? `${m}m${String(s).padStart(2, "0")}s` : `${s}s`;
+};
 
 async function loadRunning() {
   const panel = $("#running-now");
@@ -30,7 +37,7 @@ async function loadRunning() {
         if (job.status !== "in_progress") continue;
         const m = JOB_RE.exec(job.name);
         if (!m) continue;
-        items.push({ runId: run.id, tier: m[1], bench: m[2], jobUrl: job.html_url });
+        items.push({ runId: run.id, tier: m[1], bench: m[2], jobUrl: job.html_url, startedAt: job.started_at });
       }
     }
     renderRunning(items);
@@ -51,8 +58,20 @@ function renderRunning(items) {
     const dataBase = encodeURIComponent(`${RAW}/live/${it.runId}__${it.tier}-${it.bench}/data`);
     return `<li><span class="badge badge-accent">live</span>
       <a href="${esc(it.jobUrl)}" target="_blank" rel="noopener">${esc(it.tier)} / ${esc(it.bench)}</a>
+      <span class="elapsed" data-started="${esc(it.startedAt)}"></span>
       — <a href="./dashboard-ui/index.html?dataBase=${dataBase}#/runs/run_suite" target="_blank" rel="noopener">Watch live</a></li>`;
   }).join("");
+  updateElapsed();
+}
+
+// Ticks independently of loadRunning's poll interval so the elapsed time reads smoothly
+// between polls, instead of jumping only when a new snapshot of "in progress" jobs loads.
+function updateElapsed() {
+  document.querySelectorAll("#running-list .elapsed").forEach((el) => {
+    const started = el.dataset.started;
+    if (!started) return;
+    el.textContent = `· ${fmtElapsed(Date.now() - Date.parse(started))}`;
+  });
 }
 
 async function load() {
@@ -210,4 +229,9 @@ $("#f-time").addEventListener("change", () => {
 });
 load();
 loadRunning();
-setInterval(loadRunning, 60000);
+// 5 minutes, matching live_push.sh's own snapshot cadence — polling more often buys
+// nothing (the data can't have changed) and risks exhausting the unauthenticated GitHub
+// API's 60 req/hour rate limit (this call + one /jobs lookup per in-progress run, every
+// poll), which made the panel silently disappear (loadRunning's catch just hides it).
+setInterval(loadRunning, 300000);
+setInterval(updateElapsed, 1000);

--- a/site/style.css
+++ b/site/style.css
@@ -599,6 +599,7 @@ html.js .reveal-3 { transition-delay: 0.16s; }
 
 .running-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.4rem; }
 .running-list li { display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap; }
+.running-list .elapsed { color: var(--muted); font-variant-numeric: tabular-nums; }
 
 .filters { display: flex; flex-wrap: wrap; gap: 1rem; margin: 1.5rem 0; }
 .filters label { display: flex; flex-direction: column; font-size: 0.78rem; color: var(--muted); gap: 0.25rem; }


### PR DESCRIPTION
## Summary

Real-world follow-up to #177: while smoke-testing live benchmark monitoring
end-to-end (`workflow_dispatch` on `benchmarks.yml`, tier=smoke, bench=tau2),
the "Running now" panel on https://skillberry-ai.github.io/cap-evolve/benchmarks.html
silently disappeared mid-run. Root cause and two UX improvements requested
alongside the fix:

- **Rate-limit fix**: `loadRunning()` polled every 60s and issued one
  `/actions/runs/{id}/jobs` lookup per in-progress run on top of the
  `/actions/workflows/.../runs` call — enough volume from a single open tab
  to exceed GitHub's unauthenticated REST API limit (60 req/hour/IP).
  Confirmed via `curl -D -` (`x-ratelimit-remaining: 0`). The panel's
  `catch (e) { panel.hidden = true }` swallowed the failure with no visible
  error. Widened the poll to 5 minutes, matching `live_push.sh`'s own
  snapshot cadence — polling faster than the data can change buys nothing.
- **Friendly pending state instead of a raw 404**: the dashboard-ui SPA
  showed "Couldn't load run: 404 Not Found ..." when a viewer opened a live
  run before its first snapshot landed. Added a `LivePendingError` subclass
  (thrown from `getJSON()` for a 404 specifically while a live `dataBase`
  override is active) so `RunDeepDive` can render "Hold on — this run just
  started, live data will appear here shortly" and auto-recover via a 10s
  refetch once data lands, instead of surfacing the error permanently.
- **Elapsed-time timer**: each row in the "Running now" panel now shows how
  long that job has been running (e.g. "· 3m07s"), ticking every second
  independently of the 5-minute poll.

## Test plan

- [x] `node --check site/benchmarks.js`
- [x] jsdom-driven sanity check of `renderRunning`/`updateElapsed`/`fmtElapsed`
      against the real `benchmarks.html` markup (elapsed text formats
      correctly, ticks on `updateElapsed()`, panel hides on empty items)
- [x] `dashboard/frontend`: `npx vitest run` — 45/45 passing (incl. 2 new
      `RunDeepDive` tests + 2 new `data-base` tests for `LivePendingError`)
- [x] `dashboard/frontend`: `npx tsc -b` clean
- [ ] Manual verification against a real live run (recommended before/after merge, mirroring the #177 smoke test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)