### PR TITLE
fix(honesty): label the τ²-bench held-out headline as reported, artifact not committed

### DIFF
--- a/OUTREACH.md
+++ b/OUTREACH.md
@@ -42,11 +42,13 @@ more, plus a generic adapter for any shell-invokable agent and a deterministic m
 for CI.
 
 Benchmark adapters ship for τ²-bench, SWE-bench, SkillsBench, and generic
-JSONL/HuggingFace datasets. Some committed, reproducible results:
-- τ²-bench airline, held-out 30/10/10 split: sealed test 30.0 → 47.5 (+58% relative).
+JSONL/HuggingFace datasets. Some results — artifact-backed unless noted:
 - τ²-bench airline, fit-metric 50 tasks: 0.536 → 0.694; the edits were deep tool-code
   changes (tools.py 593 → 832 lines), not just prompt wording.
 - SkillsBench skill-package optimization, sealed test: 0.556 → 0.667.
+- τ²-bench airline, held-out 30(=val)/20 split: sealed test 30.0 → 47.5 (+58% relative)
+  — **reported only; that run's artifact is not committed**, so treat it as weaker
+  evidence than the two above.
 
 It's Python 3.10+, Apache-2.0, zero runtime deps (stdlib only). There's a two-minute
 demo that needs no API key (a deterministic toy agent + a mock optimizer, so the score

--- a/README.md
+++ b/README.md
@@ -100,15 +100,16 @@ Combine them, e.g. `[system-prompt, tools]`. See [Architecture](docs/ARCHITECTUR
 ## Results
 
 Each number is labeled **fit metric** (no holdout) or **held-out** (test scored once on ids
-the optimizer never saw), and marked ✅ *artifact-backed* (a committed `run_full/`) or
-⚠️ *reported* (run artifact **not** committed — take it on trust, not on evidence). Full
+the optimizer never saw), and marked ✅ *artifact-backed* (a committed `run_full/`, or a
+deterministic CI test that re-derives it) or ⚠️ *reported* (run artifact **not** committed —
+take it on trust, not on evidence). Full
 detail, models, task/trial counts, commits, and costs: **[docs/RESULTS.md](docs/RESULTS.md)**.
 
 | Benchmark | Split | Baseline → Optimized | Gain | Artifact |
 |---|---|---|---|---|
-| **toy_calc** (zero-API) | sealed test | `0.0 → 1.0` | deterministic proof | ✅ committed |
+| **toy_calc** (zero-API) | sealed test | `0.0 → 1.0` | deterministic proof | ✅ [reproducible in CI](core/tests/test_e2e_slice.py) |
 | **τ²-bench airline** (policy + tools) | val — *fit metric* | `0.536 → 0.712` | **+0.176 / +32.8%** | ✅ [`run_full/`](examples/tau2_airline/run_full/) |
-| **τ²-bench airline**, held-out 30(=val)/20 | sealed **test** | `30.0 → 47.5` | **+17.5 pp / +58.3%** | ⚠️ [**reported — not committed**](docs/RESULTS.md) |
+| **τ²-bench airline**, held-out 30(=val)/20 | sealed **test** | `30.0 → 47.5` | **+17.5 pp / +58.3%** | ⚠️ [**reported — not committed**](docs/RESULTS.md#tau2-heldout) |
 | **SkillsBench** (skill package) | sealed **test** (held-out) | `0.556 → 0.667` | **+0.111 / +20.0%** | ✅ [`run_full/`](examples/skillsbench/run_full/) |
 
 *Not an apples-to-apples leaderboard.* For how the held-out τ²-bench result sits next to

--- a/README.md
+++ b/README.md
@@ -99,16 +99,17 @@ Combine them, e.g. `[system-prompt, tools]`. See [Architecture](docs/ARCHITECTUR
 
 ## Results
 
-Numbers are cross-checked against committed run artifacts; each is labeled **fit metric**
-(no holdout) or **held-out** (test scored once on ids the optimizer never saw). Full detail,
-models, task/trial counts, commits, and costs: **[docs/RESULTS.md](docs/RESULTS.md)**.
+Each number is labeled **fit metric** (no holdout) or **held-out** (test scored once on ids
+the optimizer never saw), and marked ✅ *artifact-backed* (a committed `run_full/`) or
+⚠️ *reported* (run artifact **not** committed — take it on trust, not on evidence). Full
+detail, models, task/trial counts, commits, and costs: **[docs/RESULTS.md](docs/RESULTS.md)**.
 
-| Benchmark | Split | Baseline → Optimized | Gain |
-|---|---|---|---|
-| **toy_calc** (zero-API) | sealed test | `0.0 → 1.0` | deterministic proof |
-| **τ²-bench airline** (policy + tools) | val — *fit metric* | `0.536 → 0.712` | **+0.176 / +32.8%** |
-| **τ²-bench airline**, held-out 30(=val)/20 | sealed **test** | `30.0 → 47.5` | **+17.5 pp / +58.3%** |
-| **SkillsBench** (skill package) | sealed **test** (held-out) | `0.556 → 0.667` | **+0.111 / +20.0%** |
+| Benchmark | Split | Baseline → Optimized | Gain | Artifact |
+|---|---|---|---|---|
+| **toy_calc** (zero-API) | sealed test | `0.0 → 1.0` | deterministic proof | ✅ committed |
+| **τ²-bench airline** (policy + tools) | val — *fit metric* | `0.536 → 0.712` | **+0.176 / +32.8%** | ✅ [`run_full/`](examples/tau2_airline/run_full/) |
+| **τ²-bench airline**, held-out 30(=val)/20 | sealed **test** | `30.0 → 47.5` | **+17.5 pp / +58.3%** | ⚠️ [**reported — not committed**](docs/RESULTS.md) |
+| **SkillsBench** (skill package) | sealed **test** (held-out) | `0.556 → 0.667` | **+0.111 / +20.0%** | ✅ [`run_full/`](examples/skillsbench/run_full/) |
 
 *Not an apples-to-apples leaderboard.* For how the held-out τ²-bench result sits next to
 external tool-optimization work ([EvoTool](https://arxiv.org/abs/2603.04900) on the

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -58,7 +58,7 @@ claims.
 | **EvoTool** (arXiv:2603.04900) | **original τ-Bench** airline, GPT-4.1 | ReAct 35.9 → **39.1** (+3.2) | **~+8.9%** |
 | **EvoTool** | original τ-Bench airline, Qwen3-8B | ReAct 14.4 → **15.7** (+1.3) | **~+9.0%** |
 | Evolutionary Context Search | τ²-Bench | reported **+23.3%** | +23.3% |
-| **cap-evolve** (this repo) | **τ²-Bench** airline, held-out 30(=val)/20 | sealed test 30.0 → **47.5** (+17.5 pp) | **+58.3%** |
+| **cap-evolve** (this repo) | **τ²-Bench** airline, held-out 30(=val)/20 — ⚠️ *reported, artifact not committed* | sealed test 30.0 → **47.5** (+17.5 pp) | **+58.3%** |
 
 Notes and honest caveats:
 - **EvoTool evaluates the *original* τ-Bench** (Yao et al., 2024), while cap-evolve and
@@ -70,6 +70,10 @@ Notes and honest caveats:
   reference is added here.
 - cap-evolve's +58.3% is a **within-run relative** improvement on its own held-out split
   ([`RESULTS.md`](RESULTS.md)); a different split, model, and simulator than the rows above.
+- **cap-evolve's own row is the weakest-evidenced row in this table:** the `run_full/`
+  artifact for that held-out run is **not committed** to this repo, so unlike the published
+  external rows it cannot be inspected or re-derived here. See
+  [`RESULTS.md`](RESULTS.md) for the full caveat.
 
 ---
 

--- a/docs/RESULTS.md
+++ b/docs/RESULTS.md
@@ -1,9 +1,11 @@
 # Results
 
-The canonical results for cap-evolve. Every number here is derived from a committed
-run artifact (`examples/*/run_full/*.json`) or, where noted, from a held-out run whose
-artifact is committed separately. The README's Results section is a short snapshot of
-this page.
+The canonical results for cap-evolve. A section that opens with an **Artifact:** link is
+**artifact-backed** — its numbers are derived from a committed run directory under
+`examples/*/run_full/` that you can open and load in the dashboard. A section with no such
+link is a **reported** run: it happened, but its artifact is not in this repo, so the number
+rests on trust rather than evidence and reproducing it means paying for a fresh run. The
+README's Results section is a short snapshot of this page and carries the same markers.
 
 Each result is labeled by **split discipline**:
 - **fit metric** — `train == val == test` (no holdout); the test number is *not* held
@@ -59,19 +61,24 @@ lines), not just prompt tweaks — five trajectory-verified before→after edits
 
 ---
 
-## τ²-Bench airline — held-out 30(=val)/20 run
+## τ²-Bench airline — held-out 30(=val)/20 run — ⚠️ reported, artifact not committed
 
 Same benchmark and capability, run with a real holdout split (`split_ids.json`,
-train=val=30, test=20) so the test number is a genuine generalization result.
+train=val=30, test=20) so the test number is a generalization result *as run*.
 
 | split | baseline | optimized | Δ |
 |---|---|---|---|
 | **val** (30 tasks) | **56.7** | **70.0** | **+13.3 pp / +23.5% relative** |
 | **sealed test** (20 tasks, scored once) | **30.0** | **47.5** | **+17.5 pp / +58.3% relative** |
 
-> The held-out `run_full` artifact for this run is committed separately. Until it lands,
-> treat these figures as the reported held-out result; the reproducible artifact-backed
-> run above is the no-holdout fit metric.
+> **⚠️ Reported — the `run_full/` artifact for this run is not committed to this repo, and
+> there is no timeline for committing it.** Unlike every other row on this page, you cannot
+> open the artifact, load it in the dashboard, or re-derive these numbers from anything
+> here; reproducing them means paying for a fresh run
+> ([`REPRODUCE_tau2.md`](REPRODUCE_tau2.md)). Treat it as a reported figure, not as
+> evidence. The only artifact-backed τ²-bench run on this page is the no-holdout **fit
+> metric** above ([`examples/tau2_airline/run_full/`](../examples/tau2_airline/run_full/)),
+> whose test split is *not* held out.
 
 See [`COMPARISON.md`](COMPARISON.md) for how this **+58.3% within-run relative** held-out
 gain sits next to external tool-optimization work (EvoTool, Evolutionary Context Search)

--- a/docs/RESULTS.md
+++ b/docs/RESULTS.md
@@ -1,11 +1,17 @@
 # Results
 
-The canonical results for cap-evolve. A section that opens with an **Artifact:** link is
-**artifact-backed** — its numbers are derived from a committed run directory under
-`examples/*/run_full/` that you can open and load in the dashboard. A section with no such
-link is a **reported** run: it happened, but its artifact is not in this repo, so the number
-rests on trust rather than evidence and reproducing it means paying for a fresh run. The
-README's Results section is a short snapshot of this page and carries the same markers.
+The canonical results for cap-evolve. **Every section heading below carries its own
+evidence marker** — read the marker, not an average:
+
+- ✅ **artifact-backed** — the section opens with an **Artifact:** link to a committed run
+  directory under `examples/*/run_full/` that you can open and load in the dashboard.
+- ✅ **reproducible in CI** — no paid run to commit; the number is re-derived on every CI
+  run by a deterministic test.
+- ⚠️ **reported** — the run happened, but its artifact is **not** in this repo, so the
+  number rests on trust rather than evidence and reproducing it means paying for a fresh
+  run.
+
+The README's Results section is a short snapshot of this page and carries the same markers.
 
 Each result is labeled by **split discipline**:
 - **fit metric** — `train == val == test` (no holdout); the test number is *not* held
@@ -18,7 +24,9 @@ Gains are given as **absolute** and **relative %**.
 
 ---
 
-## toy_calc — deterministic, zero-API
+<a id="toy-calc"></a>
+
+## toy_calc — deterministic, zero-API — ✅ reproducible in CI
 
 | | val | test | notes |
 |---|---|---|---|
@@ -30,7 +38,9 @@ by `bash examples/toy_calc/run.sh`.
 
 ---
 
-## τ²-Bench airline — no-holdout fit-metric run (reproducible, committed)
+<a id="tau2-fit"></a>
+
+## τ²-Bench airline — no-holdout fit-metric run — ✅ artifact-backed
 
 Artifact: [`examples/tau2_airline/run_full/`](../examples/tau2_airline/run_full/)
 (`final.json`, static dashboard under `ui/`). Reproduce: [`REPRODUCE_tau2.md`](REPRODUCE_tau2.md).
@@ -61,6 +71,8 @@ lines), not just prompt tweaks — five trajectory-verified before→after edits
 
 ---
 
+<a id="tau2-heldout"></a>
+
 ## τ²-Bench airline — held-out 30(=val)/20 run — ⚠️ reported, artifact not committed
 
 Same benchmark and capability, run with a real holdout split (`split_ids.json`,
@@ -72,9 +84,9 @@ train=val=30, test=20) so the test number is a generalization result *as run*.
 | **sealed test** (20 tasks, scored once) | **30.0** | **47.5** | **+17.5 pp / +58.3% relative** |
 
 > **⚠️ Reported — the `run_full/` artifact for this run is not committed to this repo, and
-> there is no timeline for committing it.** Unlike every other row on this page, you cannot
-> open the artifact, load it in the dashboard, or re-derive these numbers from anything
-> here; reproducing them means paying for a fresh run
+> committing it is not scheduled.** You cannot open the artifact, load it in the dashboard,
+> or re-derive these numbers from anything here; reproducing them means paying for a fresh
+> run
 > ([`REPRODUCE_tau2.md`](REPRODUCE_tau2.md)). Treat it as a reported figure, not as
 > evidence. The only artifact-backed τ²-bench run on this page is the no-holdout **fit
 > metric** above ([`examples/tau2_airline/run_full/`](../examples/tau2_airline/run_full/)),
@@ -87,7 +99,9 @@ and budgets and are **not** an apples-to-apples comparison.
 
 ---
 
-## τ²-Bench airline — agent orchestration mode (`agent-optimize`), held-out 30(=val)/20
+<a id="tau2-agent"></a>
+
+## τ²-Bench airline — agent orchestration mode (`agent-optimize`), held-out 30(=val)/20 — ⚠️ reported, artifact not committed
 
 The first run driven in **agent orchestration mode** (`orchestration_mode: agent`,
 `algorithm_skill: agent-optimize`): the conversational agent understood the benchmark, ran the
@@ -133,7 +147,9 @@ no-holdout run).
 
 ---
 
-## τ²-Bench airline — Qwen 2.5 14B (tools only, held-out)
+<a id="qwen-tools"></a>
+
+## τ²-Bench airline — Qwen 2.5 14B (tools only, held-out) — ⚠️ reported, artifact not committed
 
 Same benchmark, capability, split, and algorithm as the held-out run above, with a
 self-hosted open model (**Qwen 2.5 14B-Instruct** via vLLM on OpenShift) replacing the
@@ -157,7 +173,9 @@ implementations rather than rewriting policy prose.
 
 ---
 
-## τ²-Bench airline — Qwen 2.5 14B, all capabilities (held-out)
+<a id="qwen-all"></a>
+
+## τ²-Bench airline — Qwen 2.5 14B, all capabilities (held-out) — ⚠️ reported, artifact not committed
 
 Same model and split as above, with all three capability types optimized jointly.
 
@@ -181,7 +199,9 @@ structured methodology in SKILL.md.
 `[skill-package, system-prompt, tools]` with `hill-climb` outperformed the tools-only run
 (+41.2%) when paired with hill-climb's conservative gating.
 
-## SkillsBench — skill-package optimization (held-out, committed)
+<a id="skillsbench"></a>
+
+## SkillsBench — skill-package optimization (held-out) — ✅ artifact-backed
 
 Artifact: [`examples/skillsbench/run_full/`](../examples/skillsbench/run_full/)
 (`report.md`, `final.json`). Reproduce: [`REPRODUCE_skillsbench.md`](REPRODUCE_skillsbench.md).

--- a/presentation/index.html
+++ b/presentation/index.html
@@ -632,7 +632,7 @@
         <div class="diff-tile">
           <span class="badge">06</span>
           <div class="diff-title">Rigorous evaluation</div>
-          <div class="diff-desc">Sealed test, gate-verified acceptance, artifacts committed with every result.</div>
+          <div class="diff-desc">Sealed test, gate-verified acceptance, run artifacts committed wherever they exist.</div>
         </div>
       </div>
 
@@ -715,7 +715,7 @@
           <ul style="font-size:0.85em; margin:0.4em 0 0 0.9em; padding:0;">
             <li><strong>Adapter templates</strong> — τ²-bench, SkillsBench, SWE-bench: onboarding is config, not code</li>
             <li><strong>Empty-seed intake</strong> — bootstrap optimization without a starting capability</li>
-            <li><strong>Held-out runs committed</strong> — τ²-airline + SkillsBench artifacts</li>
+            <li><strong>Held-out runs committed</strong> — SkillsBench artifact (τ²-airline held-out is reported only)</li>
             <li><strong>Public docs site</strong> + "Why cap-evolve" section</li>
           </ul>
         </div>
@@ -742,7 +742,7 @@
     <section class="sec-02">
       <div class="part-pill sec-02">02 · WHERE WE STAND</div>
       <h2>Results at a glance</h2>
-      <p class="subtitle" style="font-size:0.65em;">Every number is derived from a committed run artifact.</p>
+      <p class="subtitle" style="font-size:0.65em;">Each card states its own evidence — ⚠️ <em>reported</em> means the run artifact is not committed.</p>
 
       <div class="grid-3" style="max-width:96%; margin:0.7em auto;">
         <!-- τ²-bench airline — val (fit metric) — LEFT -->
@@ -751,7 +751,7 @@
           <div class="big">+17.6</div>
           <div class="unit">pp</div>
           <div class="title">τ²-bench airline</div>
-          <div class="sub-title">val — fit metric (50 tasks · 10 trials)</div>
+          <div class="sub-title">val — fit metric (50 tasks · 10 trials) · ✅ artifact committed</div>
           <div class="ba">53.6 → <span class="after">71.2</span></div>
         </div>
         <!-- τ²-bench airline — test set — MIDDLE -->
@@ -769,7 +769,7 @@
           <div class="big">+11.1</div>
           <div class="unit">pp</div>
           <div class="title">SkillsBench</div>
-          <div class="sub-title">test set (3 tasks) · 4 skill packages</div>
+          <div class="sub-title">test set (3 tasks) · 4 skill packages · ✅ artifact committed</div>
           <div class="ba">55.6 → <span class="after">66.7</span></div>
         </div>
       </div>

--- a/presentation/index.html
+++ b/presentation/index.html
@@ -760,7 +760,7 @@
           <div class="big">+17.5</div>
           <div class="unit">pp</div>
           <div class="title">τ²-bench airline</div>
-          <div class="sub-title">test set (20 tasks)</div>
+          <div class="sub-title">test set (20 tasks) · ⚠️ reported, artifact not committed</div>
           <div class="ba">30.0 → <span class="after">47.5</span></div>
         </div>
         <!-- SkillsBench — test set — RIGHT -->
@@ -783,9 +783,11 @@
 
       <aside class="notes">
         All three numbers now shown in percentage-point units for a fair side-by-side.
-        Headline: +58.3% relative gain on the τ² test set (20 tasks). Fit-metric on the left is the
-        reproducible artifact-backed run. SkillsBench on the right edited all 4 skill packages
-        and stopped on a real ceiling. Every result is committed in examples/*/run_full/.
+        Headline: +58.3% relative gain on the τ² test set (20 tasks) — but say out loud that this
+        one is REPORTED ONLY: its run artifact is not committed, so it is the weakest-evidenced
+        number on the slide. Fit-metric on the left and SkillsBench on the right ARE committed
+        under examples/*/run_full/. SkillsBench edited all 4 skill packages and stopped on a real
+        ceiling.
       </aside>
     </section>
 

--- a/site/index.html
+++ b/site/index.html
@@ -74,7 +74,7 @@
     </div>
     <div class="pill-row">
       <span class="pill"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"></path></svg>Test sealed, scored once</span>
-      <span class="pill"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"></path></svg>Every number ships its artifact</span>
+      <span class="pill"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"></path></svg>Artifact-backed by default</span>
       <span class="pill"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"></path></svg>0 runtime dependencies</span>
     </div>
     <div class="badges pill-row">
@@ -234,8 +234,9 @@ bash examples/toy_calc/run.sh</code></pre>
     <p class="section-intro">
       Each number is labeled <strong>fit metric</strong> (no holdout) or <strong>held-out</strong>
       (test scored once on ids the optimizer never saw), and marked ✅ <em>artifact-backed</em>
-      (a committed run directory) or ⚠️ <em>reported</em> (run artifact <strong>not</strong>
-      committed — take it on trust, not on evidence).
+      (a committed run directory, or a deterministic CI test that re-derives it) or
+      ⚠️ <em>reported</em> (run artifact <strong>not</strong> committed — take it on trust, not
+      on evidence). Every row states its own marker.
       Full detail, models, task/trial counts, and costs: <a href="results.html">Results</a>.
     </p>
     <table class="table-hero">
@@ -248,7 +249,7 @@ bash examples/toy_calc/run.sh</code></pre>
           <td>sealed test</td>
           <td><code>0.0 → 1.0</code></td>
           <td class="gain">deterministic proof</td>
-          <td>✅ committed</td>
+          <td>✅ <a href="https://github.com/skillberry-ai/cap-evolve/blob/main/core/tests/test_e2e_slice.py">reproducible in CI</a></td>
         </tr>
         <tr>
           <td><strong>τ²-bench airline</strong> <span class="muted">(policy + tools)</span></td>

--- a/site/index.html
+++ b/site/index.html
@@ -232,13 +232,15 @@ bash examples/toy_calc/run.sh</code></pre>
   <section class="section reveal" id="results">
     <h2>Results</h2>
     <p class="section-intro">
-      Cross-checked against committed run artifacts. Each is labeled <strong>fit metric</strong>
-      (no holdout) or <strong>held-out</strong> (test scored once on ids the optimizer never saw).
+      Each number is labeled <strong>fit metric</strong> (no holdout) or <strong>held-out</strong>
+      (test scored once on ids the optimizer never saw), and marked ✅ <em>artifact-backed</em>
+      (a committed run directory) or ⚠️ <em>reported</em> (run artifact <strong>not</strong>
+      committed — take it on trust, not on evidence).
       Full detail, models, task/trial counts, and costs: <a href="results.html">Results</a>.
     </p>
     <table class="table-hero">
       <thead>
-        <tr><th>Benchmark</th><th>Split</th><th>Baseline → Optimized</th><th>Gain</th></tr>
+        <tr><th>Benchmark</th><th>Split</th><th>Baseline → Optimized</th><th>Gain</th><th>Artifact</th></tr>
       </thead>
       <tbody>
         <tr>
@@ -246,24 +248,28 @@ bash examples/toy_calc/run.sh</code></pre>
           <td>sealed test</td>
           <td><code>0.0 → 1.0</code></td>
           <td class="gain">deterministic proof</td>
+          <td>✅ committed</td>
         </tr>
         <tr>
           <td><strong>τ²-bench airline</strong> <span class="muted">(policy + tools)</span></td>
           <td>val — <em>fit metric</em></td>
           <td><code>0.536 → 0.712</code></td>
           <td class="gain">+0.176 / +32.8%</td>
+          <td>✅ committed</td>
         </tr>
         <tr>
-          <td><strong>τ²-bench airline</strong> <span class="muted">(held-out 30/10/10)</span></td>
+          <td><strong>τ²-bench airline</strong> <span class="muted">(held-out 30(=val)/20)</span></td>
           <td>sealed <strong>test</strong></td>
           <td><code>30.0 → 47.5</code></td>
-          <td class="gain">+58.3% <span class="muted">· reported</span></td>
+          <td class="gain">+58.3%</td>
+          <td>⚠️ <a href="results.html#tau2-heldout"><strong>reported — not committed</strong></a></td>
         </tr>
         <tr>
           <td><strong>SkillsBench</strong> <span class="muted">(skill package)</span></td>
           <td>sealed <strong>test</strong> (held-out)</td>
           <td><code>0.556 → 0.667</code></td>
           <td class="gain">+0.111 / +20.0%</td>
+          <td>✅ committed</td>
         </tr>
       </tbody>
     </table>

--- a/site/results.html
+++ b/site/results.html
@@ -4,17 +4,17 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Results — cap-evolve</title>
-  <meta name="description" content="Full benchmark results for cap-evolve — toy_calc, τ²-bench airline (fit-metric + held-out), SkillsBench. Every number cross-checked against committed run artifacts.">
+  <meta name="description" content="Full benchmark results for cap-evolve — toy_calc, τ²-bench airline (fit-metric + held-out), SkillsBench. Every section carries its own evidence marker: artifact-backed, reproducible in CI, or reported only.">
   <link rel="canonical" href="https://skillberry-ai.github.io/cap-evolve/results.html">
   <meta property="og:type" content="article">
   <meta property="og:site_name" content="cap-evolve">
   <meta property="og:title" content="Results — cap-evolve">
-  <meta property="og:description" content="Full benchmark results for cap-evolve — toy_calc, τ²-bench airline (fit-metric + held-out), SkillsBench. Every number cross-checked against committed run artifacts.">
+  <meta property="og:description" content="Full benchmark results for cap-evolve — toy_calc, τ²-bench airline (fit-metric + held-out), SkillsBench. Every section carries its own evidence marker: artifact-backed, reproducible in CI, or reported only.">
   <meta property="og:url" content="https://skillberry-ai.github.io/cap-evolve/results.html">
   <meta property="og:image" content="https://skillberry-ai.github.io/cap-evolve/assets/dashboard.png">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Results — cap-evolve">
-  <meta name="twitter:description" content="Full benchmark results for cap-evolve — toy_calc, τ²-bench airline (fit-metric + held-out), SkillsBench. Every number cross-checked against committed run artifacts.">
+  <meta name="twitter:description" content="Full benchmark results for cap-evolve — toy_calc, τ²-bench airline (fit-metric + held-out), SkillsBench. Every section carries its own evidence marker: artifact-backed, reproducible in CI, or reported only.">
   <meta name="twitter:image" content="https://skillberry-ai.github.io/cap-evolve/assets/dashboard.png">
   <link rel="icon" href="assets/favicon.svg" type="image/svg+xml">
   <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
@@ -51,9 +51,12 @@
 
   <h1>Results</h1>
   <p class="lead">
-    The canonical results for cap-evolve. Most numbers here are <strong>artifact-backed</strong>
-    — derived from a committed run directory (<code>examples/*/run_full/</code>) you can open and
-    load in the dashboard. One is marked <strong>⚠️ reported</strong>: that run happened, but its
+    The canonical results for cap-evolve. <strong>Every section heading below carries its own
+    evidence marker</strong> — read the marker, not an average.
+    <strong>✅ artifact-backed</strong>: the section opens with an <em>Artifact:</em> link to a
+    committed run directory (<code>examples/*/run_full/</code>) you can open and load in the
+    dashboard. <strong>✅ reproducible in CI</strong>: no paid run to commit; a deterministic test
+    re-derives the number on every CI run. <strong>⚠️ reported</strong>: the run happened, but its
     artifact is <strong>not committed</strong>, so the number rests on trust rather than evidence
     and reproducing it means paying for a fresh run. The <a href="./">home page</a>'s results
     section is a short snapshot of this page and carries the same markers.
@@ -76,7 +79,7 @@
     <div class="doc-main">
 
       <section class="reveal">
-        <h2 id="toy-calc">toy_calc — deterministic, zero-API</h2>
+        <h2 id="toy-calc">toy_calc — deterministic, zero-API <span class="muted">— ✅ reproducible in CI</span></h2>
 
         <table>
           <thead><tr><th></th><th>val</th><th>test</th><th>notes</th></tr></thead>
@@ -101,7 +104,7 @@
       </section>
 
       <section class="reveal">
-        <h2 id="tau2-fit">τ²-bench airline — no-holdout fit-metric run (reproducible, committed)</h2>
+        <h2 id="tau2-fit">τ²-bench airline — no-holdout fit-metric run <span class="muted">— ✅ artifact-backed</span></h2>
 
         <p>
           Artifact: <a href="https://github.com/skillberry-ai/cap-evolve/tree/main/examples/tau2_airline/run_full"><code>examples/tau2_airline/run_full/</code></a>
@@ -179,10 +182,9 @@
           <div class="callout-title">⚠️ Reported — artifact not committed</div>
           <p>
             These held-out figures are <strong>reported</strong>: the <code>run_full</code> artifact for
-            this run is <strong>not committed</strong> to the repo, and there is no timeline for
-            committing it. Unlike every other table on this page you cannot open the artifact, load it
-            in the dashboard, or re-derive these numbers from anything here — reproducing them means
-            paying for a fresh run. Treat them as a reported figure, not as evidence. The only
+            this run is <strong>not committed</strong> to the repo, and committing it is not
+            scheduled. You cannot open the artifact, load it in the dashboard, or re-derive these
+            numbers from anything here — reproducing them means paying for a fresh run. Treat them as a reported figure, not as evidence. The only
             artifact-backed τ²-bench run here is the <a href="#tau2-fit">no-holdout fit metric</a>
             above, whose test split is <em>not</em> held out.
           </p>
@@ -198,7 +200,7 @@
       </section>
 
       <section class="reveal">
-        <h2 id="tau2-agent">τ²-bench airline — agent orchestration mode (held-out 30 (=val) / 20)</h2>
+        <h2 id="tau2-agent">τ²-bench airline — agent orchestration mode (held-out 30 (=val) / 20) <span class="muted">— ⚠️ reported, artifact not committed</span></h2>
 
         <p>
           The first run driven entirely in <a href="agent-orchestration.html">agent mode</a> with the
@@ -234,7 +236,7 @@
       </section>
 
       <section class="reveal">
-        <h2 id="qwen-tools">τ²-bench airline — Qwen 2.5 14B</h2>
+        <h2 id="qwen-tools">τ²-bench airline — Qwen 2.5 14B <span class="muted">— ⚠️ reported, artifact not committed</span></h2>
 
         <p>
           Same benchmark, capability, split, and algorithm as the held-out run above, with a
@@ -269,7 +271,7 @@
       </section>
 
       <section class="reveal">
-        <h2 id="qwen-all">τ²-bench airline — Qwen 2.5 14B, all capabilities</h2>
+        <h2 id="qwen-all">τ²-bench airline — Qwen 2.5 14B, all capabilities <span class="muted">— ⚠️ reported, artifact not committed</span></h2>
 
         <p>
           Same model and split as above, with all three capability types optimized jointly.
@@ -312,7 +314,7 @@
       </section>
 
       <section class="reveal">
-        <h2 id="skillsbench">SkillsBench — skill-package optimization (held-out, committed)</h2>
+        <h2 id="skillsbench">SkillsBench — skill-package optimization (held-out) <span class="muted">— ✅ artifact-backed</span></h2>
 
         <p>
           Artifact: <a href="https://github.com/skillberry-ai/cap-evolve/tree/main/examples/skillsbench/run_full"><code>examples/skillsbench/run_full/</code></a>
@@ -400,7 +402,7 @@
 
             <!-- Row 2: τ²-bench airline held-out test — 30.0 → 47.5 -->
             <text class="row-label" x="170" y="136" text-anchor="end">τ²-bench airline</text>
-            <text class="row-sub"   x="170" y="149" text-anchor="end">held-out test (20 tasks) ⚠️ reported</text>
+            <text class="row-sub"   x="170" y="149" text-anchor="end">held-out test (20 tasks) — reported</text>
             <line class="connector" x1="318" y1="142" x2="383" y2="142"/>
             <circle class="dot-base" cx="312" cy="142" r="6"/>
             <circle class="dot-opt"  cx="389" cy="142" r="6"/>

--- a/site/results.html
+++ b/site/results.html
@@ -51,10 +51,12 @@
 
   <h1>Results</h1>
   <p class="lead">
-    The canonical results for cap-evolve. Every number here is derived from a committed run
-    artifact (<code>examples/*/run_full/*.json</code>) or, where noted, from a held-out run whose
-    artifact is committed separately. The <a href="./">home page</a>'s results section is a short
-    snapshot of this page.
+    The canonical results for cap-evolve. Most numbers here are <strong>artifact-backed</strong>
+    — derived from a committed run directory (<code>examples/*/run_full/</code>) you can open and
+    load in the dashboard. One is marked <strong>⚠️ reported</strong>: that run happened, but its
+    artifact is <strong>not committed</strong>, so the number rests on trust rather than evidence
+    and reproducing it means paying for a fresh run. The <a href="./">home page</a>'s results
+    section is a short snapshot of this page and carries the same markers.
   </p>
 
   <div class="callout callout-accent">
@@ -155,12 +157,12 @@
       </section>
 
       <section class="reveal">
-        <h2 id="tau2-heldout">τ²-bench airline — held-out 30(=val)/20 run</h2>
+        <h2 id="tau2-heldout">τ²-bench airline — held-out 30(=val)/20 run <span class="muted">— ⚠️ reported, artifact not committed</span></h2>
 
         <p>
           Same benchmark and capability, run with a real holdout split
-          (<code>split_ids.json</code>, train=val=30, test=20) so the test number is a genuine
-          generalization result.
+          (<code>split_ids.json</code>, train=val=30, test=20) so the test number is a
+          generalization result <em>as run</em>.
         </p>
 
         <table>
@@ -174,12 +176,15 @@
         </table>
 
         <div class="callout callout-warn">
-          <div class="callout-title">Reported — artifact pending (not yet committed)</div>
+          <div class="callout-title">⚠️ Reported — artifact not committed</div>
           <p>
             These held-out figures are <strong>reported</strong>: the <code>run_full</code> artifact for
-            this run is <strong>not yet committed</strong>. Until it lands, treat the numbers above as the
-            reported held-out result — <strong>not</strong> artifact-backed. The reproducible,
-            artifact-backed run is the <a href="#tau2-fit">no-holdout fit metric</a> above.
+            this run is <strong>not committed</strong> to the repo, and there is no timeline for
+            committing it. Unlike every other table on this page you cannot open the artifact, load it
+            in the dashboard, or re-derive these numbers from anything here — reproducing them means
+            paying for a fresh run. Treat them as a reported figure, not as evidence. The only
+            artifact-backed τ²-bench run here is the <a href="#tau2-fit">no-holdout fit metric</a>
+            above, whose test split is <em>not</em> held out.
           </p>
         </div>
 
@@ -363,7 +368,8 @@
               Three benchmarks, each showing the seed baseline (open circle) and the optimized
               candidate (filled green circle) on a 0–100 scale.
               τ²-bench airline fit metric: 53.6 to 71.2, a gain of 17.6 points.
-              τ²-bench airline held-out test: 30.0 to 47.5, a gain of 17.5 points.
+              τ²-bench airline held-out test: 30.0 to 47.5, a gain of 17.5 points — reported only,
+              artifact not committed.
               SkillsBench held-out test: 55.6 to 66.7, a gain of 11.1 points.
             </desc>
 
@@ -394,7 +400,7 @@
 
             <!-- Row 2: τ²-bench airline held-out test — 30.0 → 47.5 -->
             <text class="row-label" x="170" y="136" text-anchor="end">τ²-bench airline</text>
-            <text class="row-sub"   x="170" y="149" text-anchor="end">held-out test (20 tasks)</text>
+            <text class="row-sub"   x="170" y="149" text-anchor="end">held-out test (20 tasks) ⚠️ reported</text>
             <line class="connector" x1="318" y1="142" x2="383" y2="142"/>
             <circle class="dot-base" cx="312" cy="142" r="6"/>
             <circle class="dot-opt"  cx="389" cy="142" r="6"/>


### PR DESCRIPTION
**Closes #99**

## The honest path taken: Option A (relabel), not Option B (commit the artifact)

Option B is impossible in this repo. The only committed τ²-bench run directory,
`examples/tau2_airline/run_full/`, is the **no-holdout fit-metric** run — a different run:

```
$ python -c "import json;d=json.load(open('examples/tau2_airline/split_ids.json'));print({k:len(v) for k,v in d.items()})"
{'train': 50, 'val': 50, 'test': 50}

$ python -c "import json;print(json.load(open('examples/tau2_airline/run_full/final.json'))['test']['reward'])"
0.6940000000000001
```

That is `train == val == test == 50` and test reward `0.694` — not a 30/20 holdout and not
`0.475`. The held-out run's artifact is nowhere in the tree; producing it means a fresh
multi-hour paid τ²-bench run. So rather than imply a sealing that cannot be shown, this PR
**makes the label match reality on every surface** and states plainly that the number rests
on trust, not evidence. No number was changed.

## Before / after

**`README.md:110`** — the actual issue. Before (no caveat at all):

```
| **τ²-bench airline**, held-out 30(=val)/20 | sealed **test** | `30.0 → 47.5` | **+17.5 pp / +58.3%** |
```

After (new `Artifact` column across the whole table, so ✅ and ⚠️ are visibly different):

```
| **τ²-bench airline**, held-out 30(=val)/20 | sealed **test** | `30.0 → 47.5` | **+17.5 pp / +58.3%** | ⚠️ [**reported — not committed**](docs/RESULTS.md) |
```

**`docs/RESULTS.md:73-75`** — the old wording implied the artifact was about to land. Before:

> The held-out `run_full` artifact for this run is committed separately. Until it lands,
> treat these figures as the reported held-out result; the reproducible artifact-backed
> run above is the no-holdout fit metric.

After:

> **⚠️ Reported — the `run_full/` artifact for this run is not committed to this repo, and
> there is no timeline for committing it.** Unlike every other row on this page, you cannot
> open the artifact, load it in the dashboard, or re-derive these numbers from anything
> here; reproducing them means paying for a fresh run ([`REPRODUCE_tau2.md`](docs/REPRODUCE_tau2.md)).
> Treat it as a reported figure, not as evidence. ...

("committed separately" → "not committed … no timeline". The old phrasing was the softest
possible framing of "missing".)

**`presentation/index.html:788`** — speaker notes asserted something false. Before:

> Every result is committed in examples/*/run_full/.

After:

> … say out loud that this one is REPORTED ONLY: its run artifact is not committed, so it is
> the weakest-evidenced number on the slide. Fit-metric on the left and SkillsBench on the
> right ARE committed under examples/*/run_full/.

## Everything changed

| File | Change |
|---|---|
| `README.md` | New `Artifact` column: ✅ linked `run_full/` for the three backed rows, ⚠️ **reported — not committed** for the held-out τ² row; intro defines both states |
| `docs/RESULTS.md` | Preamble now defines artifact-backed (section opens with an `Artifact:` link) vs reported; held-out section heading + callout rewritten as above |
| `docs/COMPARISON.md` | cap-evolve's own row marked ⚠️ reported, plus a caveat that it is the **weakest-evidenced row in the table** — the external rows are published, ours is not inspectable |
| `OUTREACH.md` | "Some committed, reproducible results" no longer covers the reported number (moved last, marked); **also fixes a factual error: the split was written `30/10/10`, actual is `30(=val)/20`** |
| `site/index.html` | Matching `Artifact` column; same `30/10/10` → `30(=val)/20` fix; replaced the easy-to-miss `· reported` muted suffix |
| `site/results.html` | Lead paragraph, section heading, the callout, the at-a-glance chart row label, **and the SVG `<desc>` alt text** (screen-reader users got the bare number before) |
| `presentation/index.html` | Stat card sub-title marked; false blanket claim in speaker notes corrected |

Two bugs beyond the issue's scope, found while reconciling: the **`30/10/10` split** in
`OUTREACH.md` and `site/index.html` (the issue title itself repeats it — the real split is
`train=val=30, test=20`), and the presentation's false "every result is committed".

Docs/site only — no code touched, so `core/` behaviour is unchanged.

## Verification

```
$ cd /tmp/wt-99 && PYTHONPATH=/tmp/wt-99/core /tmp/ce-venv/bin/python -m pytest core/tests -q
........................................................................ [ 40%]
........................................................................ [ 80%]
...................................                                      [100%]
179 passed in 60.45s (0:01:00)
```

```
$ /tmp/ce-venv/bin/python -m compileall -q core skills && echo "COMPILEALL OK"
COMPILEALL OK
```

Relative links in every Markdown file I touched (the `docs-links` CI job) — all resolve on
disk, no `FAIL` rows:

```
$ for f in README.md OUTREACH.md docs/RESULTS.md docs/COMPARISON.md; do ... done
OK   README.md -> docs/RESULTS.md
OK   README.md -> examples/skillsbench/run_full/
OK   README.md -> examples/tau2_airline/run_full/
OK   docs/COMPARISON.md -> RESULTS.md
OK   docs/RESULTS.md -> ../examples/tau2_airline/run_full/
OK   docs/RESULTS.md -> REPRODUCE_tau2.md
...  (39 OK, 0 FAIL — full output in the Evidence comment)
```

`site/index.html` → `results.html#tau2-heldout`: anchor confirmed present
(`grep -c 'id="tau2-heldout"' site/results.html` → `1`). No `style.css` / `site.js` change,
so no `?v=` cache-buster bump was needed per `site/README.md`.
