### PR TITLE
fix(docs): unify adapter contract as 3 required methods + hooks, fix stale implement-and-check signatures

### DIFF
--- a/RUN.md
+++ b/RUN.md
@@ -38,7 +38,7 @@ sends "optimize X" here). It interviews the user, scaffolds `.capevolve/project/
 > Never fabricate a NEEDED input.
 
 ## 2. Implement & check — make the contract real
-Load **`implement-and-check`**. Implement the 4 adapter methods in
+Load **`implement-and-check`**. Implement the 3 required adapter methods in
 `.capevolve/project/adapters/adapter.py` (and any selected skill's `abstract.py`),
 then run each skill's `check.py` and:
 ```

--- a/core/cap_evolve/adapter.py
+++ b/core/cap_evolve/adapter.py
@@ -1,15 +1,28 @@
 """The adapter contract — the small set of methods the OPTIMIZER agent implements.
 
-This is cap-evolve's generalization device (prior agent-optimization work had 3 adapters, SkillOpt had 5;
-we use 4, cleaner). The using-agent implements these once in
-``.capevolve/project/adapters/`` so that *any* target agent, *any* benchmark, and
-*any* capability can be driven by the same pipeline:
+This is cap-evolve's generalization device (prior agent-optimization work had 3 adapters,
+SkillOpt had 5; we require **3**, plus defaulted hooks). The using-agent implements these
+once in ``.capevolve/project/adapters/`` so that *any* target agent, *any* benchmark, and
+*any* capability can be driven by the same pipeline.
+
+**3 required** (``@abstractmethod``; ``cap-evolve check`` refuses to run until all three are real):
 
     tasks(split)                              -> list[Task]   # where eval data comes from
-    run_target(task, ctx, *, seed)            -> Rollout      # run the agent under test
+    run_target(task, ctx, *, seed=0)          -> Rollout      # run the agent under test
     score(task, rollout)                      -> Score        # 0..1 reward + ASI feedback
+
+**Defaulted hooks** (override only when the default does not fit):
+
     materialize(candidate_dir, edits=None)    -> None         # write edits into the dir (pure)
     live(candidate_dir)                       -> ctx (CM)     # make the candidate LIVE for a rollout
+    apply(candidate_dir, edits=None)          -> None         # back-compat inject hook
+
+**Optional** (the harness feature-detects these; absent by default):
+
+    trajectories(split, ctx=None)             -> Path | None  # native trace dir for the optimizer
+    runner_model()                            -> str | None   # consuming model, for check's mismatch note
+    run_batch(tasks, ctx, *, seed)                            # batched eval fast path
+    run_trials(tasks, ctx, *, n_trials, base_seed)            # batched multi-trial fast path
 
 Why ``materialize`` + ``live`` instead of a single ``apply``:
 ``apply(candidate_dir)`` used to be a *global* side effect (e.g. monkeypatching a

--- a/core/cap_evolve/adapter.py
+++ b/core/cap_evolve/adapter.py
@@ -1,9 +1,9 @@
 """The adapter contract — the small set of methods the OPTIMIZER agent implements.
 
-This is cap-evolve's generalization device (prior agent-optimization work had 3 adapters,
-SkillOpt had 5; we require **3**, plus defaulted hooks). The using-agent implements these
-once in ``.capevolve/project/adapters/`` so that *any* target agent, *any* benchmark, and
-*any* capability can be driven by the same pipeline.
+This is cap-evolve's generalization device (prior agent-optimization work had 3 adapter
+*classes*, SkillOpt had 5; we require **3 methods**, plus defaulted hooks). The
+using-agent implements these once in ``.capevolve/project/adapters/`` so that *any*
+target agent, *any* benchmark, and *any* capability can be driven by the same pipeline.
 
 **3 required** (``@abstractmethod``; ``cap-evolve check`` refuses to run until all three are real):
 
@@ -16,13 +16,16 @@ once in ``.capevolve/project/adapters/`` so that *any* target agent, *any* bench
     materialize(candidate_dir, edits=None)    -> None         # write edits into the dir (pure)
     live(candidate_dir)                       -> ctx (CM)     # make the candidate LIVE for a rollout
     apply(candidate_dir, edits=None)          -> None         # back-compat inject hook
