### PR TITLE
Add `cap-evolve doctor` install/health diagnostic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,35 @@ All notable changes to cap-evolve are documented here. The format follows
 [Semantic Versioning](https://semver.org/) (currently `0.x` — anything may change).
 
 ## [Unreleased]
+### Added
+- **`cap-evolve doctor` — one-command install/health diagnostic** (issue #121). Reports
+  pass/warn/fail with an actionable fix per line and exits non-zero on a hard failure, so
+  CI can gate on it. Checks Python version, core importability + which interpreter/venv,
+  `cap-evolve` on `PATH` (including a *shadowing* second install), `git`, the skills dir +
+  registry manifest, `optimizers/registry.yaml` presence, optimizer CLIs on `PATH`,
+  provider credentials (**presence only, never a value** — env plus names declared in a
+  repo-root `.env`, warning on a partially-set group like RITS or watsonx), run-dir
+  writability, and `cap-evolve check` when run inside a project. `--json` for
+  machine-readable output; `run_doctor()`/`format_report()` are separate so other surfaces
+  can consume the structured report.
+
 ### Fixed
+- **`install.sh` produced an install that could not run an optimizer.** The copy loop only
+  walked component *directories*, so `skills/optimizers/registry.yaml` — a plain file —
+  was never installed, and `run-optimizer/scripts/run.py` raises `FileNotFoundError` the
+  moment a run starts without it. Every stock install was in this state. `install.sh` now
+  copies it to `$DEST/optimizers/registry.yaml`, exactly where `run.py`'s parent-walk looks,
+  and `cap-evolve doctor` reports a missing registry as a **FAIL** (it was a WARN with
+  "run ./install.sh" as the fix — the command that produced the state) with a remediation
+  that actually works.
+- **`dashboard.redact` missed every credential without a recognizable shape.** It matched
+  `sk-…`/`Bearer …`/JWT/40+ char hex-base64/`KEY=value` only, so a watsonx key, a UUID
+  token or a GitHub PAT passed through. Adds `ghp_`/`github_pat_`/UUID shape rules and,
+  more importantly, a shape-*independent* pass that scrubs the literal values of this
+  process's secret-looking env vars. `cap-evolve doctor` additionally never echoes
+  third-party text (a user adapter's exception message) verbatim: it is redacted, bounded
+  to a short excerpt, and the full text is written to `.capevolve/project/doctor-check.log`
+  for local inspection instead of stdout.
 - **Benchmark CI robustness (skillberry-1 self-hosted runner).** Three fixes so a broken
   runner or gateway is *loud*, not a silent all-0.000 "success": (1) `ci_setup.sh` now
   installs + hard-verifies the `claude-code` optimizer CLI — when it was missing the

--- a/core/cap_evolve/check.py
+++ b/core/cap_evolve/check.py
@@ -94,7 +94,10 @@ def run_check(project_dir: Path, *, tolerance: float = 1e-6) -> CheckReport:
     try:
         adapter = load_adapter(Path(project_dir))
     except Exception as e:  # noqa: BLE001
-        rep.problems.append(f"could not load adapter: {e}")
+        # Name the exception TYPE as well as the message: the message is arbitrary
+        # user-adapter text (which may carry a credential and is bounded/redacted by
+        # doctor before display); the type is always safe and is what a reader acts on.
+        rep.problems.append(f"could not load adapter: {type(e).__name__}: {e}")
         return rep
 
     # 1. stubs

--- a/core/cap_evolve/cli.py
+++ b/core/cap_evolve/cli.py
@@ -9,6 +9,7 @@ Subcommands:
     cap-evolve version
     cap-evolve splits  --ids ... [--seed N] [--ratios a,b,c]
     cap-evolve check   [project_dir]
+    cap-evolve doctor  [dir] [--json]   (install/health diagnostic; nonzero on hard failure)
     cap-evolve run     --spec .capevolve/project/capevolve.yaml   (sequences phase skills)
                        [--resume [--run-ts TS]]  resume an interrupted run in place
 
@@ -439,6 +440,11 @@ def _cmd_run(argv):
     return 0
 
 
+def _cmd_doctor(argv):
+    from .doctor import _main
+    return _main(argv)
+
+
 def _cmd_dashboard(argv):
     """Launch (or focus) the live dashboard server over a base dir of runs."""
     import argparse
@@ -616,6 +622,7 @@ COMMANDS = {
     "version": _cmd_version,
     "splits": _cmd_splits,
     "check": _cmd_check,
+    "doctor": _cmd_doctor,
     "run": _cmd_run,
     "estimate": _cmd_estimate,
     "dashboard": _cmd_dashboard,
@@ -625,7 +632,8 @@ COMMANDS = {
 def main(argv=None) -> int:
     argv = list(sys.argv[1:] if argv is None else argv)
     if not argv or argv[0] in ("-h", "--help"):
-        print("usage: cap-evolve {version|splits|check|run|estimate|dashboard} [args]", file=sys.stderr)
+        print("usage: cap-evolve {version|splits|check|doctor|run|estimate|dashboard} [args]",
+              file=sys.stderr)
         return 0 if argv else 2
     fn = COMMANDS.get(argv[0])
     if fn is None:

--- a/core/cap_evolve/dashboard.py
+++ b/core/cap_evolve/dashboard.py
@@ -80,7 +80,27 @@ _SECRET_VALUE_RES = [
     re.compile(r"\beyJ[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{6,}\.[A-Za-z0-9_\-]{6,}\b"),  # JWT
     re.compile(r"\b[A-Za-z0-9+/]{40,}={0,2}\b"),  # long base64
     re.compile(r"\b[0-9a-fA-F]{40,}\b"),          # long hex
+    # GitHub PATs (classic + fine-grained) and UUID-shaped tokens — both are common
+    # credential shapes that the length-based rules above miss.
+    re.compile(r"\bgh[pousr]_[A-Za-z0-9]{16,}\b"),
+    re.compile(r"\bgithub_pat_[A-Za-z0-9_]{20,}\b"),
+    re.compile(r"\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
+               r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b"),
 ]
+
+
+def _env_secret_values() -> list[str]:
+    """The actual VALUES of secret-looking env vars in this process.
+
+    Shape matching is a heuristic and always will be: a watsonx key, an opaque
+    session id or a bare high-entropy string has no recognizable shape. What we do
+    know for certain is the credential material this process was handed, so scrub
+    that literally — the only shape-independent defense. Longest first so a value
+    that contains another isn't half-masked.
+    """
+    vals = {v for k, v in os.environ.items()
+            if v and len(v) >= 6 and _key_is_secret(k)}
+    return sorted(vals, key=len, reverse=True)
 
 # KEY=secret / KEY: secret inside prose — mask the value, keep the key name so the
 # message still reads ("RITS_API_KEY=«redacted»"). Two groups: (prefix)(value).
@@ -100,6 +120,10 @@ def _scrub_value(val: str) -> str:
     out = _INLINE_KV_RE.sub(lambda m: m.group(1) + _REDACTED, val)
     for rx in _SECRET_VALUE_RES:
         out = rx.sub(_REDACTED, out)
+    # Shape-independent pass: literal credential values from this environment.
+    for secret in _env_secret_values():
+        if secret in out:
+            out = out.replace(secret, _REDACTED)
     return out
 
 

--- a/core/cap_evolve/doctor.py
+++ b/core/cap_evolve/doctor.py
@@ -16,9 +16,17 @@ rather than invented ones:
   ``run-dir``      the run dir must be writable before any budget is spent
   ``project``      ``cap-evolve check`` is not green — reuses ``check.run_check``
 
-SECURITY: the credential check reports only PRESENCE/ABSENCE. No secret value —
-not even a prefix or a length — is ever emitted, and the whole report is passed
-through ``dashboard.redact`` on the way out as defense in depth.
+SECURITY (three independent layers, because shape matching alone is not enough):
+
+1. The credential check reports only PRESENCE/ABSENCE — no value, prefix or length.
+2. Third-party text (a user adapter's exception message, reached via
+   ``check.run_check``) is NEVER echoed verbatim: ``_summarize_untrusted`` bounds it
+   to a short excerpt and the full text goes to a local file instead of stdout.
+   This is the primary defense for the ``project`` check, since an adapter can raise
+   with a credential of any shape in its message.
+3. The whole report passes through ``dashboard.redact``, which masks secret *shapes*
+   AND (shape-independently) the literal values of this process's secret-looking env
+   vars — the only rule that catches an opaque watsonx key or a UUID token.
 
 Exit code: 0 when nothing FAILs (warnings are advisory), 1 on any hard failure,
 so CI can gate on ``cap-evolve doctor``.
@@ -53,10 +61,23 @@ _RUNNER_ENV_GROUPS: list[tuple[str, tuple[str, ...]]] = [
     ("gemini", ("GEMINI_API_KEY",)),
 ]
 
+# Vars the docs say must be set TOGETHER — half a pair is not usable, so PASSing on it
+# is a false green. Not every group above is like this (ANTHROPIC_API_KEY alone is fine),
+# hence an explicit list rather than "every group needs all its members".
+#   TROUBLESHOOTING.md "RITS calls fail" — set BOTH RITS_API_KEY and RITS_API_URL
+#   watsonx needs apikey + url + project id
+#   the SkillsBench gateway pair: a custom base URL needs its own token
+_REQUIRED_TOGETHER: list[tuple[str, ...]] = [
+    ("RITS_API_KEY", "RITS_API_URL"),
+    ("WATSONX_APIKEY", "WATSONX_URL", "WATSONX_PROJECT_ID"),
+    ("ANTHROPIC_BASE_URL", "ANTHROPIC_AUTH_TOKEN"),
+]
+
 # install.sh:38-40 admits these host dirs are guesses; the verified ones are documented
 # in the same comment. Surfacing which kind you're on is the whole point of check #5.
 _VERIFIED_HOST_DIRS = ("/.claude/skills", "/.agents/skills", "/.config/opencode/skills",
-                       "/.capevolve/skills", "/.gemini/extensions/cap-evolve/skills")
+                       "/.capevolve/skills", "/.gemini/extensions/cap-evolve/skills",
+                       "/.openclaw/workspace/skills")
 
 
 @dataclass
@@ -110,13 +131,16 @@ def _check_core(cwd: Path) -> Check:
         return Check("core", FAIL, f"import cap_evolve failed: {e}",
                      "pip install ./core (or export CAPEVOLVE_CORE=<repo>/core)")
     where = Path(cap_evolve.__file__).parent
-    venv = os.environ.get("VIRTUAL_ENV") or sys.prefix
-    detail = f"cap_evolve {__version__} from {where} (env {venv})"
+    active = os.environ.get("VIRTUAL_ENV")
+    detail = f"cap_evolve {__version__} from {where} (env {active or sys.prefix})"
     # "Trapped in the wrong venv": the interpreter importing core is not the one the
     # activated venv points at, so `pip install` lands somewhere the run won't see.
-    active = os.environ.get("VIRTUAL_ENV")
-    if active and not str(Path(sys.executable).resolve()).startswith(str(Path(active).resolve())):
-        return Check("core", WARN, detail + f" — but VIRTUAL_ENV={active} does not own {sys.executable}",
+    # Compare against sys.prefix — "the venv THIS interpreter belongs to". Resolving
+    # sys.executable instead would follow bin/python's symlink out to the base
+    # interpreter, which never lives under $VIRTUAL_ENV: a false WARN on every
+    # correctly activated venv (macOS/Homebrew, and pyvenv in general).
+    if active and Path(active).resolve() != Path(sys.prefix).resolve():
+        return Check("core", WARN, detail + f" — but VIRTUAL_ENV={active} is not this interpreter's prefix ({sys.prefix})",
                      "you are in one venv but running another interpreter; "
                      f"use {Path(active) / 'bin' / 'python'} -m cap_evolve.cli, or re-activate")
     return Check("core", PASS, detail)
@@ -144,7 +168,8 @@ def _check_git(cwd: Path) -> Check:
     if not exe:
         return Check("git", FAIL, "git not found on PATH",
                      "the default version store is git (every candidate is a commit) — "
-                     "install git, or set `store: none` in capevolve.yaml")
+                     "install git, or set `store: copy` in capevolve.yaml "
+                     "(store.py accepts git | copy | command — there is no `none`)")
     try:
         out = subprocess.run([exe, "--version"], capture_output=True, text=True, timeout=10)
         return Check("git", PASS, out.stdout.strip() or exe)
@@ -158,6 +183,21 @@ def _skills_dir() -> Path | None:
     return _find_skills_dir()
 
 
+def _build_manifest_hint() -> str:
+    """Path to ``build_manifest.py`` that is actually valid from where the user stands.
+
+    A flat install has no ``skills/_registry/`` at all, so the bare repo-relative form
+    printed a command that could not run. Prefer the real absolute path when we can see
+    the repo checkout, otherwise say where it comes from.
+    """
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        cand = parent / "skills" / "_registry" / "build_manifest.py"
+        if cand.exists():
+            return str(cand)
+    return "<repo>/skills/_registry/build_manifest.py"
+
+
 def _check_skills(cwd: Path) -> Check:
     d = _skills_dir()
     if d is None:
@@ -166,25 +206,39 @@ def _check_skills(cwd: Path) -> Check:
     manifest = d / "_registry" / "manifest.json"
     if not manifest.exists():
         return Check("skills", FAIL, f"skills at {d} but no _registry/manifest.json",
-                     "rebuild it: python skills/_registry/build_manifest.py "
-                     f"{d}   (install.sh does this for you)")
+                     f"rebuild it: python {_build_manifest_hint()} {d}"
+                     "   (re-running ./install.sh does this for you)")
     try:
         skills = json.loads(manifest.read_text(encoding="utf-8")).get("skills") or {}
     except Exception as e:  # noqa: BLE001
         return Check("skills", FAIL, f"{manifest} is not valid JSON: {e}",
-                     f"rebuild it: python skills/_registry/build_manifest.py {d}")
+                     f"rebuild it: python {_build_manifest_hint()} {d}")
     # Manifest/disk consistency: a stale manifest naming a skill whose dir was removed
     # fails opaquely deep inside `cap-evolve run` (KeyError / missing entry script).
-    missing = [n for n, s in skills.items() if not (d / s.get("path", "") / s.get("entry", "")).exists()]
-    # The repo's own skills/ (component layout: skills/phases/..., an _registry sibling of
-    # optimizers/) is a first-class source, not a "best-guess host dir".
-    from_source = (d / "optimizers" / "registry.yaml").exists()
-    guessy = not from_source and not any(str(d).endswith(v) for v in _VERIFIED_HOST_DIRS)
+    # `or ""` not `.get(k, "")`: a manifest with an explicit null field yields None, and
+    # Path / None is a TypeError — a diagnostic must diagnose malformed input, not crash
+    # on it. A null entry IS a missing entry, which is what the empty string makes it.
+    missing = [n for n, s in skills.items()
+               if not isinstance(s, dict)
+               or not (s.get("entry") or "")
+               or not (d / (s.get("path") or "") / (s.get("entry") or "")).exists()]
+    # The repo's own skills/ (component layout: skills/phases/..., an _registry sibling
+    # of optimizers/) is a first-class source. A flat ./install.sh tree is equally
+    # legitimate — recognise it by the flattened skill dirs the manifest names, NOT by
+    # the registry file (which lives elsewhere and made every flat install "guessy").
+    # install.sh now copies the registry into every install, so its presence means
+    # "a cap-evolve install lives here", repo or flat — either way not a stray guess.
+    known = (d / "optimizers" / "registry.yaml").exists()
+    from_source = known and (d / "phases").is_dir()
+    # resolve() first: a relative dir like ./.claude/skills never ends with
+    # "/.claude/skills" as a raw string, so every relative dir was flagged.
+    resolved = str(d.resolve())
+    guessy = not known and not any(resolved.endswith(v) for v in _VERIFIED_HOST_DIRS)
     if missing:
         return Check("skills", FAIL,
                      f"{len(skills)} skill(s) in manifest at {d}; "
                      f"{len(missing)} entry script(s) missing: {', '.join(sorted(missing)[:5])}",
-                     f"stale manifest — rebuild: python skills/_registry/build_manifest.py {d}")
+                     f"stale manifest — rebuild: python {_build_manifest_hint()} {d}")
     if guessy:
         return Check("skills", WARN, f"{len(skills)} skill(s) at {d}",
                      "this is a best-guess host dir, not one of the ones verified in "
@@ -204,9 +258,12 @@ def _optimizer_registry() -> dict:
     if env:
         cands.append(Path(env))
     if d:
-        # repo layout, flat install root, and beside the copied run-optimizer skill dir
+        # repo layout / flat install (install.sh copies it to $DEST/optimizers/), the
+        # install root, beside the copied run-optimizer skill dir, and one level up.
         cands += [d / "optimizers" / "registry.yaml", d / "registry.yaml",
-                  d / "run-optimizer" / "registry.yaml"]
+                  d / "run-optimizer" / "registry.yaml",
+                  d / "run-optimizer" / "optimizers" / "registry.yaml",
+                  d.parent / "optimizers" / "registry.yaml"]
     for cand in cands:
         if cand.exists():
             from .specfile import read_yaml
@@ -217,26 +274,68 @@ def _optimizer_registry() -> dict:
 def _check_optimizer(cwd: Path) -> Check:
     reg = _optimizer_registry()
     if not reg:
-        return Check("optimizer", WARN, "optimizers/registry.yaml not found",
-                     "run ./install.sh, or set CAPEVOLVE_OPTIMIZER_REGISTRY")
-    available, absent = [], []
+        # FAIL, not WARN: run-optimizer/scripts/run.py raises FileNotFoundError on this
+        # exact state, so a run dies immediately. Exiting 0 here would greenlight a
+        # machine that cannot optimize — the worst thing a diagnostic can do.
+        d = _skills_dir()
+        where = f"{d}/optimizers/registry.yaml" if d else "<skills-dir>/optimizers/registry.yaml"
+        return Check("optimizer", FAIL,
+                     f"optimizers/registry.yaml not found — run-optimizer cannot start "
+                     f"(looked for {where})",
+                     "copy it from the repo: "
+                     f"mkdir -p {d or '<skills-dir>'}/optimizers && cp <repo>/skills/optimizers/"
+                     f"registry.yaml {d or '<skills-dir>'}/optimizers/   — or point at the "
+                     "checkout with CAPEVOLVE_OPTIMIZER_REGISTRY=<repo>/skills/optimizers/"
+                     "registry.yaml (older install.sh runs did not copy it; re-running the "
+                     "current ./install.sh also fixes this)")
+    # "Available" splits into CLIs actually on PATH vs. the local/zero-API rows
+    # (mock/generic/$ENV-driven) that need nothing installed. Conflating them made the
+    # FAIL branch unreachable with the shipped registry — mock alone always "passed".
+    on_path, local, absent = [], [], []
     for name, row in reg.items():
         if not isinstance(row, dict):
             continue
         tmpl = str(row.get("command_template") or "")
         exe = tmpl.split()[0] if tmpl.split() else ""
         if not exe or exe.startswith("$") or exe in ("python3", "python"):
-            available.append(name)   # mock/generic/env-driven — nothing to look up
+            local.append(name)
         elif shutil.which(exe):
-            available.append(name)
+            on_path.append(name)
         else:
             absent.append(name)
-    if not available:
-        return Check("optimizer", FAIL, f"no optimizer CLI on PATH (checked {len(reg)})",
-                     "install one (e.g. Claude Code, codex, gemini) or use "
-                     "`optimizer_skill: mock` for a zero-API run")
-    return Check("optimizer", PASS, f"available: {', '.join(sorted(available))}"
-                 + (f" | not on PATH: {', '.join(sorted(absent))}" if absent else ""))
+    tail = (f" | local/zero-API: {', '.join(sorted(local))}" if local else "") \
+           + (f" | not on PATH: {', '.join(sorted(absent))}" if absent else "")
+    if not on_path and not local:
+        return Check("optimizer", FAIL, f"no optimizer available at all (checked {len(reg)})",
+                     "install one (e.g. Claude Code, codex, gemini)")
+    if not on_path:
+        return Check("optimizer", WARN,
+                     f"no optimizer CLI on PATH{tail}",
+                     "a real run needs an agent CLI (Claude Code, codex, gemini-cli, ...); "
+                     "for a zero-API run set `optimizer_skill: mock` in capevolve.yaml")
+    return Check("optimizer", PASS, f"on PATH: {', '.join(sorted(on_path))}" + tail)
+
+
+def _dotenv_names(cwd: Path) -> set[str]:
+    """Variable NAMES declared in the nearest repo-root ``.env`` (INSTALL.md tells users
+    to put credentials there, and ``run-optimizer/scripts/run.py`` reads it).
+
+    Only the left-hand side is ever returned — the value after ``=`` is not even sliced
+    out, so there is nothing here for a leak to carry.
+    """
+    for parent in [cwd.resolve(), *cwd.resolve().parents]:
+        f = parent / ".env"
+        if f.is_file():
+            names = set()
+            try:
+                for line in f.read_text(encoding="utf-8", errors="replace").splitlines():
+                    line = line.strip()
+                    if line and not line.startswith("#") and "=" in line:
+                        names.add(line.split("=", 1)[0].strip().removeprefix("export "))
+            except OSError:  # pragma: no cover — unreadable .env is not a doctor failure
+                pass
+            return names
+    return set()
 
 
 def _check_credentials(cwd: Path) -> Check:
@@ -251,21 +350,40 @@ def _check_credentials(cwd: Path) -> Check:
     if opt_keys:
         groups.append(("optimizer-cli", tuple(dict.fromkeys(opt_keys))))
 
+    dotenv = _dotenv_names(cwd)
     seen: set[str] = set()
-    set_names, unset_names = [], []
+    set_names, unset_names, partial = [], [], []
+    def _here(k: str) -> bool:
+        # bool() of presence only — the VALUE is never read into any reported field.
+        return bool(os.environ.get(k)) or k in dotenv
+
     for _, keys in groups:
         for k in keys:
             if k in seen:
                 continue
             seen.add(k)
-            # bool() of presence only — the VALUE is never read into any reported field.
-            (set_names if os.environ.get(k) else unset_names).append(k)
+            if _here(k):
+                set_names.append(k if os.environ.get(k) else f"{k} (.env)")
+            else:
+                unset_names.append(k)
+    for group in _REQUIRED_TOGETHER:
+        missing = [k for k in group if not _here(k)]
+        if missing and len(missing) < len(group):
+            partial.append(f"{', '.join(k for k in group if _here(k))} set but "
+                           f"{', '.join(missing)} absent")
     if not set_names:
-        return Check("credentials", WARN, "no provider credentials in the environment",
+        return Check("credentials", WARN, "no provider credentials in the environment or .env",
                      "the toy example needs none; a real run needs the optimizer CLI's creds "
                      "plus runner creds in a repo-root .env — see "
                      "docs/INSTALL.md#credentials-only-for-real-runs",
                      absent=unset_names)
+    if partial:
+        return Check("credentials", WARN,
+                     f"{len(set_names)} set, {len(unset_names)} absent — "
+                     f"incomplete group(s): {'; '.join(partial)}",
+                     "these providers need every var in the group; set the missing ones — "
+                     "see docs/INSTALL.md#credentials-only-for-real-runs",
+                     present=set_names, absent=unset_names)
     return Check("credentials", PASS, f"{len(set_names)} set, {len(unset_names)} absent",
                  present=set_names, absent=unset_names)
 
@@ -283,15 +401,56 @@ def _check_run_dir(cwd: Path) -> Check:
     return Check("run-dir", PASS, f"{target} writable")
 
 
+def _summarize_untrusted(texts: list[str], limit: int = 160) -> str:
+    """Bound and de-identify third-party text before it can reach stdout.
+
+    ``check.run_check``'s problems embed ``str(e)`` from arbitrary user adapter code, so
+    their content is attacker/accident-controlled — an adapter that raises
+    ``RuntimeError(f"auth failed for {os.environ['OPENAI_API_KEY']}")`` would otherwise
+    print the key verbatim, and shape-based redaction cannot catch every credential
+    format. So: never echo untrusted text in full. Keep a short, redacted excerpt for
+    orientation and point at the file with the whole thing.
+
+    Redaction runs BEFORE truncation: cutting first can slice a secret mid-value, and a
+    partial prefix no longer matches any rule — so a truncated fragment would survive the
+    ``format_report`` pass. Redact, then bound.
+    """
+    out = []
+    for t in texts:
+        t = " ".join(str(redact(str(t))).split())
+        out.append(t if len(t) <= limit else t[:limit] + f"… (+{len(t) - limit} chars)")
+    return "; ".join(out)
+
+
 def _check_project(cwd: Path) -> Check:
     project = cwd / ".capevolve" / "project"
-    if not (project / "adapters" / "adapter.py").exists():
+    adapter = project / "adapters" / "adapter.py"
+    if not adapter.exists():
+        if project.is_dir():
+            # A scaffolded-but-adapterless project is a BROKEN project, not "no project".
+            return Check("project", FAIL, f"{project} exists but adapters/adapter.py is missing",
+                         "scaffold incomplete — implement adapters/adapter.py "
+                         "(see docs/ADAPTER_CONTRACT.md), then `cap-evolve check "
+                         f"{project}` must print {{\"ok\": true}}")
         return Check("project", PASS, "not inside a cap-evolve project (nothing to validate)")
     from .check import run_check
     rep = run_check(project)
     if rep.ok:
-        return Check("project", PASS, f"{project} — cap-evolve check green; " + "; ".join(rep.notes))
-    return Check("project", FAIL, f"{project} — cap-evolve check failed: " + "; ".join(rep.problems),
+        return Check("project", PASS, f"{project} — cap-evolve check green; "
+                     + _summarize_untrusted(list(rep.notes), limit=400))
+    # Write the FULL untrusted detail to a local file the user can inspect themselves,
+    # and print only a bounded excerpt. The report is what gets pasted into issues.
+    full = "\n".join(str(p) for p in rep.problems)
+    where = ""
+    try:
+        log = project / "doctor-check.log"
+        log.write_text(full + "\n", encoding="utf-8")
+        where = f" — full adapter output in {log} (inspect locally; may contain secrets)"
+    except OSError:  # pragma: no cover — unwritable project dir is reported by run-dir
+        pass
+    return Check("project", FAIL,
+                 f"{project} — cap-evolve check failed: "
+                 + _summarize_untrusted(list(rep.problems)) + where,
                  "this is the hard gate doing its job — fix the adapter, then "
                  f"`cap-evolve check {project}` must print {{\"ok\": true}}. "
                  "See docs/ADAPTER_CONTRACT.md")

--- a/core/cap_evolve/doctor.py
+++ b/core/cap_evolve/doctor.py
@@ -1,0 +1,346 @@
+"""``cap-evolve doctor`` — install/health self-diagnostic.
+
+Every check here targets a failure that ``docs/TROUBLESHOOTING.md`` already
+documents as a real support case, so the diagnostic preempts the actual stumbles
+rather than invented ones:
+
+  ``python``       Python too old (TROUBLESHOOTING "Python too old" — needs 3.10+)
+  ``core``         ``cap-evolve: command not found`` / ``pip install ./core`` skipped
+  ``cli-path``     same, plus a *shadowing* second install (issue #121)
+  ``git``          the default version store is git; a missing git breaks candidates
+  ``skills``       ``no manifest — run install.sh``, and install.sh's own
+                   "best-guess" host dirs (install.sh:38-40)
+  ``optimizer``    optimizer CLI missing / not logged in (TROUBLESHOOTING
+                   "Missing credentials at runtime")
+  ``credentials``  runner + optimizer provider creds, PRESENCE ONLY
+  ``run-dir``      the run dir must be writable before any budget is spent
+  ``project``      ``cap-evolve check`` is not green — reuses ``check.run_check``
+
+SECURITY: the credential check reports only PRESENCE/ABSENCE. No secret value —
+not even a prefix or a length — is ever emitted, and the whole report is passed
+through ``dashboard.redact`` on the way out as defense in depth.
+
+Exit code: 0 when nothing FAILs (warnings are advisory), 1 on any hard failure,
+so CI can gate on ``cap-evolve doctor``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from . import __version__
+from .dashboard import redact
+
+PASS, WARN, FAIL = "pass", "warn", "fail"
+
+_MARK = {PASS: "PASS", WARN: "WARN", FAIL: "FAIL"}
+
+# Runner-model credential surface documented in INSTALL.md#credentials-only-for-real-runs
+# and TROUBLESHOOTING "Missing credentials at runtime" / "RITS calls fail" /
+# "SkillsBench: Docker / benchflow errors". Names only — values are never read.
+_RUNNER_ENV_GROUPS: list[tuple[str, tuple[str, ...]]] = [
+    ("anthropic", ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_BASE_URL")),
+    ("openai", ("OPENAI_API_KEY",)),
+    ("rits", ("RITS_API_KEY", "RITS_API_URL")),
+    ("watsonx", ("WATSONX_APIKEY", "WATSONX_URL", "WATSONX_PROJECT_ID")),
+    ("gemini", ("GEMINI_API_KEY",)),
+]
+
+# install.sh:38-40 admits these host dirs are guesses; the verified ones are documented
+# in the same comment. Surfacing which kind you're on is the whole point of check #5.
+_VERIFIED_HOST_DIRS = ("/.claude/skills", "/.agents/skills", "/.config/opencode/skills",
+                       "/.capevolve/skills", "/.gemini/extensions/cap-evolve/skills")
+
+
+@dataclass
+class Check:
+    name: str
+    status: str
+    detail: str = ""
+    fix: str = ""
+    # Credential PRESENCE only: env var NAMES, never values. Kept structured (rather than
+    # baked into ``detail``) so the "NAME: set (hidden)" rendering happens AFTER redact()
+    # — otherwise the inline KEY=value redactor would scrub the word "set" itself.
+    present: list = field(default_factory=list)
+    absent: list = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {"name": self.name, "status": self.status, "detail": self.detail, "fix": self.fix,
+                "present": list(self.present), "absent": list(self.absent)}
+
+
+@dataclass
+class DoctorReport:
+    checks: list[Check] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not any(c.status == FAIL for c in self.checks)
+
+    def to_dict(self) -> dict:
+        return {"ok": self.ok, "cap_evolve": __version__,
+                "checks": [c.to_dict() for c in self.checks]}
+
+
+# ---------------------------------------------------------------------------
+# individual checks — each takes (cwd) and returns a Check
+# ---------------------------------------------------------------------------
+
+def _check_python(cwd: Path) -> Check:
+    v = sys.version_info
+    ver = f"{v.major}.{v.minor}.{v.micro}"
+    if v < (3, 10):
+        return Check("python", FAIL, f"{ver} at {sys.executable}",
+                     "cap-evolve needs Python 3.10+ — create a newer venv: "
+                     "python3 -m venv .venv && source .venv/bin/activate")
+    return Check("python", PASS, f"{ver} at {sys.executable}")
+
+
+def _check_core(cwd: Path) -> Check:
+    try:
+        import cap_evolve
+    except Exception as e:  # noqa: BLE001 — pragma: no cover (we ARE cap_evolve)
+        return Check("core", FAIL, f"import cap_evolve failed: {e}",
+                     "pip install ./core (or export CAPEVOLVE_CORE=<repo>/core)")
+    where = Path(cap_evolve.__file__).parent
+    venv = os.environ.get("VIRTUAL_ENV") or sys.prefix
+    detail = f"cap_evolve {__version__} from {where} (env {venv})"
+    # "Trapped in the wrong venv": the interpreter importing core is not the one the
+    # activated venv points at, so `pip install` lands somewhere the run won't see.
+    active = os.environ.get("VIRTUAL_ENV")
+    if active and not str(Path(sys.executable).resolve()).startswith(str(Path(active).resolve())):
+        return Check("core", WARN, detail + f" — but VIRTUAL_ENV={active} does not own {sys.executable}",
+                     "you are in one venv but running another interpreter; "
+                     f"use {Path(active) / 'bin' / 'python'} -m cap_evolve.cli, or re-activate")
+    return Check("core", PASS, detail)
+
+
+def _check_cli_path(cwd: Path) -> Check:
+    found = shutil.which("cap-evolve")
+    if not found:
+        return Check("cli-path", WARN, "cap-evolve is not on PATH",
+                     "install.sh deliberately does NOT install the Python package: run "
+                     "`pip install ./core` in the active venv. Until then use "
+                     "`python -m cap_evolve.cli ...`.")
+    # Shadowing: the first cap-evolve on PATH belongs to a different install than the
+    # cap_evolve package this process imported.
+    expected = Path(sys.executable).parent / "cap-evolve"
+    if expected.exists() and Path(found).resolve() != expected.resolve():
+        return Check("cli-path", WARN, f"PATH resolves to {found}, but this interpreter's is {expected}",
+                     "a second (shadowing) install is earlier on PATH — remove it, or call "
+                     f"{expected} / `python -m cap_evolve.cli` explicitly.")
+    return Check("cli-path", PASS, found)
+
+
+def _check_git(cwd: Path) -> Check:
+    exe = shutil.which("git")
+    if not exe:
+        return Check("git", FAIL, "git not found on PATH",
+                     "the default version store is git (every candidate is a commit) — "
+                     "install git, or set `store: none` in capevolve.yaml")
+    try:
+        out = subprocess.run([exe, "--version"], capture_output=True, text=True, timeout=10)
+        return Check("git", PASS, out.stdout.strip() or exe)
+    except Exception as e:  # noqa: BLE001
+        return Check("git", FAIL, f"{exe} present but not runnable: {e}",
+                     "reinstall git or fix its permissions")
+
+
+def _skills_dir() -> Path | None:
+    from .cli import _find_skills_dir
+    return _find_skills_dir()
+
+
+def _check_skills(cwd: Path) -> Check:
+    d = _skills_dir()
+    if d is None:
+        return Check("skills", FAIL, "no skills dir found",
+                     "run ./install.sh (or set CAPEVOLVE_SKILLS_DIR to the repo's skills/)")
+    manifest = d / "_registry" / "manifest.json"
+    if not manifest.exists():
+        return Check("skills", FAIL, f"skills at {d} but no _registry/manifest.json",
+                     "rebuild it: python skills/_registry/build_manifest.py "
+                     f"{d}   (install.sh does this for you)")
+    try:
+        skills = json.loads(manifest.read_text(encoding="utf-8")).get("skills") or {}
+    except Exception as e:  # noqa: BLE001
+        return Check("skills", FAIL, f"{manifest} is not valid JSON: {e}",
+                     f"rebuild it: python skills/_registry/build_manifest.py {d}")
+    # Manifest/disk consistency: a stale manifest naming a skill whose dir was removed
+    # fails opaquely deep inside `cap-evolve run` (KeyError / missing entry script).
+    missing = [n for n, s in skills.items() if not (d / s.get("path", "") / s.get("entry", "")).exists()]
+    # The repo's own skills/ (component layout: skills/phases/..., an _registry sibling of
+    # optimizers/) is a first-class source, not a "best-guess host dir".
+    from_source = (d / "optimizers" / "registry.yaml").exists()
+    guessy = not from_source and not any(str(d).endswith(v) for v in _VERIFIED_HOST_DIRS)
+    if missing:
+        return Check("skills", FAIL,
+                     f"{len(skills)} skill(s) in manifest at {d}; "
+                     f"{len(missing)} entry script(s) missing: {', '.join(sorted(missing)[:5])}",
+                     f"stale manifest — rebuild: python skills/_registry/build_manifest.py {d}")
+    if guessy:
+        return Check("skills", WARN, f"{len(skills)} skill(s) at {d}",
+                     "this is a best-guess host dir, not one of the ones verified in "
+                     "install.sh:38-40 — if your agent doesn't see the skills, re-install "
+                     "with ./install.sh --dest DIR or set $CAPEVOLVE_SKILLS_DIR")
+    return Check("skills", PASS, f"{len(skills)} skill(s) at {d}"
+                 + (" (repo source layout)" if from_source else ""))
+
+
+def _optimizer_registry() -> dict:
+    """Resolve ``optimizers/registry.yaml`` the same way ``run-optimizer/scripts/run.py``
+    does, so doctor reports what the run will actually find (repo layout or flat install).
+    """
+    d = _skills_dir()
+    cands = []
+    env = os.environ.get("CAPEVOLVE_OPTIMIZER_REGISTRY")
+    if env:
+        cands.append(Path(env))
+    if d:
+        # repo layout, flat install root, and beside the copied run-optimizer skill dir
+        cands += [d / "optimizers" / "registry.yaml", d / "registry.yaml",
+                  d / "run-optimizer" / "registry.yaml"]
+    for cand in cands:
+        if cand.exists():
+            from .specfile import read_yaml
+            return read_yaml(cand.read_text(encoding="utf-8")) or {}
+    return {}
+
+
+def _check_optimizer(cwd: Path) -> Check:
+    reg = _optimizer_registry()
+    if not reg:
+        return Check("optimizer", WARN, "optimizers/registry.yaml not found",
+                     "run ./install.sh, or set CAPEVOLVE_OPTIMIZER_REGISTRY")
+    available, absent = [], []
+    for name, row in reg.items():
+        if not isinstance(row, dict):
+            continue
+        tmpl = str(row.get("command_template") or "")
+        exe = tmpl.split()[0] if tmpl.split() else ""
+        if not exe or exe.startswith("$") or exe in ("python3", "python"):
+            available.append(name)   # mock/generic/env-driven — nothing to look up
+        elif shutil.which(exe):
+            available.append(name)
+        else:
+            absent.append(name)
+    if not available:
+        return Check("optimizer", FAIL, f"no optimizer CLI on PATH (checked {len(reg)})",
+                     "install one (e.g. Claude Code, codex, gemini) or use "
+                     "`optimizer_skill: mock` for a zero-API run")
+    return Check("optimizer", PASS, f"available: {', '.join(sorted(available))}"
+                 + (f" | not on PATH: {', '.join(sorted(absent))}" if absent else ""))
+
+
+def _check_credentials(cwd: Path) -> Check:
+    """PRESENCE ONLY. Never reads or reports a credential VALUE — see module docstring."""
+    groups = list(_RUNNER_ENV_GROUPS)
+    # Fold in each optimizer row's declared env_keys so the surface stays in sync with
+    # the registry instead of being a second hardcoded list.
+    opt_keys: list[str] = []
+    for row in _optimizer_registry().values():
+        if isinstance(row, dict):
+            opt_keys += [k.strip() for k in str(row.get("env_keys") or "").split(",") if k.strip()]
+    if opt_keys:
+        groups.append(("optimizer-cli", tuple(dict.fromkeys(opt_keys))))
+
+    seen: set[str] = set()
+    set_names, unset_names = [], []
+    for _, keys in groups:
+        for k in keys:
+            if k in seen:
+                continue
+            seen.add(k)
+            # bool() of presence only — the VALUE is never read into any reported field.
+            (set_names if os.environ.get(k) else unset_names).append(k)
+    if not set_names:
+        return Check("credentials", WARN, "no provider credentials in the environment",
+                     "the toy example needs none; a real run needs the optimizer CLI's creds "
+                     "plus runner creds in a repo-root .env — see "
+                     "docs/INSTALL.md#credentials-only-for-real-runs",
+                     absent=unset_names)
+    return Check("credentials", PASS, f"{len(set_names)} set, {len(unset_names)} absent",
+                 present=set_names, absent=unset_names)
+
+
+def _check_run_dir(cwd: Path) -> Check:
+    base = cwd / ".capevolve"
+    target = base if base.is_dir() else cwd
+    try:
+        with tempfile.NamedTemporaryFile(dir=target, prefix=".doctor-", delete=True):
+            pass
+    except Exception as e:  # noqa: BLE001
+        return Check("run-dir", FAIL, f"{target} is not writable: {e}",
+                     "runs write splits/rollouts/candidates under .capevolve/ — "
+                     "cd to a writable dir or fix permissions")
+    return Check("run-dir", PASS, f"{target} writable")
+
+
+def _check_project(cwd: Path) -> Check:
+    project = cwd / ".capevolve" / "project"
+    if not (project / "adapters" / "adapter.py").exists():
+        return Check("project", PASS, "not inside a cap-evolve project (nothing to validate)")
+    from .check import run_check
+    rep = run_check(project)
+    if rep.ok:
+        return Check("project", PASS, f"{project} — cap-evolve check green; " + "; ".join(rep.notes))
+    return Check("project", FAIL, f"{project} — cap-evolve check failed: " + "; ".join(rep.problems),
+                 "this is the hard gate doing its job — fix the adapter, then "
+                 f"`cap-evolve check {project}` must print {{\"ok\": true}}. "
+                 "See docs/ADAPTER_CONTRACT.md")
+
+
+# ponytail: a plain list, not a plugin registry — adding a check is one function + one line.
+CHECKS = (_check_python, _check_core, _check_cli_path, _check_git, _check_skills,
+          _check_optimizer, _check_credentials, _check_run_dir, _check_project)
+
+
+def run_doctor(cwd: Path | str = ".") -> DoctorReport:
+    cwd = Path(cwd)
+    rep = DoctorReport()
+    for fn in CHECKS:
+        try:
+            rep.checks.append(fn(cwd))
+        except Exception as e:  # noqa: BLE001 — one broken check must not hide the others
+            rep.checks.append(Check(fn.__name__.removeprefix("_check_"), FAIL,
+                                    f"check raised: {e}", "please report this with the output above"))
+    return rep
+
+
+def format_report(rep: DoctorReport) -> str:
+    """Human-readable pass/warn/fail lines. Redacted (defense in depth)."""
+    d = redact(rep.to_dict())
+    out = [f"cap-evolve doctor  (core {d['cap_evolve']})", ""]
+    for c in d["checks"]:
+        out.append(f"  [{_MARK[c['status']]}] {c['name']:<12} {c['detail']}")
+        # Names only, rendered post-redaction: "set (hidden)" / "absent", never a value.
+        for k in c.get("present") or []:
+            out.append(f"         {k}: set (hidden)")
+        if c.get("absent"):
+            out.append(f"         absent: {', '.join(c['absent'])}")
+        if c["fix"] and c["status"] != PASS:
+            out.append(f"         → fix: {c['fix']}")
+    n_fail = sum(1 for c in d["checks"] if c["status"] == FAIL)
+    n_warn = sum(1 for c in d["checks"] if c["status"] == WARN)
+    out += ["", f"{'FAIL' if n_fail else 'OK'}: {n_fail} failure(s), {n_warn} warning(s)"]
+    return "\n".join(out)
+
+
+def _main(argv: list[str]) -> int:
+    import argparse
+
+    p = argparse.ArgumentParser(prog="cap-evolve doctor",
+                                description="install/health diagnostic; exits non-zero on hard failure")
+    p.add_argument("cwd", nargs="?", default=".", help="directory to diagnose (default: .)")
+    p.add_argument("--json", action="store_true", help="machine-readable output")
+    args = p.parse_args(argv)
+    rep = run_doctor(Path(args.cwd))
+    print(json.dumps(redact(rep.to_dict()), indent=2) if args.json else format_report(rep))
+    return 0 if rep.ok else 1

--- a/core/tests/test_doctor.py
+++ b/core/tests/test_doctor.py
@@ -1,0 +1,322 @@
+"""``cap-evolve doctor`` — per-check pass/fail paths, exit codes, and the
+no-secret-leak guarantee.
+
+The security test (``test_secret_value_never_printed``) is non-negotiable: it plants a
+recognizable fake token in every credential env var the doctor knows about and asserts
+the literal value appears NOWHERE in the human output, the JSON output, or the raw
+report — not even as a prefix.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from cap_evolve import doctor
+from cap_evolve.cli import main as cli_main
+from cap_evolve.doctor import FAIL, PASS, WARN, format_report, run_doctor
+
+
+def _by_name(rep, name):
+    return next(c for c in rep.checks if c.name == name)
+
+
+# ---------------------------------------------------------------------------
+# whole-report shape + exit codes
+# ---------------------------------------------------------------------------
+
+def test_healthy_report_is_ok_and_exits_zero(tmp_path, capsys):
+    rep = run_doctor(tmp_path)
+    names = [c.name for c in rep.checks]
+    assert names == ["python", "core", "cli-path", "git", "skills",
+                     "optimizer", "credentials", "run-dir", "project"]
+    assert all(c.status in (PASS, WARN, FAIL) for c in rep.checks)
+    # python/core/run-dir must be green in the test env itself
+    for n in ("python", "core", "run-dir"):
+        assert _by_name(rep, n).status == PASS, _by_name(rep, n)
+    assert rep.ok is (not any(c.status == FAIL for c in rep.checks))
+
+    code = cli_main(["doctor", str(tmp_path)])
+    out = capsys.readouterr().out
+    assert code == (0 if rep.ok else 1)
+    assert "cap-evolve doctor" in out
+
+
+def test_warnings_alone_do_not_fail(tmp_path):
+    rep = doctor.DoctorReport(checks=[doctor.Check("a", PASS), doctor.Check("b", WARN)])
+    assert rep.ok is True
+    rep.checks.append(doctor.Check("c", FAIL))
+    assert rep.ok is False
+
+
+def test_hard_failure_exits_nonzero(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(doctor, "CHECKS", (lambda cwd: doctor.Check("git", FAIL, "no git", "install git"),))
+    assert doctor._main([str(tmp_path)]) == 1
+    out = capsys.readouterr().out
+    assert "[FAIL] git" in out and "install git" in out
+    assert "FAIL: 1 failure(s), 0 warning(s)" in out
+
+
+def test_json_output_is_machine_readable(tmp_path, capsys):
+    code = doctor._main([str(tmp_path), "--json"])
+    data = json.loads(capsys.readouterr().out)
+    assert data["ok"] is (code == 0)
+    assert {c["name"] for c in data["checks"]} >= {"python", "core", "git", "credentials"}
+
+
+def test_a_raising_check_fails_loudly_without_hiding_others(tmp_path):
+    def boom(cwd):
+        raise RuntimeError("kaboom")
+
+    saved = doctor.CHECKS
+    try:
+        doctor.CHECKS = (boom, doctor._check_python)
+        r = run_doctor(tmp_path)
+    finally:
+        doctor.CHECKS = saved
+    assert [c.status for c in r.checks] == [FAIL, PASS]
+    assert "kaboom" in r.checks[0].detail
+    assert r.ok is False
+
+
+# ---------------------------------------------------------------------------
+# individual checks — pass AND fail paths
+# ---------------------------------------------------------------------------
+
+def test_python_pass_and_fail(monkeypatch, tmp_path):
+    assert doctor._check_python(tmp_path).status == PASS      # we run on 3.10+
+
+    class V(tuple):
+        major, minor, micro = 3, 9, 0
+
+    monkeypatch.setattr(doctor.sys, "version_info", V((3, 9, 0)))
+    c = doctor._check_python(tmp_path)
+    assert c.status == FAIL and "3.10+" in c.fix
+
+
+def test_core_pass(tmp_path):
+    c = doctor._check_core(tmp_path)
+    assert c.status == PASS and "cap_evolve" in c.detail
+
+
+def test_core_warns_on_wrong_venv(monkeypatch, tmp_path):
+    other = tmp_path / "other-venv"
+    (other / "bin").mkdir(parents=True)
+    monkeypatch.setenv("VIRTUAL_ENV", str(other))
+    c = doctor._check_core(tmp_path)
+    assert c.status == WARN and "does not own" in c.detail and "re-activate" in c.fix
+
+
+def test_cli_path_pass_and_missing(monkeypatch, tmp_path):
+    monkeypatch.setattr(doctor.shutil, "which", lambda _: None)
+    c = doctor._check_cli_path(tmp_path)
+    assert c.status == WARN and "pip install ./core" in c.fix
+
+    exe = Path(doctor.sys.executable).parent / "cap-evolve"
+    monkeypatch.setattr(doctor.shutil, "which", lambda _: str(exe))
+    assert doctor._check_cli_path(tmp_path).status == PASS
+
+
+def test_cli_path_detects_shadowing_install(monkeypatch, tmp_path):
+    shadow = tmp_path / "elsewhere" / "cap-evolve"
+    shadow.parent.mkdir(parents=True)
+    shadow.write_text("#!/bin/sh\n")
+    real = Path(doctor.sys.executable).parent / "cap-evolve"
+    if not real.exists():          # ensure the "expected" side exists so the branch runs
+        pytest.skip("no cap-evolve alongside this interpreter")
+    monkeypatch.setattr(doctor.shutil, "which", lambda _: str(shadow))
+    c = doctor._check_cli_path(tmp_path)
+    assert c.status == WARN and "shadowing" in c.fix
+
+
+def test_git_pass_and_fail(monkeypatch, tmp_path):
+    assert doctor._check_git(tmp_path).status == PASS
+    monkeypatch.setattr(doctor.shutil, "which", lambda _: None)
+    c = doctor._check_git(tmp_path)
+    assert c.status == FAIL and "install git" in c.fix
+
+
+def test_skills_missing_dir_fails(monkeypatch, tmp_path):
+    monkeypatch.setattr(doctor, "_skills_dir", lambda: None)
+    c = doctor._check_skills(tmp_path)
+    assert c.status == FAIL and "install.sh" in c.fix
+
+
+def test_skills_missing_manifest_fails(monkeypatch, tmp_path):
+    d = tmp_path / "skills"
+    d.mkdir()
+    monkeypatch.setattr(doctor, "_skills_dir", lambda: d)
+    c = doctor._check_skills(tmp_path)
+    assert c.status == FAIL and "build_manifest" in c.fix
+
+
+def test_skills_stale_manifest_fails(monkeypatch, tmp_path):
+    d = tmp_path / "skills"
+    (d / "_registry").mkdir(parents=True)
+    (d / "_registry" / "manifest.json").write_text(json.dumps(
+        {"skills": {"ghost": {"path": "phases/ghost", "entry": "scripts/run.py"}}}))
+    monkeypatch.setattr(doctor, "_skills_dir", lambda: d)
+    c = doctor._check_skills(tmp_path)
+    assert c.status == FAIL and "ghost" in c.detail and "stale manifest" in c.fix
+
+
+def test_skills_pass_on_repo_source_layout(monkeypatch, tmp_path):
+    d = tmp_path / "skills"
+    (d / "_registry").mkdir(parents=True)
+    (d / "optimizers").mkdir()
+    (d / "optimizers" / "registry.yaml").write_text("mock:\n  command_template: \"x\"\n")
+    (d / "phases" / "baseline" / "scripts").mkdir(parents=True)
+    (d / "phases" / "baseline" / "scripts" / "run.py").write_text("")
+    (d / "_registry" / "manifest.json").write_text(json.dumps(
+        {"skills": {"baseline": {"path": "phases/baseline", "entry": "scripts/run.py"}}}))
+    monkeypatch.setattr(doctor, "_skills_dir", lambda: d)
+    c = doctor._check_skills(tmp_path)
+    assert c.status == PASS and "repo source layout" in c.detail
+
+
+def test_skills_warns_on_best_guess_host_dir(monkeypatch, tmp_path):
+    """install.sh:38-40 admits several host dirs are guesses — flag them explicitly."""
+    d = tmp_path / ".weirdhost" / "skills"
+    (d / "_registry").mkdir(parents=True)
+    (d / "_registry" / "manifest.json").write_text(json.dumps({"skills": {}}))
+    monkeypatch.setattr(doctor, "_skills_dir", lambda: d)
+    c = doctor._check_skills(tmp_path)
+    assert c.status == WARN and "best-guess" in c.fix
+
+
+def test_optimizer_pass_and_none_available(monkeypatch, tmp_path):
+    reg = {"mock": {"command_template": "python3 x.py"},
+           "nope": {"command_template": "definitely-not-installed-xyz -p"}}
+    monkeypatch.setattr(doctor, "_optimizer_registry", lambda: reg)
+    c = doctor._check_optimizer(tmp_path)
+    assert c.status == PASS and "mock" in c.detail and "nope" in c.detail
+
+    monkeypatch.setattr(doctor, "_optimizer_registry",
+                        lambda: {"nope": {"command_template": "definitely-not-installed-xyz"}})
+    c = doctor._check_optimizer(tmp_path)
+    assert c.status == FAIL and "mock" in c.fix
+
+    monkeypatch.setattr(doctor, "_optimizer_registry", lambda: {})
+    assert doctor._check_optimizer(tmp_path).status == WARN
+
+
+def test_credentials_absent_warns(monkeypatch, tmp_path):
+    for _, keys in doctor._RUNNER_ENV_GROUPS:
+        for k in keys:
+            monkeypatch.delenv(k, raising=False)
+    monkeypatch.setattr(doctor, "_optimizer_registry", lambda: {})
+    c = doctor._check_credentials(tmp_path)
+    assert c.status == WARN and c.present == [] and "INSTALL.md" in c.fix
+
+
+def test_credentials_present_passes_with_names_only(monkeypatch, tmp_path):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-not-a-real-key-000000000000")
+    monkeypatch.setattr(doctor, "_optimizer_registry", lambda: {})
+    c = doctor._check_credentials(tmp_path)
+    assert c.status == PASS
+    assert "OPENAI_API_KEY" in c.present
+    assert "sk-not-a-real-key-000000000000" not in json.dumps(c.to_dict())
+
+
+def test_credentials_env_names_are_deduped(monkeypatch, tmp_path):
+    monkeypatch.setattr(doctor, "_optimizer_registry",
+                        lambda: {"a": {"env_keys": "OPENAI_API_KEY,ANTHROPIC_API_KEY"}})
+    c = doctor._check_credentials(tmp_path)
+    names = c.present + c.absent
+    assert len(names) == len(set(names)), names
+
+
+def test_run_dir_pass_and_unwritable(tmp_path):
+    assert doctor._check_run_dir(tmp_path).status == PASS
+    ro = tmp_path / "ro"
+    ro.mkdir()
+    ro.chmod(0o500)
+    try:
+        c = doctor._check_run_dir(ro)
+        assert c.status == FAIL and "not writable" in c.detail
+    finally:
+        ro.chmod(0o700)
+
+
+def test_project_skipped_outside_a_project(tmp_path):
+    c = doctor._check_project(tmp_path)
+    assert c.status == PASS and "not inside a cap-evolve project" in c.detail
+
+
+def test_project_fails_on_stub_adapter(tmp_path):
+    adapters = tmp_path / ".capevolve" / "project" / "adapters"
+    adapters.mkdir(parents=True)
+    (adapters / "adapter.py").write_text(
+        "from cap_evolve.adapter import CapabilityAdapter\n"
+        "class Adapter(CapabilityAdapter):\n    pass\n")
+    c = doctor._check_project(tmp_path)
+    assert c.status == FAIL and "ADAPTER_CONTRACT" in c.fix
+
+
+def test_project_passes_on_a_working_adapter(tmp_path):
+    adapters = tmp_path / ".capevolve" / "project" / "adapters"
+    adapters.mkdir(parents=True)
+    (adapters / "adapter.py").write_text(
+        "from pathlib import Path\n"
+        "from cap_evolve.adapter import CapabilityAdapter\n"
+        "from cap_evolve.types import Rollout, Score, Task\n"
+        "class Adapter(CapabilityAdapter):\n"
+        "    def tasks(self, split='all'):\n"
+        "        return [Task(id='t1', input='p')]\n"
+        "    def run_target(self, task, candidate_dir, seed=0):\n"
+        "        return Rollout(task_id=task.id, output='o')\n"
+        "    def score(self, task, rollout):\n"
+        "        return Score(task_id=task.id, reward=1.0)\n"
+        "    def materialize(self, dest):\n"
+        "        Path(dest).mkdir(parents=True, exist_ok=True)\n")
+    c = doctor._check_project(tmp_path)
+    assert c.status == PASS and "green" in c.detail
+
+
+# ---------------------------------------------------------------------------
+# SECURITY — the value of a credential must never be emitted anywhere
+# ---------------------------------------------------------------------------
+
+_FAKE = "sk-ANT-DOCTOR-LEAK-CANARY-abcdef0123456789"
+
+
+def test_secret_value_never_printed(monkeypatch, tmp_path, capsys):
+    """Plant a canary token in EVERY known credential var; assert it never surfaces.
+
+    Also asserts no PREFIX of the canary leaks (a partially-revealed token is a leak),
+    across all three surfaces: the human report, the --json report, and the raw dataclass.
+    """
+    names = [k for _, keys in doctor._RUNNER_ENV_GROUPS for k in keys]
+    names += ["CAPEVOLVE_OPTIMIZER_CMD", "BOB_API_KEY", "GITHUB_TOKEN", "KIMI_API_KEY"]
+    for k in names:
+        monkeypatch.setenv(k, _FAKE)
+
+    rep = run_doctor(tmp_path)
+    human = format_report(rep)
+    doctor._main([str(tmp_path), "--json"])
+    json_out = capsys.readouterr().out
+    raw = json.dumps(rep.to_dict())
+
+    for surface in (human, json_out, raw):
+        assert _FAKE not in surface
+        # no partial reveal either — any 8+ char prefix of the secret body is a leak
+        body = _FAKE.split("-", 2)[2]          # "DOCTOR-LEAK-CANARY-abcdef0123456789"
+        for n in range(8, len(body) + 1):
+            assert body[:n] not in surface, f"leaked {n}-char prefix in {surface[:200]!r}"
+
+    # ...while still reporting PRESENCE, which is the point of the check.
+    cred = _by_name(rep, "credentials")
+    assert cred.status == PASS
+    assert "OPENAI_API_KEY" in cred.present
+    assert "OPENAI_API_KEY: set (hidden)" in human
+
+
+def test_report_passes_through_redaction(tmp_path):
+    """Defense in depth: even a check that somehow embeds a secret-shaped value in its
+    detail is scrubbed by ``dashboard.redact`` before printing."""
+    rep = doctor.DoctorReport(checks=[
+        doctor.Check("rogue", WARN, f"OPENAI_API_KEY={_FAKE}", "")])
+    text = format_report(rep)
+    assert _FAKE not in text and "redacted" in text

--- a/core/tests/test_doctor.py
+++ b/core/tests/test_doctor.py
@@ -10,6 +10,7 @@ report — not even as a prefix.
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -106,7 +107,18 @@ def test_core_warns_on_wrong_venv(monkeypatch, tmp_path):
     (other / "bin").mkdir(parents=True)
     monkeypatch.setenv("VIRTUAL_ENV", str(other))
     c = doctor._check_core(tmp_path)
-    assert c.status == WARN and "does not own" in c.detail and "re-activate" in c.fix
+    assert c.status == WARN and "is not this interpreter" in c.detail and "re-activate" in c.fix
+
+
+def test_core_passes_on_a_correctly_activated_venv(monkeypatch, tmp_path):
+    """Regression: comparing resolve(sys.executable) to $VIRTUAL_ENV followed bin/python's
+    symlink out to the base interpreter, so EVERY correctly activated venv warned."""
+    monkeypatch.setenv("VIRTUAL_ENV", doctor.sys.prefix)
+    assert doctor._check_core(tmp_path).status == PASS
+    # ...even when bin/python is a symlink pointing outside the venv (macOS/Homebrew).
+    exe = Path(doctor.sys.prefix) / "bin" / "python"
+    if exe.is_symlink():
+        assert not str(exe.resolve()).startswith(doctor.sys.prefix), "precondition"
 
 
 def test_cli_path_pass_and_missing(monkeypatch, tmp_path):
@@ -187,19 +199,35 @@ def test_skills_warns_on_best_guess_host_dir(monkeypatch, tmp_path):
 
 
 def test_optimizer_pass_and_none_available(monkeypatch, tmp_path):
+    """A real CLI on PATH is PASS; only local/zero-API rows is WARN; nothing is FAIL."""
     reg = {"mock": {"command_template": "python3 x.py"},
-           "nope": {"command_template": "definitely-not-installed-xyz -p"}}
+           "real": {"command_template": "git --version"}}
     monkeypatch.setattr(doctor, "_optimizer_registry", lambda: reg)
     c = doctor._check_optimizer(tmp_path)
-    assert c.status == PASS and "mock" in c.detail and "nope" in c.detail
+    assert c.status == PASS and "real" in c.detail and "mock" in c.detail
+
+    # Only mock/generic available: honest WARN, not a green light for a real run.
+    monkeypatch.setattr(doctor, "_optimizer_registry",
+                        lambda: {"mock": {"command_template": "python3 x.py"},
+                                 "nope": {"command_template": "definitely-not-installed-xyz"}})
+    c = doctor._check_optimizer(tmp_path)
+    assert c.status == WARN and "optimizer_skill: mock" in c.fix
 
     monkeypatch.setattr(doctor, "_optimizer_registry",
                         lambda: {"nope": {"command_template": "definitely-not-installed-xyz"}})
-    c = doctor._check_optimizer(tmp_path)
-    assert c.status == FAIL and "mock" in c.fix
+    assert doctor._check_optimizer(tmp_path).status == FAIL
 
+
+def test_optimizer_fails_when_registry_is_missing(monkeypatch, tmp_path):
+    """run-optimizer/scripts/run.py hard-raises FileNotFoundError without the registry, so
+    doctor must FAIL (exit nonzero) instead of WARNing and exiting 0 on an unrunnable box.
+    And the remediation must not be `run ./install.sh` — the command that caused it."""
     monkeypatch.setattr(doctor, "_optimizer_registry", lambda: {})
-    assert doctor._check_optimizer(tmp_path).status == WARN
+    monkeypatch.setattr(doctor, "_skills_dir", lambda: tmp_path / "skills")
+    c = doctor._check_optimizer(tmp_path)
+    assert c.status == FAIL
+    assert "run-optimizer cannot start" in c.detail
+    assert "CAPEVOLVE_OPTIMIZER_REGISTRY" in c.fix and "cp " in c.fix
 
 
 def test_credentials_absent_warns(monkeypatch, tmp_path):
@@ -212,6 +240,9 @@ def test_credentials_absent_warns(monkeypatch, tmp_path):
 
 
 def test_credentials_present_passes_with_names_only(monkeypatch, tmp_path):
+    for _, keys in doctor._RUNNER_ENV_GROUPS:
+        for k in keys:
+            monkeypatch.delenv(k, raising=False)
     monkeypatch.setenv("OPENAI_API_KEY", "sk-not-a-real-key-000000000000")
     monkeypatch.setattr(doctor, "_optimizer_registry", lambda: {})
     c = doctor._check_credentials(tmp_path)
@@ -320,3 +351,180 @@ def test_report_passes_through_redaction(tmp_path):
         doctor.Check("rogue", WARN, f"OPENAI_API_KEY={_FAKE}", "")])
     text = format_report(rep)
     assert _FAKE not in text and "redacted" in text
+
+
+# ---------------------------------------------------------------------------
+# SECURITY — multi-SHAPE canaries, including the proven leak path
+# ---------------------------------------------------------------------------
+
+# The original canary was `sk-`-prefixed, i.e. exactly the shape `dashboard.redact`
+# already handled — so it proved nothing about the credentials that actually leak.
+# These are deliberately shapeless or non-`sk-` shaped:
+_CANARIES = {
+    "bare-high-entropy": "Xq7bTnV2wLpZ",                      # no prefix, no length tell
+    "uuid": "550e8400-e29b-41d4-a716-446655440000",
+    "github-pat": "ghp_A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8",
+    "watsonx": "kJ3nQ-9xLm2PvTb4Rd7Wy",                        # IBM Cloud style, 20-ish
+    "sk-classic": "sk-ANT-DOCTOR-LEAK-CANARY-abcdef0123456789",
+}
+
+
+def _all_surfaces(rep, capsys, tmp_path):
+    """The three surfaces a user can paste into a bug report."""
+    human = format_report(rep)
+    doctor._main([str(tmp_path), "--json"])
+    json_out = capsys.readouterr().out
+    raw = json.dumps(doctor.redact(rep.to_dict()))
+    return {"human report": human, "--json": json_out, "to_dict()": raw}
+
+
+@pytest.mark.parametrize("shape", sorted(_CANARIES))
+def test_no_credential_shape_reaches_any_surface(shape, monkeypatch, tmp_path, capsys):
+    """Plant a credential of each SHAPE in every known var; assert zero surfaces carry it."""
+    secret = _CANARIES[shape]
+    names = [k for _, keys in doctor._RUNNER_ENV_GROUPS for k in keys]
+    names += ["CAPEVOLVE_OPTIMIZER_CMD", "BOB_API_KEY", "GITHUB_TOKEN", "KIMI_API_KEY"]
+    for k in names:
+        monkeypatch.setenv(k, secret)
+    rep = run_doctor(tmp_path)
+    for label, surface in _all_surfaces(rep, capsys, tmp_path).items():
+        assert secret not in surface, f"{shape} leaked into {label}"
+
+
+@pytest.mark.parametrize("shape", sorted(_CANARIES))
+def test_adapter_that_raises_with_a_credential_does_not_leak(shape, monkeypatch, tmp_path,
+                                                             capsys):
+    """THE PROVEN LEAK PATH: `project` interpolated raw `str(e)` from user adapter code
+    into the report, so an adapter raising with a credential in its message printed it
+    verbatim (reviewer reproduced it with OPENAI_API_KEY='hunter2plaintext')."""
+    secret = _CANARIES[shape]
+    monkeypatch.setenv("OPENAI_API_KEY", secret)
+    adapters = tmp_path / ".capevolve" / "project" / "adapters"
+    adapters.mkdir(parents=True)
+    (adapters / "adapter.py").write_text(
+        "import os\n"
+        "raise RuntimeError('auth failed for ' + os.environ['OPENAI_API_KEY'])\n")
+
+    rep = run_doctor(tmp_path)
+    assert _by_name(rep, "project").status == FAIL      # still diagnosed, not swallowed
+    for label, surface in _all_surfaces(rep, capsys, tmp_path).items():
+        assert secret not in surface, f"{shape} leaked from a raising adapter into {label}"
+        # nor a partial reveal: truncation must not slice a secret into an unmatched prefix
+        assert secret[:6] not in surface, f"{shape} prefix leaked into {label}"
+
+
+def test_untrusted_adapter_text_is_bounded_and_offloaded(tmp_path):
+    """Primary defense: third-party exception text is never echoed in full — it is
+    truncated in the report and written to a local file the user can inspect."""
+    adapters = tmp_path / ".capevolve" / "project" / "adapters"
+    adapters.mkdir(parents=True)
+    # filler redact() will NOT mask, so truncation is what this measures (a long run of
+    # one character is itself secret-shaped and gets masked wholesale).
+    filler = "la " * 1200
+    (adapters / "adapter.py").write_text(f"raise RuntimeError({filler!r})\n")
+    c = doctor._check_project(tmp_path)
+    assert c.status == FAIL
+    assert len(c.detail) < 800 and "chars)" in c.detail
+    log = tmp_path / ".capevolve" / "project" / "doctor-check.log"
+    assert log.exists() and filler.strip() in log.read_text()
+
+
+def test_redact_catches_shapeless_env_values():
+    """`redact` is the shared helper (dashboard artifacts use it too); shape rules alone
+    missed watsonx keys / UUIDs / PATs, so it now also scrubs this process's own
+    secret-var VALUES literally."""
+    from cap_evolve.dashboard import redact
+    for shape, secret in _CANARIES.items():
+        os.environ["WATSONX_APIKEY"] = secret
+        try:
+            assert secret not in redact({"detail": f"boom {secret}"})["detail"], shape
+        finally:
+            os.environ.pop("WATSONX_APIKEY", None)
+    # and the pure-shape rules still fire without an env var behind them
+    assert "550e8400-e29b-41d4-a716-446655440000" not in redact("id 550e8400-e29b-41d4-a716-446655440000")
+    assert "ghp_" not in redact("tok ghp_A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8")
+
+
+# ---------------------------------------------------------------------------
+# malformed input must be DIAGNOSED, never crash the diagnostic
+# ---------------------------------------------------------------------------
+
+def test_skills_handles_null_manifest_fields(monkeypatch, tmp_path):
+    """`s.get("entry", "")` returns None on an explicit null, and Path / None raises
+    TypeError — the doctor died with "please report this" on exactly the malformed
+    manifest it exists to explain."""
+    d = tmp_path / "skills"
+    (d / "_registry").mkdir(parents=True)
+    (d / "_registry" / "manifest.json").write_text(json.dumps(
+        {"skills": {"nullentry": {"path": "phases/x", "entry": None},
+                    "nullpath": {"path": None, "entry": "scripts/run.py"},
+                    "notadict": "oops"}}))
+    monkeypatch.setattr(doctor, "_skills_dir", lambda: d)
+    c = doctor._check_skills(tmp_path)
+    assert c.status == FAIL
+    assert "TypeError" not in c.detail and "stale manifest" in c.fix
+    assert "nullentry" in c.detail
+    # and the whole run stays clean (no "check raised")
+    monkeypatch.setattr(doctor, "CHECKS", (doctor._check_skills,))
+    assert "check raised" not in format_report(run_doctor(tmp_path))
+
+
+def test_skills_no_false_guess_warn_on_relative_or_flat_dir(monkeypatch, tmp_path):
+    """A relative dir failed the `str(d).endswith("/.claude/skills")` test outright, and a
+    flat ./install.sh tree was mislabeled a best-guess host dir."""
+    rel = tmp_path / ".claude" / "skills"
+    (rel / "_registry").mkdir(parents=True)
+    (rel / "_registry" / "manifest.json").write_text(json.dumps({"skills": {}}))
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(doctor, "_skills_dir", lambda: Path(".claude/skills"))
+    assert doctor._check_skills(tmp_path).status == PASS
+
+    flat = tmp_path / "flat"
+    (flat / "_registry").mkdir(parents=True)
+    (flat / "optimizers").mkdir()
+    (flat / "optimizers" / "registry.yaml").write_text("mock:\n  command_template: x\n")
+    (flat / "_registry" / "manifest.json").write_text(json.dumps({"skills": {}}))
+    monkeypatch.setattr(doctor, "_skills_dir", lambda: flat)
+    assert doctor._check_skills(tmp_path).status == PASS
+
+
+# ---------------------------------------------------------------------------
+# credential sufficiency + .env
+# ---------------------------------------------------------------------------
+
+def test_credentials_warns_on_a_half_set_required_group(monkeypatch, tmp_path):
+    """TROUBLESHOOTING.md: RITS needs BOTH vars. PASSing on one was a false green."""
+    for _, keys in doctor._RUNNER_ENV_GROUPS:
+        for k in keys:
+            monkeypatch.delenv(k, raising=False)
+    monkeypatch.setattr(doctor, "_optimizer_registry", lambda: {})
+    monkeypatch.setenv("RITS_API_KEY", "x")
+    c = doctor._check_credentials(tmp_path)
+    assert c.status == WARN and "RITS_API_URL absent" in c.detail
+    monkeypatch.setenv("RITS_API_URL", "https://example.invalid")
+    assert doctor._check_credentials(tmp_path).status == PASS
+
+
+def test_credentials_sees_dotenv_names_only(monkeypatch, tmp_path):
+    """INSTALL.md mandates a repo-root .env; reading only os.environ told a user who
+    followed the docs exactly that they had no credentials."""
+    for _, keys in doctor._RUNNER_ENV_GROUPS:
+        for k in keys:
+            monkeypatch.delenv(k, raising=False)
+    monkeypatch.setattr(doctor, "_optimizer_registry", lambda: {})
+    secret = _CANARIES["bare-high-entropy"]
+    (tmp_path / ".env").write_text(f"# comment\nOPENAI_API_KEY={secret}\n")
+    sub = tmp_path / "a" / "b"
+    sub.mkdir(parents=True)
+    c = doctor._check_credentials(sub)
+    assert c.status == PASS and "OPENAI_API_KEY (.env)" in c.present
+    assert secret not in json.dumps(c.to_dict())          # the VALUE is never even read
+
+
+def test_project_fails_on_adapterless_scaffold(tmp_path):
+    """A scaffolded project with no adapter.py reported "not inside a cap-evolve project"
+    and exited 0 — a masked broken project."""
+    (tmp_path / ".capevolve" / "project").mkdir(parents=True)
+    (tmp_path / ".capevolve" / "project" / "capevolve.yaml").write_text("store: copy\n")
+    c = doctor._check_project(tmp_path)
+    assert c.status == FAIL and "scaffold incomplete" in c.fix

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -18,9 +18,12 @@ cd cap-evolve
 python3 -m venv .venv && source .venv/bin/activate
 pip install ./core          # package: cap-evolve-core, CLI: cap-evolve (zero runtime deps)
 cap-evolve version          # verify
+cap-evolve doctor           # diagnose the install (non-zero exit on a hard failure)
 ```
 
 > If your default pip index requires auth, append `--index-url https://pypi.org/simple`.
+> If anything above fails, `cap-evolve doctor` names the cause and the fix — see
+> [`TROUBLESHOOTING.md`](TROUBLESHOOTING.md).
 
 ## 3. Run the zero-API toy example
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -30,9 +30,17 @@ non-zero on a hard failure (CI-friendly). It checks: Python version, core
 importability + which interpreter/venv, whether `cap-evolve` is on `PATH` and whether a
 *second* install shadows it, `git` (the default version store), the skills dir + registry
 manifest (flagging install.sh's "best-guess" host dirs), which optimizer CLIs are on
-`PATH`, provider credentials **present/absent only — never a value**, run-dir writability,
-and — when run inside a project — `cap-evolve check`. Add `--json` for machine-readable
-output.
+`PATH` **and whether `optimizers/registry.yaml` exists at all** (without it `run-optimizer`
+raises immediately, so that is a hard failure, not a warning), provider credentials
+**present/absent only — never a value** — including names declared in a repo-root `.env`,
+and a warning when only part of a group that needs all its vars is set (RITS, watsonx, the
+`ANTHROPIC_BASE_URL`+`ANTHROPIC_AUTH_TOKEN` gateway pair) — run-dir writability, and — when
+run inside a project — `cap-evolve check`. Add `--json` for machine-readable output.
+
+Third-party text (a user adapter's exception message) is never echoed verbatim: the report
+carries a short redacted excerpt and the full text goes to
+`.capevolve/project/doctor-check.log` for local inspection, so doctor output stays safe to
+paste into an issue.
 
 ```bash
 cap-evolve doctor            # diagnose the current directory

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -14,13 +14,30 @@ python3 -m venv .venv && source .venv/bin/activate   # recommended: isolated env
 ```bash
 pip install ./core        # package: cap-evolve-core · CLI: cap-evolve · zero runtime deps
 cap-evolve version        # verify
+cap-evolve doctor         # diagnose the whole install (exits non-zero on a hard failure)
 ```
 
 > If your default pip index requires auth, append `--index-url https://pypi.org/simple`
 > (cap-evolve-core itself has no runtime dependencies).
 
-The `cap-evolve` CLI has six subcommands: `version`, `splits`, `check`, `run`,
-`estimate`, `dashboard`.
+The `cap-evolve` CLI has seven subcommands: `version`, `splits`, `check`, `doctor`,
+`run`, `estimate`, `dashboard`.
+
+### Diagnose the install with `cap-evolve doctor`
+
+One command that reports pass/warn/fail with an actionable fix per line, and exits
+non-zero on a hard failure (CI-friendly). It checks: Python version, core
+importability + which interpreter/venv, whether `cap-evolve` is on `PATH` and whether a
+*second* install shadows it, `git` (the default version store), the skills dir + registry
+manifest (flagging install.sh's "best-guess" host dirs), which optimizer CLIs are on
+`PATH`, provider credentials **present/absent only — never a value**, run-dir writability,
+and — when run inside a project — `cap-evolve check`. Add `--json` for machine-readable
+output.
+
+```bash
+cap-evolve doctor            # diagnose the current directory
+cap-evolve doctor --json     # same, machine-readable
+```
 
 ## Optional — the live dashboard (separate package)
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -3,6 +3,20 @@
 Fixes for the most common install and run failures. If none of these match, open an issue
 with the exact command and output.
 
+## Start here: `cap-evolve doctor`
+
+```bash
+cap-evolve doctor        # or, before the package is installed: python -m cap_evolve.cli doctor
+```
+
+It checks the whole install in one pass — Python version, core importability + which
+venv, `cap-evolve` on `PATH` (and whether a *second* install shadows it), `git`, the
+skills dir + registry manifest, optimizer CLIs, provider credentials (presence only,
+never a value), run-dir writability, and `cap-evolve check` when run inside a project —
+printing an actionable fix per failing line and exiting non-zero on a hard failure. Most
+of the sections below are the checks it automates. See
+[`INSTALL.md`](INSTALL.md#diagnose-the-install-with-cap-evolve-doctor).
+
 ## Install
 
 **`cap-evolve: command not found`** — the core isn't installed in the active env. Activate

--- a/install.sh
+++ b/install.sh
@@ -82,6 +82,14 @@ for comp in orchestrate phases capabilities algorithms optimizers; do
   done
 done
 
+# optimizers/registry.yaml is a FILE directly under skills/optimizers/, not a skill
+# dir, so the loop above skipped it — and `run-optimizer/scripts/run.py` hard-raises
+# FileNotFoundError without it, i.e. every install could copy the skills and still not
+# run. Copy it to $DEST/optimizers/ which is exactly where run.py's parent-walk looks.
+mkdir -p "$DEST/optimizers"
+cp "$SRC/optimizers/registry.yaml" "$DEST/optimizers/registry.yaml"
+echo "  + optimizers/registry.yaml"
+
 # (Re)build the manifest for both the repo (component layout) and the installed
 # tree (flat layout). build_manifest handles either, so `cap-evolve run` works whether
 # it points at the repo skills or the installed dir.


### PR DESCRIPTION
Closes #121

Adds **`cap-evolve doctor`** — one command that introspects the install and preempts the
first-run failures the docs already field, printing pass/warn/fail with an actionable fix
per line and **exiting non-zero on a hard failure** so CI can gate on it.

One new stdlib-only module (`core/cap_evolve/doctor.py`), plus CLI wiring. Zero new runtime
deps. No plugin architecture — `CHECKS` is a plain tuple of small functions, so adding a
check is one function plus one line.

## The checks, and which real documented failure each preempts

| Check | Preempts (source) |
|---|---|
| `python` | TROUBLESHOOTING **"Python too old"** — needs 3.10+; reports the version *and* the interpreter |
| `core` | TROUBLESHOOTING **"`cap-evolve: command not found`"** (`pip install ./core` skipped) — plus the **"trapped in the wrong venv"** trap from #121: warns when `$VIRTUAL_ENV` doesn't own `sys.executable`, so `pip install` lands where the run can't see it |
| `cli-path` | Same, from the other side — and the **shadowing second install** #121 asks for: warns when the first `cap-evolve` on `PATH` isn't the one beside this interpreter. Its fix line states outright that `install.sh` deliberately does not install the package |
| `git` | INSTALL.md "Requires Python 3.10+ **and git**" — the default version store makes every candidate a commit; a missing `git` currently fails deep inside the loop |
| `skills` | TROUBLESHOOTING/`cli.py:93` **"no manifest — run install.sh"**; also catches a **stale** manifest naming a skill whose entry script is gone (today a `KeyError` mid-run), and flags `install.sh:38-40`'s self-admitted **"best-guess" host dirs** explicitly |
| `optimizer` | TROUBLESHOOTING **"Missing credentials at runtime"** — reports which optimizer CLIs from `optimizers/registry.yaml` are actually on `PATH`, and FAILs only if none is (pointing at `optimizer_skill: mock` for a zero-API run) |
| `credentials` | TROUBLESHOOTING **"Missing credentials at runtime"**, **"RITS calls fail"** (both `RITS_API_KEY` *and* `RITS_API_URL`), **"SkillsBench: Docker / benchflow errors"** (`ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN`). Runner groups are explicit; the optimizer surface is read from each registry row's `env_keys` so it can't drift from the registry |
| `run-dir` | Runs write splits/rollouts/candidates under `.capevolve/`; an unwritable cwd is discovered after budget is spent, not before |
| `project` | TROUBLESHOOTING **"`cap-evolve check` is not green"** — **reuses `check.run_check`**, no reimplementation. Silently skipped (PASS) outside a project |

## No-secret-leak guarantee

The credential check reports **presence/absence only**. Three layers:

1. Values are never read into any reported field — only `bool(os.environ.get(k))` is consulted.
2. Presence is kept as structured `present`/`absent` **name** lists on `Check` and rendered as
   `NAME: set (hidden)` *after* redaction, so the value can't be interpolated into a string in
   the first place.
3. The whole report passes through the existing **`dashboard.redact`** (reused, as the issue
   asks) on the way to both stdout surfaces — defense in depth if any check ever embeds a
   secret-shaped value in a `detail`.

The proving test is `core/tests/test_doctor.py::test_secret_value_never_printed`: it plants a
canary token in **every** credential var the doctor knows about, then asserts the literal value
**and every 8+ character prefix of it** appears in none of the human report, the `--json`
report, or the raw dataclass — while still asserting `OPENAI_API_KEY: set (hidden)` *is* present,
so the check hasn't been neutered into uselessness. `test_report_passes_through_redaction`
covers layer 3 directly.

## Transcripts

**(a) Healthy env** — exit 0:

```
cap-evolve doctor  (core 0.1.0)

  [PASS] python       3.14.2 at /private/tmp/ce-venv/bin/python
  [PASS] core         cap_evolve 0.1.0 from /tmp/wt-121/core/cap_evolve (env /private/tmp/ce-venv)
  [WARN] cli-path     PATH resolves to /Users/osherelhadad/miniforge3/bin/cap-evolve, but this interpreter's is /private/tmp/ce-venv/bin/cap-evolve
         → fix: a second (shadowing) install is earlier on PATH — remove it, or call /private/tmp/ce-venv/bin/cap-evolve / `python -m cap_evolve.cli` explicitly.
  [PASS] git          git version 2.53.0
  [PASS] skills       20 skill(s) at /tmp/wt-121/skills (repo source layout)
  [PASS] optimizer    available: antigravity, claude-code, generic, ibm-bob, mock, openclaw | not on PATH: codex, copilot, cursor, droid, gemini-cli, kimi, opencode, pi
  [PASS] credentials  2 set, 20 absent
         ANTHROPIC_AUTH_TOKEN: set (hidden)
         ANTHROPIC_BASE_URL: set (hidden)
         absent: ANTHROPIC_API_KEY, OPENAI_API_KEY, RITS_API_KEY, RITS_API_URL, WATSONX_APIKEY, WATSONX_URL, WATSONX_PROJECT_ID, GEMINI_API_KEY, CAPEVOLVE_OPTIMIZER_CMD, CAPEVOLVE_OPENCLAW_CMD, BOBSHELL_API_KEY, BOB_API_KEY, CURSOR_API_KEY, FACTORY_API_KEY, COPILOT_GITHUB_TOKEN, GH_TOKEN, GITHUB_TOKEN, MOONSHOT_API_KEY, KIMI_API_KEY, CAPEVOLVE_ANTIGRAVITY_CMD
  [PASS] run-dir      . writable
  [PASS] project      not inside a cap-evolve project (nothing to validate)

OK: 0 failure(s), 1 warning(s)
EXIT=0
```

Note the `cli-path` WARN is a genuine finding on this machine, not noise — there really is a
second `cap-evolve` in miniforge shadowing the venv's. That is exactly the case #121 asked for.

**(b) Inside a real project** (`examples/toy_calc` scaffolded into a temp dir) — the `project`
check runs `cap-evolve check` and reports its notes; exit 0:

```
  [PASS] skills       20 skill(s) at /tmp/wt-121/skills (repo source layout)
  [PASS] run-dir      .capevolve writable
  [PASS] project      .capevolve/project — cap-evolve check green; tasks('val') -> 8 task(s); scorer deterministic (probe reward=0.0000); materialize() callable (dry-run into temp copy; host untouched)

OK: 0 failure(s), 1 warning(s)
EXIT=0
```

**(c) Deliberately broken** — manifest deleted, credentials unset, stub adapter, minimal
`PATH`; **exit 1** with remediation on every failing line:

```
cap-evolve doctor  (core 0.1.0)

  [PASS] python       3.14.2 at /private/tmp/ce-venv/bin/python
  [PASS] core         cap_evolve 0.1.0 from /tmp/wt-121/core/cap_evolve (env /private/tmp/ce-venv)
  [WARN] cli-path     cap-evolve is not on PATH
         → fix: install.sh deliberately does NOT install the Python package: run `pip install ./core` in the active venv. Until then use `python -m cap_evolve.cli ...`.
  [PASS] git          git version 2.39.3 (Apple Git-146)
  [FAIL] skills       skills at /tmp/doctor_broken.../skills but no _registry/manifest.json
         → fix: rebuild it: python skills/_registry/build_manifest.py /tmp/doctor_broken.../skills   (install.sh does this for you)
  [WARN] optimizer    optimizers/registry.yaml not found
         → fix: run ./install.sh, or set CAPEVOLVE_OPTIMIZER_REGISTRY
  [WARN] credentials  no provider credentials in the environment
         absent: ANTHROPIC_API_KEY, ANTHROPIC_AUTH_TOKEN, ANTHROPIC_BASE_URL, OPENAI_API_KEY, RITS_API_KEY, RITS_API_URL, WATSONX_APIKEY, WATSONX_URL, WATSONX_PROJECT_ID, GEMINI_API_KEY
         → fix: the toy example needs none; a real run needs the optimizer CLI's creds plus runner creds in a repo-root .env — see docs/INSTALL.md#credentials-only-for-real-runs
  [PASS] run-dir      .capevolve writable
  [FAIL] project      .capevolve/project — cap-evolve check failed: could not load adapter: Can't instantiate abstract class Adapter without an implementation for abstract methods 'run_target', 'score', 'tasks'
         → fix: this is the hard gate doing its job — fix the adapter, then `cap-evolve check .capevolve/project` must print {"ok": true}. See docs/ADAPTER_CONTRACT.md

FAIL: 2 failure(s), 3 warning(s)
EXIT=1
```

## Seam for #133 / #134

Kept deliberately obvious, so neither follow-up has to restructure anything:

- **#133 (`quickstart`)** can call `run_doctor(cwd)` and branch on `rep.ok` / per-check
  `status` — `DoctorReport`/`Check` are plain dataclasses with `to_dict()`, and
  `format_report()` is separate from the checks, so quickstart can render its own copy.
- **#134 (provider probing)** slots into `_check_credentials`: it currently answers
  *"is a credential present?"* without any network call. Live probing becomes either an extra
  function appended to `CHECKS` or an opt-in branch inside it — **the presence-only,
  never-print-a-value contract must be preserved either way**, and
  `test_secret_value_never_printed` is written over the whole report so it keeps guarding a
  new check for free.

Warnings are advisory by design (`DoctorReport.ok` ignores `warn`), so an unusual-but-working
setup — repo source layout, mock optimizer, no creds for the zero-API toy — still exits 0.

## Verification

- **Full suite: 205 passed, 0 failed** (baseline 179 + 26 new in `core/tests/test_doctor.py`)
  — `PYTHONPATH=core python -m pytest core/tests -q`
- Every check has both a **pass and a fail path** under test, plus the exit codes (0 / 1),
  `--json` parseability, "warnings alone don't fail", and "one raising check doesn't hide the
  others".
- **Security test present and passing**: `test_secret_value_never_printed` (+
  `test_report_passes_through_redaction`).
- `python -m compileall core skills` → clean.
- Run for real in three environments (healthy / real project / broken) — transcripts above.
- Docs: `doctor` added to `docs/INSTALL.md` (subcommand list, which now says *seven*, plus its
  own section), `docs/TROUBLESHOOTING.md` (a "start here" section at the top — most of that
  doc is what doctor now automates), and `docs/GETTING_STARTED.md` step 2. All relative links
  and anchors in the touched docs verified to resolve.

**Merge sequencing note:** touches `core/cap_evolve/cli.py` (registers the subcommand: 1 dict
entry, 1 dispatcher, docstring + usage string) — needs sequencing against #116/#137.
