### PR TITLE
docs: per-run detail pages for local baselines + clickable source column

### DIFF
--- a/docs/runs/local-20260729-skillsbench-baseline-gptoss120b.md
+++ b/docs/runs/local-20260729-skillsbench-baseline-gptoss120b.md
@@ -1,0 +1,63 @@
+<!-- Local benchmark run detail page. Linked from https://skillberry-ai.github.io/cap-evolve/benchmarks.html -->
+
+> **Local benchmark run** (recorded on the benchmark-history branch).
+> Ran outside the CI workflow (source: `bcarmeli`); artifacts on the recording host.
+> Benchmark: SkillsBench (all 87 tasks, fit metric — train==val==test); agent under test: aws/gpt-oss-120b.
+
+# Run summary — `run_baseline_gptoss`
+
+- **Benchmark:** `skillsbench`
+- **Agent under test:** `aws/gpt-oss-120b`
+- **Optimizer:** `none`
+- **Tasks / trials:** 87 tasks · 1 trials
+- **Iterations (actual / cap):** 0 / 3
+- **Split discipline:** fit-metric (train==val==test, no holdout)
+- **Best candidate:** `seed`
+
+## Headline
+
+|  | value |
+|---|---|
+| val_reward (mean) | **0.0396 ± 0.0191** (4.0%) |
+| pass_at_1 (fully passing) | **2/87** (2.3%) |
+| test_reward | **0.0396** |
+| test_delta (best - baseline) | 0.0 |
+| val wall-clock | 76m 53s |
+| test wall-clock | 41m 4s |
+| total wall-clock | 118m 5s |
+
+## Rollout breakdown (n = 87)
+
+- Passed (r = 1.0): **2**
+- Partial (0 < r < 1): **4**
+- Errored (infra): **11**
+- Failed (r = 0): **70**
+
+## Passing tasks
+
+- ✓ `3d-scan-calc`
+- ✓ `pddl-tpp-planning`
+
+## Partial credit
+
+| task | reward |
+|---|---|
+| `dialogue-parser` | 0.833 |
+| `lab-unit-harmonization` | 0.312 |
+| `debug-trl-grpo` | 0.250 |
+| `tictoc-unnecessary-abort-detection` | 0.050 |
+
+## Errored tasks (infra, not skill defect)
+
+- ⚠ `earthquake-phase-association`
+- ⚠ `fix-build-agentops`
+- ⚠ `fix-build-google-auto`
+- ⚠ `fix-druid-loophole-cve`
+- ⚠ `flink-query`
+- ⚠ `manufacturing-equipment-maintenance`
+- ⚠ `multilingual-video-dubbing`
+- ⚠ `python-scala-translation`
+- ⚠ `react-performance-debugging`
+- ⚠ `seismic-phase-picking`
+- ⚠ `spring-boot-jakarta-migration`
+

