### PR TITLE
perf(dashboard): memoize reduce_run on events mtime+size, drop dead SSE snapshot, paginate runs/rollouts

### DIFF
--- a/core/cap_evolve/dashboard.py
+++ b/core/cap_evolve/dashboard.py
@@ -229,8 +229,59 @@ def _step_candidate(ev: dict):
     return ev.get("candidate") or ev.get("candidate_id")
 
 
+# --- reduction cache -------------------------------------------------------
+# ``_reduce_run_uncached`` re-reads and re-folds the whole event log plus every
+# rollout file. The dashboard backend calls ``reduce_run`` on every request AND on
+# every SSE tick (~2/s), and once more per candidate in ``diff_candidate``, so a
+# long run spends most of its CPU re-deriving an answer that has not changed.
+#
+# Key: the run's ``events.jsonl`` ``(st_mtime_ns, st_size)``.
+#   * Both, not just mtime: mtime granularity is 1s on some filesystems (and plain
+#     float ``st_mtime`` rounds), so a same-second append can leave mtime looking
+#     unchanged. events.jsonl is append-only, so size always grows on a new event —
+#     size is the strong signal, mtime catches a same-length rewrite.
+#   * One key is enough for the reducer's *other* inputs (baseline.json, final.json,
+#     rollouts/, state.json, the git store) because each is written BEFORE the event
+#     that reports it is appended: harness writes baseline.json then logs "baseline",
+#     persists rollout files then logs "evaluate", finalize writes final.json then
+#     logs "finalize", the iteration commit lands then "step" is logged. So the stamp
+#     advances after those writes, never before.
+#
+# Bounded by run count: one entry per run root, holding only its newest reduction.
+_REDUCE_CACHE: dict[str, tuple[tuple[int, int], dict]] = {}
+
+
+def _events_stamp(root: Path):
+    """``(st_mtime_ns, st_size)`` of the run's event log, or ``None`` if unreadable."""
+    try:
+        st = (root / "events.jsonl").stat()
+    except OSError:
+        return None  # no event log → nothing stable to key on; never cache
+    return (st.st_mtime_ns, st.st_size)
+
+
 def reduce_run(run_dir) -> dict:
-    """Fold the run dir into ``{"graph": ..., "summary": ...}`` (redacted)."""
+    """Fold the run dir into ``{"graph": ..., "summary": ...}`` (redacted).
+
+    Memoized on the event log's mtime+size (see ``_REDUCE_CACHE``). The returned
+    object is SHARED between callers on a cache hit — treat it as read-only.
+    """
+    root = Path(run_dir.root)
+    stamp = _events_stamp(root)
+    if stamp is not None:
+        hit = _REDUCE_CACHE.get(str(root))
+        if hit is not None and hit[0] == stamp:
+            return hit[1]
+    reduced = _reduce_run_uncached(run_dir)
+    # Re-stat after the fold: if the log grew while we were folding, this result may
+    # already be stale, so don't cache it — the next call re-folds.
+    if stamp is not None and _events_stamp(root) == stamp:
+        _REDUCE_CACHE[str(root)] = (stamp, reduced)
+    return reduced
+
+
+def _reduce_run_uncached(run_dir) -> dict:
+    """The actual fold. Call ``reduce_run`` instead; this one always re-reads."""
     root = Path(run_dir.root)
     events = _read_jsonl(root / "events.jsonl")
     baseline = _read_json(root / "baseline.json")

--- a/core/cap_evolve/dashboard.py
+++ b/core/cap_evolve/dashboard.py
@@ -235,48 +235,102 @@ def _step_candidate(ev: dict):
 # every SSE tick (~2/s), and once more per candidate in ``diff_candidate``, so a
 # long run spends most of its CPU re-deriving an answer that has not changed.
 #
-# Key: the run's ``events.jsonl`` ``(st_mtime_ns, st_size)``.
-#   * Both, not just mtime: mtime granularity is 1s on some filesystems (and plain
+# Key: ``events.jsonl``'s ``(st_mtime_ns, st_size, st_ino)`` PLUS the git store's
+# ``.git`` + ``.git/logs/HEAD`` stamps. Keyed on ``root.resolve()`` so an absolute and
+# a relative path to the same run dir share one entry.
+#   * Size, not just mtime: mtime granularity is 1s on some filesystems (and plain
 #     float ``st_mtime`` rounds), so a same-second append can leave mtime looking
 #     unchanged. events.jsonl is append-only, so size always grows on a new event —
-#     size is the strong signal, mtime catches a same-length rewrite.
-#   * One key is enough for the reducer's *other* inputs (baseline.json, final.json,
-#     rollouts/, state.json, the git store) because each is written BEFORE the event
-#     that reports it is appended: harness writes baseline.json then logs "baseline",
-#     persists rollout files then logs "evaluate", finalize writes final.json then
-#     logs "finalize", the iteration commit lands then "step" is logged. So the stamp
-#     advances after those writes, never before.
+#     size is the strong signal, mtime catches a same-length rewrite, and ``st_ino``
+#     catches a same-size replace-via-rename (a new file gets a new inode).
+#   * INVARIANT the events part relies on: ``events.jsonl`` is only ever APPENDED to
+#     (``RunDir.log_event`` opens it "a"). A future writer that rewrites it in place
+#     to the same byte length within one mtime tick would serve a stale reduction —
+#     if you add such a writer, hash the file or bump a counter instead.
+#   * The event stamp alone covers baseline.json, final.json, rollouts/ and state.json,
+#     because each is written BEFORE the event reporting it: baseline.json then
+#     log_event("baseline"), rollout files (harness.py:252) then log_event("evaluate")
+#     (:311), final.json (:1964) then log_event("finalize") (:1966).
+#   * It does NOT cover the git store, whose ordering is the OPPOSITE: the harness logs
+#     "step" (harness.py:1323) and only commits 33 lines LATER (:1356); GEPA likewise
+#     logs (gepa.py:718) then commits (:635). So a commit lands with the event log
+#     untouched and ``git_log`` (:623) would stay stale for the rest of the iteration.
+#     Hence ``_git_stamp``. NOT ``.git/HEAD``: that is a constant symbolic ref
+#     ("ref: refs/heads/<branch>") and never changes on a commit — measured. ``.git``'s
+#     own mtime moves on every commit (index.lock create+rename) and ``.git/logs/HEAD``
+#     is the append-only reflog; both are branch-name agnostic, and either moving is
+#     enough to invalidate.
 #