+    trajectories(split, ctx=None)             -> Path | None  # native trace dir (default: None)
+    runner_model()                            -> str | None   # consuming model (default: None)
 
-**Optional** (the harness feature-detects these; absent by default):
+**Optional fast paths** — NOT on the base class; the harness feature-detects them with
+``hasattr`` (``harness.py`` ``has_batch``/``has_run_trials``/``has_score_batch``) and only
+uses them when present:
 
-    trajectories(split, ctx=None)             -> Path | None  # native trace dir for the optimizer
-    runner_model()                            -> str | None   # consuming model, for check's mismatch note
     run_batch(tasks, ctx, *, seed)                            # batched eval fast path
     run_trials(tasks, ctx, *, n_trials, base_seed)            # batched multi-trial fast path
+    score_batch(tasks, rollouts)              -> {id: Score}  # batched scoring fast path
 
 Why ``materialize`` + ``live`` instead of a single ``apply``:
 ``apply(candidate_dir)`` used to be a *global* side effect (e.g. monkeypatching a

--- a/docs/ADAPTER_CONTRACT.md
+++ b/docs/ADAPTER_CONTRACT.md
@@ -47,9 +47,10 @@ def materialize(self, candidate_dir, edits=None) -> None   # PURE write of {comp
 def live(self, candidate_dir)                              # @contextmanager: make the candidate live for ONE eval, yield ctx
 def apply(self, candidate_dir, edits=None) -> None         # back-compat inject hook (env var / config patch / copy)
 def trajectories(self, split, ctx=None) -> Path | None     # the runner's NATIVE trace dir for the last eval (default: None)
+def runner_model(self) -> str | None                       # the CONSUMING model id, for check's mismatch note (default: None)
 ```
 
-Two more optional methods are **not** on the base class — the harness probes for them
+Three more optional fast paths are **not** on the base class — the harness probes for them
 with `hasattr` (`core/cap_evolve/harness.py`) and uses them when present:
 
 ```python

--- a/docs/how-to/cap-evolve-with-exgentic-tau2.md
+++ b/docs/how-to/cap-evolve-with-exgentic-tau2.md
@@ -79,7 +79,7 @@ Follow RUN.md to run a cap-evolve optimization. Here is everything intake needs:
 
 Claude will:
 1. Run **intake** — scaffold `.capevolve/project/` with the adapter, capevolve.yaml, and split_ids.json
-2. Run **implement-and-check** — implement all 4 adapter methods and verify with `cap-evolve check`
+2. Run **implement-and-check** — implement the 3 required adapter methods and verify with `cap-evolve check`
 3. Run **baseline** — score the seed capability on val
 4. Run **all-at-once** — propose edits, gate on val, commit accepted candidates to git
 5. Run **finalize** and **report** — sealed test score + dashboard

--- a/examples/toy_calc/README.md
+++ b/examples/toy_calc/README.md
@@ -6,7 +6,8 @@ succeeds when the system prompt contains the marker `[CALC]`, so the optimizatio
 (the `mock` optimizer adds `[CALC]`) provably raises the score. Used as the CI gate.
 
 ## Files
-- `adapter.py` — the 4-method `CapabilityAdapter` (deterministic agent + exact-match scorer).
+- `adapter.py` — a `CapabilityAdapter`: the 3 required methods (deterministic agent +
+  exact-match scorer) plus an `apply` hook override.
 - `capability/prompt.txt` — the seed system prompt (no `[CALC]`).
 - `mock_script.json` — the deterministic edit the `mock` optimizer applies.
 - `tasks.jsonl` — 8 arithmetic tasks.

--- a/site/getting-started.html
+++ b/site/getting-started.html
@@ -116,7 +116,7 @@ cap-evolve version          # verify</code></pre>
     </a>
     <a class="card" href="optimize-your-own.html">
       <div class="card-title">Optimize your own agent</div>
-      <p class="card-desc">Wire the 4-method adapter to your agent + benchmark and let cap-evolve improve it.</p>
+      <p class="card-desc">Wire the 3-method adapter to your agent + benchmark and let cap-evolve improve it.</p>
     </a>
     <a class="card" href="results.html">
       <div class="card-title">See the results</div>

--- a/skills/phases/implement-and-check/SKILL.md
+++ b/skills/phases/implement-and-check/SKILL.md
@@ -35,10 +35,13 @@ cheaper to fail here than after a full optimization run.
      gold-answer leakage — it becomes the diagnosis signal).
 
    Then override a **defaulted hook** only if its default does not fit your capability:
