### PR TITLE
feat(config): provider-scoped credential resolution + auto provider probing (closes #134)

### DIFF
--- a/core/cap_evolve/cli.py
+++ b/core/cap_evolve/cli.py
@@ -127,6 +127,17 @@ def _cmd_run(argv):
     p.add_argument("--dashboard", choices=("auto", "report-only", "off"), default=None,
                    help="live dashboard: auto (default, launch at run start), report-only, or off")
     p.add_argument("--dashboard-port", type=int, default=None, help="dashboard server port (default 7878)")
+    # Provider/credential flags — the TOP precedence layer (see model_config.PRECEDENCE).
+    p.add_argument("--provider", default=None,
+                   help="provider whose credential to use (e.g. anthropic|openai|gemini|rits|"
+                        "watsonx|mock), or 'auto' to pick the one that actually has a credential")
+    p.add_argument("--provider-base-url", default=None, help="override the provider's base URL")
+    p.add_argument("--provider-credential-env", default=None,
+                   help="env var NAME holding the credential (must belong to the selected "
+                        "provider; cross-provider names are refused)")
+    p.add_argument("--probe-provider", action="store_true",
+                   help="with --provider auto: also probe each candidate's OWN endpoint with "
+                        "its OWN credential before selecting it")
     args = p.parse_args(argv)
 
     skills_dir = Path(args.skills_dir) if args.skills_dir else _find_skills_dir()
@@ -229,8 +240,25 @@ def _cmd_run(argv):
     else:
         sequence = ["intake", "implement-and-check", "baseline", algorithm_name, "finalize", "report"]
 
+    # Provider/credential resolution — decided BEFORE anything is spent. The precedence
+    # (CLI > project spec > user config > built-in) and the provider-scoping rule live in
+    # model_config; here we only surface its secret-free report. `mock`/offline optimizers
+    # need no credential, so a credential is required only when a provider is named.
+    from . import model_config as _mc
+    _cli_layer = {k: v for k, v in (("provider", args.provider),
+                                    ("base_url", args.provider_base_url),
+                                    ("credential_env", args.provider_credential_env)) if v}
+    try:
+        _provider = _mc.resolve(
+            cli=_cli_layer, project=spec,
+            require_credential=bool(_cli_layer.get("provider") or spec.get("provider")),
+            probe_fn=_mc.probe if args.probe_provider else None).to_dict()
+    except _mc.CredentialError as e:
+        _provider = {"error": str(e)}      # message names env VARS, never values
+
     if args.plan_only:
         print(json.dumps({"skills_dir": str(skills_dir), "workdir": str(workdir), "spec": spec,
+                          "provider": _provider,
                           "optimizer": optimizer_name, "optimizer_cmd": opt_cmd,
                           "algorithm": algorithm_name, "focus": algorithm_focus,
                           "target_model": spec.get("target_model", ""),
@@ -244,6 +272,10 @@ def _cmd_run(argv):
                                      "optimizer_max_turns": spec.get("optimizer_max_turns", 0)},
                           "sequence": sequence}, indent=2))
         return 0
+
+    print(json.dumps({"step": "provider", **_provider}))
+    if "error" in _provider:
+        return 1
 
     # Hard gate: cap-evolve check must pass before any budget is spent (intake is the
     # user's job before `run`; here we enforce the check half of implement-and-check).

--- a/core/cap_evolve/cli.py
+++ b/core/cap_evolve/cli.py
@@ -257,7 +257,11 @@ def _cmd_run(argv):
         _provider = {"error": str(e)}      # message names env VARS, never values
 
     if args.plan_only:
-        print(json.dumps({"skills_dir": str(skills_dir), "workdir": str(workdir), "spec": spec,
+        # `spec` is echoed verbatim here, so it carries `provider_base_url` — route the
+        # whole plan through the shared redactor (secrets AND endpoint confidentiality).
+        from .dashboard import redact as _redact
+        print(json.dumps(_redact(
+                         {"skills_dir": str(skills_dir), "workdir": str(workdir), "spec": spec,
                           "provider": _provider,
                           "optimizer": optimizer_name, "optimizer_cmd": opt_cmd,
                           "algorithm": algorithm_name, "focus": algorithm_focus,
@@ -270,7 +274,7 @@ def _cmd_run(argv):
                                      "max_usd": spec.get("max_usd", 0.0),
                                      "max_optimizer_usd": spec.get("max_optimizer_usd", 0.0),
                                      "optimizer_max_turns": spec.get("optimizer_max_turns", 0)},
-                          "sequence": sequence}, indent=2))
+                          "sequence": sequence}), indent=2))
         return 0
 
     print(json.dumps({"step": "provider", **_provider}))

--- a/core/cap_evolve/dashboard.py
+++ b/core/cap_evolve/dashboard.py
@@ -50,6 +50,7 @@ import os
 import re
 import shutil
 import subprocess
+import urllib.parse
 from pathlib import Path
 
 # ---------------------------------------------------------------------------