-# Bounded by run count: one entry per run root, holding only its newest reduction.
-_REDUCE_CACHE: dict[str, tuple[tuple[int, int], dict]] = {}
+# Bounded: FIFO-capped at ``_REDUCE_MAX`` entries (the dashboard is a long-lived
+# process and ``list_runs`` installs one entry per discovered run).
+_REDUCE_CACHE: dict[str, tuple[tuple, dict]] = {}
+_REDUCE_MAX = 32
+
+
+def _stat_stamp(path: Path) -> tuple[int, int]:
+    """``(st_mtime_ns, st_size)``, or ``(0, 0)`` when the path is absent/unreadable."""
+    try:
+        st = path.stat()
+    except OSError:
+        return (0, 0)
+    return (st.st_mtime_ns, st.st_size)
+
+
+def _git_stamp(root: Path) -> tuple[int, int, int, int]:
+    """Stamp for the run's git store — moves on every ``VersionStore.commit``."""
+    return _stat_stamp(root / ".git") + _stat_stamp(root / ".git" / "logs" / "HEAD")
+
+
+def _resolve(root: Path) -> Path:
+    """``root.resolve()``, falling back to the path itself if resolution fails.
+
+    ``RunDir.open`` (rundir.py:201) does not resolve, and ``reduce_run`` is a public
+    API called with relative paths (report/scripts/run.py, check.py, export_static.py),
+    so without this an absolute and a relative path to one run dir get two entries.
+    """
+    try:
+        return root.resolve()
+    except OSError:
+        return root
 
 
 def _events_stamp(root: Path):
-    """``(st_mtime_ns, st_size)`` of the run's event log, or ``None`` if unreadable."""
+    """Full cache stamp for a run dir, or ``None`` when there is no event log.
+
+    ``(events mtime_ns, size, inode) + git stamp``. ~3 extra ``stat`` calls versus one
+    (~2 us each, measured) against a ~230 ms fold — noise.
+    """
     try:
         st = (root / "events.jsonl").stat()
     except OSError:
         return None  # no event log → nothing stable to key on; never cache
-    return (st.st_mtime_ns, st.st_size)
+    return (st.st_mtime_ns, st.st_size, st.st_ino) + _git_stamp(root)
 
 
 def reduce_run(run_dir) -> dict:
     """Fold the run dir into ``{"graph": ..., "summary": ...}`` (redacted).
 
-    Memoized on the event log's mtime+size (see ``_REDUCE_CACHE``). The returned
-    object is SHARED between callers on a cache hit — treat it as read-only.
+    Memoized on the event log's mtime+size+inode and the git store's stamp (see
+    ``_REDUCE_CACHE``). The returned object is SHARED between callers on a cache
+    hit — treat it as read-only.
     """
     root = Path(run_dir.root)
+    # ponytail: no lock around the miss path — N cold concurrent readers each fold
+    # (duplicate work, never a torn read: ``reduced`` is fully built before the
+    # single atomic dict store). Add a module lock if thundering herd shows up.
+    key = str(_resolve(root))
     stamp = _events_stamp(root)
     if stamp is not None:
-        hit = _REDUCE_CACHE.get(str(root))
+        hit = _REDUCE_CACHE.get(key)
         if hit is not None and hit[0] == stamp:
             return hit[1]
     reduced = _reduce_run_uncached(run_dir)
     # Re-stat after the fold: if the log grew while we were folding, this result may
     # already be stale, so don't cache it — the next call re-folds.
     if stamp is not None and _events_stamp(root) == stamp:
-        _REDUCE_CACHE[str(root)] = (stamp, reduced)
+        _REDUCE_CACHE[key] = (stamp, reduced)
+        while len(_REDUCE_CACHE) > _REDUCE_MAX:  # dicts are insertion-ordered → FIFO
+            _REDUCE_CACHE.pop(next(iter(_REDUCE_CACHE)))
     return reduced
 
 