-   `materialize(candidate_dir, edits=None)` (pure write of `{component: text}` edits),
+   `materialize(candidate_dir, edits=None)` (default: pure write of each
+   `{component: text}` edit as a file under `candidate_dir` — override to support a
+   capability-specific patch format),
    `live(candidate_dir)` (context manager yielding `ctx`), `apply(candidate_dir, edits=None)`
-   (back-compat inject). Optional extras: `trajectories`, `runner_model`, `run_batch`,
-   `run_trials`.
+   (back-compat inject), `trajectories(split, ctx=None)` / `runner_model()` (both default
+   to `None`). Separately, `run_batch` / `run_trials` / `score_batch` are not on the base
+   class — the harness feature-detects them with `hasattr` and uses them if you define them.
 2. **Implement any selected skill's `scripts/abstract.py`** (most are concrete and
    need nothing).
 3. **Run the gate:**
@@ -47,7 +50,7 @@ cheaper to fail here than after a full optimization run.
        --skill-check <skills>/capabilities/<cap>/scripts/check.py
    ```
    It runs `cap-evolve check` (adapter: no stubs, `tasks` non-empty + stable, scorer
-   deterministic, `materialize()` callable) and each named skill's `check.py`. **Exit 0 =
+   deterministic, `materialize()` probed) and each named skill's `check.py`. **Exit 0 =
    green; the JSON lists exactly what is still stubbed or non-deterministic.**
 4. **Pipeline-wiring self-test (runs automatically once the check is green).** A
    green adapter is necessary but not sufficient — the optimizer also needs its
@@ -81,8 +84,11 @@ cheaper to fail here than after a full optimization run.
   the "reward" includes scorer noise the optimizer cannot learn from. (Target
   *stochasticity* is fine and is handled by multi-trial evaluation; *scorer*
   nondeterminism is a bug.)
-- **`materialize()` callable** — an edit that cannot be materialized cannot be
-  evaluated. The check probes it against a temp copy (pure, so the host is untouched).
+- **`materialize()` probed** — an edit that cannot be materialized cannot be
+  evaluated, so the check calls it against a temp copy (pure, so the host is untouched).
+  This one is a probe, not an assertion: a raise is reported as a **note** and does not
+  fail the check (`core/cap_evolve/check.py:166-167`), because a real adapter may need its
+  full environment. Green here means "callable or explained", not "edit path verified".
 
 ## Do not proceed until green
 If it reports stubs or non-determinism, fix them and re-run. This is the standard

--- a/skills/phases/implement-and-check/SKILL.md
+++ b/skills/phases/implement-and-check/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: implement-and-check
-description: The HARD GATE that must pass before any optimization budget is spent. Use right after intake. Walks the agent through implementing the 4 adapter methods (and any selected skill's abstract methods), then runs `cap-evolve check` on the project plus each involved skill's check.py, refusing to proceed until everything is implemented and deterministic — and listing exactly what is still stubbed.
+description: The HARD GATE that must pass before any optimization budget is spent. Use right after intake. Walks the agent through implementing the 3 required adapter methods plus any defaulted hooks that need overriding (and any selected skill's abstract methods), then runs `cap-evolve check` on the project plus each involved skill's check.py, refusing to proceed until everything is implemented and deterministic — and listing exactly what is still stubbed.
 component: phase
 argument-hint: "--project .capevolve/project --skill-check PATH"
 allowed-tools: Read, Write, Edit, Bash
@@ -24,14 +24,21 @@ cheaper to fail here than after a full optimization run.
   is fully implemented and deterministic. `baseline` will not run without it.
 
 ## Steps
-1. **Implement the four adapter methods** in
-   `.capevolve/project/adapters/adapter.py` (see `docs/ADAPTER_CONTRACT.md`):
+1. **Implement the 3 required adapter methods** in
+   `.capevolve/project/adapters/adapter.py` (see `docs/ADAPTER_CONTRACT.md`). These
+   three are `@abstractmethod` — the gate refuses to run until all three are real:
    - `tasks(split)` — yield the evaluation tasks (non-empty, stable across calls).
-   - `run_target(task, capability)` — run the agent under test; capture output +
-     trace into a `Rollout`.
+   - `run_target(task, ctx, *, seed=0)` — run the agent under test with the candidate
+     live as `ctx`; capture output + trace into a `Rollout`. Forward `seed` if the
+     runner is stochastic.
    - `score(task, rollout)` — return a reward in `[0,1]` + general feedback (no
      gold-answer leakage — it becomes the diagnosis signal).
-   - `apply(capability, edit)` — materialize a proposed edit onto a copy.
+
+   Then override a **defaulted hook** only if its default does not fit your capability:
+   `materialize(candidate_dir, edits=None)` (pure write of `{component: text}` edits),
+   `live(candidate_dir)` (context manager yielding `ctx`), `apply(candidate_dir, edits=None)`
+   (back-compat inject). Optional extras: `trajectories`, `runner_model`, `run_batch`,
+   `run_trials`.
 2. **Implement any selected skill's `scripts/abstract.py`** (most are concrete and
    need nothing).
 3. **Run the gate:**
@@ -40,7 +47,7 @@ cheaper to fail here than after a full optimization run.
        --skill-check <skills>/capabilities/<cap>/scripts/check.py
    ```
    It runs `cap-evolve check` (adapter: no stubs, `tasks` non-empty + stable, scorer
-   deterministic, `apply` callable) and each named skill's `check.py`. **Exit 0 =
+   deterministic, `materialize()` callable) and each named skill's `check.py`. **Exit 0 =
    green; the JSON lists exactly what is still stubbed or non-deterministic.**
 4. **Pipeline-wiring self-test (runs automatically once the check is green).** A
    green adapter is necessary but not sufficient — the optimizer also needs its