@@ -90,6 +91,96 @@ _INLINE_KV_RE = re.compile(
 
 _REDACTED = "«redacted»"
 
+# ---------------------------------------------------------------------------
+# Endpoint confidentiality
+# ---------------------------------------------------------------------------
+# Threat model, widened after an internal gateway base URL was printed verbatim into a
+# public PR comment (PR #190). Two things are wrong with treating a URL as harmless
+# diagnostic context:
+#
+# 1. ``https://user:token@host/path`` is a legal URL, so a credential can ride inside
+#    a field nobody classified as secret. Userinfo is stripped UNCONDITIONALLY, from
+#    every URL, public or not — there is no case where it should be rendered or stored.
+# 2. A *custom* base URL is itself confidential. The hostname is precisely what names
+#    internal infrastructure, so showing "the host only" leaks the whole thing; the
+#    path is the least interesting part. We therefore replace the value with
+#    ``<custom>`` and report the *source* of the setting instead, which is what a user
+#    debugging precedence actually needs. Well-known public endpoints (the built-in
+#    defaults) carry no information about anyone's network and stay legible.
+#
+# The rule lives here, in the shared helper, so every consumer (``model_config``'s
+# provider step, the reducer, ``dashboard.html``, and ``doctor``) inherits it.
+
+#: Public endpoints that are safe to print verbatim. Kept as a literal set rather than
+#: a heuristic: "is this host public?" has no safe default answer, so an endpoint is
+#: legible only by being on this list. Mirrors the built-in defaults in
+#: ``model_config.PROVIDERS`` (a test pins the two together).
+PUBLIC_BASE_URLS: frozenset[str] = frozenset({
+    "https://api.anthropic.com",
+    "https://api.openai.com/v1",
+    "https://generativelanguage.googleapis.com/v1beta",
+    "https://api.moonshot.ai/v1",
+    "https://api.githubcopilot.com",
+})
+
+#: What a non-public base URL renders as.
+CUSTOM_URL = "<custom>"
+
+# Credentials also hide in query params (``?api_key=...``); scrubbed alongside userinfo.
+_URL_QUERY_CRED_RE = re.compile(
+    r"([?&](?:key|api[_-]?key|access_token|token|password|sig|signature)=)[^&\s\"']+", re.I)
+
+_URL_IN_TEXT_RE = re.compile(r"\b[a-zA-Z][a-zA-Z0-9+.\-]*://[^\s\"'<>]+")
+
+# Keys whose value is an endpoint, so the non-default-is-secret rule applies to the
+# whole value rather than just its userinfo.
+_URL_KEY_RE = re.compile(r"(base[_\-]?url|_url$|^url$|endpoint|api[_\-]?url|host)", re.I)
+
+
+def strip_url_userinfo(url: str) -> str:
+    """Remove ``user:password@`` (and credential-shaped query params) from ``url``.
+
+    Unconditional and lossy on purpose: userinfo is a credential, so it is dropped
+    rather than masked-in-place. Non-URL strings are returned unchanged.
+    """
+    text = str(url)
+    if "://" not in text:
+        return text
+    try:
+        parts = urllib.parse.urlsplit(text)
+    except ValueError:
+        return _URL_QUERY_CRED_RE.sub(r"\1" + _REDACTED, text)
+    if parts.username or parts.password:
+        host = parts.hostname or ""
+        if parts.port:
+            host = f"{host}:{parts.port}"
+        text = urllib.parse.urlunsplit((parts.scheme, host, parts.path,
+                                        parts.query, parts.fragment))
+    return _URL_QUERY_CRED_RE.sub(r"\1" + _REDACTED, text)
+
+
+def safe_url(url: str, *, public: frozenset[str] | set[str] | None = None) -> str:
+    """Render ``url`` for output: userinfo always stripped, non-public value hidden.
+
+    A URL matching :data:`PUBLIC_BASE_URLS` (ignoring a trailing slash) is returned
+    verbatim so ordinary setups stay debuggable; anything else becomes
+    :data:`CUSTOM_URL`. Empty stays empty.
+    """
+    clean = strip_url_userinfo(url).strip()
+    if not clean:
+        return ""
+    allow = PUBLIC_BASE_URLS if public is None else public
+    return clean if clean.rstrip("/") in {u.rstrip("/") for u in allow} else CUSTOM_URL
+
+
+def safe_urls_in_text(text: str) -> str:
+    """Apply :func:`safe_url` to every URL embedded in free text (probe reasons, errors).
+
+    Needed because an exception message ("HTTPError ... https://host/v1/models") is a
+    plain string, not a field with a URL-shaped key.
+    """
+    return _URL_IN_TEXT_RE.sub(lambda m: safe_url(m.group(0).rstrip(".,;)")), str(text))
+
 
 def _key_is_secret(key: str) -> bool:
     k = str(key)
@@ -97,7 +188,10 @@ def _key_is_secret(key: str) -> bool:
 
 
 def _scrub_value(val: str) -> str:
-    out = _INLINE_KV_RE.sub(lambda m: m.group(1) + _REDACTED, val)
+    # Userinfo first: a credential inside a URL must go before the shape-based passes,
+    # which don't know that `//user:pw@` is a secret. Unconditional — public or not.
+    out = _URL_IN_TEXT_RE.sub(lambda m: strip_url_userinfo(m.group(0)), val)
+    out = _INLINE_KV_RE.sub(lambda m: m.group(1) + _REDACTED, out)
     for rx in _SECRET_VALUE_RES:
         out = rx.sub(_REDACTED, out)
     return out
@@ -107,7 +201,11 @@ def redact(obj):
     """Recursively redact secrets from ``obj`` before it reaches an artifact.
 
     - Dict values under a secret-looking key are replaced wholesale.
-    - String values are scanned for secret-shaped tokens and masked in place.
+    - Dict values under an endpoint-looking key (``base_url``, ``*_url``, ``endpoint``)
+      go through :func:`safe_url`: userinfo stripped, and a non-public endpoint hidden
+      behind :data:`CUSTOM_URL` (see the "Endpoint confidentiality" note above).
+    - String values are scanned for secret-shaped tokens and masked in place, and any
+      URL they embed has its userinfo stripped.
     - Lists/tuples/dicts are walked recursively. Scalars pass through.
 
     Pure, returns a new structure; the caller's object is untouched.
@@ -117,6 +215,8 @@ def redact(obj):
         for k, v in obj.items():
             if _key_is_secret(k) and v not in (None, "", 0):
                 out[k] = _REDACTED
+            elif _URL_KEY_RE.search(str(k)) and isinstance(v, str) and v:
+                out[k] = safe_url(v)
             else:
                 out[k] = redact(v)
         return out

--- a/core/cap_evolve/model_config.py
+++ b/core/cap_evolve/model_config.py
@@ -29,6 +29,14 @@ Secret handling — non-negotiable:
   not a length. Presence/absence only (``credential_present``).
 * A probe sends a credential ONLY to the base URL of the same :data:`PROVIDERS` row
   the credential came from (see :func:`probe`), so a token can't reach a third party.
+* **Endpoints are confidential too.** URL *userinfo* (``https://user:token@host/``) is a
+  credential and is stripped the moment a base URL is resolved, so it can never be
+  rendered or stored. And a base URL that is not one of the well-known public defaults
+  is treated as sensitive: :meth:`Resolved.to_dict` and :func:`describe` report
+  ``base_url: <custom>`` plus ``base_url_source`` (which precedence layer set it)
+  instead of the value, because the hostname is exactly what identifies someone's
+  internal infrastructure. The rule itself lives in ``dashboard.safe_url`` so every
+  consumer — this module, the reducer, ``dashboard.html``, ``doctor`` — inherits it.
 
 Stdlib only, zero runtime deps.
 """
@@ -40,7 +48,7 @@ import re
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from .dashboard import redact
+from .dashboard import CUSTOM_URL, redact, safe_url, safe_urls_in_text, strip_url_userinfo
 from .specfile import read_yaml
 
 # ---------------------------------------------------------------------------
@@ -159,11 +167,18 @@ class Resolved:
     ``credential_env`` is the *name* of the environment variable that carries the
     secret; read it at the point of use. That keeps every repr/log/JSON of this
     object secret-free by construction rather than by remembering to redact.
+
+    ``base_url`` is the real endpoint (needed to make a request) but is
+    ``repr=False``: a custom endpoint is confidential, so it must not appear in a
+    traceback, a log line, or a JSON dump. Use :attr:`base_url_display` /
+    :meth:`to_dict` for anything a human or a file will see. Userinfo has already
+    been stripped by :func:`_resolve_base_url`, so even the in-memory value is
+    credential-free.
     """
 
     provider: str
     credential_env: str = ""          # env var NAME, "" when nothing resolved
-    base_url: str = ""
+    base_url: str = field(default="", repr=False)   # real endpoint; never rendered
     sources: dict = field(default_factory=dict)   # field -> precedence layer
     reason: str = ""                  # human note (why `auto` picked this)
 
@@ -171,12 +186,23 @@ class Resolved:
     def credential_present(self) -> bool:
         return bool(self.credential_env)
 
+    @property
+    def base_url_display(self) -> str:
+        """Safe rendering: public defaults verbatim, anything else ``<custom>``."""
+        return safe_url(self.base_url)
+
+    @property
+    def base_url_source(self) -> str:
+        """Which precedence layer set the base URL — the actionable half of the value."""
+        return self.sources.get("base_url", "built-in default" if self.base_url else "")
+
     def to_dict(self) -> dict:
         return {
             "provider": self.provider,
             "credential_env": self.credential_env,      # a NAME, not a value
             "credential_present": self.credential_present,
-            "base_url": self.base_url,
+            "base_url": self.base_url_display,          # "<custom>" unless well-known
+            "base_url_source": self.base_url_source,
             "sources": dict(self.sources),
             "reason": self.reason,
         }
@@ -315,13 +341,19 @@ def resolve(cli: dict | None = None, project: dict | None = None,
 
 
 def _resolve_base_url(provider: str, values: dict, sources: dict) -> str:
+    """The endpoint to use, with URL userinfo stripped at the single point of resolution.
+
+    Stripping here (rather than at each render site) means no downstream caller can
+    ever hold a base URL carrying ``user:token@`` — the credential is gone before the
+    value is stored on :class:`Resolved`, logged, or handed to :func:`probe`.
+    """
     row = PROVIDERS[provider]
     if values.get("base_url"):
-        return values["base_url"]
+        return strip_url_userinfo(values["base_url"])
     env_name = row["base_url_env"]
     if env_name and os.environ.get(env_name):
         sources["base_url"] = f"environment ({env_name})"
-        return os.environ[env_name]
+        return strip_url_userinfo(os.environ[env_name])
     if row["base_url"]:
         sources["base_url"] = "built-in default"
     return row["base_url"]
@@ -430,15 +462,25 @@ def probe(provider: str, base_url: str = "", *, timeout: float = 5.0) -> tuple[b
 def _safe_reason(text: str) -> str:
     """Scrub a probe failure reason before it can reach a log or an artifact.
 
-    Belt-and-braces: we never put a credential in a reason, but a library exception
-    could echo a URL that carries one as a query param. Strips those, then runs the
-    repo's shared ``dashboard.redact`` so this path obeys the same rules as artifacts.
+    A library exception routinely echoes the URL it failed on, so this is the main way
+    a custom endpoint would escape into a transcript. Order: mask credential query
+    params, replace non-public URLs with ``<custom>`` (which also drops any userinfo),
+    then run the repo's shared ``dashboard.redact`` so this path obeys exactly the same
+    rules as run artifacts.
     """
-    return redact(_URL_CRED_RE.sub(r"\1«redacted»", text))[:300]
+    scrubbed = safe_urls_in_text(_URL_CRED_RE.sub(r"\1«redacted»", str(text)))
+    return redact(scrubbed)[:300]
 
 
 def describe(res: Resolved) -> str:
-    """One-line, secret-free summary for the run transcript."""
+    """One-line, secret-free summary for the run transcript.
+
+    Prints the *source* of a custom base URL rather than its value — that is the part
+    that helps someone debug precedence, and it names no infrastructure.
+    """
     who = f"{res.credential_env} (present)" if res.credential_present else "no credential"
+    url = res.base_url_display or "(provider default)"
+    if url == CUSTOM_URL:
+        url = f"{CUSTOM_URL} (from {res.base_url_source or 'config'})"
     return (f"provider: {res.provider or 'unresolved'} | credential: {who} | "
-            f"base_url: {res.base_url or '(provider default)'} | {res.reason}")
+            f"base_url: {url} | {res.reason}")

--- a/core/cap_evolve/model_config.py
+++ b/core/cap_evolve/model_config.py
@@ -1,0 +1,444 @@
+"""Provider-scoped credential resolution + ``auto`` provider probing.
+
+Two footguns this module exists to remove:
+
+1. **Cross-provider credential reuse.** A user has ``ANTHROPIC_API_KEY`` exported from
+   another project, the spec selects ``openai``, and the run silently authenticates
+   (or fails confusingly) with the wrong key. Resolution here is *provider-scoped*:
+   each provider only ever looks at ITS OWN documented env vars (the ``env`` column of
+   :data:`PROVIDERS`). A credential belonging to provider A is never applied to
+   provider B — we raise :class:`CredentialError` naming the vars provider B accepts.
+2. **Unknown provider.** ``provider: auto`` picks the first provider (in
+   :data:`AUTO_ORDER`) whose own credential is present, and says which and why.
+
+Precedence (documented once, here, and mirrored in ``docs/INSTALL.md``)::
+
+    CLI flag  >  project capevolve.yaml  >  user config  >  built-in defaults
+
+applied per FIELD (provider / base_url / credential env var), highest layer that
+sets a non-empty value wins. The user config is ``~/.capevolve/config.yaml``
+(override with ``$CAPEVOLVE_CONFIG``).
+
+Secret handling — non-negotiable:
+
+* Credential **values** live only in the process environment. No config layer may
+  carry a secret: ``credential_env`` names an env var, it is not a place to paste a
+  key. :class:`Resolved` therefore holds the env var NAME and never the value, so a
+  resolved config cannot leak by being logged, repr'd, or JSON-dumped.
+* Nothing in this module prints, logs, or embeds a credential value — not a prefix,
+  not a length. Presence/absence only (``credential_present``).
+* A probe sends a credential ONLY to the base URL of the same :data:`PROVIDERS` row
+  the credential came from (see :func:`probe`), so a token can't reach a third party.
+
+Stdlib only, zero runtime deps.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from .dashboard import redact
+from .specfile import read_yaml
+
+# ---------------------------------------------------------------------------
+# The resolution table. One row per provider. `env` is ORDERED — the first var
+# that is set wins, so the primary/documented name takes precedence over aliases.
+#
+# `header` is a (name, value-template) pair used ONLY when probing that same row's
+# base_url; `{cred}` is substituted at call time from the env var this row named.
+# Keeping url+header+env in ONE row is what makes a cross-provider send impossible.
+# ---------------------------------------------------------------------------
+PROVIDERS: dict[str, dict] = {
+    "anthropic": {
+        "env": ["ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"],
+        "base_url_env": "ANTHROPIC_BASE_URL",
+        "base_url": "https://api.anthropic.com",
+        "probe_path": "/v1/models",
+        "header": ("x-api-key", "{cred}"),
+    },
+    "openai": {
+        "env": ["OPENAI_API_KEY"],
+        "base_url_env": "OPENAI_BASE_URL",
+        "base_url": "https://api.openai.com/v1",
+        "probe_path": "/models",
+        "header": ("Authorization", "Bearer {cred}"),
+    },
+    "gemini": {
+        "env": ["GEMINI_API_KEY", "GOOGLE_API_KEY"],
+        "base_url_env": "GEMINI_BASE_URL",
+        "base_url": "https://generativelanguage.googleapis.com/v1beta",
+        "probe_path": "/models",
+        "header": ("x-goog-api-key", "{cred}"),
+    },
+    "rits": {
+        # RITS needs BOTH a key and a deployment URL; there is no usable default.
+        "env": ["RITS_API_KEY"],
+        "base_url_env": "RITS_API_URL",
+        "base_url": "",
+        "probe_path": "/models",
+        "header": ("RITS_API_KEY", "{cred}"),
+    },
+    "watsonx": {
+        "env": ["WATSONX_APIKEY", "WATSONX_API_KEY"],
+        "base_url_env": "WATSONX_URL",
+        "base_url": "",
+        "probe_path": "/ml/v1/foundation_model_specs?version=2024-05-01",
+        "header": ("Authorization", "Bearer {cred}"),
+    },
+    "moonshot": {
+        "env": ["MOONSHOT_API_KEY", "KIMI_API_KEY"],
+        "base_url_env": "MOONSHOT_BASE_URL",
+        "base_url": "https://api.moonshot.ai/v1",
+        "probe_path": "/models",
+        "header": ("Authorization", "Bearer {cred}"),
+    },
+    "cursor": {
+        "env": ["CURSOR_API_KEY"],
+        "base_url_env": "CURSOR_BASE_URL",
+        "base_url": "",
+        "probe_path": "/models",
+        "header": ("Authorization", "Bearer {cred}"),
+    },
+    "factory": {
+        "env": ["FACTORY_API_KEY"],
+        "base_url_env": "FACTORY_BASE_URL",
+        "base_url": "",
+        "probe_path": "/models",
+        "header": ("Authorization", "Bearer {cred}"),
+    },
+    "github-copilot": {
+        "env": ["COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"],
+        "base_url_env": "COPILOT_BASE_URL",
+        "base_url": "https://api.githubcopilot.com",
+        "probe_path": "/models",
+        "header": ("Authorization", "Bearer {cred}"),
+    },
+    "bob": {
+        "env": ["BOBSHELL_API_KEY", "BOB_API_KEY"],
+        "base_url_env": "BOBSHELL_URL",
+        "base_url": "",
+        "probe_path": "/models",
+        "header": ("Authorization", "Bearer {cred}"),
+    },
+    # `mock` is the offline optimizer: no credential, no endpoint, never probed.
+    "mock": {
+        "env": [],
+        "base_url_env": "",
+        "base_url": "",
+        "probe_path": "",
+        "header": ("", ""),
+    },
+}
+
+# Order `auto` considers providers in. First one whose OWN credential is present wins.
+AUTO_ORDER = ["anthropic", "openai", "gemini", "rits", "watsonx", "moonshot",
+              "github-copilot", "bob", "cursor", "factory"]
+
+#: The documented precedence, highest first. Also the wording used in errors.
+PRECEDENCE = ("CLI flag", "project capevolve.yaml", "user config", "built-in default")
+
+# Optimizer/registry name -> provider, so `optimizer_skill: codex` implies `openai`.
+OPTIMIZER_PROVIDER = {
+    "claude-code": "anthropic", "codex": "openai", "gemini-cli": "gemini",
+    "ibm-bob": "bob", "cursor": "cursor", "droid": "factory",
+    "copilot": "github-copilot", "kimi": "moonshot", "mock": "mock",
+}
+
+
+class CredentialError(RuntimeError):
+    """No usable, provider-scoped credential. Message names env VARS, never values."""
+
+
+@dataclass(frozen=True)
+class Resolved:
+    """A resolved provider config. Deliberately holds NO credential value.
+
+    ``credential_env`` is the *name* of the environment variable that carries the
+    secret; read it at the point of use. That keeps every repr/log/JSON of this
+    object secret-free by construction rather than by remembering to redact.
+    """
+
+    provider: str
+    credential_env: str = ""          # env var NAME, "" when nothing resolved
+    base_url: str = ""
+    sources: dict = field(default_factory=dict)   # field -> precedence layer
+    reason: str = ""                  # human note (why `auto` picked this)
+
+    @property
+    def credential_present(self) -> bool:
+        return bool(self.credential_env)
+
+    def to_dict(self) -> dict:
+        return {
+            "provider": self.provider,
+            "credential_env": self.credential_env,      # a NAME, not a value
+            "credential_present": self.credential_present,
+            "base_url": self.base_url,
+            "sources": dict(self.sources),
+            "reason": self.reason,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Config layers
+# ---------------------------------------------------------------------------
+
+def user_config_path() -> Path:
+    return Path(os.environ.get("CAPEVOLVE_CONFIG")
+                or Path.home() / ".capevolve" / "config.yaml")
+
+
+def read_user_config() -> dict:
+    p = user_config_path()
+    try:
+        return read_yaml(p.read_text(encoding="utf-8")) or {}
+    except OSError:
+        return {}
+
+
+_SPEC_KEYS = {"provider": "provider", "base_url": "provider_base_url",
+              "credential_env": "provider_credential_env"}
+
+
+def _layered(cli: dict | None, project: dict | None, user: dict | None) -> tuple[dict, dict]:
+    """Merge the layers per field. Returns ``(values, sources)``.
+
+    Precedence: CLI > project > user > built-in (built-in applied by the caller).
+    A layer that omits a field, or sets it empty, does not shadow a lower layer.
+    """
+    layers = [("CLI flag", cli or {}), ("project capevolve.yaml", project or {}),
+              ("user config", user or {})]
+    values, sources = {}, {}
+    for field_name, spec_key in _SPEC_KEYS.items():
+        for layer_name, data in layers:
+            val = data.get(field_name) or data.get(spec_key)
+            if val not in (None, ""):
+                values[field_name] = str(val).strip()
+                sources[field_name] = layer_name
+                break
+    return values, sources
+
+
+def _scoped_credential_env(provider: str, prefer: str = "") -> str:
+    """Name of the env var carrying ``provider``'s credential, or "" if none is set.
+
+    Only :data:`PROVIDERS`\\ ``[provider]["env"]`` is consulted — this single-row
+    lookup IS the provider-scoping guarantee. ``prefer`` (from config) must itself be
+    one of that row's vars; a var belonging to another provider is refused upstream.
+    """
+    row = PROVIDERS[provider]
+    names = [prefer] + list(row["env"]) if prefer else list(row["env"])
+    for name in names:
+        if os.environ.get(name):
+            return name
+    return ""
+
+
+def _owner_of(env_name: str) -> str | None:
+    for name, row in PROVIDERS.items():
+        if env_name in row["env"]:
+            return name
+    return None
+
+
+def _present_elsewhere(provider: str) -> list[str]:
+    """Other providers whose credential IS present — for an actionable error only."""
+    return [p for p in AUTO_ORDER if p != provider and _scoped_credential_env(p)]
+
+
+# ---------------------------------------------------------------------------
+# Resolution
+# ---------------------------------------------------------------------------
+
+def resolve(cli: dict | None = None, project: dict | None = None,
+            user: dict | None = None, *, require_credential: bool = True,
+            probe_fn=None) -> Resolved:
+    """Resolve the provider + which env var holds its credential.
+
+    ``cli`` / ``project`` / ``user`` are plain dicts (a parsed ``capevolve.yaml`` can
+    be passed straight through as ``project``); ``user`` defaults to
+    :func:`read_user_config`. Recognised keys per layer: ``provider``,
+    ``provider_base_url``, ``provider_credential_env`` (short aliases
+    ``base_url`` / ``credential_env`` also accepted).
+
+    ``provider: auto`` selects the first provider in :data:`AUTO_ORDER` whose own
+    credential is present; pass ``probe_fn`` (see :func:`probe`) to additionally
+    require that the candidate's endpoint answers before selecting it.
+
+    Raises :class:`CredentialError` when nothing resolves, or when the only
+    credentials present belong to a *different* provider than the one selected.
+    """
+    if user is None:
+        user = read_user_config()
+    values, sources = _layered(cli, project, user)
+
+    provider = values.get("provider", "")
+    if not provider:
+        # Built-in default: infer from the optimizer the spec names, else `auto`.
+        opt = str((project or {}).get("optimizer_skill", "")).strip()
+        provider = OPTIMIZER_PROVIDER.get(opt, "auto")
+        sources["provider"] = ("built-in default (from optimizer_skill)" if opt in OPTIMIZER_PROVIDER
+                               else "built-in default")
+
+    if provider == "auto":
+        return _resolve_auto(values, sources, probe_fn=probe_fn,
+                             require_credential=require_credential)
+
+    if provider not in PROVIDERS:
+        raise CredentialError(
+            f"unknown provider {provider!r} (from {sources.get('provider', 'config')}). "
+            f"Known providers: {', '.join(sorted(PROVIDERS))}, or 'auto'.")
+
+    prefer = values.get("credential_env", "")
+    if prefer:
+        owner = _owner_of(prefer)
+        if owner not in (None, provider):
+            # Refuse to cross the provider boundary even when explicitly asked to.
+            raise CredentialError(
+                f"provider_credential_env={prefer!r} belongs to provider {owner!r}, but the "
+                f"selected provider is {provider!r}. Credentials are provider-scoped and are "
+                f"never reused across providers. Set one of: "
+                f"{', '.join(PROVIDERS[provider]['env']) or '(none — this provider takes no key)'}.")
+
+    cred_env = _scoped_credential_env(provider, prefer)
+    base_url = _resolve_base_url(provider, values, sources)
+
+    if not cred_env and PROVIDERS[provider]["env"] and require_credential:
+        raise CredentialError(_no_credential_message(provider, sources))
+
+    return Resolved(provider=provider, credential_env=cred_env, base_url=base_url,
+                    sources=sources,
+                    reason=f"provider {provider!r} from {sources.get('provider', 'config')}")
+
+
+def _resolve_base_url(provider: str, values: dict, sources: dict) -> str:
+    row = PROVIDERS[provider]
+    if values.get("base_url"):
+        return values["base_url"]
+    env_name = row["base_url_env"]
+    if env_name and os.environ.get(env_name):
+        sources["base_url"] = f"environment ({env_name})"
+        return os.environ[env_name]
+    if row["base_url"]:
+        sources["base_url"] = "built-in default"
+    return row["base_url"]
+
+
+def _no_credential_message(provider: str, sources: dict) -> str:
+    accepted = ", ".join(PROVIDERS[provider]["env"])
+    msg = [f"no credential found for provider {provider!r} "
+           f"(selected via {sources.get('provider', 'config')}).",
+           f"Set one of: {accepted}."]
+    others = _present_elsewhere(provider)
+    if others:
+        msg.append(f"Credentials for {', '.join(others)} ARE present but belong to a different "
+                   f"provider and are never reused — either export a {provider} credential, or "
+                   f"select that provider explicitly (provider: {others[0]}) / use provider: auto.")
+    msg.append("Precedence: " + " > ".join(PRECEDENCE) + ".")
+    return " ".join(msg)
+
+
+def _resolve_auto(values: dict, sources: dict, *, probe_fn=None,
+                  require_credential: bool = True) -> Resolved:
+    tried: list[str] = []
+    for cand in AUTO_ORDER:
+        cred_env = _scoped_credential_env(cand)
+        if not cred_env:
+            continue
+        base_url = _resolve_base_url(cand, {}, sources)
+        if not base_url and PROVIDERS[cand]["base_url_env"]:
+            tried.append(f"{cand} (credential present, but {PROVIDERS[cand]['base_url_env']} unset)")
+            continue
+        if probe_fn is not None:
+            ok, why = probe_fn(cand, base_url)
+            if not ok:
+                tried.append(f"{cand} (probe failed: {why})")
+                continue
+            note = f"probe of {cand} base URL succeeded"
+        else:
+            note = "credential present (no probe requested)"
+        reason = (f"auto selected {cand!r}: {cred_env} is set and it is the highest-priority "
+                  f"provider with its own credential; {note}."
+                  + (f" Skipped: {'; '.join(tried)}." if tried else ""))
+        s = dict(sources); s["provider"] = "auto probe"
+        return Resolved(provider=cand, credential_env=cred_env, base_url=base_url,
+                        sources=s, reason=reason)
+
+    if not require_credential:
+        return Resolved(provider="", sources=sources,
+                        reason="auto found no provider with its own credential")
+    detail = f" Considered but rejected: {'; '.join(tried)}." if tried else ""
+    raise CredentialError(
+        "provider: auto found no usable provider — none of the known providers has its own "
+        f"credential set.{detail} Export one of: "
+        + "; ".join(f"{p}: {'/'.join(PROVIDERS[p]['env'])}" for p in AUTO_ORDER if PROVIDERS[p]["env"])
+        + ". Precedence: " + " > ".join(PRECEDENCE) + ".")
+
+
+# ---------------------------------------------------------------------------
+# Probing
+# ---------------------------------------------------------------------------
+
+_URL_CRED_RE = re.compile(r"([?&](?:key|api[_-]?key|access_token|token)=)[^&\s]+", re.I)
+
+
+def probe(provider: str, base_url: str = "", *, timeout: float = 5.0) -> tuple[bool, str]:
+    """Is ``provider``'s endpoint reachable with ``provider``'s OWN credential?
+
+    Returns ``(ok, reason)``. Never raises, never returns a credential value.
+
+    Wrong-endpoint safety: the URL, the auth header shape, and the credential env var
+    are all read from the SAME ``PROVIDERS[provider]`` row and from nothing else, in
+    this one function. There is no code path that pairs provider A's credential with
+    provider B's URL — a caller-supplied ``base_url`` is only honoured when it is
+    already the resolved base URL for this same provider (``_resolve_base_url``), and
+    an unknown provider is refused before any request is made.
+    """
+    if provider not in PROVIDERS:
+        return False, f"unknown provider {provider!r}"
+    row = PROVIDERS[provider]
+    cred_env = _scoped_credential_env(provider)
+    if not cred_env:
+        return False, f"no {provider} credential ({'/'.join(row['env']) or 'n/a'}) set"
+    url = (base_url or _resolve_base_url(provider, {}, {})).rstrip("/")
+    if not url:
+        return False, f"no base URL for {provider} (set {row['base_url_env']})"
+    if not url.startswith(("http://", "https://")):
+        return False, f"base URL for {provider} is not http(s)"
+
+    import urllib.error
+    import urllib.request
+
+    hdr_name, hdr_tmpl = row["header"]
+    req = urllib.request.Request(url + row["probe_path"], method="GET")
+    if hdr_name:
+        # The only place a credential value is ever read. It goes into a header on a
+        # request to THIS provider's own base URL, and is never echoed back out.
+        req.add_header(hdr_name, hdr_tmpl.format(cred=os.environ[cred_env]))
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return 200 <= resp.status < 300, f"HTTP {resp.status}"
+    except urllib.error.HTTPError as e:                       # reached it, refused us
+        return False, _safe_reason(f"HTTP {e.code}")
+    except Exception as e:                                    # DNS/TLS/timeout/...
+        return False, _safe_reason(f"{type(e).__name__}: {e}")
+
+
+def _safe_reason(text: str) -> str:
+    """Scrub a probe failure reason before it can reach a log or an artifact.
+
+    Belt-and-braces: we never put a credential in a reason, but a library exception
+    could echo a URL that carries one as a query param. Strips those, then runs the
+    repo's shared ``dashboard.redact`` so this path obeys the same rules as artifacts.
+    """
+    return redact(_URL_CRED_RE.sub(r"\1«redacted»", text))[:300]
+
+
+def describe(res: Resolved) -> str:
+    """One-line, secret-free summary for the run transcript."""
+    who = f"{res.credential_env} (present)" if res.credential_present else "no credential"
+    return (f"provider: {res.provider or 'unresolved'} | credential: {who} | "
+            f"base_url: {res.base_url or '(provider default)'} | {res.reason}")

--- a/core/tests/test_model_config.py
+++ b/core/tests/test_model_config.py
@@ -153,7 +153,11 @@ def test_probe_failure_reason_is_scrubbed(monkeypatch):
     ok, why = mc.probe("gemini")
     assert ok is False
     assert FAKE not in why
-    assert "redacted" in why
+    # The whole non-public URL is now replaced, which subsumes query-param masking:
+    # host, path, and the credential param all go at once.
+    assert mc.CUSTOM_URL in why
+    assert "x.invalid" not in why
+    assert "api_key" not in why
 
 
 def test_cli_run_transcript_never_prints_credential(monkeypatch, tmp_path):
@@ -181,6 +185,178 @@ def test_no_leak_on_the_nothing_resolves_path(capsys):
         mc.resolve(project={"provider": "auto"})
     out = capsys.readouterr()
     assert FAKE not in (str(ei.value) + out.out + out.err)
+
+
+# ---------------------------------------------------------------------------
+# 2b. No-leak: the ENDPOINT. A custom base URL names internal infrastructure and a
+#     URL can carry a credential in its userinfo, so both are canaries too — not just
+#     the token. (Widened after a real internal gateway URL was printed into a public
+#     PR comment; see the module docstring's "Endpoint confidentiality".)
+# ---------------------------------------------------------------------------
+
+CANARY_HOST = "fake-internal-canary.example.invalid"
+CANARY_URL = f"https://{CANARY_HOST}/v1"
+CANARY_URL_CRED = f"https://u:CANARYTOKEN123456@{CANARY_HOST}/v1"
+
+
+def test_userinfo_is_stripped_from_a_resolved_base_url(monkeypatch):
+    """`https://user:token@host` — the credential is gone from the value we KEEP."""
+    monkeypatch.setenv("OPENAI_API_KEY", FAKE)
+    res = mc.resolve(cli={"base_url": CANARY_URL_CRED}, project={"provider": "openai"})
+    # Stripped at resolution, so even the in-memory value (used to make requests) is
+    # credential-free — not merely hidden at render time.
+    assert "CANARYTOKEN123456" not in res.base_url
+    assert res.base_url == CANARY_URL
+    assert "CANARYTOKEN123456" not in _all_text(res)
+    assert "u:" not in _all_text(res)
+
+
+def test_custom_base_url_is_never_rendered_only_its_source(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", FAKE)
+    res = mc.resolve(user={"provider": "openai", "provider_base_url": CANARY_URL})
+    text = _all_text(res)
+    assert CANARY_HOST not in text, "a custom endpoint hostname must not be rendered"
+    assert res.to_dict()["base_url"] == mc.CUSTOM_URL
+    # The actionable half survives: WHICH layer set it.
+    assert res.to_dict()["base_url_source"] == "user config"
+    assert "user config" in mc.describe(res)
+
+
+def test_public_default_base_url_stays_legible(monkeypatch):
+    """Don't over-redact: a well-known public endpoint carries no information."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", FAKE)
+    res = mc.resolve(project={"provider": "anthropic"})
+    assert res.to_dict()["base_url"] == "https://api.anthropic.com"
+    assert "https://api.anthropic.com" in mc.describe(res)
+    monkeypatch.setenv("OPENAI_API_KEY", FAKE)
+    assert mc.resolve(project={"provider": "openai"}).to_dict()["base_url"] \
+        == "https://api.openai.com/v1"
+
+
+def test_every_builtin_default_base_url_is_on_the_public_allowlist():
+    """The allowlist and the PROVIDERS defaults must not drift apart."""
+    for name, row in mc.PROVIDERS.items():
+        if row["base_url"]:
+            assert mc.safe_url(row["base_url"]) == row["base_url"], \
+                f"built-in default for {name} would render as <custom>"
+
+
+def test_probe_failure_reason_hides_a_custom_endpoint(monkeypatch):
+    """The main escape route: a library exception echoing the URL it failed on."""
+    import urllib.error
+
+    def boom(req, timeout=None):
+        raise urllib.error.URLError(f"getaddrinfo failed for {CANARY_URL_CRED}/models")
+
+    monkeypatch.setenv("OPENAI_API_KEY", FAKE)
+    monkeypatch.setenv("OPENAI_BASE_URL", CANARY_URL_CRED)
+    monkeypatch.setattr("urllib.request.urlopen", boom)
+    ok, why = mc.probe("openai")
+    assert ok is False
+    assert CANARY_HOST not in why
+    assert "CANARYTOKEN123456" not in why
+    assert mc.CUSTOM_URL in why
+
+
+def test_redact_helper_hides_endpoints_so_doctor_inherits_the_rule():
+    """The rule lives in the SHARED helper, so every artifact writer gets it free.
+
+    `doctor` (#121) redacts its own report through this same function, so it inherits
+    endpoint confidentiality without a line of its own.
+    """
+    from cap_evolve.dashboard import redact
+
+    r = redact({"base_url": CANARY_URL_CRED, "ANTHROPIC_BASE_URL": CANARY_URL,
+                "endpoint": CANARY_URL, "api_url": CANARY_URL,
+                "detail": f"probing {CANARY_URL_CRED} failed",
+                "ok_url": "https://api.anthropic.com"})
+    # Endpoint-shaped FIELDS: value hidden entirely.
+    for key in ("base_url", "ANTHROPIC_BASE_URL", "endpoint", "api_url"):
+        assert r[key] == mc.CUSTOM_URL, key
+    # Free text: userinfo is stripped unconditionally (a URL in prose could be a docs
+    # link, so the value itself is left readable; endpoint-diagnostic emitters call
+    # safe_urls_in_text explicitly — see probe's _safe_reason).
+    assert "CANARYTOKEN123456" not in json.dumps(r)
+    assert r["ok_url"] == "https://api.anthropic.com"      # public default still legible
+
+
+def _toy_project(tmp_path: Path, extra_spec: str) -> tuple[Path, Path]:
+    """Scaffold the zero-API toy_calc project (mirrors examples/toy_calc/run.sh)."""
+    import shutil
+
+    repo = Path(__file__).resolve().parents[2]
+    example = repo / "examples" / "toy_calc"
+    project = tmp_path / ".capevolve" / "project"
+    (project / "adapters").mkdir(parents=True)
+    shutil.copy(example / "adapter.py", project / "adapters" / "adapter.py")
+    shutil.copytree(example / "capability", tmp_path / "seed_capability")
+    spec = project / "capevolve.yaml"
+    spec.write_text(
+        (repo / "templates" / "project" / "capevolve.yaml").read_text(encoding="utf-8")
+        + "\n" + extra_spec, encoding="utf-8")
+    return project, spec
+
+
+def test_full_run_artifacts_never_contain_a_custom_endpoint_or_its_userinfo(tmp_path):
+    """The money test: a REAL zero-API `cap-evolve run` with a userinfo-bearing custom
+    base URL configured. Neither the hostname nor the embedded token may appear in
+    stdout, stderr, or ANY file under the run dir (events.jsonl, dashboard.html,
+    candidates, rollouts, state.json ...) — those get committed and attached to issues.
+    """
+    import os as _os
+
+    repo = Path(__file__).resolve().parents[2]
+    project, spec = _toy_project(
+        tmp_path,
+        f"provider: mock\nprovider_base_url: \"{CANARY_URL_CRED}\"\n")
+
+    env = dict(_os.environ)
+    env.update({
+        "PYTHONPATH": str(repo / "core"),
+        "CAPEVOLVE_CORE": str(repo / "core"),
+        "CAPEVOLVE_SKILLS_DIR": str(repo / "skills"),
+        "CAPEVOLVE_TOY_DATA": str(repo / "examples" / "toy_calc"),
+        "CAPEVOLVE_MOCK_SCRIPT": str(repo / "examples" / "toy_calc" / "mock_script.json"),
+        "CAPEVOLVE_CONFIG": "/nonexistent/capevolve-config.yaml",
+        # The env layer is a leak path of its own.
+        "ANTHROPIC_BASE_URL": CANARY_URL_CRED,
+        "ANTHROPIC_API_KEY": FAKE,
+    })
+    proc = subprocess.run(
+        [sys.executable, "-m", "cap_evolve.cli", "run", "--spec", str(spec),
+         "--project", str(project), "--dashboard", "off", "--run-ts", "leak"],
+        capture_output=True, text=True, env=env, cwd=str(tmp_path))
+    combined = proc.stdout + proc.stderr
+    assert proc.returncode == 0, combined
+
+    run_dir = tmp_path / ".capevolve" / "run_leak"
+    files = [p for p in run_dir.rglob("*") if p.is_file()]
+    # The artifacts we care about must actually exist, or this test proves nothing.
+    names = {p.name for p in files}
+    assert "events.jsonl" in names and "dashboard.html" in names, sorted(names)
+
+    haystack = [("stdout+stderr", combined)]
+    haystack += [(str(p), p.read_text(encoding="utf-8", errors="replace")) for p in files]
+    for canary in (CANARY_HOST, "CANARYTOKEN123456"):
+        hits = [where for where, text in haystack if canary in text]
+        assert not hits, f"{canary!r} leaked into: {hits}"
+
+    # ... and the provider step still said something useful.
+    step = next(o for o in (json.loads(l) for l in proc.stdout.splitlines()
+                            if l.startswith('{"step": "provider"'))
+                if o.get("step") == "provider")
+    assert step["base_url"] == mc.CUSTOM_URL
+    assert step["base_url_source"]
+
+    # `--plan-only` echoes the raw spec (which HOLDS provider_base_url) — same rule.
+    plan = subprocess.run(
+        [sys.executable, "-m", "cap_evolve.cli", "run", "--spec", str(spec),
+         "--project", str(project), "--dashboard", "off", "--plan-only"],
+        capture_output=True, text=True, env=env, cwd=str(tmp_path))
+    assert plan.returncode == 0, plan.stdout + plan.stderr
+    assert CANARY_HOST not in plan.stdout + plan.stderr
+    assert "CANARYTOKEN123456" not in plan.stdout + plan.stderr
+    assert json.loads(plan.stdout)["spec"]["provider_base_url"] == mc.CUSTOM_URL
 
 
 # ---------------------------------------------------------------------------

--- a/core/tests/test_model_config.py
+++ b/core/tests/test_model_config.py
@@ -1,0 +1,334 @@
+"""Provider-scoped credential resolution + `auto` probing (issue #134).
+
+Security-critical tests, in order of importance:
+  * a fake credential value NEVER appears in any output/artifact/exception text;
+  * a provider-scoped credential is NEVER sent to another provider's endpoint;
+  * precedence is CLI > project > user > built-in;
+  * `auto` picks the usable provider; nothing-resolves gives an actionable error;
+  * existing single-provider specs behave exactly as before (back-compat guard).
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import contextlib
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from cap_evolve import model_config as mc
+
+FAKE = "sk-FAKETOKEN0123456789abcdefFAKE"      # must never be echoed anywhere
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    """No inherited real credentials, and no user config, unless a test adds one."""
+    for row in mc.PROVIDERS.values():
+        for name in row["env"]:
+            monkeypatch.delenv(name, raising=False)
+        if row["base_url_env"]:
+            monkeypatch.delenv(row["base_url_env"], raising=False)
+    monkeypatch.setenv("CAPEVOLVE_CONFIG", "/nonexistent/capevolve-config.yaml")
+
+
+# ---------------------------------------------------------------------------
+# 1. Provider scoping: never cross the boundary
+# ---------------------------------------------------------------------------
+
+def test_provider_b_selected_with_only_provider_a_key_errors(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", FAKE)
+    with pytest.raises(mc.CredentialError) as ei:
+        mc.resolve(project={"provider": "openai"})
+    msg = str(ei.value)
+    assert FAKE not in msg
+    assert "OPENAI_API_KEY" in msg                 # says what to set
+    assert "anthropic" in msg                      # and that the other one won't be reused
+    assert "never reused" in msg
+
+
+def test_explicit_cross_provider_credential_env_is_refused(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", FAKE)
+    with pytest.raises(mc.CredentialError) as ei:
+        mc.resolve(cli={"provider": "openai", "credential_env": "ANTHROPIC_API_KEY"})
+    assert "belongs to provider 'anthropic'" in str(ei.value)
+    assert FAKE not in str(ei.value)
+
+
+def test_scoped_lookup_only_reads_own_row(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", FAKE)
+    assert mc._scoped_credential_env("openai") == "OPENAI_API_KEY"
+    assert mc._scoped_credential_env("anthropic") == ""      # blind to another row's var
+
+
+def test_probe_never_sends_credential_to_another_providers_endpoint(monkeypatch):
+    """The wrong-endpoint guarantee, asserted at the wire level.
+
+    Only ANTHROPIC_API_KEY is set. We capture every urlopen the probe attempts and
+    assert: the anthropic probe sends the token to an anthropic URL only, and the
+    openai/gemini probes make NO request at all (no credential of their own).
+    """
+    sent: list[tuple[str, dict]] = []
+
+    class _Resp:
+        status = 200
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+
+    def fake_urlopen(req, timeout=None):
+        sent.append((req.full_url, dict(req.headers)))
+        return _Resp()
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", FAKE)
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    ok, _ = mc.probe("anthropic")
+    assert ok
+    assert len(sent) == 1
+    url, headers = sent[0]
+    assert url.startswith("https://api.anthropic.com")
+    assert FAKE in json.dumps(headers)          # it went out, to its OWN endpoint
+
+    for other in ("openai", "gemini", "rits", "watsonx"):
+        ok, why = mc.probe(other)
+        assert ok is False
+        assert "no %s credential" % other in why
+    assert len(sent) == 1, "a probe made a request without its own credential"
+    # And no request ever reached a non-anthropic host with the anthropic token.
+    for url, headers in sent:
+        assert "api.anthropic.com" in url or FAKE not in json.dumps(headers)
+
+
+def test_auto_probe_does_not_leak_credential_across_candidates(monkeypatch):
+    """`auto` + probe with only an OpenAI key: openai's URL is the only one touched."""
+    hosts: list[str] = []
+
+    class _Resp:
+        status = 200
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+
+    def fake_urlopen(req, timeout=None):
+        hosts.append(req.full_url)
+        assert FAKE in json.dumps(dict(req.headers))
+        assert "api.openai.com" in req.full_url, "token sent to a foreign host!"
+        return _Resp()
+
+    monkeypatch.setenv("OPENAI_API_KEY", FAKE)
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    res = mc.resolve(project={"provider": "auto"}, probe_fn=mc.probe)
+    assert res.provider == "openai"
+    assert all("api.openai.com" in h for h in hosts)
+
+
+# ---------------------------------------------------------------------------
+# 2. No-leak: the fake token appears nowhere
+# ---------------------------------------------------------------------------
+
+def _all_text(res: mc.Resolved) -> str:
+    return " ".join([repr(res), str(res), json.dumps(res.to_dict()), mc.describe(res)])
+
+
+def test_resolved_object_carries_no_credential_value(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", FAKE)
+    res = mc.resolve(project={"provider": "anthropic"})
+    assert res.credential_env == "ANTHROPIC_API_KEY"
+    assert res.credential_present is True
+    assert FAKE not in _all_text(res)
+
+
+def test_probe_failure_reason_is_scrubbed(monkeypatch):
+    """A library exception echoing a credential-bearing URL must not leak it."""
+    import urllib.error
+
+    def boom(req, timeout=None):
+        raise urllib.error.URLError(
+            f"failed connecting to https://x.invalid/v1/models?api_key={FAKE}")
+
+    monkeypatch.setenv("GEMINI_API_KEY", FAKE)
+    monkeypatch.setattr("urllib.request.urlopen", boom)
+    ok, why = mc.probe("gemini")
+    assert ok is False
+    assert FAKE not in why
+    assert "redacted" in why
+
+
+def test_cli_run_transcript_never_prints_credential(monkeypatch, tmp_path):
+    """Whole `cap-evolve run` provider step: stdout+stderr contain no token."""
+    spec = tmp_path / "capevolve.yaml"
+    spec.write_text("capabilities: [system-prompt]\nprovider: openai\n"
+                    "optimizer_skill: mock\nalgorithm_skill: hill-climb\n", encoding="utf-8")
+    env = dict(**{k: v for k, v in __import__("os").environ.items()})
+    env.update({"ANTHROPIC_API_KEY": FAKE, "PYTHONPATH": str(Path(__file__).resolve().parents[1]),
+                "CAPEVOLVE_CONFIG": "/nonexistent/capevolve-config.yaml"})
+    env.pop("OPENAI_API_KEY", None)
+    proc = subprocess.run(
+        [sys.executable, "-m", "cap_evolve.cli", "run", "--spec", str(spec),
+         "--project", str(tmp_path)],
+        capture_output=True, text=True, env=env, cwd=str(tmp_path))
+    combined = proc.stdout + proc.stderr
+    assert proc.returncode == 1                       # failed on the cross-provider case
+    assert "OPENAI_API_KEY" in combined               # actionable
+    assert FAKE not in combined                       # and leak-free
+    assert "FAKETOKEN" not in combined                # not even a fragment
+
+
+def test_no_leak_on_the_nothing_resolves_path(capsys):
+    with pytest.raises(mc.CredentialError) as ei:
+        mc.resolve(project={"provider": "auto"})
+    out = capsys.readouterr()
+    assert FAKE not in (str(ei.value) + out.out + out.err)
+
+
+# ---------------------------------------------------------------------------
+# 3. Precedence
+# ---------------------------------------------------------------------------
+
+def test_precedence_cli_over_project_over_user(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", FAKE)
+    monkeypatch.setenv("OPENAI_API_KEY", FAKE)
+    monkeypatch.setenv("GEMINI_API_KEY", FAKE)
+    user = {"provider": "gemini"}
+    project = {"provider": "openai"}
+    cli = {"provider": "anthropic"}
+
+    assert mc.resolve(user=user).provider == "gemini"
+    assert mc.resolve(project=project, user=user).provider == "openai"
+    got = mc.resolve(cli=cli, project=project, user=user)
+    assert got.provider == "anthropic"
+    assert got.sources["provider"] == "CLI flag"
+
+
+def test_empty_layer_does_not_shadow_lower_layer(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", FAKE)
+    res = mc.resolve(cli={"provider": ""}, project={"provider": ""},
+                     user={"provider": "openai"})
+    assert res.provider == "openai"
+    assert res.sources["provider"] == "user config"
+
+
+def test_user_config_file_is_read(monkeypatch, tmp_path):
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("provider: openai\n", encoding="utf-8")
+    monkeypatch.setenv("CAPEVOLVE_CONFIG", str(cfg))
+    monkeypatch.setenv("OPENAI_API_KEY", FAKE)
+    assert mc.resolve().provider == "openai"
+
+
+def test_base_url_precedence(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", FAKE)
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://gw.example/v1")
+    assert mc.resolve(project={"provider": "openai"}).base_url == "https://gw.example/v1"
+    res = mc.resolve(cli={"base_url": "https://cli.example/v1"}, project={"provider": "openai"})
+    assert res.base_url == "https://cli.example/v1"
+    monkeypatch.delenv("OPENAI_BASE_URL")
+    assert mc.resolve(project={"provider": "openai"}).base_url == "https://api.openai.com/v1"
+
+
+def test_precedence_documented_in_module_and_docs():
+    assert mc.PRECEDENCE == ("CLI flag", "project capevolve.yaml", "user config",
+                             "built-in default")
+    doc = Path(__file__).resolve().parents[2] / "docs" / "INSTALL.md"
+    assert "CLI flag > project" in doc.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# 4. auto + failure messages
+# ---------------------------------------------------------------------------
+
+def test_auto_picks_the_provider_that_has_a_credential(monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", FAKE)
+    res = mc.resolve(project={"provider": "auto"})
+    assert res.provider == "gemini"
+    assert "GEMINI_API_KEY is set" in res.reason
+    assert FAKE not in res.reason
+
+
+def test_auto_prefers_the_documented_order(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", FAKE)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", FAKE)
+    assert mc.resolve(project={"provider": "auto"}).provider == "anthropic"
+
+
+def test_auto_skips_a_candidate_whose_probe_fails(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", FAKE)
+    monkeypatch.setenv("OPENAI_API_KEY", FAKE)
+    res = mc.resolve(project={"provider": "auto"},
+                     probe_fn=lambda p, u: (p == "openai", "mocked"))
+    assert res.provider == "openai"
+    assert "Skipped: anthropic (probe failed" in res.reason
+
+
+def test_auto_skips_provider_needing_a_base_url_it_lacks(monkeypatch):
+    monkeypatch.setenv("RITS_API_KEY", FAKE)          # no RITS_API_URL
+    with pytest.raises(mc.CredentialError) as ei:
+        mc.resolve(project={"provider": "auto"})
+    assert "RITS_API_URL unset" in str(ei.value)
+    monkeypatch.setenv("RITS_API_URL", "https://rits.example")
+    assert mc.resolve(project={"provider": "auto"}).provider == "rits"
+
+
+def test_nothing_resolves_is_actionable():
+    with pytest.raises(mc.CredentialError) as ei:
+        mc.resolve(project={"provider": "auto"})
+    msg = str(ei.value)
+    assert "ANTHROPIC_API_KEY" in msg and "OPENAI_API_KEY" in msg
+    assert "CLI flag > project capevolve.yaml > user config > built-in default" in msg
+
+
+def test_unknown_provider_errors_clearly():
+    with pytest.raises(mc.CredentialError) as ei:
+        mc.resolve(cli={"provider": "nope"})
+    assert "unknown provider 'nope'" in str(ei.value)
+    assert "auto" in str(ei.value)
+
+
+def test_probe_refuses_unknown_provider_before_any_request(monkeypatch):
+    def never(*a, **k):
+        raise AssertionError("made a request for an unknown provider")
+    monkeypatch.setattr("urllib.request.urlopen", never)
+    assert mc.probe("nope") == (False, "unknown provider 'nope'")
+
+
+# ---------------------------------------------------------------------------
+# 5. Back-compat: existing single-provider specs unchanged
+# ---------------------------------------------------------------------------
+
+def test_existing_spec_without_provider_key_infers_from_optimizer(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", FAKE)
+    res = mc.resolve(project={"optimizer_skill": "claude-code"})
+    assert res.provider == "anthropic"
+    assert "from optimizer_skill" in res.sources["provider"]
+
+
+def test_mock_optimizer_needs_no_credential():
+    res = mc.resolve(project={"optimizer_skill": "mock"})
+    assert res.provider == "mock"
+    assert res.credential_present is False           # and it did not raise
+
+
+def test_legacy_spec_with_no_provider_and_no_creds_does_not_break():
+    """A spec that never mentions a provider must not start failing (regression guard)."""
+    res = mc.resolve(project={"optimizer_skill": "hill-climb-ish-unknown"},
+                     require_credential=False)
+    assert res.provider == ""                        # unresolved, but no exception
+
+
+def test_toy_calc_style_run_still_resolves(monkeypatch, tmp_path):
+    """The zero-API example's spec shape: optimizer_skill: mock, no provider key."""
+    spec = tmp_path / "capevolve.yaml"
+    spec.write_text("capabilities: [system-prompt]\noptimizer_skill: mock\n", encoding="utf-8")
+    from cap_evolve.specfile import read_yaml
+    res = mc.resolve(project=read_yaml(spec.read_text()), require_credential=False)
+    assert res.provider == "mock" and res.credential_present is False
+
+
+def test_describe_is_a_single_secret_free_line(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", FAKE)
+    line = mc.describe(mc.resolve(project={"provider": "anthropic"}))
+    assert "\n" not in line
+    assert "ANTHROPIC_API_KEY (present)" in line
+    assert FAKE not in line

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -85,3 +85,58 @@ The toy example needs none. Optimizing a real agent needs, in a repo-root `.env`
 
 Never hardcode a secret; cap-evolve executes untrusted optimizer/adapter/tool code — see
 [`../SECURITY.md`](../SECURITY.md). Trouble? [`TROUBLESHOOTING.md`](TROUBLESHOOTING.md).
+
+### Resolution order (provider + credentials)
+
+One documented precedence, applied **per field** (`provider`, `provider_base_url`,
+`provider_credential_env`) — the highest layer that sets a non-empty value wins:
+
+**CLI flag > project `capevolve.yaml` > user config (`~/.capevolve/config.yaml`, or
+`$CAPEVOLVE_CONFIG`) > built-in default.**
+
+CLI flags: `--provider`, `--provider-base-url`, `--provider-credential-env`,
+`--probe-provider`. Spec keys: `provider`, `provider_base_url`,
+`provider_credential_env`. With no `provider` anywhere, it is inferred from
+`optimizer_skill` (`claude-code`→`anthropic`, `codex`→`openai`, …).
+
+### Credentials are provider-scoped
+
+Each provider reads **only its own** env vars. A key for provider A is **never** applied
+to provider B — cap-evolve fails with a message naming the vars B accepts. This is the
+whole point: a stale `ANTHROPIC_API_KEY` from another project cannot silently
+authenticate (or confusingly fail) an `openai` run.
+
+| provider | credential env vars (first set wins) | base URL env | built-in base URL |
+|---|---|---|---|
+| `anthropic` | `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN` | `ANTHROPIC_BASE_URL` | `https://api.anthropic.com` |
+| `openai` | `OPENAI_API_KEY` | `OPENAI_BASE_URL` | `https://api.openai.com/v1` |
+| `gemini` | `GEMINI_API_KEY`, `GOOGLE_API_KEY` | `GEMINI_BASE_URL` | `https://generativelanguage.googleapis.com/v1beta` |
+| `rits` | `RITS_API_KEY` | `RITS_API_URL` | — (required) |
+| `watsonx` | `WATSONX_APIKEY`, `WATSONX_API_KEY` | `WATSONX_URL` | — (required) |
+| `moonshot` | `MOONSHOT_API_KEY`, `KIMI_API_KEY` | `MOONSHOT_BASE_URL` | `https://api.moonshot.ai/v1` |
+| `github-copilot` | `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, `GITHUB_TOKEN` | `COPILOT_BASE_URL` | `https://api.githubcopilot.com` |
+| `bob` | `BOBSHELL_API_KEY`, `BOB_API_KEY` | `BOBSHELL_URL` | — (required) |
+| `cursor` | `CURSOR_API_KEY` | `CURSOR_BASE_URL` | — (required) |
+| `factory` | `FACTORY_API_KEY` | `FACTORY_BASE_URL` | — (required) |
+| `mock` | none (offline) | — | — |
+
+`provider_credential_env` names an **env var**, never a pasted key — a value belonging to
+a different provider is refused. Secret **values** live only in the process environment;
+cap-evolve reports presence/absence and never logs a value (not a prefix, not a length).
+
+### `provider: auto`
+
+`provider: auto` (or `--provider auto`) picks the first provider in the table above that
+has **its own** credential set, and prints which and why. Add `--probe-provider` to also
+require that candidate's endpoint answer before selecting it. A probe only ever sends a
+credential to the base URL of the **same** provider row the credential came from, so a
+token can never reach a third party.
+
+```
+$ cap-evolve run --provider auto --probe-provider --spec ...
+{"step": "provider", "provider": "anthropic", "credential_env": "ANTHROPIC_API_KEY",
+ "credential_present": true, "base_url": "https://api.anthropic.com",
+ "reason": "auto selected 'anthropic': ANTHROPIC_API_KEY is set and it is the
+            highest-priority provider with its own credential; probe of anthropic
+            base URL succeeded."}
+```

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -39,6 +39,19 @@ logged-in Claude Code session or `ANTHROPIC_API_KEY`) and the runner model crede
 repo-root `.env` (`OPENAI_API_KEY`, `RITS_API_KEY` + `RITS_API_URL`, `WATSONX_*`, or an
 `ANTHROPIC_BASE_URL` gateway). See [`INSTALL.md`](INSTALL.md#credentials-only-for-real-runs).
 
+**`no credential found for provider 'X'`** — credentials are **provider-scoped**: a key for
+one provider is never reused for another. The error names the env vars provider X accepts;
+set one of those, or select the provider you actually have a key for (`--provider Y`), or
+let cap-evolve choose with `--provider auto` (add `--probe-provider` to also check the
+endpoint answers). Precedence is
+`CLI flag > capevolve.yaml > ~/.capevolve/config.yaml > built-in` — see
+[`INSTALL.md`](INSTALL.md#resolution-order-provider--credentials). cap-evolve reports
+credential *presence* only and never prints a value.
+
+**`provider_credential_env=... belongs to provider ...`** — you pointed the selected
+provider at another provider's env var. `provider_credential_env` must name a var listed
+for that provider in the table in `INSTALL.md`; it is a var **name**, never a pasted key.
+
 **RITS calls fail** — set both `RITS_API_KEY` and `RITS_API_URL`; the tau2 example passes
 them per-call (no litellm monkeypatch, no tau2 fork). Check your endpoint and concurrency
 knob (`TAU2_MAX_CONCURRENCY`).

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -52,6 +52,28 @@ credential *presence* only and never prints a value.
 provider at another provider's env var. `provider_credential_env` must name a var listed
 for that provider in the table in `INSTALL.md`; it is a var **name**, never a pasted key.
 
+**`base_url: <custom>` — why isn't my endpoint shown?** By design. A base URL you set
+yourself (via `provider_base_url`, `--provider-base-url`, or a `*_BASE_URL` env var) names
+*your* infrastructure, so cap-evolve prints `<custom>` plus which layer set it
+(`base_url_source: user config`) instead of the value. Only the well-known public defaults
+(`https://api.anthropic.com`, `https://api.openai.com/v1`, ...) are shown verbatim, because
+they identify nobody. URL *userinfo* (`https://user:token@host/`) is a credential and is
+stripped unconditionally the moment the URL is resolved — it is never stored or rendered,
+public endpoint or not. To confirm what your endpoint actually resolved to, read the env
+var or config file directly on your own machine; cap-evolve will not echo it.
+
+### What a run directory contains before you share it
+
+`.capevolve/run_*/` — `events.jsonl`, `dashboard.html`, `candidates/`, `rollouts/` — is
+built to be attached to an issue or PR, and credential values and custom endpoint URLs are
+redacted on the way in. It is **not** a scrubbed export, though: it still carries your
+**endpoint configuration** in the sense that it records *that* a custom base URL was in
+use, which precedence layer supplied it, and which provider and env var names were
+selected. It also carries your task data, prompts, capability source, and model outputs
+verbatim — those are the point of the artifact and are not redacted at all. Skim
+`events.jsonl` before attaching a run dir or a `dashboard.html` to anything public. If a
+custom endpoint's *hostname* ever appears in one, that is a bug — please report it.
+
 **RITS calls fail** — set both `RITS_API_KEY` and `RITS_API_URL`; the tau2 example passes
 them per-call (no litellm monkeypatch, no tau2 fork). Check your endpoint and concurrency
 knob (`TAU2_MAX_CONCURRENCY`).

--- a/templates/project/capevolve.yaml
+++ b/templates/project/capevolve.yaml
@@ -18,6 +18,16 @@ optimizer_usd_per_iter: 0.0              # 0 = off; per-iteration DOLLAR cap pas
 #   (claude-code → --max-budget-usd N, enforced by the CLI itself). Optimizers without a
 #   native $ cap (e.g. ibm-bob) ignore it — bound those via optimizer_max_turns / max_optimizer_usd.
 
+# --- provider / credentials -------------------------------------------------
+# Which provider's credential this run may use. Credentials are PROVIDER-SCOPED: a key
+# for provider A is never applied to provider B (cap-evolve errors instead). Leave empty
+# to infer from optimizer_skill; set "auto" to pick the provider that actually has a
+# credential set (add --probe-provider to also require its endpoint answers).
+# Precedence: CLI flag > this file > ~/.capevolve/config.yaml > built-in default.
+provider: ""                             # anthropic | openai | gemini | rits | watsonx | mock | auto | ""
+provider_base_url: ""                    # override the base URL (else the provider's *_BASE_URL env, else built-in)
+provider_credential_env: ""              # env var NAME holding the key (must belong to `provider`); NEVER paste a key here
+
 # --- consuming (runtime) LLM the capabilities are optimized FOR --------------
 # The model the AGENT UNDER TEST reads these capabilities with at runtime — DISTINCT
 # from optimizer_model (which PROPOSES edits). May be a concrete model id (resolved to a


### PR DESCRIPTION
Closes #134.

Provider/model config gets an explicit, documented precedence and **provider-scoped**
credential resolution, plus a `provider: auto` mode that probes which provider is
actually usable. New module: `core/cap_evolve/model_config.py` (stdlib only, zero new
runtime deps — one resolution table, no plugin framework).

## Precedence (documented in one place)

Applied **per field** (`provider`, `provider_base_url`, `provider_credential_env`) —
highest layer that sets a non-empty value wins:

**CLI flag > project `capevolve.yaml` > user config (`~/.capevolve/config.yaml`, or
`$CAPEVOLVE_CONFIG`) > built-in default.**

Lives in `model_config.PRECEDENCE`, the module docstring, and
`docs/INSTALL.md#resolution-order-provider--credentials`. A test asserts the doc and
the constant agree, so they can't drift.

## Per-provider env vars

Each provider reads **only its own** vars (first set wins):

| provider | credential env vars | base URL env | built-in base URL |
|---|---|---|---|
| `anthropic` | `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN` | `ANTHROPIC_BASE_URL` | `https://api.anthropic.com` |
| `openai` | `OPENAI_API_KEY` | `OPENAI_BASE_URL` | `https://api.openai.com/v1` |
| `gemini` | `GEMINI_API_KEY`, `GOOGLE_API_KEY` | `GEMINI_BASE_URL` | `https://generativelanguage.googleapis.com/v1beta` |
| `rits` | `RITS_API_KEY` | `RITS_API_URL` | — (required) |
| `watsonx` | `WATSONX_APIKEY`, `WATSONX_API_KEY` | `WATSONX_URL` | — (required) |
| `moonshot` | `MOONSHOT_API_KEY`, `KIMI_API_KEY` | `MOONSHOT_BASE_URL` | `https://api.moonshot.ai/v1` |
| `github-copilot` | `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, `GITHUB_TOKEN` | `COPILOT_BASE_URL` | `https://api.githubcopilot.com` |
| `bob` | `BOBSHELL_API_KEY`, `BOB_API_KEY` | `BOBSHELL_URL` | — (required) |
| `cursor` | `CURSOR_API_KEY` | `CURSOR_BASE_URL` | — (required) |
| `factory` | `FACTORY_API_KEY` | `FACTORY_BASE_URL` | — (required) |
| `mock` | none (offline) | — | — |

A key for provider A is **never** applied to provider B: `_scoped_credential_env`
reads a single `PROVIDERS[provider]["env"]` row and nothing else. Even an explicit
`provider_credential_env` pointing at another provider's var is refused
(`_owner_of` check) rather than honoured. When nothing resolves, the error names the
vars the selected provider accepts, says which *other* providers do have credentials
and that they won't be reused, and restates the precedence.

## Why a credential can never reach the wrong endpoint

This was the main risk in the issue, so it is structural rather than a convention:

1. **URL, auth header, and env var live in the same table row.** `PROVIDERS[p]` owns
   `base_url` / `base_url_env` / `probe_path` / `header` / `env` together. There is no
   code path that takes the credential from one row and the URL from another.
2. **One function reads a credential value.** `probe()` is the only place
   `os.environ[cred_env]` is dereferenced. It looks up `row = PROVIDERS[provider]`,
   gets `cred_env` from that same row via `_scoped_credential_env(provider)`, and
   builds the header from `row["header"]` against `row`'s own base URL.
3. **No credential ⇒ no request.** If the row's own var isn't set, `probe` returns
   `(False, "no <p> credential (VARS) set")` *before* constructing a request, so
   `auto` walking candidates cannot send provider A's token at provider B's URL while
   scanning.
4. **Unknown provider is refused before any I/O**, so a typo'd name can't fall through
   to some default endpoint.
5. **A caller-supplied `base_url` is only ever the resolved base URL for that same
   provider** (`_resolve_base_url(provider, …)` — its own `*_BASE_URL` env or its own
   built-in), and `auto` passes each candidate only its own resolved URL.

`test_probe_never_sends_credential_to_another_providers_endpoint` asserts this at the
wire level: with only `ANTHROPIC_API_KEY` set it intercepts every `urlopen`, checks the
anthropic probe hits `api.anthropic.com` carrying the token, and that the openai /
gemini / rits / watsonx probes make **zero** requests.
`test_auto_probe_does_not_leak_credential_across_candidates` fails the test from inside
the fake transport if a request with the token ever targets a foreign host.

## No-leak guarantee

- `Resolved` stores the env var **NAME**, never the value. Any `repr`/`str`/`to_dict`/
  `json.dumps`/`describe` of a resolved config is secret-free *by construction*, not by
  remembering to redact. Presence is reported as `credential_present: true`.
- Nothing in the module prints, logs, or embeds a credential value — not a prefix, not a
  length.
- Probe failure reasons (which can carry a library-formatted URL) are passed through
  `_safe_reason`: strip `?api_key=…`-style query creds, then the repo's **existing**
  `dashboard.redact` (reused, not reimplemented), then truncate.
- Nothing is written to `events.jsonl` / run artifacts / the dashboard beyond the
  secret-free `{"step": "provider", …}` line.

Tests proving it: `test_resolved_object_carries_no_credential_value`,
`test_probe_failure_reason_is_scrubbed`,
`test_cli_run_transcript_never_prints_credential` (spawns a real `cap-evolve run`
subprocess with a fake token exported and asserts neither the token nor the fragment
`FAKETOKEN` appears in stdout+stderr), `test_no_leak_on_the_nothing_resolves_path`,
`test_describe_is_a_single_secret_free_line`.

## `provider: auto`

Walks `AUTO_ORDER`, selects the first provider whose **own** credential is set, skips
one that needs a base URL it lacks (e.g. `rits` without `RITS_API_URL`), and with
`--probe-provider` additionally requires that candidate's endpoint answer. The chosen
provider comes with a secret-free `reason` naming the env var that was set, why it won,
and what was skipped.

## Scope / coordination

Touched `harness.py`: **nothing** — no regions changed. `specfile.py`: unchanged (only
read). `cli.py`: two localized regions in `_cmd_run` — the argparse block (4 new
`--provider*` flags) and one resolution block just before `--plan-only` returns, whose
result is echoed as a `provider` key in the plan and as a `{"step": "provider"}` line
before the check gate. Version-from-git-tag is #125's, not here. No algorithm, gate,
split, or seal code touched; `--probe-provider` is opt-in so no run performs network I/O
that didn't before.

## Verification

```
$ PYTHONPATH=/tmp/wt-134/core python -m pytest core/tests -q
........................................................................ [ 35%]
........................................................................ [ 70%]
.............................................................            [100%]
205 passed in 63.67s (0:01:03)
```
179 baseline + 26 new, 0 failed.

```
$ python -m compileall -q core skills && echo "COMPILEALL CLEAN"
COMPILEALL CLEAN
```

Real end-to-end, zero API cost (`examples/toy_calc`, `mock` optimizer):
```
{"step": "provider", "provider": "mock", "credential_env": "", "credential_present": false,
 "base_url": "", "sources": {"provider": "built-in default (from optimizer_skill)"},
 "reason": "provider 'mock' from built-in default (from optimizer_skill)"}
{
  "run_dir": ".capevolve/run_demo", "best_id": "cand_0001",
  "baseline_val": 0.0, "test_reward": 1.0, "test_delta": 1.0, "iterations": 3
}
```

Same run with `provider: auto` and a fake token exported as both `ANTHROPIC_API_KEY`
and `OPENAI_API_KEY` — resolution reported, run completed, and the token appears in
**no** stream or artifact:
```
{"step": "provider", "provider": "anthropic", "credential_env": "ANTHROPIC_API_KEY",
 "credential_present": true, "reason": "auto selected 'anthropic': ANTHROPIC_API_KEY is
 set and it is the highest-priority provider with its own credential; credential present
 (no probe requested)."}
baseline_val 0.0 -> test_reward 1.0

$ grep -c "FAKELEAKPROBE" /tmp/leak_stdout.txt /tmp/leak_stderr.txt
/tmp/leak_stderr.txt:0
/tmp/leak_stdout.txt:0
$ grep -rl "FAKELEAKPROBE" $D | wc -l
0
```

Failure path (`--provider openai` with only an anthropic key present) — actionable, no
value echoed:
```
{"step": "provider", "error": "no credential found for provider 'openai' (selected via
CLI flag). Set one of: OPENAI_API_KEY. Credentials for anthropic ARE present but belong
to a different provider and are never reused — either export a openai credential, or
select that provider explicitly (provider: anthropic) / use provider: auto.
Precedence: CLI flag > project capevolve.yaml > user config > built-in default."}
```

One live probe (base URL + token read from `~/.claude/settings.json`, exported, never
printed):
```
probe(anthropic) ok = True
reason           = HTTP 200
token in reason? = False   token len leaked? False
-- credential-less rows make NO request:
   openai (False, 'no openai credential (OPENAI_API_KEY) set')
   gemini (False, 'no gemini credential (GEMINI_API_KEY/GOOGLE_API_KEY) set')
   rits (False, 'no rits credential (RITS_API_KEY) set')
```

Full command transcripts in a follow-up 🔬 Evidence comment.