--- a/docs/runs/local-20260729-skillsbench-baseline-opus46.md
+++ b/docs/runs/local-20260729-skillsbench-baseline-opus46.md
@@ -1,0 +1,80 @@
+<!-- Local benchmark run detail page. Linked from https://skillberry-ai.github.io/cap-evolve/benchmarks.html -->
+
+> **Local benchmark run** (recorded on the benchmark-history branch).
+> Ran outside the CI workflow (source: `bcarmeli`); artifacts on the recording host.
+> Benchmark: SkillsBench (all 87 tasks, fit metric — train==val==test); agent under test: claude-opus-4-6.
+
+# Run summary — `run_baseline_opus`
+
+- **Benchmark:** `skillsbench`
+- **Agent under test:** `claude-opus-4-6`
+- **Optimizer:** `none`
+- **Tasks / trials:** 87 tasks · 1 trials
+- **Iterations (actual / cap):** 0 / 3
+- **Split discipline:** fit-metric (train==val==test, no holdout)
+- **Best candidate:** `seed`
+
+## Headline
+
+|  | value |
+|---|---|
+| val_reward (mean) | **0.2809 ± 0.0475** (28.1%) |
+| pass_at_1 (fully passing) | **23/87** (26.4%) |
+| test_reward | **0.2809** |
+| test_delta (best - baseline) | 0.0 |
+| val wall-clock | 106m 59s |
+| test wall-clock | 41m 38s |
+| total wall-clock | 148m 42s |
+
+## Rollout breakdown (n = 87)
+
+- Passed (r = 1.0): **23**
+- Partial (0 < r < 1): **3**
+- Errored (infra): **8**
+- Failed (r = 0): **53**
+
+## Passing tasks
+
+- ✓ `3d-scan-calc`
+- ✓ `adaptive-cruise-control`
+- ✓ `citation-check`
+- ✓ `court-form-filling`
+- ✓ `crystallographic-wyckoff-position-analysis`
+- ✓ `econ-detrending-correlation`
+- ✓ `exam-block-sequencing`
+- ✓ `fix-erlang-ssh-cve`
+- ✓ `glm-lake-mendota`
+- ✓ `gravitational-wave-detection`
+- ✓ `hvac-control`
+- ✓ `lean4-proof`
+- ✓ `mars-clouds-clustering`
+- ✓ `offer-letter-generator`
+- ✓ `parallel-tfidf-search`
+- ✓ `pddl-tpp-planning`
+- ✓ `pdf-excel-diff`
+- ✓ `powerlifting-coef-calc`
+- ✓ `pptx-reference-formatting`
+- ✓ `protein-expression-analysis`
+- ✓ `spring-boot-jakarta-migration`
+- ✓ `threejs-to-obj`
+- ✓ `tictoc-unnecessary-abort-detection`
+
+## Partial credit
+
+| task | reward |
+|---|---|
+| `dialogue-parser` | 0.667 |
+| `lab-unit-harmonization` | 0.521 |
+| `debug-trl-grpo` | 0.250 |
+
+## Errored tasks (infra, not skill defect)
+
+- ⚠ `earthquake-phase-association`
+- ⚠ `energy-ac-optimal-power-flow`
+- ⚠ `fix-druid-loophole-cve`
+- ⚠ `fix-visual-stability`
+- ⚠ `multilingual-video-dubbing`
+- ⚠ `python-scala-translation`
+- ⚠ `quantum-numerical-simulation`
+- ⚠ `seismic-phase-picking`
+

--- a/site/benchmarks.js
+++ b/site/benchmarks.js
@@ -160,9 +160,14 @@ function render() {
     const ui = r.has_ui
       ? `<a href="./benchmark-ui/runs/${encodeURIComponent(r.run_id)}__${esc(r.tier || "smoke")}-${encodeURIComponent(r.bench)}/ui/index.html#/runs/run_suite" target="_blank" rel="noopener">Open UI</a>`
       : `<span class="muted">—</span>`;
+    // Source column: link to the PR when set, else to `summary_url` when set
+    // (per-run detail page for local/manual runs). Backward compatible: records
+    // without `pr` or `summary_url` render as plain text.
     const src = r.pr
       ? `<a href="https://github.com/skillberry-ai/cap-evolve/pull/${encodeURIComponent(r.pr)}">${esc(r.source)}</a>`
-      : esc(r.source || "—");
+      : r.summary_url
+        ? `<a href="${esc(r.summary_url)}" target="_blank" rel="noopener">${esc(r.source || "—")}</a>`
+        : esc(r.source || "—");
     const badge = `<span class="badge ${esc(r.conclusion)}">${esc(r.conclusion)}</span>`;
     const date = esc((r.date || "").replace("T", " ").replace("Z", ""));
     const tier = esc(r.tier || "smoke");


### PR DESCRIPTION
## Summary

Two companion pieces of infra so **local benchmark runs** (recorded on `benchmark-history` with `source: <username>`) can show a **clickable detail page** on [skillberry-ai.github.io/cap-evolve/benchmarks.html](https://skillberry-ai.github.io/cap-evolve/benchmarks.html).

- Two Markdown detail pages under `docs/runs/` — the SkillsBench full-87 baselines I just ran locally (gpt-oss-120b at val=0.040, opus-4-6 at val=0.281). Each page is the SUMMARY.md format used in `docs/RESULTS.md`: headline table, per-task pass/partial/errored lists, split discipline, wall-clock.
- `site/benchmarks.js` gets a **backward-compatible** tweak: if a record has a new optional `summary_url` field, the **source column** links to it. If not, renders as before (plain text for manual runs; PR link when `pr` is set).

Backward compatibility: **all existing records render identically** — the new branch is only taken when `r.summary_url` is truthy, which no existing record has.

Companion PR on `benchmark-history` adds the two record JSONs pointing at these detail pages.

## Test plan

- [ ] Visit https://skillberry-ai.github.io/cap-evolve/benchmarks.html after merge; verify the two new rows show `bcarmeli` as a clickable link that opens the detail page.
- [ ] Verify existing rows still render (PR-source rows still link to their PR; manual rows still plain-text).
- [ ] Confirm the two detail pages render as expected on github.com (`docs/runs/local-*.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