@@ -74,7 +81,8 @@ cheaper to fail here than after a full optimization run.
   the "reward" includes scorer noise the optimizer cannot learn from. (Target
   *stochasticity* is fine and is handled by multi-trial evaluation; *scorer*
   nondeterminism is a bug.)
-- **`apply` callable** — an edit that cannot be materialized cannot be evaluated.
+- **`materialize()` callable** — an edit that cannot be materialized cannot be
+  evaluated. The check probes it against a temp copy (pure, so the host is untouched).
 
 ## Do not proceed until green
 If it reports stubs or non-determinism, fix them and re-run. This is the standard
@@ -83,7 +91,7 @@ apparatus works before you trust any measurement it produces. A green check is
 the only honest entry into `baseline`.
 
 ## What good vs bad looks like
-- **Good:** `{"ok": true}` with all four methods concrete, a deterministic scorer,
+- **Good:** `{"ok": true}` with all 3 required methods concrete, a deterministic scorer,
   and every involved skill's check green.
 - **Bad:** proceeding on a red check "to save time"; a scorer that returns
   different rewards for the same rollout; an empty/placeholder `tasks()`; feedback

--- a/skills/phases/implement-and-check/references/concepts.md
+++ b/skills/phases/implement-and-check/references/concepts.md
@@ -6,17 +6,21 @@
 
 ## The adapter is the contract
 
-cap-evolve measures everything through four methods the user implements. The
-check verifies each is real:
+cap-evolve measures everything through **3 required methods** the user implements
+(plus defaulted hooks). The check verifies each required one is real:
 
-| method        | contract                                            | failure if stubbed                |
-|---------------|-----------------------------------------------------|-----------------------------------|
-| `tasks(split)`| non-empty, stable across calls                      | mean over nothing; unstable split |
-| `run_target`  | runs the agent, captures output + trace into Rollout| no behavior to score              |
-| `score`       | reward ∈ [0,1] + general feedback, deterministic    | every candidate scores the same   |
-| `apply`       | materializes an edit onto a copy                    | candidates can't be built         |
+| method                             | contract                                            | failure if stubbed                |
+|------------------------------------|-----------------------------------------------------|-----------------------------------|
+| `tasks(split)`                     | non-empty, stable across calls                      | mean over nothing; unstable split |
+| `run_target(task, ctx, *, seed=0)` | runs the agent, captures output + trace into Rollout| no behavior to score              |
+| `score(task, rollout)`             | reward ∈ [0,1] + general feedback, deterministic    | every candidate scores the same   |
 