--- a/core/tests/test_dashboard_cache.py
+++ b/core/tests/test_dashboard_cache.py
@@ -1,0 +1,151 @@
+"""``reduce_run`` is memoized on events.jsonl mtime+size (issue #119).
+
+The dashboard backend re-folds the whole event log on every request and every SSE
+tick, so the reduction is memoized. A stale reduction served during a LIVE run would
+be worse than no cache at all, so the invalidation cases are the ones that matter:
+an append must re-fold, and a same-second append (mtime unchanged at 1s resolution)
+must still re-fold because the size moved.
+"""
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO / "core"))
+
+_EVENTS = [
+    {"kind": "splits", "train": 4, "val": 2, "test": 2, "seed": 0},
+    {"kind": "baseline", "val": 0.25, "stderr": 0.0},
+    {"kind": "step", "candidate": "cand_0001", "accept": True, "reason": "up",
+     "val": 0.75, "parent": "seed", "parent_val": 0.25},
+]
+_BASELINE = {"val": {"reward": 0.25, "per_task": [
+    {"task_id": "t1", "reward": 0.0}, {"task_id": "t2", "reward": 0.5}]}, "best_id": "seed"}
+
+
+def _mk_run(tmp: Path, events=_EVENTS):
+    from cap_evolve import Budget, RunDir
+    rd = RunDir.create(tmp, ts="t", budget=Budget())
+    rd.events_path.write_text("\n".join(json.dumps(e) for e in events) + "\n",
+                              encoding="utf-8")
+    (rd.root / "baseline.json").write_text(json.dumps(_BASELINE), encoding="utf-8")
+    return rd
+
+
+def _spy(monkeypatch):
+    """Count real folds by wrapping the uncached reducer."""
+    from cap_evolve import dashboard
+    dashboard._REDUCE_CACHE.clear()
+    calls = []
+    real = dashboard._reduce_run_uncached
+
+    def counting(run_dir):
+        calls.append(1)
+        return real(run_dir)
+
+    monkeypatch.setattr(dashboard, "_reduce_run_uncached", counting)
+    return dashboard, calls
+
+
+def test_unchanged_event_log_hits_the_cache(monkeypatch):
+    dashboard, calls = _spy(monkeypatch)
+    with tempfile.TemporaryDirectory() as d:
+        rd = _mk_run(Path(d))
+        first = dashboard.reduce_run(rd)
+        second = dashboard.reduce_run(rd)
+        assert len(calls) == 1, f"expected one fold, got {len(calls)}"
+        assert second is first  # served from cache, not re-derived
+        assert first["summary"]["best_val"] == 0.75
+
+
+def test_appending_an_event_invalidates_the_cache(monkeypatch):
+    """The critical case: a live run appends, the next read must NOT be stale."""
+    dashboard, calls = _spy(monkeypatch)
+    with tempfile.TemporaryDirectory() as d:
+        rd = _mk_run(Path(d))
+        before = dashboard.reduce_run(rd)
+        assert before["summary"]["counts"]["total"] == 2  # seed + cand_0001
+        with rd.events_path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps({"kind": "step", "candidate": "cand_0002",
+                                 "accept": True, "reason": "up", "val": 0.9,
+                                 "parent": "cand_0001", "parent_val": 0.75}) + "\n")
+        after = dashboard.reduce_run(rd)
+        assert len(calls) == 2, "append must re-fold"
+        assert after["summary"]["counts"]["total"] == 3
+        assert after["summary"]["best_val"] == 0.9  # fresh, not the cached 0.75
+
+
+def test_same_mtime_append_still_invalidates(monkeypatch):
+    """mtime alone is not enough: force the mtime back, size must still bust the key."""
+    dashboard, calls = _spy(monkeypatch)
+    with tempfile.TemporaryDirectory() as d:
+        rd = _mk_run(Path(d))
+        dashboard.reduce_run(rd)
+        st = rd.events_path.stat()
+        with rd.events_path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps({"kind": "step", "candidate": "cand_0002",
+                                 "accept": True, "reason": "up", "val": 0.9,
+                                 "parent": "cand_0001"}) + "\n")
+        # Pretend the append happened within one mtime tick of the cached read.
+        os.utime(rd.events_path, ns=(st.st_atime_ns, st.st_mtime_ns))
+        assert rd.events_path.stat().st_mtime_ns == st.st_mtime_ns
+        after = dashboard.reduce_run(rd)
+        assert len(calls) == 2, "size change must invalidate even at identical mtime"
+        assert after["summary"]["best_val"] == 0.9
+
+
+def test_two_runs_do_not_share_a_cache_entry(monkeypatch):
+    dashboard, calls = _spy(monkeypatch)
+    with tempfile.TemporaryDirectory() as d1, tempfile.TemporaryDirectory() as d2:
+        a = _mk_run(Path(d1))
+        b = _mk_run(Path(d2), events=_EVENTS + [
+            {"kind": "step", "candidate": "cand_0002", "accept": True,
+             "reason": "up", "val": 0.95, "parent": "cand_0001"}])
+        ra, rb = dashboard.reduce_run(a), dashboard.reduce_run(b)
+        assert len(calls) == 2
+        assert ra["summary"]["best_val"] == 0.75
+        assert rb["summary"]["best_val"] == 0.95
+        # and each still hits its own entry
+        assert dashboard.reduce_run(a) is ra and dashboard.reduce_run(b) is rb
+        assert len(calls) == 2
+
+
+def test_repeat_reduce_reuses_the_same_object_behavioral():
+    """No internals: on an unchanged log the second reduce returns the SAME object.
+
+    Fails on the pre-#119 reducer (each call built a fresh structure) and is the
+    property the dashboard's per-request / per-SSE-tick path actually relies on.
+    """
+    from cap_evolve import dashboard
+    with tempfile.TemporaryDirectory() as d:
+        rd = _mk_run(Path(d))
+        assert dashboard.reduce_run(rd) is dashboard.reduce_run(rd)
+
+
+def test_reduce_after_append_reflects_the_new_event_behavioral():
+    """No internals: appending must be visible on the very next reduce."""
+    from cap_evolve import dashboard
+    with tempfile.TemporaryDirectory() as d:
+        rd = _mk_run(Path(d))
+        assert dashboard.reduce_run(rd)["summary"]["best_val"] == 0.75
+        with rd.events_path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps({"kind": "step", "candidate": "cand_0002",
+                                 "accept": True, "reason": "up", "val": 0.9,
+                                 "parent": "cand_0001"}) + "\n")
+        r = dashboard.reduce_run(rd)
+        assert r["summary"]["best_val"] == 0.9
+        assert r["summary"]["counts"]["total"] == 3
+
+
+def test_missing_event_log_is_never_cached(monkeypatch):
+    """No events.jsonl → no stable stamp → always re-fold (correct over fast)."""
+    dashboard, calls = _spy(monkeypatch)
+    with tempfile.TemporaryDirectory() as d:
+        rd = _mk_run(Path(d))
+        rd.events_path.unlink()
+        dashboard.reduce_run(rd)
+        dashboard.reduce_run(rd)
+        assert len(calls) == 2

