### PR TITLE
Move the tools/subagent optimizer playbook out of generic intake into the tools capability

### DIFF
--- a/skills/capabilities/tools/SKILL.md
+++ b/skills/capabilities/tools/SKILL.md
@@ -679,3 +679,8 @@ python scripts/run.py --path <capability_dir>     # candidate + policy + validit
   fill, toolset design, the policy) with cited sources.
 - [`references/examples.md`](references/examples.md) — worked before/after edits.
 - [`references/pitfalls.md`](references/pitfalls.md) — failure modes and how to detect them.
+- [`references/optimizer-playbook.md`](references/optimizer-playbook.md) — what the
+  authored optimizer INSTRUCTIONS must demand when `tools` is selected: the
+  existing-tool-code mandate, the depth mandate's tools wording, and the two-phase
+  (diagnose fan-out → implement fan-out → merge) subagent pattern. `intake` points
+  here rather than inlining it.

--- a/skills/capabilities/tools/references/optimizer-playbook.md
+++ b/skills/capabilities/tools/references/optimizer-playbook.md
@@ -1,0 +1,57 @@
+# Optimizer playbook for the `tools` capability
+
+What the **authored optimizer instructions** must demand when `tools` is among the
+selected capabilities. `intake` writes those instructions
+(`.capevolve/project/optimizer/INSTRUCTIONS.md`) but stays capability-agnostic; this
+file is the `tools`-specific half it points at. Encode every item below into the
+authored INSTRUCTIONS — verbatim or tightened for the benchmark at hand.
+
+- [Depth mandate (tools wording)](#depth-mandate-tools-wording)
+- [The EXISTING-tool-code mandate](#the-existing-tool-code-mandate)
+- [The explicit TWO-PHASE subagent pattern](#the-explicit-two-phase-subagent-pattern)
+- [What an under-used iteration looks like](#what-an-under-used-iteration-looks-like)
+
+## Depth mandate (tools wording)
+
+`intake` demands a substantial multi-root-cause pass in capability-neutral terms.
+When `tools` is selected, make that demand concrete with this snippet:
+
+> "Each iteration is a substantial, multi-root-cause pass. Diagnose ALL clusters
+> and fix as many as possible in ONE candidate — improve multiple tools' code,
+> validation, and return values/errors; add new tools; sharpen many tool docs;
+> and fix the prompt — together. Scope each fix to protect passing tasks; do NOT
+> trade breadth for caution. A single small edit is an under-used iteration."
+
+## The EXISTING-tool-code mandate
+
+Demand: convert violated textual rules into in-code checks across MANY EXISTING tool
+bodies — most violated rules govern a tool that already exists, so the fix is an
+in-body guard there, not a new tool. State plainly: *a docstring-only iteration (or
+one that only adds a single new tool + rewords docstrings, leaving rules as prose)
+is under-used.*
+
+The edit classes this mandate ranges over — and the before/after diffs that show an
+in-body guard replacing a prose rule — are in
+[`../SKILL.md`](../SKILL.md) ("What you can change here", "The highest-leverage
+edit") and [`examples.md`](examples.md).
+
+## The explicit TWO-PHASE subagent pattern
+
+Require:
+
+1. **Phase 1 — diagnose fan-out.** One read-only subagent per trajectory-group → a
+   tight issue list; the main agent dedups those into clusters.
+2. **Phase 2 — implement fan-out.** One edit-subagent per ISSUE, each in its own
+   worktree, each PREFERRING to edit the EXISTING tool's code body to enforce its
+   rule.
+3. **Merge.** The main agent merges all edits into ONE candidate.
+
+Point the optimizer at `./guidance/optimizer/<name>.md` for that agent's concrete
+trigger phrasing.
+
+## What an under-used iteration looks like
+
+Authored INSTRUCTIONS fail this playbook when they let an iteration pass by adding
+one tool + rewording docstrings (leaving violated rules as prose) — or when they
+omit the existing-tool-code mandate or the explicit two-phase (diagnose fan-out →
+implement fan-out → merge) subagent pattern.

--- a/skills/capabilities/tools/references/optimizer-playbook.md
+++ b/skills/capabilities/tools/references/optimizer-playbook.md
@@ -9,7 +9,6 @@ authored INSTRUCTIONS — verbatim or tightened for the benchmark at hand.
 - [Depth mandate (tools wording)](#depth-mandate-tools-wording)
 - [The EXISTING-tool-code mandate](#the-existing-tool-code-mandate)
 - [The explicit TWO-PHASE subagent pattern](#the-explicit-two-phase-subagent-pattern)
-- [What an under-used iteration looks like](#what-an-under-used-iteration-looks-like)
 
 ## Depth mandate (tools wording)
 
@@ -19,7 +18,9 @@ When `tools` is selected, make that demand concrete with this snippet:
 > "Each iteration is a substantial, multi-root-cause pass. Diagnose ALL clusters
 > and fix as many as possible in ONE candidate — improve multiple tools' code,
 > validation, and return values/errors; add new tools; sharpen many tool docs;
-> and fix the prompt — together. Scope each fix to protect passing tasks; do NOT
+> and fix the prompt (only if `system-prompt` is ALSO among the selected
+> capabilities — on a `tools`-only run drop this clause and leave the prompt
+> alone) — together. Scope each fix to protect passing tasks; do NOT
 > trade breadth for caution. A single small edit is an under-used iteration."
 
 ## The EXISTING-tool-code mandate
@@ -49,9 +50,4 @@ Require:
 Point the optimizer at `./guidance/optimizer/<name>.md` for that agent's concrete
 trigger phrasing.
 
-## What an under-used iteration looks like
-
-Authored INSTRUCTIONS fail this playbook when they let an iteration pass by adding
-one tool + rewording docstrings (leaving violated rules as prose) — or when they
-omit the existing-tool-code mandate or the explicit two-phase (diagnose fan-out →
-implement fan-out → merge) subagent pattern.
+Authored INSTRUCTIONS fail this playbook when they omit either mandate above.

--- a/skills/phases/intake/SKILL.md
+++ b/skills/phases/intake/SKILL.md
@@ -93,34 +93,28 @@ inputs. The metric / GitHub / stop-condition questions below feed directly into 
    guidance, skill references, and edit-space ONLY for the capabilities actually
    listed in `capevolve.yaml: capabilities`.
    - **DEPTH MANDATE — address ALL failure clusters each iteration.** The authored
-     instructions must demand a substantial multi-root-cause pass. Produce this
-     target snippet:
-     > "Each iteration is a substantial, multi-root-cause pass. Diagnose ALL clusters
-     > and fix as many as possible in ONE candidate — improve multiple tools' code,
-     > validation, and return values/errors; add new tools; sharpen many tool docs;
-     > and fix the prompt — together. Scope each fix to protect passing tasks; do NOT
-     > trade breadth for caution. A single small edit is an under-used iteration."
+     instructions must demand a substantial multi-root-cause pass: diagnose ALL
+     clusters and fix as many as possible in ONE candidate, spanning EVERY edit class
+     the selected capabilities offer (each capability's SKILL.md enumerates its own).
+     Scope each fix to protect passing tasks; do NOT trade breadth for caution. State
+     plainly that a single small edit is an under-used iteration. For the concrete
+     per-capability wording of this mandate, use the selected capability's own
+     optimizer playbook (see the capability-playbook rule below).
    - **State the GOAL up front:** maximize the eval score — make the largest
      improvement you can this iteration, grounded in the trajectories.
-   - **The authored INSTRUCTIONS MUST encode all three of these (generic, capability-scoped):**
+   - **The authored INSTRUCTIONS MUST encode all of these (generic, capability-scoped):**
      1. **STEP-0 reading mandate.** Before diagnosing, the optimizer must READ
         `./guidance/<cap>/SKILL.md` (for EACH selected capability) and the optimizer
         features reference under `./guidance/optimizer/`. State this as an explicit
         first step.
-     2. **The EXISTING-tool-code mandate** (when `tools` is selected). Demand: convert
-        violated textual rules into in-code checks across MANY EXISTING tool bodies —
-        most violated rules govern a tool that already exists, so the fix is an in-body
-        guard there, not a new tool. State plainly: *a docstring-only iteration (or one
-        that only adds a single new tool + rewords docstrings, leaving rules as prose)
-        is under-used.*
-     3. **The explicit TWO-PHASE subagent pattern.** Require: Phase 1 — diagnose
-        fan-out (one read-only subagent per trajectory-group → tight issue list; main
-        dedups into clusters); Phase 2 — implement fan-out (one edit-subagent per
-        ISSUE, each in its own worktree, each PREFERRING to edit the EXISTING tool's
-        code body to enforce its rule); then the main agent MERGES all edits into ONE
-        candidate. Point at `./guidance/optimizer/<name>.md` for the agent's concrete
-        trigger phrasing.
-     4. **The NON-OVERFITTING guardrail.** Demand that every prompt/tool edit encode
+     2. **Each selected capability's own optimizer playbook.** For EVERY capability in
+        `capevolve.yaml: capabilities`, load that capability's playbook from its skill
+        (`skills/capabilities/<cap>/references/`, e.g. `tools` →
+        [`optimizer-playbook.md`](../../capabilities/tools/references/optimizer-playbook.md))
+        and fold its edit-depth demands and subagent-fan-out pattern into the authored
+        INSTRUCTIONS. Do NOT restate one capability's playbook here — it lives with
+        that capability and evolves with it.
+     3. **The NON-OVERFITTING guardrail.** Demand that every prompt/tool edit encode
         a GENERAL rule/policy/validation that generalizes across the whole class of
         inputs — NEVER hardcode a specific task's id/value/date/name/answer. A guard
         must fire on the general condition (e.g. "id not in the user's profile"), not
@@ -128,13 +122,13 @@ inputs. The metric / GitHub / stop-condition questions below feed directly into 
         only helps one task is forbidden — it overfits, fails the held-out gate, and
         hurts other tasks. Per-task specifics are for understanding the failure CLASS
         only; the fix must be general.
-     5. **EXPLOIT ground-truth/eval present in the trajectories (diagnosis only).**
+     4. **EXPLOIT ground-truth/eval present in the trajectories (diagnosis only).**
         Tell the optimizer that when `./trajectories/` include ground-truth /
         expected actions / a reward breakdown, it should USE them during diagnosis to
         localize the exact defect (expected vs actual action/argument/value) — and if
         not present, infer from the traces + feedback. State plainly that ground truth
         informs the failure class only; the resulting edit must still be GENERAL
-        (guardrail 4) and never copy a gold value.
+        (guardrail 3) and never copy a gold value.
    - **Capability-scoping (the key rule):** reference `./guidance/<cap>/SKILL.md`
      and present the editable artifacts **for the selected caps only**. If only
      `tools` is selected, do NOT include any prompt-editing guidance, do NOT
@@ -247,10 +241,9 @@ this whole integration autonomously.
   the gold answer into feedback; test == train with no note; budget left at a
   default that cannot possibly find a gain; the run proceeded past a missing
   NEEDED input "to keep moving".
-- **Bad:** authored INSTRUCTIONS that let an iteration pass by adding one tool +
-  rewording docstrings (leaving violated rules as prose) — or that omit the STEP-0
-  reading mandate, the existing-tool-code mandate, or the explicit two-phase
-  (diagnose fan-out → implement fan-out → merge) subagent pattern.
+- **Bad:** authored INSTRUCTIONS that omit the STEP-0 reading mandate, or that skip a
+  selected capability's own optimizer playbook — so an iteration can pass on a
+  cosmetic edit that the capability's playbook calls under-used.
 
 ## References
 - `references/concepts.md` — the inputs contract, NEEDED vs RECOMMENDED

--- a/skills/phases/intake/SKILL.md
+++ b/skills/phases/intake/SKILL.md
@@ -108,12 +108,16 @@ inputs. The metric / GitHub / stop-condition questions below feed directly into 
         features reference under `./guidance/optimizer/`. State this as an explicit
         first step.
      2. **Each selected capability's own optimizer playbook.** For EVERY capability in
-        `capevolve.yaml: capabilities`, load that capability's playbook from its skill
-        (`skills/capabilities/<cap>/references/`, e.g. `tools` →
-        [`optimizer-playbook.md`](../../capabilities/tools/references/optimizer-playbook.md))
-        and fold its edit-depth demands and subagent-fan-out pattern into the authored
-        INSTRUCTIONS. Do NOT restate one capability's playbook here — it lives with
-        that capability and evolves with it.
+        `capevolve.yaml: capabilities`, load that capability's playbook from its skill.
+        Both path forms matter, each for its own reader: YOU read it in this repo at
+        `skills/capabilities/<cap>/references/` (e.g. `tools` →
+        [`optimizer-playbook.md`](../../capabilities/tools/references/optimizer-playbook.md)),
+        but any path you WRITE INTO the authored INSTRUCTIONS must be the
+        runtime-materialized form `./guidance/<cap>/references/` — the repo-relative
+        path does not resolve in the optimizer's working dir. Fold its edit-depth
+        demands and subagent-fan-out pattern into the authored INSTRUCTIONS. Do NOT
+        restate one capability's playbook here — it lives with that capability and
+        evolves with it.
      3. **The NON-OVERFITTING guardrail.** Demand that every prompt/tool edit encode
         a GENERAL rule/policy/validation that generalizes across the whole class of
         inputs — NEVER hardcode a specific task's id/value/date/name/answer. A guard


### PR DESCRIPTION
Closes #106

## The boundary decision

`skills/phases/intake/SKILL.md` step 5 (authoring the optimizer INSTRUCTIONS) inlined a **tools-specific** playbook under a "when `tools` is selected" gate. It dominated the step, so a `system-prompt`-only or `skill-package`-only run read paragraphs of tool-code advice that did not apply.

**Moved out (capability-specific — all of it is about tool bodies, docstrings, and the tools fan-out):**

| Old location | What it was |
|---|---|
| `intake/SKILL.md:95-102` | The DEPTH MANDATE's **target snippet**, whose text enumerates tools edit classes ("improve multiple tools' code, validation, and return values/errors; add new tools; sharpen many tool docs") |
| `intake/SKILL.md:110-115` | **The EXISTING-tool-code mandate** — in-body guards across MANY EXISTING tool bodies; "a docstring-only iteration … is under-used" |
| `intake/SKILL.md:116-122` | **The explicit TWO-PHASE subagent pattern** — diagnose fan-out → implement fan-out (each subagent "PREFERRING to edit the EXISTING tool's code body") → merge |
| `intake/SKILL.md:250-253` | The "Bad intake" bullet restating the two mandates above in tools terms |

**Stayed in intake (genuinely generic — true for every capability):**

- The **DEPTH MANDATE itself**, restated capability-neutrally: diagnose ALL clusters, fix as many as possible in ONE candidate, spanning every edit class *the selected capabilities offer*, scoped to protect passing tasks, and a single small edit is an under-used iteration. The *demand* is generic; only its tools-flavored wording moved.
- **STEP-0 reading mandate** (read `./guidance/<cap>/SKILL.md` + `./guidance/optimizer/`) — mandate 1, unchanged.
- **NON-OVERFITTING guardrail** and **ground-truth-is-for-diagnosis-only** — mandates 3 and 4 (renumbered from 4 and 5; the internal "guardrail 4" cross-reference was updated to "guardrail 3").
- **Capability-scoping rule**, the four cross-iteration files (`LEDGER.md` / `JOURNAL.md` / `RUNMAP.md` / `prior_iterations/`), `PROCESS.md`, all spec keys, the ask-if-missing discipline, and the whole surrounding flow — untouched.

The tools-only mandates are replaced by one generic pointer (new mandate 2): *"For EVERY capability in `capevolve.yaml: capabilities`, load that capability's playbook from its skill (`skills/capabilities/<cap>/references/`) … Do NOT restate one capability's playbook here — it lives with that capability and evolves with it."* This is the pattern issue point 3 asks for, and it is why nothing needs re-editing when `tools` evolves.

Per issue point 3, the other capabilities were checked and already keep their guidance in their own skill: `system-prompt` (198 lines + `references/concepts.md`), `skill-package` (122 + 3 references), `mcp-tool` (235 + `references/concepts.md`). None of them leak into intake.

The harness already copies each selected capability skill **whole** into the optimizer's `./guidance/<cap>/` (`core/cap_evolve/harness.py:1032-1046`), so the new reference reaches the optimizer with no harness change.

## Destination path (for #107)

```
skills/capabilities/tools/references/optimizer-playbook.md
```

One level deep under the `tools` skill, alongside the existing `concepts.md` / `examples.md` / `pitfalls.md`, with a TOC and a link from `tools/SKILL.md`'s References section. #107's split of `tools/SKILL.md` (686 lines, over the ~500 bar) can move further body sections into this same `references/` directory; this file does not claim any of the section names currently in the body.

## Before / after line counts

| File | Before | After | Δ |
|---|---|---|---|
| `skills/phases/intake/SKILL.md` | 258 | **251** | −7 |
| `skills/capabilities/tools/SKILL.md` | 681 | **686** | +5 (References entry only) |
| `skills/capabilities/tools/references/optimizer-playbook.md` | — | **57** | new |

Intake shrank by 7 body lines while dropping ~28 lines of tools content, because the generic depth mandate and the new capability-playbook pointer were written back in its place. Both SKILL.md bodies are unchanged in structure; `tools/SKILL.md` at 686 lines is over the ~500 bar and is #107's job, not widened by this PR beyond the 5-line References entry.

## Verification

```
$ /tmp/ce-venv/bin/python skills/_registry/build_manifest.py skills
wrote skills/_registry/manifest.json (20 skill(s))
  algorithm: agent-optimize, evograph, gepa, hill-climb, skillopt
  capability: mcp-tool, skill-package, system-prompt, tools
  optimizer: run-optimizer
  orchestrate: orchestrate, using-cap-evolve
  phase: baseline, diagnose, evaluate, finalize, gate, implement-and-check, intake, report
rc=0
```

```
$ /tmp/ce-venv/bin/python skills/phases/intake/scripts/check.py
{
  "skill": "intake",
  "ok": true,
  "problems": [],
  "notes": [
    "run entry exposes main()",
    "mines existing task files",
    "mines existing capability artifacts",
    "scaffolds the adapter stub + spec"
  ]
}
rc=0

$ /tmp/ce-venv/bin/python skills/capabilities/tools/scripts/check.py
{
  "skill": "tools",
  "ok": true,
  "problems": [],
  "notes": [
    "full action set (schema/code/compose) allowed by default"
  ]
}
rc=0
```

```
$ PYTHONPATH=/tmp/wt-106/core /tmp/ce-venv/bin/python -m pytest core/tests -q
........................................................................ [ 40%]
........................................................................ [ 80%]
...................................                                      [100%]
179 passed in 63.48s (0:01:03)

$ /tmp/ce-venv/bin/python -m compileall -q core skills
compileall rc=0
```

**Nothing lost in the move.** All 26 substantive claims from the old intake block were checked against the new playbook (whitespace/markdown-normalized substring match): `claims: 26  preserved in playbook: 26  lost: 0`. The 4 phrases still present in intake are the capability-neutral ones that deliberately stayed (the generic depth demand and the `./guidance/optimizer/<name>.md` reference).

**No dangling references to the old location.**

```
$ grep -c "EXISTING-tool-code\|TWO-PHASE\|docstring-only\|diagnose fan-out" skills/phases/intake/SKILL.md
0
$ grep -niE "tool body|in-body|docstring|tool surface|tools\.json|frontmatter|mcp server|skill package" skills/phases/intake/SKILL.md
(no output — exit 1)
```

Reading intake cold for a `system-prompt`-only run now contains zero tool-code instructions, which is the issue's stated test.

**Reachable per the skill-authoring rules** — one level deep and linked from SKILL.md:

```
$ ls -1 skills/capabilities/tools/references/
concepts.md
examples.md
optimizer-playbook.md
pitfalls.md
$ grep -n "optimizer-playbook" skills/capabilities/tools/SKILL.md skills/phases/intake/SKILL.md
skills/capabilities/tools/SKILL.md:682:- [`references/optimizer-playbook.md`](references/optimizer-playbook.md) — what the
skills/phases/intake/SKILL.md:113:        [`optimizer-playbook.md`](../../capabilities/tools/references/optimizer-playbook.md))
```

No empty placeholders; frontmatter on both SKILL.md files is untouched and valid (manifest builds).