-If any method is a stub, the optimization still *runs* — it just produces a number
+Beyond those three, `materialize(candidate_dir, edits=None)`, `live(candidate_dir)` and
+`apply(candidate_dir, edits=None)` are **defaulted hooks** — they already work for the
+common case, so override them only when the default does not fit. Optional extras
+(`trajectories`, `runner_model`, `run_batch`, `run_trials`) are feature-detected.
+
+If any required method is a stub, the optimization still *runs* — it just produces a number
 that measures nothing. The whole point of a pre-budget gate is to make that
 failure loud and early instead of silent and expensive.
 
@@ -28,8 +32,9 @@ failure loud and early instead of silent and expensive.
   `tasks()` is empty, there is nothing to average; if it shuffles between calls,
   the split is not reproducible and train/val/test stop being disjoint across
   reruns.
-- **`apply` callable.** An edit that cannot be materialized onto a capability copy
-  cannot be evaluated — the loop would propose into the void.
+- **`materialize()` callable.** An edit that cannot be materialized onto a capability
+  copy cannot be evaluated — the loop would propose into the void. The check probes it
+  against a temp copy; because `materialize` is pure, the host is never mutated.
 
 ## Scorer determinism vs target stochasticity — a crucial distinction
 

--- a/skills/phases/implement-and-check/references/concepts.md
+++ b/skills/phases/implement-and-check/references/concepts.md
@@ -15,10 +15,13 @@ cap-evolve measures everything through **3 required methods** the user implement
 | `run_target(task, ctx, *, seed=0)` | runs the agent, captures output + trace into Rollout| no behavior to score              |
 | `score(task, rollout)`             | reward ∈ [0,1] + general feedback, deterministic    | every candidate scores the same   |
 
-Beyond those three, `materialize(candidate_dir, edits=None)`, `live(candidate_dir)` and
-`apply(candidate_dir, edits=None)` are **defaulted hooks** — they already work for the
-common case, so override them only when the default does not fit. Optional extras
-(`trajectories`, `runner_model`, `run_batch`, `run_trials`) are feature-detected.
+Beyond those three, `materialize(candidate_dir, edits=None)`, `live(candidate_dir)`,
+`apply(candidate_dir, edits=None)`, `trajectories(split, ctx=None)` and `runner_model()`
+are **defaulted hooks** — they are defined on the base class with working defaults (the
+last two `return None`) and are called unconditionally, so override them only when the
+default does not fit. Separately, `run_batch` / `run_trials` / `score_batch` are **not** on
+the base class at all; the harness feature-detects them with `hasattr` and uses them only
+when an adapter defines them.
 
 If any required method is a stub, the optimization still *runs* — it just produces a number
 that measures nothing. The whole point of a pre-budget gate is to make that
@@ -32,9 +35,11 @@ failure loud and early instead of silent and expensive.
   `tasks()` is empty, there is nothing to average; if it shuffles between calls,
   the split is not reproducible and train/val/test stop being disjoint across
   reruns.
-- **`materialize()` callable.** An edit that cannot be materialized onto a capability
-  copy cannot be evaluated — the loop would propose into the void. The check probes it
-  against a temp copy; because `materialize` is pure, the host is never mutated.
+- **`materialize()` probed.** An edit that cannot be materialized onto a capability
+  copy cannot be evaluated — the loop would propose into the void. The check calls it
+  against a temp copy; because `materialize` is pure, the host is never mutated. This is a
+  **probe, not an assertion**: a raise is reported as a note and does NOT fail the check
+  (`check.py:166-167`), because a real adapter may legitimately need its full environment.
 
 ## Scorer determinism vs target stochasticity — a crucial distinction
 

--- a/skills/phases/intake/SKILL.md
+++ b/skills/phases/intake/SKILL.md
@@ -227,7 +227,7 @@ ask-if-missing loop — is yours, driven by this SKILL.md and `inputs/INPUTS.md`
 
 Then implement `adapters/adapter.py`, fill `capevolve.yaml`, and proceed to
 `implement-and-check`. Together, **intake → implement-and-check** is the *full
-integration*: scaffold → implement the 4 adapter methods → `cap-evolve check` green,
+integration*: scaffold → implement the 3 required adapter methods → `cap-evolve check` green,
 before any budget is spent. The using-agent (e.g. the chosen optimizer) can run
 this whole integration autonomously.
 
