### PR TITLE
Protected-paths tamper guard: verify the optimizer never edited scoring/eval/task files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,15 +27,36 @@ All notable changes to cap-evolve are documented here. The format follows
   inside `evaluate_candidate` — the chokepoint every evaluation (baseline, each
   iteration's val gate, `finalize`) goes through — plus GEPA's minibatch path. Any
   modification, deletion, or newly-added protected file logs a `tamper_detected` event
-  (surfaced in the dashboard summary) and raises `TamperError` naming the file, before
-  the candidate can be scored, snapshotted, become best, or seal the test split.
-  Defaults derive from the project layout (`adapters/`, `capevolve.yaml`, the spec's
-  `dataset_source`/`split_ids_file`, any `*gold*` file); override with
-  `protected_paths` in `capevolve.yaml`. The capability dir is never protected — it
-  is the target. The existing `PreToolUse` honesty hook now also denies writes to a
-  protected path so the model gets the feedback before wasting an iteration.
-  Content hash, not mtime (spoofable); `__pycache__`/`*.pyc` excluded so importing
-  the adapter during a normal run is not a false positive. Zero new deps (`hashlib`).
+  (surfaced as a red banner at the top of the dashboard and of `report.md`) and raises
+  `TamperError` naming the file, before the candidate can be scored, snapshotted,
+  become best, or seal the test split. Verification runs **both before and after** every
+  scoring pass — `evaluate_candidate`, GEPA's `_eval_minibatch`, and once more
+  immediately before `finalize` burns the seal — so a writer that lands *during* scoring
+  (a detached grandchild outliving the optimizer subprocess) invalidates the score
+  instead of being recorded. The manifest itself is protected: its digest is logged in
+  `events.jsonl`, and a manifest that goes missing, becomes unparseable, or stops
+  matching that digest is a hard failure rather than a silent re-record from the current
+  (possibly tampered) tree. Bytecode is hashed like any other file — `load_adapter` sets
+  `sys.dont_write_bytecode` and clears the adapter's `__pycache__`, closing the PEP 552
+  `UNCHECKED_HASH` pyc attack (a planted cache entry ran a hacked `score()` with the
+  source's SHA-256 unchanged) without needing a `.pyc` exclusion. A protected file
+  replaced by a symlink reads as a change rather than de-protecting itself. Defaults
+  derive from the project layout (`adapters/`, `capevolve.yaml`, the spec's
+  `dataset_source`/`split_ids_file`, `*gold*` **data** files — prose like
+  `docs/golden-rules.md` is no longer swept in); override with `protected_paths` in
+  `capevolve.yaml`, where a malformed or empty value is a hard error, never a silent
+  fallback to the defaults. The capability dir is never protected — it is the target.
+  `--reuse-baseline` inherits the prior run's manifest and refuses a prior run that
+  logged a tamper. The `PreToolUse` honesty hook denies writes to protected paths
+  (case-folded, for APFS/NTFS) and to the run's own evidence (`protected.json`,
+  `events.jsonl`, `state.json`, `best.txt`). Content hash, not mtime (spoofable). Zero
+  new deps (`hashlib`). `docs/HONEST_EVAL.md` states the guarantee as **tamper-evident**
+  — detection, not prevention — with its residual gaps named.
+- **YAML block sequences in `capevolve.yaml`.** The zero-dependency fallback parser
+  (used whenever PyYAML is absent, the documented default state) only understood the flow
+  form `key: [a, b]`; the idiomatic block form silently parsed as `{}`. Every
+  list-valued key was affected — including `protected_paths`, where it meant a declared
+  grader quietly fell back to the defaults with no warning.
 - **SWE-bench oracle mode + calibrated smoke selection.** The SWE-bench adapter gains
   `SWEBENCH_ORACLE=1`, which attaches the "Oracle" retrieval context (the file[s] the
   gold patch touches, from `princeton-nlp/SWE-bench_Lite_oracle`'s `text` field) to the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,21 @@ All notable changes to cap-evolve are documented here. The format follows
   longer looks like a capability regression.
 
 ### Added
+- **Protected-paths tamper guard (honesty).** New `cap_evolve/protect.py` proves the
+  optimizer never edited the scorer / eval harness / task data. A SHA-256 manifest of
+  the protected paths is recorded at `baseline` (`protected.json`) and re-verified
+  inside `evaluate_candidate` — the chokepoint every evaluation (baseline, each
+  iteration's val gate, `finalize`) goes through — plus GEPA's minibatch path. Any
+  modification, deletion, or newly-added protected file logs a `tamper_detected` event
+  (surfaced in the dashboard summary) and raises `TamperError` naming the file, before
+  the candidate can be scored, snapshotted, become best, or seal the test split.
+  Defaults derive from the project layout (`adapters/`, `capevolve.yaml`, the spec's
+  `dataset_source`/`split_ids_file`, any `*gold*` file); override with
+  `protected_paths` in `capevolve.yaml`. The capability dir is never protected — it
+  is the target. The existing `PreToolUse` honesty hook now also denies writes to a
+  protected path so the model gets the feedback before wasting an iteration.
+  Content hash, not mtime (spoofable); `__pycache__`/`*.pyc` excluded so importing
+  the adapter during a normal run is not a false positive. Zero new deps (`hashlib`).
 - **SWE-bench oracle mode + calibrated smoke selection.** The SWE-bench adapter gains
   `SWEBENCH_ORACLE=1`, which attaches the "Oracle" retrieval context (the file[s] the
   gold patch touches, from `princeton-nlp/SWE-bench_Lite_oracle`'s `text` field) to the

--- a/core/cap_evolve/__init__.py
+++ b/core/cap_evolve/__init__.py
@@ -17,6 +17,7 @@ from .cache import EvalCache, hash_candidate_dir
 from .gate import GateDecision, TrainGateError, decide
 from .lr_schedule import build_schedule
 from .memory import History, RejectedMemory
+from .protect import TamperError
 from .rundir import Budget, RunDir, Spent
 from .selection import PICKERS, STRATEGIES, pick, validate_strategy
 from .splits import Splits, TestSealError, make_splits
@@ -45,6 +46,7 @@ __all__ = [
     "RunDir",
     "Spent",
     "Splits",
+    "TamperError",
     "TestSealError",
     "make_splits",
     "aggregate",

--- a/core/cap_evolve/check.py
+++ b/core/cap_evolve/check.py
@@ -51,6 +51,32 @@ def load_adapter(project_dir: Path) -> CapabilityAdapter:
     if adir not in sys.path:
         sys.path.insert(0, adir)
 
+    # Honesty (#142): the adapter IS the grader, so it must be executed from the
+    # source bytes the protected-paths manifest hashes — never from a bytecode cache.
+    # A PEP 552 ``UNCHECKED_HASH`` pyc planted in the adapter's cache slot skips
+    # mtime, size AND hash validation, so ``SourceFileLoader`` would happily run a
+    # hacked ``score()`` while ``adapter.py`` stayed byte-identical to the manifest.
+    # Two lines close that: drop any pre-existing cache (so only source can run) and
+    # suppress writing a new one (so ``.pyc`` files can be hashed like anything else
+    # instead of being excluded from protection).
+    # ponytail: set process-wide and never restored, on purpose. Restoring it would
+    # let a helper imported LAZILY from inside ``score()`` write a pyc mid-scoring,
+    # which the (now correctly pyc-aware) guard would read as an added protected file
+    # and abort a legitimate run on. A run process that never writes bytecode costs
+    # only a little import time.
+    import shutil
+    cache_dir = mod_path.parent / "__pycache__"
+    if cache_dir.exists():
+        # Not silent: a cache dir next to the grader is either stale build residue or a
+        # plant, and either way the operator should know we destroyed it. A plant made
+        # DURING a run is caught by the manifest instead (it reads as an added protected
+        # file); this line covers one that predates the manifest, where the outcome is
+        # neutralization rather than detection.
+        print(f"cap-evolve: removed bytecode cache {cache_dir} before loading the "
+              "adapter — the grader must execute from the hashed source only.",
+              file=sys.stderr)
+        shutil.rmtree(cache_dir, ignore_errors=True)
+    sys.dont_write_bytecode = True
     spec = importlib.util.spec_from_file_location("forge_project_adapter", mod_path)
     mod = importlib.util.module_from_spec(spec)
     assert spec and spec.loader

--- a/core/cap_evolve/dashboard.py
+++ b/core/cap_evolve/dashboard.py
@@ -567,6 +567,9 @@ def reduce_run(run_dir) -> dict:
         "budget": (run_dir.budget.to_dict() if sp is not None else None),
         "spent": (sp.to_dict() if sp is not None else None),
         "budget_warnings": [e for e in events if e.get("kind") == "budget_warning"],
+        # Protected-path tamper events (#142): an honesty signal, so it rides
+        # alongside the gate warnings instead of staying buried in events.jsonl.
+        "tamper_events": [e for e in events if e.get("kind") == "tamper_detected"],
         "gate_warnings": gate_warnings,
         "diagnoses": diagnoses,
         "git_log": _git_log(root),

--- a/core/cap_evolve/dashboard.py
+++ b/core/cap_evolve/dashboard.py
@@ -793,6 +793,18 @@ def render_ansi(reduced: dict, *, color: bool = True, top_n: int = 8) -> str:
             lines.append(line)
         lines.append("")
 
+    # Tamper events FIRST and in red (#142 N4): a guard nobody can see is half a
+    # guard. Every number in this summary is void if one of these fired.
+    if s.get("tamper_events"):
+        lines.append(c(_C.RED, f"🚨 {len(s['tamper_events'])} TAMPER EVENT(S) — "
+                               "protected scorer / eval harness / task data changed. "
+                               "Every score in this run is UNTRUSTWORTHY."))
+        for ev in s["tamper_events"][:5]:
+            for ch in (ev.get("changes") or [])[:5]:
+                lines.append(c(_C.RED, f"  {ch.get('change', '?')} {ch.get('path', '?')}"
+                                       f"  ({ev.get('context') or 'unknown context'})"))
+        lines.append("")
+
     if s["gate_warnings"]:
         lines.append(c(_C.YELLOW, f"⚠ {len(s['gate_warnings'])} gate warning(s):"))
         for w in s["gate_warnings"][:3]:
@@ -897,6 +909,24 @@ function showTip(e,txt){tip.textContent=txt;tip.style.display='block';
   tip.style.left=Math.min(e.clientX+14,innerWidth-330)+'px';tip.style.top=(e.clientY+14)+'px';}
 function hideTip(){tip.style.display='none';}
 function sec(title){const s=$('section');s.append($('h2',{text:title}));main.append(s);return s;}
+
+/* ---------- 0. TAMPER banner (#142) ----------
+   Above everything, because if a protected path changed every number below it is
+   void. A guard nobody can see is half a guard. */
+(function(){
+  const T=S.tamper_events||[]; if(!T.length)return;
+  const s=sec('🚨 Tamper detected — scores untrustworthy');
+  s.append($('p',{text:T.length+' tamper event(s): a PROTECTED path (scorer / eval '+
+    'harness / task data / gold answers) changed during this run. Every reward, gate '+
+    'decision and sealed test number in this report was produced alongside an edited '+
+    'grader and must not be reported as a result.'}));
+  T.forEach(e=>{(e.changes||[]).forEach(ch=>{const a=$('div',{class:'ann'});
+    a.append($('div',{class:'who',text:(ch.change||'?')+' · '+(e.context||'')}),
+      $('div',{text:(ch.path||'?')+'  expected '+String(ch.expected_sha256||'—').slice(0,12)+
+        '…  actual '+String(ch.actual_sha256||'—').slice(0,12)+'…'}));s.append(a);});});
+  s.querySelectorAll('.ann').forEach(a=>{a.style.borderLeftColor='#e5534b';});
+  s.querySelector('h2').style.color='#e5534b';
+})();
 
 /* ---------- 1. KPI strip ---------- */
 (function(){

--- a/core/cap_evolve/gepa.py
+++ b/core/cap_evolve/gepa.py
@@ -51,6 +51,7 @@ from pathlib import Path
 from typing import Callable
 
 from . import gate as gate_mod
+from . import protect
 from . import selection
 from .cache import EvalCache, hash_candidate_dir
 from .harness import (
@@ -134,6 +135,12 @@ def _eval_minibatch(
     honest gate). One trial per task — the minibatch is a cheap signal, not the
     significance test.
     """
+    # Tamper guard (#142): the minibatch is its own (local) gate and it writes
+    # ``EvalCache`` entries, so it must not run against an edited scorer either.
+    # ``evaluate_candidate`` guards the full-val/test path; this guards GEPA's
+    # cheap path, which bypasses it.
+    protect.verify(run_dir, context=f"minibatch eval of {tag}")
+
     all_train = {t.id: t for t in adapter.tasks("all")}
     tasks = [all_train[tid] for tid in task_ids if tid in all_train]
     out_dir = run_dir.rollouts / "train"

--- a/core/cap_evolve/gepa.py
+++ b/core/cap_evolve/gepa.py
@@ -184,6 +184,13 @@ def _eval_minibatch(
             if cache is not None:
                 cache.put(chash, task.id, sc.reward, sc.feedback or "")
 
+    # POST-scoring guard (#142), matching ``evaluate_candidate``: the pre-check above
+    # only proves the grader was clean when the minibatch STARTED. This path both gates
+    # a child locally and writes ``EvalCache`` entries that later iterations trust, so a
+    # writer that lands during scoring must invalidate the result here rather than be
+    # cached as truth.
+    protect.verify(run_dir, context=f"post-minibatch eval of {tag}")
+
     elapsed = time.time() - t0
     # Count ONLY rollouts actually fired (cache hits cost nothing) toward budget.
     run_dir.update_spent(metric_calls=n_called, usd=run_cost,

--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -311,6 +311,23 @@ def evaluate_candidate(
             metrics=_aggregate_metrics(per_task_metrics[tid], mean(tr)),
         ))
 
+    # POST-scoring tamper guard (#142 step 3). The pre-check above proves the grader
+    # was clean when scoring STARTED; on its own that is a TOCTOU fence with the whole
+    # scoring window open behind it. ``optimizer_from_command`` uses ``subprocess.run``,
+    # which waits only on the direct child — a ``Popen(start_new_session=True)``
+    # grandchild outlives it and can rewrite ground truth WHILE ``run_target`` and
+    # ``score`` read it. Re-verifying here, before ``aggregate_scores`` produces the
+    # number and before any caller can ``set_best`` / ``commit_test``, means the
+    # manifest is checked against the state the scorer actually observed: the score is
+    # discarded rather than recorded, for val and for the sealed test alike.
+    #
+    # ponytail: bracketing, not locking. The residual window is the gap between the
+    # last ``score()`` read and this hash — a writer that lands inside it and is
+    # reverted before the hash still wins. Closing that needs the scorer to hash the
+    # bytes it reads (per-read verification), which is a much bigger change; the honest
+    # claim is a bracket, and HONEST_EVAL.md states it as one.
+    protect_mod.verify(run_dir, context=f"post-{split} eval of {tag}")
+
     elapsed = time.time() - t0
     run_dir.update_spent(metric_calls=len(tasks) * n_trials, usd=run_cost,
                          runner_tokens=run_tokens, runner_seconds=elapsed)
@@ -326,6 +343,11 @@ def split_result_from_rollouts(run_dir: RunDir, tag: str, split: str = "val", ks
 
     Used to RESUME a run from the current best candidate (its val score is read
     back from disk) without re-scoring it.
+
+    Deliberately NOT tamper-guarded (#142): it re-reads rollouts already persisted and
+    already verified by the ``evaluate_candidate`` that produced them, and produces no
+    new score. Verifying here would only re-check the manifest at an arbitrary later
+    moment and could fail a resume for a change that post-dates the number being read.
     """
     import json as _json
     from .stats import mean, stderr
@@ -433,10 +455,40 @@ def reuse_baseline(prior_run_dir: Path, *, run_dir: RunDir) -> SplitResult:
 
     run_dir.set_best("seed")
 
+    # Tamper provenance for an INHERITED baseline (#142). This number was produced by
+    # another run's grader, which this run never hashed. If that run logged a tamper the
+    # baseline is fiction, so refuse it; otherwise carry its manifest forward so this
+    # run verifies against the tree the reused number was actually scored on, instead of
+    # re-recording whatever the tree looks like now.
+    prior_events = prior / "events.jsonl"
+    if prior_events.exists():
+        for line in prior_events.read_text(encoding="utf-8").splitlines():
+            if '"tamper_detected"' in line:
+                raise protect_mod.TamperError(
+                    f"cap-evolve: refusing to reuse the baseline from {prior} — that run "
+                    "logged a tamper_detected event, so its baseline was scored against a "
+                    "grader that changed mid-run. Reusing it would inherit a fabricated "
+                    "number as this run's reference point. Re-run baseline from a clean "
+                    "checkout."
+                )
+    prior_manifest = prior / protect_mod.MANIFEST_NAME
+    if prior_manifest.exists() and not (run_dir.root / protect_mod.MANIFEST_NAME).exists():
+        shutil.copyfile(prior_manifest, run_dir.root / protect_mod.MANIFEST_NAME)
+        try:
+            payload = json.loads(prior_manifest.read_text(encoding="utf-8"))
+        except Exception:  # noqa: BLE001 — an unreadable prior manifest is no provenance
+            payload = None
+        if payload is not None:
+            run_dir.log_event("protected_manifest", n_files=len(payload.get("files") or {}),
+                              globs=payload.get("globs") or [],
+                              digest=protect_mod.manifest_digest(payload),
+                              inherited_from=str(prior))
+
     baseline_data = json.loads(prior_baseline.read_text(encoding="utf-8"))
     result = SplitResult.from_dict(baseline_data["val"])
     run_dir.log_event("baseline_reused", prior_run_dir=str(prior),
-                      val=result.reward, stderr=result.stderr)
+                      val=result.reward, stderr=result.stderr,
+                      protected_manifest_inherited=prior_manifest.exists())
     return result
 
 
@@ -1267,6 +1319,12 @@ def run_step(
     # anything. ``baseline`` normally does this first, but ``--reuse-baseline``
     # skips the baseline eval, so without this the first manifest would be taken
     # AFTER an optimizer step and would bless a tampered grader.
+    #
+    # This is also what makes the guard correct under ``--resume``: the call is
+    # idempotent when the manifest is intact (it re-reads it), so a resumed run keeps
+    # verifying against the ORIGINAL baseline hashes rather than re-recording from the
+    # current tree. If the manifest is gone or altered it raises instead — deleting it
+    # was the one way ``--resume`` could launder a tampered file.
     protect_mod.ensure_manifest(run_dir, project_dir)
 
     optimizer_error = None
@@ -1974,6 +2032,12 @@ def finalize(adapter, *, run_dir: RunDir, best_dir: Path, n_trials: int = 1, ks=
         payload["test_baseline"] = result.to_dict()
         payload["baseline_id"] = run_dir.best_id
         payload["test_delta"] = 0.0
+
+    # Last gate before the seal burns (#142). ``evaluate_candidate`` already
+    # pre- and post-checks each test eval; this covers the remaining gap between the
+    # final ``score()`` and the irreversible ``commit_test``, so the headline number is
+    # never sealed against a grader that changed at any point during finalize.
+    protect_mod.verify(run_dir, context="finalize (pre-seal)")
 
     _atomic_write(run_dir.root / "final.json", json.dumps(payload, indent=2))
     run_dir.commit_test()  # burn the seal ONLY now that the result(s) are computed + written

--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import Callable
 
 from . import gate as gate_mod
+from . import protect as protect_mod
 from .loop import SplitResult, aggregate_scores
 from .rundir import RunDir, _atomic_write
 from .splits import Splits, make_splits
@@ -182,6 +183,13 @@ def evaluate_candidate(
     been computed and written — a crash mid-scoring leaves the seal unused so a
     retry can still score test exactly once. That is ``finalize``'s job.
     """
+    # Protected-paths tamper guard (#142). This is THE chokepoint every evaluation
+    # goes through — baseline, each iteration's val eval, and finalize — so the guard
+    # is on the path every run takes rather than an opt-in extra. It raises
+    # ``TamperError`` BEFORE any scoring, snapshot, ``set_best`` or ``commit_test``,
+    # so a candidate produced alongside an edited scorer can neither advance nor seal.
+    protect_mod.verify(run_dir, context=f"{split} eval of {tag}")
+
     if split == "test":
         run_dir.reserve_test()  # raises TestSealError on reuse; does NOT burn the seal yet
 
@@ -1254,6 +1262,12 @@ def run_step(
                               capability_sources=capability_sources, project_dir=project_dir)
 
     instructions = _augment_instructions(instructions, workdir, run_dir, rejected, history)
+
+    # Record the pristine protected-path hashes BEFORE the optimizer can touch
+    # anything. ``baseline`` normally does this first, but ``--reuse-baseline``
+    # skips the baseline eval, so without this the first manifest would be taken
+    # AFTER an optimizer step and would bless a tampered grader.
+    protect_mod.ensure_manifest(run_dir, project_dir)
 
     optimizer_error = None
     opt_cost_usd, opt_tokens = 0.0, 0

--- a/core/cap_evolve/protect.py
+++ b/core/cap_evolve/protect.py
@@ -1,0 +1,262 @@
+"""Protected-paths tamper guard — proof the optimizer never edited the grader.
+
+cap-evolve already makes the *evaluation* honest (seeded splits, a sealed test
+split, a val-only significance gate). But when the capability under optimization
+is tool code or a skill package, the optimizer is a coding agent with write tools
+running next to the project — nothing structural stopped it from editing the
+**scorer / eval harness / task data** instead of the target. A candidate that
+"improves" by rewriting ``score()`` is reward hacking, and every number after it
+is fiction.
+
+This module makes "only edit the target, never the grader" a *structural*
+guarantee, the same posture the test seal already has:
+
+  1. ``ensure_manifest`` records a SHA-256 of every protected file at the START of
+     a run (``baseline``), persisted as ``protected.json`` in the run dir.
+  2. ``verify`` re-hashes them after every optimizer invocation and again before
+     ``finalize`` burns the seal. Any change / deletion / newly-added protected
+     file logs a ``tamper_detected`` event and raises ``TamperError``, naming the
+     file — the run aborts, so the candidate cannot advance and the test split
+     cannot be sealed on a tampered grader.
+
+Why a content hash: mtime is trivially spoofable (``os.utime``) and a size check
+misses same-length edits. SHA-256 over the bytes is the only claim we can make
+honestly — and ``hashlib`` is stdlib, so this costs zero dependencies.
+
+What counts as protected (defaults, derived from the project layout):
+  * ``adapters/`` — ``tasks()`` / ``run_target()`` / ``score()`` live here: the
+    ground truth and the grader;
+  * ``capevolve.yaml`` — declares splits, ratios, gate mode/k, budget;
+  * the ``dataset_source`` and ``split_ids_file`` the spec names (task data + the
+    frozen partition), when they resolve to real paths;
+  * anything matching ``*gold*`` in the project dir (answer keys).
+The seed capability dir is deliberately NOT protected — it is the target.
+
+Override with a ``protected_paths`` list in ``capevolve.yaml`` (project-relative
+paths, dirs, or glob patterns). That replaces the defaults entirely, so a project
+whose grader lives elsewhere can declare it.
+
+Pure stdlib (hashlib + json).
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import hashlib
+import json
+from pathlib import Path
+
+from .specfile import read_yaml
+
+MANIFEST_NAME = "protected.json"
+
+# Default protected globs, relative to the project dir. Every entry is optional:
+# a project that has no tasks.jsonl simply contributes nothing from that entry.
+_DEFAULT_GLOBS = ("adapters", "capevolve.yaml", "*gold*", "**/*gold*")
+
+# Never hashed: caches/vcs churn that is not content. ``__pycache__`` matters a
+# lot — ``check.load_adapter`` execs ``adapters/adapter.py``, and importing a
+# sibling helper writes ``adapters/__pycache__/*.pyc`` DURING a legitimate run.
+# Hashing those would flag every normal run as tampering (a guard that blocks
+# normal runs is worse than no guard).
+_SKIP_DIRS = {"__pycache__", ".git", ".mypy_cache", ".pytest_cache", ".ruff_cache"}
+_SKIP_SUFFIXES = {".pyc", ".pyo"}
+
+
+class TamperError(RuntimeError):
+    """A protected (scoring / eval / task-data) file changed during the run."""
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1 << 16), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _skip(rel_parts: tuple[str, ...], name: str) -> bool:
+    return (any(p in _SKIP_DIRS for p in rel_parts)
+            or Path(name).suffix in _SKIP_SUFFIXES)
+
+
+def project_dir_for(run_dir) -> Path | None:
+    """The ``.capevolve/project`` sibling of a run dir, or None.
+
+    Lets the guard run in ``gepa``/``skillopt``, which don't thread a
+    ``project_dir`` — the layout is fixed (``.capevolve/run_<ts>`` next to
+    ``.capevolve/project``), so no new plumbing is needed to find the grader.
+    """
+    proj = Path(run_dir.root).parent / "project"
+    return proj if (proj / "adapters" / "adapter.py").exists() else None
+
+
+def protected_globs(project_dir: Path) -> list[str]:
+    """The declared protected globs: ``protected_paths`` from the spec, else defaults."""
+    cfg = Path(project_dir) / "capevolve.yaml"
+    if cfg.exists():
+        try:
+            spec = read_yaml(cfg.read_text(encoding="utf-8")) or {}
+        except Exception:  # noqa: BLE001 — a malformed spec must not disable the guard
+            spec = {}
+        declared = spec.get("protected_paths")
+        if isinstance(declared, str):
+            declared = [declared]
+        if declared:
+            return [str(x) for x in declared if str(x).strip()]
+        # Defaults + whatever data paths this spec actually names.
+        extra = [str(spec[k]) for k in ("dataset_source", "split_ids_file")
+                 if str(spec.get(k) or "").strip() and str(spec.get(k)) != "adapter"]
+        return [*_DEFAULT_GLOBS, *extra]
+    return list(_DEFAULT_GLOBS)
+
+
+def resolve_protected(project_dir: Path, *, exclude: Path | None = None) -> dict[str, Path]:
+    """Expand the declared globs into ``{project-relative path -> file}``.
+
+    Directories expand to their whole subtree. ``exclude`` (the run dir) is never
+    protected — it holds the run's own mutable state. Missing entries are
+    tolerated: the defaults are layout guesses, not requirements.
+    """
+    pdir = Path(project_dir).resolve()
+    ex = Path(exclude).resolve() if exclude is not None else None
+    out: dict[str, Path] = {}
+
+    def _add(p: Path) -> None:
+        if not p.is_file():
+            return
+        try:
+            rel = p.resolve().relative_to(pdir)
+        except ValueError:
+            return  # outside the project dir (a stray absolute glob) — ignore
+        if ex is not None:
+            try:
+                p.resolve().relative_to(ex)
+                return  # inside the run dir
+            except ValueError:
+                pass
+        if _skip(rel.parts, p.name):
+            return
+        out[str(rel).replace("\\", "/")] = p
+
+    for pattern in protected_globs(pdir):
+        pat = str(pattern).strip().lstrip("/")
+        if not pat:
+            continue
+        direct = pdir / pat
+        if direct.is_dir():
+            for child in direct.rglob("*"):
+                _add(child)
+            continue
+        if direct.is_file():
+            _add(direct)
+            continue
+        for hit in pdir.glob(pat):
+            if hit.is_dir():
+                for child in hit.rglob("*"):
+                    _add(child)
+            else:
+                _add(hit)
+    return out
+
+
+def build_manifest(project_dir: Path, *, exclude: Path | None = None) -> dict[str, str]:
+    """``{project-relative path -> sha256}`` for every protected file, right now."""
+    files = resolve_protected(project_dir, exclude=exclude)
+    return {rel: _sha256(p) for rel, p in sorted(files.items())}
+
+
+def ensure_manifest(run_dir, project_dir: Path | None = None) -> dict | None:
+    """Record the pristine protected-file hashes, once per run (idempotent).
+
+    Called at ``baseline`` (so the manifest is taken before any optimizer runs)
+    and defensively before each optimizer invocation, which also covers a resumed
+    run whose manifest predates this feature. Returns the manifest payload, or
+    None when there is no project dir to protect (e.g. a bare unit test).
+    """
+    pdir = Path(project_dir) if project_dir else project_dir_for(run_dir)
+    if pdir is None or not Path(pdir).is_dir():
+        return None
+    path = Path(run_dir.root) / MANIFEST_NAME
+    if path.exists():
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except Exception:  # noqa: BLE001 — torn manifest: re-record rather than crash
+            pass
+    payload = {"project_dir": str(Path(pdir).resolve()),
+               "globs": protected_globs(Path(pdir)),
+               "files": build_manifest(pdir, exclude=Path(run_dir.root))}
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    run_dir.log_event("protected_manifest", n_files=len(payload["files"]),
+                      globs=payload["globs"])
+    return payload
+
+
+def diff_manifest(recorded: dict[str, str], current: dict[str, str]) -> list[dict]:
+    """Every difference between a recorded and a current manifest."""
+    out: list[dict] = []
+    for rel, want in sorted(recorded.items()):
+        got = current.get(rel)
+        if got is None:
+            out.append({"path": rel, "change": "deleted", "expected_sha256": want})
+        elif got != want:
+            out.append({"path": rel, "change": "modified",
+                        "expected_sha256": want, "actual_sha256": got})
+    for rel in sorted(set(current) - set(recorded)):
+        out.append({"path": rel, "change": "added", "actual_sha256": current[rel]})
+    return out
+
+
+def verify(run_dir, project_dir: Path | None = None, *, context: str = "") -> list[dict]:
+    """Re-hash the protected files; raise ``TamperError`` on ANY difference.
+
+    Returns ``[]`` when clean (or when there is nothing to protect). On a
+    mismatch a ``tamper_detected`` event is logged BEFORE raising, so the audit
+    log records the tamper even though the run aborts. We deliberately do not
+    "repair" the file — the evidence stays on disk for the human to inspect.
+    """
+    recorded = ensure_manifest(run_dir, project_dir)
+    if not recorded:
+        return []
+    pdir = Path(recorded.get("project_dir") or (project_dir or ""))
+    if not pdir.is_dir():
+        return []
+    current = build_manifest(pdir, exclude=Path(run_dir.root))
+    changes = diff_manifest(recorded.get("files") or {}, current)
+    if not changes:
+        return []
+    run_dir.log_event("tamper_detected", context=context, changes=changes,
+                      project_dir=str(pdir))
+    named = "; ".join(f"{c['change']} {c['path']}" for c in changes[:8])
+    if len(changes) > 8:
+        named += f"; (+{len(changes) - 8} more)"
+    raise TamperError(
+        f"cap-evolve TAMPER DETECTED{f' during {context}' if context else ''}: "
+        f"{len(changes)} protected file(s) changed under {pdir} — {named}. "
+        "Protected paths are the scorer / eval harness / task data; a candidate that "
+        "edits them is reward hacking, so this run is aborted (the score is discarded "
+        "and the test split is NOT sealed). Optimize the capability, not the grader. "
+        f"Recorded hashes: {Path(run_dir.root) / MANIFEST_NAME}. "
+        "If a path is legitimately editable, remove it from `protected_paths` in "
+        "capevolve.yaml and start a new run."
+    )
+
+
+def is_protected(project_dir: Path, path: Path) -> bool:
+    """Would ``path`` be protected for ``project_dir``? (used by the honesty hook)."""
+    pdir = Path(project_dir).resolve()
+    try:
+        rel = str(Path(path).resolve().relative_to(pdir)).replace("\\", "/")
+    except ValueError:
+        return False
+    if _skip(Path(rel).parts, Path(rel).name):
+        return False
+    for pattern in protected_globs(pdir):
+        pat = str(pattern).strip().lstrip("/")
+        if not pat:
+            continue
+        if rel == pat or rel.startswith(pat.rstrip("/") + "/"):
+            return True
+        if fnmatch.fnmatch(rel, pat) or fnmatch.fnmatch(Path(rel).name, pat):
+            return True
+    return False

--- a/core/cap_evolve/protect.py
+++ b/core/cap_evolve/protect.py
@@ -44,6 +44,7 @@ from __future__ import annotations
 import fnmatch
 import hashlib
 import json
+import os
 from pathlib import Path
 
 from .specfile import read_yaml
@@ -52,15 +53,32 @@ MANIFEST_NAME = "protected.json"
 
 # Default protected globs, relative to the project dir. Every entry is optional:
 # a project that has no tasks.jsonl simply contributes nothing from that entry.
-_DEFAULT_GLOBS = ("adapters", "capevolve.yaml", "*gold*", "**/*gold*")
+# ``*gold*`` is deliberately narrowed to DATA suffixes: the bare glob also caught
+# prose like ``docs/golden-rules.md`` / ``GOLDEN_PATH.md``, and because
+# ``protected_paths`` replaces the defaults wholesale that foot-gun could only be
+# escaped by re-enumerating every default.
+_DEFAULT_GLOBS = (
+    "adapters", "capevolve.yaml",
+    "*gold*.json", "*gold*.jsonl", "*gold*.yaml", "*gold*.yml", "*gold*.csv", "*gold*.txt",
+    "**/*gold*.json", "**/*gold*.jsonl", "**/*gold*.yaml", "**/*gold*.yml",
+    "**/*gold*.csv", "**/*gold*.txt",
+)
 
-# Never hashed: caches/vcs churn that is not content. ``__pycache__`` matters a
-# lot — ``check.load_adapter`` execs ``adapters/adapter.py``, and importing a
-# sibling helper writes ``adapters/__pycache__/*.pyc`` DURING a legitimate run.
-# Hashing those would flag every normal run as tampering (a guard that blocks
-# normal runs is worse than no guard).
-_SKIP_DIRS = {"__pycache__", ".git", ".mypy_cache", ".pytest_cache", ".ruff_cache"}
-_SKIP_SUFFIXES = {".pyc", ".pyo"}
+# Never hashed: VCS / tool caches that are not project content.
+#
+# ``__pycache__`` and ``*.pyc`` are NOT on this list, deliberately. An earlier
+# revision skipped them because ``check.load_adapter`` writes
+# ``adapters/__pycache__/*.pyc`` during a legitimate run — but that exclusion was a
+# working reward hack: a PEP 552 ``UNCHECKED_HASH`` pyc planted in the adapter's
+# cache slot executes a hacked ``score()`` while ``adapter.py``'s SHA-256 stays
+# byte-identical to the manifest (unchecked-hash pycs skip mtime, size AND hash
+# validation, so relying on cache invalidation is no defence either). The fix is to
+# stop the write, not to stop looking: ``load_adapter`` sets
+# ``sys.dont_write_bytecode`` around ``exec_module``, so no ``.pyc`` appears during a
+# legitimate run and bytecode is hashed like any other file. A pyc that shows up
+# mid-run IS tampering, and now reads as an ``added`` protected file.
+_SKIP_DIRS = {".git", ".mypy_cache", ".pytest_cache", ".ruff_cache"}
+_SKIP_SUFFIXES: frozenset[str] = frozenset()
 
 
 class TamperError(RuntimeError):
@@ -68,8 +86,24 @@ class TamperError(RuntimeError):
 
 
 def _sha256(path: Path) -> str:
+    """SHA-256 of a protected file's bytes.
+
+    A symlink never gets hashed by following it: the bytes behind a symlink can be
+    changed without touching anything inside the project dir, so following one would
+    hand back a hash the guard cannot actually vouch for. Symlinks (and anything else
+    that is not a regular file) get a distinct sentinel instead, which makes
+    "regular file replaced by symlink" — and the reverse — a ``modified`` change.
+    """
+    p = Path(path)
+    if p.is_symlink():
+        try:
+            return "symlink:" + os.readlink(p)
+        except OSError as e:  # noqa: BLE001 — an unreadable link is still not a file
+            return f"symlink:<unreadable {e.errno}>"
+    if not p.is_file():
+        return "not-a-regular-file"
     h = hashlib.sha256()
-    with path.open("rb") as f:
+    with p.open("rb") as f:
         for chunk in iter(lambda: f.read(1 << 16), b""):
             h.update(chunk)
     return h.hexdigest()
@@ -92,18 +126,44 @@ def project_dir_for(run_dir) -> Path | None:
 
 
 def protected_globs(project_dir: Path) -> list[str]:
-    """The declared protected globs: ``protected_paths`` from the spec, else defaults."""
+    """The declared protected globs: ``protected_paths`` from the spec, else defaults.
+
+    A ``protected_paths`` key that is present but not a list/str is a HARD error.
+    Silently falling back to the defaults meant a project that declared its grader —
+    and got it wrong, or hit a parser gap — believed it was protected while it was
+    not. For an honesty guard, "your config did not apply" must never be silent.
+    """
     cfg = Path(project_dir) / "capevolve.yaml"
     if cfg.exists():
         try:
             spec = read_yaml(cfg.read_text(encoding="utf-8")) or {}
-        except Exception:  # noqa: BLE001 — a malformed spec must not disable the guard
-            spec = {}
+        except Exception as e:  # noqa: BLE001 — a malformed spec must not disable the guard
+            raise TamperError(
+                f"cap-evolve: cannot read {cfg} to determine the protected paths "
+                f"({e}). Refusing to run with an unknown protected set — fix the spec."
+            ) from e
         declared = spec.get("protected_paths")
         if isinstance(declared, str):
             declared = [declared]
-        if declared:
-            return [str(x) for x in declared if str(x).strip()]
+        if isinstance(declared, (list, tuple)):
+            out = [str(x) for x in declared if str(x).strip()]
+            if out:
+                return out
+            raise TamperError(
+                f"cap-evolve: `protected_paths` in {cfg} is an EMPTY list. That would "
+                "protect nothing (the scorer / eval harness / task data would all be "
+                "optimizer-writable). Remove the key to use the defaults, or declare "
+                "the paths."
+            )
+        if declared is not None:
+            raise TamperError(
+                f"cap-evolve: `protected_paths` in {cfg} did not parse as a list "
+                f"(got {type(declared).__name__}: {declared!r}). Falling back to the "
+                "defaults would silently leave a declared grader unprotected, so this "
+                "is a hard error. Write it as a YAML list — either "
+                "`protected_paths: [adapters, gold.json]` or a block list with `- ` "
+                "items."
+            )
         # Defaults + whatever data paths this spec actually names.
         extra = [str(spec[k]) for k in ("dataset_source", "split_ids_file")
                  if str(spec.get(k) or "").strip() and str(spec.get(k)) != "adapter"]
@@ -111,31 +171,48 @@ def protected_globs(project_dir: Path) -> list[str]:
     return list(_DEFAULT_GLOBS)
 
 
-def resolve_protected(project_dir: Path, *, exclude: Path | None = None) -> dict[str, Path]:
+def resolve_protected(project_dir: Path, *, exclude: Path | None = None,
+                      unprotected: list[str] | None = None) -> dict[str, Path]:
     """Expand the declared globs into ``{project-relative path -> file}``.
 
     Directories expand to their whole subtree. ``exclude`` (the run dir) is never
     protected — it holds the run's own mutable state. Missing entries are
     tolerated: the defaults are layout guesses, not requirements.
+
+    Pass ``unprotected`` (a list) to collect every glob that matched nothing inside
+    the project dir. Only paths under ``project_dir`` can be protected, so an
+    absolute ``dataset_source`` pointing at a benchmark checkout elsewhere (a common
+    swebench-style layout) contributes nothing — the caller warns about that rather
+    than letting "I declared it and it wasn't protected" stay invisible.
     """
     pdir = Path(project_dir).resolve()
     ex = Path(exclude).resolve() if exclude is not None else None
     out: dict[str, Path] = {}
 
     def _add(p: Path) -> None:
-        if not p.is_file():
-            return
+        # Compute ``rel`` from the UN-resolved path. Resolving first followed
+        # symlinks, so replacing a protected file BY a symlink pointing outside the
+        # project silently dropped it from the protected set (target outside pdir →
+        # ValueError → return): a free de-protection. The relative name is what the
+        # manifest keys on, so it must come from the name as declared.
         try:
-            rel = p.resolve().relative_to(pdir)
+            rel = Path(os.path.relpath(p, pdir))
         except ValueError:
+            return  # different drive (Windows) — not inside the project
+        if rel.parts and rel.parts[0] == "..":
             return  # outside the project dir (a stray absolute glob) — ignore
+        if _skip(rel.parts, p.name):
+            return
         if ex is not None:
             try:
                 p.resolve().relative_to(ex)
                 return  # inside the run dir
-            except ValueError:
+            except (ValueError, OSError):
                 pass
-        if _skip(rel.parts, p.name):
+        # A symlink is kept in the set (``_sha256`` turns it into a sentinel hash)
+        # rather than dropped: a protected path that BECOMES a symlink must read as a
+        # change, not as an exemption.
+        if not p.is_symlink() and not p.is_file():
             return
         out[str(rel).replace("\\", "/")] = p
 
@@ -143,27 +220,97 @@ def resolve_protected(project_dir: Path, *, exclude: Path | None = None) -> dict
         pat = str(pattern).strip().lstrip("/")
         if not pat:
             continue
+        before = len(out)
         direct = pdir / pat
         if direct.is_dir():
             for child in direct.rglob("*"):
                 _add(child)
-            continue
-        if direct.is_file():
+        elif direct.is_symlink() or direct.is_file():
             _add(direct)
-            continue
-        for hit in pdir.glob(pat):
-            if hit.is_dir():
-                for child in hit.rglob("*"):
-                    _add(child)
-            else:
-                _add(hit)
+        else:
+            for hit in pdir.glob(pat):
+                if hit.is_dir():
+                    for child in hit.rglob("*"):
+                        _add(child)
+                else:
+                    _add(hit)
+        if unprotected is not None and len(out) == before and _looks_declared(pat):
+            unprotected.append(pat)
     return out
 
 
-def build_manifest(project_dir: Path, *, exclude: Path | None = None) -> dict[str, str]:
+def _looks_declared(pat: str) -> bool:
+    """Is this glob an explicit declaration rather than one of our layout guesses?
+
+    The defaults are optional by design (a project with no ``*gold*.json`` is not
+    misconfigured), so only non-default patterns are worth warning about.
+    """
+    return pat not in _DEFAULT_GLOBS
+
+
+def build_manifest(project_dir: Path, *, exclude: Path | None = None,
+                   unprotected: list[str] | None = None) -> dict[str, str]:
     """``{project-relative path -> sha256}`` for every protected file, right now."""
-    files = resolve_protected(project_dir, exclude=exclude)
+    files = resolve_protected(project_dir, exclude=exclude, unprotected=unprotected)
     return {rel: _sha256(p) for rel, p in sorted(files.items())}
+
+
+def manifest_digest(payload: dict) -> str:
+    """SHA-256 of the manifest's canonical JSON — the manifest hashing itself.
+
+    Recorded in the ``protected_manifest`` event so the manifest is covered by the
+    same kind of evidence it provides for everything else. Rewriting
+    ``protected.json`` to bless a tampered tree now also requires forging this digest
+    in ``events.jsonl``.
+    """
+    canon = json.dumps({k: payload.get(k) for k in ("project_dir", "globs", "files")},
+                       sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canon.encode("utf-8")).hexdigest()
+
+
+def _recorded_manifest_events(run_dir) -> list[dict]:
+    """Every ``protected_manifest`` event this run has logged (oldest first)."""
+    out: list[dict] = []
+    p = Path(run_dir.root) / "events.jsonl"
+    if not p.exists():
+        return out
+    try:
+        for line in p.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line or "protected_manifest" not in line:
+                continue
+            try:
+                rec = json.loads(line)
+            except Exception:  # noqa: BLE001 — a torn line is not evidence either way
+                continue
+            if rec.get("kind") == "protected_manifest":
+                out.append(rec)
+    except OSError:
+        pass
+    return out
+
+
+def _manifest_gone(run_dir, prior: list[dict], why: str) -> "TamperError":
+    """A manifest that was recorded and is now missing/unreadable/altered is tamper.
+
+    Re-recording from the current tree is only legitimate at FIRST creation. After
+    that, the manifest's absence or corruption is itself the evidence — silently
+    rebuilding it would let one optimizer step (clobber ``protected.json``, hack the
+    grader) launder a tampered tree inside a single run.
+    """
+    run_dir.log_event("tamper_detected", context="protected manifest", changes=[
+        {"path": MANIFEST_NAME, "change": "manifest_" + why,
+         "expected_sha256": (prior[-1].get("digest") if prior else None)}])
+    return TamperError(
+        f"cap-evolve TAMPER DETECTED: this run recorded a protected-paths manifest "
+        f"({len(prior)} protected_manifest event(s) in events.jsonl) but "
+        f"{Path(run_dir.root) / MANIFEST_NAME} is now {why}. The manifest is the "
+        "evidence that the scorer / eval harness / task data were not edited; "
+        "destroying or rewriting it is itself reward hacking, so this run is aborted "
+        "(the score is discarded and the test split is NOT sealed). Re-recording the "
+        "hashes from the current tree would bless whatever state the tree is in now. "
+        "Start a new run from a clean checkout. Full detail in events.jsonl."
+    )
 
 
 def ensure_manifest(run_dir, project_dir: Path | None = None) -> dict | None:
@@ -173,22 +320,58 @@ def ensure_manifest(run_dir, project_dir: Path | None = None) -> dict | None:
     and defensively before each optimizer invocation, which also covers a resumed
     run whose manifest predates this feature. Returns the manifest payload, or
     None when there is no project dir to protect (e.g. a bare unit test).
+
+    Raises ``TamperError`` if this run already recorded a manifest and the file is
+    now missing, unparseable, or no longer matches the digest logged with it.
     """
     pdir = Path(project_dir) if project_dir else project_dir_for(run_dir)
     if pdir is None or not Path(pdir).is_dir():
+        # A project with no ``adapters/adapter.py`` gets ZERO protection. Log it once
+        # so "the guard found nothing to protect" is distinguishable from "the guard
+        # ran and the tree was clean" in the audit log (#142 N6).
+        if not _recorded_manifest_events(run_dir) and not getattr(
+                run_dir, "_protect_skip_logged", False):
+            run_dir.log_event("protected_manifest_skipped", reason=(
+                "no project dir with adapters/adapter.py next to the run dir — nothing "
+                "is protected for this run"), project_dir=str(pdir) if pdir else None)
+            try:
+                run_dir._protect_skip_logged = True
+            except Exception:  # noqa: BLE001 — slots/frozen run_dir: one extra line is fine
+                pass
         return None
     path = Path(run_dir.root) / MANIFEST_NAME
+    prior = _recorded_manifest_events(run_dir)
     if path.exists():
         try:
-            return json.loads(path.read_text(encoding="utf-8"))
-        except Exception:  # noqa: BLE001 — torn manifest: re-record rather than crash
-            pass
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:  # noqa: BLE001
+            if prior:
+                raise _manifest_gone(run_dir, prior, "unparseable") from None
+            payload = None  # first creation raced/torn: recording it now is honest
+        else:
+            want = prior[-1].get("digest") if prior else None
+            if want and manifest_digest(payload) != want:
+                raise _manifest_gone(run_dir, prior, "altered")
+            return payload
+    elif prior:
+        raise _manifest_gone(run_dir, prior, "missing")
+
+    unprotected: list[str] = []
     payload = {"project_dir": str(Path(pdir).resolve()),
                "globs": protected_globs(Path(pdir)),
-               "files": build_manifest(pdir, exclude=Path(run_dir.root))}
+               "files": build_manifest(pdir, exclude=Path(run_dir.root),
+                                       unprotected=unprotected)}
     path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
     run_dir.log_event("protected_manifest", n_files=len(payload["files"]),
-                      globs=payload["globs"])
+                      globs=payload["globs"], digest=manifest_digest(payload))
+    if unprotected:
+        # Only paths INSIDE the project dir can be protected. A declared glob that
+        # matched nothing there (typically ground truth in a benchmark checkout
+        # referenced by absolute path) is silently unguarded — say so (#142 N7).
+        run_dir.log_event("protected_paths_unmatched", globs=unprotected, reason=(
+            "declared protected path(s) matched no file inside the project dir, so "
+            "they are NOT covered by the tamper manifest — only paths under "
+            f"{Path(pdir).resolve()} can be hashed"))
     return payload
 
 
@@ -229,7 +412,7 @@ def verify(run_dir, project_dir: Path | None = None, *, context: str = "") -> li
                       project_dir=str(pdir))
     named = "; ".join(f"{c['change']} {c['path']}" for c in changes[:8])
     if len(changes) > 8:
-        named += f"; (+{len(changes) - 8} more)"
+        named += f"; (+{len(changes) - 8} more — full list in events.jsonl)"
     raise TamperError(
         f"cap-evolve TAMPER DETECTED{f' during {context}' if context else ''}: "
         f"{len(changes)} protected file(s) changed under {pdir} — {named}. "
@@ -243,20 +426,37 @@ def verify(run_dir, project_dir: Path | None = None, *, context: str = "") -> li
 
 
 def is_protected(project_dir: Path, path: Path) -> bool:
-    """Would ``path`` be protected for ``project_dir``? (used by the honesty hook)."""
+    """Would ``path`` be protected for ``project_dir``? (used by the honesty hook).
+
+    Path comparison is case-folded. On a case-insensitive filesystem (APFS/NTFS
+    default) ``Adapters/adapter.py`` is the SAME inode as the protected
+    ``adapters/adapter.py``, so a case-varied spelling used to slip past the hook
+    untouched (#142 N2) — and ``os.path.normcase`` does not help, it is a no-op on
+    POSIX including macOS. Folding unconditionally can only over-block, and only for a
+    genuinely distinct file whose name differs from a protected one by case alone; for
+    an honesty guard that is the right direction to err.
+    """
     pdir = Path(project_dir).resolve()
+    p = Path(path)
+    # Resolve the PARENT, keep the final component as named — same reason as ``_add``:
+    # fully resolving follows a symlink out of the project dir, so a protected path that
+    # is (or is replaced by) a symlink answered False and the hook allowed the write.
     try:
-        rel = str(Path(path).resolve().relative_to(pdir)).replace("\\", "/")
-    except ValueError:
+        p = p.parent.resolve() / p.name
+        rel = str(Path(os.path.relpath(p, pdir))).replace("\\", "/")
+    except (ValueError, OSError):
+        return False
+    if rel == ".." or rel.startswith("../"):
         return False
     if _skip(Path(rel).parts, Path(rel).name):
         return False
+    nrel, nname = rel.lower(), Path(rel).name.lower()
     for pattern in protected_globs(pdir):
-        pat = str(pattern).strip().lstrip("/")
+        pat = str(pattern).strip().lstrip("/").lower()
         if not pat:
             continue
-        if rel == pat or rel.startswith(pat.rstrip("/") + "/"):
+        if nrel == pat or nrel.startswith(pat.rstrip("/") + "/"):
             return True
-        if fnmatch.fnmatch(rel, pat) or fnmatch.fnmatch(Path(rel).name, pat):
+        if fnmatch.fnmatch(nrel, pat) or fnmatch.fnmatch(nname, pat):
             return True
     return False

--- a/core/cap_evolve/specfile.py
+++ b/core/cap_evolve/specfile.py
@@ -77,19 +77,37 @@ def read_yaml(text: str) -> dict:
         pass
     data: dict = {}
     stack = [(-1, data)]  # (indent, container)
+    pending: tuple[dict, str] | None = None  # (container, key) awaiting a block list
     for raw in text.splitlines():
         line = _strip_comment(raw).rstrip()
-        if not line.strip() or ":" not in line:
+        if not line.strip():
             continue
         indent = len(line) - len(line.lstrip())
-        key, _, val = line.strip().partition(":")
+        stripped = line.strip()
+        # Block sequences (``key:`` then ``  - item``). Without this the flow form
+        # ``key: [a, b]`` parsed but the idiomatic block form silently became ``{}``,
+        # so e.g. a ``protected_paths`` block list fell back to defaults with no
+        # warning — a config that quietly does not apply (#142 N3).
+        if stripped.startswith("- "):
+            if pending is not None:
+                cont, k = pending
+                if not isinstance(cont.get(k), list):
+                    cont[k] = []
+                cont[k].append(_coerce(stripped[2:]))
+            continue
+        if ":" not in stripped:
+            continue
+        pending = None
+        key, _, val = stripped.partition(":")
         key = key.strip()
         while stack and indent <= stack[-1][0]:
             stack.pop()
         container = stack[-1][1] if stack else data
         if val.strip() == "":
+            # Could be a nested mapping OR a block sequence — decide on the next line.
             container[key] = {}
             stack.append((indent, container[key]))
+            pending = (container, key)
         else:
             container[key] = _coerce(val)
     return data

--- a/core/tests/test_protected_paths.py
+++ b/core/tests/test_protected_paths.py
@@ -102,17 +102,158 @@ def test_override_replaces_defaults(tmp_path):
     assert set(files) == {"tasks.jsonl"}
 
 
-def test_pycache_never_protected(tmp_path):
-    """Importing the adapter writes adapters/__pycache__/*.pyc during a NORMAL run —
-    hashing that would flag every legitimate run."""
+def test_pycache_IS_protected(tmp_path):
+    """BYPASS 1 regression: bytecode must be hashed, not excluded.
+
+    An earlier revision skipped ``__pycache__``/``*.pyc`` because ``load_adapter``
+    wrote them during a run. That exclusion was a working reward hack: a PEP 552
+    UNCHECKED_HASH pyc in the adapter's cache slot runs a hacked ``score()`` while
+    ``adapter.py``'s SHA-256 stays identical to the manifest. The exclusion is gone
+    and ``load_adapter`` no longer writes bytecode, so a pyc appearing mid-run is
+    tamper. Verified end to end by ``test_planted_unchecked_hash_pyc_is_caught``.
+    """
     from cap_evolve import protect
     _, project, _ = _project(tmp_path)
     pyc = project / "adapters" / "__pycache__" / "adapter.cpython-311.pyc"
     pyc.parent.mkdir(parents=True)
     pyc.write_bytes(b"\x00compiled")
-    assert not any("__pycache__" in f for f in protect.resolve_protected(project))
-    assert protect.is_protected(project, pyc) is False
+    assert "adapters/__pycache__/adapter.cpython-311.pyc" in protect.resolve_protected(project)
+    assert protect.is_protected(project, pyc) is True
     assert protect.is_protected(project, project / "adapters" / "adapter.py") is True
+
+
+def test_load_adapter_writes_no_bytecode(tmp_path):
+    """BYPASS 1, the other half: ``load_adapter`` must leave no ``.pyc`` behind.
+
+    This is what makes hashing bytecode safe — if the loader still wrote a pyc, the
+    (now pyc-aware) guard would flag every legitimate run. It must also refuse to
+    execute a pre-existing cache, so only the hashed source can run.
+    """
+    import py_compile
+
+    from cap_evolve.check import load_adapter
+    _, project, _ = _project(tmp_path)
+    cache = project / "adapters" / "__pycache__"
+
+    # A stale/planted cache is destroyed rather than honoured.
+    cache.mkdir(parents=True, exist_ok=True)
+    (cache / "adapter.cpython-311.pyc").write_bytes(b"\x00junk")
+    py_compile.compile(str(project / "adapters" / "adapter.py"), doraise=True,
+                       invalidation_mode=py_compile.PycInvalidationMode.UNCHECKED_HASH)
+
+    load_adapter(project)
+    leftover = sorted(p.name for p in cache.rglob("*")) if cache.exists() else []
+    assert leftover == [], f"load_adapter left bytecode behind: {leftover}"
+
+
+def test_case_folded_path_is_protected_on_case_insensitive_fs(tmp_path):
+    """N2: ``Adapters/adapter.py`` is the same inode as the protected path on APFS."""
+    from cap_evolve import protect
+    _, project, _ = _project(tmp_path)
+    varied = project / "Adapters" / "adapter.py"
+    if not varied.exists():
+        pytest.skip("case-sensitive filesystem — no case-folding hazard here")
+    assert protect.is_protected(project, varied) is True
+
+
+def test_symlinked_protected_file_is_tamper_not_an_exemption(tmp_path):
+    """BYPASS 4 regression: replacing a protected file BY a symlink used to
+    de-protect it silently (``.resolve()`` followed the link out of the project dir,
+    so the path vanished from the protected set with no event and no error)."""
+    from cap_evolve import RunDir, protect
+    base, project, _ = _project(tmp_path)
+    run_dir = RunDir.create(base, ts="lnk")
+    protect.ensure_manifest(run_dir, project)
+
+    outside = tmp_path / "editable.yaml"
+    outside.write_text("gate_mode: strict\n", encoding="utf-8")
+    tgt = project / "capevolve.yaml"
+    tgt.unlink()
+    tgt.symlink_to(outside)
+
+    # Still in the protected set (not silently dropped) AND reported as changed.
+    assert "capevolve.yaml" in protect.resolve_protected(project)
+    with pytest.raises(protect.TamperError) as ei:
+        protect.verify(run_dir, project, context="symlink swap")
+    assert "capevolve.yaml" in str(ei.value)
+    events = [json.loads(x) for x in
+              (run_dir.root / "events.jsonl").read_text(encoding="utf-8").splitlines()]
+    assert [e for e in events if e.get("kind") == "tamper_detected"]
+
+
+def test_torn_manifest_after_baseline_is_a_hard_failure(tmp_path):
+    """BYPASS 2 regression: a missing/clobbered/altered manifest must NOT be
+    silently re-recorded from the (possibly tampered) current tree."""
+    from cap_evolve import RunDir, protect
+    base, project, _ = _project(tmp_path)
+
+    for mode in ("clobber", "delete", "alter"):
+        run_dir = RunDir.create(base, ts=f"torn_{mode}")
+        first = protect.ensure_manifest(run_dir, project)
+        assert first, "baseline must record a manifest"
+        mpath = run_dir.root / protect.MANIFEST_NAME
+
+        # Reward-hack the grader, then attack the evidence.
+        grader = project / "adapters" / "adapter.py"
+        original = grader.read_text(encoding="utf-8")
+        grader.write_text(original + "\n# reward hack\n", encoding="utf-8")
+        if mode == "clobber":
+            mpath.write_text("CORRUPT", encoding="utf-8")
+        elif mode == "delete":
+            mpath.unlink()
+        else:  # a syntactically valid manifest that blesses the tampered tree
+            mpath.write_text(json.dumps({
+                "project_dir": str(project.resolve()),
+                "globs": protect.protected_globs(project),
+                "files": protect.build_manifest(project, exclude=run_dir.root),
+            }, indent=2), encoding="utf-8")
+
+        with pytest.raises(protect.TamperError) as ei:
+            protect.verify(run_dir, project, context=f"{mode} attack")
+        assert "manifest" in str(ei.value).lower() or "adapter.py" in str(ei.value)
+        grader.write_text(original, encoding="utf-8")
+
+
+def test_malformed_protected_paths_is_a_hard_error(tmp_path):
+    """N3: a ``protected_paths`` that does not parse as a list must NOT silently fall
+    back to the defaults — a config that quietly doesn't apply is the dangerous case.
+    The block-list form now parses correctly; a mapping is rejected."""
+    from cap_evolve import protect
+    from cap_evolve.specfile import read_yaml
+
+    # The idiomatic block form used to parse as {} and fall through to the defaults.
+    assert read_yaml("protected_paths:\n  - a.py\n  - b/\n")["protected_paths"] == ["a.py", "b/"]
+
+    _, project, _ = _project(tmp_path)
+    (project / "capevolve.yaml").write_text(
+        "capability_path: seed_capability\nprotected_paths:\n  nested: oops\n", encoding="utf-8")
+    with pytest.raises(protect.TamperError, match="did not parse as a list"):
+        protect.protected_globs(project)
+
+    (project / "capevolve.yaml").write_text(
+        "capability_path: seed_capability\nprotected_paths: []\n", encoding="utf-8")
+    with pytest.raises(protect.TamperError, match="EMPTY list"):
+        protect.protected_globs(project)
+
+
+def test_block_list_protected_paths_applies(tmp_path):
+    """N3, positive: the block-list form is honoured, replacing the defaults."""
+    from cap_evolve import protect
+    _, project, _ = _project(tmp_path,
+                             extra_yaml="protected_paths:\n  - tasks.jsonl\n")
+    assert set(protect.resolve_protected(project)) == {"tasks.jsonl"}
+
+
+def test_gold_glob_does_not_over_protect_prose(tmp_path):
+    """N5: ``*gold*`` used to protect ``docs/golden-rules.md``; it is data-only now."""
+    from cap_evolve import protect
+    _, project, _ = _project(tmp_path)
+    (project / "docs").mkdir()
+    (project / "docs" / "golden-rules.md").write_text("prose\n", encoding="utf-8")
+    (project / "gold_answers.json").write_text("{}\n", encoding="utf-8")
+    files = protect.resolve_protected(project)
+    assert "gold_answers.json" in files, "gold DATA must still be protected"
+    assert "docs/golden-rules.md" not in files
 
 
 def test_content_hash_not_mtime(tmp_path):
@@ -247,6 +388,210 @@ def test_dashboard_surfaces_tamper_events(tmp_path):
     summary = reduce_run(run_dir)["summary"]
     assert len(summary["tamper_events"]) == 1
     assert summary["tamper_events"][0]["context"] == "unit"
+
+
+def test_planted_unchecked_hash_pyc_is_caught(tmp_path):
+    """BYPASS 1, end to end: a PEP 552 UNCHECKED_HASH pyc planted in the adapter's
+    cache slot used to execute a hacked ``score()`` with ``adapter.py``'s SHA-256 still
+    byte-identical to the manifest — a fabricated sealed number with ``tamper_detected:
+    0``. Now bytecode is hashed, so the plant is an ``added`` protected file and the
+    run aborts. Also asserts the planted bytecode never runs.
+    """
+    import py_compile
+
+    from cap_evolve import RunDir, harness, protect
+    from cap_evolve.check import load_adapter
+    base, project, seed = _project(tmp_path)
+    run_dir = RunDir.create(base, ts="pyc")
+    harness.ensure_splits(_toy_adapter(), run_dir, seed=0)
+    protect.ensure_manifest(run_dir, project)
+
+    grader = project / "adapters" / "adapter.py"
+    sha_before = protect._sha256(grader)
+
+    # Compile an EVIL adapter into the PRISTINE adapter's cache slot, with the
+    # invalidation mode that skips mtime, size AND hash validation.
+    evil = tmp_path / "evil_adapter.py"
+    evil.write_text(grader.read_text(encoding="utf-8").replace(
+        "reward=1.0 if ok else 0.0", "reward=1.0"), encoding="utf-8")
+    cache_slot = (project / "adapters" / "__pycache__" /
+                  f"adapter.cpython-{sys.version_info.major}{sys.version_info.minor}.pyc")
+    cache_slot.parent.mkdir(parents=True, exist_ok=True)
+    py_compile.compile(str(evil), cfile=str(cache_slot), dfile=str(grader), doraise=True,
+                       invalidation_mode=py_compile.PycInvalidationMode.UNCHECKED_HASH)
+    assert cache_slot.exists()
+    assert protect._sha256(grader) == sha_before, "the source is untouched, as in the attack"
+
+    # (a) The guard sees the plant.
+    with pytest.raises(protect.TamperError) as ei:
+        protect.verify(run_dir, project, context="pyc plant")
+    assert "__pycache__" in str(ei.value)
+
+    # (b) And even if it somehow ran, ``load_adapter`` refuses to execute the cache.
+    #     Re-plant (the verify above did not remove it) and confirm honest scoring.
+    py_compile.compile(str(evil), cfile=str(cache_slot), dfile=str(grader), doraise=True,
+                       invalidation_mode=py_compile.PycInvalidationMode.UNCHECKED_HASH)
+    live = load_adapter(project)
+    task = next(t for t in live.tasks("all"))
+    from cap_evolve.harness import _live
+    with _live(live, seed) as ctx:
+        sc = live.score(task, live.run_target(task, ctx, seed=0))
+    assert sc.reward == 0.0, "the planted HACKED score() must not have executed"
+
+
+def test_post_scoring_check_catches_a_racing_writer(tmp_path):
+    """BYPASS 3 regression: a writer that edits ground truth AFTER the pre-check but
+    DURING scoring (a detached grandchild of the optimizer subprocess outlives
+    ``subprocess.run``) used to yield an accepted reward with 0 tamper events. The
+    post-scoring re-verify inside ``evaluate_candidate`` now discards that score.
+    """
+    from cap_evolve import RunDir, harness, protect
+    base, project, seed = _project(tmp_path)
+    adapter = _toy_adapter()
+    run_dir = RunDir.create(base, ts="race")
+    harness.ensure_splits(adapter, run_dir, seed=0)
+    protect.ensure_manifest(run_dir, project)
+
+    # Simulate the racing writer precisely: it lands after the pre-check, while the
+    # scorer is mid-pass. Patching ``score`` is how we hit that window deterministically
+    # (a sleeping subprocess would make the test slow and flaky).
+    real_score = adapter.score
+    fired = {"n": 0}
+
+    def _score_and_race(task, rollout):
+        fired["n"] += 1
+        if fired["n"] == 1:
+            (project / "tasks.jsonl").write_text('{"id":"t1","input":"1+1","target":"99"}\n',
+                                                 encoding="utf-8")
+        return real_score(task, rollout)
+
+    adapter.score = _score_and_race
+    try:
+        with pytest.raises(protect.TamperError) as ei:
+            harness.evaluate_candidate(adapter, seed, run_dir=run_dir, split="val", tag="raced")
+    finally:
+        adapter.score = real_score
+
+    assert "post-val eval of raced" in str(ei.value), \
+        "the POST-scoring check must be the one that fires"
+    assert fired["n"] >= 1, "scoring did happen — the pre-check alone would have missed this"
+    events = [json.loads(x) for x in
+              run_dir.events_path.read_text(encoding="utf-8").splitlines() if x.strip()]
+    tampers = [e for e in events if e["kind"] == "tamper_detected"]
+    assert tampers and tampers[-1]["context"] == "post-val eval of raced"
+    # No score was recorded for the raced eval.
+    assert not [e for e in events if e["kind"] == "evaluate" and e.get("tag") == "raced"]
+
+
+def test_finalize_reverifies_before_burning_the_seal(tmp_path):
+    """The sealed headline number specifically: a tamper landing during finalize must
+    leave ``test_used`` False and write no ``final.json``."""
+    from cap_evolve import RunDir, harness, protect
+    base, project, seed = _project(tmp_path)
+    adapter = _toy_adapter()
+    run_dir = RunDir.create(base, ts="fin")
+    harness.ensure_splits(adapter, run_dir, seed=0)
+    harness.baseline(adapter, seed, run_dir=run_dir)
+
+    real_score = adapter.score
+    fired = {"n": 0}
+
+    def _score_and_race(task, rollout):
+        fired["n"] += 1
+        if fired["n"] == 1:
+            g = project / "adapters" / "adapter.py"
+            g.write_text(g.read_text(encoding="utf-8") + "\n# hacked mid-finalize\n",
+                         encoding="utf-8")
+        return real_score(task, rollout)
+
+    adapter.score = _score_and_race
+    try:
+        with pytest.raises(protect.TamperError):
+            harness.finalize(adapter, run_dir=run_dir,
+                             best_dir=run_dir.candidate_dir(run_dir.best_id))
+    finally:
+        adapter.score = real_score
+
+    assert run_dir.read_splits().test_used is False, "the seal must NOT be burned"
+    assert not (run_dir.root / "final.json").exists()
+
+
+def test_gepa_minibatch_post_check(tmp_path):
+    """The post-check covers GEPA's cheap local-gate path too, which also populates
+    ``EvalCache`` — a raced minibatch must not be cached as truth."""
+    from cap_evolve import RunDir, harness, protect
+    from cap_evolve.gepa import _eval_minibatch
+    base, project, seed = _project(tmp_path)
+    adapter = _toy_adapter()
+    run_dir = RunDir.create(base, ts="mb")
+    harness.ensure_splits(adapter, run_dir, seed=0)
+    protect.ensure_manifest(run_dir, project)
+
+    real_score = adapter.score
+
+    def _score_and_race(task, rollout):
+        (project / "tasks.jsonl").write_text("raced\n", encoding="utf-8")
+        return real_score(task, rollout)
+
+    adapter.score = _score_and_race
+    ids = [t.id for t in adapter.tasks("all")][:1]
+    try:
+        with pytest.raises(protect.TamperError, match="post-minibatch"):
+            _eval_minibatch(adapter, seed, run_dir=run_dir, task_ids=ids, tag="mb1",
+                            cache=None)
+    finally:
+        adapter.score = real_score
+
+
+def test_reuse_baseline_refuses_a_tampered_prior_run(tmp_path):
+    """A reused baseline carries tamper provenance: a prior run that logged a tamper is
+    refused, and a clean prior run's manifest is inherited rather than re-recorded."""
+    from cap_evolve import Budget, RunDir, harness, protect
+    base, project, seed = _project(tmp_path)
+    adapter = _toy_adapter()
+
+    prior = RunDir.create(base, ts="prior", budget=Budget(max_iterations=1))
+    harness.ensure_splits(adapter, prior, seed=0)
+    harness.baseline(adapter, seed, run_dir=prior)
+    prior_manifest = (prior.root / protect.MANIFEST_NAME).read_text(encoding="utf-8")
+
+    # (a) clean prior run → manifest inherited, not rebuilt from the current tree.
+    fresh = RunDir.create(base, ts="fresh")
+    harness.reuse_baseline(prior.root, run_dir=fresh)
+    assert (fresh.root / protect.MANIFEST_NAME).read_text(encoding="utf-8") == prior_manifest
+    events = [json.loads(x) for x in
+              fresh.events_path.read_text(encoding="utf-8").splitlines() if x.strip()]
+    assert any(e.get("kind") == "protected_manifest" and e.get("inherited_from")
+               for e in events)
+
+    # (b) prior run logged a tamper → refuse to inherit the number at all.
+    prior.log_event("tamper_detected", context="prior run", changes=[])
+    with pytest.raises(protect.TamperError, match="refusing to reuse the baseline"):
+        harness.reuse_baseline(prior.root, run_dir=RunDir.create(base, ts="fresh2"))
+
+
+def test_hook_denies_writes_to_the_run_evidence(tmp_path):
+    """BYPASS 2, the hook layer: ``protected.json`` / ``events.jsonl`` writes were
+    allowed (exit 0), which is what made the manifest rewrite reachable."""
+    sys.path.insert(0, str(REPO / "plugins" / "cap-evolve" / "hooks"))
+    import importlib
+    hook = importlib.import_module("deny_sealed_edits")
+    from cap_evolve import RunDir, harness
+    base, project, _ = _project(tmp_path)
+    run_dir = RunDir.create(base, ts="ev")
+    harness.ensure_splits(_toy_adapter(), run_dir, seed=0)
+    os.environ["CAPEVOLVE_RUN_DIR"] = str(run_dir.root)
+    try:
+        for name in ("protected.json", "events.jsonl", "state.json", "best.txt"):
+            rc = hook.decide({"tool_name": "Write", "cwd": str(base),
+                              "tool_input": {"file_path": str(run_dir.root / name)}})
+            assert rc == 2, f"writing {name} must be blocked"
+        pyc = project / "adapters" / "__pycache__" / "adapter.cpython-314.pyc"
+        assert hook.decide({"tool_name": "Write", "cwd": str(base),
+                            "tool_input": {"file_path": str(pyc)}}) == 2, \
+            "a pyc under a protected dir must be blocked (it is protected now)"
+    finally:
+        os.environ.pop("CAPEVOLVE_RUN_DIR", None)
 
 
 def test_hook_blocks_a_protected_write(tmp_path):

--- a/core/tests/test_protected_paths.py
+++ b/core/tests/test_protected_paths.py
@@ -1,0 +1,270 @@
+"""Protected-paths tamper guard (#142).
+
+Adversarial case: an optimizer that edits the project's grader (adapters/adapter.py)
+must make the run FAIL with a message naming the tampered file, log a
+``tamper_detected`` event, and never advance the candidate or seal the test split.
+
+Negative case (the one that matters more): a legitimate candidate edit — the mock
+optimizer changing the capability under optimization — must NOT be flagged. A guard
+that blocks normal runs is worse than no guard.
+"""
+
+import importlib.util
+import json
+import os
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+CORE = REPO / "core"
+EXAMPLE = REPO / "examples" / "toy_calc"
+MOCK_RUN = REPO / "skills" / "optimizers" / "run-optimizer" / "scripts" / "run.py"
+
+sys.path.insert(0, str(CORE))
+
+
+@pytest.fixture(autouse=True)
+def _env():
+    old = dict(os.environ)
+    os.environ["CAPEVOLVE_CORE"] = str(CORE)
+    os.environ["CAPEVOLVE_TOY_DATA"] = str(EXAMPLE)
+    os.environ["CAPEVOLVE_MOCK_SCRIPT"] = str(EXAMPLE / "mock_script.json")
+    yield
+    os.environ.clear()
+    os.environ.update(old)
+
+
+def _toy_adapter():
+    spec = importlib.util.spec_from_file_location("toy_calc_adapter_prot", EXAMPLE / "adapter.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.Adapter()
+
+
+def _project(tmp_path: Path, *, extra_yaml: str = "") -> tuple[Path, Path, Path]:
+    """A realistic project layout: .capevolve/project + seed capability.
+
+    Returns ``(base, project_dir, seed_dir)`` where ``base`` is the ``.capevolve``
+    dir the run dir is created under — so ``protect.project_dir_for`` finds the
+    project the same way a real run does.
+    """
+    base = tmp_path / ".capevolve"
+    project = base / "project"
+    (project / "adapters").mkdir(parents=True)
+    shutil.copy(EXAMPLE / "adapter.py", project / "adapters" / "adapter.py")
+    shutil.copy(EXAMPLE / "tasks.jsonl", project / "tasks.jsonl")
+    (project / "capevolve.yaml").write_text(
+        "capability_path: seed_capability\ndataset_source: tasks.jsonl\n" + extra_yaml,
+        encoding="utf-8")
+    seed = project / "seed_capability"
+    shutil.copytree(EXAMPLE / "capability", seed)
+    return base, project, seed
+
+
+def _mock_optimizer():
+    from cap_evolve import harness
+    return harness.optimizer_from_command(
+        ["python3", str(MOCK_RUN), "--name", "mock", "--workdir", "{workdir}",
+         "--prompt", "{prompt}"])
+
+
+def _tamper_optimizer(grader: Path):
+    """An optimizer that edits the GRADER instead of the capability (reward hacking)."""
+    def _run(workdir, instructions):  # noqa: ARG001
+        src = grader.read_text(encoding="utf-8")
+        # "make score() always return 1.0" — the classic reward hack
+        grader.write_text(src.replace("reward=1.0 if ok else 0.0", "reward=1.0"),
+                          encoding="utf-8")
+        return None
+    return _run
+
+
+# ---- unit level ------------------------------------------------------------
+
+def test_defaults_protect_grader_and_data_not_the_capability(tmp_path):
+    from cap_evolve import protect
+    _, project, _ = _project(tmp_path)
+    files = protect.resolve_protected(project)
+    assert "adapters/adapter.py" in files, "the grader must be protected"
+    assert "capevolve.yaml" in files
+    assert "tasks.jsonl" in files, "dataset_source must be protected"
+    assert not any(f.startswith("seed_capability/") for f in files), \
+        "the capability under optimization must NOT be protected"
+
+
+def test_override_replaces_defaults(tmp_path):
+    from cap_evolve import protect
+    _, project, _ = _project(tmp_path, extra_yaml="protected_paths: [tasks.jsonl]\n")
+    files = protect.resolve_protected(project)
+    assert set(files) == {"tasks.jsonl"}
+
+
+def test_pycache_never_protected(tmp_path):
+    """Importing the adapter writes adapters/__pycache__/*.pyc during a NORMAL run —
+    hashing that would flag every legitimate run."""
+    from cap_evolve import protect
+    _, project, _ = _project(tmp_path)
+    pyc = project / "adapters" / "__pycache__" / "adapter.cpython-311.pyc"
+    pyc.parent.mkdir(parents=True)
+    pyc.write_bytes(b"\x00compiled")
+    assert not any("__pycache__" in f for f in protect.resolve_protected(project))
+    assert protect.is_protected(project, pyc) is False
+    assert protect.is_protected(project, project / "adapters" / "adapter.py") is True
+
+
+def test_content_hash_not_mtime(tmp_path):
+    """A same-size, same-mtime edit is still caught — mtime alone is spoofable."""
+    from cap_evolve import RunDir, protect
+    base, project, _ = _project(tmp_path)
+    run_dir = RunDir.create(base, ts="hash")
+    protect.ensure_manifest(run_dir, project)
+    target = project / "tasks.jsonl"
+    st = target.stat()
+    body = target.read_text(encoding="utf-8")
+    target.write_text(body.replace('"target": "7"', '"target": "9"'), encoding="utf-8")
+    assert len(target.read_text(encoding="utf-8")) == len(body), "same size on purpose"
+    os.utime(target, (st.st_atime, st.st_mtime))  # spoof mtime back
+    with pytest.raises(protect.TamperError) as ei:
+        protect.verify(run_dir, project)
+    assert "tasks.jsonl" in str(ei.value)
+
+
+# ---- end to end ------------------------------------------------------------
+
+def test_adversarial_optimizer_editing_the_grader_fails_the_run(tmp_path):
+    from cap_evolve import Budget, RunDir, TamperError, harness
+    base, project, seed = _project(tmp_path)
+    adapter = _toy_adapter()
+    run_dir = RunDir.create(base, ts="tamper", budget=Budget(max_iterations=3))
+    harness.ensure_splits(adapter, run_dir, seed=0)
+    b = harness.baseline(adapter, seed, run_dir=run_dir)
+    assert b.reward == 0.0
+    best_before = run_dir.best_id
+
+    grader = project / "adapters" / "adapter.py"
+    with pytest.raises(TamperError) as ei:
+        harness.run_step(
+            adapter, run_dir=run_dir, parent_dir=run_dir.candidate_dir("seed"),
+            optimizer=_tamper_optimizer(grader), instructions="(hack the grader)",
+            current_val=b, project_dir=project,
+            gate_kwargs={"mode": "significant", "k_se": 1.0},
+        )
+
+    msg = str(ei.value)
+    assert "TAMPER DETECTED" in msg
+    assert "adapters/adapter.py" in msg, "the message must NAME the tampered file"
+
+    events = [json.loads(l) for l in
+              run_dir.events_path.read_text(encoding="utf-8").splitlines() if l.strip()]
+    tampers = [e for e in events if e["kind"] == "tamper_detected"]
+    assert len(tampers) == 1
+    assert tampers[0]["changes"][0] == {
+        "path": "adapters/adapter.py", "change": "modified",
+        "expected_sha256": tampers[0]["changes"][0]["expected_sha256"],
+        "actual_sha256": tampers[0]["changes"][0]["actual_sha256"],
+    }
+    assert (tampers[0]["changes"][0]["expected_sha256"]
+            != tampers[0]["changes"][0]["actual_sha256"])
+
+    # The candidate could not advance...
+    assert run_dir.best_id == best_before
+    # ...and the test split was never sealed, so the headline number is unspendable
+    # on a tampered grader.
+    assert run_dir.read_splits().test_used is False
+    with pytest.raises(TamperError):
+        harness.finalize(adapter, run_dir=run_dir,
+                         best_dir=run_dir.candidate_dir(run_dir.best_id))
+    assert run_dir.read_splits().test_used is False
+
+
+def test_legitimate_candidate_edit_is_not_flagged(tmp_path):
+    """The real mock optimizer editing the CAPABILITY must run clean to a sealed test."""
+    from cap_evolve import Budget, RunDir, harness
+    base, project, seed = _project(tmp_path)
+    adapter = _toy_adapter()
+    run_dir = RunDir.create(base, ts="clean", budget=Budget(max_iterations=3))
+    harness.ensure_splits(adapter, run_dir, seed=0)
+    b = harness.baseline(adapter, seed, run_dir=run_dir)
+
+    step = harness.run_step(
+        adapter, run_dir=run_dir, parent_dir=run_dir.candidate_dir("seed"),
+        optimizer=_mock_optimizer(), instructions="improve val pass rate",
+        current_val=b, project_dir=project,
+        gate_kwargs={"mode": "significant", "k_se": 1.0},
+    )
+    assert step["accepted"] is True, "a legitimate edit must not be blocked"
+    payload = harness.finalize(adapter, run_dir=run_dir,
+                              best_dir=run_dir.candidate_dir(run_dir.best_id),
+                              baseline_dir=run_dir.candidate_dir("seed"))
+    assert payload["test"]["reward"] == 1.0
+
+    events = [json.loads(l) for l in
+              run_dir.events_path.read_text(encoding="utf-8").splitlines() if l.strip()]
+    assert not [e for e in events if e["kind"] == "tamper_detected"], \
+        "NO false positive on a normal run"
+    assert [e for e in events if e["kind"] == "protected_manifest"], \
+        "the manifest must have been recorded"
+
+
+def test_no_project_dir_is_a_silent_noop(tmp_path):
+    """Bare unit-test / library use (no .capevolve/project) must be unaffected."""
+    from cap_evolve import RunDir, harness
+    adapter = _toy_adapter()
+    seed = tmp_path / "seed"
+    shutil.copytree(EXAMPLE / "capability", seed)
+    run_dir = RunDir.create(tmp_path / "nowhere", ts="bare")
+    harness.ensure_splits(adapter, run_dir, seed=0)
+    assert harness.baseline(adapter, seed, run_dir=run_dir).reward == 0.0
+    assert not (run_dir.root / "protected.json").exists()
+
+
+def test_deleted_and_added_protected_files_are_caught(tmp_path):
+    from cap_evolve import RunDir, protect
+    base, project, _ = _project(tmp_path)
+    run_dir = RunDir.create(base, ts="delta")
+    protect.ensure_manifest(run_dir, project)
+    (project / "tasks.jsonl").unlink()
+    (project / "adapters" / "sneaky_scorer.py").write_text("# extra grader\n", encoding="utf-8")
+    with pytest.raises(protect.TamperError) as ei:
+        protect.verify(run_dir, project)
+    msg = str(ei.value)
+    assert "deleted tasks.jsonl" in msg
+    assert "added adapters/sneaky_scorer.py" in msg
+
+
+def test_dashboard_surfaces_tamper_events(tmp_path):
+    from cap_evolve import RunDir, protect
+    from cap_evolve.dashboard import reduce_run
+    base, project, _ = _project(tmp_path)
+    run_dir = RunDir.create(base, ts="dash")
+    protect.ensure_manifest(run_dir, project)
+    (project / "tasks.jsonl").write_text("tampered\n", encoding="utf-8")
+    with pytest.raises(protect.TamperError):
+        protect.verify(run_dir, project, context="unit")
+    summary = reduce_run(run_dir)["summary"]
+    assert len(summary["tamper_events"]) == 1
+    assert summary["tamper_events"][0]["context"] == "unit"
+
+
+def test_hook_blocks_a_protected_write(tmp_path):
+    """The PreToolUse honesty hook denies the write early (core still enforces)."""
+    sys.path.insert(0, str(REPO / "plugins" / "cap-evolve" / "hooks"))
+    import importlib
+    hook = importlib.import_module("deny_sealed_edits")
+    from cap_evolve import RunDir, harness
+    base, project, _ = _project(tmp_path)
+    run_dir = RunDir.create(base, ts="hook")
+    harness.ensure_splits(_toy_adapter(), run_dir, seed=0)
+    os.environ["CAPEVOLVE_RUN_DIR"] = str(run_dir.root)
+    try:
+        blocked = hook.decide({"tool_name": "Edit", "cwd": str(base),
+                               "tool_input": {"file_path": str(project / "adapters" / "adapter.py")}})
+        allowed = hook.decide({"tool_name": "Edit", "cwd": str(base),
+                               "tool_input": {"file_path": str(project / "seed_capability" / "prompt.txt")}})
+    finally:
+        os.environ.pop("CAPEVOLVE_RUN_DIR", None)
+    assert blocked == 2, "editing the grader must be blocked"
+    assert allowed == 0, "editing the capability must be allowed"

--- a/docs/HONEST_EVAL.md
+++ b/docs/HONEST_EVAL.md
@@ -28,17 +28,55 @@ construction*, and the rules below are enforced in code, not just documented.
    mean and stderr; `combined_stderr` mixes between-task and within-task error;
    `pass_k` reports the probability all k i.i.d. trials succeed (tau-bench style).
 
-5. **The grader is tamper-proof.** Guarantees 1–4 make the *evaluation* honest, but
+5. **The grader is tamper-evident.** Guarantees 1–4 make the *evaluation* honest, but
    when the capability is tool code or a skill package the optimizer is a coding
    agent with write tools — it could "improve" by editing `score()` instead of the
    target. `protect.py` SHA-256s the **protected paths** (by default `adapters/`,
-   `capevolve.yaml`, the spec's `dataset_source` / `split_ids_file`, and any
-   `*gold*` file) at `baseline` into `protected.json`, and re-verifies them inside
-   `evaluate_candidate` — the chokepoint *every* evaluation goes through. Any
-   change logs a `tamper_detected` event and raises `TamperError`, before the
-   candidate can be scored, snapshotted, made best, or sealed. A content hash, not
-   mtime: `os.utime` is a one-liner. Declare a different grader location with
-   `protected_paths` in `capevolve.yaml`.
+   `capevolve.yaml`, the spec's `dataset_source` / `split_ids_file`, and `*gold*`
+   data files) at `baseline` into `protected.json`, and re-verifies them **both before
+   and after** every scoring pass — inside `evaluate_candidate` (the chokepoint every
+   fresh score goes through), inside GEPA's `_eval_minibatch`, and once more
+   immediately before `finalize` burns the seal. Any difference logs a
+   `tamper_detected` event and raises `TamperError`, so the score is discarded rather
+   than recorded and the test split is not sealed. A content hash, not mtime:
+   `os.utime` is a one-liner. Declare a different grader location with
+   `protected_paths` in `capevolve.yaml` (a malformed `protected_paths` is a hard
+   error, never a silent fallback to the defaults).
+
+   **Exactly what is guaranteed — and what is not.** This is *detection, not
+   prevention*: nothing stops a write, and a hacked grader can execute. What is
+   guaranteed is that a **byte-level change to a declared protected file, made at any
+   point between `baseline` and `finalize`, is detected and aborts the run before the
+   affected score is recorded, made best, or sealed** — and that the evidence
+   (`protected.json` plus the `tamper_detected` event's expected/actual hashes) is
+   left on disk. Concretely covered: source edits, deletions, newly-added protected
+   files, a same-length edit with the mtime restored, a planted `.pyc` (`load_adapter`
+   sets `sys.dont_write_bytecode` and clears the cache dir, so bytecode is hashed like
+   any other file instead of being excluded), a protected file replaced by a symlink,
+   a destroyed or rewritten `protected.json` (which hard-fails against the digest
+   logged in `events.jsonl` rather than re-recording from the current tree), and a
+   writer that lands *during* scoring (the post-scoring check).
+
+   Residual gaps, stated plainly:
+   - **A narrow race remains.** The post-check brackets the scoring window; it does
+     not lock it. A writer that changes a protected file after the scorer's last read
+     and restores it before the post-check hash is not detected. Closing that would
+     require the scorer to hash the bytes it reads.
+   - **Ground truth outside the project dir is not protected** — only paths under
+     `.capevolve/project` can be hashed. A declared glob that matches nothing there
+     logs `protected_paths_unmatched`, so the omission is visible, but it is still an
+     omission.
+   - **A project with no `adapters/adapter.py` gets no protection at all**, logged as
+     `protected_manifest_skipped`.
+   - **Detection is per-run.** The manifest records the tree as it was at *this* run's
+     baseline; it does not attest that the checkout was clean to begin with.
+     `--reuse-baseline` inherits the prior run's manifest and refuses a prior run that
+     logged a tamper, but a grader hacked *before* baseline is recorded as pristine.
+   - **The `PreToolUse` hook is the advisory half, not the enforcement.** It blocks a
+     model's `Edit`/`Write` to a protected path, `protected.json`, `events.jsonl`,
+     `state.json` and `best.txt` with exit 2, but it fails open on internal error and
+     only sees Claude Code's own tools — a shell command or a subprocess bypasses it
+     entirely. Core's hash check is the guarantee.
 
 ## Why no central engine?
 

--- a/docs/HONEST_EVAL.md
+++ b/docs/HONEST_EVAL.md
@@ -5,7 +5,7 @@ prompt/skill/tool against a metric is trivially gameable — you can hill-climb 
 the same data you report. The substrate (`cap_evolve`) makes that hard *by
 construction*, and the rules below are enforced in code, not just documented.
 
-## The four guarantees
+## The five guarantees
 
 1. **Seeded, frozen splits.** `make_splits(task_ids, seed, ratios)` partitions
    tasks deterministically. The split is written to the run dir once
@@ -27,6 +27,18 @@ construction*, and the rules below are enforced in code, not just documented.
 4. **Variance is measured, not assumed.** With `num_trials > 1`, each task gets a
    mean and stderr; `combined_stderr` mixes between-task and within-task error;
    `pass_k` reports the probability all k i.i.d. trials succeed (tau-bench style).
+
+5. **The grader is tamper-proof.** Guarantees 1–4 make the *evaluation* honest, but
+   when the capability is tool code or a skill package the optimizer is a coding
+   agent with write tools — it could "improve" by editing `score()` instead of the
+   target. `protect.py` SHA-256s the **protected paths** (by default `adapters/`,
+   `capevolve.yaml`, the spec's `dataset_source` / `split_ids_file`, and any
+   `*gold*` file) at `baseline` into `protected.json`, and re-verifies them inside
+   `evaluate_candidate` — the chokepoint *every* evaluation goes through. Any
+   change logs a `tamper_detected` event and raises `TamperError`, before the
+   candidate can be scored, snapshotted, made best, or sealed. A content hash, not
+   mtime: `os.utime` is a one-liner. Declare a different grader location with
+   `protected_paths` in `capevolve.yaml`.
 
 ## Why no central engine?
 

--- a/plugins/cap-evolve/hooks/deny_sealed_edits.py
+++ b/plugins/cap-evolve/hooks/deny_sealed_edits.py
@@ -81,6 +81,27 @@ def decide(payload: dict) -> int:
             "seed; re-partitioning would invalidate the honest test number."
         )
 
+    # The run's own EVIDENCE files (#142). ``protected.json`` is the tamper manifest;
+    # rewriting it used to let one optimizer step bless a hacked grader (core now hard-
+    # fails on a missing/altered manifest, but the manifest lives in a dir the optimizer
+    # can write, so denying the write here is the cheap outer layer). ``events.jsonl``
+    # carries the manifest digest that makes that hard-fail work; ``state.json`` and
+    # ``best.txt`` are the run's spend and lineage of record.
+    for name, why in (
+        ("protected.json", "the SHA-256 manifest of the protected scorer / eval harness "
+                           "/ task data — the evidence they were not edited"),
+        ("events.jsonl", "the append-only audit log, which carries the manifest digest"),
+        ("state.json", "the run's recorded budget spend"),
+        ("best.txt", "the run's best-candidate pointer"),
+    ):
+        if rt == (run_dir / name).resolve():
+            return H.emit_block(
+                f"cap-evolve: refusing to edit {tstr} — {name} is {why}. Editing the "
+                "run's own evidence is reward hacking whatever it would be changed to; "
+                "core aborts the run if this file goes missing or stops matching its "
+                "logged digest. Optimize the capability, not the record."
+            )
+
     # Anything under rollouts/test/ of the active run is the held-out evaluation.
     test_roll = (run_dir / "rollouts" / "test").resolve()
     try:
@@ -120,8 +141,13 @@ def decide(payload: dict) -> int:
                     "of these files before every evaluation and will abort the run with "
                     "tamper_detected. Optimize the capability, not the grader."
                 )
-        except Exception:  # noqa: BLE001 — fail open, core still enforces
-            pass
+        except Exception as e:  # noqa: BLE001 — fail open, core still enforces
+            # Say so on stderr. A silently permissive honesty hook is worse than a
+            # loud broken one: without this line a typo here degrades the model-visible
+            # half of the guard with no signal anywhere.
+            print(f"cap-evolve: protected-path hook check failed ({e}) — falling open; "
+                  "core still re-verifies the SHA-256 manifest before every evaluation.",
+                  file=sys.stderr)
 
     return 0
 

--- a/plugins/cap-evolve/hooks/deny_sealed_edits.py
+++ b/plugins/cap-evolve/hooks/deny_sealed_edits.py
@@ -103,6 +103,26 @@ def decide(payload: dict) -> int:
                 "read-only outside finalize()."
             )
 
+    # Declared PROTECTED paths (#142) — the scorer / eval harness / task data. Core
+    # already detects a tamper after the fact (SHA-256 manifest re-verified before
+    # every evaluation, aborting the run), but that costs a whole iteration; blocking
+    # the write here turns the same rule into feedback the model can act on. Core
+    # remains the enforcement, this is the early, model-visible half.
+    proj = H.project_dir_for(run_dir)
+    if proj is not None and H.core_importable():
+        try:
+            from cap_evolve import protect  # noqa: PLC0415
+            if protect.is_protected(proj, rt):
+                return H.emit_block(
+                    f"cap-evolve: refusing to edit {tstr} — it is a PROTECTED path "
+                    "(scorer / eval harness / task data / gold answers) for this run. "
+                    "Editing it is reward hacking: core re-verifies a SHA-256 manifest "
+                    "of these files before every evaluation and will abort the run with "
+                    "tamper_detected. Optimize the capability, not the grader."
+                )
+        except Exception:  # noqa: BLE001 — fail open, core still enforces
+            pass
+
     return 0
 
 

--- a/skills/phases/report/scripts/run.py
+++ b/skills/phases/report/scripts/run.py
@@ -100,6 +100,36 @@ def main(argv=None) -> int:
         "",
         sealed_note,
     ]
+
+    # Tamper events (#142) go at the TOP of the report, not the bottom: if a protected
+    # path changed, every number above is void and the reader must see that first.
+    tampers = []
+    ev = run_dir.root / "events.jsonl"
+    if ev.exists():
+        for line in ev.read_text(encoding="utf-8").splitlines():
+            if '"tamper_detected"' not in line:
+                continue
+            try:
+                tampers.append(json.loads(line))
+            except Exception:  # noqa: BLE001
+                pass
+    if tampers:
+        banner = [
+            f"> ## 🚨 TAMPER DETECTED — {len(tampers)} event(s)",
+            ">",
+            "> A PROTECTED path (scorer / eval harness / task data / gold answers) changed "
+            "during this run. Every number below was produced alongside an edited grader "
+            "and **must not be reported as a result**.",
+            ">",
+        ]
+        for e in tampers:
+            for ch in (e.get("changes") or []):
+                banner.append(f"> - `{ch.get('change')}` `{ch.get('path')}` "
+                              f"({e.get('context') or 'unknown context'})")
+        banner.append("")
+        md = md[:1] + banner + md[1:]  # after the H1, before the numbers
+        summary["tamper_events"] = len(tampers)
+
     (run_dir.root / "report.md").write_text("\n".join(md) + "\n", encoding="utf-8")
 
     if not args.no_dashboard:

--- a/templates/project/capevolve.yaml
+++ b/templates/project/capevolve.yaml
@@ -65,6 +65,17 @@ split_ids_file: ""
 # --- scoring ----------------------------------------------------------------
 num_trials: 1
 
+# --- protected paths (tamper guard) -----------------------------------------
+# Files the OPTIMIZER must never edit: the scorer / eval harness / task data / gold
+# answers. cap-evolve SHA-256s them at baseline and re-verifies before every
+# evaluation; any change aborts the run with a `tamper_detected` event (the score is
+# discarded and the test split is never sealed). Leave EMPTY for the sane defaults
+# derived from this layout: adapters/, capevolve.yaml, dataset_source,
+# split_ids_file, and any *gold* file. Setting it REPLACES those defaults — list
+# project-relative paths, dirs, or globs. The capability dir is never protected
+# (it is the target being optimized).
+protected_paths: []
+
 # --- metrics (display) ------------------------------------------------------
 # The GATE always uses the PRIMARY metric only (= the scalar reward). Secondaries
 # are shown in the dashboard/results but never affect accept/reject.

--- a/templates/project/capevolve.yaml
+++ b/templates/project/capevolve.yaml
@@ -67,14 +67,19 @@ num_trials: 1
 
 # --- protected paths (tamper guard) -----------------------------------------
 # Files the OPTIMIZER must never edit: the scorer / eval harness / task data / gold
-# answers. cap-evolve SHA-256s them at baseline and re-verifies before every
-# evaluation; any change aborts the run with a `tamper_detected` event (the score is
-# discarded and the test split is never sealed). Leave EMPTY for the sane defaults
-# derived from this layout: adapters/, capevolve.yaml, dataset_source,
-# split_ids_file, and any *gold* file. Setting it REPLACES those defaults — list
-# project-relative paths, dirs, or globs. The capability dir is never protected
-# (it is the target being optimized).
-protected_paths: []
+# answers. cap-evolve SHA-256s them at baseline and re-verifies BEFORE AND AFTER
+# every scoring pass; any change aborts the run with a `tamper_detected` event (the
+# score is discarded and the test split is never sealed).
+#
+# OMIT this key (as below) for the sane defaults derived from this layout:
+# adapters/, capevolve.yaml, dataset_source, split_ids_file, and *gold* DATA files
+# (*gold*.json/.jsonl/.yaml/.csv/.txt — prose like docs/golden-rules.md is not
+# protected). Setting it REPLACES those defaults — list project-relative paths, dirs,
+# or globs, either inline (`protected_paths: [adapters, gold.json]`) or as a YAML
+# block list. An EMPTY list, or anything that does not parse as a list, is a HARD
+# ERROR rather than a silent fallback: "protects nothing" must never happen by
+# accident. The capability dir is never protected (it is the target).
+# protected_paths: [adapters, capevolve.yaml, tasks.jsonl]
 
 # --- metrics (display) ------------------------------------------------------
 # The GATE always uses the PRIMARY metric only (= the scalar reward). Secondaries


### PR DESCRIPTION
Closes #142

## What this is

cap-evolve enforces honesty on the *evaluation* side — seeded frozen splits, a sealed test split, a val-only significance gate. But when the capability under optimization is **tool code or a skill package**, the optimizer is a coding agent with write tools running next to the project, and nothing structural stopped it from "improving" by editing the **scorer / eval harness / task data** instead of the target. A candidate that rewrites `score()` to return `1.0` is reward hacking, and every number after it is fiction.

This makes *"only edit the target, never the grader"* a structural guarantee, the same posture the test seal already has: a SHA-256 manifest of the protected paths, recorded before any optimizer runs and re-verified on the path every run takes.

## Threat model

**What this DOES protect against.** An optimizer (or anything else in the process) that modifies, deletes, or adds a file under the declared protected paths at any point between `baseline` and `finalize`. Concretely: monkeypatching `score()`, loosening the exact-match check, rewriting `tasks.jsonl` targets to match what the agent already outputs, editing a gold/answer-key file, dropping in a second scorer module, or changing `capevolve.yaml`'s split ratios / gate mode / `k_se` mid-run. Detection is byte-exact and pre-scoring: the run aborts before the tampered grader can produce a score, before the candidate is snapshotted or becomes `best`, and before the test seal is burned — so a tampered run cannot yield a headline number at all.

**What this does NOT protect against.** It is tamper *detection*, not prevention (see "why not read-only" below), and it is not a sandbox. It cannot stop: an adapter that reads its ground truth from somewhere outside the project dir (a network fetch, an env var, an absolute path elsewhere on disk — those bytes are not in the manifest); a grader that is *already* wrong or lenient at baseline (the manifest freezes whatever is there, it does not audit it); an optimizer that also rewrites `protected.json` itself or the `protected_paths` declaration and *starts a new run* (the manifest is only authoritative within one run — cross-run trust needs a signed/off-host manifest, out of scope); reward hacking that stays entirely inside the capability (e.g. a tool that special-cases the eval's inputs — that is a scorer-design problem, not a tamper problem); or a genuinely malicious process with the privileges to rewrite the run dir. It is one more structural rail, not a security boundary.

## Design decisions

**Detection mechanism: SHA-256 over file bytes.** mtime alone is spoofable in one line (`os.utime`), and a size comparison misses same-length edits (`"7"` → `"9"` in a targets file). A content hash is the only claim we can make honestly. There is a test asserting exactly this: a same-size edit with the mtime restored is still caught. `hashlib` is stdlib, so this is **zero new runtime deps** per the house rules.

**Where the check runs: inside `evaluate_candidate`.** This is the single chokepoint every evaluation goes through — `baseline`, each iteration's val gate (hill-climb, skillopt, agent-optimize, evograph all route through `run_step` → `evaluate_candidate`), and `finalize`. Putting the guard anywhere else (a new phase skill, a flag on `run_step`, an opt-in call) would be theatre: an algorithm that forgot to call it would silently lose the protection. `gepa`'s cheap minibatch path (`_eval_minibatch`) deliberately bypasses `evaluate_candidate`, so it is guarded too — it is its own local gate and it writes `EvalCache` entries, so it must not run against an edited scorer either. This is a root-cause placement, not a per-caller patch: one guard where all callers already route through.

The manifest is recorded at `baseline` (before any optimizer exists) and, defensively, again in `run_step` before the optimizer is invoked — because `--reuse-baseline` **skips** the baseline eval, and without that second call the first manifest would be taken *after* an optimizer step and would happily bless an already-tampered grader.

**How protected paths are declared.** Sane defaults derived from the actual project layout, with a single-key override — no speculative config system:

| Default glob | Why |
|---|---|
| `adapters/` | `tasks()` / `run_target()` / `score()` live here: the ground truth and the grader |
| `capevolve.yaml` | declares splits, ratios, gate mode + `k_se`, budget |
| the spec's `dataset_source` | the task data |
| the spec's `split_ids_file` | the pinned partition |
| `*gold*`, `**/*gold*` | answer keys |

Override with `protected_paths: [...]` in `capevolve.yaml` (project-relative paths, dirs, or globs). It **replaces** the defaults, so a project whose grader lives elsewhere can declare it precisely. The seed capability dir is never protected — it is the target being optimized.

**Why not OS read-only locks** (the Arbor prior art also chmods the files). Skipped deliberately: `chmod` is trivially reversible by the same process that would tamper, so it adds no real guarantee over the hash; it breaks on shared/CI checkouts and needs careful teardown on crash (leaving a developer's repo read-only is a worse bug than the one we are fixing); and the hash already catches every case the lock would. Add it when someone has a concrete threat the hash misses.

## False-positive analysis

A guard that blocks normal runs is worse than no guard, so the negative case got more attention than the adversarial one.

- **`__pycache__` / `*.pyc` are excluded.** This is the real trap: `check.load_adapter` **execs** `adapters/adapter.py`, and importing a sibling helper writes `adapters/__pycache__/*.pyc` *during a legitimate run*. Hashing those would flag every single normal run as tampering. Also skipped: `.git`, `.mypy_cache`, `.pytest_cache`, `.ruff_cache`.
- **The run dir is excluded** from the manifest (it holds the run's own mutable state — `state.json`, rollouts, `events.jsonl`).
- **The capability dir is not protected**, so the optimizer's actual job never trips the guard. Proven by `test_legitimate_candidate_edit_is_not_flagged` and by the real end-to-end run below, which reaches a sealed test of 1.0 with zero tamper events.
- **Missing default paths are tolerated** — the defaults are layout guesses, not requirements, so a project without `tasks.jsonl` contributes nothing from that entry rather than erroring.
- **No project dir → silent no-op.** Bare library/unit-test use (no `.capevolve/project`) is completely unaffected; no `protected.json` is even written.
- **A malformed `capevolve.yaml` falls back to the defaults** rather than disabling the guard (fail closed on the honesty path).
- The whole pre-existing 179-test suite passes unchanged, which is itself the broad false-positive check.

## Also

- `tamper_detected` events are surfaced in the dashboard summary (`summary.tamper_events`), alongside the gate warnings — an honesty signal, not something buried in `events.jsonl` (issue point 4).
- The existing `PreToolUse` honesty hook (`deny_sealed_edits.py`, which already guards `splits.json` / `rollouts/test/` / gold files) is **extended**, not duplicated: it now also denies a write to a protected path, so the model gets actionable feedback instead of burning a whole iteration. Core remains the enforcement; the hook is the early, model-visible half, and it fails open.
- `docs/HONEST_EVAL.md` "four guarantees" → **five**.

## Verification

Every claim below is pasted output. Full transcripts (including the complete adversarial run) are in the 🔬 Evidence comment.

### Test suite

```
$ PYTHONPATH=/tmp/wt-142/core python -m pytest core/tests -q -k "not test_maybe_launch_spawns_when_available"
........................................................................ [ 38%]
........................................................................ [ 76%]
............................................                             [100%]
188 passed, 1 deselected in 67.67s (0:01:07)
```

**188 passed, 0 failed** = 179 baseline + 9, plus 1 deselected. The 10th new test is included; the deselection is `test_dashboard_launch.py::test_maybe_launch_spawns_when_available`, a **pre-existing environmental flake unrelated to this branch** — it asserts a hardcoded port 7878 and another process on this machine holds it. Proven pre-existing by stashing every change and re-running on clean `origin/main`:

```
$ git stash -u -q && python -m pytest core/tests/test_dashboard_launch.py -q
FAILED core/tests/test_dashboard_launch.py::test_maybe_launch_spawns_when_available
1 failed, 6 passed in 0.03s
E       AssertionError: assert 'http://127.0.0.1:7882' == 'http://127.0.0.1:7878'

$ lsof -iTCP:7878 -sTCP:LISTEN
Python  20104 osherelhadad    6u  IPv4 ...  TCP localhost:7878 (LISTEN)
```

The 10 new tests alone:
```
$ PYTHONPATH=/tmp/wt-142/core python -m pytest core/tests/test_protected_paths.py -q
..........                                                               [100%]
10 passed in 0.85s
```

### compileall

```
$ python -m compileall -q core skills
COMPILEALL_OK rc=0
```

### End-to-end, zero API cost — (a) clean run passes the guard

Real `cap-evolve run` on `examples/toy_calc` with the `mock` optimizer:

```
$ python -m cap_evolve.cli run --spec .capevolve/project/capevolve.yaml --project .capevolve/project --run-ts demo
{
  "run_dir": ".capevolve/run_demo",
  "best_id": "cand_0001",
  "baseline_val": 0.0,
  "test_reward": 1.0,
  "test_baseline_reward": 0.0,
  "test_delta": 1.0,
  "iterations": 3,
  "dashboard": ".capevolve/run_demo/dashboard.html"
}
```

The manifest was recorded and nothing was flagged:

```
$ cat .capevolve/run_demo/protected.json
{
  "project_dir": "/private/tmp/e2e-clean/.capevolve/project",
  "globs": ["adapters", "capevolve.yaml", "*gold*", "**/*gold*", "tasks.jsonl"],
  "files": {
    "adapters/adapter.py": "fa876b75ff8d00968d741158d964eec1134f49256c12f222b33b1277b6ee9650",
    "capevolve.yaml":      "cdc91ae68c9841b68bcfcd508e2a98b90832e346d2ae298d41c0bc84e845d7c1",
    "tasks.jsonl":         "2ba70d56bce14825146be518b5766b14bdabd9c43a8129db633be4f21afdc323"
  }
}

$ grep -o '"kind": "[a-z_]*"' .capevolve/run_demo/events.jsonl | sort | uniq -c
   1 "kind": "baseline"
   6 "kind": "evaluate"
   1 "kind": "finalize"
   3 "kind": "gate_warning"
   1 "kind": "protected_manifest"
   1 "kind": "splits"
   3 "kind": "step"

$ grep -c tamper_detected .capevolve/run_demo/events.jsonl
0
```

**Clean run: baseline 0.0 → test 1.0, sealed, manifest recorded, zero tamper events. No false positive.**

### End-to-end — (b) a tampered protected file fails the run

Same example, same real CLI. The `mock` optimizer's edit script is pointed at a path that escapes the workdir and appends a reward hack to the project's grader — i.e. an optimizer that hacks `score()` instead of the prompt:

```json
{"edits": [{"file": "../../../project/adapters/adapter.py", "op": "append",
  "text": "\nAdapter.score = lambda self, task, rollout: Score(task_id=task.id, reward=1.0, ...)\n"}]}
```

```
$ python -m cap_evolve.cli run --spec .capevolve/project/capevolve.yaml --project .capevolve/project --run-ts demo
{"step": "algorithm", "error": "...
  File \"core/cap_evolve/harness.py\", line 1297, in run_step
    cand_val = evaluate_candidate(adapter, workdir, run_dir=run_dir, split=\"val\", ...)
  File \"core/cap_evolve/harness.py\", line 191, in evaluate_candidate
    protect_mod.verify(run_dir, context=f\"{split} eval of {tag}\")
  File \"core/cap_evolve/protect.py\", line 233, in verify
    raise TamperError(
cap_evolve.protect.TamperError: cap-evolve TAMPER DETECTED during val eval of cand_0001:
1 protected file(s) changed under /private/tmp/e2e-tamper/.capevolve/project —
modified adapters/adapter.py. Protected paths are the scorer / eval harness / task data;
a candidate that edits them is reward hacking, so this run is aborted (the score is
discarded and the test split is NOT sealed). Optimize the capability, not the grader.
Recorded hashes: .capevolve/run_demo/protected.json. If a path is legitimately editable,
remove it from `protected_paths` in capevolve.yaml and start a new run."}

EXIT CODE = 1
```

The event, both hashes, and the untouched seal:

```
$ grep tamper_detected .capevolve/run_demo/events.jsonl | python -m json.tool
{
    "kind": "tamper_detected",
    "context": "val eval of cand_0001",
    "changes": [{
        "path": "adapters/adapter.py",
        "change": "modified",
        "expected_sha256": "fa876b75ff8d00968d741158d964eec1134f49256c12f222b33b1277b6ee9650",
        "actual_sha256":   "963a0be644b0647b45db8f6f48663bb5a5b2a01c3e1eaf41a23615adb3204322"
    }],
    "project_dir": "/private/tmp/e2e-tamper/.capevolve/project"
}

$ python -c "...print('test_used =', json.load(open('splits.json'))['test_used'])"
test_used = False

$ ls .capevolve/run_demo/final.json
ls: .capevolve/run_demo/final.json: No such file or directory
```

**Tampered run: exit code 1, error names `adapters/adapter.py`, event logged with expected vs actual hash, test split never sealed, no `final.json` — the hacked grader cannot produce a headline number.**
