### PR TITLE
docs: document the real gate modes (paired is the default; add simplicity_tiebreak)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,10 @@ significant margin → commit — and reports one honest number. It optimizes wh
 - **Learn from real agent failures.** Every iteration reads full trajectories and per-task
   causal feedback (which task ids a prior edit *broke* and *fixed*), so edits are large and
   don't regress the wins.
-- **Keep evaluation honest.** Acceptance is a val-only significance gate (Δ > k·SE); the
-  test split is sealed and scored exactly once. Both live in the core, not in editable docs.
+- **Keep evaluation honest.** Acceptance is a val-only significance gate (Δ > k·SE) — by
+  default the per-task [**`paired`** test](docs/HONEST_EVAL.md#gate-modes) over the same
+  val tasks; the test split is sealed and scored exactly once. Both live in the core, not
+  in editable docs.
 - **Inspect every change.** Each candidate is a git commit; the dashboard shows costs,
   timing, diffs, lineage, and a tasks × iterations pass/fail heatmap.
 

--- a/RUN.md
+++ b/RUN.md
@@ -75,6 +75,8 @@ artifact.
   default rule is `gate_mode: paired` — mean(per-task Δ) over the same val tasks must
   clear `gate_k_se · SE(Δ)`. Four other modes (`significant`, `threshold`, `strict`,
   `simplicity_tiebreak`): [docs/HONEST_EVAL.md § Gate modes](docs/HONEST_EVAL.md#gate-modes).
+  At the default `gate_k_se: 1.0`, `paired` needs **≥2 improved tasks** — a gain on
+  exactly one of `n` lands `mean(Δ) = SE(Δ)` and is rejected.
 - Only the **primary** metric (the scalar reward) gates; shown-only secondaries (e.g. `cost_usd`, `db_match`) are displayed but never affect accept/reject.
 - Multi-trial scoring reports mean + stderr; pass^k is reported when trials > 1.
 - Rejected approaches are remembered and never re-proposed.

--- a/RUN.md
+++ b/RUN.md
@@ -71,7 +71,10 @@ artifact.
 
 ## The rules (enforced by cap_evolve, restated here for bare hosts)
 - Train/val/test are split once with a seed; **test is scored only at finalize**.
-- Acceptance is gated on **val**, never on the data the optimizer edited against.
+- Acceptance is gated on **val**, never on the data the optimizer edited against. The
+  default rule is `gate_mode: paired` — mean(per-task Δ) over the same val tasks must
+  clear `gate_k_se · SE(Δ)`. Four other modes (`significant`, `threshold`, `strict`,
+  `simplicity_tiebreak`): [docs/HONEST_EVAL.md § Gate modes](docs/HONEST_EVAL.md#gate-modes).
 - Only the **primary** metric (the scalar reward) gates; shown-only secondaries (e.g. `cost_usd`, `db_match`) are displayed but never affect accept/reject.
 - Multi-trial scoring reports mean + stderr; pass^k is reported when trials > 1.
 - Rejected approaches are remembered and never re-proposed.

--- a/ci/benchmarks/README.md
+++ b/ci/benchmarks/README.md
@@ -93,7 +93,7 @@ has a **Type** column + filter.
   | `optimizer_model` | `claude-opus-4-8` | the optimization model (Claude Code's model) — dropdown, same gateway-alias list as `agent_model` |
   | `optimizer_usd_per_iter` | `0` (unlimited) | per-iteration $ cap on the optimizer — `0` disables Claude Code's native `--max-budget-usd` cap entirely; set e.g. `4.0` to bound it |
   | `optimizer_max_turns` | `80` | per-iteration turn cap on the optimizer |
-  | `gate_k_se` | `1.0` | acceptance-gate strictness (accept iff Δ > k_se·SE) |
+  | `gate_k_se` | `1.0` | acceptance-gate strictness — accept iff Δ > k_se·SE, on the default `gate_mode: paired` (per-task paired SE over the same val tasks; see [docs/HONEST_EVAL.md](../../docs/HONEST_EVAL.md#gate-modes)) |
   | `algorithm_focus` | `all` | hill-climb schedule: `all` \| `cyclic` \| `hardest-first` |
 
   Overriding `agent_model` takes precedence over any per-task `agent` a curated `tasks.json`

--- a/core/cap_evolve/gate.py
+++ b/core/cap_evolve/gate.py
@@ -1,9 +1,23 @@
 """Acceptance gate — the rule that decides whether a candidate edit is kept.
 
-The default is the *significance* gate (prior agent-optimization work's ``val_improvement_significant``):
-accept only when the val improvement exceeds k standard errors, so noise does
-not get mistaken for progress. All gates compare on VAL and never on TRAIN —
-``decide`` takes an explicit ``split`` and refuses anything but ``val``.
+The default mode for every real run is ``paired``. The harness scores candidate and
+current on the SAME val tasks, so it passes ``paired_deltas`` and sets
+``mode="paired"`` whenever the caller has not pinned a mode and per-task data
+aligns (``harness.py`` ``_gate_and_record``, ``gepa.py`` ``_full_val_gate``); the
+shipped ``gate_mode`` in ``templates/project/capevolve.yaml`` is ``paired`` too.
+Paired tests mean(per-task Δ) against the SE of those deltas, which cancels the
+cross-task variance and is far more powerful than the unpaired test.
+
+``decide``'s own ``mode`` parameter still defaults to ``significant`` (prior
+agent-optimization work's ``val_improvement_significant``) because that is the only
+mode a bare caller with no per-task data can honestly apply; ``paired`` also falls
+back to it when ``paired_deltas`` is empty.
+
+Modes: ``paired`` (default in runs) | ``significant`` | ``threshold`` | ``strict``
+| ``simplicity_tiebreak`` — see ``decide``'s docstring and the "Gate modes" table
+in ``docs/HONEST_EVAL.md``. Every mode's bar is a form of Δ > bar, every mode
+compares on VAL and never on TRAIN — ``decide`` takes an explicit ``split`` and
+refuses anything but ``val``.
 """
 
 from __future__ import annotations
@@ -72,8 +86,10 @@ def decide(
 ) -> GateDecision:
     """Decide whether to accept the candidate.
 
-    Modes:
-      - ``paired``: accept iff mean(per-task Δ) > k * SE(Δ), where Δ[t] =
+    Modes (``paired`` is the default for real runs — the harness selects it; the
+    ``mode`` parameter below defaults to ``significant`` only for bare callers that
+    have no per-task data to pair):
+      - ``paired`` (DEFAULT in runs): accept iff mean(per-task Δ) > k * SE(Δ), where Δ[t] =
         cand_reward[t] - curr_reward[t] over the SAME val tasks. This is the
         correct, far more powerful test: candidate and current are scored on the
         same tasks, so the cross-task variance cancels and only the *paired*

--- a/core/cap_evolve/gate.py
+++ b/core/cap_evolve/gate.py
@@ -94,17 +94,28 @@ def decide(
         correct, far more powerful test: candidate and current are scored on the
         same tasks, so the cross-task variance cancels and only the *paired*
         variance counts. Requires ``paired_deltas``; the loop uses it by default
-        when per-task data is available, else falls back to ``significant``.
+        when per-task data is available, else falls back to ``significant`` (which is
+        announced: the reason is prefixed ``paired→significant`` and a
+        ``gate_warning`` is logged). NOTE at ``k_se=1.0``: a gain on exactly ONE of
+        n tasks gives mean(Δ) = SE(Δ) *exactly*, so the strict ``>`` rejects it —
+        regardless of n and regardless of how large that one gain is. Banking needs
+        ≥2 improved tasks, or ``k_se < 1.0``.
       - ``significant``: accept iff delta > k * combined_SE (treats cand & current
         as INDEPENDENT samples — correct only when they were not scored on the
         same tasks; less powerful than ``paired``).
-      - ``threshold``:   accept iff delta > ``threshold`` (a flat margin).
+      - ``threshold``:   accept iff delta > ``threshold`` (a flat margin). Note
+        ``threshold`` defaults to ``0.0``, so leaving it unset makes this mode
+        identical to ``strict``.
       - ``strict``:      accept iff delta > 0 (any improvement).
       - ``simplicity_tiebreak``: like strict, but on a (near-)tie prefer the
-        smaller candidate (``candidate_size`` < ``current_size``).
+        smaller candidate (``candidate_size`` < ``current_size``). PRECONDITION:
+        needs both sizes; nothing in the harness or the algorithms populates them
+        today, so in a real run this mode behaves exactly like ``strict`` (issue
+        #206 tracks plumbing the sizes).
 
     ``run_dir`` (optional) is used only to log a ``gate_warning`` event when an SE
-    collapses to 0 (so the silent degeneration to strict is auditable).
+    collapses to 0 or ``paired`` falls back to ``significant`` (so neither
+    degradation is silent).
     """
     if split.lower() != "val":
         raise TrainGateError(
@@ -113,14 +124,24 @@ def decide(
         )
 
     delta = candidate_val - current_val
+    fell_back = ""
 
     if mode == "paired":
         deltas = list(paired_deltas or [])
         if not deltas:
             # No paired data — fall back to the independent significance test rather
             # than silently passing. (The loop should pass paired_deltas; this guards
-            # a direct caller.)
+            # a direct caller.) Announce it: asking for the strongest test and getting
+            # the weaker one must not be invisible, same posture as _warn_se_zero.
             mode = "significant"
+            fell_back = "paired→significant (no per-task deltas): "
+            log = getattr(run_dir, "log_event", None) if run_dir is not None else None
+            if callable(log):
+                log("gate_warning", mode="paired",
+                    reason=("mode='paired' was requested but no paired_deltas were "
+                            "supplied, so the weaker unpaired 'significant' test was "
+                            "applied instead. Pass per-task cand-curr deltas over the "
+                            "same val tasks to get the paired test."))
         else:
             n = len(deltas)
             mean_d = sum(deltas) / n
@@ -159,7 +180,7 @@ def decide(
             ok = delta > 0
             return GateDecision(
                 accept=ok,
-                reason=(f"Δ={delta:+.4f} {'>' if ok else '<='} 0 "
+                reason=(f"{fell_back}Δ={delta:+.4f} {'>' if ok else '<='} 0 "
                         f"(SE=0 → STRICT fallback, warned)"),
                 delta=delta, threshold=0.0,
             )
@@ -168,7 +189,7 @@ def decide(
         return GateDecision(
             accept=ok,
             reason=(
-                f"Δ={delta:+.4f} {'>' if ok else '<='} {k_se}·SE={bar:.4f} "
+                f"{fell_back}Δ={delta:+.4f} {'>' if ok else '<='} {k_se}·SE={bar:.4f} "
                 f"(SE={se:.4f})"
             ),
             delta=delta,

--- a/core/tests/test_documented_cli.py
+++ b/core/tests/test_documented_cli.py
@@ -1,0 +1,92 @@
+"""Every CLI invocation shown in the docs actually parses.
+
+Docs are the agent-facing API: `orchestrate` and the algorithm skills tell an agent
+to run these exact command lines. A flag that was renamed, or a `--mode` value the
+script's `choices` never had, turns a documented instruction into an exit-2 crash —
+or worse, silently does something else. Nothing else in CI covers the phase
+`scripts/run.py` surface, so this scans the docs and checks each flag (and each
+enumerated value) against the real argparse.
+
+Catches the class in #203 (docs instructing `cap-evolve finalize`, which does not
+exist) and the `--mode paired` breakage fixed in #198.
+"""
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+# `$S` / `$SKILLS_DIR` etc. all stand in for the skills dir; a bare `scripts/run.py`
+# in a SKILL.md means that skill's own script.
+_SCRIPT = re.compile(r'(?:"?\$\{?\w+\}?"?/|\.\.\./)?([\w./-]*scripts/run\.py)')
+_FLAG = re.compile(r"(--[a-z][a-z0-9-]*)")
+# Placeholders (`<best_mean>`, `{workdir}`) and shell vars are not values to validate.
+_PLACEHOLDER = re.compile(r"^[<{$]|^'")
+
+
+def _spec(script: Path) -> tuple[set[str], dict[str, set[str]]]:
+    """(known flags, {flag: allowed choices}) from the script's own --help."""
+    out = subprocess.run([sys.executable, str(script), "--help"],
+                         capture_output=True, text=True, cwd=script.parent)
+    help_text = out.stdout + out.stderr
+    choices = {f"--{f}": set(v.split(","))
+               for f, v in re.findall(r"--([a-z][a-z0-9-]*) \{([^}]+)\}", help_text)}
+    return set(_FLAG.findall(help_text)), choices
+
+
+def _resolve(raw: str, doc: Path) -> Path | None:
+    for cand in (REPO / "skills" / raw, REPO / raw,
+                 doc.parent / raw):  # bare `scripts/run.py` inside a SKILL.md
+        if cand.is_file():
+            return cand
+    return None
+
+
+def test_documented_run_py_invocations_parse():
+    docs = [p for p in REPO.glob("**/*.md")
+            if "node_modules" not in p.parts and ".git" not in p.parts
+            # design specs/plans describe past or proposed states, not runnable commands
+            and "specs" not in p.parts and "plans" not in p.parts]
+    scanned, findings = 0, []
+    for doc in docs:
+        for line in doc.read_text(errors="replace").splitlines():
+            if "scripts/run.py" not in line or not line.lstrip().startswith(("python", "$")):
+                continue
+            m = _SCRIPT.search(line)
+            script = _resolve(m.group(1), doc) if m else None
+            if script is None:
+                continue
+            scanned += 1
+            known, choices = _spec(script)
+            # only the command itself runs; a trailing `# ...` comment is prose
+            tokens = line.split(" #")[0].split()
+            for i, tok in enumerate(tokens):
+                if not tok.startswith("--"):
+                    continue
+                flag, _, inline = tok.partition("=")
+                if flag not in known:
+                    findings.append(f"{doc.relative_to(REPO)}: {script.name} has no {flag}")
+                    continue
+                if flag in choices:
+                    val = inline or (tokens[i + 1] if i + 1 < len(tokens) else "")
+                    if val and not _PLACEHOLDER.match(val) and val not in choices[flag]:
+                        findings.append(
+                            f"{doc.relative_to(REPO)}: {flag} {val!r} not in "
+                            f"{sorted(choices[flag])}")
+    assert scanned > 20, f"scanner found only {scanned} invocations — regex likely broke"
+    assert not findings, "documented CLI invocations that do not parse:\n" + "\n".join(findings)
+
+
+def test_gate_check_py_passes():
+    """CI runs only `pytest core/tests`, so no skill `check.py` was ever exercised.
+
+    The gate's check.py is what covers the `--paired-deltas` parsing and the paired
+    k_se=1.0 rule, so run it here rather than leaving that coverage CI-invisible.
+    (A general runner for all 20 skills' check.py belongs in its own change; several
+    need network/optimizer setup. ponytail: one skill now, widen when CI can afford it.)
+    """
+    check = REPO / "skills" / "phases" / "gate" / "scripts" / "check.py"
+    out = subprocess.run([sys.executable, str(check)], capture_output=True, text=True,
+                         cwd=check.parent)
+    assert out.returncode == 0, f"gate check.py failed:\n{out.stdout}\n{out.stderr}"

--- a/docs/ADAPTER_CONTRACT.md
+++ b/docs/ADAPTER_CONTRACT.md
@@ -101,15 +101,22 @@ Which rule turns your `reward` into an accept/reject — `gate_mode` in
   variance cancels; this is the most powerful test and what the harness picks itself.
 - `significant` — accept iff `Δ(means) > k_se · sqrt(SE_cand² + SE_curr²)`. For
   unpaired comparisons; weaker, since it pays for cross-task variance.
-- `threshold` — accept iff `Δ > threshold` (flat domain margin).
+- `threshold` — accept iff `Δ > threshold` (flat domain margin). `threshold` defaults
+  to `0.0`, so leaving it unset makes this identical to `strict`.
 - `strict` — accept iff `Δ > 0`. Only for a near-zero-variance scorer.
 - `simplicity_tiebreak` — `strict`, plus on a near-tie prefer the smaller candidate.
+  ⚠️ Requires `candidate_size`/`current_size`, which nothing in the harness populates,
+  so today it behaves exactly like `strict`
+  ([#206](https://github.com/skillberry-ai/cap-evolve/issues/206)).
+
+At the default `gate_k_se: 1.0`, `paired` rejects a gain on exactly one of `n` tasks
+(`mean(Δ) = SE(Δ)` exactly, at any `n` and any magnitude) — ≥2 improved tasks, or
+`gate_k_se < 1.0`.
 
 The bar matters for your `score()`: a deterministic scorer with graded rewards gives
 the paired test real between-task spread, whereas an all-or-nothing scorer at
 `num_trials=1` can collapse the SE to 0, which triggers a logged `gate_warning` and a
-strict fallback. Full table, the single-task-gain property, and the small-sample
-caveat: [`HONEST_EVAL.md` § Gate modes](HONEST_EVAL.md#gate-modes).
+strict fallback. Full table, the `k_se = 1.0` rule, and the small-sample caveat: [`HONEST_EVAL.md` § Gate modes](HONEST_EVAL.md#gate-modes).
 
 ## Everything else is provided
 

--- a/docs/ADAPTER_CONTRACT.md
+++ b/docs/ADAPTER_CONTRACT.md
@@ -86,9 +86,30 @@ implemented, `tasks` is non-empty and stable, and `score` is deterministic. This
 mandatory before any budget is spent — a half-wired adapter can only produce a
 dishonest number.
 
-The gate reads only the **primary** metric (the scalar `reward`). Any shown-only
-secondaries a `score()` returns are carried through for display but can never move an
-accept/reject decision or the sealed number.
+The acceptance gate reads only the **primary** metric (the scalar `reward`). Any
+shown-only secondaries a `score()` returns are carried through for display but can
+never move an accept/reject decision or the sealed number.
+
+## Gate modes
+
+Which rule turns your `reward` into an accept/reject — `gate_mode` in
+`capevolve.yaml`, strictness via `gate_k_se` (default `1.0`). All val-only
+(`core/cap_evolve/gate.py`):
+
+- **`paired` — the default.** Accept iff `mean(per-task Δ) > k_se · SE(Δ)` over the
+  same val tasks. Candidate and current are scored on identical tasks, so cross-task
+  variance cancels; this is the most powerful test and what the harness picks itself.
+- `significant` — accept iff `Δ(means) > k_se · sqrt(SE_cand² + SE_curr²)`. For
+  unpaired comparisons; weaker, since it pays for cross-task variance.
+- `threshold` — accept iff `Δ > threshold` (flat domain margin).
+- `strict` — accept iff `Δ > 0`. Only for a near-zero-variance scorer.
+- `simplicity_tiebreak` — `strict`, plus on a near-tie prefer the smaller candidate.
+
+The bar matters for your `score()`: a deterministic scorer with graded rewards gives
+the paired test real between-task spread, whereas an all-or-nothing scorer at
+`num_trials=1` can collapse the SE to 0, which triggers a logged `gate_warning` and a
+strict fallback. Full table, the single-task-gain property, and the small-sample
+caveat: [`HONEST_EVAL.md` § Gate modes](HONEST_EVAL.md#gate-modes).
 
 ## Everything else is provided
 

--- a/docs/AGENT_ORCHESTRATION.md
+++ b/docs/AGENT_ORCHESTRATION.md
@@ -86,8 +86,10 @@ The agent then drives the loop against `run_dir`, using the phase scripts direct
 S="$CAPEVOLVE_SKILLS_DIR"; R=.capevolve/run_myrun; P=.capevolve/project
 # honest full-val eval of a candidate dir/id (writes rollouts+results):
 python "$S/phases/evaluate/scripts/run.py" --run-dir "$R" --project "$P" --candidate "$R/work/cand_1" --split val --n-trials 1
-# the significance gate:
-python "$S/phases/gate/scripts/run.py" --mode paired --k-se 1.0 --current <best_mean> --candidate <cand_mean> --current-stderr <s> --candidate-stderr <s>
+# the significance gate (paired is the default mode; it NEEDS the per-task deltas —
+# without them it falls back to the weaker unpaired `significant`, which the reason says):
+python "$S/phases/gate/scripts/run.py" --mode paired --k-se 1.0 --current <best_mean> --candidate <cand_mean> --paired-deltas <d1,d2,... per-task cand-curr over the shared val tasks>
+# no per-task data? then: --mode significant --current-stderr <s> --candidate-stderr <s>
 # spend snapshot (the "see your constraints" step — no new command needed):
 python -c "from cap_evolve import RunDir; import json; print(json.dumps(RunDir.open('$R').spent.to_dict(), indent=2))"
 # seal test ONCE + report:

--- a/docs/HONEST_EVAL.md
+++ b/docs/HONEST_EVAL.md
@@ -18,8 +18,8 @@ construction*, and the rules below are enforced in code, not just documented.
 3. **Acceptance is gated on val, with significance.** `gate.decide(...)` refuses
    any split but `val` (`TrainGateError`) and, by default, accepts a candidate
    only when the improvement exceeds `k · SE` — so noise is not mistaken for
-   progress (`mode="significant"`). Other modes (`strict`, `threshold`,
-   `simplicity_tiebreak`) exist but never relax the val-only rule. The gate reads
+   progress. The default mode in a real run is **`paired`** (see [Gate
+   modes](#gate-modes)); no mode relaxes the val-only rule. The gate reads
    only the **primary** metric (the scalar `reward`); any shown-only secondary
    metrics a scorer emits (`Score.metrics`) are for display and cannot move the
    decision.
@@ -27,6 +27,56 @@ construction*, and the rules below are enforced in code, not just documented.
 4. **Variance is measured, not assumed.** With `num_trials > 1`, each task gets a
    mean and stderr; `combined_stderr` mixes between-task and within-task error;
    `pass_k` reports the probability all k i.i.d. trials succeed (tau-bench style).
+
+## Gate modes
+
+Set with `gate_mode` in `capevolve.yaml` (strictness with `gate_k_se`, default
+`1.0`). All five live in `core/cap_evolve/gate.py` `decide()`; all are val-only.
+
+| `gate_mode` | rule | when to use |
+|---|---|---|
+| **`paired`** — **the default** | accept iff `mean(per-task Δ) > k_se · SE(Δ)`, where `Δ[t] = cand[t] − curr[t]` over the same val tasks | default and recommended: candidate and current are scored on the *same* tasks, so cross-task variance cancels and the test is far more powerful than `significant` |
+| `significant` | accept iff `Δ(means) > k_se · sqrt(SE_cand² + SE_curr²)` | when the two sides were *not* scored on the same tasks. Less powerful — it pays for cross-task variance that the paired test cancels |
+| `threshold` | accept iff `Δ > threshold` (flat margin) | you have a domain minimum worthwhile gain ("don't bother unless +2pp") |
+| `strict` | accept iff `Δ > 0` | only with a near-zero-variance scorer (deterministic, single correct answer) |
+| `simplicity_tiebreak` | `Δ > 0` accepts; on a near-tie (`abs(Δ) ≤ 1e-9`) accept the *smaller* candidate (`candidate_size < current_size`) | Occam bias against edits that bloat without earning it |
+
+**`paired` is what actually runs by default.** `templates/project/capevolve.yaml`
+ships `gate_mode: paired`, and the harness sets `mode="paired"` itself whenever the
+caller pinned no mode and per-task val data aligns (`harness.py`
+`_gate_and_record`, `gepa.py` `_full_val_gate`). The algorithm skills'
+`--gate-mode auto` means exactly "let the engine pick paired".
+
+Note the one asymmetry: `gate.decide()`'s own `mode=` parameter still defaults to
+`"significant"`, because a bare caller passing only two means and two SEs has no
+per-task data to pair. `paired` also falls back to `significant` when
+`paired_deltas` is empty.
+
+### Why `paired` banks single-task gains
+
+Under `paired`, the SE comes from the *spread between tasks' deltas*, not from
+per-trial noise — so it is non-zero even at `num_trials=1`. A candidate that fixes
+one task out of `n` and breaks nothing gets `Δ̄ = 1/n` and `SE = 1/n` exactly, so at
+the default `k_se=1.0` it just misses the strict `Δ̄ > k·SE` bar, while at the
+`gate_k_se: 0.2` the examples use it accepts. Under `significant` at
+`num_trials=1`, both SEs come from the between-task spread of the *absolute* scores
+(`combined_stderr`), which is much larger — a one-task gain on 10 tasks faces a
+`0.233·k` bar instead of `0.100·k`.
+
+### Small-sample caveat (current behavior)
+
+The bar is a fixed `k · SE`, with no t-correction and no minimum-val-size guard, so
+it is optimistic on tiny val splits. Two degenerate cases are handled loudly, never
+silently:
+
+- **`SE = 0`** (`paired` with `n=1`, or every task moved identically; `significant`
+  with a zero combined SE, typically `num_trials=1`) — the gate logs a
+  `gate_warning` event and applies a documented **strict fallback** (accept any
+  `Δ > 0`). The decision `reason` says `SE=0 → STRICT fallback, warned`.
+- **no paired data** — `paired` falls back to `significant` rather than passing.
+
+Fix: raise `num_trials` and use a val split big enough that between-task spread is
+meaningful.
 
 ## Why no central engine?
 

--- a/docs/HONEST_EVAL.md
+++ b/docs/HONEST_EVAL.md
@@ -37,9 +37,9 @@ Set with `gate_mode` in `capevolve.yaml` (strictness with `gate_k_se`, default
 |---|---|---|
 | **`paired`** — **the default** | accept iff `mean(per-task Δ) > k_se · SE(Δ)`, where `Δ[t] = cand[t] − curr[t]` over the same val tasks | default and recommended: candidate and current are scored on the *same* tasks, so cross-task variance cancels and the test is far more powerful than `significant` |
 | `significant` | accept iff `Δ(means) > k_se · sqrt(SE_cand² + SE_curr²)` | when the two sides were *not* scored on the same tasks. Less powerful — it pays for cross-task variance that the paired test cancels |
-| `threshold` | accept iff `Δ > threshold` (flat margin) | you have a domain minimum worthwhile gain ("don't bother unless +2pp") |
+| `threshold` | accept iff `Δ > threshold` (flat margin) | you have a domain minimum worthwhile gain ("don't bother unless +2pp"). Note `threshold` defaults to `0.0`, so leaving it unset makes this identical to `strict` |
 | `strict` | accept iff `Δ > 0` | only with a near-zero-variance scorer (deterministic, single correct answer) |
-| `simplicity_tiebreak` | `Δ > 0` accepts; on a near-tie (`abs(Δ) ≤ 1e-9`) accept the *smaller* candidate (`candidate_size < current_size`) | Occam bias against edits that bloat without earning it |
+| `simplicity_tiebreak` | `Δ > 0` accepts; on a near-tie (`abs(Δ) ≤ 1e-9`) accept the *smaller* candidate (`candidate_size < current_size`) | Occam bias against edits that bloat without earning it. ⚠️ **Requires `candidate_size`/`current_size`, which nothing in the harness currently populates — so today this mode behaves exactly like `strict`** ([#206](https://github.com/skillberry-ai/cap-evolve/issues/206)) |
 
 **`paired` is what actually runs by default.** `templates/project/capevolve.yaml`
 ships `gate_mode: paired`, and the harness sets `mode="paired"` itself whenever the
@@ -52,16 +52,34 @@ Note the one asymmetry: `gate.decide()`'s own `mode=` parameter still defaults t
 per-task data to pair. `paired` also falls back to `significant` when
 `paired_deltas` is empty.
 
-### Why `paired` banks single-task gains
+### The `k_se = 1.0` rule: improve ≥2 tasks, or bank nothing
 
 Under `paired`, the SE comes from the *spread between tasks' deltas*, not from
-per-trial noise — so it is non-zero even at `num_trials=1`. A candidate that fixes
-one task out of `n` and breaks nothing gets `Δ̄ = 1/n` and `SE = 1/n` exactly, so at
-the default `k_se=1.0` it just misses the strict `Δ̄ > k·SE` bar, while at the
-`gate_k_se: 0.2` the examples use it accepts. Under `significant` at
-`num_trials=1`, both SEs come from the between-task spread of the *absolute* scores
-(`combined_stderr`), which is much larger — a one-task gain on 10 tasks faces a
-`0.233·k` bar instead of `0.100·k`.
+per-trial noise — so it is non-zero even at `num_trials=1`, where `significant`
+cannot form a bar at all. But that same spread has one sharp consequence at the
+shipped default `gate_k_se: 1.0`:
+
+> **A candidate that improves exactly ONE of `n` val tasks can never be accepted at
+> `k_se = 1.0`.** Fix one task by `m`, break nothing: `Δ̄ = m/n` and `SE(Δ) = m/n` —
+> *exactly equal* — so the strict `Δ̄ > k·SE` comparison rejects it.
+
+Both parameters cancel out of that identity, which is what makes it a rule rather
+than an edge case:
+
+- **Magnitude-independent.** The `m` cancels, so fixing one task **perfectly**
+  (`m = 1.0`) is rejected identically to nudging it by `0.01`.
+- **`n`-independent.** The `n` cancels too, so a larger val split does *not* help.
+  (`n = 20` happens to accept only because `0.05` is not exactly representable in
+  IEEE-754 binary — floating-point slack, not a rule. `n = 50` rejects again.)
+
+**So: improve ≥2 tasks at `k_se = 1.0`, or lower `gate_k_se`** — the examples use
+`0.2`, where a 1-of-n gain banks. Two improved tasks of `n` clear the bar at every
+`n` (`n=10`: `Δ̄ = 0.2000 > SE = 0.1333`).
+
+This is not an argument against `paired`. For every other shape of gain it is
+strictly more powerful than `significant`, whose SEs come from the between-task
+spread of the *absolute* scores (`combined_stderr`) and are much larger — a
+one-task gain on 10 tasks faces a `0.233·k` bar there instead of `0.100·k`.
 
 ### Small-sample caveat (current behavior)
 

--- a/docs/OPTIMIZE_YOUR_OWN.md
+++ b/docs/OPTIMIZE_YOUR_OWN.md
@@ -118,11 +118,15 @@ you want intake to ask):
 |---|---|
 | **`paired`** (**default**) | `mean(per-task Δ) > k_se · SE(Δ)` over the same val tasks — cross-task variance cancels, so this is the most powerful test and the one the harness picks itself (`--gate-mode auto`) |
 | `significant` | `Δ(means) > k_se · sqrt(SE_cand² + SE_curr²)` — unpaired, weaker |
-| `threshold` | `Δ > threshold` — flat domain margin |
+| `threshold` | `Δ > threshold` — flat domain margin. `threshold` defaults to `0.0`, so unset = `strict` |
 | `strict` | `Δ > 0` — only for a near-zero-variance scorer |
-| `simplicity_tiebreak` | `strict`, plus on a near-tie prefer the smaller candidate |
+| `simplicity_tiebreak` | `strict`, plus on a near-tie prefer the smaller candidate. ⚠️ needs `candidate_size`/`current_size`, which the harness does not populate — **behaves as `strict` today** ([#206](https://github.com/skillberry-ai/cap-evolve/issues/206)) |
 
-Details, why `paired` banks a single-task gain, and the small-sample caveat:
+**At the default `gate_k_se: 1.0`, a gain on exactly one of `n` tasks gives
+`mean(Δ) = SE(Δ)` exactly and is rejected** (at any `n`, at any magnitude) — improve
+≥2 tasks, or set `gate_k_se` below 1.0 as the examples do.
+
+That rule in full, and the small-sample caveat:
 [`HONEST_EVAL.md` § Gate modes](HONEST_EVAL.md#gate-modes).
 
 ## B — drive the `cap-evolve` CLI yourself

--- a/docs/OPTIMIZE_YOUR_OWN.md
+++ b/docs/OPTIMIZE_YOUR_OWN.md
@@ -100,12 +100,30 @@ you want intake to ask):
 - max_optimizer_usd:    <cumulative optimizer-only $ cap; 0 = unlimited>
 - optimizer_usd_per_iter: <PER-ITERATION $ cap enforced by the optimizer CLI itself, e.g. claude `--max-budget-usd N`>
 - optimizer_max_turns:  <per-iteration WORK cap passed to the agent CLI, e.g. claude `--max-turns N`>
-- gate:                 <significant (k_se) | strict | threshold>
-                        # significant: accept only if Δ > k_se · SE — k_se is how many standard errors
-                        # the val gain must clear (e.g. 0.2 = lenient, 1.0 = strict) so noise isn't mistaken for progress
+- gate_mode:            <paired (DEFAULT) | significant | threshold | strict | simplicity_tiebreak>
+- gate_k_se:            <how many standard errors the val gain must clear; default 1.0
+                        # (e.g. 0.2 = lenient, 1.0 = strict) so noise isn't mistaken for progress>
+                        # paired (default): Δ = per-task cand−curr on the SAME val tasks; accept if mean(Δ) > k_se·SE(Δ)
+                        # see docs/HONEST_EVAL.md#gate-modes for all five modes
 - stall:                <stop after N consecutive rejects; 0 = run all max_iterations>
 - store:                git          # versions every iteration as a commit for an inspectable process
 ```
+
+### Gate modes
+
+`gate_mode` picks the acceptance rule; all five are val-only
+(`core/cap_evolve/gate.py`), and `gate_k_se` sets strictness (default `1.0`):
+
+| `gate_mode` | rule |
+|---|---|
+| **`paired`** (**default**) | `mean(per-task Δ) > k_se · SE(Δ)` over the same val tasks — cross-task variance cancels, so this is the most powerful test and the one the harness picks itself (`--gate-mode auto`) |
+| `significant` | `Δ(means) > k_se · sqrt(SE_cand² + SE_curr²)` — unpaired, weaker |
+| `threshold` | `Δ > threshold` — flat domain margin |
+| `strict` | `Δ > 0` — only for a near-zero-variance scorer |
+| `simplicity_tiebreak` | `strict`, plus on a near-tie prefer the smaller candidate |
+
+Details, why `paired` banks a single-task gain, and the small-sample caveat:
+[`HONEST_EVAL.md` § Gate modes](HONEST_EVAL.md#gate-modes).
 
 ## B — drive the `cap-evolve` CLI yourself
 

--- a/docs/REPRODUCE_tau2.md
+++ b/docs/REPRODUCE_tau2.md
@@ -138,7 +138,7 @@ cap-evolve run --spec .../capevolve.yaml --project ... --run-ts full --dashboard
 
 Run config (from `examples/tau2_airline/capevolve.yaml`): `hill-climb --focus all`,
 `max_iterations 10`, `num_trials 10`, `split_ids_file split_ids.json` (no-holdout fit),
-`gate_mode significant` `gate_k_se 0.2`, `store git`, `max_usd 400`,
+`gate_mode paired` `gate_k_se 0.2`, `store git`, `max_usd 400`,
 `optimizer_usd_per_iter 40`, `TAU2_MAX_CONCURRENCY 125`.
 
 ## 6. Inspect the process
@@ -209,7 +209,7 @@ evaluates on **full val**, and accepts only through the paired gate — using th
 ```bash
 S="$CAPEVOLVE_SKILLS_DIR"; R=e2e/tau2/.capevolve/run_e2e; P=e2e/tau2/.capevolve/project
 python "$S/phases/evaluate/scripts/run.py" --run-dir "$R" --project "$P" --candidate "$R/work/cand_1" --split val --n-trials 1
-python "$S/phases/gate/scripts/run.py"     --mode significant --k-se 1.0 --current <best_mean> --candidate <cand_mean> --candidate-stderr <se> --current-stderr <se>
+python "$S/phases/gate/scripts/run.py"     --mode paired --k-se 1.0 --current <best_mean> --candidate <cand_mean> --paired-deltas <per-task cand-curr deltas, comma-separated>   # paired is the default gate; --mode significant + --candidate-stderr/--current-stderr if you have no per-task data
 # on accept: RunDir.snapshot + set_best + log_event (see AGENT_ORCHESTRATION.md)
 python -c "from cap_evolve import RunDir; import json; print(json.dumps(RunDir.open('$R').spent.to_dict(), indent=2))"  # constraint re-read
 

--- a/docs/how-to/cap-evolve-with-exgentic-tau2.md
+++ b/docs/how-to/cap-evolve-with-exgentic-tau2.md
@@ -74,7 +74,8 @@ Follow RUN.md to run a cap-evolve optimization. Here is everything intake needs:
 - algorithm: all-at-once
 - max_iterations: 20
 - num_trials: 5      (tau2 is stochastic — more trials = lower noise)
-- gate: significant, k_se: 0.5
+- gate_mode: significant, gate_k_se: 0.5   (deliberate override of the `paired` default —
+  this walkthrough's val is ~1 task, where paired SE collapses; see step 4 below)
 ```
 
 Claude will:
@@ -205,7 +206,10 @@ algorithm_skill:    all-at-once
 dataset_source:     adapter
 split_ids_file:     "inputs/split_ids.json"
 num_trials:         5
-gate_mode:          significant
+gate_mode:          significant   # deliberate override of the paired default: this walkthrough
+                                  # has ~1 val task, so paired (n=1) would collapse its SE to 0
+                                  # and fall back to strict. significant + num_trials 5 keeps a
+                                  # real bar. See docs/HONEST_EVAL.md#gate-modes.
 gate_k_se:          0.5
 max_iterations:     20
 stall:              5

--- a/examples/skillsbench/PROMPT.md
+++ b/examples/skillsbench/PROMPT.md
@@ -255,7 +255,8 @@ exists). Here is everything intake needs:
 - per-iteration optimizer $ cap:  optimizer_usd_per_iter 40   (claude --max-budget-usd, CLI-enforced; OPTIMIZER ONLY)
 - optimizer_max_turns: 200      (generous; the $ cap is the real per-iteration ceiling)
 - max_optimizer_usd: 400        max_usd: 600   (total ceiling incl. the sonnet docker rollouts)
-- gate:             paired (per-task paired SE — banks real 1-task gains), k_se 0.2
+- gate:             paired (per-task paired SE), k_se 0.2 — below 1.0 so a 1-of-n gain banks
+                    (at k_se 1.0, mean(Δ)=SE exactly for 1-of-n, so >=2 improved tasks are needed)
 - store:            git          (every iteration committed for an inspectable process)
 - note:             Docker rollouts are slow; run the full optimization in the background.
 ```

--- a/examples/skillsbench/capevolve.yaml
+++ b/examples/skillsbench/capevolve.yaml
@@ -38,8 +38,10 @@ num_trials: 3                            # the sonnet agent is STOCHASTIC: singl
 #   per-task mean + SE (and pass^k), so the paired gate distinguishes signal from noise.
 
 # --- acceptance gate --------------------------------------------------------
-gate_mode: paired                        # per-task paired SE — banks real 1-task gains on train==val
-gate_k_se: 0.2                           # accept gains clearing a 0.2·SE bar
+gate_mode: paired                        # per-task paired SE, same tasks both sides (train==val here)
+gate_k_se: 0.2                           # accept gains clearing a 0.2·SE bar. Below 1.0 deliberately:
+                                         # a 1-of-n gain gives mean(Δ)=SE exactly, so it banks at 0.2 but
+                                         # NOT at the default 1.0 (which needs >=2 improved tasks).
 
 # --- budget -----------------------------------------------------------------
 max_iterations: 7

--- a/examples/tau2_airline/PROMPT.md
+++ b/examples/tau2_airline/PROMPT.md
@@ -177,7 +177,8 @@ exists). Here is everything intake needs:
 - per-iteration optimizer $ cap:  optimizer_usd_per_iter 40   (claude --max-budget-usd, enforced by the CLI itself)
 - optimizer_max_turns: 400      (generous; the $ cap is the real per-iteration ceiling)
 - max_usd: 400      max_optimizer_usd: 400
-- gate:             paired (per-task paired SE — banks real 1-task gains), k_se 0.2
+- gate:             paired (per-task paired SE), k_se 0.2 — below 1.0 so a 1-of-n gain banks
+                    (at k_se 1.0, mean(Δ)=SE exactly for 1-of-n, so >=2 improved tasks are needed)
 - store:            git          (every iteration committed for an inspectable process)
 ```
 

--- a/examples/tau2_airline/capevolve.yaml
+++ b/examples/tau2_airline/capevolve.yaml
@@ -39,7 +39,7 @@ split_ids_file: split_ids.json
 num_trials: 10              # gpt-oss is stochastic; 10 trials → mean+stderr + pass^k
 
 # --- acceptance gate --------------------------------------------------------
-gate_mode: paired                        # paired (recommended) | significant | strict | threshold | simplicity_tiebreak
+gate_mode: paired                        # paired (the default) | significant | threshold | strict | simplicity_tiebreak
 #   paired tests mean(per-task Δ) on the SAME tasks both sides → SE ~2-3x smaller than
 #   the combined-SE `significant` test, so a real 1-task gain actually banks instead of
 #   being lost in between-task variance. Falls back to significant when no per-task data.

--- a/examples/tau2_airline/capevolve.yaml
+++ b/examples/tau2_airline/capevolve.yaml
@@ -40,9 +40,11 @@ num_trials: 10              # gpt-oss is stochastic; 10 trials → mean+stderr +
 
 # --- acceptance gate --------------------------------------------------------
 gate_mode: paired                        # paired (the default) | significant | threshold | strict | simplicity_tiebreak
-#   paired tests mean(per-task Δ) on the SAME tasks both sides → SE ~2-3x smaller than
-#   the combined-SE `significant` test, so a real 1-task gain actually banks instead of
-#   being lost in between-task variance. Falls back to significant when no per-task data.
+#   paired tests mean(per-task Δ) on the SAME tasks both sides, so cross-task variance
+#   cancels and the SE is smaller than the combined-SE `significant` test's. Falls back to
+#   significant (announced) when no per-task data.
+#   Why k_se 0.2 and not the default 1.0: a gain on exactly 1 of n tasks gives
+#   mean(Δ)=SE(Δ) exactly, so it never clears 1.0 — at any n, at any magnitude. 0.2 banks it.
 gate_k_se: 0.2                           # accept gains that clear a 0.2·SE bar (on the paired SE)
 
 # --- budget -----------------------------------------------------------------

--- a/site/optimize-your-own.html
+++ b/site/optimize-your-own.html
@@ -197,11 +197,24 @@ you want intake to ask):
 - max_optimizer_usd:    &lt;cumulative optimizer-only $ cap; 0 = unlimited&gt;
 - optimizer_usd_per_iter: &lt;PER-ITERATION $ cap enforced by the optimizer CLI itself, e.g. claude `--max-budget-usd N`&gt;
 - optimizer_max_turns:  &lt;per-iteration WORK cap passed to the agent CLI, e.g. claude `--max-turns N`&gt;
-- gate:                 &lt;significant (k_se) | strict | threshold&gt;
-                        # significant: accept only if Δ &gt; k_se · SE — k_se is how many standard errors
-                        # the val gain must clear (e.g. 0.2 = lenient, 1.0 = strict) so noise isn't mistaken for progress
+- gate_mode:            &lt;paired (DEFAULT) | significant | threshold | strict | simplicity_tiebreak&gt;
+- gate_k_se:            &lt;how many standard errors the val gain must clear; default 1.0
+                        # (e.g. 0.2 = lenient, 1.0 = strict) so noise isn't mistaken for progress&gt;
+                        # paired (default): Δ = per-task cand−curr on the SAME val tasks; accept if mean(Δ) &gt; k_se·SE(Δ)
 - stall:                &lt;stop after N consecutive rejects; 0 = run all max_iterations&gt;
 - store:                git          # versions every iteration as a commit for an inspectable process</code></pre>
+    <p><strong>Gate modes.</strong> <code>gate_mode</code> picks the acceptance rule; all five are
+    val-only (<code>core/cap_evolve/gate.py</code>), and <code>gate_k_se</code> sets strictness
+    (default <code>1.0</code>):</p>
+    <ul>
+      <li><code>paired</code> — <strong>the default</strong>: <code>mean(per-task Δ) &gt; k_se · SE(Δ)</code>
+      over the same val tasks. Cross-task variance cancels, so this is the most powerful test and the
+      one the engine picks itself (<code>--gate-mode auto</code>).</li>
+      <li><code>significant</code> — <code>Δ(means) &gt; k_se · sqrt(SE_cand² + SE_curr²)</code>; unpaired, weaker.</li>
+      <li><code>threshold</code> — <code>Δ &gt; threshold</code>, a flat domain margin.</li>
+      <li><code>strict</code> — <code>Δ &gt; 0</code>; only for a near-zero-variance scorer.</li>
+      <li><code>simplicity_tiebreak</code> — <code>strict</code>, plus on a near-tie prefer the smaller candidate.</li>
+    </ul>
   </section>
 
   <h2 class="reveal">B — Drive the <code>cap-evolve</code> CLI yourself</h2>

--- a/site/optimize-your-own.html
+++ b/site/optimize-your-own.html
@@ -211,10 +211,17 @@ you want intake to ask):
       over the same val tasks. Cross-task variance cancels, so this is the most powerful test and the
       one the engine picks itself (<code>--gate-mode auto</code>).</li>
       <li><code>significant</code> — <code>Δ(means) &gt; k_se · sqrt(SE_cand² + SE_curr²)</code>; unpaired, weaker.</li>
-      <li><code>threshold</code> — <code>Δ &gt; threshold</code>, a flat domain margin.</li>
+      <li><code>threshold</code> — <code>Δ &gt; threshold</code>, a flat domain margin. <code>threshold</code>
+      defaults to <code>0.0</code>, so leaving it unset is identical to <code>strict</code>.</li>
       <li><code>strict</code> — <code>Δ &gt; 0</code>; only for a near-zero-variance scorer.</li>
-      <li><code>simplicity_tiebreak</code> — <code>strict</code>, plus on a near-tie prefer the smaller candidate.</li>
+      <li><code>simplicity_tiebreak</code> — <code>strict</code>, plus on a near-tie prefer the smaller candidate.
+      ⚠️ Requires <code>candidate_size</code>/<code>current_size</code>, which the harness does not populate —
+      so today it behaves exactly like <code>strict</code>
+      (<a href="https://github.com/skillberry-ai/cap-evolve/issues/206">#206</a>).</li>
     </ul>
+    <p>At the default <code>gate_k_se: 1.0</code>, <code>paired</code> rejects a gain on exactly one of
+    <code>n</code> tasks — <code>mean(Δ) = SE(Δ)</code> exactly, at any <code>n</code> and any magnitude.
+    Improve &ge;2 tasks, or set <code>gate_k_se</code> below 1.0 as the examples do.</p>
   </section>
 
   <h2 class="reveal">B — Drive the <code>cap-evolve</code> CLI yourself</h2>

--- a/skills/_registry/manifest.json
+++ b/skills/_registry/manifest.json
@@ -413,7 +413,7 @@
     "gate": {
       "component": "phase",
       "path": "phases/gate",
-      "summary": "Apply the acceptance decision (always on val; significance by default).",
+      "summary": "Apply the acceptance decision (always on val; paired per-task significance by default).",
       "entry": "scripts/run.py",
       "abstract": "scripts/abstract.py",
       "check": "scripts/check.py",

--- a/skills/algorithms/agent-optimize/SKILL.md
+++ b/skills/algorithms/agent-optimize/SKILL.md
@@ -65,11 +65,14 @@ Each round:
    python "$S/phases/evaluate/scripts/run.py" --run-dir "$R" --project "$P" \
           --candidate "$R/work/cand_N" --split val --n-trials <num_trials>
    ```
-   Then apply the significance gate against the current best's val mean:
+   Then apply the significance gate against the current best's val mean. `paired` is the
+   default mode and needs the per-task deltas (`cand[t] − curr[t]` over the same val
+   tasks) — without them it falls back to the weaker unpaired `significant` test:
    ```bash
    python "$S/phases/gate/scripts/run.py" --mode paired --k-se <gate_k_se> \
           --current <best_mean> --candidate <cand_mean> \
-          --current-stderr <best_se> --candidate-stderr <cand_se>
+          --paired-deltas <d1,d2,...>            # per-task cand-curr over shared val tasks
+   # no per-task data? then: --mode significant --current-stderr <best_se> --candidate-stderr <cand_se>
    ```
    Accept **only** if the gate says Δ > k·SE. Also apply **no-regression**: reject if the
    candidate breaks any val task the current best passed, even when the mean rises.

--- a/skills/algorithms/gepa/scripts/run.py
+++ b/skills/algorithms/gepa/scripts/run.py
@@ -44,7 +44,7 @@ def main(argv=None) -> int:
     p.add_argument("--merge-cadence", type=int, default=3,
                    help="attempt a system-aware merge every Nth accept")
     p.add_argument("--gate-mode", default="auto",
-                   help="auto = let the engine pick the paired gate (recommended; candidate & current share val tasks); or significant|paired|strict|threshold")
+                   help="auto = let the engine pick the paired gate (the default; candidate & current share val tasks); or pin one of paired|significant|threshold|strict|simplicity_tiebreak — see docs/HONEST_EVAL.md#gate-modes")
     p.add_argument("--k-se", type=float, default=1.0)
     p.add_argument("--seed", type=int, default=0)
     p.add_argument("--store", default="git", help="git|copy|command")

--- a/skills/algorithms/hill-climb/scripts/run.py
+++ b/skills/algorithms/hill-climb/scripts/run.py
@@ -45,7 +45,7 @@ def main(argv=None) -> int:
     p.add_argument("--max-iterations", type=int, default=10)
     p.add_argument("--n-trials", type=int, default=1)
     p.add_argument("--gate-mode", default="auto",
-                   help="auto = let the engine pick the paired gate (recommended; candidate & current share val tasks); or significant|paired|strict|threshold")
+                   help="auto = let the engine pick the paired gate (the default; candidate & current share val tasks); or pin one of paired|significant|threshold|strict|simplicity_tiebreak — see docs/HONEST_EVAL.md#gate-modes")
     p.add_argument("--k-se", type=float, default=1.0)
     p.add_argument("--store", default="git", help="git|copy|command")
     p.add_argument("--store-commit-cmd", default=None)

--- a/skills/algorithms/skillopt/SKILL.md
+++ b/skills/algorithms/skillopt/SKILL.md
@@ -72,10 +72,13 @@ epoch-boundary meta step; `--no-regression` adds a SWE-bench-style dual gate.
 
 ## Pitfall: small val sets
 
-The default gate is `significant`/`paired` (NOT naive strict-greater) so a tiny
-val set does not reject every edit on noise. With a small val set, raise
-`--n-trials` (real per-trial variance) or use a **graded** reward so the paired
-significance test has signal. Only the slow update is a "meta" step — it is still
+The default gate is `paired` — the per-task paired significance test, which
+`--gate-mode auto` lets the engine pick — not naive strict-greater, so a tiny val set
+does not reject every edit on noise. With a small val set, raise `--n-trials` (real
+per-trial variance) or use a **graded** reward so the paired significance test has
+signal; see [`docs/HONEST_EVAL.md` § Gate
+modes](../../../docs/HONEST_EVAL.md#gate-modes) for all five modes and the
+small-sample caveat. Only the slow update is a "meta" step — it is still
 **gated on val**, never force-accepted, and its train sample is small + counted in
 budget (toggle with `--no-slow-update`).
 

--- a/skills/algorithms/skillopt/references/concepts.md
+++ b/skills/algorithms/skillopt/references/concepts.md
@@ -92,7 +92,7 @@ failures without breaking any STABLE SUCCESS") and run ONE extra `run_step` —
 
 - **Gate on val, test sealed.** Acceptance always routes through `gate.decide` on
   the VAL split; the test seal is only touched by `finalize`.
-- **Default to `significant`/`paired`, not strict.** A tiny val set with a naive
+- **Default to `paired` (the per-task paired test), not strict.** A tiny val set with a naive
   strict-greater gate rejects almost everything on noise. With a small val set,
   raise `--n-trials` for real per-trial variance, or use a **graded** reward so
   the paired significance test has signal.

--- a/skills/algorithms/skillopt/scripts/run.py
+++ b/skills/algorithms/skillopt/scripts/run.py
@@ -54,7 +54,7 @@ def main(argv=None) -> int:
                    help="how the edit budget decays over the run")
     p.add_argument("--n-trials", type=int, default=1)
     p.add_argument("--gate-mode", default="auto",
-                   help="auto = let the engine pick the paired gate (recommended; candidate & current share val tasks); or significant|paired|strict|threshold")
+                   help="auto = let the engine pick the paired gate (the default; candidate & current share val tasks); or pin one of paired|significant|threshold|strict|simplicity_tiebreak — see docs/HONEST_EVAL.md#gate-modes")
     p.add_argument("--k-se", type=float, default=1.0)
     su = p.add_mutually_exclusive_group()
     su.add_argument("--slow-update", dest="slow_update", action="store_true", default=True,

--- a/skills/phases/gate/SKILL.md
+++ b/skills/phases/gate/SKILL.md
@@ -48,7 +48,15 @@ unlikely to be noise.
 identically; `significant` with single-trial `stderr=0`), the gate does **not**
 silently act strict: it logs a `gate_warning` event and applies a documented strict
 fallback (`Δ > 0`), with `SE=0 → STRICT fallback, warned` in the decision `reason`.
-Score with multiple trials (see `evaluate`) so the bar is real.
+Score with multiple trials (see `evaluate`) so the bar is real. `paired` falling back
+to `significant` (no per-task deltas) is announced the same way, prefixed
+`paired→significant (no per-task deltas):`.
+
+> **`gate_warning` events cannot be logged from this standalone script** — `run.py`
+> takes no `--run-dir`, so `decide(run_dir=...)` is always `None` here and the JSON
+> `reason` is the only channel for either fallback. In a real run the harness passes
+> the run dir, so the events land in the run log. Don't hunt for a `gate_warning`
+> after a standalone invocation; read the `reason`.
 
 ## Modes
 Set via `gate_mode` in `capevolve.yaml` (`--mode` here); strictness via `gate_k_se`.
@@ -57,8 +65,11 @@ Set via `gate_mode` in `capevolve.yaml` (`--mode` here); strictness via `gate_k_
   SAME val tasks — the most powerful test. The harness builds the deltas and selects
   this mode itself whenever per-task val data aligns; that is what the algorithms'
   `--gate-mode auto` means. Its SE comes from the spread *between* tasks' deltas, so
-  it is non-zero even at `num_trials=1` — which is why `paired` can bank a real
-  single-task gain that `significant` would drown in cross-task variance.
+  it is non-zero even at `num_trials=1` — a bar `significant` cannot even form there.
+  **The `k_se=1.0` rule:** improving exactly one of `n` tasks gives `mean(Δ) = SE(Δ)`
+  *exactly*, so the strict `>` rejects it — at every `n`, and no matter how large that
+  one gain is. **Improve ≥2 tasks at `k_se=1.0`, or bank nothing** (`gate_k_se: 0.2`,
+  as the examples use, banks a 1-of-n gain).
 - `significant`: the independent-samples form above. Weaker than `paired`. It is the
   default of this standalone script (and of `gate.decide`'s `mode=` parameter) only
   because a caller with two means and two SEs has no per-task data to pair; `paired`
@@ -66,10 +77,14 @@ Set via `gate_mode` in `capevolve.yaml` (`--mode` here); strictness via `gate_k_
 - `strict`: `Δ > 0` — any improvement. Only safe with a near-zero-variance scorer
   (deterministic, single correct answer).
 - `threshold`: `Δ > T` — a flat margin (use when you have a domain minimum
-  worthwhile gain, e.g. "don't bother unless +2pp").
+  worthwhile gain, e.g. "don't bother unless +2pp"). `T` defaults to `0.0`, so
+  `--mode threshold` without `--threshold` is exactly `strict`.
 - `simplicity_tiebreak`: like strict, but on a (near-)tie (`abs(Δ) ≤ 1e-9`) prefer
   the smaller candidate — an Occam bias against bloated edits that don't earn their
-  size.
+  size. ⚠️ **It requires `candidate_size`/`current_size`, and nothing in the harness
+  or the algorithms supplies them, so in a real run it is bit-identical to `strict`**
+  ([#206](https://github.com/skillberry-ai/cap-evolve/issues/206) tracks plumbing
+  the sizes). Only `core/tests/test_core.py` exercises the tiebreak branch.
 
 Full table and the small-sample caveat:
 [`docs/HONEST_EVAL.md` § Gate modes](../../../docs/HONEST_EVAL.md#gate-modes).

--- a/skills/phases/gate/SKILL.md
+++ b/skills/phases/gate/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: gate
-description: Apply the acceptance decision that keeps optimization honest — always on the val split, by default requiring the improvement to exceed the significance bar (Δ > k·SE) so noise is not mistaken for progress. Use to inspect or reproduce a single accept/reject decision; the algorithms apply it internally every iteration.
+description: Apply the acceptance decision that keeps optimization honest — always on the val split, by default (mode paired) requiring the mean per-task improvement to exceed the significance bar (Δ > k·SE) so noise is not mistaken for progress. Use to inspect or reproduce a single accept/reject decision; the algorithms apply it internally every iteration.
 component: phase
-argument-hint: "--current R --candidate R --mode significant --k-se 1.0"
+argument-hint: "--current R --candidate R --mode paired --k-se 1.0 --paired-deltas 1,0,0"
 allowed-tools: Bash
 provides: [decision]
 needs: [scores]
@@ -16,7 +16,8 @@ amplifier: try enough candidates and some will *look* better by chance alone
 (the more candidates you screen, the larger the expected best-of-noise). The gate
 is the rule that keeps a lucky draw from being promoted to "the new best". It
 refuses any split but `val`, and by default accepts a candidate only when its val
-reward beats the current best by **more than `k` standard errors**.
+reward beats the current best by **more than `k` standard errors**. The default mode
+in a real run is **`paired`** — the per-task paired test over the same val tasks.
 
 ## Inputs / outputs (manifest tokens)
 - **needs:** `scores` — the candidate's and current best's val reward *and*
@@ -25,30 +26,53 @@ reward beats the current best by **more than `k` standard errors**.
 - **provides:** `decision` — `{accept, reason, delta, threshold}`, the audit
   record of why a candidate was kept or rejected.
 
-## The significance rule (default)
+## The significance rule
 ```
+# paired (the default in a real run) — candidate & current on the SAME val tasks
+Δ[t] = cand_reward[t] − curr_reward[t]
+accept  ⟺  mean(Δ)  >  k · SE(Δ)
+
+# significant — the two means treated as INDEPENDENT samples
 SE = sqrt(candidate_stderr^2 + current_stderr^2)     # SE of the difference
 accept  ⟺  Δ = candidate_val − current_val  >  k · SE
 ```
-This is the standard test for "is the difference real?": the SE of a difference
-of two independent means is the root-sum-of-squares of their SEs, and `Δ > k·SE`
-asks whether the gap clears `k` standard errors of that difference. `k=1` is
-lenient (~1σ); raise it to be stricter. It is the textual-optimization analogue of
-Koehn's bootstrap significance test for metric differences — accept only when the
-gap is unlikely to be noise.
+Both ask "is the difference real?", but pairing is the stronger form: because the
+same tasks are scored on both sides, the cross-task variance cancels and only the
+paired variance counts. The unpaired version root-sum-squares the two SEs, which is
+correct only when the two sides were not scored on the same tasks. `k=1` is lenient
+(~1σ); raise it to be stricter. This is the textual-optimization analogue of Koehn's
+bootstrap significance test for metric differences — accept only when the gap is
+unlikely to be noise.
 
-**Single-trial scores report `stderr=0`, collapsing `k·SE` to 0** — then
-`significant` silently degrades to `strict` and accepts any positive blip. If you
-run the significance gate, score with multiple trials (see `evaluate`).
+**When the SE collapses to 0** (`paired` with `n=1` or every task moving
+identically; `significant` with single-trial `stderr=0`), the gate does **not**
+silently act strict: it logs a `gate_warning` event and applies a documented strict
+fallback (`Δ > 0`), with `SE=0 → STRICT fallback, warned` in the decision `reason`.
+Score with multiple trials (see `evaluate`) so the bar is real.
 
 ## Modes
-- `significant` (default): `Δ > k·SE` — variance-aware, the honest choice.
+Set via `gate_mode` in `capevolve.yaml` (`--mode` here); strictness via `gate_k_se`.
+
+- `paired` (**the default in every real run**): `mean(per-task Δ) > k·SE(Δ)` over the
+  SAME val tasks — the most powerful test. The harness builds the deltas and selects
+  this mode itself whenever per-task val data aligns; that is what the algorithms'
+  `--gate-mode auto` means. Its SE comes from the spread *between* tasks' deltas, so
+  it is non-zero even at `num_trials=1` — which is why `paired` can bank a real
+  single-task gain that `significant` would drown in cross-task variance.
+- `significant`: the independent-samples form above. Weaker than `paired`. It is the
+  default of this standalone script (and of `gate.decide`'s `mode=` parameter) only
+  because a caller with two means and two SEs has no per-task data to pair; `paired`
+  falls back to it when no deltas are supplied.
 - `strict`: `Δ > 0` — any improvement. Only safe with a near-zero-variance scorer
   (deterministic, single correct answer).
 - `threshold`: `Δ > T` — a flat margin (use when you have a domain minimum
   worthwhile gain, e.g. "don't bother unless +2pp").
-- `simplicity_tiebreak`: like strict, but on a (near-)tie prefer the smaller
-  candidate — an Occam bias against bloated edits that don't earn their size.
+- `simplicity_tiebreak`: like strict, but on a (near-)tie (`abs(Δ) ≤ 1e-9`) prefer
+  the smaller candidate — an Occam bias against bloated edits that don't earn their
+  size.
+
+Full table and the small-sample caveat:
+[`docs/HONEST_EVAL.md` § Gate modes](../../../docs/HONEST_EVAL.md#gate-modes).
 
 ## No-regression (the second gate)
 A mean can rise while previously-passing tasks silently break. Pair the
@@ -64,15 +88,20 @@ This phase runs two ways from the **same** SKILL.md: standalone as the slash com
 
 ## How to run
 ```
+# unpaired (two means + two SEs)
 python scripts/run.py --current 0.50 --candidate 0.62 \
     --mode significant --k-se 1.0 --candidate-stderr 0.03 --current-stderr 0.03
+
+# reproduce the paired decision a real run makes (per-task cand-curr deltas)
+python scripts/run.py --current 0.50 --candidate 0.60 \
+    --mode paired --k-se 0.2 --paired-deltas 1,0,0,0,0,0,0,0,0,0
 ```
 Algorithms call the gate internally every iteration via the harness; this skill
 exists so a human or agent can reproduce and *understand* a single decision.
 
 ## What good vs bad looks like
-- **Good:** `significant` mode with real multi-trial SEs; a no-regression check on
-  top; every accept/reject logged with its `reason`.
+- **Good:** `paired` (or `significant`) mode with real per-task/multi-trial SEs; a
+  no-regression check on top; every accept/reject logged with its `reason`.
 - **Bad:** gating on `train` (the tool refuses this — it overfits the optimizer to
   the data it edits against); `strict` mode on a noisy agent (accepts noise);
   raising the mean while quietly regressing tasks because no-regression was off.

--- a/skills/phases/gate/meta.yaml
+++ b/skills/phases/gate/meta.yaml
@@ -1,6 +1,6 @@
 component: phase
 name: gate
-summary: Apply the acceptance decision (always on val; significance by default).
+summary: Apply the acceptance decision (always on val; paired per-task significance by default).
 entry: scripts/run.py
 abstract: scripts/abstract.py
 check: scripts/check.py

--- a/skills/phases/gate/references/concepts.md
+++ b/skills/phases/gate/references/concepts.md
@@ -16,16 +16,40 @@ to admit only differences large enough that noise is an implausible explanation.
 
 ## The significance test (Δ > k·SE)
 
-Each candidate carries a val mean and a standard error. The two means are
-independent estimates, so the **standard error of their difference** is:
+Two forms, differing only in how the **standard error of the difference** is computed.
+
+**Paired (`paired`, the default in a real run).** Candidate and current are scored on
+the *same* val tasks, so the honest unit of analysis is the per-task difference:
+
+```
+Δ[t]    = cand_reward[t] − curr_reward[t]     # over the shared val tasks
+SE_diff = sqrt( var(Δ) / n )                  # sample variance, n−1 denominator
+accept  ⟺  mean(Δ) > k · SE_diff
+```
+
+Pairing cancels the between-task variance — a task that is simply *hard* pulls both
+sides down equally and contributes nothing to `var(Δ)` — so the paired test is
+substantially more powerful. Its SE also stays non-zero at `num_trials=1`, because it
+measures the spread between tasks' *deltas* rather than per-trial noise. That is why
+`paired` can bank a single-task gain the unpaired test rejects: fixing one task of `n`
+and breaking nothing gives `mean(Δ) = SE_diff = 1/n` exactly, which clears any
+`k < 1` (the default `k=1` just misses, since the comparison is strict).
+
+**Unpaired (`significant`).** When the two sides were *not* scored on the same tasks,
+the two means are independent estimates, so the SE of their difference is the
+root-sum-of-squares of their SEs:
 
 ```
 SE_diff = sqrt(SE_candidate^2 + SE_current^2)
+accept  ⟺  Δ = candidate − current > k · SE_diff
 ```
 
-Accept iff `Δ = candidate − current > k · SE_diff`. This is the
-textual-optimization analogue of a two-sample significance test: `k` is how many
-standard errors of the difference the gap must clear.
+Each `SE` here is a `combined_stderr` over *absolute* per-task scores, so it carries
+the full between-task spread — on the same data typically a few times larger than the
+paired SE, which is exactly the power that pairing recovers.
+
+Either way `k` is how many standard errors of the difference the gap must clear — the
+textual-optimization analogue of a two-sample significance test.
 
 - **k = 1** (default): ~1σ — lenient; lets through gains that are *probably* real
   but lets some noise slip. Good early, when you want momentum.
@@ -37,9 +61,17 @@ scores is only meaningful if it survives a significance test (he uses bootstrap
 resampling). The `significant` gate enforces the same idea online, per iteration.
 
 **The SE must be real.** With one trial per task the within-task SE is 0, so
-`SE_diff` can collapse and `k·SE` → 0, silently turning `significant` into
-`strict`. Run multiple trials (see the `evaluate` reference) before trusting the
-significance gate.
+`SE_diff` can collapse and `k·SE` → 0. The gate does *not* silently become `strict`
+when that happens: it logs a `gate_warning` event and applies the documented strict
+fallback (`Δ > 0`), tagging the decision `reason` with
+`SE=0 → STRICT fallback, warned`. Run multiple trials (see the `evaluate` reference)
+before trusting the significance gate. `paired` hits this only at `n=1` shared tasks
+or when every task moved identically.
+
+**Small-sample caveat (current behavior).** The bar is a fixed `k · SE` — a z-style
+critical value with no t-correction and no minimum-val-size guard — so it is
+optimistic on tiny val splits, where a couple of lucky per-task deltas can clear it.
+Prefer a val split large enough that between-task spread is meaningful.
 
 ## No-regression: the second gate
 
@@ -71,12 +103,17 @@ mean can quietly trade away reliability.
 
 ## Modes, briefly
 
-| mode                  | rule                              | when                                  |
-|-----------------------|-----------------------------------|---------------------------------------|
-| `significant`         | Δ > k·SE                          | default; any stochastic scorer        |
-| `strict`              | Δ > 0                             | only near-zero-variance scorers       |
-| `threshold`           | Δ > T                             | you have a domain "minimum worth it"  |
-| `simplicity_tiebreak` | Δ > 0, else prefer smaller on tie | bias against edits that bloat for free |
+| mode                  | rule                                   | when                                  |
+|-----------------------|----------------------------------------|---------------------------------------|
+| **`paired`**          | mean(per-task Δ) > k·SE(Δ), same tasks  | **the default**; most powerful test    |
+| `significant`         | Δ(means) > k·sqrt(SE_c²+SE_p²)          | unpaired comparisons; weaker           |
+| `threshold`           | Δ > T                                  | you have a domain "minimum worth it"  |
+| `strict`              | Δ > 0                                  | only near-zero-variance scorers       |
+| `simplicity_tiebreak` | Δ > 0, else prefer smaller on tie      | bias against edits that bloat for free |
+
+`gate.decide`'s `mode=` parameter defaults to `significant` because a bare caller has
+no per-task data to pair; the harness passes `paired_deltas` and selects `paired`
+itself, and `paired` falls back to `significant` when no deltas are supplied.
 
 ## Sources
 - Koehn, "Statistical Significance Tests for Machine Translation Evaluation"

--- a/skills/phases/gate/references/concepts.md
+++ b/skills/phases/gate/references/concepts.md
@@ -30,10 +30,16 @@ accept  ⟺  mean(Δ) > k · SE_diff
 Pairing cancels the between-task variance — a task that is simply *hard* pulls both
 sides down equally and contributes nothing to `var(Δ)` — so the paired test is
 substantially more powerful. Its SE also stays non-zero at `num_trials=1`, because it
-measures the spread between tasks' *deltas* rather than per-trial noise. That is why
-`paired` can bank a single-task gain the unpaired test rejects: fixing one task of `n`
-and breaking nothing gives `mean(Δ) = SE_diff = 1/n` exactly, which clears any
-`k < 1` (the default `k=1` just misses, since the comparison is strict).
+measures the spread between tasks' *deltas* rather than per-trial noise. It also means the
+paired bar has one sharp, easily-missed consequence at the default `k = 1`:
+
+> **Improving exactly one task of `n` can never be banked at `k_se = 1.0`.** Fixing
+> one task by `m` and breaking nothing gives `mean(Δ) = m/n` and `SE_diff = m/n` —
+> *identical* — so the strict `>` rejects it. The `m` cancels, so fixing one task
+> **perfectly** is rejected exactly as a tiny nudge is; and `n` cancels, so a bigger
+> val split does not help either. **Improve ≥2 tasks at `k_se = 1.0`, or lower
+> `gate_k_se` below 1.0** (the examples use `0.2`). `paired` is still strictly more
+> powerful than unpaired for every other shape of gain, which is why it is the default.
 
 **Unpaired (`significant`).** When the two sides were *not* scored on the same tasks,
 the two means are independent estimates, so the SE of their difference is the
@@ -107,13 +113,15 @@ mean can quietly trade away reliability.
 |-----------------------|----------------------------------------|---------------------------------------|
 | **`paired`**          | mean(per-task Δ) > k·SE(Δ), same tasks  | **the default**; most powerful test    |
 | `significant`         | Δ(means) > k·sqrt(SE_c²+SE_p²)          | unpaired comparisons; weaker           |
-| `threshold`           | Δ > T                                  | you have a domain "minimum worth it"  |
+| `threshold`           | Δ > T                                  | you have a domain "minimum worth it" (T defaults to 0.0 = `strict`) |
 | `strict`              | Δ > 0                                  | only near-zero-variance scorers       |
-| `simplicity_tiebreak` | Δ > 0, else prefer smaller on tie      | bias against edits that bloat for free |
+| `simplicity_tiebreak` | Δ > 0, else prefer smaller on tie      | ⚠️ needs `candidate_size`/`current_size`, which the harness never sets — **`strict` today** ([#206](https://github.com/skillberry-ai/cap-evolve/issues/206)) |
 
 `gate.decide`'s `mode=` parameter defaults to `significant` because a bare caller has
 no per-task data to pair; the harness passes `paired_deltas` and selects `paired`
-itself, and `paired` falls back to `significant` when no deltas are supplied.
+itself, and `paired` falls back to `significant` when no deltas are supplied — which
+is announced: the `reason` is prefixed `paired→significant (no per-task deltas):` and
+a `gate_warning` event is logged when a `run_dir` is available.
 
 ## Sources
 - Koehn, "Statistical Significance Tests for Machine Translation Evaluation"

--- a/skills/phases/gate/scripts/check.py
+++ b/skills/phases/gate/scripts/check.py
@@ -1,5 +1,6 @@
-"""Contract: the gate refuses split=train, and at SE=0 the significance mode
-falls back to strict (accept any Δ>0) instead of silently mis-acting.
+"""Contract: the gate refuses split=train, at SE=0 the significance mode falls back
+to strict (accept any Δ>0) instead of silently mis-acting, and the CLI's
+``--paired-deltas`` refuses malformed or inconsistent input rather than gating on it.
 """
 
 from __future__ import annotations
@@ -12,9 +13,24 @@ from cap_evolve.gate import TrainGateError, decide
 from cap_evolve.skillcheck import Checker, import_run
 
 
+def _paired_cli(run, deltas: str, current=0.5, candidate=0.6):
+    """Parse deltas the way run.py's CLI does; return ('error', msg) on refusal."""
+    box = []
+
+    def error(msg):
+        raise ValueError(msg)
+
+    try:
+        box.append(run.parse_paired_deltas(deltas, current, candidate, error))
+    except ValueError as exc:
+        return ("error", str(exc))
+    return ("ok", box[0])
+
+
 def main() -> int:
     c = Checker("gate")
-    c.require_main(import_run())
+    run = import_run()
+    c.require_main(run)
 
     # 1. refuses gating on train
     try:
@@ -40,6 +56,45 @@ def main() -> int:
     c.check(not d_noise.accept,
             f"tiny Δ below the SE bar should be rejected: {d_noise.to_dict()}",
             note="improvement within noise is rejected")
+
+    # 4. paired — the mode every real run uses. A gain on exactly 1 of n tasks lands
+    #    mean(Δ)=SE(Δ) exactly, so k_se=1.0 REJECTS it at any n; 2 of n clears it.
+    one_of_10 = [1.0] + [0.0] * 9
+    d_one = decide(0.5, 0.6, split="val", mode="paired", k_se=1.0, paired_deltas=one_of_10)
+    d_one_lenient = decide(0.5, 0.6, split="val", mode="paired", k_se=0.2,
+                           paired_deltas=one_of_10)
+    d_two = decide(0.5, 0.7, split="val", mode="paired", k_se=1.0,
+                   paired_deltas=[1.0, 1.0] + [0.0] * 8)
+    c.check(not d_one.accept and "n=10" in d_one.reason,
+            f"1-of-n gain must NOT clear k_se=1.0 (mean=SE exactly): {d_one.to_dict()}",
+            note="paired at k_se=1.0 rejects a 1-of-n gain (mean(Δ)=SE(Δ))")
+    c.check(d_one_lenient.accept,
+            f"1-of-n gain must clear k_se=0.2: {d_one_lenient.to_dict()}")
+    c.check(d_two.accept,
+            f"2-of-n gain must clear k_se=1.0: {d_two.to_dict()}",
+            note="paired banks >=2 improved tasks at the default k_se")
+
+    # 5. paired with no deltas falls back to significant, and SAYS SO
+    d_fb = decide(0.5, 0.62, split="val", mode="paired", k_se=1.0,
+                  candidate_stderr=0.03, current_stderr=0.03)
+    c.check("paired→significant" in d_fb.reason,
+            f"paired-without-deltas fallback must be announced in the reason: {d_fb.to_dict()}",
+            note="paired→significant fallback is disclosed, not silent")
+
+    # 6. the CLI refuses malformed and inconsistent --paired-deltas rather than
+    #    printing a confident decision for an n the run never used.
+    for bad, why in [("1,abc,0", "non-numeric"), ("1;0;0", "semicolons"),
+                     ("1,0", "wrong length (mean 0.5 != candidate-current 0.1)")]:
+        kind, msg = _paired_cli(run, bad)
+        c.check(kind == "error", f"--paired-deltas {bad!r} ({why}) must be refused, got {msg!r}",
+                note=f"--paired-deltas refuses {why}")
+    kind, val = _paired_cli(run, "")
+    c.check(kind == "ok" and val is None,
+            f"empty --paired-deltas must yield None (documented fallback), got {val!r}")
+    kind, val = _paired_cli(run, "1, 0, 0, 0, 0, 0, 0, 0, 0, 0,")
+    c.check(kind == "ok" and val == one_of_10,
+            f"consistent --paired-deltas must parse (whitespace/trailing comma ok), got {val!r}",
+            note="happy path parses; mean(Δ) is cross-checked against candidate-current")
 
     return c.emit()
 

--- a/skills/phases/gate/scripts/run.py
+++ b/skills/phases/gate/scripts/run.py
@@ -21,17 +21,25 @@ def main(argv=None) -> int:
     p.add_argument("--current", type=float, required=True, help="current best val reward")
     p.add_argument("--candidate", type=float, required=True, help="candidate val reward")
     p.add_argument("--mode", default="significant",
-                   choices=["significant", "strict", "threshold", "simplicity_tiebreak"])
+                   choices=["paired", "significant", "strict", "threshold", "simplicity_tiebreak"],
+                   help="paired is the default in real runs (the harness pairs per-task val "
+                        "rewards itself). This standalone front-end defaults to significant "
+                        "because it takes means+SEs, not per-task data; pass --paired-deltas "
+                        "to reproduce a paired decision.")
+    p.add_argument("--paired-deltas", default="",
+                   help="comma-separated per-task deltas (cand-curr over the SAME val tasks) "
+                        "for --mode paired; without them paired falls back to significant")
     p.add_argument("--k-se", type=float, default=1.0)
     p.add_argument("--candidate-stderr", type=float, default=0.0)
     p.add_argument("--current-stderr", type=float, default=0.0)
     p.add_argument("--threshold", type=float, default=0.0)
     args = p.parse_args(argv)
 
+    deltas = [float(x) for x in args.paired_deltas.split(",") if x.strip()] or None
     d = decide(
         args.current, args.candidate, split="val", mode=args.mode, k_se=args.k_se,
         candidate_stderr=args.candidate_stderr, current_stderr=args.current_stderr,
-        threshold=args.threshold,
+        threshold=args.threshold, paired_deltas=deltas,
     )
     print(json.dumps(d.to_dict(), indent=2))
     return 0

--- a/skills/phases/gate/scripts/run.py
+++ b/skills/phases/gate/scripts/run.py
@@ -16,6 +16,38 @@ import _bootstrap  # noqa: F401
 from cap_evolve.gate import decide
 
 
+# The pasted list and the two means must describe the SAME comparison: mean(Δ) is
+# candidate − current by construction. Cross-checking them is the only length check
+# possible here (the script never sees the val split), and it catches a truncated
+# paste, a wrong-order paste, and flipped signs at once — each of which would
+# otherwise print a confident accept/reject for an n the run never used.
+# ponytail: 1e-4, not 1e-6, so means copied at the 4dp the dashboard prints still
+# pass; truncation/mis-paste errors are orders of magnitude larger than that.
+_DELTA_TOL = 1e-4
+
+
+def parse_paired_deltas(raw: str, current: float, candidate: float, error):
+    """Parse --paired-deltas, or call ``error`` (argparse: exit 2) with a fix."""
+    fields = [x.strip() for x in raw.split(",") if x.strip()]
+    if not fields:
+        return None
+    try:
+        deltas = [float(x) for x in fields]
+    except ValueError as exc:
+        error(f"--paired-deltas: {exc}. Expected comma-separated numbers "
+              f"(e.g. 1,0,0,0,0), one per val task; got {raw!r}.")
+    mean_d = sum(deltas) / len(deltas)
+    if abs(mean_d - (candidate - current)) > _DELTA_TOL:
+        error(
+            f"--paired-deltas has {len(deltas)} value(s) whose mean is {mean_d:+.4f}, "
+            f"but --candidate minus --current is {candidate - current:+.4f}. The deltas "
+            "must be the per-task cand-curr over ALL val tasks used for those means "
+            "(a truncated paste is the usual cause) — otherwise the decision reports a "
+            "gain and an n the run never made."
+        )
+    return deltas
+
+
 def main(argv=None) -> int:
     p = argparse.ArgumentParser(prog="gate")
     p.add_argument("--current", type=float, required=True, help="current best val reward")
@@ -28,14 +60,17 @@ def main(argv=None) -> int:
                         "to reproduce a paired decision.")
     p.add_argument("--paired-deltas", default="",
                    help="comma-separated per-task deltas (cand-curr over the SAME val tasks) "
-                        "for --mode paired; without them paired falls back to significant")
+                        "for --mode paired; without them paired falls back to significant. "
+                        "mean(deltas) must equal --candidate minus --current (that is what "
+                        "'the same tasks both sides' means), so a truncated or mis-pasted "
+                        "list is refused instead of silently gating on the wrong n")
     p.add_argument("--k-se", type=float, default=1.0)
     p.add_argument("--candidate-stderr", type=float, default=0.0)
     p.add_argument("--current-stderr", type=float, default=0.0)
     p.add_argument("--threshold", type=float, default=0.0)
     args = p.parse_args(argv)
 
-    deltas = [float(x) for x in args.paired_deltas.split(",") if x.strip()] or None
+    deltas = parse_paired_deltas(args.paired_deltas, args.current, args.candidate, p.error)
     d = decide(
         args.current, args.candidate, split="val", mode=args.mode, k_se=args.k_se,
         candidate_stderr=args.candidate_stderr, current_stderr=args.current_stderr,

--- a/skills/phases/intake/SKILL.md
+++ b/skills/phases/intake/SKILL.md
@@ -42,6 +42,23 @@ inputs. The metric / GitHub / stop-condition questions below feed directly into 
 - Which ONE gates accept/reject? — single choice → `metric_primary`. (This is the only metric the gate uses.)
 - For each shown metric, is higher or lower better? → `metric_directions` (parallel to `metrics_display`).
 
+### Gate mode
+- Ask only if the user wants to change it; **default `gate_mode: paired`** with
+  `gate_k_se: 1.0`. All five modes live in `core/cap_evolve/gate.py`, all val-only:
+  - **`paired` (default)** — accept iff `mean(per-task Δ) > k_se · SE(Δ)` over the SAME
+    val tasks. Cross-task variance cancels, so it is the most powerful test, and the
+    harness selects it itself when per-task data aligns (`--gate-mode auto`). Its SE
+    comes from the between-task spread of the deltas, so it stays real at
+    `num_trials=1` and can bank a genuine single-task gain.
+  - `significant` — accept iff `Δ(means) > k_se · sqrt(SE_cand² + SE_curr²)`. Unpaired
+    and weaker; it pays for cross-task variance the paired test cancels.
+  - `threshold` — accept iff `Δ > threshold` (a flat domain margin).
+  - `strict` — accept iff `Δ > 0`; only for a near-zero-variance scorer.
+  - `simplicity_tiebreak` — `strict`, plus on a near-tie prefer the smaller candidate.
+- `gate_k_se` is how many SEs the val gain must clear (`0.2` lenient … `1.0` strict).
+  Full table and the small-sample caveat:
+  [`docs/HONEST_EVAL.md` § Gate modes](../../../docs/HONEST_EVAL.md#gate-modes).
+
 ### GitHub integration
 - `gh auth status` = authed? Offer: mirror the algorithm's work items as issues + ship winner as PR (`Closes #n`) → `github_integration: true`; else offer `gh auth login` or skip → `false`. WHAT gets mirrored is algorithm-specific (the `algorithm_skill` defines it — e.g. evo-graph → weaknesses). GitHub is mirror-only; the run dir stays authoritative.
 

--- a/skills/phases/intake/SKILL.md
+++ b/skills/phases/intake/SKILL.md
@@ -49,12 +49,18 @@ inputs. The metric / GitHub / stop-condition questions below feed directly into 
     val tasks. Cross-task variance cancels, so it is the most powerful test, and the
     harness selects it itself when per-task data aligns (`--gate-mode auto`). Its SE
     comes from the between-task spread of the deltas, so it stays real at
-    `num_trials=1` and can bank a genuine single-task gain.
+    `num_trials=1`. **At the default `gate_k_se: 1.0` a gain on exactly one of `n`
+    tasks gives `mean(Δ) = SE(Δ)` exactly and is therefore REJECTED** — at any `n`,
+    at any magnitude. Banking needs ≥2 improved tasks, or `gate_k_se < 1.0`.
   - `significant` — accept iff `Δ(means) > k_se · sqrt(SE_cand² + SE_curr²)`. Unpaired
     and weaker; it pays for cross-task variance the paired test cancels.
-  - `threshold` — accept iff `Δ > threshold` (a flat domain margin).
+  - `threshold` — accept iff `Δ > threshold` (a flat domain margin; `threshold`
+    defaults to `0.0`, so unset = `strict`).
   - `strict` — accept iff `Δ > 0`; only for a near-zero-variance scorer.
   - `simplicity_tiebreak` — `strict`, plus on a near-tie prefer the smaller candidate.
+    ⚠️ Needs `candidate_size`/`current_size`, which nothing in the harness populates —
+    it behaves as `strict` today ([#206](https://github.com/skillberry-ai/cap-evolve/issues/206)).
+    Do not offer it as a working Occam bias.
 - `gate_k_se` is how many SEs the val gain must clear (`0.2` lenient … `1.0` strict).
   Full table and the small-sample caveat:
   [`docs/HONEST_EVAL.md` § Gate modes](../../../docs/HONEST_EVAL.md#gate-modes).

--- a/skills/phases/intake/inputs/INPUTS.md
+++ b/skills/phases/intake/inputs/INPUTS.md
@@ -162,10 +162,12 @@ path, how to obtain it, and the alternatives. Never invent a NEEDED input.
   address ALL failure clusters each iteration (parallel subagents → merge into one
   candidate where supported). See intake SKILL.md step 5.
 
-- **gate**: `gate_mode` (**paired** recommended — per-task paired SE on the same tasks
-  both sides, ~2-3x smaller than combined-SE `significant`, so real 1-task gains bank;
-  also: significant|strict|threshold|simplicity_tiebreak), `gate_k_se` (default 1.0; the
-  examples use 0.2). Add `--no-regression` to forbid breaking passing tasks.
+- **gate**: `gate_mode` (**`paired` — the DEFAULT**: per-task paired SE on the same tasks
+  both sides, smaller than combined-SE `significant`, so real 1-task gains bank; also:
+  `significant`|`threshold`|`strict`|`simplicity_tiebreak` — see
+  [docs/HONEST_EVAL.md § Gate modes](../../../../docs/HONEST_EVAL.md#gate-modes)),
+  `gate_k_se` (default 1.0; the examples use 0.2). Add `--no-regression` to forbid
+  breaking passing tasks.
 
 - **metrics (display)**: which numbers to surface and which one GATES.
   - `metric_primary`: the single metric that decides accept/reject (= the scalar reward). Blank = use the reward directly.

--- a/skills/phases/intake/inputs/INPUTS.md
+++ b/skills/phases/intake/inputs/INPUTS.md
@@ -163,7 +163,9 @@ path, how to obtain it, and the alternatives. Never invent a NEEDED input.
   candidate where supported). See intake SKILL.md step 5.
 
 - **gate**: `gate_mode` (**`paired` — the DEFAULT**: per-task paired SE on the same tasks
-  both sides, smaller than combined-SE `significant`, so real 1-task gains bank; also:
+  both sides, smaller than combined-SE `significant`. At the default `gate_k_se: 1.0` a
+  gain on exactly 1 of `n` tasks lands *exactly* on the bar (`mean(Δ) = SE(Δ)`) and is
+  rejected, so banking needs ≥2 improved tasks or `gate_k_se < 1.0`; also:
   `significant`|`threshold`|`strict`|`simplicity_tiebreak` — see
   [docs/HONEST_EVAL.md § Gate modes](../../../../docs/HONEST_EVAL.md#gate-modes)),
   `gate_k_se` (default 1.0; the examples use 0.2). Add `--no-regression` to forbid

--- a/templates/project/capevolve.yaml
+++ b/templates/project/capevolve.yaml
@@ -77,8 +77,14 @@ github_integration: false    # mirror-only: mirror the algorithm's work items as
 stop_condition: ""           # agent-mode free-text halt rule, re-read each round (e.g. "stop when val acc >= 0.9 or 5 rounds")
 
 # --- acceptance gate --------------------------------------------------------
-gate_mode: paired                        # DEFAULT: per-task paired SE, same tasks both sides — banks real 1-task gains.
+gate_mode: paired                        # DEFAULT: per-task paired SE, same tasks both sides — cross-task
+                                         # variance cancels, so it is the most powerful test and works at num_trials=1.
                                          # Others: significant | threshold | strict | simplicity_tiebreak (docs/HONEST_EVAL.md#gate-modes)
+# gate_k_se: how many SEs the val gain must clear. 1.0 is deliberately conservative:
+# improving exactly ONE of n tasks gives mean(Δ)=SE(Δ) exactly, so it does NOT clear
+# 1.0 — at any n, and no matter how large that single gain is. You need >=2 improved
+# tasks to bank at 1.0. That is the intended default (one task moving is weak evidence
+# it wasn't luck); set 0.2, as the examples do, to bank single-task gains.
 gate_k_se: 1.0
 
 # --- budget -----------------------------------------------------------------

--- a/templates/project/capevolve.yaml
+++ b/templates/project/capevolve.yaml
@@ -77,7 +77,8 @@ github_integration: false    # mirror-only: mirror the algorithm's work items as
 stop_condition: ""           # agent-mode free-text halt rule, re-read each round (e.g. "stop when val acc >= 0.9 or 5 rounds")
 
 # --- acceptance gate --------------------------------------------------------
-gate_mode: paired                        # paired (recommended: per-task paired SE, same tasks both sides — banks real 1-task gains) | significant | strict | threshold | simplicity_tiebreak
+gate_mode: paired                        # DEFAULT: per-task paired SE, same tasks both sides — banks real 1-task gains.
+                                         # Others: significant | threshold | strict | simplicity_tiebreak (docs/HONEST_EVAL.md#gate-modes)
 gate_k_se: 1.0
 
 # --- budget -----------------------------------------------------------------


### PR DESCRIPTION
Closes #104

## Ground truth (from the code, not the docs)

Every mode that exists in `core/cap_evolve/gate.py`, its real behavior, and which is really the default:

| `gate_mode` | Behavior | Default? | Proof (`file:line`) |
|---|---|---|---|
| **`paired`** | `accept ⟺ mean(per-task Δ) > k_se · SE(Δ)` where `Δ[t] = cand[t] − curr[t]` over shared val tasks; `SE = sqrt(var(Δ)/n)` (n−1 denominator). Falls back to `significant` when `paired_deltas` is empty. | **YES — the default for every real run** | `gate.py:117-151`; selected by `harness.py:1293` (`gate_kwargs["mode"] = "paired"`) and `gepa.py:703` (`gk["mode"] = "paired"`), both guarded by `if "mode" not in … and paired_deltas is not None`; shipped default `templates/project/capevolve.yaml:80` |
| `significant` | `accept ⟺ Δ(means) > k_se · sqrt(SE_cand² + SE_curr²)` — independent-samples test. | No — but it *is* the default of `decide()`'s own `mode=` parameter | `gate.py:153-176`; parameter default `gate.py:77` (`mode: str = "significant"`) |
| `threshold` | `accept ⟺ Δ > threshold` (flat margin). | No | `gate.py:178-180` |
| `strict` | `accept ⟺ Δ > 0`. | No | `gate.py:182-184` |
| `simplicity_tiebreak` | `Δ > 0` accepts; on a near-tie (`abs(Δ) ≤ 1e-9`) accept if `candidate_size < current_size`. | No | `gate.py:186-198` |

Anything else raises `ValueError: unknown gate mode` (`gate.py:200`), so this list is exhaustive.

**The asymmetry the old docs tripped over.** `decide()`'s `mode=` parameter really does default to `"significant"` — because a bare caller passing two means and two SEs has no per-task data to pair. But no real run goes through that path: the harness always builds `paired_deltas` and sets `mode="paired"`. Both facts are now documented together instead of one contradicting the other.

**Why `paired` matters (verified empirically, not asserted).** Its SE comes from the spread *between* tasks' deltas, not per-trial noise, so it is non-zero even at `num_trials=1`. Fixing one task of `n` and breaking nothing gives `mean(Δ) = SE = 1/n` exactly:

```
$ python -c "from cap_evolve.gate import decide; ..."
2 False paired Δ̄=+0.5000 <= 1.0·SE=0.5000 (SE=0.5000, n=2)
10 False paired Δ̄=+0.1000 <= 1.0·SE=0.1000 (SE=0.1000, n=10)
20 True  paired Δ̄=+0.0500 > 1.0·SE=0.0500 (SE=0.0500, n=20)   # float slack
```

So at the default `k_se=1.0` a 1-task gain just misses (the comparison is strict), and at the `gate_k_se: 0.2` the examples use it accepts. Under `significant` at `num_trials=1` the same 1-of-10 gain faces a `0.233·k` bar instead of `0.100·k` (`combined_stderr` carries the full between-task spread). The docs now state this precisely rather than the vaguer "~2-3x" claim that was in `INPUTS.md`.

## Bug found and fixed during the sweep

`docs/REPRODUCE_tau2.md` and `skills/algorithms/agent-optimize/SKILL.md` instructed agents to run the gate phase with `--mode paired`, but `skills/phases/gate/scripts/run.py` restricted `--mode` to `significant|strict|threshold|simplicity_tiebreak`:

```
$ python skills/phases/gate/scripts/run.py --current 0.5 --candidate 0.6 --mode paired
gate: error: argument --mode: invalid choice: 'paired' (choose from significant, strict, threshold, simplicity_tiebreak)
```

Every documented paired invocation exited 2. Added `paired` to the choices plus a `--paired-deltas` flag, so the default mode is actually reproducible standalone (it needs per-task deltas, which the old signature had no way to accept).

## Every surface fixed

**Code / docstrings**
- `core/cap_evolve/gate.py` — module docstring no longer claims `significant` is the default; states `paired` is the run default, cites the two selection sites, explains the parameter asymmetry, enumerates all five modes. `decide()`'s mode list marks `paired` as DEFAULT.
- `skills/phases/gate/scripts/run.py` — `paired` accepted; new `--paired-deltas`.
- `skills/algorithms/{hill-climb,gepa,skillopt}/scripts/run.py` — `--gate-mode` help said "recommended" and omitted `simplicity_tiebreak`; now says "the default" and lists all five.

**Canonical docs**
- `docs/HONEST_EVAL.md` — **new `## Gate modes` section** (the cross-link target #104 asked for): full table, the paired/single-task-gain explanation, and a small-sample caveat subsection. Guarantee 3 no longer says `mode="significant"`.
- `docs/ADAPTER_CONTRACT.md` — new `## Gate modes` next to "The gate", framed around what it means for your `score()`.
- `docs/OPTIMIZE_YOUR_OWN.md` — the spec block said `gate: <significant (k_se) | strict | threshold>`, which is not even the right key name; now `gate_mode` / `gate_k_se` with the real five, plus a `### Gate modes` table.
- `site/optimize-your-own.html` — the same block mirrored in HTML (would otherwise have drifted).
- `README.md`, `RUN.md`, `ci/benchmarks/README.md` — one-line gate descriptions now name `paired` and link the section.

**Skills**
- `skills/phases/intake/SKILL.md` — new `### Gate mode` intake question with all five modes (#104 item 2).
- `skills/phases/intake/inputs/INPUTS.md` — "**paired** recommended" → "the DEFAULT", exact wording, cross-link.
- `skills/phases/gate/SKILL.md` — frontmatter `description`/`argument-hint` said `--mode significant`; body's "significance rule (default)" documented only the unpaired formula and claimed SE=0 makes it "silently degrade" (it does not — it logs `gate_warning`). Both formulas now shown, `paired` marked default, working paired example in "How to run".
- `skills/phases/gate/references/concepts.md` — the significance-test section derived only the unpaired SE; now derives both and explains why pairing cancels between-task variance. Modes table gained `paired`. SE=0 and small-sample paragraphs corrected.
- `skills/phases/gate/meta.yaml` — manifest summary said "significance by default"; now "paired per-task significance by default" (manifest rebuilt).
- `skills/algorithms/skillopt/{SKILL.md,references/concepts.md}` — "`significant`/`paired`" (ambiguous about which) → `paired`.
- `skills/algorithms/agent-optimize/SKILL.md` — its `--mode paired` recipe passed `--current-stderr/--candidate-stderr`, which paired ignores; now passes `--paired-deltas` with the unpaired fallback noted.

**Config**
- `templates/project/capevolve.yaml`, `examples/tau2_airline/capevolve.yaml` — comments say "the default" rather than "recommended".
- `docs/REPRODUCE_tau2.md` — claimed `gate_mode significant` for a run whose `capevolve.yaml` is `paired`; corrected, and its gate-phase recipe updated.
- `docs/how-to/cap-evolve-with-exgentic-tau2.md` — keeps `significant`, but now documents *why* it is a deliberate override (its val is ~1 task, where the paired SE collapses to 0). Both mentions (line 77 summary and the yaml block) updated.

## Note for #113

#113 will change the small-sample behavior this PR documents. The paragraphs it must update:

- `docs/HONEST_EVAL.md` → `### Small-sample caveat (current behavior)` — explicitly states the bar is a fixed `k · SE` with **no t-correction and no minimum-val-size guard**, and is optimistic on tiny val splits. If #113 adds a t-based critical value or a min-val guard, this is the paragraph to rewrite.
- `skills/phases/gate/references/concepts.md` → the `**Small-sample caveat (current behavior)**` paragraph (same claim, skill-level).
- Both surfaces document the `SE = 0 → gate_warning + strict fallback` path (`gate.py:132-143`, `gate.py:155-165`). If #113 replaces that fallback with a widened bar or a low-confidence flag, the "Two degenerate cases are handled loudly" list and the SKILL.md "When the SE collapses to 0" paragraph both change.

I deliberately described current behavior only, and labelled it "(current behavior)" so #113's diff is obvious.

## Verification

`pytest core/tests -q` — 179 passed, 0 failed (baseline 179):
```
$ cd /tmp/wt-104 && PYTHONPATH=/tmp/wt-104/core python -m pytest core/tests -q
........................................................................ [ 40%]
........................................................................ [ 80%]
...................................                                      [100%]
179 passed in 63.65s (0:01:03)
```

`compileall` clean:
```
$ python -m compileall -q core skills && echo "COMPILEALL_CLEAN"
COMPILEALL_CLEAN
```

Manifest rebuilt + every touched skill's `check.py` prints `"ok": true`:
```
$ python skills/_registry/build_manifest.py skills
  algorithm: agent-optimize, evograph, gepa, hill-climb, skillopt
  capability: mcp-tool, skill-package, system-prompt, tools
  optimizer: run-optimizer
  orchestrate: orchestrate, using-cap-evolve
  phase: baseline, diagnose, evaluate, finalize, gate, implement-and-check, intake, report

=== phases/gate
  "ok": true,
=== phases/intake
  "ok": true,
=== algorithms/skillopt
  "ok": true,
=== algorithms/hill-climb
  "ok": true,
=== algorithms/gepa
  "ok": true,
=== algorithms/agent-optimize
  "ok": true,
```

The newly documented CLI examples actually run (they did not before):
```
$ python scripts/run.py --current 0.50 --candidate 0.60 --mode paired --k-se 0.2 --paired-deltas 1,0,0,0,0,0,0,0,0,0
{"accept": true,  "reason": "paired Δ̄=+0.1000 > 0.2·SE=0.0200 (SE=0.1000, n=10)", "delta": 0.1, "threshold": 0.02}
$ python scripts/run.py --current 0.50 --candidate 0.60 --mode paired --k-se 1.0 --paired-deltas 1,0,0,0,0,0,0,0,0,0
{"accept": false, "reason": "paired Δ̄=+0.1000 <= 1.0·SE=0.1000 (SE=0.1000, n=10)", "delta": 0.1, "threshold": 0.1}
```

Every relative link + anchor in the changed markdown resolves on disk (67 checked, 0 broken).

Issue #104's own acceptance check:
```
$ grep -rln "paired" docs/ skills/phases/intake/SKILL.md
docs/ADAPTER_CONTRACT.md  docs/HONEST_EVAL.md  docs/OPTIMIZE_YOUR_OWN.md
docs/REPRODUCE_skillsbench.md  docs/REPRODUCE_tau2.md  skills/phases/intake/SKILL.md ...
$ grep -rl "simplicity_tiebreak" docs/ skills/phases/intake/SKILL.md
docs/ADAPTER_CONTRACT.md  docs/HONEST_EVAL.md  docs/OPTIMIZE_YOUR_OWN.md  skills/phases/intake/SKILL.md
```