--- a/core/tests/test_dashboard_cache.py
+++ b/core/tests/test_dashboard_cache.py
@@ -1,10 +1,16 @@
-"""``reduce_run`` is memoized on events.jsonl mtime+size (issue #119).
+"""``reduce_run`` is memoized on events.jsonl mtime+size+inode and the git store's
+stamp (issue #119).
 
 The dashboard backend re-folds the whole event log on every request and every SSE
 tick, so the reduction is memoized. A stale reduction served during a LIVE run would
 be worse than no cache at all, so the invalidation cases are the ones that matter:
-an append must re-fold, and a same-second append (mtime unchanged at 1s resolution)
-must still re-fold because the size moved.
+an append must re-fold; a same-second append (mtime unchanged at 1s resolution) must
+still re-fold because the size moved; a same-size replace-via-rename must re-fold
+because the inode moved; and a git commit must re-fold even though the harness logs
+its event BEFORE committing, so the event log has not moved at all.
+
+Also pinned here: the FIFO cap (the dashboard is long-lived) and the resolved cache
+key (an absolute and a relative path to one run dir must share one entry).
 """
 
 import json
@@ -38,7 +44,9 @@ def _mk_run(tmp: Path, events=_EVENTS):
 def _spy(monkeypatch):
     """Count real folds by wrapping the uncached reducer."""
     from cap_evolve import dashboard
-    dashboard._REDUCE_CACHE.clear()
+    # A fresh dict rather than .clear() on the shared global, so monkeypatch restores
+    # whatever the rest of the suite had instead of leaving it permanently emptied.
+    monkeypatch.setattr(dashboard, "_REDUCE_CACHE", {})
     calls = []
     real = dashboard._reduce_run_uncached
 
@@ -149,3 +157,107 @@ def test_missing_event_log_is_never_cached(monkeypatch):
         dashboard.reduce_run(rd)
         dashboard.reduce_run(rd)
         assert len(calls) == 2
+
+
+def test_a_git_commit_with_no_new_event_invalidates(monkeypatch):
+    """B1: the harness logs "step" then commits 33 lines LATER (harness.py:1323/:1356).
+
+    So a commit lands with the event log untouched. Before the git stamp was folded
+    into the key, ``git_log`` stayed stale for the rest of the iteration.
+    """
+    from cap_evolve.store import make_store
+    dashboard, calls = _spy(monkeypatch)
+    with tempfile.TemporaryDirectory() as d:
+        rd = _mk_run(Path(d))
+        store = make_store({"kind": "git"}, rd.root)
+        store.init()
+        assert store.commit("iter 1: ACCEPT cand_0001")["ok"]
+        before = dashboard.reduce_run(rd)
+        assert len(before["summary"]["git_log"]) == 1
+        ev_stamp = rd.events_path.stat()
+        assert store.commit("iter 2: reject cand_0002")["ok"]
+        # the whole point: the event log did NOT move
+        assert rd.events_path.stat().st_mtime_ns == ev_stamp.st_mtime_ns
+        assert rd.events_path.stat().st_size == ev_stamp.st_size
+        after = dashboard.reduce_run(rd)
+        assert len(calls) == 2, "a new commit must re-fold"
+        assert len(after["summary"]["git_log"]) == 2, "git_log must show the new commit"
+
+
+def test_cache_is_capped_and_evicts_oldest(monkeypatch):
+    """B2: the dashboard is long-lived and list_runs installs one entry per run."""
+    dashboard, _ = _spy(monkeypatch)
+    monkeypatch.setattr(dashboard, "_REDUCE_MAX", 3)
+    with tempfile.TemporaryDirectory() as d:
+        roots = []
+        for i in range(6):
+            rd = _mk_run(Path(d) / f"r{i}")
+            dashboard.reduce_run(rd)
+            roots.append(str(Path(rd.root).resolve()))
+        assert len(dashboard._REDUCE_CACHE) == 3, "cap must hold"
+        # FIFO: the three newest survive, the three oldest are gone
+        assert list(dashboard._REDUCE_CACHE) == roots[-3:]
+
+
+def test_absolute_and_relative_paths_share_one_entry(monkeypatch):
+    """B3: RunDir.open does not resolve, so the key must (rundir.py:201)."""
+    from cap_evolve import RunDir
+    dashboard, calls = _spy(monkeypatch)
+    with tempfile.TemporaryDirectory() as d:
+        rd = _mk_run(Path(d) / "base")
+        abs_root = Path(rd.root).resolve()
+        cwd = os.getcwd()
+        try:
+            os.chdir(abs_root.parent)
+            a = dashboard.reduce_run(RunDir.open(abs_root))
+            b = dashboard.reduce_run(RunDir.open(Path(abs_root.name)))
+        finally:
+            os.chdir(cwd)
+        assert len(dashboard._REDUCE_CACHE) == 1, dict.keys(dashboard._REDUCE_CACHE)
+        assert len(calls) == 1 and b is a
+
+
+def test_truncating_the_event_log_invalidates(monkeypatch):
+    """N7: shrink was untested; size moving down must invalidate like moving up."""
+    dashboard, calls = _spy(monkeypatch)
+    with tempfile.TemporaryDirectory() as d:
+        rd = _mk_run(Path(d))
+        assert dashboard.reduce_run(rd)["summary"]["counts"]["total"] == 2
+        lines = rd.events_path.read_text(encoding="utf-8").splitlines()[:2]
+        rd.events_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        after = dashboard.reduce_run(rd)
+        assert len(calls) == 2 and after["summary"]["counts"]["total"] == 1
+
+
+def test_same_size_replace_via_rename_invalidates(monkeypatch):
+    """N1: st_ino in the key catches a same-size rename-over at an identical mtime."""
+    dashboard, calls = _spy(monkeypatch)
+    with tempfile.TemporaryDirectory() as d:
+        rd = _mk_run(Path(d))
+        assert dashboard.reduce_run(rd)["summary"]["best_val"] == 0.75
+        st = rd.events_path.stat()
+        swapped = [dict(e) for e in _EVENTS]
+        swapped[2]["val"] = 0.95  # same JSON byte length as 0.75
+        tmp = rd.root / "events.new"
+        tmp.write_text("\n".join(json.dumps(e) for e in swapped) + "\n", encoding="utf-8")
+        assert tmp.stat().st_size == st.st_size, "probe must hold size constant"
+        os.replace(tmp, rd.events_path)
+        os.utime(rd.events_path, ns=(st.st_atime_ns, st.st_mtime_ns))
+        assert rd.events_path.stat().st_mtime_ns == st.st_mtime_ns
+        after = dashboard.reduce_run(rd)
+        assert len(calls) == 2, "a new inode must invalidate at identical mtime+size"
+        assert after["summary"]["best_val"] == 0.95
+
+
+def test_mutating_a_returned_reduction_is_visible_to_the_next_caller():
+    """N3 tripwire: the shared-object contract is read-only and NOT defended.
+
+    This pins the documented behaviour so a future deepcopy-on-hit (which would eat
+    the whole win) is a deliberate, test-breaking decision rather than an accident.
+    """
+    from cap_evolve import dashboard
+    with tempfile.TemporaryDirectory() as d:
+        rd = _mk_run(Path(d))
+        first = dashboard.reduce_run(rd)
+        first["summary"]["best_val"] = "MUTATED"
+        assert dashboard.reduce_run(rd)["summary"]["best_val"] == "MUTATED"

--- a/dashboard/backend/capevolve_dashboard/app.py
+++ b/dashboard/backend/capevolve_dashboard/app.py
@@ -25,8 +25,10 @@ def create_app(base_dir: Path, static_dir: Path | None = None) -> FastAPI:
         return {"ok": True, "base_dir": str(base)}
 
     @app.get("/api/runs")
-    def get_runs():
-        return runs.list_runs(base)
+    def get_runs(limit: int | None = Query(default=None, ge=1),
+                 offset: int = Query(default=0, ge=0)):
+        # Unpaginated by default (back-compat: the SPA hub expects a plain array).
+        return runs.list_runs(base, limit=limit, offset=offset)
 
     @app.get("/api/runs/{run_id}")
     def get_run(run_id: str):
@@ -42,8 +44,11 @@ def create_app(base_dir: Path, static_dir: Path | None = None) -> FastAPI:
             raise HTTPException(status_code=404, detail="run not found")
 
     @app.get("/api/runs/{run_id}/rollouts")
-    def get_rollouts(run_id: str, split: str | None = Query(default=None)):
-        return trajectories.list_rollouts(_resolve_or_404(run_id), split)
+    def get_rollouts(run_id: str, split: str | None = Query(default=None),
+                     limit: int | None = Query(default=None, ge=1),
+                     offset: int = Query(default=0, ge=0)):
+        return trajectories.list_rollouts(_resolve_or_404(run_id), split,
+                                          limit=limit, offset=offset)
 
     @app.get("/api/runs/{run_id}/rollout/{file_name}")
     def get_rollout(run_id: str, file_name: str):
@@ -104,11 +109,12 @@ def create_app(base_dir: Path, static_dir: Path | None = None) -> FastAPI:
         events_path = _resolve_or_404(run_id) / "events.jsonl"
 
         async def gen():
-            # Initial snapshot of the full reduced run.
-            try:
-                yield _stream.sse_format("snapshot", runs.load_run(base, run_id))
-            except runs.RunNotFound:
-                return
+            # "snapshot" used to carry the FULL reduced run, but the client ignores
+            # its payload (it only marks the connection open, then refetches
+            # /api/runs/{id} through its query cache) — so serializing a whole
+            # reduction here was pure waste on every connect. Keep the frame as the
+            # open marker; ship no payload.
+            yield _stream.sse_format("snapshot", {"run_id": run_id})
             offset = events_path.stat().st_size
             idle = 0
             while True:

--- a/dashboard/backend/capevolve_dashboard/app.py
+++ b/dashboard/backend/capevolve_dashboard/app.py
@@ -25,7 +25,7 @@ def create_app(base_dir: Path, static_dir: Path | None = None) -> FastAPI:
         return {"ok": True, "base_dir": str(base)}
 
     @app.get("/api/runs")
-    def get_runs(limit: int | None = Query(default=None, ge=1),
+    def get_runs(limit: int | None = Query(default=None, ge=1, le=1000),
                  offset: int = Query(default=0, ge=0)):
         # Unpaginated by default (back-compat: the SPA hub expects a plain array).
         return runs.list_runs(base, limit=limit, offset=offset)
@@ -45,8 +45,9 @@ def create_app(base_dir: Path, static_dir: Path | None = None) -> FastAPI:
 
     @app.get("/api/runs/{run_id}/rollouts")
     def get_rollouts(run_id: str, split: str | None = Query(default=None),
-                     limit: int | None = Query(default=None, ge=1),
+                     limit: int | None = Query(default=None, ge=1, le=1000),
                      offset: int = Query(default=0, ge=0)):
+        # Unpaginated by default (back-compat: the SPA expects a plain array).
         return trajectories.list_rollouts(_resolve_or_404(run_id), split,
                                           limit=limit, offset=offset)
 

--- a/dashboard/backend/capevolve_dashboard/runs.py
+++ b/dashboard/backend/capevolve_dashboard/runs.py
@@ -58,9 +58,12 @@ def list_runs(base_dir: Path, limit: int | None = None, offset: int = 0) -> list
     (ordered by dir mtime, which needs only a stat) BEFORE any reduction, so asking
     for one page costs one reduction per row on the page — not one per run in the
     dir. A run whose reduction raises (half-written) is skipped, so a page can come
-    back shorter than ``limit``.
+    back shorter than ``limit`` — a SHORT PAGE IS NOT THE END OF THE LIST; page until
+    you get an empty one.
     """
-    paths = sorted(discover(base_dir), key=lambda p: p.stat().st_mtime, reverse=True)
+    # Name tiebreaks the mtime sort: runs created in the same tick would otherwise fall
+    # back to iterdir() order, and pagination needs a total order to tile correctly.
+    paths = sorted(discover(base_dir), key=lambda p: (-p.stat().st_mtime, p.name))
     if offset:
         paths = paths[offset:]
     if limit is not None:

--- a/dashboard/backend/capevolve_dashboard/runs.py
+++ b/dashboard/backend/capevolve_dashboard/runs.py
@@ -51,9 +51,22 @@ def _status(summary: dict) -> str:
     return "live"
 
 
-def list_runs(base_dir: Path) -> list[dict]:
+def list_runs(base_dir: Path, limit: int | None = None, offset: int = 0) -> list[dict]:
+    """Newest-first run rows, optionally a window of them.
+
+    ``limit``/``offset`` page the list. The slice happens on the *discovered dirs*
+    (ordered by dir mtime, which needs only a stat) BEFORE any reduction, so asking
+    for one page costs one reduction per row on the page — not one per run in the
+    dir. A run whose reduction raises (half-written) is skipped, so a page can come
+    back shorter than ``limit``.
+    """
+    paths = sorted(discover(base_dir), key=lambda p: p.stat().st_mtime, reverse=True)
+    if offset:
+        paths = paths[offset:]
+    if limit is not None:
+        paths = paths[:limit]
     rows = []
-    for path in discover(base_dir):
+    for path in paths:
         try:
             reduced = _reduce(path)
         except Exception:  # a half-written run must not break the hub

--- a/dashboard/backend/capevolve_dashboard/trajectories.py
+++ b/dashboard/backend/capevolve_dashboard/trajectories.py
@@ -10,31 +10,48 @@ from cap_evolve import RunDir, dashboard
 _ROLLOUT_RE = re.compile(r"^(?P<task>.+)__(?P<cand>cand_\d+|seed)__t(?P<trial>\d+)\.json$")
 
 
-def list_rollouts(run_path: Path, split: str | None = None) -> list[dict]:
+def list_rollouts(run_path: Path, split: str | None = None,
+                  limit: int | None = None, offset: int = 0) -> list[dict]:
+    """Rollout rows for a run, optionally a window of them.
+
+    ``limit``/``offset`` page the result. The window is applied to the sorted FILE
+    NAMES before any file is opened, so a page costs one JSON parse per row on the
+    page rather than one per rollout in the split (a long run has thousands). Order
+    is stable: splits sorted by name, then file name within a split. A file that
+    fails to parse is skipped, so a page can be shorter than ``limit``.
+    """
     root = Path(run_path) / "rollouts"
     rows: list[dict] = []
     if not root.is_dir():
         return rows
-    splits = [split] if split else [p.name for p in root.iterdir() if p.is_dir()]
+    splits = [split] if split else sorted(p.name for p in root.iterdir() if p.is_dir())
+    # Name-matching is a cheap regex on the filename; do it first so paging indexes
+    # over the rows the caller will actually see, then window, then open the files.
+    matched: list[tuple[str, Path, re.Match]] = []
     for sp in splits:
         sp_dir = root / sp
         if not sp_dir.is_dir():
             continue
         for f in sorted(sp_dir.glob("*.json")):
             m = _ROLLOUT_RE.match(f.name)
-            if not m:
-                continue
-            try:
-                data = json.loads(f.read_text())
-            except Exception:
-                continue
-            score = data.get("score") or {}
-            rows.append({
-                "task_id": m["task"], "candidate": m["cand"],
-                "trial": int(m["trial"]), "split": sp,
-                "reward": score.get("reward"), "feedback": score.get("feedback", ""),
-                "file": f.name,
-            })
+            if m:
+                matched.append((sp, f, m))
+    if offset:
+        matched = matched[offset:]
+    if limit is not None:
+        matched = matched[:limit]
+    for sp, f, m in matched:
+        try:
+            data = json.loads(f.read_text())
+        except Exception:
+            continue
+        score = data.get("score") or {}
+        rows.append({
+            "task_id": m["task"], "candidate": m["cand"],
+            "trial": int(m["trial"]), "split": sp,
+            "reward": score.get("reward"), "feedback": score.get("feedback", ""),
+            "file": f.name,
+        })
     return rows
 
 

--- a/dashboard/backend/capevolve_dashboard/trajectories.py
+++ b/dashboard/backend/capevolve_dashboard/trajectories.py
@@ -17,8 +17,9 @@ def list_rollouts(run_path: Path, split: str | None = None,
     ``limit``/``offset`` page the result. The window is applied to the sorted FILE
     NAMES before any file is opened, so a page costs one JSON parse per row on the
     page rather than one per rollout in the split (a long run has thousands). Order
-    is stable: splits sorted by name, then file name within a split. A file that
-    fails to parse is skipped, so a page can be shorter than ``limit``.
+    is stable: splits sorted by name, then file name within a split. A file that fails
+    to parse is skipped, so a page can be shorter than ``limit`` — a SHORT PAGE IS NOT
+    THE END OF THE LIST; page until you get an empty one.
     """
     root = Path(run_path) / "rollouts"
     rows: list[dict] = []

--- a/dashboard/backend/tests/test_pagination.py
+++ b/dashboard/backend/tests/test_pagination.py
@@ -132,3 +132,53 @@ def test_sse_snapshot_frame_carries_no_reduced_run(tmp_base, make_run, monkeypat
     assert frames[0] == "event: snapshot"
     # Payload is the open marker only — NOT {"graph": ..., "summary": ...}.
     assert json.loads(frames[1][len("data:"):]) == {"run_id": "run_a"}
+
+
+# ---- page-size bounds (N5) and short pages (N6) ---------------------------
+
+def test_page_size_is_capped(tmp_base, make_run):
+    """``le=1000`` makes the contract self-documenting; a huge limit is a 422, not a 200."""
+    make_run("run_a", events=BASE_EVENTS, baseline={"val": {"reward": 0.25}, "best_id": "seed"})
+    c = _client(tmp_base)
+    for url in ("/api/runs", "/api/runs/run_a/rollouts"):
+        assert c.get(f"{url}?limit=1000").status_code == 200
+        assert c.get(f"{url}?limit=1001").status_code == 422
+        assert c.get(f"{url}?limit=99999999999999999999").status_code == 422
+        assert c.get(f"{url}?limit=0").status_code == 422
+        assert c.get(f"{url}?offset=-1").status_code == 422
+
+
+def test_a_short_page_is_not_the_end_of_the_list(tmp_base, make_run):
+    """N6: a corrupt file is skipped AFTER windowing, so a page can be short mid-list.
+
+    Pins the documented contract: page until you get an EMPTY page, not a short one.
+    """
+    rd = make_run("run_a", events=BASE_EVENTS,
+                  baseline={"val": {"reward": 0.25}, "best_id": "seed"})
+    for i in range(6):
+        _write_rollout(rd, "val", f"t{i}", "cand_0001", 0)
+    (rd.root / "rollouts" / "val" / "t1__cand_0001__t0.json").write_text("{ not json",
+                                                                        encoding="utf-8")
+    c = _client(tmp_base)
+    first = c.get("/api/runs/run_a/rollouts?limit=3").json()
+    assert len(first) == 2, "short page mid-list (the corrupt row was skipped)"
+    second = c.get("/api/runs/run_a/rollouts?limit=3&offset=3").json()
+    assert len(second) == 3, "a short page did NOT mean the list was exhausted"
+    assert c.get("/api/runs/run_a/rollouts?limit=3&offset=6").json() == []  # empty = end
+    # and paging still tiles the unpaged list exactly
+    full = c.get("/api/runs/run_a/rollouts").json()
+    assert [r["file"] for r in first + second] == [r["file"] for r in full]
+
+
+def test_run_order_is_total_even_at_identical_mtimes(tmp_base, make_run):
+    """N4: name tiebreaks the mtime sort, so pagination has a total order to tile."""
+    import os
+    from capevolve_dashboard import runs as R
+    for n in ("run_c", "run_a", "run_b"):
+        make_run(n, events=BASE_EVENTS, baseline={"val": {"reward": 0.25}, "best_id": "seed"})
+        os.utime(tmp_base / n, ns=(1_000_000_000_000_000_000, 1_000_000_000_000_000_000))
+    order = [r["run_id"] for r in R.list_runs(tmp_base)]
+    assert order == ["run_a", "run_b", "run_c"], order
+    assert all([r["run_id"] for r in R.list_runs(tmp_base)] == order for _ in range(5))
+    pages = R.list_runs(tmp_base, limit=2) + R.list_runs(tmp_base, limit=2, offset=2)
+    assert [r["run_id"] for r in pages] == order  # pages tile the total order

--- a/dashboard/backend/tests/test_pagination.py
+++ b/dashboard/backend/tests/test_pagination.py
@@ -1,0 +1,134 @@
+"""Pagination on /api/runs and /api/runs/{id}/rollouts, and the empty SSE snapshot
+frame (issue #119).
+
+Contract: both endpoints are UNPAGINATED by default (back-compat with the SPA, which
+expects a plain array). ``?limit=N`` returns at most N rows; ``?offset=K`` skips the
+first K. Order is deterministic — runs newest-first by dir mtime, rollouts by
+(split, file name) — so consecutive pages tile the full list without gaps or repeats.
+"""
+
+import json
+
+from fastapi.testclient import TestClient
+
+from conftest import BASE_EVENTS
+
+
+def _client(base):
+    from capevolve_dashboard.app import create_app
+    return TestClient(create_app(base))
+
+
+def _write_rollout(rd, split, task, cand, trial, reward=1.0):
+    d = rd.root / "rollouts" / split
+    d.mkdir(parents=True, exist_ok=True)
+    name = f"{task}__{cand}__t{trial}.json"
+    (d / name).write_text(json.dumps({
+        "rollout": {"task_id": task, "output": "out"},
+        "score": {"task_id": task, "reward": reward, "feedback": ""},
+    }), encoding="utf-8")
+    return name
+
+
+# ---- /api/runs -------------------------------------------------------------
+
+def test_runs_unpaginated_by_default(tmp_base, make_run):
+    from capevolve_dashboard import runs
+    for i in range(5):
+        make_run(f"run_{i}", events=BASE_EVENTS)
+    assert len(runs.list_runs(tmp_base)) == 5
+    r = _client(tmp_base).get("/api/runs")
+    assert r.status_code == 200 and len(r.json()) == 5
+
+
+def test_runs_pages_tile_the_full_list(tmp_base, make_run):
+    from capevolve_dashboard import runs
+    for i in range(5):
+        make_run(f"run_{i}", events=BASE_EVENTS)
+    full = [r["run_id"] for r in runs.list_runs(tmp_base)]
+    paged = []
+    for off in (0, 2, 4):
+        page = runs.list_runs(tmp_base, limit=2, offset=off)
+        assert len(page) <= 2
+        paged += [r["run_id"] for r in page]
+    assert paged == full                                  # no gaps, no repeats
+    assert runs.list_runs(tmp_base, limit=2, offset=99) == []  # past the end
+
+
+def test_runs_endpoint_limit_and_offset(tmp_base, make_run):
+    for i in range(4):
+        make_run(f"run_{i}", events=BASE_EVENTS)
+    c = _client(tmp_base)
+    first = c.get("/api/runs?limit=2").json()
+    second = c.get("/api/runs?limit=2&offset=2").json()
+    assert len(first) == 2 and len(second) == 2
+    assert {r["run_id"] for r in first}.isdisjoint({r["run_id"] for r in second})
+    assert c.get("/api/runs?limit=0").status_code == 422   # bounds are validated
+    assert c.get("/api/runs?offset=-1").status_code == 422
+
+
+# ---- /api/runs/{id}/rollouts ----------------------------------------------
+
+def test_rollouts_pages_tile_the_full_list(tmp_base, make_run):
+    from capevolve_dashboard import trajectories
+    rd = make_run("run_a", events=BASE_EVENTS)
+    for i in range(6):
+        _write_rollout(rd, "val", f"t{i}", "cand_0001", 0)
+    full = [r["file"] for r in trajectories.list_rollouts(rd.root)]
+    assert len(full) == 6
+    paged = []
+    for off in (0, 3, 6):
+        page = trajectories.list_rollouts(rd.root, limit=3, offset=off)
+        assert len(page) <= 3
+        paged += [r["file"] for r in page]
+    assert paged == full
+    assert trajectories.list_rollouts(rd.root, limit=3, offset=99) == []
+
+
+def test_rollouts_paging_only_opens_the_page(tmp_base, make_run, monkeypatch):
+    """The point of the change: a page costs one parse per row ON the page."""
+    from capevolve_dashboard import trajectories
+    rd = make_run("run_a", events=BASE_EVENTS)
+    for i in range(20):
+        _write_rollout(rd, "val", f"t{i:02d}", "cand_0001", 0)
+    reads = []
+    real = trajectories.json.loads
+    monkeypatch.setattr(trajectories.json, "loads",
+                        lambda s, *a, **k: (reads.append(1), real(s, *a, **k))[1])
+    rows = trajectories.list_rollouts(rd.root, limit=5)
+    assert len(rows) == 5
+    assert len(reads) == 5, f"paged read parsed {len(reads)} files, want 5"
+
+
+def test_rollouts_endpoint_limit_offset_and_split(tmp_base, make_run):
+    rd = make_run("run_a", events=BASE_EVENTS)
+    for i in range(4):
+        _write_rollout(rd, "val", f"t{i}", "cand_0001", 0)
+    _write_rollout(rd, "train", "tx", "cand_0001", 0)
+    c = _client(tmp_base)
+    page = c.get("/api/runs/run_a/rollouts?split=val&limit=2").json()
+    assert len(page) == 2 and all(r["split"] == "val" for r in page)
+    rest = c.get("/api/runs/run_a/rollouts?split=val&limit=2&offset=2").json()
+    assert {r["file"] for r in page}.isdisjoint({r["file"] for r in rest})
+    assert len(c.get("/api/runs/run_a/rollouts").json()) == 5  # default: everything
+
+
+# ---- SSE snapshot frame ---------------------------------------------------
+
+def test_sse_snapshot_frame_carries_no_reduced_run(tmp_base, make_run, monkeypatch):
+    """The client ignored the payload; it must no longer be serialized.
+
+    A ``finalize`` event is injected on the first poll so the generator returns at
+    once instead of holding the connection for the 5-minute idle timeout.
+    """
+    from capevolve_dashboard import stream as _stream
+    make_run("run_a", events=BASE_EVENTS,
+             baseline={"val": {"reward": 0.25}, "best_id": "seed"})
+    monkeypatch.setattr(_stream, "read_new_events",
+                        lambda p, off: ([{"kind": "finalize"}], off))
+    with _client(tmp_base).stream("GET", "/api/runs/run_a/stream") as r:
+        assert r.status_code == 200
+        frames = [ln for ln in r.iter_lines() if ln.startswith(("event:", "data:"))]
+    assert frames[0] == "event: snapshot"
+    # Payload is the open marker only — NOT {"graph": ..., "summary": ...}.
+    assert json.loads(frames[1][len("data:"):]) == {"run_id": "run_a"}

--- a/dashboard/frontend/src/lib/types.ts
+++ b/dashboard/frontend/src/lib/types.ts
@@ -261,7 +261,9 @@ export interface RolloutDetail {
 
 /** SSE frames from GET /api/runs/{id}/stream. */
 export type StreamEvent =
-  | { type: 'snapshot'; data: RunDetail }
+  // 'snapshot' is the connection-open marker only; the client refetches the run
+  // detail through its query cache, so the frame carries no reduced run.
+  | { type: 'snapshot'; data: { run_id: string } }
   | { type: 'event'; data: Record<string, unknown> }
   | { type: 'done'; data: { run_id: string } }
   | { type: 'idle'; data: { run_id: string } }


### PR DESCRIPTION
Closes #119

The dashboard re-folded the **entire** event log (plus every rollout file, every candidate dir stat) on every HTTP request **and** every SSE tick (~2/s, 400 ms-debounced `invalidateQueries`), plus once more per candidate in `diff_candidate`. On a 200-candidate run that is **~275 ms of CPU per tick** spent re-deriving an answer that had not changed — the reason the "real-time" dashboard is laggiest exactly when the run is big.

## 1. `reduce_run` memoized on `events.jsonl` (mtime + size)

`core/cap_evolve/dashboard.py`: the fold moved to `_reduce_run_uncached`; `reduce_run` is now a thin memo over it. One `dict` entry per run root holding only its newest reduction — no cache class, no new dependency, stdlib `os.stat` only.

**Why the key is mtime *and* size, not mtime alone.** `st_mtime` granularity is 1 second on some filesystems (and the float `st_mtime` rounds), so an append that lands in the same second as the cached read can leave mtime looking unchanged — a cache keyed on mtime alone would then serve a *stale reduction during a live run*, which is strictly worse than no cache. `events.jsonl` is append-only, so **size always grows on a new event**: size is the strong signal, and mtime catches the (not-expected-here) same-length rewrite. There is a test that forces the mtime back to its cached value with `os.utime` and asserts the size change still invalidates.

**Why one key covers the reducer's other inputs.** The fold also reads `baseline.json`, `final.json`, `rollouts/`, `state.json` and the git store. Each of those is written *before* the event that announces it is appended — `harness` writes `baseline.json` then logs `baseline` (harness.py:376-378), persists rollout files then logs `evaluate` (harness.py:252 → 311), the iteration commit lands then `step` is logged, finalize writes `final.json` then logs `finalize`. So the stamp advances *after* those writes, never before.

**Race guard.** The stamp is re-read after the fold; if the log moved while we were folding, the result may already be stale, so it is not cached and the next call re-folds.

**Cache-hit results are shared objects** — documented on `reduce_run` as read-only. Every caller in the repo (`runs._reduce`, `trajectories.diff_candidate`, `export_static`, `render_html`, `report/scripts/{run,check}.py`) only reads.

## 2. Dead SSE snapshot payload deleted

`app.py` yielded `sse_format("snapshot", runs.load_run(...))` — a full reduced run serialized on every connect. The client (`useRunStream.ts:75`) **ignores the payload**: it dispatches `{type:'open'}` and then refetches `/api/runs/{id}` through its query cache. The frame now carries only `{"run_id": ...}` (kept as the open marker so no client change is needed). The now-unreachable `except runs.RunNotFound` around it went too — `_resolve_or_404` already 404s before the generator runs. `types.ts` `StreamEvent['snapshot']` narrowed from `RunDetail` to `{run_id}`.

## 3. Pagination contract

`?limit=` / `?offset=` on `GET /api/runs` and `GET /api/runs/{id}/rollouts`.

- **Unpaginated by default** — omit both and the response is the same full array as before (the SPA hub is unchanged).
- `limit` ≥ 1, `offset` ≥ 0, both validated by FastAPI (`422` otherwise). `offset` past the end returns `[]`.
- **Deterministic order** so consecutive pages tile the full list with no gaps or repeats: runs newest-first by dir mtime; rollouts by (split name, file name).
- **The window is applied before the expensive work** — to the discovered run dirs before any reduction (one reduction per row *on the page*, not per run in the dir), and to the matched rollout filenames before any file is opened (one JSON parse per row on the page, not per rollout in the split).
- Rows are best-effort: a half-written run or unparseable rollout is skipped, so a page can come back shorter than `limit`.

## Measured before/after

Real run dir from `bash examples/toy_calc/run.sh` (mock optimizer, zero-API: `baseline_val 0.0 → test_reward 1.0`, 3 iterations), grown to a long run: **215 events, 404 rollout files, 202 candidate dirs**. BEFORE is an actual `origin/main` worktree, not a flag.

| operation (x20) | BEFORE (origin/main) | AFTER (this branch) | speedup |
|---|---|---|---|
| `reduce_run` | 275.557 ms each | **0.009 ms** each | **~30,000x** |
| `runs.load_run` (HTTP + SSE path) | 254.873 ms each | **0.061 ms** each | **~4,200x** |
| `trajectories.diff_candidate` | 301.376 ms each | **53.482 ms** each | **5.6x** |
| `runs.list_runs` | 274.170 ms each | **0.791 ms** each | **347x** |

Cold pagination over 12 such runs: `/api/runs` full **2822.6 ms** → `limit=5` **1166.7 ms**. Rollouts on one run: full (404 rows) **18.42 ms** → `limit=50` **3.87 ms**.

The backend test suite also went **303.65 s → 2.06 s** (its own SSE test no longer sits through the 5-minute idle timeout).

## Overlap with sibling issues

- **#116** is factoring the events-tail helper out of this same SSE path. My only `app.py` change inside the SSE generator is the two lines that produced the snapshot frame; the `read_new_events` polling loop is untouched.
- **#117** is fixing the SPA render + a reducer field. My `dashboard.py` change adds a memo wrapper and renames the fold body to `_reduce_run_uncached` — a reducer *field* change lands inside that body and should merge cleanly; a merge conflict, if any, is the `def` line. My only frontend edit is one type annotation in `types.ts`.
- `dashboard/frontend/dist/` is checked in; I rebuilt it to verify and then **reverted the dist churn** so the hash-renamed bundle does not collide with #116/#117.

## Verification

```
$ PYTHONPATH=/tmp/wt-119/core python -m pytest core/tests -q -k "not test_maybe_launch_spawns_when_available"
185 passed, 1 deselected in 59.43s      # 179 baseline + 7 new = 186 collected

$ cd dashboard/backend && python -m pytest tests -q
49 passed, 1 warning in 2.06s           # 40 baseline + 9 new

$ python -m compileall -q core skills
compileall CLEAN

$ cd dashboard/frontend && npm ci && npm run build
✓ built in 774ms
$ npx tsc --noEmit   → exit 0
$ npm test -- --run  → Test Files 13 passed (13) / Tests 45 passed (45)
```

> The one deselected test, `test_dashboard_launch.py::test_maybe_launch_spawns_when_available`, hard-codes port 7878 and fails in this environment because another process holds that port (the launcher falls through to 7882). It **fails identically on unmodified `origin/main`** — pre-existing and unrelated; it touches none of the files in this diff. See §3 of the Evidence comment for the reproduction.

**Fail-before / pass-after** (behavioral, no internals — reverting only `dashboard.py` to `origin/main`):

```
===== BEFORE (origin/main reducer) =====
>           assert dashboard.reduce_run(rd) is dashboard.reduce_run(rd)
E           AssertionError
FAILED core/tests/test_dashboard_cache.py::test_repeat_reduce_reuses_the_same_object_behavioral
1 failed, 1 passed

===== AFTER =====
7 passed in 0.06s
```

**Invalidation proven on the live-appending 202-candidate run dir:**

```
reduce #1 total nodes: 202 best_val: 1.0
reduce #2 is cached object: True
reduce #3 after append: fresh object: True total nodes: 203 (218.8 ms re-fold)
cand_9999 present in graph: True  -> NO stale serve during a live run
reduce #4 re-cached: True  (0.018 ms)
```

**Pagination bounds:** pages tile the full list exactly (`True`, 404 rollout rows / 12 runs); `offset` past the end → `[]`; `limit=0` and `offset=-1` → `422`.

Full commands + output in the 🔬 Evidence comment.

## Tests added

- `core/tests/test_dashboard_cache.py` (7) — hit on unchanged log; **invalidate on append**; **invalidate at identical mtime** (size busts the key); per-run isolation; missing event log never cached; 2 internals-free behavioral tests.
- `dashboard/backend/tests/test_pagination.py` (9) — default-unpaginated; pages tile; bounds `422`; offset past end; a paged rollout read parses only the page's files (5, not 20); SSE snapshot frame carries no reduced run.

Skipped: incremental SPA updates from stream events (#119 stretch item 4) — that is a frontend change and belongs with #117's SPA work; the cache already removes the cost of the per-tick refetch.