@@ -254,5 +254,5 @@ this whole integration autonomously.
 
 ## References
 - `references/concepts.md` — the inputs contract, NEEDED vs RECOMMENDED
-  rationale, the four adapter methods, and split/trial/budget guidance with
+  rationale, the 3 required adapter methods, and split/trial/budget guidance with
   sources.

--- a/skills/phases/intake/SKILL.md
+++ b/skills/phases/intake/SKILL.md
@@ -227,8 +227,8 @@ ask-if-missing loop — is yours, driven by this SKILL.md and `inputs/INPUTS.md`
 
 Then implement `adapters/adapter.py`, fill `capevolve.yaml`, and proceed to
 `implement-and-check`. Together, **intake → implement-and-check** is the *full
-integration*: scaffold → implement the 3 required adapter methods → `cap-evolve check` green,
-before any budget is spent. The using-agent (e.g. the chosen optimizer) can run
+integration*: scaffold → implement the 3 required adapter methods →
+`cap-evolve check` green, before any budget is spent. The using-agent (e.g. the chosen optimizer) can run
 this whole integration autonomously.
 
 > **Worked example (onboard a new benchmark from a prompt):** see `examples/` for

--- a/skills/phases/intake/references/concepts.md
+++ b/skills/phases/intake/references/concepts.md
@@ -23,8 +23,10 @@ live?". Their defaults already work for file-shaped capabilities, but they still
 real **capability artifact** to write into — so that is a NEEDED input too.
 
 If any of these cannot be filled from a real input, the optimization cannot
-produce a meaningful number. That is why those four inputs are NEEDED, not
-RECOMMENDED.
+produce a meaningful number. That is why the tasks dataset, the runner, the scorer and
+the capability artifact are NEEDED, not RECOMMENDED (`inputs/INPUTS.md` lists two more
+NEEDED inputs — metric-extraction source and trajectories path — which back the
+same three methods rather than adding new ones).
 
 ## NEEDED vs RECOMMENDED — and why the split exists
 

--- a/skills/phases/intake/references/concepts.md
+++ b/skills/phases/intake/references/concepts.md
@@ -7,16 +7,20 @@
 
 ## The adapter is the whole interface
 
-Everything cap-evolve measures flows through four methods the user implements in
-`.capevolve/project/adapters/adapter.py`. intake's job is to make sure each one
-*can* be implemented from real inputs:
+Everything cap-evolve measures flows through **3 required methods** the user implements in
+`.capevolve/project/adapters/adapter.py` (plus defaulted hooks). intake's job is to make
+sure each one *can* be implemented from real inputs:
 
-| method        | question it answers                              | NEEDED input behind it |
-|---------------|--------------------------------------------------|------------------------|
-| `tasks(split)`| what problems do we evaluate on?                 | tasks dataset          |
-| `run_target(task, capability)` | how do we run the agent under test? | target agent / runner |
-| `score(task, rollout)` | how does a rollout become a reward in [0,1] + feedback? | scorer |
-| `apply(capability, edit)` | how is a proposed edit materialized?      | capability artifact    |
+| method                             | question it answers                              | NEEDED input behind it |
+|------------------------------------|--------------------------------------------------|------------------------|
+| `tasks(split)`                     | what problems do we evaluate on?                 | tasks dataset          |
+| `run_target(task, ctx, *, seed=0)` | how do we run the agent under test?              | target agent / runner  |
+| `score(task, rollout)`             | how does a rollout become a reward in [0,1] + feedback? | scorer          |
+
+The defaulted hooks `materialize(candidate_dir, edits=None)` / `live(candidate_dir)` /
+`apply(candidate_dir, edits=None)` answer "how is a proposed edit materialized and made
+live?". Their defaults already work for file-shaped capabilities, but they still need a
+real **capability artifact** to write into — so that is a NEEDED input too.
 
 If any of these cannot be filled from a real input, the optimization cannot
 produce a meaningful number. That is why those four inputs are NEEDED, not

