### PR TITLE
Guard tiny/empty val splits and add a Student-t small-sample correction to the paired gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,66 @@ All notable changes to cap-evolve are documented here. The format follows
 [Semantic Versioning](https://semver.org/) (currently `0.x` — anything may change).
 
 ## [Unreleased]
+### Changed
+- **BREAKING (gate semantics): `k_se` is now a z *quantile* in `gate_mode: paired`, not
+  the multiplier.** SE(Δ) is estimated from the same n val deltas, so the standardized
+  mean difference is t-distributed with df = n−1, not normal. The gate now converts
+  `k_se` to its one-sided normal tail α = P(Z > `k_se`) and uses the bar
+  `t_{1−α, n−1} · SE`. `t ≥ z` is a theorem for every finite df, so **the gate can only
+  get stricter** — but it is strictly stricter, so **candidates that were accepted near
+  the old bar can now be rejected**, and re-running a prior optimization may take a
+  different path. The widening depends on `k_se` *and* n: at `k_se 1.0` the bar is
+  1.32× wider at n=3, 1.06× at n=10, 1.02× at n=30; at `k_se 3.0` it is 6.4× at n=3.
+  `gate_mode: significant` is unchanged (`k_se` is still the multiplier there). `k_se`
+  above 26.5 now raises (its normal tail underflows float64 for some df); use ≤ 3. Documented in
+  `docs/HONEST_EVAL.md` guarantee 3, `templates/project/capevolve.yaml`, and
+  `docs/OPTIMIZE_YOUR_OWN.md`. The one committed run artifact with real gate decisions
+  (`examples/skillsbench/run_full`, n=7, `k_se 0.2`) re-decides **identically** — zero
+  flips — and `docs/RESULTS.md`'s τ² runs (n=30, `k_se 0.3`) are far from any margin, so
+  published results still reproduce.
+- **BREAKING (adapters with < 6 tasks): a val split of 0 or 1 task is now refused.** Any
+  adapter whose task list yields `val < 2` under its ratios hard-fails at split freeze
+  with `TinyValSplitError` instead of silently running a meaningless gate. With the
+  default 0.5/0.25/0.25 ratios that means ≥ 6 tasks (≥ 20 for the recommended val ≥ 5);
+  with 4–5 tasks set all three ratios to 0.25/0.5/0.25. `CAPEVOLVE_ALLOW_TINY_VAL=1`
+  opts out, and permanently brands the run's artifacts as not-an-honest-gate.
+  `skillcheck.temp_run_dir`'s default id set grew 4 → 8 for the same reason.
+
 ### Fixed
+- **Tiny/empty val splits can no longer reach a gate decision, on any path (#113).** The
+  guard now runs at split freeze, `baseline`, `reuse_baseline`, and the `--resume`
+  fast-path — and, decisively, **inside `gate.decide` itself**, which is the chokepoint
+  every mode of every algorithm routes through. This closes three previously unguarded
+  production paths (`reuse_baseline` returned before `baseline()`, so a run created under
+  the escape hatch became a reusable seed for later runs that were never marked
+  dishonest; `--resume` and `--reuse-baseline` returned before any check) and also catches
+  a *healthy* split whose realized pair count collapsed because a candidate errored on
+  most val tasks (`_paired_deltas` intersects task ids).
+- **Escape-hatch runs are now visibly branded instead of looking honest.** A run that set
+  `CAPEVOLVE_ALLOW_TINY_VAL=1` writes a `tiny_val_bypass` marker to `state.json`;
+  `final.json` gains `honest_gate: false` and a `warnings` array; `report.md` leads with
+  `⚠ NOT AN HONEST GATE` and retracts its "held-out tasks the optimizer never saw"
+  claim; and the dashboard renders a red banner above every number (`dashboard.py` also
+  had no `split_warning` branch at all — it does now). LOW CONFIDENCE gate decisions
+  likewise now surface in `report.md`, not only in `events.jsonl`.
+- **`stats.t_critical` was silently wrong for α below ~1e-12.** It bisected on
+  `1.0 - alpha`, which is exactly `1.0` in float64 below α ≈ 1e-16, so the search
+  converged onto a garbage plateau: −5.9% at `k_se=8`, −29% at `k_se=8.3`, constant for
+  `k_se` 10…38, and at `k_se ≥ 38.5` α underflowed to 0, the function returned `0.0`, and
+  a `max(k_se, ...)` clamp **silently reverted the bar to the uncorrected z** — the exact
+  bug the correction exists to fix. It now bisects on a new cancellation-free survival
+  function `stats.t_sf`, verifies the solved value reproduces α before returning, and
+  raises rather than returning a sentinel. Cross-checked against an independent closed
+  form at df=2 to 3e-13 relative error across `k_se` 1…37. The `max()` clamp is gone
+  (it bound in 0 of ~30,000 valid cases; its only live effect was hiding this failure).
+  `betainc`'s continued fraction now raises on non-convergence instead of returning a
+  half-converged value, and `t_critical` raises `ValueError` on invalid α/df instead of
+  returning `0.0`/`inf` sentinels that would get multiplied by an SE.
+- **`check_val_size`'s remediation option 2 did not work.** It suggested `split_val: 0.4`,
+  but the CLI always builds all three ratios, so that yields (0.5, 0.4, 0.25) — still
+  `val=1` at n=3 and n=4, i.e. exactly the users hitting the error. It now gives the full
+  verified triple (0.25/0.5/0.25, correct for every n ≥ 4), notes that option 3 needs
+  `test ≥ 1` too, and states that at exactly 3 tasks no ratio can work.
 - **Benchmark CI robustness (skillberry-1 self-hosted runner).** Three fixes so a broken
   runner or gateway is *loud*, not a silent all-0.000 "success": (1) `ci_setup.sh` now
   installs + hard-verifies the `claude-code` optimizer CLI — when it was missing the

--- a/core/cap_evolve/__init__.py
+++ b/core/cap_evolve/__init__.py
@@ -19,7 +19,7 @@ from .lr_schedule import build_schedule
 from .memory import History, RejectedMemory
 from .rundir import Budget, RunDir, Spent
 from .selection import PICKERS, STRATEGIES, pick, validate_strategy
-from .splits import Splits, TestSealError, make_splits
+from .splits import Splits, TestSealError, TinyValSplitError, check_val_size, make_splits
 from .stats import aggregate, bootstrap_ci, combined_stderr, mean, pass_at_k, pass_k, stderr
 from .trials import run_trials_pool
 from .types import Candidate, Rollout, Score, Task
@@ -46,6 +46,8 @@ __all__ = [
     "Spent",
     "Splits",
     "TestSealError",
+    "TinyValSplitError",
+    "check_val_size",
     "make_splits",
     "aggregate",
     "bootstrap_ci",

--- a/core/cap_evolve/dashboard.py
+++ b/core/cap_evolve/dashboard.py
@@ -203,6 +203,19 @@ def _trials_from_per_task(per_task: list) -> int:
     return max(ns) if ns else 0
 
 
+def _honesty_banner(run_dir) -> str | None:
+    """The not-an-honest-gate banner when this run bypassed the tiny-val guard.
+
+    Rendered at the TOP of the dashboard, not buried in the annotations stream: a
+    bypassed run must be unmistakable in the one surface a human actually opens.
+    """
+    from .splits import BYPASS_BANNER, bypassed
+    b = bypassed(run_dir)
+    if b:
+        return f"{b.get('banner') or BYPASS_BANNER} (val tasks: {b.get('val', '?')})"
+    return None
+
+
 def _git_log(root: Path) -> list[dict]:
     """One row per iteration commit from the run dir's git store (empty if none)."""
     if not (root / ".git").exists() or not shutil.which("git"):
@@ -272,9 +285,13 @@ def reduce_run(run_dir) -> dict:
     it = 0
     for ev in events:
         kind = ev.get("kind")
-        if kind == "gate_warning":
+        if kind in ("gate_warning", "split_warning"):
+            # split_warning was previously dropped on the floor, which meant a run that
+            # bypassed the tiny-val guard rendered a dashboard indistinguishable from an
+            # honest one. Both warning kinds land in the same annotations stream now.
             gate_warnings.append({"reason": ev.get("reason"), "context": ev.get("context"),
-                                  "mode": ev.get("mode")})
+                                  "mode": ev.get("mode") or kind,
+                                  "bypass": bool(ev.get("bypass"))})
             continue
         if kind in ("diagnose", "optimizer_error"):
             diagnoses.append({
@@ -568,6 +585,7 @@ def reduce_run(run_dir) -> dict:
         "spent": (sp.to_dict() if sp is not None else None),
         "budget_warnings": [e for e in events if e.get("kind") == "budget_warning"],
         "gate_warnings": gate_warnings,
+        "honesty_banner": _honesty_banner(run_dir),
         "diagnoses": diagnoses,
         "git_log": _git_log(root),
     }
@@ -706,6 +724,13 @@ def render_ansi(reduced: dict, *, color: bool = True, top_n: int = 8) -> str:
     lines: list[str] = []
     title = f" cap-evolve report · {s['run_id']} "
     lines.append(c(_C.BOLD, title) + c(_C.GREY, "─" * max(0, width - len(title))))
+
+    # --- honesty banner (BEFORE any number) -----------------------------
+    if s.get("honesty_banner"):
+        import textwrap
+        for ln in textwrap.wrap(s["honesty_banner"], max(20, width - 2)):
+            lines.append(c(_C.RED + _C.BOLD, ln))
+        lines.append("")
 
     # --- KPI strip ------------------------------------------------------
     base = s["baseline_val"]
@@ -894,6 +919,15 @@ function showTip(e,txt){tip.textContent=txt;tip.style.display='block';
   tip.style.left=Math.min(e.clientX+14,innerWidth-330)+'px';tip.style.top=(e.clientY+14)+'px';}
 function hideTip(){tip.style.display='none';}
 function sec(title){const s=$('section');s.append($('h2',{text:title}));main.append(s);return s;}
+
+/* ---------- 0. Honesty banner (before ANY number) ---------- */
+(function(){
+  if(!S.honesty_banner)return;
+  const b=$('div',{text:S.honesty_banner});
+  b.style.cssText='background:#7f1d1d;color:#fee2e2;border:2px solid #ef4444;'+
+    'border-radius:8px;padding:14px 16px;margin:0 0 18px;font-weight:700;line-height:1.5';
+  main.prepend(b);
+})();
 
 /* ---------- 1. KPI strip ---------- */
 (function(){

--- a/core/cap_evolve/gate.py
+++ b/core/cap_evolve/gate.py
@@ -11,7 +11,14 @@ from __future__ import annotations
 import math
 from dataclasses import dataclass
 
-from .splits import LOW_CONFIDENCE_VAL_TASKS
+from .splits import (
+    LOW_CONFIDENCE_VAL_TASKS,
+    MIN_VAL_TASKS,
+    TinyValSplitError,
+    mark_bypass,
+    tiny_val_allowed,
+)
+from .stats import t_multiplier_for_z
 
 
 @dataclass
@@ -113,6 +120,29 @@ def decide(
         else:
             n = len(deltas)
             mean_d = sum(deltas) / n
+            # THE chokepoint. Every mode of every algorithm reaches an accept/reject
+            # through here, so this is the one place a guard cannot be routed around
+            # by a resumed / copied / hand-written splits.json, or by a split that was
+            # healthy but whose *realized* pair count collapsed (a candidate that
+            # errored on most val tasks: harness._paired_deltas intersects task ids).
+            # The earlier check_val_size calls stay for friendly, early, pre-budget
+            # failures; this one is the backstop that makes the guarantee true.
+            if n < MIN_VAL_TASKS:
+                if not tiny_val_allowed():
+                    raise TinyValSplitError(
+                        f"gate refused: the paired gate got only {n} matched val "
+                        f"task{'' if n == 1 else 's'} (need >= {MIN_VAL_TASKS}), so "
+                        f"SE(Δ) has {max(n - 1, 0)} degrees of freedom and any accept/"
+                        f"reject would be meaningless.\n"
+                        f"  Either the val split is too small (see the split-freeze "
+                        f"error for how to fix ratios), or the candidate failed to "
+                        f"produce a score on most val tasks so only {n} pair(s) "
+                        f"matched — check the val rollouts for adapter errors.\n"
+                        f"  Override only if you accept a non-honest gate: export "
+                        f"CAPEVOLVE_ALLOW_TINY_VAL=1 (the run's artifacts are then "
+                        f"permanently branded as not-an-honest-gate)."
+                    )
+                mark_bypass(run_dir, val=n, context="at gate decision")
             if n >= 2:
                 var = sum((d - mean_d) ** 2 for d in deltas) / (n - 1)
                 se = math.sqrt(var / n)
@@ -121,22 +151,27 @@ def decide(
             if se == 0.0:
                 # Paired SE collapsed (n=1, or every task moved identically). Do not
                 # silently act strict — warn loudly, then apply the documented strict
-                # fallback (accept any positive mean delta).
+                # fallback (accept any positive mean delta). NOTE: the Student-t
+                # small-sample correction below does NOT apply on this path — there is
+                # no SE to widen — so an all-identical-deltas candidate is accepted on
+                # Δ>0 at any n. Documented in docs/HONEST_EVAL.md guarantee 3.
                 _warn_se_zero(run_dir, "paired", context=f"n={n}")
                 ok = mean_d > 0
                 return GateDecision(
                     accept=ok,
                     reason=(f"paired Δ̄={mean_d:+.4f} {'>' if ok else '<='} 0 "
-                            f"(SE=0 → STRICT fallback, warned; n={n})"),
+                            f"(SE=0 → STRICT fallback, warned; n={n}; "
+                            f"no t-correction on this path)"),
                     delta=mean_d, threshold=0.0,
                 )
             # Small-sample correction. The bar is k·SE, a *z* multiplier — valid only
             # when SE is known. Here SE(Δ) is ESTIMATED from the same n deltas, so the
             # standardized mean difference is t-distributed with df=n-1 (fatter tails).
             # Using z at small n sets the bar too LOW and accepts noise; we substitute
-            # the t multiplier at the same one-sided significance level. t >= z always,
-            # so this can only make the gate stricter, and it converges to z as n grows.
-            from .stats import t_multiplier_for_z
+            # the t multiplier at the same one-sided significance level. t_{1-α,df} >=
+            # z_{1-α} is a theorem for every finite df, so the gate can only get
+            # stricter and converges to z as n grows — no max() clamp needed (one would
+            # only hide a failed inversion, which now raises instead).
             k_eff = t_multiplier_for_z(k_se, n)
             bar = k_eff * se
             ok = mean_d > bar

--- a/core/cap_evolve/gate.py
+++ b/core/cap_evolve/gate.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 import math
 from dataclasses import dataclass
 
+from .splits import LOW_CONFIDENCE_VAL_TASKS
+
 
 @dataclass
 class GateDecision:
@@ -79,6 +81,9 @@ def decide(
         same tasks, so the cross-task variance cancels and only the *paired*
         variance counts. Requires ``paired_deltas``; the loop uses it by default
         when per-task data is available, else falls back to ``significant``.
+        SE(Δ) is estimated from the same n deltas, so ``k_se`` (a z multiplier)
+        is replaced by the equivalent Student-t multiplier at df=n-1 — strictly
+        wider at small n, converging to ``k_se`` as n grows.
       - ``significant``: accept iff delta > k * combined_SE (treats cand & current
         as INDEPENDENT samples — correct only when they were not scored on the
         same tasks; less powerful than ``paired``).
@@ -125,12 +130,33 @@ def decide(
                             f"(SE=0 → STRICT fallback, warned; n={n})"),
                     delta=mean_d, threshold=0.0,
                 )
-            bar = k_se * se
+            # Small-sample correction. The bar is k·SE, a *z* multiplier — valid only
+            # when SE is known. Here SE(Δ) is ESTIMATED from the same n deltas, so the
+            # standardized mean difference is t-distributed with df=n-1 (fatter tails).
+            # Using z at small n sets the bar too LOW and accepts noise; we substitute
+            # the t multiplier at the same one-sided significance level. t >= z always,
+            # so this can only make the gate stricter, and it converges to z as n grows.
+            from .stats import t_multiplier_for_z
+            k_eff = t_multiplier_for_z(k_se, n)
+            bar = k_eff * se
             ok = mean_d > bar
+            corr = "" if abs(k_eff - k_se) < 5e-5 else f", t-corrected from {k_se}·SE"
+            low_conf = ""
+            if n < LOW_CONFIDENCE_VAL_TASKS:
+                low_conf = f" [LOW CONFIDENCE: only {n} val tasks]"
+                if run_dir is not None:
+                    log = getattr(run_dir, "log_event", None)
+                    if callable(log):
+                        log("gate_warning", mode="paired", n=n, k_se=k_se, k_eff=round(k_eff, 4),
+                            reason=(f"paired gate decided on only {n} val tasks "
+                                    f"(< {LOW_CONFIDENCE_VAL_TASKS}); a Student-t correction "
+                                    f"(df={n - 1}) widened the bar from {k_se}·SE to "
+                                    f"{k_eff:.4f}·SE, but this decision is low confidence — "
+                                    f"add val tasks or raise n_trials."))
             return GateDecision(
                 accept=ok,
-                reason=(f"paired Δ̄={mean_d:+.4f} {'>' if ok else '<='} {k_se}·SE={bar:.4f} "
-                        f"(SE={se:.4f}, n={n})"),
+                reason=(f"paired Δ̄={mean_d:+.4f} {'>' if ok else '<='} {k_eff:.4f}·SE={bar:.4f} "
+                        f"(SE={se:.4f}, n={n}, df={n - 1}{corr}){low_conf}"),
                 delta=mean_d, threshold=bar,
             )
 

--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import Callable
 
 from . import gate as gate_mod
+from . import splits as splits_mod
 from .loop import SplitResult, aggregate_scores
 from .rundir import RunDir, _atomic_write
 from .splits import Splits, check_val_size, make_splits
@@ -412,6 +413,10 @@ def reuse_baseline(prior_run_dir: Path, *, run_dir: RunDir) -> SplitResult:
     prior_split_obj = Splits.from_dict(json.loads(prior_splits.read_text(encoding="utf-8")))
     fresh_split = Splits(train=list(prior_split_obj.train), val=list(prior_split_obj.val),
                          test=list(prior_split_obj.test), seed=prior_split_obj.seed)
+    # Guard BEFORE writing: a prior run created under CAPEVOLVE_ALLOW_TINY_VAL must not
+    # become a reusable seed for a fresh run that nothing marks as dishonest. Checking
+    # first also means nothing is frozen into this run dir on refusal.
+    check_val_size(fresh_split, context="at baseline reuse", run_dir=run_dir)
     run_dir.write_splits(fresh_split)
 
     # Copy baseline.json verbatim (the recorded seed val score + best_id).
@@ -1967,6 +1972,15 @@ def finalize(adapter, *, run_dir: RunDir, best_dir: Path, n_trials: int = 1, ks=
         payload["test_baseline"] = result.to_dict()
         payload["baseline_id"] = run_dir.best_id
         payload["test_delta"] = 0.0
+
+    # Brand a bypassed run in the durable artifact. A run whose acceptance gate was
+    # not a significance test must not produce a final.json that is byte-identical in
+    # shape to an honest one — report.md and the dashboard both read this back.
+    bypass = splits_mod.bypassed(run_dir)
+    if bypass:
+        payload["honest_gate"] = False
+        payload["warnings"] = [splits_mod.BYPASS_BANNER]
+        payload["tiny_val_bypass"] = bypass
 
     _atomic_write(run_dir.root / "final.json", json.dumps(payload, indent=2))
     run_dir.commit_test()  # burn the seal ONLY now that the result(s) are computed + written

--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -26,7 +26,7 @@ from typing import Callable
 from . import gate as gate_mod
 from .loop import SplitResult, aggregate_scores
 from .rundir import RunDir, _atomic_write
-from .splits import Splits, make_splits
+from .splits import Splits, check_val_size, make_splits
 from .types import Rollout, Score, Task
 
 # An optimizer mutates ``workdir`` in place. It MAY return a dict reporting its own
@@ -89,6 +89,9 @@ def ensure_splits(adapter, run_dir: RunDir, *, seed: int = 0, ratios=(0.5, 0.25,
     else:
         all_tasks = adapter.tasks("all")
         splits = make_splits([t.id for t in all_tasks], seed=seed, ratios=ratios)
+    # Refuse an unusable val split BEFORE freezing it — an empty/1-task val makes the
+    # acceptance gate meaningless, and the whole point of the gate is honesty.
+    check_val_size(splits, context="at split freeze", run_dir=run_dir)
     run_dir.write_splits(splits)
     run_dir.log_event("splits", train=len(splits.train), val=len(splits.val),
                       test=len(splits.test), seed=seed)
@@ -362,6 +365,10 @@ def baseline(adapter, seed_dir: Path, *, run_dir: RunDir, n_trials: int = 1, ks=
     needed and snapshotted as an empty candidate. The optimizer will create the
     initial capability content from the failing trajectories.
     """
+    # Second guard point: a hand-written / resumed splits.json never went through
+    # ensure_splits, so re-check before spending any budget on a run whose gate
+    # could not possibly be honest.
+    check_val_size(run_dir.read_splits(), context="at baseline", run_dir=run_dir)
     seed_dir = Path(seed_dir)
     if not seed_dir.exists():
         # Accept an empty seed, but make it auditable: a typo'd capability_path would

--- a/core/cap_evolve/skillcheck.py
+++ b/core/cap_evolve/skillcheck.py
@@ -83,9 +83,14 @@ def import_module(name: str):
 
 # ---- synthetic run state for behavioral checks ----------------------------
 
-def temp_run_dir(tmp: Path, *, ids=("a", "b", "c", "d"), seed: int = 0,
+def temp_run_dir(tmp: Path, *, ids=("a", "b", "c", "d", "e", "f", "g", "h"), seed: int = 0,
                  ratios=(0.5, 0.25, 0.25)):
-    """A throwaway RunDir with a frozen seeded split over synthetic task ids."""
+    """A throwaway RunDir with a frozen seeded split over synthetic task ids.
+
+    The default is 8 ids so the frozen split satisfies the tiny-val guard (>= 2 val
+    tasks). The old 4-id default produced val=["b"] — a split cap-evolve now refuses —
+    which every skill ``check.py`` would trip on.
+    """
     from cap_evolve import RunDir
     from cap_evolve.splits import make_splits
     rd = RunDir.create(Path(tmp) / ".capevolve", ts="chk")

--- a/core/cap_evolve/splits.py
+++ b/core/cap_evolve/splits.py
@@ -31,43 +31,88 @@ LOW_CONFIDENCE_VAL_TASKS = 5
 #: honest significance test for that run.
 _ALLOW_TINY_ENV = "CAPEVOLVE_ALLOW_TINY_VAL"
 
+#: Marker persisted into the run dir (``state.json``) the first time the escape
+#: hatch actually lets an unusable val split through. Everything downstream that
+#: publishes a number — ``final.json``, ``report.md``, the dashboard — reads it and
+#: brands the run, so a bypassed run can never be mistaken for an honest one.
+BYPASS_STATE_KEY = "tiny_val_bypass"
+
+#: The banner every human-facing artifact of a bypassed run must carry.
+BYPASS_BANNER = (
+    "⚠ NOT AN HONEST GATE — CAPEVOLVE_ALLOW_TINY_VAL was set and the val split is "
+    "below the minimum for a significance test; acceptance decisions in this run are "
+    "meaningless and the held-out numbers must not be published as a benchmark result."
+)
+
 
 class TinyValSplitError(RuntimeError):
     """Raised when the val split is too small for the gate to mean anything."""
 
 
+def tiny_val_allowed() -> bool:
+    """True when the ``CAPEVOLVE_ALLOW_TINY_VAL`` escape hatch is set.
+
+    Single source of truth so the guard and every artifact-branding site agree.
+    """
+    return bool(os.environ.get(_ALLOW_TINY_ENV))
+
+
+def mark_bypass(run_dir, *, val: int, context: str = "") -> None:
+    """Record in the run dir that the tiny-val guard was bypassed.
+
+    Durable (``state.json``), not just an event line: ``final.json``, ``report.md``
+    and the dashboard all read it back, so the brand survives into the artifacts a
+    human actually looks at.
+    """
+    if run_dir is None:
+        return
+    try:
+        state = run_dir._read_state()
+        if state.get(BYPASS_STATE_KEY):
+            return
+        state[BYPASS_STATE_KEY] = {"val": val, "context": context, "banner": BYPASS_BANNER}
+        run_dir._write_state(state)
+    except Exception:  # noqa: BLE001 — branding must never crash a run
+        pass
+    log = getattr(run_dir, "log_event", None)
+    if callable(log):
+        log("split_warning", val=val, bypass=True, context=context, reason=BYPASS_BANNER)
+
+
+def bypassed(run_dir) -> dict | None:
+    """Return the recorded bypass marker for ``run_dir``, or None."""
+    if run_dir is None:
+        return None
+    try:
+        return run_dir._read_state().get(BYPASS_STATE_KEY) or None
+    except Exception:  # noqa: BLE001
+        return None
+
+
 def check_val_size(splits: "Splits", *, context: str = "", run_dir=None) -> str | None:
     """Refuse an unusable val split; warn on a merely small one.
 
-    Called at split-freeze time (``ensure_splits``) and again at ``baseline`` — the
-    two moments a run commits to a val split — so a hand-written or resumed
-    ``splits.json`` cannot sneak past. Returns the warning text when val is small
-    but usable (also logged as a ``split_warning`` event), else ``None``.
+    Called from every path that commits a run to a val split (``ensure_splits``,
+    ``baseline``, ``reuse_baseline``, ``--resume``) *and* from ``gate.decide`` itself,
+    which is the point of decision no caller can route around. Returns the warning
+    text when val is small but usable (also logged as a ``split_warning`` event),
+    else ``None``.
     """
     n = len(splits.val)
     where = f" ({context})" if context else ""
-    if n < MIN_VAL_TASKS and not os.environ.get(_ALLOW_TINY_ENV):
-        detail = ("is EMPTY" if n == 0 else
-                  "has exactly 1 task, so the paired delta has 0 degrees of freedom "
-                  "(SE undefined) and the gate degenerates to 'any Δ>0 wins'")
-        raise TinyValSplitError(
-            f"val split{where} {detail} — the acceptance gate would produce a "
-            f"meaningless decision, so cap-evolve refuses to start.\n"
-            f"  train={len(splits.train)} val={n} test={len(splits.test)}\n"
-            f"Fix one of:\n"
-            f"  1. Add tasks: with the default 0.5/0.25/0.25 ratios you need >= 6 "
-            f"tasks for val >= 2, and >= 20 for val >= 5 (recommended).\n"
-            f"  2. Set explicit ratios, e.g. split_val: 0.4 in capevolve.yaml.\n"
-            f"  3. Pin the split yourself via split_ids_file "
-            f"({{\"train\": [...], \"val\": [...], \"test\": [...]}}).\n"
-            f"  4. Only if you accept a non-honest gate: export "
-            f"{_ALLOW_TINY_ENV}=1."
-        )
+    if n < MIN_VAL_TASKS:
+        if not tiny_val_allowed():
+            raise TinyValSplitError(_tiny_val_message(n, where,
+                                                     len(splits.train), len(splits.test)))
+        # Escape hatch engaged: let it through, but brand the run permanently.
+        mark_bypass(run_dir, val=n, context=context)
+        return BYPASS_BANNER
     if n < LOW_CONFIDENCE_VAL_TASKS:
-        msg = (f"val split{where} has only {n} tasks (< {LOW_CONFIDENCE_VAL_TASKS}) — "
-               f"acceptance decisions are LOW CONFIDENCE. The gate applies a "
-               f"Student-t small-sample correction (df={max(n - 1, 0)}), which widens "
-               f"the bar, but the honest fix is more val tasks.")
+        msg = (f"val split{where} has only {n} task{'' if n == 1 else 's'} "
+               f"(< {LOW_CONFIDENCE_VAL_TASKS}) — acceptance decisions are LOW "
+               f"CONFIDENCE. The gate applies a Student-t small-sample correction "
+               f"(df={n - 1}), which widens the bar, but the honest fix is more "
+               f"val tasks.")
         if run_dir is not None:
             log = getattr(run_dir, "log_event", None)
             if callable(log):
@@ -75,6 +120,41 @@ def check_val_size(splits: "Splits", *, context: str = "", run_dir=None) -> str 
                     reason=msg)
         return msg
     return None
+
+
+def _tiny_val_message(n: int, where: str, n_train: int, n_test: int) -> str:
+    detail = ("is EMPTY" if n == 0 else
+              "has exactly 1 task, so the paired delta has 0 degrees of freedom "
+              "(SE undefined) and the gate degenerates to 'any Δ>0 wins'")
+    # Remediation 2 is stated as a FULL ratio triple, because the CLI always builds
+    # all three (`split_train,split_val,split_test`) — setting only `split_val: 0.4`
+    # leaves (0.5, 0.4, 0.25), which still yields val=1 at n=3 and n=4, i.e. exactly
+    # the users who see this error. 0.25/0.5/0.25 is verified to give val>=2 AND
+    # test>=1 AND train>=1 for every n >= 4.
+    return (
+        f"val split{where} {detail} — the acceptance gate would produce a "
+        f"meaningless decision, so cap-evolve refuses to start.\n"
+        f"  train={n_train} val={n} test={n_test}\n"
+        f"Fix one of:\n"
+        f"  1. Add tasks: with the default 0.5/0.25/0.25 ratios you need >= 6 "
+        f"tasks for val >= 2, and >= 20 for val >= 5 (recommended).\n"
+        f"  2. With 4 or 5 tasks, set ALL THREE ratios so val gets the biggest "
+        f"share — in capevolve.yaml:\n"
+        f"       split_train: 0.25\n"
+        f"       split_val:   0.5\n"
+        f"       split_test:  0.25\n"
+        f"     (val >= 2 for every n >= 4. Setting split_val alone does NOT work: "
+        f"the other two keep their defaults, giving 0.5/0.4/0.25 → val=1 at n=3 "
+        f"and n=4.)\n"
+        f"  3. Pin the split yourself via split_ids_file "
+        f"({{\"train\": [...], \"val\": [...], \"test\": [...]}}) — val needs >= 2 ids "
+        f"AND test needs >= 1, or finalize fails later.\n"
+        f"  4. Only if you accept a non-honest gate: export "
+        f"{_ALLOW_TINY_ENV}=1. The run's report.md, final.json and dashboard will "
+        f"be permanently branded '{BYPASS_BANNER[:32]}…'.\n"
+        f"  NOTE: with exactly 3 tasks no ratio can work — val >= 2 leaves only 1 "
+        f"task for train+test, so one of them is empty. Add a 4th task."
+    )
 
 
 class TestSealError(RuntimeError):

--- a/core/cap_evolve/splits.py
+++ b/core/cap_evolve/splits.py
@@ -11,9 +11,70 @@ splits written at intake/baseline time.
 
 from __future__ import annotations
 
+import os
 import random
 from dataclasses import dataclass, field
 from typing import Sequence
+
+#: Below this many val tasks the significance gate is statistically meaningless.
+#: n=0 → nothing to decide on; n=1 → SE(Δ) is undefined (df=0) so the gate always
+#: degenerates to "any Δ>0 wins". Both are hard errors.
+MIN_VAL_TASKS = 2
+
+#: Below this many val tasks the gate still runs but is flagged low-confidence:
+#: with df=n-1 <= 3 the t bar is wide and a couple of lucky per-task deltas
+#: dominate. Warned, not refused.
+LOW_CONFIDENCE_VAL_TASKS = 5
+
+#: Escape hatch for deliberately degenerate runs (smoke tests, single-task
+#: debugging). Setting it means you accept that the acceptance gate is NOT an
+#: honest significance test for that run.
+_ALLOW_TINY_ENV = "CAPEVOLVE_ALLOW_TINY_VAL"
+
+
+class TinyValSplitError(RuntimeError):
+    """Raised when the val split is too small for the gate to mean anything."""
+
+
+def check_val_size(splits: "Splits", *, context: str = "", run_dir=None) -> str | None:
+    """Refuse an unusable val split; warn on a merely small one.
+
+    Called at split-freeze time (``ensure_splits``) and again at ``baseline`` — the
+    two moments a run commits to a val split — so a hand-written or resumed
+    ``splits.json`` cannot sneak past. Returns the warning text when val is small
+    but usable (also logged as a ``split_warning`` event), else ``None``.
+    """
+    n = len(splits.val)
+    where = f" ({context})" if context else ""
+    if n < MIN_VAL_TASKS and not os.environ.get(_ALLOW_TINY_ENV):
+        detail = ("is EMPTY" if n == 0 else
+                  "has exactly 1 task, so the paired delta has 0 degrees of freedom "
+                  "(SE undefined) and the gate degenerates to 'any Δ>0 wins'")
+        raise TinyValSplitError(
+            f"val split{where} {detail} — the acceptance gate would produce a "
+            f"meaningless decision, so cap-evolve refuses to start.\n"
+            f"  train={len(splits.train)} val={n} test={len(splits.test)}\n"
+            f"Fix one of:\n"
+            f"  1. Add tasks: with the default 0.5/0.25/0.25 ratios you need >= 6 "
+            f"tasks for val >= 2, and >= 20 for val >= 5 (recommended).\n"
+            f"  2. Set explicit ratios, e.g. split_val: 0.4 in capevolve.yaml.\n"
+            f"  3. Pin the split yourself via split_ids_file "
+            f"({{\"train\": [...], \"val\": [...], \"test\": [...]}}).\n"
+            f"  4. Only if you accept a non-honest gate: export "
+            f"{_ALLOW_TINY_ENV}=1."
+        )
+    if n < LOW_CONFIDENCE_VAL_TASKS:
+        msg = (f"val split{where} has only {n} tasks (< {LOW_CONFIDENCE_VAL_TASKS}) — "
+               f"acceptance decisions are LOW CONFIDENCE. The gate applies a "
+               f"Student-t small-sample correction (df={max(n - 1, 0)}), which widens "
+               f"the bar, but the honest fix is more val tasks.")
+        if run_dir is not None:
+            log = getattr(run_dir, "log_event", None)
+            if callable(log):
+                log("split_warning", val=n, min_recommended=LOW_CONFIDENCE_VAL_TASKS,
+                    reason=msg)
+        return msg
+    return None
 
 
 class TestSealError(RuntimeError):

--- a/core/cap_evolve/stats.py
+++ b/core/cap_evolve/stats.py
@@ -8,6 +8,10 @@ References:
 - tau-bench / tau2-bench pass^k (probability all k i.i.d. trials succeed).
 - prior agent-optimization work ``eval/base.py`` combined_stderr (mixes between-sample and within-sample
   trial error).
+- Student's t CDF via the regularized incomplete beta function: Abramowitz &
+  Stegun, *Handbook of Mathematical Functions* (1964) §26.7.1; the continued
+  fraction for I_x(a,b) is Numerical Recipes in C (2nd ed.) §6.4 ``betacf``
+  with Lentz's modification.
 """
 
 from __future__ import annotations
@@ -113,3 +117,118 @@ def bootstrap_ci(xs: Sequence[float], confidence: float = 0.95, resamples: int =
 def aggregate(per_task_means: Sequence[float]) -> float:
     """Headline score = mean reward across tasks."""
     return mean(per_task_means)
+
+
+# ---- small-sample (Student's t) machinery ---------------------------------
+#
+# Why this exists: the significance gate's bar is ``k·SE``, i.e. a *z* multiplier.
+# That is only valid when SE is known / n is large. With n val tasks the paired SE
+# is ESTIMATED from the same n deltas, so the standardized mean difference follows
+# a t distribution with df = n-1, whose tails are fatter than the normal's. Using
+# z at small n therefore sets the bar TOO LOW and accepts noise — precisely the
+# failure the gate exists to prevent. ``t_critical`` returns the t multiplier at
+# the same one-sided significance level as the requested z, so the bar widens at
+# small n and converges to k as n grows.
+
+
+def _betacf(a: float, b: float, x: float) -> float:
+    """Continued fraction for the incomplete beta function (NR in C 2e §6.4)."""
+    tiny, eps, itmax = 1e-30, 3e-16, 300
+    qab, qap, qam = a + b, a + 1.0, a - 1.0
+    c = 1.0
+    d = 1.0 - qab * x / qap
+    if abs(d) < tiny:
+        d = tiny
+    d = 1.0 / d
+    h = d
+    for m in range(1, itmax + 1):
+        m2 = 2 * m
+        aa = m * (b - m) * x / ((qam + m2) * (a + m2))
+        d = 1.0 + aa * d
+        if abs(d) < tiny:
+            d = tiny
+        c = 1.0 + aa / c
+        if abs(c) < tiny:
+            c = tiny
+        d = 1.0 / d
+        h *= d * c
+        aa = -(a + m) * (qab + m) * x / ((a + m2) * (qap + m2))
+        d = 1.0 + aa * d
+        if abs(d) < tiny:
+            d = tiny
+        c = 1.0 + aa / c
+        if abs(c) < tiny:
+            c = tiny
+        d = 1.0 / d
+        delta = d * c
+        h *= delta
+        if abs(delta - 1.0) < eps:
+            break
+    return h
+
+
+def betainc(a: float, b: float, x: float) -> float:
+    """Regularized incomplete beta I_x(a,b). Stdlib-only (A&S §26.5.8)."""
+    if x <= 0.0:
+        return 0.0
+    if x >= 1.0:
+        return 1.0
+    lbeta = math.lgamma(a + b) - math.lgamma(a) - math.lgamma(b)
+    front = math.exp(lbeta + a * math.log(x) + b * math.log(1.0 - x))
+    if x < (a + 1.0) / (a + b + 2.0):
+        return front * _betacf(a, b, x) / a
+    return 1.0 - front * _betacf(b, a, 1.0 - x) / b
+
+
+def t_cdf(t: float, df: float) -> float:
+    """P(T <= t) for Student's t with ``df`` degrees of freedom (A&S §26.7.1)."""
+    if df <= 0:
+        return float("nan")
+    if t == 0.0:
+        return 0.5
+    x = df / (df + t * t)
+    tail = 0.5 * betainc(df / 2.0, 0.5, x)   # P(T > |t|)
+    return 1.0 - tail if t > 0 else tail
+
+
+def normal_sf(z: float) -> float:
+    """One-sided upper tail P(Z > z) of the standard normal."""
+    return 0.5 * math.erfc(z / math.sqrt(2.0))
+
+
+def t_critical(alpha: float, df: float) -> float:
+    """One-sided t critical value: the ``t`` with P(T > t) == ``alpha``.
+
+    Solved by bisection on the monotone CDF — no scipy, no lookup table, exact to
+    1e-10 for any df >= 1 (so it also covers non-integer k_se-derived alphas).
+    """
+    if df <= 0 or not (0.0 < alpha < 0.5):
+        return float("inf") if df <= 0 else 0.0
+    lo, hi = 0.0, 1.0
+    while t_cdf(hi, df) < 1.0 - alpha and hi < 1e12:
+        hi *= 2.0
+    for _ in range(200):
+        mid = (lo + hi) / 2.0
+        if t_cdf(mid, df) < 1.0 - alpha:
+            lo = mid
+        else:
+            hi = mid
+        if hi - lo < 1e-11:
+            break
+    return (lo + hi) / 2.0
+
+
+def t_multiplier_for_z(k_se: float, n: int) -> float:
+    """The t multiplier matching a z multiplier ``k_se`` at sample size ``n``.
+
+    Converts ``k_se`` to its one-sided normal significance level α, then returns
+    ``t_{1-α, df=n-1}``. Always >= ``k_se`` (t tails are fatter than z), so the
+    gate can only get STRICTER; the ratio → 1 as n grows.
+    Returns ``k_se`` unchanged when there is no usable df (n < 2).
+    """
+    if n < 2 or k_se <= 0:
+        return k_se
+    alpha = normal_sf(k_se)
+    if not (0.0 < alpha < 0.5):
+        return k_se
+    return max(k_se, t_critical(alpha, n - 1))

--- a/core/cap_evolve/stats.py
+++ b/core/cap_evolve/stats.py
@@ -164,6 +164,11 @@ def _betacf(a: float, b: float, x: float) -> float:
         h *= delta
         if abs(delta - 1.0) < eps:
             break
+    else:
+        raise RuntimeError(
+            f"incomplete beta continued fraction failed to converge in {itmax} "
+            f"iterations at a={a!r} b={b!r} x={x!r}"
+        )
     return h
 
 
@@ -180,15 +185,33 @@ def betainc(a: float, b: float, x: float) -> float:
     return 1.0 - front * _betacf(b, a, 1.0 - x) / b
 
 
-def t_cdf(t: float, df: float) -> float:
-    """P(T <= t) for Student's t with ``df`` degrees of freedom (A&S §26.7.1)."""
+def t_sf(t: float, df: float) -> float:
+    """Upper tail P(T > t) for Student's t, computed WITHOUT cancellation.
+
+    This is the tail-space primitive everything else is built on. ``t_cdf`` has to
+    form ``1 - tail``, which is exactly ``1.0`` in float64 once ``tail < 1.1e-16``;
+    ``t_sf`` never does that subtraction, so it stays accurate into the far tail
+    (α down to ~1e-300) and is the only safe thing to root-find against.
+    """
     if df <= 0:
         return float("nan")
     if t == 0.0:
         return 0.5
     x = df / (df + t * t)
     tail = 0.5 * betainc(df / 2.0, 0.5, x)   # P(T > |t|)
-    return 1.0 - tail if t > 0 else tail
+    return tail if t > 0 else 1.0 - tail
+
+
+def t_cdf(t: float, df: float) -> float:
+    """P(T <= t) for Student's t with ``df`` degrees of freedom (A&S §26.7.1).
+
+    Note: for ``t`` in the far upper tail this saturates at exactly 1.0 (the tail
+    mass is below float64 resolution next to 1). Use ``t_sf`` whenever you care
+    about the tail — in particular never root-find on ``1 - alpha`` here.
+    """
+    if df <= 0:
+        return float("nan")
+    return 1.0 - t_sf(t, df)
 
 
 def normal_sf(z: float) -> float:
@@ -196,39 +219,87 @@ def normal_sf(z: float) -> float:
     return 0.5 * math.erfc(z / math.sqrt(2.0))
 
 
+#: The documented supported range for ``k_se``. Above this the inversion is not
+#: representable for every df: the answer scales like α^(−1/df), so at df=1 it needs
+#: a ``t`` whose square overflows float64 (α ≈ 1e-155 → t ≈ 1e155, t² = inf). 26.5 is
+#: the largest z for which every df from 1 upward inverts cleanly. Anything above
+#: raises — a k_se this large rejects everything anyway, and returning the
+#: uncorrected z bar instead (what the old ``max()`` clamp did) is the one outcome
+#: this module must never produce.
+MAX_SUPPORTED_K_SE = 26.5
+
+
 def t_critical(alpha: float, df: float) -> float:
     """One-sided t critical value: the ``t`` with P(T > t) == ``alpha``.
 
-    Solved by bisection on the monotone CDF — no scipy, no lookup table, exact to
-    1e-10 for any df >= 1 (so it also covers non-integer k_se-derived alphas).
+    Bisects on the *survival function* (``t_sf``), never on ``1 - alpha``: the
+    latter is exactly 1.0 in float64 for α below ~1.1e-16, which silently turns
+    the search into a garbage plateau. Bracketing is geometric so the enormous
+    dynamic range (t up to ~1e157 at α~1e-300) is covered, and the answer is
+    VERIFIED against ``t_sf`` before it is returned — a wrong critical value in
+    the acceptance gate must be an exception, never a number.
+
+    Raises ``ValueError`` for α outside (0, 0.5) or df <= 0 (both are programming
+    errors, and a sentinel would get silently multiplied by an SE), and
+    ``RuntimeError`` if the solved value does not reproduce ``alpha`` — which is
+    the only remaining failure mode, hit when the answer needs a ``t`` so large
+    that ``t*t`` overflows float64 (α below ~1e-155 at df=1). Loud, never silent.
     """
-    if df <= 0 or not (0.0 < alpha < 0.5):
-        return float("inf") if df <= 0 else 0.0
+    if df <= 0:
+        raise ValueError(f"t_critical needs df > 0, got {df!r}")
+    if not (0.0 < alpha < 0.5):
+        raise ValueError(
+            f"t_critical needs 0 < alpha < 0.5, got {alpha!r} "
+            "(alpha <= 0 usually means an upstream float64 underflow)"
+        )
     lo, hi = 0.0, 1.0
-    while t_cdf(hi, df) < 1.0 - alpha and hi < 1e12:
-        hi *= 2.0
-    for _ in range(200):
+    while t_sf(hi, df) > alpha:
+        lo, hi = hi, hi * 2.0
+        if hi > 1e300:
+            raise RuntimeError(f"t_critical could not bracket alpha={alpha!r} at df={df!r}")
+    for _ in range(400):
         mid = (lo + hi) / 2.0
-        if t_cdf(mid, df) < 1.0 - alpha:
+        if t_sf(mid, df) > alpha:
             lo = mid
         else:
             hi = mid
-        if hi - lo < 1e-11:
+        if hi - lo <= 1e-12 * max(1.0, hi):
             break
-    return (lo + hi) / 2.0
+    t = (lo + hi) / 2.0
+    got = t_sf(t, df)
+    if not math.isfinite(got) or abs(got - alpha) > 1e-6 * alpha:
+        raise RuntimeError(
+            f"t_critical failed to invert alpha={alpha!r} at df={df!r}: "
+            f"solved t={t!r} has P(T>t)={got!r}"
+        )
+    return t
 
 
 def t_multiplier_for_z(k_se: float, n: int) -> float:
     """The t multiplier matching a z multiplier ``k_se`` at sample size ``n``.
 
     Converts ``k_se`` to its one-sided normal significance level α, then returns
-    ``t_{1-α, df=n-1}``. Always >= ``k_se`` (t tails are fatter than z), so the
-    gate can only get STRICTER; the ratio → 1 as n grows.
-    Returns ``k_se`` unchanged when there is no usable df (n < 2).
+    ``t_{1-α, df=n-1}``. ``t_{1-α,df} >= z_{1-α}`` is a theorem for every finite
+    df (t has strictly fatter tails), so no ``max(k_se, ...)`` clamp is needed —
+    and a clamp would be actively harmful: its only live effect would be to
+    convert a numerically failed inversion into a silent revert to the raw z bar,
+    i.e. exactly the bug this correction exists to fix. Invalid input raises.
+
+    Returns ``k_se`` unchanged only when there is genuinely no df (n < 2) or the
+    bar is degenerate (k_se <= 0).
     """
     if n < 2 or k_se <= 0:
         return k_se
+    if k_se > MAX_SUPPORTED_K_SE:
+        raise ValueError(
+            f"k_se={k_se} exceeds the supported range (<= {MAX_SUPPORTED_K_SE}): its "
+            "one-sided normal tail underflows float64, so no Student-t correction can "
+            "be computed. A bar this wide rejects everything anyway — use k_se <= 3."
+        )
     alpha = normal_sf(k_se)
     if not (0.0 < alpha < 0.5):
-        return k_se
-    return max(k_se, t_critical(alpha, n - 1))
+        raise ValueError(
+            f"k_se={k_se} maps to a one-sided alpha of {alpha!r}, outside (0, 0.5); "
+            "cannot compute a Student-t multiplier."
+        )
+    return t_critical(alpha, n - 1)

--- a/core/tests/test_empty_seed.py
+++ b/core/tests/test_empty_seed.py
@@ -130,7 +130,9 @@ def _toy_adapter():
 
     class EmptyAdapter(CapabilityAdapter):
         def tasks(self, split):
-            return [Task(id=f"t{i}", input=f"input-{i}") for i in range(4)]
+            # 8 tasks (not 4): with the default 0.5/0.25/0.25 ratios, 4 tasks yield a
+            # 1-task val split, which check_val_size now rightly refuses (issue #113).
+            return [Task(id=f"t{i}", input=f"input-{i}") for i in range(8)]
         def run_target(self, task, ctx, *, seed=0):
             return Rollout(task_id=task.id, output="empty", trace="empty trajectory")
         def score(self, task, rollout):

--- a/core/tests/test_small_samples.py
+++ b/core/tests/test_small_samples.py
@@ -224,3 +224,368 @@ def test_large_n_has_no_low_confidence_flag():
     d = decide(0.5, 0.6, split="val", mode="paired",
                paired_deltas=[0.1] * 9 + [0.05], k_se=1.0)
     assert "LOW CONFIDENCE" not in d.reason
+
+
+# ---- review fixes: one regression test per blocking finding ----------------
+#
+# The PR's original guard sat at ensure_splits + baseline only. Review found three
+# production paths that reach a gate decision without passing either, plus a
+# silently-wrong t critical value and a remediation string that doesn't work.
+
+def _val1_run_dir(tmp_path, ts="v1"):
+    """A run dir with a hand-written val=1 splits.json + baseline.json (the exact
+    shape a resumed / copied run has)."""
+    import json
+
+    from cap_evolve import RunDir
+    rd = RunDir.create(tmp_path / ".capevolve", ts=ts)
+    rd.write_splits(Splits(train=["t0"], val=["t1"], test=["t2"], seed=0))
+    (rd.root / "baseline.json").write_text(
+        json.dumps({"val": {"reward": 0.0, "stderr": 0.0}, "best_id": "seed"}), encoding="utf-8")
+    return rd
+
+
+def _load_phase_script(phase):
+    """Import a phase's ``run.py`` under a unique module name.
+
+    Every phase ships a module literally named ``run``, so ``import run`` returns
+    whichever one got cached first.
+    """
+    import importlib.util
+    path = REPO / "skills" / "phases" / phase / "scripts" / "run.py"
+    sys.path.insert(0, str(path.parent))
+    try:
+        spec = importlib.util.spec_from_file_location(f"_phase_{phase}_run", path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+    finally:
+        sys.path.remove(str(path.parent))
+
+
+# --- BLOCKING 1: harness.reuse_baseline copied splits.json before any guard ---
+
+def test_reuse_baseline_refuses_tiny_val(tmp_path, monkeypatch):
+    """A prior run's val=1 split must not be resurrectable into a fresh run.
+
+    Before the fix ``reuse_baseline`` returned before ``baseline()`` ran, so an
+    escape-hatch run's split became a reusable seed for later runs that nothing
+    marked as dishonest.
+    """
+    from cap_evolve import RunDir, harness
+    monkeypatch.delenv("CAPEVOLVE_ALLOW_TINY_VAL", raising=False)
+    prior = _val1_run_dir(tmp_path / "prior", ts="prior")
+    fresh = RunDir.create(tmp_path / "fresh" / ".capevolve", ts="fresh")
+    with pytest.raises(TinyValSplitError) as ei:
+        harness.reuse_baseline(prior.root, run_dir=fresh)
+    assert "at baseline reuse" in str(ei.value)
+    # Refused BEFORE freezing: nothing was written into the fresh run dir.
+    assert not fresh.splits_path.exists()
+
+
+def test_reuse_baseline_accepts_healthy_val(tmp_path, monkeypatch):
+    """The guard is not overreach: a normal split still reuses fine."""
+    import json
+
+    from cap_evolve import RunDir, harness
+    monkeypatch.delenv("CAPEVOLVE_ALLOW_TINY_VAL", raising=False)
+    prior = RunDir.create(tmp_path / "prior" / ".capevolve", ts="p2")
+    prior.write_splits(make_splits([f"t{i}" for i in range(20)], seed=0))
+    (prior.root / "baseline.json").write_text(
+        json.dumps({"val": {"reward": 0.25, "stderr": 0.1}, "best_id": "seed"}), encoding="utf-8")
+    fresh = RunDir.create(tmp_path / "fresh" / ".capevolve", ts="f2")
+    res = harness.reuse_baseline(prior.root, run_dir=fresh)
+    assert res.reward == 0.25
+    assert len(fresh.read_splits().val) >= MIN_VAL_TASKS
+
+
+# --- BLOCKING 2: the baseline --resume fast path returned before any guard ---
+
+def test_baseline_resume_fast_path_refuses_tiny_val(tmp_path, monkeypatch):
+    """``baseline --resume`` on a val=1 run dir must fail, not exit 0."""
+    monkeypatch.delenv("CAPEVOLVE_ALLOW_TINY_VAL", raising=False)
+    rd = _val1_run_dir(tmp_path, ts="res")
+    mod = _load_phase_script("baseline")
+    with pytest.raises(TinyValSplitError) as ei:
+        mod.main(["--base", str(tmp_path / ".capevolve"), "--project", str(tmp_path),
+                  "--capability", str(tmp_path / "cap"), "--run-ts", "res", "--resume"])
+    assert "at resume" in str(ei.value)
+    assert rd.root.exists()  # sanity: we really did target the prepared dir
+
+
+# --- BLOCKING 1+2+7: the chokepoint — gate.decide itself refuses n<2 ---------
+
+@pytest.mark.parametrize("deltas", [[0.5], [0.0], [-0.3], []])
+def test_gate_decide_itself_refuses_fewer_than_two_pairs(deltas, monkeypatch):
+    """No caller can reach an accept/reject with n<2, whatever path it came from.
+
+    ``[]`` is the documented fall-through to ``significant`` (no paired data at all),
+    so only n==1 raises; both are covered here so the boundary is pinned.
+    """
+    monkeypatch.delenv("CAPEVOLVE_ALLOW_TINY_VAL", raising=False)
+    if not deltas:
+        d = decide(0.5, 0.6, split="val", mode="paired", paired_deltas=deltas, k_se=1.0)
+        assert "Δ=" in d.reason  # fell through to the independent significance test
+        return
+    with pytest.raises(TinyValSplitError) as ei:
+        decide(0.5, 0.6, split="val", mode="paired", paired_deltas=deltas, k_se=1.0)
+    assert "gate refused" in str(ei.value)
+    assert f">= {MIN_VAL_TASKS}" in str(ei.value)
+
+
+def test_gate_refuses_collapsed_pair_count_from_healthy_split(monkeypatch):
+    """Finding 7: a candidate that errored on 4 of 5 val tasks leaves n=1 pairs.
+
+    The split is healthy, so ``check_val_size`` on the split cannot catch this — only
+    the guard inside ``decide`` can. Before the fix this was ACCEPTED via the SE=0
+    strict fallback (a candidate that crashed on 80% of val).
+    """
+    monkeypatch.delenv("CAPEVOLVE_ALLOW_TINY_VAL", raising=False)
+    healthy = make_splits([f"t{i}" for i in range(20)], seed=0)
+    assert len(healthy.val) >= LOW_CONFIDENCE_VAL_TASKS  # split itself is fine
+    with pytest.raises(TinyValSplitError):
+        decide(0.5, 0.6, split="val", mode="paired", paired_deltas=[0.0999], k_se=1.0)
+
+
+def test_gate_with_two_pairs_still_decides(monkeypatch):
+    """n==2 is the boundary and must still work (df=1, the 1.837x bar)."""
+    monkeypatch.delenv("CAPEVOLVE_ALLOW_TINY_VAL", raising=False)
+    d = decide(0.5, 0.6, split="val", mode="paired", paired_deltas=[0.0, 0.2], k_se=1.0)
+    assert d.accept is False  # Δ̄=0.10 <= 1.8373*0.10
+    assert "df=1" in d.reason
+
+
+def test_gate_bypass_env_lets_n1_through_but_marks_it(tmp_path, monkeypatch):
+    """The escape hatch still works at the gate — and brands the run dir."""
+    from cap_evolve import RunDir
+    from cap_evolve.splits import bypassed
+    monkeypatch.setenv("CAPEVOLVE_ALLOW_TINY_VAL", "1")
+    rd = RunDir.create(tmp_path / ".capevolve", ts="byp")
+    d = decide(0.5, 0.6, split="val", mode="paired", paired_deltas=[0.5], k_se=1.0, run_dir=rd)
+    assert d.accept is True
+    mark = bypassed(rd)
+    assert mark and mark["val"] == 1 and "NOT AN HONEST GATE" in mark["banner"]
+
+
+# --- BLOCKING 3: bypassed runs are branded in the durable artifacts ---------
+
+def test_bypass_marker_is_durable_and_reaches_final_json(tmp_path, monkeypatch):
+    import json
+
+    from cap_evolve import RunDir
+    from cap_evolve.splits import BYPASS_BANNER, bypassed, check_val_size
+    monkeypatch.setenv("CAPEVOLVE_ALLOW_TINY_VAL", "1")
+    rd = RunDir.create(tmp_path / ".capevolve", ts="mark")
+    msg = check_val_size(Splits(train=["a"], val=["b"], test=["c"]),
+                         context="at split freeze", run_dir=rd)
+    assert msg == BYPASS_BANNER
+    # Durable in state.json, not just an event line that scrolls away.
+    assert bypassed(rd)["val"] == 1
+    assert "tiny_val_bypass" in (rd.root / "state.json").read_text(encoding="utf-8")
+    # And it is what finalize stamps into final.json.
+    payload = {"test": {"reward": 0.0}, "best_id": "seed"}
+    b = bypassed(rd)
+    payload.update({"honest_gate": False, "warnings": [BYPASS_BANNER], "tiny_val_bypass": b})
+    assert json.loads(json.dumps(payload))["honest_gate"] is False
+
+
+def test_report_md_brands_a_bypassed_run(tmp_path, monkeypatch):
+    """report.md must LEAD with the banner and retract the honesty claim."""
+    import json
+
+    from cap_evolve import RunDir
+    monkeypatch.setenv("CAPEVOLVE_ALLOW_TINY_VAL", "1")
+    rd = RunDir.create(tmp_path / ".capevolve", ts="rep")
+    rd.write_splits(Splits(train=["a"], val=["b"], test=["c"]))
+    rd.set_best("cand_0001")
+    from cap_evolve.splits import check_val_size
+    check_val_size(rd.read_splits(), context="at split freeze", run_dir=rd)
+    (rd.root / "baseline.json").write_text(json.dumps({"val": {"reward": 0.0}}), encoding="utf-8")
+    (rd.root / "final.json").write_text(json.dumps({
+        "test": {"reward": 0.5}, "best_id": "cand_0001", "baseline_id": "seed",
+        "test_baseline": {"reward": 0.0}, "test_delta": 0.5, "honest_gate": False,
+    }), encoding="utf-8")
+    rep = _load_phase_script("report")
+    assert rep.main(["--run-dir", str(rd.root), "--no-dashboard"]) == 0
+    md = (rd.root / "report.md").read_text(encoding="utf-8")
+    assert "NOT AN HONEST GATE" in md
+    assert "Honest gate: no — BYPASSED" in md
+    # The old text claimed the improvement was honest; it must now be retracted.
+    assert "NOT AN HONEST RESULT" in md
+    assert md.index("NOT AN HONEST GATE") < md.index("Held-out test")
+
+
+def test_dashboard_surfaces_split_warning_and_banner(tmp_path, monkeypatch):
+    """dashboard.py had NO split_warning branch at all, and no banner."""
+    import json
+
+    from cap_evolve import RunDir, dashboard
+    from cap_evolve.splits import check_val_size
+    monkeypatch.setenv("CAPEVOLVE_ALLOW_TINY_VAL", "1")
+    rd = RunDir.create(tmp_path / ".capevolve", ts="dash")
+    rd.write_splits(Splits(train=["a"], val=["b"], test=["c"]))
+    check_val_size(rd.read_splits(), context="at split freeze", run_dir=rd)
+    (rd.root / "baseline.json").write_text(json.dumps({"val": {"reward": 0.0}}), encoding="utf-8")
+    reduced = dashboard.reduce_run(rd)
+    s = reduced["summary"]
+    assert s["honesty_banner"] and "NOT AN HONEST GATE" in s["honesty_banner"]
+    assert any("NOT AN HONEST GATE" in (w.get("reason") or "") for w in s["gate_warnings"])
+    ansi = dashboard.render_ansi(reduced, color=False)
+    assert "NOT AN HONEST GATE" in ansi
+    html = dashboard.render_html(reduced) if hasattr(dashboard, "render_html") else ""
+    if html:
+        assert "honesty_banner" in html
+
+
+def test_honest_run_has_no_banner(tmp_path):
+    """The branding must not fire on a normal run."""
+    import json
+
+    from cap_evolve import RunDir, dashboard
+    rd = RunDir.create(tmp_path / ".capevolve", ts="ok")
+    rd.write_splits(make_splits([f"t{i}" for i in range(20)], seed=0))
+    (rd.root / "baseline.json").write_text(json.dumps({"val": {"reward": 0.0}}), encoding="utf-8")
+    assert dashboard.reduce_run(rd)["summary"]["honesty_banner"] is None
+
+
+def test_split_warning_does_not_claim_a_correction_at_df_zero(tmp_path, monkeypatch):
+    """The old warning said 'Student-t correction (df=0)' at n<2 — a lie: at n<2 the
+    gate takes the SE=0 strict fallback and no correction is applied."""
+    from cap_evolve import RunDir
+    from cap_evolve.splits import check_val_size
+    monkeypatch.setenv("CAPEVOLVE_ALLOW_TINY_VAL", "1")
+    rd = RunDir.create(tmp_path / ".capevolve", ts="lie")
+    msg = check_val_size(Splits(train=["a"], val=["b"], test=["c"]), run_dir=rd)
+    assert "df=0" not in msg
+    assert "Student-t" not in msg
+
+
+# --- BLOCKING 4: t_critical is correct-or-loud, never silently wrong --------
+
+def _indep_t_inv_df2(alpha):
+    """Independent closed-form inverse for df=2, zero shared code with stats.py.
+
+    P(T>t) = 1/(A(A+t)) with A=sqrt(2+t^2)  =>  with S=1/alpha,  t=(S-2)/sqrt(2S-2).
+    Algebraically cancellation-free, so it stays exact into the far tail.
+    """
+    S = 1.0 / alpha
+    return (S - 2.0) / math.sqrt(2.0 * S - 2.0)
+
+
+@pytest.mark.parametrize("k_se", [1.0, 2.0, 5.0, 7.0, 8.0, 8.3, 10.0, 20.0, 26.5])
+def test_t_multiplier_matches_independent_closed_form_at_high_k(k_se):
+    """The measured errors were -5.9% at k=8, -29% at k=8.3, saturated 10..38."""
+    got = stats.t_multiplier_for_z(k_se, 3)          # df = 2
+    want = _indep_t_inv_df2(stats.normal_sf(k_se))
+    assert got == pytest.approx(want, rel=1e-9), f"k_se={k_se}: {got} vs {want}"
+
+
+def test_t_multiplier_is_strictly_monotonic_in_k_se():
+    """It used to SATURATE at a constant for k_se 10..38, so raising the bar did
+    nothing at all."""
+    vals = [stats.t_multiplier_for_z(k, 3) for k in (8.0, 8.3, 10.0, 15.0, 20.0, 26.5)]
+    assert all(b > a for a, b in zip(vals, vals[1:])), vals
+
+
+@pytest.mark.parametrize("k_se", [26.6, 30.0, 38.5, 40.0, 100.0])
+def test_t_multiplier_raises_instead_of_silently_reverting_to_z(k_se):
+    """At k_se >= ~38.5 the normal tail underflows to 0.0. The old code returned the
+    RAW k_se — i.e. the uncorrected z bar, the original bug, with no warning."""
+    with pytest.raises(ValueError) as ei:
+        stats.t_multiplier_for_z(k_se, 3)
+    assert "supported range" in str(ei.value)
+    # and the answer is emphatically not the silent z revert
+    assert str(k_se) in str(ei.value)
+
+
+def test_t_critical_raises_on_invalid_inputs_instead_of_sentinels():
+    """0.0 / inf sentinels get silently multiplied by an SE (nit 12)."""
+    for alpha in (0.0, -0.1, 0.5, 0.9, 1.0):
+        with pytest.raises(ValueError):
+            stats.t_critical(alpha, 5)
+    for df in (0, -1):
+        with pytest.raises(ValueError):
+            stats.t_critical(0.05, df)
+
+
+def test_t_sf_is_cancellation_free_in_the_far_tail():
+    """``t_cdf`` saturates at 1.0 below ~1e-16 of tail mass; ``t_sf`` must not.
+
+    Cross-checked against the exact df=2 form 1/(A(A+t)), A=sqrt(2+t^2).
+    """
+    for t in (1e3, 1e6, 1e7, 1e8, 1e12):
+        A = math.sqrt(2.0 + t * t)
+        assert stats.t_sf(t, 2) == pytest.approx(1.0 / (A * (A + t)), rel=1e-12)
+    assert stats.t_cdf(1e12, 2) == 1.0        # documented saturation
+    assert stats.t_sf(1e12, 2) > 0.0          # tail space still resolves it
+
+
+def test_t_multiplier_never_falls_below_k_se():
+    """t >= z is a theorem; the removed max() clamp bound in 0 of ~30k cases, so
+    dropping it must not change any valid answer."""
+    for k in (0.05, 0.2, 0.5, 1.0, 2.0, 3.0):
+        for n in (2, 3, 5, 10, 100, 3000):
+            assert stats.t_multiplier_for_z(k, n) >= k
+
+
+def test_betainc_raises_on_non_convergence(monkeypatch):
+    """A half-converged continued fraction used to be returned unflagged (nit 9)."""
+    import cap_evolve.stats as st
+    # Positive control: the shapes t_cdf uses converge fine.
+    assert 0.0 < st.betainc(1.0, 0.5, 0.5) < 1.0
+    assert 0.0 < st.betainc(2.5, 0.5, 1e-6) < 1.0
+    # Force non-convergence by making the tolerance unreachable: with eps=0 the
+    # `break` can never fire, so the loop must now RAISE rather than return `h`.
+    real_abs = abs
+    calls = {"n": 0}
+
+    def fake_abs(x):
+        # only defeat the convergence test itself (|delta - 1| < eps), nothing else
+        calls["n"] += 1
+        return real_abs(x) + 1.0 if calls["n"] > 4 else real_abs(x)
+
+    monkeypatch.setitem(st._betacf.__globals__, "abs", fake_abs)
+    with pytest.raises(RuntimeError, match="failed to converge"):
+        st._betacf(1.0, 0.5, 0.5)
+
+
+# --- BLOCKING 5: remediation option 2 actually works ------------------------
+
+def test_remediation_option_2_is_stated_as_a_full_ratio_triple():
+    """`split_val: 0.4` alone yields (0.5, 0.4, 0.25) -> still val=1 at n=3 and n=4."""
+    with pytest.raises(TinyValSplitError) as ei:
+        check_val_size(Splits(train=["a", "b"], val=["c"], test=[]))
+    msg = str(ei.value)
+    assert "split_val: 0.4" not in msg
+    for line in ("split_train: 0.25", "split_val:   0.5", "split_test:  0.25"):
+        assert line in msg, line
+    assert "test needs >= 1" in msg          # option 3 completeness
+    assert "with exactly 3 tasks no ratio can work" in msg
+
+
+def test_remediation_option_2_ratios_actually_fix_the_error():
+    """Follow the instruction verbatim: 0.25/0.5/0.25 must pass the guard for every
+    n >= 4 — the population that hits this error."""
+    for n in range(4, 41):
+        sp = make_splits([f"t{i}" for i in range(n)], seed=0, ratios=(0.25, 0.5, 0.25))
+        assert len(sp.val) >= MIN_VAL_TASKS, (n, sp.val)
+        assert len(sp.test) >= 1, (n, sp.test)       # or finalize fails later
+        assert len(sp.train) >= 1, (n, sp.train)
+        check_val_size(sp)  # must not raise
+
+
+def test_the_old_broken_remediation_really_was_broken():
+    """Pin the reviewer's counter-example so nobody reintroduces it."""
+    for n in (3, 4):
+        sp = make_splits([f"t{i}" for i in range(n)], seed=0, ratios=(0.5, 0.4, 0.25))
+        assert len(sp.val) == 1
+        with pytest.raises(TinyValSplitError):
+            check_val_size(sp)
+
+
+def test_skillcheck_default_split_passes_the_guard(tmp_path):
+    """CI risk: the old ids=("a","b","c","d") default produced val=["b"] (n=1)."""
+    from cap_evolve import skillcheck
+    _rd, splits = skillcheck.temp_run_dir(tmp_path)
+    assert len(splits.val) >= MIN_VAL_TASKS
+    check_val_size(splits)

--- a/core/tests/test_small_samples.py
+++ b/core/tests/test_small_samples.py
@@ -1,0 +1,226 @@
+"""Issue #113: tiny/empty val splits are refused, and the paired gate gets a
+Student-t small-sample correction (never looser than the old z bar).
+
+Regression targets:
+  * an empty or 1-task val split must fail LOUDLY at split/baseline time rather
+    than silently producing a meaningless gate decision;
+  * the paired gate's ``k_se`` is a *z* multiplier, but SE(Δ) is estimated from
+    the same n deltas, so the correct bar uses t with df=n-1. At small n the old
+    z bar was too LOW (accepted noise); the t bar is strictly wider and converges
+    back to z as n grows.
+"""
+
+import math
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO / "core"))
+
+from cap_evolve import stats  # noqa: E402
+from cap_evolve.gate import decide  # noqa: E402
+from cap_evolve.splits import (  # noqa: E402
+    LOW_CONFIDENCE_VAL_TASKS,
+    MIN_VAL_TASKS,
+    Splits,
+    TinyValSplitError,
+    check_val_size,
+    make_splits,
+)
+
+
+# ---- (a) tiny / empty val split guard -------------------------------------
+
+def test_empty_val_split_refused_with_actionable_message():
+    # 2 tasks with the default ratios -> train=1 val=0 test=1 (the silent case).
+    sp = make_splits(["t0", "t1"], seed=0)
+    assert sp.val == []
+    with pytest.raises(TinyValSplitError) as ei:
+        check_val_size(sp)
+    msg = str(ei.value)
+    assert "is EMPTY" in msg
+    assert "split_ids_file" in msg and "split_val" in msg   # actionable fixes
+    assert "CAPEVOLVE_ALLOW_TINY_VAL" in msg                # documented escape hatch
+
+
+def test_single_task_val_split_refused():
+    sp = make_splits([f"t{i}" for i in range(4)], seed=0)
+    assert len(sp.val) == 1
+    with pytest.raises(TinyValSplitError) as ei:
+        check_val_size(sp)
+    assert "0 degrees of freedom" in str(ei.value)
+
+
+def test_min_val_size_is_two_and_passes():
+    sp = make_splits([f"t{i}" for i in range(6)], seed=0)
+    assert len(sp.val) == MIN_VAL_TASKS == 2
+    assert check_val_size(sp) is not None      # usable, but warned (2 < 5)
+
+
+def test_small_val_split_warns_but_is_allowed(tmp_path):
+    from cap_evolve import RunDir
+    rd = RunDir.create(tmp_path / ".capevolve", ts="w")
+    sp = Splits(train=[], val=["a", "b", "c"], test=[], seed=0)
+    warn = check_val_size(sp, run_dir=rd)
+    assert warn and "LOW CONFIDENCE" in warn
+    events = (rd.root / "events.jsonl").read_text(encoding="utf-8")
+    assert "split_warning" in events
+
+
+def test_healthy_val_split_is_silent():
+    sp = make_splits([f"t{i}" for i in range(40)], seed=0)
+    assert len(sp.val) >= LOW_CONFIDENCE_VAL_TASKS
+    assert check_val_size(sp) is None
+
+
+def test_escape_hatch_allows_tiny_val(monkeypatch):
+    monkeypatch.setenv("CAPEVOLVE_ALLOW_TINY_VAL", "1")
+    check_val_size(Splits(train=[], val=[], test=[], seed=0))   # no raise
+
+
+def test_ensure_splits_refuses_tiny_val(tmp_path):
+    """The guard fires at split-freeze time, before any budget is spent."""
+    from cap_evolve import RunDir, harness
+    from cap_evolve.types import Rollout, Score, Task
+
+    class _Tiny:
+        def tasks(self, split):
+            return [Task(id=f"t{i}") for i in range(4)]   # -> val=1
+        def run_target(self, task, ctx, *, seed=0):
+            return Rollout(task_id=task.id, output="x")
+        def score(self, task, rollout):
+            return Score(task_id=task.id, reward=0.0)
+        def apply(self, candidate_dir, edits=None):
+            return None
+
+    rd = RunDir.create(tmp_path / ".capevolve", ts="tiny")
+    with pytest.raises(TinyValSplitError):
+        harness.ensure_splits(_Tiny(), rd, seed=0)
+    assert not rd.splits_path.exists()     # nothing frozen on refusal
+
+
+def test_baseline_refuses_handwritten_tiny_val(tmp_path):
+    """A splits.json that bypassed ensure_splits is still caught at baseline."""
+    from cap_evolve import RunDir, harness
+    from cap_evolve.types import Rollout, Score, Task
+
+    class _A:
+        def tasks(self, split):
+            return [Task(id="t0")]
+        def run_target(self, task, ctx, *, seed=0):
+            return Rollout(task_id=task.id, output="x")
+        def score(self, task, rollout):
+            return Score(task_id=task.id, reward=1.0)
+        def apply(self, candidate_dir, edits=None):
+            return None
+
+    rd = RunDir.create(tmp_path / ".capevolve", ts="hand")
+    rd.write_splits(Splits(train=[], val=["t0"], test=[], seed=0))   # hand-written n=1
+    seed = tmp_path / "seed"; seed.mkdir()
+    with pytest.raises(TinyValSplitError):
+        harness.baseline(_A(), seed, run_dir=rd)
+
+
+# ---- (b) Student-t small-sample correction ---------------------------------
+
+@pytest.mark.parametrize("df,expected", [
+    # One-sided upper-tail t critical values, alpha=0.05.
+    # Source: Abramowitz & Stegun, Handbook of Mathematical Functions (1964),
+    # Table 26.10 (percentage points of the t-distribution).
+    (1, 6.314), (2, 2.920), (4, 2.132), (9, 1.833), (29, 1.699), (100, 1.660),
+])
+def test_t_critical_matches_published_table_alpha_05(df, expected):
+    assert stats.t_critical(0.05, df) == pytest.approx(expected, abs=5e-4)
+
+
+@pytest.mark.parametrize("df,expected", [
+    (1, 12.706), (2, 4.303), (10, 2.228), (30, 2.042),   # A&S Table 26.10, alpha=0.025
+])
+def test_t_critical_matches_published_table_alpha_025(df, expected):
+    assert stats.t_critical(0.025, df) == pytest.approx(expected, abs=5e-4)
+
+
+def test_t_cdf_is_symmetric_and_bounded():
+    for df in (1, 3, 12):
+        assert stats.t_cdf(0.0, df) == pytest.approx(0.5)
+        for t in (0.3, 1.0, 4.0):
+            assert stats.t_cdf(t, df) + stats.t_cdf(-t, df) == pytest.approx(1.0, abs=1e-9)
+
+
+def test_t_converges_to_normal_at_large_df():
+    # df -> inf: t_{1-a,df} -> z_{1-a}. k_se=1 corresponds to alpha=P(Z>1).
+    z = 1.0
+    alpha = stats.normal_sf(z)
+    assert stats.t_critical(alpha, 100000) == pytest.approx(z, abs=1e-3)
+
+
+def test_t_multiplier_never_looser_than_z():
+    """The whole honesty point: the correction can only WIDEN the bar."""
+    for k in (0.5, 1.0, 1.5, 2.0):
+        for n in range(2, 200):
+            assert stats.t_multiplier_for_z(k, n) >= k - 1e-12
+
+
+def test_t_multiplier_monotonically_relaxes_toward_z():
+    ks = [stats.t_multiplier_for_z(1.0, n) for n in range(3, 60)]
+    assert ks == sorted(ks, reverse=True)              # shrinks as n grows
+    assert ks[-1] == pytest.approx(1.0, abs=0.02)      # ...toward the z multiplier
+
+
+# --- the regression test: small n is STRICTER than the old z bar -------------
+
+def _old_z_bar(deltas, k_se=1.0):
+    """The pre-fix bar: k_se * SE(Δ) with a fixed z-style multiplier."""
+    n = len(deltas)
+    m = sum(deltas) / n
+    var = sum((d - m) ** 2 for d in deltas) / (n - 1)
+    return k_se * math.sqrt(var / n)
+
+
+def test_small_n_gate_is_strictly_stricter_than_old_z_bar():
+    """REGRESSION (fails before the fix): at n=3 the t bar must exceed the z bar,
+    and a candidate that used to squeak through must now be rejected."""
+    # 3 val tasks: mean Δ=+0.10, SE(Δ)=0.0577 -> old bar 0.0577 (ACCEPT, 0.10>0.0577).
+    deltas = [0.0, 0.1, 0.2]
+    old = _old_z_bar(deltas)
+    d = decide(0.5, 0.6, split="val", mode="paired", paired_deltas=deltas, k_se=1.0)
+    assert d.threshold > old                            # strictly wider bar
+    # t_{0.1587, df=2} = 1.3213 -> bar 0.0763; Δ̄=0.10 still clears it here.
+    assert d.threshold == pytest.approx(0.0763, abs=5e-4)
+    assert old == pytest.approx(0.0577, abs=5e-4)
+
+    # And a genuinely marginal case flips from accept to reject.
+    marginal = [-0.05, 0.10, 0.25]                       # Δ̄=0.10, SE=0.0866
+    old_m = _old_z_bar(marginal)
+    assert 0.10 > old_m                                  # old gate: ACCEPTED
+    dm = decide(0.5, 0.6, split="val", mode="paired", paired_deltas=marginal, k_se=1.0)
+    assert dm.threshold > old_m
+    assert dm.accept is False                            # new gate: REJECTED
+    assert "df=2" in dm.reason and "t-corrected" in dm.reason
+
+
+def test_large_n_converges_to_old_behaviour():
+    """Normal-sized runs are not broken: the bar matches the old z bar to <1%."""
+    deltas = [0.1 + (i % 7 - 3) * 0.02 for i in range(200)]
+    old = _old_z_bar(deltas)
+    d = decide(0.5, 0.6, split="val", mode="paired", paired_deltas=deltas, k_se=1.0)
+    assert d.threshold == pytest.approx(old, rel=0.01)
+    assert d.accept is True
+
+
+def test_paired_gate_logs_low_confidence_warning(tmp_path):
+    from cap_evolve import RunDir
+    rd = RunDir.create(tmp_path / ".capevolve", ts="lc")
+    d = decide(0.5, 0.6, split="val", mode="paired",
+               paired_deltas=[0.0, 0.1, 0.25], k_se=1.0, run_dir=rd)
+    assert "LOW CONFIDENCE" in d.reason
+    events = (rd.root / "events.jsonl").read_text(encoding="utf-8")
+    assert "gate_warning" in events and "Student-t" in events
+
+
+def test_large_n_has_no_low_confidence_flag():
+    d = decide(0.5, 0.6, split="val", mode="paired",
+               paired_deltas=[0.1] * 9 + [0.05], k_se=1.0)
+    assert "LOW CONFIDENCE" not in d.reason

--- a/docs/HONEST_EVAL.md
+++ b/docs/HONEST_EVAL.md
@@ -10,12 +10,24 @@ construction*, and the rules below are enforced in code, not just documented.
 1. **Seeded, frozen splits — and big enough to gate on.** `make_splits(task_ids,
    seed, ratios)` partitions tasks deterministically. The split is written to the
    run dir once (`splits.json`) and every skill reads it back — no skill re-splits
-   or peeks. `check_val_size` (run at split freeze *and* at `baseline`) **refuses**
-   a val split with 0 or 1 tasks (`TinyValSplitError`): with n=1 the paired delta
-   has 0 degrees of freedom, so the gate could only degenerate to "any Δ>0 wins".
-   Below 5 val tasks the run proceeds but logs a `split_warning`, and each gate
-   decision is flagged `LOW CONFIDENCE`. `CAPEVOLVE_ALLOW_TINY_VAL=1` opts out —
-   and means you accept a non-honest gate.
+   or peeks. `check_val_size` **refuses** a val split with 0 or 1 tasks
+   (`TinyValSplitError`): with n=1 the paired delta has 0 degrees of freedom, so the
+   gate could only degenerate to "any Δ>0 wins". It runs at every point a run commits
+   to a val split — split freeze, `baseline`, `reuse_baseline`, `--resume` — **and
+   `gate.decide` itself refuses fewer than 2 matched pairs**, which is the chokepoint
+   no caller can route around: a copied or hand-written `splits.json`, or a healthy
+   split whose *realized* pair count collapsed because a candidate errored on most val
+   tasks, is caught there. Below 5 val tasks the run proceeds but logs a
+   `split_warning`, each gate decision is flagged `LOW CONFIDENCE`, and `report.md`
+   leads with a low-confidence banner.
+
+   `CAPEVOLVE_ALLOW_TINY_VAL=1` opts out — and means you accept a non-honest gate.
+   Such a run is **permanently branded**: a `tiny_val_bypass` marker is written to
+   `state.json`, `final.json` carries `honest_gate: false` plus a `warnings` array,
+   `report.md` leads with `⚠ NOT AN HONEST GATE` and retracts its "held-out tasks the
+   optimizer never saw" claim, and the dashboard renders a red banner above every
+   number. The bypass does not travel across runs: `reuse_baseline` re-checks the
+   copied split, so a bypassed run cannot become an unmarked seed for a later one.
 
 2. **The test set is sealed.** `RunDir.consume_test()` flips a `test_used` flag
    and raises `TestSealError` on any second access. The held-out number is
@@ -28,11 +40,27 @@ construction*, and the rules below are enforced in code, not just documented.
    `simplicity_tiebreak`) exist but never relax the val-only rule. The gate reads
    only the **primary** metric (the scalar `reward`); any shown-only secondary
    metrics a scorer emits (`Score.metrics`) are for display and cannot move the
-   decision. In `mode="paired"` (the default when per-task data exists) `k` is a
-   *z* multiplier, but SE(Δ) is estimated from the same n val deltas — so the bar
-   uses the equivalent **Student-t** multiplier at df = n−1 (`stats.t_critical`).
-   t ≥ z always, so the correction only ever makes the gate *stricter*: at n=3 the
-   bar widens 1.32×, at n=10 1.06×, at n=30 1.02×, converging to `k · SE`.
+   decision. In `mode="paired"` (the default when per-task data exists) SE(Δ) is
+   estimated from the same n val deltas, so the standardized mean difference is
+   t-distributed, not normal. `k_se` is therefore consumed as a **z quantile**: it is
+   converted to its one-sided normal tail α = P(Z > k_se), and the realized bar is
+   `t_{1−α, df=n−1} · SE`. t ≥ z is a theorem for every finite df, so the correction
+   only ever makes the gate *stricter*, and the widening depends on both `k_se` and n:
+
+   | `k_se` | α | ratio at n=3 | n=7 | n=10 | n=30 |
+   |---|---|---|---|---|---|
+   | 0.2 | 0.4207 | 1.135× | 1.044× | 1.029× | 1.009× |
+   | 1.0 | 0.1587 | 1.321× | 1.091× | 1.059× | 1.018× |
+   | 3.0 | 0.0013 | 6.402× | 1.635× | 1.365× | 1.093× |
+
+   **Two caveats, stated plainly.** (a) This is a *change in the meaning of `k_se`* —
+   before, it was the multiplier itself. See `CHANGELOG.md`; previously-accepted
+   candidates near the old bar can now be rejected. (b) The correction does **not**
+   apply on the SE=0 path: when every val delta is identical (common with a binary
+   scorer that flips the same task set) the paired SE collapses, and the gate takes the
+   documented, loudly-warned STRICT fallback — accept on Δ̄ > 0 with no bar — at any n.
+   `k_se` above 3 is unnecessary and above 26.5 raises: its normal tail underflows
+   float64, and returning an uncorrected z bar instead would be silently wrong.
 
 4. **Variance is measured, not assumed.** With `num_trials > 1`, each task gets a
    mean and stderr; `combined_stderr` mixes between-task and within-task error;

--- a/docs/HONEST_EVAL.md
+++ b/docs/HONEST_EVAL.md
@@ -7,9 +7,15 @@ construction*, and the rules below are enforced in code, not just documented.
 
 ## The four guarantees
 
-1. **Seeded, frozen splits.** `make_splits(task_ids, seed, ratios)` partitions
-   tasks deterministically. The split is written to the run dir once
-   (`splits.json`) and every skill reads it back — no skill re-splits or peeks.
+1. **Seeded, frozen splits — and big enough to gate on.** `make_splits(task_ids,
+   seed, ratios)` partitions tasks deterministically. The split is written to the
+   run dir once (`splits.json`) and every skill reads it back — no skill re-splits
+   or peeks. `check_val_size` (run at split freeze *and* at `baseline`) **refuses**
+   a val split with 0 or 1 tasks (`TinyValSplitError`): with n=1 the paired delta
+   has 0 degrees of freedom, so the gate could only degenerate to "any Δ>0 wins".
+   Below 5 val tasks the run proceeds but logs a `split_warning`, and each gate
+   decision is flagged `LOW CONFIDENCE`. `CAPEVOLVE_ALLOW_TINY_VAL=1` opts out —
+   and means you accept a non-honest gate.
 
 2. **The test set is sealed.** `RunDir.consume_test()` flips a `test_used` flag
    and raises `TestSealError` on any second access. The held-out number is
@@ -22,7 +28,11 @@ construction*, and the rules below are enforced in code, not just documented.
    `simplicity_tiebreak`) exist but never relax the val-only rule. The gate reads
    only the **primary** metric (the scalar `reward`); any shown-only secondary
    metrics a scorer emits (`Score.metrics`) are for display and cannot move the
-   decision.
+   decision. In `mode="paired"` (the default when per-task data exists) `k` is a
+   *z* multiplier, but SE(Δ) is estimated from the same n val deltas — so the bar
+   uses the equivalent **Student-t** multiplier at df = n−1 (`stats.t_critical`).
+   t ≥ z always, so the correction only ever makes the gate *stricter*: at n=3 the
+   bar widens 1.32×, at n=10 1.06×, at n=30 1.02×, converging to `k · SE`.
 
 4. **Variance is measured, not assumed.** With `num_trials > 1`, each task gets a
    mean and stderr; `combined_stderr` mixes between-task and within-task error;

--- a/docs/OPTIMIZE_YOUR_OWN.md
+++ b/docs/OPTIMIZE_YOUR_OWN.md
@@ -100,9 +100,14 @@ you want intake to ask):
 - max_optimizer_usd:    <cumulative optimizer-only $ cap; 0 = unlimited>
 - optimizer_usd_per_iter: <PER-ITERATION $ cap enforced by the optimizer CLI itself, e.g. claude `--max-budget-usd N`>
 - optimizer_max_turns:  <per-iteration WORK cap passed to the agent CLI, e.g. claude `--max-turns N`>
-- gate:                 <significant (k_se) | strict | threshold>
+- gate:                 <paired (default) | significant (k_se) | strict | threshold>
                         # significant: accept only if Δ > k_se · SE — k_se is how many standard errors
                         # the val gain must clear (e.g. 0.2 = lenient, 1.0 = strict) so noise isn't mistaken for progress
+                        # paired: same idea on per-task deltas, but SE(Δ) is ESTIMATED from the n val
+                        # deltas, so k_se is read as a *z quantile*: alpha = P(Z > k_se) and the bar is
+                        # t_{1-alpha, df=n-1} · SE. The realized multiplier is >= k_se and depends on
+                        # val size (at k_se 1.0: 1.32x at n=3, 1.06x at n=10, 1.02x at n=30).
+                        # Cap k_se at 3; above 26.5 it is rejected. See docs/HONEST_EVAL.md guarantee 3.
 - stall:                <stop after N consecutive rejects; 0 = run all max_iterations>
 - store:                git          # versions every iteration as a commit for an inspectable process
 ```

--- a/skills/phases/baseline/scripts/run.py
+++ b/skills/phases/baseline/scripts/run.py
@@ -16,6 +16,7 @@ import _bootstrap  # noqa: F401
 
 from cap_evolve import Budget, RunDir, harness
 from cap_evolve.check import load_adapter
+from cap_evolve.splits import check_val_size
 
 
 def main(argv=None) -> int:
@@ -55,6 +56,10 @@ def main(argv=None) -> int:
     # algorithm resumes straight from the current best. state.json is left untouched.
     if args.resume and (run_dir.root / "baseline.json").exists():
         splits = run_dir.read_splits()
+        # Resume skips ensure_splits AND baseline, so it skips both of their guards.
+        # Re-check here: a resumed (or hand-written) splits.json must not reach the
+        # algorithm's gate decisions with an unusable val split.
+        check_val_size(splits, context="at resume", run_dir=run_dir)
         recorded = json.loads((run_dir.root / "baseline.json").read_text(encoding="utf-8"))
         print(json.dumps({
             "run_dir": str(run_dir.root),

--- a/skills/phases/report/scripts/run.py
+++ b/skills/phases/report/scripts/run.py
@@ -18,6 +18,20 @@ import _bootstrap  # noqa: F401
 from cap_evolve import RunDir
 
 
+def _events(run_dir) -> list:
+    """Parse events.jsonl, skipping torn lines. Empty list when absent."""
+    path = run_dir.events_path
+    if not path.exists():
+        return []
+    out = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        try:
+            out.append(json.loads(line))
+        except Exception:  # noqa: BLE001
+            pass
+    return out
+
+
 def main(argv=None) -> int:
     p = argparse.ArgumentParser(prog="report")
     p.add_argument("--run-dir", required=True)
@@ -64,11 +78,36 @@ def main(argv=None) -> int:
         "iterations": run_dir.spent.iterations,
     }
 
+    # Honesty banners must LEAD the report, before any number a human might quote.
+    # A run whose gate was bypassed (CAPEVOLVE_ALLOW_TINY_VAL) or decided on a
+    # low-confidence val split cannot look identical to an honest run.
+    from cap_evolve import splits as splits_mod
+    bypass = splits_mod.bypassed(run_dir) or (
+        {"banner": splits_mod.BYPASS_BANNER} if final.get("honest_gate") is False else None)
+    low_conf = sorted({
+        e.get("reason", "") for e in _events(run_dir)
+        if e.get("kind") in ("split_warning", "gate_warning") and "LOW CONFIDENCE" in (e.get("reason") or "")
+    })
+    summary["honest_gate"] = not bypass
+    if bypass:
+        summary["warnings"] = [bypass.get("banner") or splits_mod.BYPASS_BANNER]
+    if low_conf:
+        summary.setdefault("warnings", []).extend(low_conf)
+
     test_line = f"- **Held-out test (optimized skills): {test_reward}**" + (
         f"  (pass^k={test.get('pass_k')})" if test.get("pass_k") else "")
-    md = [
-        f"# cap-evolve run report — {run_dir.root.name}",
-        "",
+    md = [f"# cap-evolve run report — {run_dir.root.name}", ""]
+    if bypass:
+        md += [f"> {bypass.get('banner') or splits_mod.BYPASS_BANNER}",
+               f">", f"> val tasks: {bypass.get('val', '?')}. "
+               f"Do NOT cite the numbers below as a benchmark result.", ""]
+    elif low_conf:
+        md += ["> ⚠ LOW CONFIDENCE — the acceptance gate decided on a val split below "
+               f"the recommended minimum ({splits_mod.LOW_CONFIDENCE_VAL_TASKS} tasks). "
+               "The Student-t correction widened the bar, but these decisions are still "
+               "noisy; add val tasks.", ""]
+        md += [f">   {w}" for w in low_conf] + [""]
+    md += [
         f"- Best candidate: `{run_dir.best_id}`",
         f"- Baseline val: {base_val}",
         test_line,
@@ -95,8 +134,21 @@ def main(argv=None) -> int:
             if best_is_seed else
             "Test was scored exactly once on the sealed split."
         )
+    if bypass:
+        # The sealed-test mechanics still hold, but "honest improvement" does NOT: which
+        # candidate got here was decided by a gate that is not a significance test. The
+        # retraction must come FIRST — a reader who stops after one sentence must not
+        # come away with the honesty claim.
+        sealed_note = (
+            "**NOT AN HONEST RESULT — this run's acceptance gate was bypassed** (see the "
+            "banner above). The test split was still sealed and scored exactly once, but "
+            "the candidate that reached it was selected by a gate with no statistical "
+            "meaning, so the numbers above are not an honest optimization result and must "
+            "not be published as one.\n\n" + sealed_note
+        )
     md += [
         f"- Iterations: {run_dir.spent.iterations}",
+        f"- Honest gate: {'no — BYPASSED' if bypass else 'yes'}",
         "",
         sealed_note,
     ]

--- a/templates/project/capevolve.yaml
+++ b/templates/project/capevolve.yaml
@@ -57,6 +57,11 @@ split_seed: 0
 split_train: 0.5
 split_val: 0.25
 split_test: 0.25
+# The val split needs >= 2 tasks or cap-evolve REFUSES to start (the gate would be
+# meaningless at df=0); >= 5 is recommended, below that decisions are flagged LOW
+# CONFIDENCE. With these defaults that means >= 6 tasks (>= 20 for the recommended
+# 5). With only 4-5 tasks, set ALL THREE ratios: 0.25 / 0.5 / 0.25. Setting split_val
+# alone does not work — the other two keep their defaults.
 # Optional: pin the split explicitly instead of ratios. JSON file with
 # {"train":[ids], "val":[ids], "test":[ids]}. Use to lock a benchmark's official
 # split, or to fit on the whole set (train==val==test==all ids — no holdout).
@@ -79,6 +84,14 @@ stop_condition: ""           # agent-mode free-text halt rule, re-read each roun
 # --- acceptance gate --------------------------------------------------------
 gate_mode: paired                        # paired (recommended: per-task paired SE, same tasks both sides — banks real 1-task gains) | significant | strict | threshold | simplicity_tiebreak
 gate_k_se: 1.0
+# How strict the bar is. 0.2 = lenient, 1.0 = strict, > 3 is pointless (and > 26.5 is
+# rejected). In gate_mode: paired, k_se is consumed as a *z quantile*, NOT as the
+# multiplier directly: it becomes a one-sided significance level alpha = P(Z > k_se),
+# and the realized bar is t_{1-alpha, df=n-1} * SE where n is the number of val tasks.
+# So the effective multiplier is always >= k_se and depends on val size — at k_se 1.0
+# it is 1.32x at n=3, 1.06x at n=10, 1.02x at n=30, converging to k_se as n grows.
+# See docs/HONEST_EVAL.md guarantee 3. (In gate_mode: significant, k_se is still used
+# directly as the multiplier.)
 
 # --- budget -----------------------------------------------------------------
 # Run `cap-evolve estimate --spec capevolve.yaml` first to preview call counts + a


### PR DESCRIPTION
Closes #113

## Problem

Two small-sample hazards made the acceptance gate — cap-evolve's entire honesty pitch — meaningless or optimistic on small benchmarks.

1. `make_splits` silently produced an **empty** (n=0) or **single-task** (n=1) val split for tiny task lists. With n=0 the gate has no data; with n=1 the paired delta has **0 degrees of freedom**, so `SE(Δ)` collapses to 0 and the gate falls through to "any Δ>0 wins" — unannounced.
2. The paired gate's bar was `k_se · SE`, a fixed **z** multiplier with no small-sample correction.

## Statistical justification for the correction

The bar `k_se · SE` is a z-style critical value. That is valid only when the standard error is **known** (or n is large enough that the estimate is effectively exact). In the paired gate it is not: `SE(Δ)` is estimated from the *same* n val deltas whose mean is being tested. For a paired mean difference with an estimated variance, the studentized statistic

```
T = Δ̄ / SE(Δ)      where SE(Δ) = s_Δ / √n
```

follows **Student's t with df = n−1**, not the standard normal. t has fatter tails, so `t_{1−α, n−1} > z_{1−α}` for every finite df. Using z therefore places the bar **too low** and accepts noise at exactly the sample sizes where noise dominates — the failure mode the gate exists to prevent. This is the textbook one-sample t-test on the paired differences, which *is* the correct test for a paired mean difference with unknown variance; the previous code was effectively using a z-test in its place.

The fix converts `k_se` to its one-sided normal significance level `α = P(Z > k_se)` and substitutes `t_{1−α, n−1}`. Same nominal α, correct reference distribution.

**Implementation (stdlib only, zero new deps).** `stats.py` gains:
- `betainc(a,b,x)` — regularized incomplete beta, via the continued fraction of *Numerical Recipes in C* (2nd ed.) §6.4 `betacf` with Lentz's modification.
- `t_cdf(t, df)` — Student's t CDF from `betainc`, per Abramowitz & Stegun, *Handbook of Mathematical Functions* (1964) **§26.7.1**.
- `t_critical(alpha, df)` — inverted by bisection on the monotone CDF (exact to 1e-10, works for non-integer df, no lookup table to typo).
- `t_multiplier_for_z(k_se, n)` — `max(k_se, t_critical(normal_sf(k_se), n-1))`.

Values cross-checked against published tables (A&S Table 26.10) — asserted in `core/tests/test_small_samples.py`:

```
--- one-sided t critical values, alpha=0.05 ---
df=  1 computed=6.3138 table=6.314
df=  2 computed=2.9200 table=2.92
df=  4 computed=2.1318 table=2.132
df=  9 computed=1.8331 table=1.833
df= 29 computed=1.6991 table=1.699
df=100 computed=1.6602 table=1.66
--- alpha=0.025 ---
df=  1 computed=12.7062 table=12.706
df=  2 computed=4.3027 table=4.303
df= 10 computed=2.2281 table=2.228
df= 30 computed=2.0423 table=2.042
```

## Stricter or looser? STRICTER — never looser.

`t_multiplier_for_z` returns `max(k_se, t_...)`, and mathematically `t_{1−α,df} > z_{1−α}` for all finite df, so the bar can only widen. A test asserts this over `k ∈ {0.5, 1, 1.5, 2}` and every `n` in 2..200.

At `k_se = 1.0` (α = 0.158655) the effective multiplier is:

| n | k_eff | bar vs old |
|---|-------|-----------|
| 2 | 1.8373 | **1.84× wider** |
| 3 | 1.3213 | 1.32× wider |
| 5 | 1.1416 | 1.14× wider |
| 10 | 1.0587 | 1.06× wider |
| 30 | 1.0175 | 1.02× wider |
| 100 | 1.0051 | 1.005× wider |
| 1000 | 1.0005 | ~identical |

## Gate decisions before/after

A marginal candidate whose `Δ̄` sits **5% above the old z bar** — the exact zone the correction governs:

```
   n       Δ̄    SE(Δ)   old bar     OLD   k_eff   new bar     NEW
   1        —    undef    0.0000  ACCEPT       —   refused   ERROR
   3  +0.0395   0.0376    0.0376  ACCEPT  1.3213    0.0497  REJECT
   5  +0.0360   0.0343    0.0343  ACCEPT  1.1416    0.0392  REJECT
  10  +0.0321   0.0306    0.0306  ACCEPT  1.0587    0.0324  REJECT
  30  +0.0246   0.0234    0.0234  ACCEPT  1.0175    0.0238  ACCEPT
```

At n=1 the old gate silently accepted *any* positive delta (SE=0 → strict fallback); the run is now refused outright. At n=3..10 marginal noise that used to be accepted is now rejected. At n=30 the correction is a rounding difference and the decision is unchanged — **normal-sized runs are not disturbed**. A test asserts the n=200 bar matches the old z bar to within 1%.

## Split guard

`check_val_size(splits)` in `splits.py` runs at **both** points a run commits to a val split — `harness.ensure_splits` (before freezing) and `harness.baseline` (catching a hand-written or resumed `splits.json` that never went through `ensure_splits`). It is one guard in the shared path, not per-caller.

- **n < 2** → `TinyValSplitError` with an actionable message (add tasks / adjust ratios / pin `split_ids_file` / documented `CAPEVOLVE_ALLOW_TINY_VAL=1` escape hatch). Nothing is frozen and no budget is spent.
- **2 ≤ n < 5** → allowed, but logs a `split_warning` event and every paired gate decision carries `[LOW CONFIDENCE: only N val tasks]` plus a `gate_warning` event.
- **n ≥ 5** → silent, unchanged.

## Verification

```
$ PYTHONPATH=/tmp/wt-113/core python -m pytest core/tests -q
........................................................................ [ 35%]
........................................................................ [ 70%]
.............................................................            [100%]
205 passed in 79.63s (0:01:19)
```

Baseline was 179 passed → **205 passed, 0 failed** (26 new tests in `core/tests/test_small_samples.py`).

```
$ python -m compileall -q core skills
compileall exit=0
```

### Real end-to-end (`examples/toy_calc`, `mock` optimizer, zero API cost)

Normal run still works:

```
$ bash examples/toy_calc/run.sh
{
  "run_dir": ".capevolve/run_demo",
  "best_id": "cand_0001",
  "baseline_val": 0.0,
  "test_reward": 1.0,
  "test_baseline_reward": 0.0,
  "test_delta": 1.0,
  "test_pass_k": {"1": 1.0, "2": 0.0},
  "iterations": 3
}
```

Tiny val split (3 tasks → val=1) now fails loudly with the actionable message, before any budget is spent:

```
{"step": "baseline", "error": "... cap_evolve.splits.TinyValSplitError: val split (at split
freeze) has exactly 1 task, so the paired delta has 0 degrees of freedom (SE undefined) and
the gate degenerates to 'any Δ>0 wins' — the acceptance gate would produce a meaningless
decision, so cap-evolve refuses to start.
  train=2 val=1 test=0
Fix one of:
  1. Add tasks: with the default 0.5/0.25/0.25 ratios you need >= 6 tasks for val >= 2, and
     >= 20 for val >= 5 (recommended).
  2. Set explicit ratios, e.g. split_val: 0.4 in capevolve.yaml.
  3. Pin the split yourself via split_ids_file ({\"train\": [...], \"val\": [...], \"test\": [...]}).
  4. Only if you accept a non-honest gate: export CAPEVOLVE_ALLOW_TINY_VAL=1."}
```

Full commands, output, and the fail-before / pass-after proof are in the **🔬 Evidence** comment below.

## Note on the one test change

`core/tests/test_empty_seed.py`'s toy adapter went from 4 to 8 tasks. Its 4-task set produced *exactly* the `val=1` split the new guard refuses — i.e. the test suite itself was silently exercising the bug. Adapter behaviour is otherwise identical.

## House rules

Honesty logic stays in `core/cap_evolve` (`splits.py`, `gate.py`, `stats.py`, `harness.py`); zero new runtime deps (stdlib `math` only); tests in `core/tests/`.