--- a/skills/phases/intake/scripts/run.py
+++ b/skills/phases/intake/scripts/run.py
@@ -89,7 +89,7 @@ def main(argv=None) -> int:
         "created": created,
         "next": [
             "reuse the discovered artifacts where possible (don't re-author them)",
-            "implement the 4 methods in adapters/adapter.py",
+            "implement the 3 required methods in adapters/adapter.py",
             "fill capevolve.yaml (capability / optimizer / algorithm / budget)",
             "resolve NEEDED inputs (ask the user for any that are missing)",
             "run: cap-evolve check " + str(project) + "  (implement-and-check gates this)",

--- a/skills/phases/intake/scripts/run.py
+++ b/skills/phases/intake/scripts/run.py
@@ -9,7 +9,7 @@ What the SCRIPT does (this file):
      stub, inputs/, capevolve.yaml, PROJECT.md).
 
 What the OPTIMIZER AGENT does (driven by SKILL.md, not this script): decide the
-capability/optimizer/algorithm, **implement the 4 adapter methods**, and fill the
+capability/optimizer/algorithm, **implement the 3 required adapter methods**, and fill the
 spec. What the USER does: supply NEEDED inputs the agent cannot infer.
 
 Advancing past intake is gated by ``implement-and-check`` (runs ``cap-evolve

--- a/templates/skill/scripts/abstract.py
+++ b/templates/skill/scripts/abstract.py
@@ -5,8 +5,9 @@ NotImplementedError with the "IMPLEMENT ME" marker so `check.py` can detect and
 report exactly what is unfilled. Replace the body, keep the signature.
 
 Many skills delegate to the project-level adapter in
-``.capevolve/project/adapters/adapter.py`` (the 4-method CapabilityAdapter). If this
-skill's work is fully covered there, import and call it rather than duplicating.
+``.capevolve/project/adapters/adapter.py`` (the CapabilityAdapter: 3 required methods
+plus defaulted hooks). If this skill's work is fully covered there, import and call it
+rather than duplicating.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Closes #103

## Ground truth

Established by reading the code, not the docs:

- **`core/cap_evolve/adapter.py`** — exactly **3 `@abstractmethod`s**:
  `tasks(split)`, `run_target(task, ctx, *, seed=0)`, `score(task, rollout)`.
  Defaulted hooks: `materialize(candidate_dir, edits=None)`, `live(candidate_dir)`,
  `apply(candidate_dir, edits=None)`. Optional/feature-detected: `trajectories(split, ctx=None)`,
  `runner_model()`, and `run_batch` / `run_trials` (probed via `hasattr` in `harness.py:201-202`).
- **`core/cap_evolve/check.py`** — the gate checks: no IMPLEMENT-ME stubs, `tasks('val')`
  non-empty + stable, deterministic `score()`, and probes **`materialize()`** into a temp
  copy (`check.py:146-165`) — deliberately *not* `apply()`/`live()`, so the host is never mutated.

Canonical phrasing adopted everywhere: **"3 required methods + defaulted hooks (+ optional)."**

## Surfaces fixed

| file | old | new |
|---|---|---|
| `core/cap_evolve/adapter.py:3-12` | "we use 4, cleaner" then a flat list of **5** methods | "we require **3**, plus defaulted hooks"; list split into 3 required / 3 defaulted hooks / 4 optional |
| `skills/phases/implement-and-check/SKILL.md:3` (frontmatter description) | "implementing the 4 adapter methods" | "implementing the 3 required adapter methods plus any defaulted hooks that need overriding" |
| `skills/phases/implement-and-check/SKILL.md:27` | "Implement the **four** adapter methods" | "Implement the **3 required** adapter methods" |
| `skills/phases/implement-and-check/SKILL.md:30` | `run_target(task, capability)` (signature does not exist) | `run_target(task, ctx, *, seed=0)` + note to forward `seed` when stochastic |
| `skills/phases/implement-and-check/SKILL.md:34` | `apply(capability, edit)` — listed as a **required** method (signature does not exist) | removed from the required list; replaced by a defaulted-hooks paragraph with real signatures `materialize(candidate_dir, edits=None)` / `live(candidate_dir)` / `apply(candidate_dir, edits=None)` + optional extras |
| `skills/phases/implement-and-check/SKILL.md:43` | check described as verifying "`apply` callable" | "`materialize()` callable" (what check.py actually probes) |
| `skills/phases/implement-and-check/SKILL.md:77` | "**`apply` callable**" bullet | "**`materialize()` callable**" + notes the temp-copy probe is pure |
| `skills/phases/implement-and-check/SKILL.md:86` | "all **four** methods concrete" | "all **3 required** methods concrete" |
| `skills/phases/implement-and-check/references/concepts.md:9-17` | "through **four** methods"; contract table row for `apply` | "through **3 required** methods (plus defaulted hooks)"; table trimmed to the 3 abstracts with full signatures; hooks/optional described below |
| `skills/phases/implement-and-check/references/concepts.md:31` | "**`apply` callable**" bullet | "**`materialize()` callable**" bullet |
| `skills/phases/intake/references/concepts.md:10-19` | "flows through **four** methods"; rows `run_target(task, capability)` and `apply(capability, edit)` | "flows through **3 required** methods (plus defaulted hooks)"; real signatures; hook paragraph explains why the capability artifact is still a NEEDED input |
| `skills/phases/intake/SKILL.md:230` | "implement the 4 adapter methods" | "implement the 3 required adapter methods" |
| `skills/phases/intake/SKILL.md:257` | "the **four** adapter methods" | "the **3 required** adapter methods" |
| `skills/phases/intake/scripts/run.py:12` | "**implement the 4 adapter methods**" | "**implement the 3 required adapter methods**" |
| `RUN.md:41` | "Implement the 4 adapter methods" | "Implement the 3 required adapter methods" |
| `docs/how-to/cap-evolve-with-exgentic-tau2.md:82` | "implement all 4 adapter methods" | "implement the 3 required adapter methods" |

Already correct, left as-is (they were the ground-truth-aligned side of the drift):
`docs/ADAPTER_CONTRACT.md:8`, `docs/OPTIMIZE_YOUR_OWN.md:4`, `docs/ADAPTER_TEMPLATES.md:121`,
`README.md:141`, `templates/project/adapters/adapter.py:1`, `templates/adapters/README.md:71`,
`site/optimize-your-own.html:54`.

`skills/_registry/manifest.json` needed **no** change: it stores a hand-written `summary`
("HARD GATE: run cap-evolve check + each involved skill's check until green."), not the
SKILL.md frontmatter `description`. Rebuilding the manifest produced a zero-byte diff.

## Verification

Issue's own test 1 — `grep -rniE "4 adapter methods|four adapter methods" . --exclude-dir=.git`:

```
(exit 1)
```

Issue's own test 2 — `grep -rnE "run_target\(task, capability\)|apply\(capability, edit\)" skills docs`:

```
(exit 1)
```

Self-contradiction in adapter.py — `grep -rn "we use 4" . --exclude-dir=.git`:

```
(exit 1)
```

Residual `four (methods|inputs|adapter)` sweep:

```
skills/phases/intake/references/concepts.md:26:produce a meaningful number. That is why those four inputs are NEEDED, not
```

(correct and intentional — that sentence counts the four NEEDED *inputs*, not methods.)

Tests:

```
$ PYTHONPATH=/tmp/wt-103/core python -m pytest core/tests -q
........................................................................ [ 40%]
........................................................................ [ 80%]
...................................                                      [100%]
179 passed in 61.89s (0:01:01)
```

```
$ python -m compileall -q core skills
compileall clean (exit 0)
```

Skills touched, so per CONTRIBUTING:

```
$ python skills/_registry/build_manifest.py skills
  algorithm: agent-optimize, evograph, gepa, hill-climb, skillopt
  capability: mcp-tool, skill-package, system-prompt, tools
  optimizer: run-optimizer
  orchestrate: orchestrate, using-cap-evolve
  phase: baseline, diagnose, evaluate, finalize, gate, implement-and-check, intake, report

$ git diff --stat skills/_registry/manifest.json
(no output — unchanged)

$ python skills/phases/implement-and-check/scripts/check.py
{
  "skill": "implement-and-check",
  "ok": true,
  "problems": [],
  "notes": [
    "run entry exposes main()",
    "refuses a project with no/stubbed adapter",
    "flags unimplemented adapter methods"
  ]
}

$ python skills/phases/intake/scripts/check.py
{
  "skill": "intake",
  "ok": true,
  "problems": [],
  "notes": [
    "run entry exposes main()",
    "mines existing task files",
    "mines existing capability artifacts",
    "scaffolds the adapter stub + spec"
  ]
}
```

Docs-only + one docstring; no behavior change, so no new `core/tests/` test (the existing
179 cover `check.py`/`adapter.py` semantics unchanged).
