### PR TITLE
fix(algorithm): give GEPA & SkillOpt the same optimizer context as hill-climb, un-gate the CLI flags

### DIFF
--- a/core/cap_evolve/__init__.py
+++ b/core/cap_evolve/__init__.py
@@ -17,6 +17,7 @@ from .cache import EvalCache, hash_candidate_dir
 from .gate import GateDecision, TrainGateError, decide
 from .lr_schedule import build_schedule
 from .memory import History, RejectedMemory
+from .optimizer_context import OptimizerContext
 from .rundir import Budget, RunDir, Spent
 from .selection import PICKERS, STRATEGIES, pick, validate_strategy
 from .splits import Splits, TestSealError, make_splits
@@ -41,6 +42,7 @@ __all__ = [
     "decide",
     "History",
     "RejectedMemory",
+    "OptimizerContext",
     "Budget",
     "RunDir",
     "Spent",

--- a/core/cap_evolve/cache.py
+++ b/core/cap_evolve/cache.py
@@ -22,29 +22,20 @@ import hashlib
 import json
 from pathlib import Path
 
+from .optimizer_context import INJECTED_DIRS, INJECTED_NAMES
+
 # Files that are NOT part of the capability (optimizer scratch, memory, vcs); they
-# must not perturb the content hash or every iteration would miss the cache.
+# must not perturb the content hash or every iteration would miss the cache. The
+# INJECTED_* halves are the optimizer-context read-context (``trajectories/``,
+# ``guidance/``, the native per-agent skill dirs and instructions files) — one
+# definition in ``optimizer_context``, folded in here as a plain constant expression
+# (no import-time set mutation, so there is no import-order dependence to reason about;
+# ``optimizer_context`` imports only ``.loop`` and ``.rundir`` at module level).
 _IGNORE_NAMES = {"MEMORY.md", "STATE.md", "INSTRUCTIONS.md", "REJECTED.md", "FOCUS.md",
                  "REFLECTION.md",
                  # cross-iteration state files (clean-ownership redesign) — scratch, not capability
-                 "LEDGER.md", "JOURNAL.md", "PROCESS.md", "RUNMAP.md"}
-_IGNORE_DIRS = {".git", "__pycache__"}
-
-
-def _load_injected_ignores() -> None:
-    """Fold in everything the optimizer-context seam injects into a workdir.
-
-    Injected read-context (``trajectories/``, ``guidance/``, the native per-agent skills
-    dirs and instructions files) is NOT capability content, so it must not perturb the
-    hash — otherwise a GEPA minibatch would miss the cache on every iteration. Imported
-    lazily so this module stays at the bottom of the import graph.
-    """
-    from .optimizer_context import INJECTED_DIRS, INJECTED_NAMES
-    _IGNORE_DIRS.update(INJECTED_DIRS)
-    _IGNORE_NAMES.update(INJECTED_NAMES)
-
-
-_load_injected_ignores()
+                 "LEDGER.md", "JOURNAL.md", "PROCESS.md", "RUNMAP.md"} | set(INJECTED_NAMES)
+_IGNORE_DIRS = {".git", "__pycache__"} | set(INJECTED_DIRS)
 
 
 def hash_candidate_dir(candidate_dir: Path) -> str:

--- a/core/cap_evolve/cache.py
+++ b/core/cap_evolve/cache.py
@@ -28,7 +28,23 @@ _IGNORE_NAMES = {"MEMORY.md", "STATE.md", "INSTRUCTIONS.md", "REJECTED.md", "FOC
                  "REFLECTION.md",
                  # cross-iteration state files (clean-ownership redesign) — scratch, not capability
                  "LEDGER.md", "JOURNAL.md", "PROCESS.md", "RUNMAP.md"}
-_IGNORE_DIRS = {".git", "__pycache__", "prior_iterations"}
+_IGNORE_DIRS = {".git", "__pycache__"}
+
+
+def _load_injected_ignores() -> None:
+    """Fold in everything the optimizer-context seam injects into a workdir.
+
+    Injected read-context (``trajectories/``, ``guidance/``, the native per-agent skills
+    dirs and instructions files) is NOT capability content, so it must not perturb the
+    hash — otherwise a GEPA minibatch would miss the cache on every iteration. Imported
+    lazily so this module stays at the bottom of the import graph.
+    """
+    from .optimizer_context import INJECTED_DIRS, INJECTED_NAMES
+    _IGNORE_DIRS.update(INJECTED_DIRS)
+    _IGNORE_NAMES.update(INJECTED_NAMES)
+
+
+_load_injected_ignores()
 
 
 def hash_candidate_dir(candidate_dir: Path) -> str:

--- a/core/cap_evolve/cli.py
+++ b/core/cap_evolve/cli.py
@@ -86,6 +86,53 @@ def _resolve_algorithm(name: str) -> tuple[str, str | None]:
     return name, None
 
 
+# Algorithms whose run.py declares the shared optimizer-context flag set (via
+# ``OptimizerContext.add_arguments``). The agent-driven ones (evograph, agent-optimize)
+# have no deterministic loop and only tolerate the base flags, so they are excluded —
+# an explicit list, not a silent per-flag drop (issue #109).
+_OPTIMIZER_CONTEXT_ALGORITHMS = ("hill-climb", "gepa", "skillopt")
+
+
+def _optimizer_context_flags(spec: dict, project: str, optimizer_name: str) -> list[str]:
+    """Build the optimizer-context CLI flags from the spec, for ANY algorithm.
+
+    Every value here is "what context does the optimizer get" — the capability brief +
+    guidance, the intake-authored instructions template, the benchmark repo, supporting
+    source files, the optimizer's own features reference, and the consuming-LLM profile.
+    Paths are resolved project-relative when not absolute.
+    """
+    out: list[str] = []
+
+    def _project_rel(value) -> Path:
+        p = Path(str(value))
+        return p if p.is_absolute() or p.exists() else Path(project) / str(value)
+
+    def _csv(value) -> list[str]:
+        if isinstance(value, str):
+            return [v.strip() for v in value.split(",") if v.strip()]
+        return [str(v).strip() for v in (value or []) if str(v).strip()]
+
+    caps = _csv(spec.get("capabilities"))
+    if caps:
+        out += ["--capabilities", ",".join(caps)]
+    if optimizer_name:
+        out += ["--optimizer-name", str(optimizer_name)]
+    instr_p = _project_rel(spec.get("optimizer_instructions_file")
+                           or "optimizer/INSTRUCTIONS.md")
+    if instr_p.exists():
+        out += ["--instructions-file", str(instr_p)]
+    if spec.get("runner_repo_path"):
+        out += ["--bench-repo", str(_project_rel(spec["runner_repo_path"]))]
+    csrc = _csv(spec.get("capability_sources"))
+    if csrc:
+        out += ["--capability-sources", ",".join(csrc)]
+    if spec.get("target_model"):
+        out += ["--target-model", str(spec["target_model"])]
+    if spec.get("target_profile_file"):
+        out += ["--target-profile-file", str(_project_rel(spec["target_profile_file"]))]
+    return out
+
+
 def _resolve_skills(skills_dir: Path) -> dict:
     manifest = skills_dir / "_registry" / "manifest.json"
     if not manifest.exists():
@@ -345,54 +392,14 @@ def _cmd_run(argv):
         alg_cmd += ["--resume"]
     if algorithm_focus is not None:
         alg_cmd += ["--focus", algorithm_focus]
-    # Surface the selected capability skills to the optimizer prompt so it knows the
-    # allowed edit space (e.g. tools → may add composite tools). hill-climb consumes
-    # --capabilities; algorithms without the flag ignore the extra arg via argparse error,
-    # so only pass it to those that accept it.
-    caps = spec.get("capabilities") or []
-    if isinstance(caps, str):
-        caps = [c.strip() for c in caps.split(",") if c.strip()]
-    if caps and algorithm_name == "hill-climb":
-        alg_cmd += ["--capabilities", ",".join(str(c) for c in caps)]
-    # Thread the resolved optimizer NAME so the harness can copy that optimizer's
-    # features reference (parallel-subagent capabilities etc.) into each iteration's
-    # workdir. Only hill-climb accepts the flag; other algorithms ignore it.
-    if algorithm_name == "hill-climb":
-        alg_cmd += ["--optimizer-name", str(optimizer_name)]
-    # Optimizer-instructions template (intake-authored, per benchmark) + benchmark repo
-    # as read-only optimizer context. Both are resolved project-relative if not absolute.
-    # The instructions file defaults to the scaffolded project/optimizer/INSTRUCTIONS.md.
-    if algorithm_name == "hill-climb":
-        instr = spec.get("optimizer_instructions_file") or "optimizer/INSTRUCTIONS.md"
-        instr_p = Path(instr)
-        if not instr_p.is_absolute() and not instr_p.exists():
-            instr_p = Path(project) / instr
-        if instr_p.exists():
-            alg_cmd += ["--instructions-file", str(instr_p)]
-        repo = spec.get("runner_repo_path")
-        if repo:
-            repo_p = Path(str(repo))
-            if not repo_p.is_absolute() and not repo_p.exists():
-                repo_p = Path(project) / str(repo)
-            alg_cmd += ["--bench-repo", str(repo_p)]
-        # Supporting source files (data models / types the tools import) copied verbatim
-        # into the optimizer's ./guidance/sources/ so it can write correct code. Resolved
-        # project-relative by the harness; we pass them through as given.
-        csrc = spec.get("capability_sources") or []
-        if isinstance(csrc, str):
-            csrc = [c.strip() for c in csrc.split(",") if c.strip()]
-        if csrc:
-            alg_cmd += ["--capability-sources", ",".join(str(c) for c in csrc)]
-        # Consuming/runtime LLM the capabilities are optimized FOR (distinct from the
-        # optimizer model). A model id or a tier keyword; steers the optimizer prompt.
-        if spec.get("target_model"):
-            alg_cmd += ["--target-model", str(spec["target_model"])]
-        tpf = spec.get("target_profile_file")
-        if tpf:
-            tpf_p = Path(str(tpf))
-            if not tpf_p.is_absolute() and not tpf_p.exists():
-                tpf_p = Path(project) / str(tpf)
-            alg_cmd += ["--target-profile-file", str(tpf_p)]
+    # Optimizer-context flags — what the optimizer is GIVEN. These used to be gated
+    # behind `algorithm_name == "hill-climb"`, so a user who configured a capability
+    # brief, an instructions template, a bench repo, capability sources or a target model
+    # had them SILENTLY DROPPED on gepa/skillopt (issue #109). Every deterministic
+    # algorithm now declares the same flag set via
+    # OptimizerContext.add_arguments, so they are passed unconditionally.
+    if algorithm_name in _OPTIMIZER_CONTEXT_ALGORITHMS:
+        alg_cmd += _optimizer_context_flags(spec, project, optimizer_name)
     # gepa treats metric-calls as its PRIMARY budget; forward it explicitly (hill-climb
     # has no such flag and enforces the same cap via run_dir.budget_exhausted()).
     if algorithm_name == "gepa" and spec.get("max_metric_calls"):

--- a/core/cap_evolve/dashboard.py
+++ b/core/cap_evolve/dashboard.py
@@ -52,6 +52,8 @@ import shutil
 import subprocess
 from pathlib import Path
 
+from .rundir import ITERATION_EVENT_KINDS, iteration_candidate as _step_candidate
+
 # ---------------------------------------------------------------------------
 # Secret redaction
 # ---------------------------------------------------------------------------
@@ -225,8 +227,9 @@ def _git_log(root: Path) -> list[dict]:
 
 # Step-like events carry a candidate, an accept flag, and per-iteration cost/time.
 # Different algorithms name the candidate field differently; normalise here.
-def _step_candidate(ev: dict):
-    return ev.get("candidate") or ev.get("candidate_id")
+# Both live in rundir now (imported at the top), so the dashboard and the
+# LEDGER/RUNMAP/prior_iterations builders read the SAME set — a fourth algorithm
+# kind can't desync a fifth consumer.
 
 
 def reduce_run(run_dir) -> dict:
@@ -283,7 +286,7 @@ def reduce_run(run_dir) -> dict:
                 "text": ev.get("error") or ev.get("summary") or ev.get("note") or "",
             })
             continue
-        if kind not in ("step", "skillopt_step", "gepa_val_gate"):
+        if kind not in ITERATION_EVENT_KINDS:
             continue
 
         cid = _step_candidate(ev)
@@ -392,7 +395,7 @@ def reduce_run(run_dir) -> dict:
     # separately by headless backends as opt_cost_usd when present.
     opt_usd = 0.0
     for ev in events:
-        if ev.get("kind") in ("step", "skillopt_step", "gepa_val_gate"):
+        if ev.get("kind") in ITERATION_EVENT_KINDS:
             opt_usd += float(ev.get("opt_cost_usd") or ev.get("optimizer_cost_usd") or 0.0)
     tokens = sum(int(n.get("tokens") or 0) for n in nodes.values())
     intake_usd = intake_tokens = intake_secs = 0.0

--- a/core/cap_evolve/gepa.py
+++ b/core/cap_evolve/gepa.py
@@ -51,9 +51,11 @@ from pathlib import Path
 from typing import Callable
 
 from . import gate as gate_mod
+from . import optimizer_context as oc
 from . import selection
 from .cache import EvalCache, hash_candidate_dir
 from .harness import (
+    _SNAPSHOT_IGNORE,
     _augment_instructions,
     _init_memory_store,
     _live,
@@ -62,6 +64,9 @@ from .harness import (
     split_result_from_rollouts,
 )
 from .loop import SplitResult, aggregate_scores
+from .optimizer_context import OptimizerContext
+from .optimizer_context import inject as inject_optimizer_context
+from .optimizer_context import render_instructions
 from .rundir import RunDir
 from .types import Rollout, Score
 
@@ -75,7 +80,9 @@ _NON_COMPONENT = {
     # cross-iteration state files (clean-ownership redesign) — scratch, not capability
     "LEDGER.md", "JOURNAL.md", "PROCESS.md", "RUNMAP.md",
 }
-_NON_COMPONENT_DIRS = {".git", "__pycache__", "prior_iterations"}
+_NON_COMPONENT_DIRS = {".git", "__pycache__"} | set(oc.INJECTED_DIRS)
+# The injected agent-instructions files (CLAUDE.md / AGENTS.md / …) are read-context too.
+_NON_COMPONENT |= set(oc.INJECTED_NAMES)
 
 
 # ---- components (editable capability files) -------------------------------
@@ -274,16 +281,24 @@ def _write_focus(workdir: Path, components: list[str], focus: list[str] | None) 
     return ", ".join(focus) if focus else "(all)"
 
 
-def _instructions(reflection_summary: str, focus_label: str, mb_ids: list[str]) -> str:
+def _gepa_block(reflection_summary: str, focus_label: str, mb_ids: list[str]) -> str:
+    """GEPA's own tail block: the reflective-dataset + component-focus pointers.
+
+    This is the ``extra`` passed to ``optimizer_context.render_instructions`` — the
+    GEPA-specific part of the prompt. The shared part (capability brief, failure index,
+    bench repo, parallel note, consuming-LLM reader block, the benchmark-authored
+    template) comes from the seam, so GEPA is no longer prompt-poorer than hill-climb.
+    """
     return (
-        "# GEPA reflective optimization step\n\n"
+        "\n## GEPA reflective optimization step\n\n"
         f"Minibatch task ids: {', '.join(map(str, mb_ids))}\n"
         f"Component focus: {focus_label}\n\n"
         "Read `REFLECTION.md` (the reflective dataset over the parent's failing "
         "minibatch tasks: inputs, the agent's output/trajectory, and feedback) and "
-        "`FOCUS.md` (which component(s) to edit). Diagnose the common root cause and "
-        "make ONE targeted edit to the focused component(s) that should fix the "
-        "general pattern.\n\n"
+        "`FOCUS.md` (which component(s) to edit). `./trajectories/` holds the SAME "
+        "minibatch rollouts VERBATIM and untruncated — read them when REFLECTION.md's "
+        "excerpts are not enough. Diagnose the common root cause and make ONE targeted "
+        "edit to the focused component(s) that should fix the general pattern.\n\n"
         f"Summary: {reflection_summary}\n"
     )
 
@@ -460,6 +475,7 @@ def gepa_loop(
     seed: int = 0,
     store=None,
     resume: bool = False,
+    ctx=None,
 ) -> dict:
     """Run GEPA's sample-efficient reflective Pareto loop.
 
@@ -476,6 +492,10 @@ def gepa_loop(
         frequency-weighted as GEPA prescribes).
     max_merges / merge_cadence : system-aware merge budget + how often to attempt
         a merge (every Nth accept).
+    ctx : an ``optimizer_context.OptimizerContext`` — what the optimizer is GIVEN
+        (capability guidance + brief, trajectories, the benchmark-authored instructions
+        template, bench repo, its own features reference, the consuming-LLM profile).
+        The same bundle hill-climb and SkillOpt use, so all three prompt identically.
 
     Returns a result dict in the same shape as ``hill_climb_loop`` /
     ``hill_climb_loop`` (plus GEPA-specific fields). The run's ``best_id`` is set to the
@@ -483,6 +503,7 @@ def gepa_loop(
     """
     gate_kwargs = dict(gate_kwargs or {})
     rejected, history, store = _init_memory_store(run_dir, store)
+    ctx = ctx or OptimizerContext()
     cache = EvalCache(run_dir.root / "eval_cache.json")
     rng = random.Random(seed)
     run_dir.log_event("gepa_start", seed=seed, minibatch_size=minibatch_size,
@@ -557,6 +578,13 @@ def gepa_loop(
         workdir.parent.mkdir(parents=True, exist_ok=True)
         shutil.copytree(parent_dir, workdir)
 
+        # Optimizer read-context (trajectories + capability/diagnose/optimizer guidance +
+        # native skills), through the SAME seam hill-climb uses. Scoped to the parent's
+        # minibatch tag so ./trajectories/ holds exactly the rollouts REFLECTION.md
+        # summarizes — verbatim and untruncated.
+        inject_optimizer_context(adapter, run_dir, workdir, split="train", ctx=ctx,
+                                 tag=f"mb_p_{n:04d}")
+
         comps = _components(workdir)
         if component_selector == "round_robin" and comps:
             focus = [comps[comp_cursor % len(comps)]]
@@ -565,7 +593,10 @@ def gepa_loop(
             focus = None  # 'all'
         refl_summary = _write_reflection(workdir, parent_mb)
         focus_label = _write_focus(workdir, comps, focus)
-        instructions = _instructions(refl_summary, focus_label, mb)
+        instructions = render_instructions(
+            parent_mb, mb, f"GEPA minibatch of {len(mb)} train task(s)", ctx=ctx,
+            algorithm="gepa", run_dir=run_dir, parent_id=parent["id"],
+            extra=_gepa_block(refl_summary, focus_label, mb))
         instructions = _augment_instructions(instructions, workdir, run_dir, rejected, history)
 
         opt_error = None
@@ -625,7 +656,8 @@ def gepa_loop(
         summary = (f"candidate {cid} (val {cand_val.reward:.3f}, "
                    f"Δ {cand_val.reward - parent_result.reward:+.3f})")
         if accepted:
-            run_dir.snapshot(cid, workdir)
+            # Same exclusions run_step uses: the injected read-context is not capability.
+            run_dir.snapshot(cid, workdir, ignore=_SNAPSHOT_IGNORE)
             child_dir = run_dir.candidate_dir(cid)
             pool.append(_entry(cid, child_dir, cand_val, parent=parent["id"]))
             lineage[cid] = parent["id"]
@@ -784,7 +816,7 @@ def _try_merge(
     run_dir.update_spent(iterations=1, accepted=accepted)
     summary = f"merge {mid} of {a['id']}+{b['id']} (val {cand_val.reward:.3f})"
     if accepted:
-        run_dir.snapshot(mid, workdir)
+        run_dir.snapshot(mid, workdir, ignore=_SNAPSHOT_IGNORE)
         pool.append(_entry(mid, run_dir.candidate_dir(mid), cand_val, parent=base_parent["id"]))
         lineage[mid] = base_parent["id"]
         history.add(mid, summary, cand_val.reward)

--- a/core/cap_evolve/gepa.py
+++ b/core/cap_evolve/gepa.py
@@ -281,24 +281,39 @@ def _write_focus(workdir: Path, components: list[str], focus: list[str] | None) 
     return ", ".join(focus) if focus else "(all)"
 
 
-def _gepa_block(reflection_summary: str, focus_label: str, mb_ids: list[str]) -> str:
+def _gepa_block(reflection_summary: str, focus_label: str, mb_ids: list[str],
+                *, has_trajectories: bool = True) -> str:
     """GEPA's own tail block: the reflective-dataset + component-focus pointers.
 
     This is the ``extra`` passed to ``optimizer_context.render_instructions`` — the
     GEPA-specific part of the prompt. The shared part (capability brief, failure index,
     bench repo, parallel note, consuming-LLM reader block, the benchmark-authored
     template) comes from the seam, so GEPA is no longer prompt-poorer than hill-climb.
+
+    ``has_trajectories`` gates the "``./trajectories/`` holds the SAME minibatch
+    rollouts VERBATIM" claim: a fully-cached minibatch persists no rollout files, and
+    the seam then OMITS the dir rather than substituting another iteration's traces
+    (see ``harness._copy_step_trajectories``). Claiming a dir that isn't there — or
+    worse, one holding a different iteration's traces — is the failure mode this pins.
     """
+    traj = (
+        "`./trajectories/` holds the SAME minibatch rollouts VERBATIM and untruncated "
+        "— read them when REFLECTION.md's excerpts are not enough. "
+        if has_trajectories else
+        "This minibatch was served entirely from the eval cache, so NO rollout files "
+        "were persisted for it: there is no `./trajectories/` for this step and "
+        "REFLECTION.md's excerpts are the whole record. Do not look for traces "
+        "elsewhere in the workdir — any you find belong to a DIFFERENT iteration. "
+    )
     return (
         "\n## GEPA reflective optimization step\n\n"
         f"Minibatch task ids: {', '.join(map(str, mb_ids))}\n"
         f"Component focus: {focus_label}\n\n"
         "Read `REFLECTION.md` (the reflective dataset over the parent's failing "
         "minibatch tasks: inputs, the agent's output/trajectory, and feedback) and "
-        "`FOCUS.md` (which component(s) to edit). `./trajectories/` holds the SAME "
-        "minibatch rollouts VERBATIM and untruncated — read them when REFLECTION.md's "
-        "excerpts are not enough. Diagnose the common root cause and make ONE targeted "
-        "edit to the focused component(s) that should fix the general pattern.\n\n"
+        f"`FOCUS.md` (which component(s) to edit). {traj}Diagnose the common root cause "
+        "and make ONE targeted edit to the focused component(s) that should fix the "
+        "general pattern.\n\n"
         f"Summary: {reflection_summary}\n"
     )
 
@@ -581,9 +596,11 @@ def gepa_loop(
         # Optimizer read-context (trajectories + capability/diagnose/optimizer guidance +
         # native skills), through the SAME seam hill-climb uses. Scoped to the parent's
         # minibatch tag so ./trajectories/ holds exactly the rollouts REFLECTION.md
-        # summarizes — verbatim and untruncated.
+        # summarizes — verbatim and untruncated, or nothing at all when the minibatch
+        # came from the eval cache (never another iteration's traces).
         inject_optimizer_context(adapter, run_dir, workdir, split="train", ctx=ctx,
                                  tag=f"mb_p_{n:04d}")
+        has_traj = (workdir / "trajectories").is_dir()
 
         comps = _components(workdir)
         if component_selector == "round_robin" and comps:
@@ -596,7 +613,7 @@ def gepa_loop(
         instructions = render_instructions(
             parent_mb, mb, f"GEPA minibatch of {len(mb)} train task(s)", ctx=ctx,
             algorithm="gepa", run_dir=run_dir, parent_id=parent["id"],
-            extra=_gepa_block(refl_summary, focus_label, mb))
+            extra=_gepa_block(refl_summary, focus_label, mb, has_trajectories=has_traj))
         instructions = _augment_instructions(instructions, workdir, run_dir, rejected, history)
 
         opt_error = None
@@ -663,6 +680,11 @@ def gepa_loop(
             lineage[cid] = parent["id"]
             history.add(cid, summary, cand_val.reward)
             accepts += 1
+            # Publish the running best NOW, not only at loop exit: LEDGER.md's
+            # "Current best:" line (and every other best_id reader) comes from run
+            # state, so leaving it at "seed" for the whole run told GEPA's optimizer
+            # its best candidate was the seed even after an accept.
+            run_dir.set_best(max(pool, key=lambda c: c["val"])["id"])
             if store is not None:
                 store.commit(f"iter {n+1}: ACCEPT {summary}", tag="best", accepted=True)
         else:

--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -24,8 +24,11 @@ from pathlib import Path
 from typing import Callable
 
 from . import gate as gate_mod
+# Module-level is safe: optimizer_context imports only .loop/.rundir eagerly and
+# lazy-imports harness inside its function bodies, so there is no cycle to dodge.
+from . import optimizer_context as _oc
 from .loop import SplitResult, aggregate_scores
-from .rundir import RunDir, _atomic_write
+from .rundir import RunDir, _atomic_write, iteration_candidate
 from .splits import Splits, make_splits
 from .types import Rollout, Score, Task
 
@@ -627,24 +630,15 @@ def _diff_capabilities(parent_dir: Path, cand_dir: Path, *, max_chars: int = 800
 
 
 def _parent_map(run_dir: RunDir) -> dict[str, str]:
-    """Map each candidate id -> the parent id it was forked from, from ``step`` events.
+    """Map each candidate id -> the parent id it was forked from, from iteration events.
 
-    Falls back to "seed" for any candidate whose parent is unknown. Best-effort: an
-    unreadable/absent events log yields an empty map."""
-    parent_of: dict[str, str] = {}
-    try:
-        if not run_dir.events_path.exists():
-            return {}
-        for line in run_dir.events_path.read_text(encoding="utf-8").splitlines():
-            line = line.strip()
-            if not line:
-                continue
-            rec = json.loads(line)
-            if rec.get("kind") == "step" and rec.get("candidate"):
-                parent_of[str(rec["candidate"])] = str(rec.get("parent") or "seed")
-    except Exception:  # noqa: BLE001
-        return parent_of
-    return parent_of
+    Reads EVERY ``ITERATION_EVENT_KINDS`` event, not just ``step`` — GEPA bypasses
+    ``run_step`` and emits ``gepa_val_gate``, so a ``kind == "step"`` filter here made
+    GEPA's whole cross-iteration history channel (LEDGER/RUNMAP/prior_iterations)
+    permanently empty. Falls back to "seed" when the parent edge is absent."""
+    return {cid: str(rec.get("parent") or rec.get("parent_id") or "seed")
+            for rec in run_dir.iteration_events()
+            if (cid := iteration_candidate(rec))}
 
 
 def _per_task_rewards(run_dir: RunDir, tag: str, split: str = "val") -> dict[str, float]:
@@ -729,25 +723,15 @@ def _build_ledger(workdir: Path, run_dir: RunDir, rejected, history) -> None:
     its outcome + the exact tasks it broke/fixed. Deterministic — the objective record;
     the optimizer's own narrative lives in JOURNAL.md."""
     parent_of = _parent_map(run_dir)
-    # Outcome per candidate from step events (accept/reject + val + parent).
-    rows: list[dict] = []
-    try:
-        if run_dir.events_path.exists():
-            for line in run_dir.events_path.read_text(encoding="utf-8").splitlines():
-                line = line.strip()
-                if not line:
-                    continue
-                rec = json.loads(line)
-                if rec.get("kind") == "step" and rec.get("candidate"):
-                    rows.append(rec)
-    except Exception:  # noqa: BLE001
-        rows = []
+    # Outcome per candidate from EVERY iteration event kind (accept/reject + val +
+    # parent) — see RunDir.iteration_events; "step" alone omits GEPA entirely.
+    rows = run_dir.iteration_events()
 
     table = ["| iter | candidate | parent | outcome | val | Δ vs parent | broke (were passing) | fixed |",
              "| --- | --- | --- | --- | --- | --- | --- | --- |"]
     for i, rec in enumerate(rows, 1):
-        cid = str(rec.get("candidate"))
-        par = str(rec.get("parent") or "seed")
+        cid = str(iteration_candidate(rec))
+        par = str(rec.get("parent") or rec.get("parent_id") or "seed")
         outcome = "ACCEPT" if rec.get("accept") else "reject"
         val = rec.get("val")
         pval = rec.get("parent_val")
@@ -840,25 +824,15 @@ def _build_runmap(workdir: Path, run_dir: RunDir) -> None:
     ``workdir/prior_iterations/<cid>/`` so the optimizer has REAL in-dir access to all
     prior iterations' working dirs (not just the parent's trajectories)."""
     parent_of = _parent_map(run_dir)
-    rows: list[dict] = []
-    try:
-        if run_dir.events_path.exists():
-            for line in run_dir.events_path.read_text(encoding="utf-8").splitlines():
-                line = line.strip()
-                if not line:
-                    continue
-                rec = json.loads(line)
-                if rec.get("kind") == "step" and rec.get("candidate"):
-                    rows.append(rec)
-    except Exception:  # noqa: BLE001
-        rows = []
+    # Every iteration event kind, not just "step" — GEPA emits "gepa_val_gate".
+    rows = run_dir.iteration_events()
 
     prior_root = workdir / "prior_iterations"
     table = ["| iter | candidate | parent | outcome | val | ./prior_iterations/<id>/ |",
              "| --- | --- | --- | --- | --- | --- |"]
     for i, rec in enumerate(rows, 1):
-        cid = str(rec.get("candidate"))
-        par = str(rec.get("parent") or "seed")
+        cid = str(iteration_candidate(rec))
+        par = str(rec.get("parent") or rec.get("parent_id") or "seed")
         outcome = "ACCEPT" if rec.get("accept") else "reject"
         val = rec.get("val")
         vstr = f"{val:.3f}" if isinstance(val, (int, float)) else ""
@@ -975,10 +949,23 @@ def _copy_step_trajectories(adapter, run_dir: RunDir, workdir: Path, split: str,
                               what=f"trajectories/{tag}", error=str(e)[:300])
             return False
 
-    # An explicit tag (GEPA's parent-minibatch eval) wins; otherwise resolve the
-    # best/parent candidate id from run state (the parent this step forks from),
-    # falling back to the seed tag when no candidate has been accepted yet.
-    if tag and _copy_tag(str(tag)):
+    # An explicit tag (GEPA's parent-minibatch eval) is a PIN, not a preference: the
+    # prompt tells the optimizer these are that exact minibatch's rollouts verbatim.
+    # A fully-cached minibatch writes no rollout files (the eval cache stores only
+    # reward+feedback — see #111), so falling through here would hand the optimizer
+    # ANOTHER iteration's traces while still claiming they are this one's. Omit
+    # loudly instead: no trajectories/ dir, a warning event, and the prompt block
+    # is made conditional on the dir existing at the call site.
+    if tag:
+        if _copy_tag(str(tag)):
+            return
+        if dst.exists():
+            shutil.rmtree(dst, ignore_errors=True)
+        run_dir.log_event(
+            "optimizer_context_warning", what=f"trajectories/{tag}",
+            error="no rollouts persisted for the pinned eval tag (fully-cached "
+                  "minibatch); trajectories/ OMITTED rather than substituting another "
+                  "iteration's traces")
         return
     best_id = None
     try:
@@ -1606,12 +1593,8 @@ _DEFAULT_INSTRUCTIONS_TEMPLATE = (
 # snapshot and surface via RUNMAP/prior_iterations. LEDGER/JOURNAL/RUNMAP + prior_iterations/
 # are framework-injected read-context (LEDGER/RUNMAP regenerated, JOURNAL is run-level),
 # so they must not bloat candidates/ or pollute diffs.
-def _snapshot_ignore() -> tuple[str, ...]:
-    from .optimizer_context import INJECTED_DIRS, INJECTED_NAMES
-    return INJECTED_DIRS + INJECTED_NAMES + ("LEDGER.md", "JOURNAL.md", "RUNMAP.md")
-
-
-_SNAPSHOT_IGNORE = _snapshot_ignore()
+_SNAPSHOT_IGNORE = (_oc.INJECTED_DIRS + _oc.INJECTED_NAMES
+                    + ("LEDGER.md", "JOURNAL.md", "RUNMAP.md"))
 
 
 def _failures_block(always_fail, flaky, errored) -> str:
@@ -1776,10 +1759,21 @@ def _focus_instructions(current_val: SplitResult, focus_ids, label: str,
     intake phase per benchmark, with a generic default shipped in ``templates/``. Only
     the per-iteration data (the focus summary, the failure index, the capability/algorithm
     briefs, the benchmark-repo pointer) is computed here and substituted.
+
+    ``focus_ids`` must name tasks that are IN ``current_val`` — it narrows that result,
+    it cannot add to it. Callers passing ids from a different split (SkillOpt handed
+    train minibatch ids against a val result, and splits are disjoint by construction)
+    would otherwise filter the failure index down to nothing and get a confident
+    "0 failing of 0 tasks" prompt. On zero overlap we do NOT filter, and we say so.
     """
     per = current_val.per_task
+    scoped = True
     if focus_ids is not None:
-        per = [pt for pt in per if pt.get("task_id") in set(focus_ids)]
+        known = {pt.get("task_id") for pt in per}
+        if set(focus_ids) & known:
+            per = [pt for pt in per if pt.get("task_id") in set(focus_ids)]
+        else:
+            scoped = False  # disjoint id sets: filtering would empty the failure index
     errored, always_fail, flaky, solid = _classify(per)
     n = len(per)
 
@@ -1787,6 +1781,10 @@ def _focus_instructions(current_val: SplitResult, focus_ids, label: str,
         f"Focus: {label}. Current val reward {current_val.reward:.3f}: "
         f"{len(solid)} solid / {len(flaky)} flaky / {len(always_fail)} failing"
         + (f" / {len(errored)} infra-errored" if errored else "") + f" of {n} tasks."
+        + ("" if scoped else
+           " (The failure index below covers ALL scored tasks: this step's focus ids "
+           "are from a different split than the scored result, so there is no per-focus "
+           "breakdown — fix the shared root cause, which is what generalizes anyway.)")
     )
     failures = _failures_block(always_fail, flaky, errored)
     passing = _passing_block(solid)

--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -933,7 +933,8 @@ def _augment_instructions(instructions: str, workdir: Path, run_dir: RunDir,
     return f"{instructions}\n\n{pointer}\n"
 
 
-def _copy_step_trajectories(adapter, run_dir: RunDir, workdir: Path, split: str) -> None:
+def _copy_step_trajectories(adapter, run_dir: RunDir, workdir: Path, split: str,
+                            tag: str | None = None) -> None:
     """Copy ONLY the current best/parent candidate's per-tag rollouts for ``split``
     into ``workdir/trajectories/`` — the single step the optimizer builds on.
 
@@ -948,6 +949,10 @@ def _copy_step_trajectories(adapter, run_dir: RunDir, workdir: Path, split: str)
       4. as a last resort, the whole ``rollouts/<split>/`` dir.
     The per-tag copy is preferred even when the adapter returns a native dir, because
     the native dir generally cannot be scoped to one candidate.
+
+    ``tag`` pins the eval tag explicitly instead of resolving the run's best candidate —
+    GEPA needs the PARENT's minibatch traces (tag ``mb_p_NNNN``), which are the step it
+    actually reflects on. The same fallback chain applies if that tag has no rollouts.
     """
     dst = workdir / "trajectories"
 
@@ -970,8 +975,11 @@ def _copy_step_trajectories(adapter, run_dir: RunDir, workdir: Path, split: str)
                               what=f"trajectories/{tag}", error=str(e)[:300])
             return False
 
-    # Resolve the best/parent candidate id from run state (the parent this step forks
-    # from), falling back to the seed tag when no candidate has been accepted yet.
+    # An explicit tag (GEPA's parent-minibatch eval) wins; otherwise resolve the
+    # best/parent candidate id from run state (the parent this step forks from),
+    # falling back to the seed tag when no candidate has been accepted yet.
+    if tag and _copy_tag(str(tag)):
+        return
     best_id = None
     try:
         best_id = run_dir.best_id
@@ -1004,8 +1012,13 @@ def _copy_step_trajectories(adapter, run_dir: RunDir, workdir: Path, split: str)
 
 def _inject_optimizer_context(adapter, run_dir: RunDir, workdir: Path, *, split: str,
                               capabilities=None, optimizer_name: str | None = None,
-                              capability_sources=None, project_dir: Path | None = None) -> None:
+                              capability_sources=None, project_dir: Path | None = None,
+                              tag: str | None = None) -> None:
     """Give the optimizer everything it needs to read, inside its own working dir.
+
+    Call it through ``optimizer_context.inject`` (the shared seam every algorithm uses)
+    rather than directly, so new injected artifacts reach hill-climb, GEPA and SkillOpt
+    at once.
 
     Copies, VERBATIM and without parsing:
       - the CURRENT BEST/PARENT candidate's per-tag trajectories for the most recent
@@ -1027,7 +1040,7 @@ def _inject_optimizer_context(adapter, run_dir: RunDir, workdir: Path, *, split:
     # this split, so the optimizer analyzes the step it builds on (not seed + every
     # rejected candidate mixed together). Always preserves the "something to read"
     # guarantee via per-tag fallback then the native dir.
-    _copy_step_trajectories(adapter, run_dir, workdir, split)
+    _copy_step_trajectories(adapter, run_dir, workdir, split, tag=tag)
 
     # 2) capability skills as local guidance
     caps = [c for c in (capabilities or []) if c]
@@ -1227,8 +1240,13 @@ def run_step(
     optimizer_name: str | None = None,
     capability_sources=None,
     project_dir: Path | None = None,
+    ctx=None,
 ) -> dict:
     """Materialize parent → optimize → evaluate on val → gate → accept/reject.
+
+    ``ctx`` is an ``optimizer_context.OptimizerContext``; when given it supersedes the
+    individual ``capabilities`` / ``optimizer_name`` / ``capability_sources`` /
+    ``project_dir`` kwargs (kept for direct callers).
 
     Returns a dict describing the step. On accept, the candidate is snapshotted
     and becomes the run's best.
@@ -1248,10 +1266,13 @@ def run_step(
     workdir.parent.mkdir(parents=True, exist_ok=True)
     shutil.copytree(parent_dir, workdir)
 
-    # Give the optimizer the full trajectories + capability guidance, in its own dir.
-    _inject_optimizer_context(adapter, run_dir, workdir, split=eval_split,
-                              capabilities=capabilities, optimizer_name=optimizer_name,
-                              capability_sources=capability_sources, project_dir=project_dir)
+    # Give the optimizer the full trajectories + capability guidance, in its own dir —
+    # through the shared seam, so hill-climb / GEPA / SkillOpt inject identically.
+    from .optimizer_context import OptimizerContext, inject as _inject
+    _inject(adapter, run_dir, workdir, split=eval_split,
+            ctx=ctx or OptimizerContext(
+                capabilities=capabilities or [], optimizer_name=optimizer_name,
+                capability_sources=capability_sources or [], project_dir=project_dir))
 
     instructions = _augment_instructions(instructions, workdir, run_dir, rejected, history)
 
@@ -1585,10 +1606,12 @@ _DEFAULT_INSTRUCTIONS_TEMPLATE = (
 # snapshot and surface via RUNMAP/prior_iterations. LEDGER/JOURNAL/RUNMAP + prior_iterations/
 # are framework-injected read-context (LEDGER/RUNMAP regenerated, JOURNAL is run-level),
 # so they must not bloat candidates/ or pollute diffs.
-_SNAPSHOT_IGNORE = ("trajectories", "guidance", "prior_iterations",
-                    "LEDGER.md", "JOURNAL.md", "RUNMAP.md",
-                    ".claude", ".agents", ".gemini", ".opencode", ".bob",
-                    "CLAUDE.md", "AGENTS.md", "GEMINI.md")
+def _snapshot_ignore() -> tuple[str, ...]:
+    from .optimizer_context import INJECTED_DIRS, INJECTED_NAMES
+    return INJECTED_DIRS + INJECTED_NAMES + ("LEDGER.md", "JOURNAL.md", "RUNMAP.md")
+
+
+_SNAPSHOT_IGNORE = _snapshot_ignore()
 
 
 def _failures_block(always_fail, flaky, errored) -> str:
@@ -1848,6 +1871,7 @@ def hill_climb_loop(
     algorithm: str = "hill_climb",
     no_regression: bool = False,
     store=None,
+    ctx=None,
     capabilities=None,
     instructions_file=None,
     bench_repo: str | None = None,
@@ -1864,14 +1888,22 @@ def hill_climb_loop(
     reflection emphasizes — and (for hardest-first) the order. Parent is always
     the current best (global hill-climb). The ``gepa`` algorithm uses its own
     per-instance frontier and parent selection (see ``cap_evolve.gepa``).
+
+    ``ctx`` is an ``optimizer_context.OptimizerContext`` bundling what the optimizer is
+    given (capabilities, instructions template, bench repo, optimizer name, capability
+    sources, consuming-LLM profile) — the same bundle ``gepa_loop`` / ``skillopt_loop``
+    take. The individual kwargs remain for direct callers and build a ctx when none is
+    passed.
     """
     gate_kwargs = dict(gate_kwargs or {})
     rejected, history, store = _init_memory_store(run_dir, store)
 
-    # Resolve the consuming-LLM profile once; its brief steers every iteration's prompt.
-    from . import target_profile as _tp
-    _profile = _tp.resolve(target_model, target_profile_file, project_dir=project_dir)
-    _target_reader = _tp.reader_block(_profile)
+    from .optimizer_context import OptimizerContext, render_instructions
+    ctx = ctx or OptimizerContext(
+        capabilities=capabilities or [], optimizer_name=optimizer_name,
+        instructions_file=instructions_file, bench_repo=bench_repo,
+        capability_sources=capability_sources or [], project_dir=project_dir,
+        target_model=target_model, target_profile_file=target_profile_file)
 
     # establish a focus order over the train tasks when needed
     train_ids = run_dir.read_splits().train
@@ -1895,19 +1927,13 @@ def hill_climb_loop(
             label = f"task {focus_ids[0]}" if focus_ids else "train"
         else:
             focus_ids, label = None, focus
-        seed_empty = _capability_is_empty(capabilities, run_dir.candidate_dir(run_dir.best_id))
-        instructions = _focus_instructions(current_val, focus_ids, label,
-                                            capabilities=capabilities, algorithm=algorithm,
-                                            instructions_file=instructions_file,
-                                            bench_repo=bench_repo, optimizer_name=optimizer_name,
-                                            seed_empty=seed_empty, target_reader=_target_reader)
+        instructions = render_instructions(current_val, focus_ids, label, ctx=ctx,
+                                          algorithm=algorithm, run_dir=run_dir)
         step = run_step(
             adapter, run_dir=run_dir, parent_dir=run_dir.candidate_dir(run_dir.best_id),
             optimizer=optimizer, instructions=instructions, current_val=current_val,
             n_trials=n_trials, gate_kwargs=gate_kwargs, no_regression=no_regression,
-            rejected=rejected, history=history, store=store, capabilities=capabilities,
-            optimizer_name=optimizer_name, capability_sources=capability_sources,
-            project_dir=project_dir,
+            rejected=rejected, history=history, store=store, ctx=ctx,
         )
         steps.append(step)
         if step["accepted"]:

--- a/core/cap_evolve/optimizer_context.py
+++ b/core/cap_evolve/optimizer_context.py
@@ -1,0 +1,218 @@
+"""The ONE optimizer-context seam every algorithm routes through.
+
+Before this module, ``hill-climb`` was the only algorithm that gave its optimizer a
+full working context: ``harness.run_step`` called ``_inject_optimizer_context``
+(trajectories + capability guidance + native-skill placement) and
+``harness._focus_instructions`` rendered the benchmark-authored prompt template with
+the capability brief, the failure index, the bench-repo pointer and the parallel-fan-out
+note. ``gepa`` bypasses ``run_step`` entirely and ``skillopt`` called
+``_focus_instructions`` with no capability/optimizer arguments, so both flagship
+algorithms proposed edits from a thinner prompt than the basic climber.
+
+This module is the shared seam that fixes that, and the extension point for future
+work (see the issue cluster #114/#115/#128/#129/#130/#137/#140):
+
+  * :class:`OptimizerContext` — the per-run bundle of "what context does the optimizer
+    get" knobs, parsed once (from a spec/CLI) and threaded into every algorithm loop as
+    ONE argument instead of eight.
+  * :func:`inject` — the FILE side: everything copied into the optimizer's own workdir
+    (``./trajectories/``, ``./guidance/<cap>/``, ``./guidance/sources/``,
+    ``./guidance/diagnose/``, ``./guidance/optimizer/<name>.md`` and the native
+    per-agent skills dir). Add a new injected artifact HERE and every algorithm gets it.
+  * :func:`render_instructions` — the PROMPT side: the rendered per-iteration
+    INSTRUCTIONS (template + capability brief + failure index + bench repo + parallel
+    note + consuming-LLM reader block), plus an ``extra`` tail for an algorithm's own
+    block (GEPA's reflective dataset pointer, SkillOpt's edit-budget/rejected buffer).
+    Add a new prompt block HERE and every algorithm gets it.
+
+Both functions delegate to the existing honesty-neutral helpers in ``harness`` (imported
+lazily inside the bodies, since ``harness`` calls back into this module) — nothing about
+splits, the gate, or the seal is touched here.
+
+Pure stdlib.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from .loop import SplitResult
+from .rundir import RunDir
+
+
+# Everything :func:`inject` writes into the optimizer's workdir. These are READ-context,
+# never part of the capability, so they must be excluded from: the candidate snapshot
+# (``harness._SNAPSHOT_IGNORE``), GEPA's editable-component list (``gepa._components``)
+# and the eval-cache content hash (``cache.hash_candidate_dir``). One list, three
+# consumers — add a newly injected artifact here and all three stay correct.
+INJECTED_DIRS = ("trajectories", "guidance", "prior_iterations",
+                 ".claude", ".agents", ".gemini", ".opencode", ".bob", ".cursor")
+INJECTED_NAMES = ("CLAUDE.md", "AGENTS.md", "GEMINI.md")
+
+
+def _csv(value) -> list[str]:
+    """Accept a list OR a comma-separated string (the shape CLI flags arrive in)."""
+    if not value:
+        return []
+    if isinstance(value, str):
+        return [v.strip() for v in value.split(",") if v.strip()]
+    return [str(v).strip() for v in value if str(v).strip()]
+
+
+@dataclass
+class OptimizerContext:
+    """What context the optimizer gets — identical for every algorithm.
+
+    Every field was previously hill-climb-only plumbing. Constructing this once and
+    passing it to ``hill_climb_loop`` / ``gepa_loop`` / ``skillopt_loop`` is what makes
+    the three algorithms prompt-equivalent.
+    """
+
+    capabilities: list[str] = field(default_factory=list)
+    optimizer_name: str | None = None
+    instructions_file: str | None = None
+    bench_repo: str | None = None
+    capability_sources: list[str] = field(default_factory=list)
+    project_dir: Path | None = None
+    target_model: str = ""
+    target_profile_file: str | None = None
+
+    def __post_init__(self) -> None:
+        self.capabilities = _csv(self.capabilities)
+        self.capability_sources = _csv(self.capability_sources)
+        if self.project_dir is not None:
+            self.project_dir = Path(self.project_dir)
+        self._reader: str | None = None
+        self._profile = None
+
+    @classmethod
+    def from_args(cls, args) -> OptimizerContext:
+        """Build from an argparse namespace using the standard algorithm flag names.
+
+        Every deterministic algorithm's ``scripts/run.py`` declares the same flag set
+        (``--capabilities --instructions-file --bench-repo --optimizer-name
+        --capability-sources --target-model --target-profile-file``), so this is the one
+        place that maps them onto the context. Missing attributes are tolerated.
+        """
+        get = lambda name, default=None: getattr(args, name, default)  # noqa: E731
+        return cls(
+            capabilities=get("capabilities", "") or "",
+            optimizer_name=get("optimizer_name") or None,
+            instructions_file=get("instructions_file") or None,
+            bench_repo=get("bench_repo") or None,
+            capability_sources=get("capability_sources", "") or "",
+            project_dir=Path(get("project")) if get("project") else None,
+            target_model=get("target_model", "") or "",
+            target_profile_file=get("target_profile_file") or None,
+        )
+
+    @staticmethod
+    def add_arguments(parser) -> None:
+        """Declare the standard optimizer-context flags on an algorithm's argparse.
+
+        Every deterministic algorithm's ``scripts/run.py`` calls this, so ``cap-evolve
+        run`` can pass the flags unconditionally instead of gating them on
+        ``algorithm == "hill-climb"`` (which silently dropped them for GEPA/SkillOpt).
+        """
+        parser.add_argument("--capabilities", default="",
+                            help="comma-separated capability skills under optimization "
+                                 "(e.g. 'system-prompt,tools'); surfaced to the optimizer "
+                                 "so it knows the allowed edit space")
+        parser.add_argument("--instructions-file", default=None,
+                            help="optimizer-instructions template (intake-authored) to "
+                                 "render the per-iteration prompt from; defaults to the "
+                                 "shipped template")
+        parser.add_argument("--bench-repo", default=None,
+                            help="path to the benchmark/runner source, surfaced to the "
+                                 "optimizer as read-only context")
+        parser.add_argument("--optimizer-name", default=None,
+                            help="resolved optimizer name (registry row); used to copy "
+                                 "that optimizer's features reference + native skills "
+                                 "into the optimizer workdir")
+        parser.add_argument("--capability-sources", default="",
+                            help="comma-separated supporting source files (data models / "
+                                 "types the tools import) copied verbatim into the "
+                                 "optimizer's ./guidance/sources/; relative to --project")
+        parser.add_argument("--target-model", default="",
+                            help="consuming/runtime model id or tier keyword "
+                                 "(frontier|strong|mid|weak)")
+        parser.add_argument("--target-profile-file", default=None,
+                            help="optional project-local brief overriding the tier's "
+                                 "built-in brief")
+
+    def profile(self):
+        """The resolved consuming-LLM ``TargetProfile`` (cached)."""
+        if self._profile is None:
+            from . import target_profile as _tp
+            self._profile = _tp.resolve(self.target_model, self.target_profile_file,
+                                        project_dir=self.project_dir)
+        return self._profile
+
+    def target_reader(self) -> str:
+        """The consuming-LLM ("reader") brief block, resolved once and cached."""
+        if self._reader is None:
+            from . import target_profile as _tp
+            self._reader = _tp.reader_block(self.profile())
+        return self._reader
+
+    def log_profile(self, run_dir: RunDir) -> None:
+        """Record the resolved consuming-LLM profile so report + dashboard surface it.
+
+        Called by every algorithm's ``run.py``; previously hill-climb-only.
+        """
+        prof = self.profile()
+        if not prof.is_agnostic:
+            run_dir.log_event("target_profile", model=prof.model, tier=prof.tier,
+                              suggested_num_trials=prof.suggested_num_trials,
+                              resolution_note=prof.resolution_note)
+
+
+def inject(adapter, run_dir: RunDir, workdir: Path, *, split: str,
+           ctx: OptimizerContext | None = None, tag: str | None = None) -> None:
+    """Copy the optimizer's read-context into ``workdir`` (the FILE side of the seam).
+
+    ``tag`` scopes ``./trajectories/`` to a specific eval tag — GEPA needs the *parent's
+    minibatch* traces (not the run's current best), which is exactly the verbatim,
+    untruncated data its ``REFLECTION.md`` only summarizes. Omit it to keep the
+    best/parent-then-seed fallback chain used by hill-climb and SkillOpt.
+    """
+    from . import harness
+    ctx = ctx or OptimizerContext()
+    harness._inject_optimizer_context(
+        adapter, run_dir, workdir, split=split,
+        capabilities=ctx.capabilities, optimizer_name=ctx.optimizer_name,
+        capability_sources=ctx.capability_sources, project_dir=ctx.project_dir,
+        tag=tag,
+    )
+
+
+def render_instructions(current: SplitResult, focus_ids, label: str, *,
+                        ctx: OptimizerContext | None = None,
+                        algorithm: str = "hill-climb",
+                        run_dir: RunDir | None = None,
+                        parent_id: str | None = None,
+                        extra: str = "") -> str:
+    """Render one iteration's INSTRUCTIONS (the PROMPT side of the seam).
+
+    ``current`` is the result the failure index is built from (full val for hill-climb /
+    SkillOpt, the parent's minibatch for GEPA); ``focus_ids`` narrows it; ``extra`` is the
+    algorithm's own tail block. When ``run_dir`` is given the empty-seed signal is
+    computed from the parent candidate (``parent_id``, default the run's best).
+    """
+    from . import harness
+    ctx = ctx or OptimizerContext()
+    seed_empty = None
+    if run_dir is not None:
+        cid = parent_id or run_dir.best_id
+        if cid:
+            seed_empty = harness._capability_is_empty(ctx.capabilities,
+                                                      run_dir.candidate_dir(cid))
+    text = harness._focus_instructions(
+        current, focus_ids, label,
+        capabilities=ctx.capabilities, algorithm=algorithm,
+        instructions_file=ctx.instructions_file, bench_repo=ctx.bench_repo,
+        optimizer_name=ctx.optimizer_name, seed_empty=seed_empty,
+        target_reader=ctx.target_reader(),
+    )
+    return f"{text}\n{extra}" if extra else text

--- a/core/cap_evolve/optimizer_context.py
+++ b/core/cap_evolve/optimizer_context.py
@@ -187,18 +187,41 @@ def inject(adapter, run_dir: RunDir, workdir: Path, *, split: str,
     )
 
 
-def render_instructions(current: SplitResult, focus_ids, label: str, *,
+# Hard ceiling on ONE iteration's assembled INSTRUCTIONS. Every individual block is
+# already bounded (``always_fail[:10]``, ``flaky[:8]``, ``errored[:25]``,
+# ``actionable[:12]``, per-field ``[:800]``) but nothing bounded the SUM — and the
+# cross-iteration blocks (LEDGER/RUNMAP rows, the JOURNAL, the rejected buffer) grow with
+# the run, so a 100-iteration run could balloon the optimizer prompt. 60k chars ≈ 15k
+# tokens, well above every measured render (largest observed: 4,655 B, GEPA iteration 1).
+# ponytail: one global cap; per-block budgets only when a real run actually hits this.
+MAX_INSTRUCTIONS_CHARS = 60_000
+
+
+def render_instructions(scored_result: SplitResult, focus_ids, label: str, *,
                         ctx: OptimizerContext | None = None,
                         algorithm: str = "hill-climb",
                         run_dir: RunDir | None = None,
                         parent_id: str | None = None,
-                        extra: str = "") -> str:
+                        extra: str = "",
+                        max_chars: int = MAX_INSTRUCTIONS_CHARS) -> str:
     """Render one iteration's INSTRUCTIONS (the PROMPT side of the seam).
 
-    ``current`` is the result the failure index is built from (full val for hill-climb /
-    SkillOpt, the parent's minibatch for GEPA); ``focus_ids`` narrows it; ``extra`` is the
-    algorithm's own tail block. When ``run_dir`` is given the empty-seed signal is
-    computed from the parent candidate (``parent_id``, default the run's best).
+    ``scored_result`` is the evaluated result the failure index is built FROM (full val
+    for hill-climb / SkillOpt, the parent's minibatch for GEPA). ``focus_ids`` NARROWS
+    that result, so it must name tasks that are IN it — ids from another split are
+    disjoint by construction and would filter the failure index down to nothing.
+    ``harness._focus_instructions`` refuses to filter on zero overlap and says so in the
+    prompt instead of reporting a confident "0 failing of 0 tasks". The parameter is
+    named ``scored_result`` (not ``current``) so that invariant is visible at every call
+    site rather than living in this docstring.
+
+    ``extra`` is the algorithm's own tail block and stays LAST. Blocks that EVERY
+    algorithm should get belong in the shared body instead — it already receives
+    ``run_dir``, so #128's ``INSIGHTS.md`` and #129's ``rejected.jsonl`` need no
+    signature change.
+
+    When ``run_dir`` is given the empty-seed signal is computed from the parent candidate
+    (``parent_id``, default the run's best). The assembled text is capped at ``max_chars``.
     """
     from . import harness
     ctx = ctx or OptimizerContext()
@@ -209,10 +232,18 @@ def render_instructions(current: SplitResult, focus_ids, label: str, *,
             seed_empty = harness._capability_is_empty(ctx.capabilities,
                                                       run_dir.candidate_dir(cid))
     text = harness._focus_instructions(
-        current, focus_ids, label,
+        scored_result, focus_ids, label,
         capabilities=ctx.capabilities, algorithm=algorithm,
         instructions_file=ctx.instructions_file, bench_repo=ctx.bench_repo,
         optimizer_name=ctx.optimizer_name, seed_empty=seed_empty,
         target_reader=ctx.target_reader(),
     )
-    return f"{text}\n{extra}" if extra else text
+    out = f"{text}\n{extra}" if extra else text
+    if max_chars and len(out) > max_chars:
+        # Keep the head (task framing, capability brief, failure index) and the tail
+        # (the algorithm's own block); elide the middle, which is the part that grows.
+        keep = max(max_chars - 200, 200)
+        head, tail = out[: (keep * 7) // 10], out[-(keep * 3) // 10:]
+        out = (f"{head}\n\n... [{len(out) - keep} chars elided to keep this prompt under "
+               f"{max_chars} chars — the full record is in the run dir] ...\n\n{tail}")
+    return out

--- a/core/cap_evolve/rundir.py
+++ b/core/cap_evolve/rundir.py
@@ -27,6 +27,21 @@ from pathlib import Path
 from .splits import Splits
 
 
+# Every event kind that records ONE evaluated iteration (a candidate + its gate
+# outcome + its val score). ``harness.run_step`` emits "step"; GEPA bypasses
+# run_step and emits "gepa_val_gate"; SkillOpt additionally emits "skillopt_step".
+# ONE definition, every consumer (dashboard lineage, LEDGER, RUNMAP,
+# prior_iterations/) — filtering on "step" alone makes GEPA's whole
+# cross-iteration history channel silently empty.
+ITERATION_EVENT_KINDS = ("step", "skillopt_step", "gepa_val_gate")
+
+
+def iteration_candidate(ev: dict) -> str | None:
+    """The candidate id on an iteration event (kinds differ on the field name)."""
+    cid = ev.get("candidate") or ev.get("candidate_id")
+    return str(cid) if cid else None
+
+
 def _atomic_write(path: Path, text: str) -> None:
     """Write ``text`` to ``path`` atomically (tmp file + ``os.replace``).
 
@@ -395,3 +410,26 @@ class RunDir:
         rec = {"t": time.time(), "kind": kind, **fields}
         with self.events_path.open("a", encoding="utf-8") as f:
             f.write(json.dumps(rec, default=str) + "\n")
+
+    def iteration_events(self) -> list[dict]:
+        """Every event that represents ONE evaluated iteration, in order.
+
+        See :data:`ITERATION_EVENT_KINDS` — read this instead of filtering
+        ``kind == "step"`` by hand, or the algorithms that emit their own kind
+        (GEPA, SkillOpt) silently disappear from whatever you are building.
+        Best-effort: an unreadable/absent events log yields whatever parsed.
+        """
+        out: list[dict] = []
+        try:
+            if not self.events_path.exists():
+                return out
+            for line in self.events_path.read_text(encoding="utf-8").splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                rec = json.loads(line)
+                if rec.get("kind") in ITERATION_EVENT_KINDS and iteration_candidate(rec):
+                    out.append(rec)
+        except Exception:  # noqa: BLE001
+            return out
+        return out

--- a/core/cap_evolve/skillopt.py
+++ b/core/cap_evolve/skillopt.py
@@ -51,6 +51,7 @@ from pathlib import Path
 from . import harness
 from .lr_schedule import build_schedule
 from .loop import SplitResult
+from .optimizer_context import OptimizerContext, render_instructions
 from .rundir import RunDir
 
 # Buffer bounds (PITFALL: the rejected-edit buffer must be reset + bounded per
@@ -213,6 +214,7 @@ def skillopt_loop(
     slow_update_sample: int = 20,
     algorithm: str = "skillopt",
     store=None,
+    ctx=None,
 ) -> dict:
     """Run the SkillOpt epochs × mini-batches climb.
 
@@ -220,11 +222,17 @@ def skillopt_loop(
     ``harness.hill_climb_loop`` (single lineage, parent = current best) and reuses
     ``harness.run_step`` for the honesty-critical materialize→gate→accept cycle.
 
+    ``ctx`` is an ``optimizer_context.OptimizerContext`` — what the optimizer is GIVEN
+    (capability guidance + brief, trajectories, the benchmark-authored instructions
+    template, bench repo, its own features reference, the consuming-LLM profile). The
+    same bundle hill-climb and GEPA use, so all three prompt identically.
+
     Returns a result dict shaped like ``hill_climb_loop``'s, plus ``epochs`` /
     ``edit_budget_schedule`` / ``slow_updates`` / per-epoch ``epoch_stats``.
     """
     gate_kwargs = dict(gate_kwargs or {})
     rejected, history, store = harness._init_memory_store(run_dir, store)
+    ctx = ctx or OptimizerContext()
 
     train_ids = list(run_dir.read_splits().train)
     n_train = len(train_ids)
@@ -287,8 +295,10 @@ def skillopt_loop(
 
             label = f"epoch {epoch}/{epochs} step {s + 1}/{steps_per_epoch} "
             label += f"(mini-batch of {len(minibatch_ids)} train tasks, L={L})"
-            instructions = harness._focus_instructions(current_val, minibatch_ids, label)
-            instructions += "\n" + _buffer_block(L, step_buffer, rejected_this_epoch)
+            instructions = render_instructions(
+                current_val, minibatch_ids, label, ctx=ctx, algorithm=algorithm,
+                run_dir=run_dir,
+                extra=_buffer_block(L, step_buffer, rejected_this_epoch))
 
             cid = f"so_e{epoch:02d}s{s + 1:02d}"
             parent_dir = run_dir.candidate_dir(run_dir.best_id)  # single lineage: always best
@@ -297,6 +307,7 @@ def skillopt_loop(
                 optimizer=optimizer, instructions=instructions, current_val=current_val,
                 n_trials=n_trials, gate_kwargs=gate_kwargs, candidate_id=cid,
                 no_regression=no_regression, rejected=rejected, history=history, store=store,
+                ctx=ctx,
             )
             cand_val = SplitResult.from_dict(step["candidate_val"])
             accepted = bool(step["accepted"])
@@ -348,7 +359,7 @@ def skillopt_loop(
                 prev_epoch_skill=prev_epoch_skill, prev_epoch_best_id=prev_epoch_best_id,
                 epoch=epoch, sample=slow_update_sample, edit_budget=schedule[-1] if schedule else edit_budget,
                 n_trials=n_trials, gate_kwargs=gate_kwargs, no_regression=no_regression,
-                rejected=rejected, history=history, store=store,
+                rejected=rejected, history=history, store=store, ctx=ctx,
             )
             if slow_rec is not None:
                 slow_updates.append(slow_rec)
@@ -422,7 +433,7 @@ def _run_slow_update(
     adapter, *, run_dir: RunDir, optimizer, current_val: SplitResult,
     prev_epoch_skill: SplitResult, prev_epoch_best_id, epoch: int, sample: int,
     edit_budget: int, n_trials: int, gate_kwargs: dict, no_regression: bool,
-    rejected, history, store,
+    rejected, history, store, ctx=None,
 ) -> dict | None:
     """Re-evaluate the epoch-start skill vs current best on a small TRAIN subset,
     categorize, and run ONE extra gated step. Counted in budget; sample is small
@@ -461,8 +472,15 @@ def _run_slow_update(
                       stable_success=len(categories["stable_success"]),
                       improved=len(categories["improved"]))
 
-    instructions = _slow_update_instructions(epoch, categories)
-    instructions += "\n" + _buffer_block(edit_budget, [], [])  # carry the consolidating L budget
+    # The longitudinal block is this step's own framing; the shared seam still supplies
+    # the capability brief / edit space / bench repo / reader block around it, so the slow
+    # update is not prompt-poorer than a normal step.
+    extra = (_slow_update_instructions(epoch, categories) + "\n"
+             + _buffer_block(edit_budget, [], []))  # carry the consolidating L budget
+    instructions = render_instructions(
+        current_val, sample_ids, f"epoch {epoch} slow/meta update "
+        f"({len(sample_ids)} sampled train tasks)", ctx=ctx, algorithm="skillopt",
+        run_dir=run_dir, extra=extra)
 
     cid = f"so_e{epoch:02d}_slow"
     step = harness.run_step(
@@ -470,6 +488,7 @@ def _run_slow_update(
         optimizer=optimizer, instructions=instructions, current_val=current_val,
         n_trials=n_trials, gate_kwargs=gate_kwargs, candidate_id=cid,
         no_regression=no_regression, rejected=rejected, history=history, store=store,
+        ctx=ctx,
     )
     step["epoch"] = epoch
     step["step_in_epoch"] = "slow"

--- a/core/tests/test_optimizer_context_parity.py
+++ b/core/tests/test_optimizer_context_parity.py
@@ -1,0 +1,267 @@
+"""Issue #109 — GEPA and SkillOpt get the SAME optimizer context as hill-climb.
+
+Before the fix:
+  * ``gepa_loop`` bypassed ``run_step``, so its optimizer workdir had no
+    ``./trajectories/``, no ``./guidance/<cap>/`` and no native-skill injection, and its
+    prompt was a hand-rolled string with no capability brief / bench repo / reader block;
+  * ``skillopt_loop`` had no capability/optimizer parameters at all and called
+    ``_focus_instructions`` bare, so ``CAP_BRIEF`` was empty and the ``PARALLEL`` note
+    always claimed a sequential optimizer;
+  * ``cap-evolve run`` gated ``--capabilities / --instructions-file / --bench-repo /
+    --optimizer-name / --capability-sources / --target-model / --target-profile-file``
+    behind ``algorithm == "hill-climb"``, silently dropping them for the other two.
+
+These tests assert the injected FILES, the rendered PROMPT and the CLI flag plumbing for
+all three algorithms.
+"""
+
+import os
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+CORE = REPO / "core"
+EXAMPLE = REPO / "examples" / "toy_calc"
+MOCK_RUN = REPO / "skills" / "optimizers" / "run-optimizer" / "scripts" / "run.py"
+
+sys.path.insert(0, str(CORE))
+
+
+@pytest.fixture(autouse=True)
+def _env():
+    old = dict(os.environ)
+    os.environ["CAPEVOLVE_CORE"] = str(CORE)
+    os.environ["CAPEVOLVE_TOY_DATA"] = str(EXAMPLE)
+    os.environ["CAPEVOLVE_MOCK_SCRIPT"] = str(EXAMPLE / "mock_script.json")
+    yield
+    os.environ.clear()
+    os.environ.update(old)
+
+
+def _toy_adapter():
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("toy_ctx_parity", EXAMPLE / "adapter.py")
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m.Adapter()
+
+
+def _setup(tmp_path, ts, **budget):
+    from cap_evolve import Budget, RunDir, harness
+    adapter = _toy_adapter()
+    seed = tmp_path / f"seed_{ts}"
+    shutil.copytree(EXAMPLE / "capability", seed)
+    run_dir = RunDir.create(tmp_path / ".capevolve", ts=ts, budget=Budget(**budget))
+    harness.ensure_splits(adapter, run_dir, seed=0)
+    base = harness.baseline(adapter, seed, run_dir=run_dir)
+    return adapter, run_dir, base
+
+
+def _ctx(tmp_path):
+    """The full optimizer context a real run configures, with a custom template so we
+    can prove the intake-authored instructions file is honored per-algorithm."""
+    from cap_evolve.optimizer_context import OptimizerContext
+    tmpl = tmp_path / "INSTRUCTIONS.tmpl.md"
+    tmpl.write_text(
+        "CUSTOM-TEMPLATE-MARKER\n{{FOCUS_SUMMARY}}\n{{CAP_BRIEF}}\n{{ALGO_BRIEF}}\n"
+        "{{BENCH_REPO}}\n{{PARALLEL_NOTE}}\n{{FAILURES}}\n{{PASSING}}\n"
+        "{{EMPTY_SEED}}\n{{TARGET_READER}}\n./trajectories/\n",
+        encoding="utf-8")
+    src = tmp_path / "models.py"
+    src.write_text("# the data model the tools import\nVERSION = 1\n", encoding="utf-8")
+    return OptimizerContext(
+        capabilities="system-prompt", optimizer_name="claude-code",
+        instructions_file=str(tmpl), bench_repo="/tmp/somebench",
+        capability_sources=str(src), project_dir=tmp_path,
+        target_model="weak")
+
+
+def _assert_full_context(workdir: Path):
+    """Every artifact + prompt block that used to be hill-climb-only."""
+    # --- injected FILES
+    assert (workdir / "trajectories").is_dir(), "no ./trajectories/ injected"
+    assert any((workdir / "trajectories").iterdir()), "./trajectories/ is empty"
+    assert (workdir / "guidance" / "system-prompt" / "SKILL.md").exists(), \
+        "capability skill not copied to ./guidance/<cap>/"
+    assert (workdir / "guidance" / "diagnose" / "SKILL.md").exists(), \
+        "diagnose skill not copied to ./guidance/diagnose/"
+    assert (workdir / "guidance" / "sources" / "models.py").exists(), \
+        "capability_sources not copied to ./guidance/sources/"
+    assert (workdir / "guidance" / "optimizer" / "claude-code.md").exists(), \
+        "optimizer features reference not copied"
+    # native per-agent skill placement (claude-code row of the registry)
+    assert (workdir / ".claude" / "skills" / "system-prompt" / "SKILL.md").exists(), \
+        "native skills dir not populated"
+    assert "cap-evolve:native-skills" in (workdir / "CLAUDE.md").read_text(encoding="utf-8")
+
+    # --- rendered PROMPT
+    instr = (workdir / "INSTRUCTIONS.md").read_text(encoding="utf-8")
+    assert "{{" not in instr, "template placeholder left unrendered"
+    assert "CUSTOM-TEMPLATE-MARKER" in instr, "--instructions-file template ignored"
+    assert "What you are editing (the allowed edit space)" in instr, "no CAP_BRIEF"
+    assert "./guidance/system-prompt/SKILL.md" in instr, "CAP_BRIEF has no capability"
+    assert "/tmp/somebench" in instr, "no bench-repo pointer"
+    assert "fan out" in instr.lower(), "PARALLEL note not adapted to a parallel optimizer"
+    assert "./trajectories/" in instr, "no trajectories read-pointer"
+    return instr
+
+
+def test_hill_climb_full_context_baseline(tmp_path):
+    """The reference behavior GEPA/SkillOpt must match."""
+    from cap_evolve import harness
+    adapter, run_dir, base = _setup(tmp_path, "hc", max_iterations=1, stall=3)
+    optimizer = harness.optimizer_from_command(
+        ["python3", str(MOCK_RUN), "--name", "mock", "--workdir", "{workdir}",
+         "--prompt", "{prompt}"])
+    harness.hill_climb_loop(
+        adapter, run_dir=run_dir, optimizer=optimizer, current_val=base,
+        focus="all", max_iterations=1, gate_kwargs={"mode": "significant", "k_se": 1.0},
+        algorithm="hill-climb", ctx=_ctx(tmp_path))
+    _assert_full_context(run_dir.root / "work" / "cand_0001")
+
+
+def test_gepa_optimizer_gets_full_context(tmp_path):
+    """FAILS BEFORE THE FIX: gepa_loop had no ctx param and never injected."""
+    from cap_evolve import gepa, harness
+    adapter, run_dir, base = _setup(tmp_path, "gp", max_iterations=1, stall=5)
+    optimizer = harness.optimizer_from_command(
+        ["python3", str(MOCK_RUN), "--name", "mock", "--workdir", "{workdir}",
+         "--prompt", "{prompt}"])
+    gepa.gepa_loop(adapter, run_dir=run_dir, optimizer=optimizer, seed_val=base,
+                   max_iterations=1, minibatch_size=3, max_merges=0,
+                   gate_kwargs={"mode": "significant", "k_se": 1.0},
+                   ctx=_ctx(tmp_path))
+    instr = _assert_full_context(run_dir.root / "work" / "gepa_0001")
+    # GEPA keeps its own reflective block ON TOP of the shared context
+    assert "GEPA reflective optimization step" in instr
+    assert (run_dir.root / "work" / "gepa_0001" / "REFLECTION.md").exists()
+    assert (run_dir.root / "work" / "gepa_0001" / "FOCUS.md").exists()
+
+
+def test_gepa_trajectories_scoped_to_parent_minibatch(tmp_path):
+    """./trajectories/ carries the VERBATIM rollouts REFLECTION.md only summarizes."""
+    from cap_evolve import gepa, harness
+    adapter, run_dir, base = _setup(tmp_path, "gt", max_iterations=1, stall=5)
+    optimizer = harness.optimizer_from_command(
+        ["python3", str(MOCK_RUN), "--name", "mock", "--workdir", "{workdir}",
+         "--prompt", "{prompt}"])
+    gepa.gepa_loop(adapter, run_dir=run_dir, optimizer=optimizer, seed_val=base,
+                   max_iterations=1, minibatch_size=3, max_merges=0,
+                   gate_kwargs={"mode": "significant", "k_se": 1.0},
+                   ctx=_ctx(tmp_path))
+    names = [p.name for p in (run_dir.root / "work" / "gepa_0001" / "trajectories").iterdir()]
+    assert names and all("__mb_p_0000__" in n for n in names), \
+        f"trajectories not scoped to the parent minibatch tag: {names}"
+
+
+def test_gepa_injected_context_excluded_from_component_list_and_snapshot(tmp_path):
+    """Injected read-context must not become an editable 'component', must not bust the
+    eval-cache hash, and must not be snapshotted as part of the candidate."""
+    from cap_evolve import gepa, harness
+    from cap_evolve.cache import hash_candidate_dir
+    adapter, run_dir, base = _setup(tmp_path, "gc", max_iterations=1, stall=5)
+    optimizer = harness.optimizer_from_command(
+        ["python3", str(MOCK_RUN), "--name", "mock", "--workdir", "{workdir}",
+         "--prompt", "{prompt}"])
+    gepa.gepa_loop(adapter, run_dir=run_dir, optimizer=optimizer, seed_val=base,
+                   max_iterations=1, minibatch_size=3, max_merges=0,
+                   gate_kwargs={"mode": "significant", "k_se": 1.0},
+                   ctx=_ctx(tmp_path))
+    workdir = run_dir.root / "work" / "gepa_0001"
+    comps = gepa._components(workdir)
+    assert comps == ["prompt.txt"], f"injected context leaked into components: {comps}"
+    # hash ignores the injected dirs: a bare copy of the capability hashes the same
+    bare = tmp_path / "bare"
+    bare.mkdir()
+    shutil.copyfile(workdir / "prompt.txt", bare / "prompt.txt")
+    assert hash_candidate_dir(workdir) == hash_candidate_dir(bare)
+    snap = run_dir.candidate_dir("gepa_0001")
+    if snap.exists():  # only if the candidate was accepted
+        assert not (snap / "trajectories").exists()
+        assert not (snap / "guidance").exists()
+
+
+def test_skillopt_optimizer_gets_full_context(tmp_path):
+    """FAILS BEFORE THE FIX: skillopt_loop had no capabilities/optimizer_name params."""
+    from cap_evolve import harness, skillopt
+    adapter, run_dir, base = _setup(tmp_path, "so", max_iterations=1, stall=5)
+    optimizer = harness.optimizer_from_command(
+        ["python3", str(MOCK_RUN), "--name", "mock", "--workdir", "{workdir}",
+         "--prompt", "{prompt}"])
+    skillopt.skillopt_loop(adapter, run_dir=run_dir, optimizer=optimizer,
+                           current_val=base, epochs=1, batch_size=4,
+                           gate_kwargs={"mode": "significant", "k_se": 1.0},
+                           slow_update=False, ctx=_ctx(tmp_path))
+    instr = _assert_full_context(run_dir.root / "work" / "so_e01s01")
+    # SkillOpt keeps its textual learning rate block ON TOP of the shared context
+    assert "SkillOpt step budget (textual learning rate)" in instr
+
+
+def test_optimizer_context_from_args_and_flag_declaration():
+    """The shared flag set parses into an equivalent context (the seam the CLI uses)."""
+    import argparse
+    from cap_evolve.optimizer_context import OptimizerContext
+
+    p = argparse.ArgumentParser()
+    p.add_argument("--project")
+    OptimizerContext.add_arguments(p)
+    args = p.parse_args([
+        "--project", "/proj", "--capabilities", "system-prompt,tools",
+        "--instructions-file", "/tmp/t.md", "--bench-repo", "/tmp/bench",
+        "--optimizer-name", "claude-code", "--capability-sources", "a.py,b.py",
+        "--target-model", "weak", "--target-profile-file", "/tmp/p.md"])
+    ctx = OptimizerContext.from_args(args)
+    assert ctx.capabilities == ["system-prompt", "tools"]
+    assert ctx.capability_sources == ["a.py", "b.py"]
+    assert ctx.optimizer_name == "claude-code"
+    assert ctx.instructions_file == "/tmp/t.md"
+    assert ctx.bench_repo == "/tmp/bench"
+    assert ctx.target_model == "weak"
+    assert ctx.target_profile_file == "/tmp/p.md"
+    assert ctx.project_dir == Path("/proj")
+
+
+@pytest.mark.parametrize("algorithm", ["hill-climb", "gepa", "skillopt"])
+def test_every_algorithm_run_py_accepts_the_context_flags(algorithm):
+    """FAILS BEFORE THE FIX for gepa/skillopt: argparse rejected the flags entirely,
+    which is why cli.py gated them behind hill-climb."""
+    import subprocess
+    run_py = REPO / "skills" / "algorithms" / algorithm / "scripts" / "run.py"
+    out = subprocess.run([sys.executable, str(run_py), "--help"],
+                         capture_output=True, text=True,
+                         env={**os.environ, "CAPEVOLVE_CORE": str(CORE)})
+    assert out.returncode == 0, out.stderr
+    for flag in ("--capabilities", "--instructions-file", "--bench-repo",
+                 "--optimizer-name", "--capability-sources", "--target-model",
+                 "--target-profile-file"):
+        assert flag in out.stdout, f"{algorithm} run.py does not accept {flag}"
+
+
+@pytest.mark.parametrize("algorithm", ["hill-climb", "gepa", "skillopt"])
+def test_cli_passes_context_flags_to_every_algorithm(algorithm):
+    """FAILS BEFORE THE FIX: cli.py only emitted these for hill-climb."""
+    from cap_evolve import cli
+    assert algorithm in cli._OPTIMIZER_CONTEXT_ALGORITHMS
+    spec = {"capabilities": ["system-prompt", "tools"],
+            "runner_repo_path": "/tmp/bench",
+            "capability_sources": ["models.py"],
+            "target_model": "weak",
+            "target_profile_file": "/tmp/prof.md"}
+    flags = cli._optimizer_context_flags(spec, "/proj", "claude-code")
+    assert flags[flags.index("--capabilities") + 1] == "system-prompt,tools"
+    assert flags[flags.index("--optimizer-name") + 1] == "claude-code"
+    assert flags[flags.index("--bench-repo") + 1] == "/tmp/bench"
+    assert flags[flags.index("--capability-sources") + 1] == "models.py"
+    assert flags[flags.index("--target-model") + 1] == "weak"
+    assert flags[flags.index("--target-profile-file") + 1] == "/tmp/prof.md"
+
+
+def test_agent_driven_algorithms_are_not_sent_context_flags():
+    """evograph / agent-optimize have no deterministic loop — excluded on purpose,
+    not silently dropped per-flag."""
+    from cap_evolve import cli
+    assert "evograph" not in cli._OPTIMIZER_CONTEXT_ALGORITHMS
+    assert "agent-optimize" not in cli._OPTIMIZER_CONTEXT_ALGORITHMS

--- a/core/tests/test_optimizer_context_parity.py
+++ b/core/tests/test_optimizer_context_parity.py
@@ -265,3 +265,177 @@ def test_agent_driven_algorithms_are_not_sent_context_flags():
     from cap_evolve import cli
     assert "evograph" not in cli._OPTIMIZER_CONTEXT_ALGORITHMS
     assert "agent-optimize" not in cli._OPTIMIZER_CONTEXT_ALGORITHMS
+
+
+# ---------------------------------------------------------------------------
+# Review-round regressions (PR #199): the three blocking findings.
+# ---------------------------------------------------------------------------
+
+def test_gepa_gets_a_populated_history_channel_and_its_true_best(tmp_path):
+    """BLOCKING 1: LEDGER/RUNMAP/prior_iterations were EMPTY for GEPA.
+
+    ``_parent_map`` / ``_build_ledger`` / ``_build_runmap`` filtered ``kind == "step"``,
+    but GEPA bypasses ``run_step`` and emits ``gepa_val_gate`` — so its whole
+    cross-iteration memory channel stayed empty while the prompt told the optimizer to
+    read it, and ``run_dir.best_id`` stayed "seed" until loop exit. #128/#129/#130 all
+    read exactly this channel.
+    """
+    from cap_evolve import gepa, harness
+    adapter, run_dir, base = _setup(tmp_path, "gh", max_iterations=2, stall=5)
+    optimizer = harness.optimizer_from_command(
+        ["python3", str(MOCK_RUN), "--name", "mock", "--workdir", "{workdir}",
+         "--prompt", "{prompt}"])
+    gepa.gepa_loop(adapter, run_dir=run_dir, optimizer=optimizer, seed_val=base,
+                   max_iterations=2, minibatch_size=3, max_merges=0,
+                   gate_kwargs={"mode": "significant", "k_se": 1.0},
+                   ctx=_ctx(tmp_path))
+
+    # The shared kind set must include GEPA's kind, for every consumer.
+    from cap_evolve.rundir import ITERATION_EVENT_KINDS
+    assert "gepa_val_gate" in ITERATION_EVENT_KINDS
+    evs = run_dir.iteration_events()
+    assert evs, "no iteration events recognised for a GEPA run"
+    assert any(e["kind"] == "gepa_val_gate" for e in evs)
+
+    # iteration 2's workdir must SEE iteration 1.
+    wd2 = run_dir.root / "work" / "gepa_0002"
+    ledger = (wd2 / "LEDGER.md").read_text(encoding="utf-8")
+    runmap = (wd2 / "RUNMAP.md").read_text(encoding="utf-8")
+    assert "(baseline only)" not in ledger, f"LEDGER still empty for GEPA:\n{ledger}"
+    assert "gepa_0001" in ledger, f"iteration 1 missing from LEDGER:\n{ledger}"
+    assert "(no prior iterations yet)" not in runmap, f"RUNMAP still empty:\n{runmap}"
+    assert "gepa_0001" in runmap
+    prior = wd2 / "prior_iterations" / "gepa_0001"
+    assert prior.is_dir() and any(prior.iterdir()), "prior_iterations/ never populated"
+
+    # ...and must be told its TRUE best, not "seed", once an accept happened.
+    assert run_dir.best_id == "gepa_0001", f"best_id is {run_dir.best_id!r}"
+    assert "## Current best: gepa_0001" in ledger
+
+
+def test_gepa_cache_hit_never_substitutes_another_iterations_trajectories(tmp_path):
+    """BLOCKING 2: the pinned ``tag=`` fell through on a cache hit.
+
+    A fully-cached minibatch persists no rollout files, so ``_copy_tag`` failed and the
+    chain silently handed the optimizer the PREVIOUS iteration's traces (including
+    ``mb_c_*`` child rollouts) while the prompt claimed they were "the SAME minibatch
+    VERBATIM". A pin must be honoured or omitted loudly — never substituted.
+    """
+    from cap_evolve import harness
+    adapter, run_dir, _ = _setup(tmp_path, "ct", max_iterations=1, stall=5)
+    workdir = tmp_path / "wd"
+    workdir.mkdir()
+    stale = workdir / "trajectories"
+    stale.mkdir()
+    (stale / "a1__mb_p_0000__t0.json").write_text("{}", encoding="utf-8")
+
+    # Pin a tag that has NO persisted rollouts (exactly the cache-hit case).
+    harness._copy_step_trajectories(adapter, run_dir, workdir, "train",
+                                    tag="mb_p_0007")
+    assert not stale.exists(), "stale trajectories/ left in place for an unmet pin"
+
+    kinds = [e for e in run_dir.iteration_events()]  # touch the reader too
+    warn = [json_line for json_line in
+            run_dir.events_path.read_text(encoding="utf-8").splitlines()
+            if "optimizer_context_warning" in json_line and "mb_p_0007" in json_line]
+    assert warn, "unmet trajectory pin failed SILENTLY (no warning event)"
+    assert "OMITTED" in warn[0]
+    assert kinds == kinds  # no-op; keeps the reader exercised without asserting count
+
+    # ...and the prompt block must not claim a dir that isn't there.
+    from cap_evolve import gepa
+    with_traj = gepa._gepa_block("s", "prompt.txt", ["a1"], has_trajectories=True)
+    without = gepa._gepa_block("s", "prompt.txt", ["a1"], has_trajectories=False)
+    assert "SAME minibatch rollouts VERBATIM" in with_traj
+    assert "SAME minibatch rollouts VERBATIM" not in without
+    assert "served entirely from the eval cache" in without
+
+
+def test_focus_ids_from_a_disjoint_split_do_not_empty_the_failure_index(tmp_path):
+    """BLOCKING 3: SkillOpt's failure index was always "of 0 tasks".
+
+    ``render_instructions`` got a VAL result narrowed by TRAIN ids — disjoint by
+    construction — so the intersection was always empty and the optimizer was told
+    there was nothing to fix. Zero overlap must fall back to the unfiltered index and
+    say so, not report a confident empty one.
+    """
+    from cap_evolve import skillopt, harness
+    from cap_evolve.optimizer_context import render_instructions
+    adapter, run_dir, base = _setup(tmp_path, "fi", max_iterations=2, stall=5)
+
+    # Unit: val result + train-shaped ids => full index, with the caveat sentence.
+    train_ids = list(run_dir.read_splits().train)
+    val_ids = {pt["task_id"] for pt in base.per_task}
+    assert not (set(train_ids) & val_ids), "fixture splits are not disjoint"
+    out = render_instructions(base, train_ids, "mb", ctx=_ctx(tmp_path))
+    assert " of 0 tasks." not in out, f"failure index emptied by disjoint ids:\n{out[:400]}"
+    assert "ALWAYS-failing task(s)" in out, "no failure index rendered"
+    assert "different split than the scored result" in out, "silent fallback (no caveat)"
+
+    # End to end: a real SkillOpt step's INSTRUCTIONS.md has a non-empty index.
+    optimizer = harness.optimizer_from_command(
+        ["python3", str(MOCK_RUN), "--name", "mock", "--workdir", "{workdir}",
+         "--prompt", "{prompt}"])
+    skillopt.skillopt_loop(adapter, run_dir=run_dir, optimizer=optimizer,
+                           current_val=base, epochs=1, batch_size=2,
+                           edit_budget=2,
+                           gate_kwargs={"mode": "significant", "k_se": 1.0},
+                           ctx=_ctx(tmp_path))
+    step_dirs = sorted((run_dir.root / "work").glob("so_*"))
+    assert step_dirs, "no skillopt workdir"
+    instr = (step_dirs[0] / "INSTRUCTIONS.md").read_text(encoding="utf-8")
+    assert " of 0 tasks." not in instr, f"SkillOpt index still empty:\n{instr[:400]}"
+    assert "ALWAYS-failing task(s)" in instr
+    assert "No actionable failures in focus" not in instr
+
+
+def test_assembled_instructions_are_globally_capped():
+    """Non-blocking 7: every block was bounded, the SUM was not."""
+    from cap_evolve.loop import SplitResult
+    from cap_evolve.optimizer_context import MAX_INSTRUCTIONS_CHARS, render_instructions
+    res = SplitResult(split="val", reward=0.0, stderr=0.0, per_task=[
+        {"task_id": "a1", "reward": 0.0, "feedback": "x" * 200, "trial_rewards": [0.0]}])
+    out = render_instructions(res, None, "all", extra="Z" * 200_000, max_chars=5_000)
+    assert len(out) <= 5_000 + 300, len(out)
+    assert "chars elided to keep this prompt under" in out
+    assert MAX_INSTRUCTIONS_CHARS >= 10_000  # a normal render must never be truncated
+
+
+@pytest.mark.parametrize("algo", ["hill-climb", "gepa", "skillopt"])
+def test_target_profile_file_reaches_every_algorithms_prompt(tmp_path, algo):
+    """Non-blocking 8: ``--target-profile-file`` was only covered by a unit test.
+
+    Real fixture profile file, real loop, all three algorithms: the project-local brief
+    must OVERRIDE the tier's built-in brief in the rendered prompt.
+    """
+    from cap_evolve import gepa, harness, skillopt
+    from cap_evolve.optimizer_context import OptimizerContext
+    prof = tmp_path / "reader.md"
+    prof.write_text("FIXTURE-READER-BRIEF-199: the consuming model needs explicit rules.",
+                    encoding="utf-8")
+    tmpl = tmp_path / "t.md"
+    tmpl.write_text("{{FOCUS_SUMMARY}}\n{{TARGET_READER}}\n{{FAILURES}}\n", encoding="utf-8")
+    ctx = OptimizerContext(capabilities="system-prompt", instructions_file=str(tmpl),
+                           target_model="mid", target_profile_file=str(prof),
+                           project_dir=tmp_path)
+    adapter, run_dir, base = _setup(tmp_path, f"tp{abs(hash(algo)) % 997}",
+                                   max_iterations=1, stall=5)
+    optimizer = harness.optimizer_from_command(
+        ["python3", str(MOCK_RUN), "--name", "mock", "--workdir", "{workdir}",
+         "--prompt", "{prompt}"])
+    common = dict(run_dir=run_dir, optimizer=optimizer, ctx=ctx,
+                  gate_kwargs={"mode": "significant", "k_se": 1.0})
+    if algo == "hill-climb":
+        harness.hill_climb_loop(adapter, current_val=base, focus="all",
+                                max_iterations=1, algorithm="hill-climb", **common)
+    elif algo == "gepa":
+        gepa.gepa_loop(adapter, seed_val=base, max_iterations=1, minibatch_size=3,
+                       max_merges=0, **common)
+    else:
+        skillopt.skillopt_loop(adapter, current_val=base, epochs=1, batch_size=2,
+                               edit_budget=2, **common)
+    instrs = [p.read_text(encoding="utf-8")
+              for p in (run_dir.root / "work").glob("*/INSTRUCTIONS.md")]
+    assert instrs, f"no INSTRUCTIONS.md written for {algo}"
+    assert any("FIXTURE-READER-BRIEF-199" in i for i in instrs), \
+        f"--target-profile-file brief never reached {algo}'s prompt"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -36,7 +36,11 @@ See [`HONEST_EVAL.md`](HONEST_EVAL.md) for the splitting / gating / sealing guar
 ## What the optimizer receives each iteration
 
 The harness assembles a **capability-scoped** working dir per iteration, then runs your
-chosen coding-agent CLI in it:
+chosen coding-agent CLI in it. This is assembled by **one shared seam**,
+[`core/cap_evolve/optimizer_context.py`](../core/cap_evolve/optimizer_context.py)
+(`inject()` = the files, `render_instructions()` = the prompt), and **every deterministic
+algorithm — `hill-climb`, `gepa`, `skillopt` — routes through it**, so all three get the
+identical context. Add an artifact or a prompt block there and all three inherit it:
 
 - **The selected capability skill(s)** — both as `./guidance/<cap>/` *and* placed natively
   in the agent's own skills dir (e.g. `.claude/skills/`) so a headless agent auto-loads
@@ -59,6 +63,11 @@ chosen coding-agent CLI in it:
 | `JOURNAL.md` | optimizer | append-only HANDOVER across the run (tried / worked / regressed / refuted / focus-next) |
 | `PROCESS.md` | optimizer | EXPLAINABILITY, snapshotted per candidate |
 | `RUNMAP.md` + `prior_iterations/` | framework | a manifest plus every prior iteration's PROCESS.md and capability diff, for real prior-work access |
+
+These are built from the run's iteration events. The recognised kinds live in ONE place —
+`rundir.ITERATION_EVENT_KINDS` (`step`, `skillopt_step`, `gepa_val_gate`), read via
+`RunDir.iteration_events()` — because algorithms that emit their own kind (GEPA bypasses
+`run_step`) would otherwise be invisible to these builders and get an empty history.
 
 Because it sees all failure clusters, the protect-set, and the prior causal impact at once,
 the optimizer produces **one bold, multi-part candidate per iteration that addresses every

--- a/skills/algorithms/gepa/SKILL.md
+++ b/skills/algorithms/gepa/SKILL.md
@@ -105,6 +105,23 @@ test stays sealed for `finalize`.
 ## Agent-mode loop
 When `orchestration_mode: agent`, drive gepa yourself: maintain the candidate pool/Pareto frontier; each round pick a parent (per gepa's selection), reflect on its val feedback to propose an edit, evaluate on **val** via cap-evolve, gate Δ>k·SE, accept→snapshot & add to the frontier / reject→drop. Metric-calls is the primary budget. Log rounds to the run dir; between rounds verify rollouts+results landed so the dashboard reflects the frontier. Re-read `stop_condition`; stop on it/budget. Seal once with `cap-evolve finalize`, then `report`.
 
+
+## What the optimizer receives each iteration
+
+Identical for all three deterministic algorithms — one shared seam,
+`core/cap_evolve/optimizer_context.py` (`inject()` writes the files, `render_instructions()`
+renders the prompt): the per-iteration `INSTRUCTIONS.md` rendered from the intake-authored
+template (`--instructions-file`) with the capability brief (`--capabilities`), the failure
+index, the bench-repo pointer (`--bench-repo`), the parallel-fan-out note and the
+consuming-LLM reader block (`--target-model` / `--target-profile-file`); plus
+`./trajectories/`, `./guidance/<cap>/`, `./guidance/diagnose/`, `./guidance/sources/`
+(`--capability-sources`), `./guidance/optimizer/<name>.md` (`--optimizer-name`), the
+native per-agent skills dir, and the cross-iteration
+`LEDGER.md` / `JOURNAL.md` / `RUNMAP.md` + `prior_iterations/`. `cap-evolve run` passes
+every one of those flags to this algorithm — see `docs/ARCHITECTURE.md`.
+
+This algorithm adds its own tail block on top (`REFLECTION.md` + `FOCUS.md` pointers).
+
 ## References
 
 - `references/concepts.md` — the GEPA economy, reflective dataset / actionable side

--- a/skills/algorithms/gepa/scripts/run.py
+++ b/skills/algorithms/gepa/scripts/run.py
@@ -20,6 +20,7 @@ import _bootstrap  # noqa: F401
 from cap_evolve import RunDir, gepa, harness
 from cap_evolve.check import load_adapter
 from cap_evolve.loop import SplitResult
+from cap_evolve.optimizer_context import OptimizerContext
 from cap_evolve.store import make_store
 
 ALGO = "gepa"
@@ -54,9 +55,12 @@ def main(argv=None) -> int:
     p.add_argument("--resume", action="store_true",
                    help="reconstruct the pool/frontier from the run dir and continue the "
                         "search instead of restarting from the seed")
+    OptimizerContext.add_arguments(p)
     args = p.parse_args(argv)
 
     run_dir = RunDir.open(Path(args.run_dir))
+    ctx = OptimizerContext.from_args(args)
+    ctx.log_profile(run_dir)   # consuming-LLM profile -> report + dashboard
     store = make_store({"store": args.store, "store_commit_cmd": args.store_commit_cmd}, run_dir.root)
     adapter = load_adapter(Path(args.project))
     optimizer = harness.optimizer_from_command(shlex.split(args.optimizer))
@@ -73,7 +77,7 @@ def main(argv=None) -> int:
         gate_kwargs=({"k_se": args.k_se} if args.gate_mode == "auto"
                      else {"mode": args.gate_mode, "k_se": args.k_se}),
         no_regression=args.no_regression, seed=args.seed, store=store,
-        resume=args.resume,
+        resume=args.resume, ctx=ctx,
     )
     print(json.dumps(result, indent=2))
     return 0

--- a/skills/algorithms/hill-climb/SKILL.md
+++ b/skills/algorithms/hill-climb/SKILL.md
@@ -52,5 +52,20 @@ Back-compat: `--focus all-at-once` is accepted and treated as `all`.
 ## Agent-mode loop
 When `orchestration_mode: agent`, drive hill-climb yourself: from the baseline best, each iteration — propose ONE edit to the capability (per `--focus`: all / cyclic / hardest-first), evaluate the candidate on **val** via cap-evolve (writes rollouts+results), gate Δ>k·SE, accept→snapshot via the store / reject→revert. Log each iteration to the run dir's event log. Re-read `stop_condition`; stop on it or on stall/budget. Between iterations, confirm the run dir got this iteration's rollouts + event so the dashboard stays current. Seal once with `cap-evolve finalize`, then `report`.
 
+
+## What the optimizer receives each iteration
+
+Identical for all three deterministic algorithms — one shared seam,
+`core/cap_evolve/optimizer_context.py` (`inject()` writes the files, `render_instructions()`
+renders the prompt): the per-iteration `INSTRUCTIONS.md` rendered from the intake-authored
+template (`--instructions-file`) with the capability brief (`--capabilities`), the failure
+index, the bench-repo pointer (`--bench-repo`), the parallel-fan-out note and the
+consuming-LLM reader block (`--target-model` / `--target-profile-file`); plus
+`./trajectories/`, `./guidance/<cap>/`, `./guidance/diagnose/`, `./guidance/sources/`
+(`--capability-sources`), `./guidance/optimizer/<name>.md` (`--optimizer-name`), the
+native per-agent skills dir, and the cross-iteration
+`LEDGER.md` / `JOURNAL.md` / `RUNMAP.md` + `prior_iterations/`. `cap-evolve run` passes
+every one of those flags to this algorithm — see `docs/ARCHITECTURE.md`.
+
 ## References
 - `references/focus-schedules.md` — how each schedule builds its focus set.

--- a/skills/algorithms/hill-climb/scripts/run.py
+++ b/skills/algorithms/hill-climb/scripts/run.py
@@ -27,6 +27,7 @@ from cap_evolve import RunDir, harness
 from cap_evolve.store import make_store
 from cap_evolve.check import load_adapter
 from cap_evolve.loop import SplitResult
+from cap_evolve.optimizer_context import OptimizerContext
 
 FOCUS_CHOICES = ("all", "cyclic", "hardest-first")
 ALGO = "hill-climb"
@@ -54,27 +55,7 @@ def main(argv=None) -> int:
     p.add_argument("--resume", action="store_true",
                    help="continue from the run's current best candidate (read its val "
                         "from rollouts) instead of baseline")
-    p.add_argument("--capabilities", default="",
-                   help="comma-separated capability skills under optimization (e.g. "
-                        "'system-prompt,tools'); surfaced to the optimizer so it knows "
-                        "the allowed edit space")
-    p.add_argument("--instructions-file", default=None,
-                   help="optimizer-instructions template (intake-authored) to render the "
-                        "per-iteration prompt from; defaults to the shipped template")
-    p.add_argument("--bench-repo", default=None,
-                   help="path to the benchmark/runner source, surfaced to the optimizer "
-                        "as read-only context")
-    p.add_argument("--optimizer-name", default=None,
-                   help="resolved optimizer name (registry row); used to copy that "
-                        "optimizer's features reference into the optimizer workdir")
-    p.add_argument("--capability-sources", default="",
-                   help="comma-separated supporting source files (data models / types "
-                        "the tools import) copied verbatim into the optimizer's "
-                        "./guidance/sources/; resolved relative to --project")
-    p.add_argument("--target-model", default="",
-                   help="consuming/runtime model id or tier keyword (frontier|strong|mid|weak)")
-    p.add_argument("--target-profile-file", default=None,
-                   help="optional project-local brief overriding the tier's built-in brief")
+    OptimizerContext.add_arguments(p)
     args = p.parse_args(argv)
 
     focus = _LEGACY_FOCUS.get(args.focus, args.focus)
@@ -83,13 +64,8 @@ def main(argv=None) -> int:
         return 2
 
     run_dir = RunDir.open(Path(args.run_dir))
-    # Record the resolved consuming-LLM profile so report + dashboard can surface it.
-    from cap_evolve import target_profile as _tp
-    _prof = _tp.resolve(args.target_model, args.target_profile_file, project_dir=args.project)
-    if not _prof.is_agnostic:
-        run_dir.log_event("target_profile", model=_prof.model, tier=_prof.tier,
-                          suggested_num_trials=_prof.suggested_num_trials,
-                          resolution_note=_prof.resolution_note)
+    ctx = OptimizerContext.from_args(args)
+    ctx.log_profile(run_dir)   # consuming-LLM profile -> report + dashboard
     store = make_store({"store": args.store, "store_commit_cmd": args.store_commit_cmd}, run_dir.root)
     adapter = load_adapter(Path(args.project))
     optimizer = harness.optimizer_from_command(shlex.split(args.optimizer))
@@ -105,13 +81,7 @@ def main(argv=None) -> int:
         gate_kwargs=({"k_se": args.k_se} if args.gate_mode == "auto"
                      else {"mode": args.gate_mode, "k_se": args.k_se}),
         algorithm=f"{ALGO}:{focus}", no_regression=args.no_regression, store=store,
-        capabilities=[c.strip() for c in args.capabilities.split(",") if c.strip()],
-        instructions_file=args.instructions_file, bench_repo=args.bench_repo,
-        optimizer_name=args.optimizer_name,
-        capability_sources=[s.strip() for s in args.capability_sources.split(",") if s.strip()],
-        project_dir=Path(args.project),
-        target_model=args.target_model,
-        target_profile_file=args.target_profile_file,
+        ctx=ctx,
     )
     print(json.dumps(result, indent=2))
     return 0

--- a/skills/algorithms/skillopt/SKILL.md
+++ b/skills/algorithms/skillopt/SKILL.md
@@ -82,6 +82,23 @@ budget (toggle with `--no-slow-update`).
 ## Agent-mode loop
 When `orchestration_mode: agent`, drive skillopt yourself: single-lineage climb with a textual learning rate over epochs/minibatches — each step propose an edit sized to the current LR, evaluate on **val** (minibatch then full as skillopt prescribes) via cap-evolve, gate Δ>k·SE, accept→snapshot / reject→revert & decay. Log steps to the run dir; between steps verify rollouts+results landed for the dashboard. Re-read `stop_condition`; stop on it/stall/budget. Seal once with `cap-evolve finalize`, then `report`.
 
+
+## What the optimizer receives each iteration
+
+Identical for all three deterministic algorithms — one shared seam,
+`core/cap_evolve/optimizer_context.py` (`inject()` writes the files, `render_instructions()`
+renders the prompt): the per-iteration `INSTRUCTIONS.md` rendered from the intake-authored
+template (`--instructions-file`) with the capability brief (`--capabilities`), the failure
+index, the bench-repo pointer (`--bench-repo`), the parallel-fan-out note and the
+consuming-LLM reader block (`--target-model` / `--target-profile-file`); plus
+`./trajectories/`, `./guidance/<cap>/`, `./guidance/diagnose/`, `./guidance/sources/`
+(`--capability-sources`), `./guidance/optimizer/<name>.md` (`--optimizer-name`), the
+native per-agent skills dir, and the cross-iteration
+`LEDGER.md` / `JOURNAL.md` / `RUNMAP.md` + `prior_iterations/`. `cap-evolve run` passes
+every one of those flags to this algorithm — see `docs/ARCHITECTURE.md`.
+
+This algorithm adds its own tail block on top (the L edit budget + the rejected/failure-pattern buffer).
+
 ## References
 - `references/concepts.md` — the SkillOpt loop in detail, the textual-LR schedule,
   the buffer/slow-update mechanics, and citations (arXiv:2605.23904).

--- a/skills/algorithms/skillopt/scripts/run.py
+++ b/skills/algorithms/skillopt/scripts/run.py
@@ -24,6 +24,7 @@ import _bootstrap  # noqa: F401
 from cap_evolve import RunDir, harness, skillopt
 from cap_evolve.check import load_adapter
 from cap_evolve.loop import SplitResult
+from cap_evolve.optimizer_context import OptimizerContext
 from cap_evolve.store import make_store
 
 ALGO = "skillopt"
@@ -69,9 +70,12 @@ def main(argv=None) -> int:
     p.add_argument("--store-commit-cmd", default=None)
     p.add_argument("--resume", action="store_true",
                    help="continue from the run's current best instead of baseline")
+    OptimizerContext.add_arguments(p)
     args = p.parse_args(argv)
 
     run_dir = RunDir.open(Path(args.run_dir))
+    ctx = OptimizerContext.from_args(args)
+    ctx.log_profile(run_dir)   # consuming-LLM profile -> report + dashboard
     store = make_store({"store": args.store, "store_commit_cmd": args.store_commit_cmd}, run_dir.root)
     adapter = load_adapter(Path(args.project))
     optimizer = harness.optimizer_from_command(shlex.split(args.optimizer))
@@ -90,6 +94,7 @@ def main(argv=None) -> int:
                      else {"mode": args.gate_mode, "k_se": args.k_se}),
         no_regression=args.no_regression, slow_update=args.slow_update,
         slow_update_sample=args.slow_update_sample, algorithm=ALGO, store=store,
+        ctx=ctx,
     )
     print(json.dumps(result, indent=2))
     return 0

--- a/templates/project/capevolve.yaml
+++ b/templates/project/capevolve.yaml
@@ -36,7 +36,9 @@ algorithm_skill: hill-climb              # algorithms/<skill>: hill-climb | gepa
 algorithm_focus: all                     # hill-climb schedule: all | cyclic | hardest-first
 orchestration_mode: deterministic        # deterministic (cap-evolve sequences the loop) | agent (the coding agent drives the loop via cap-evolve primitives, sealing with `cap-evolve finalize`)
 
-# --- what context the optimizer gets (hill-climb) ---------------------------
+# --- what context the optimizer gets (ALL algorithms) -----------------------
+# Applies identically to hill-climb, gepa and skillopt — they share one injection
+# seam (core/cap_evolve/optimizer_context.py).
 # The per-iteration optimizer prompt is RENDERED from this template (intake authors it,
 # customized per benchmark). Defaults to the scaffolded optimizer/INSTRUCTIONS.md.
 optimizer_instructions_file: optimizer/INSTRUCTIONS.md


### PR DESCRIPTION
Closes #109

The two flagship algorithms ran with a **thinner** optimizer context than the basic climber. `_inject_optimizer_context` was only reachable from `harness.run_step` (the hill-climb path) — GEPA bypasses `run_step` entirely, and `skillopt_loop` had no capability/optimizer parameters at all. On the CLI side, seven optimizer-context flags were gated behind `if algorithm_name == "hill-climb"` and **silently dropped** for gepa/skillopt.

## Before / after — what the optimizer actually receives

Measured with a real run (`OptimizerContext(capabilities="system-prompt", optimizer_name="claude-code", bench_repo=…, capability_sources=…, target_model="weak")`), same toy_calc adapter, same mock optimizer:

| | GEPA before | GEPA after | SkillOpt before | SkillOpt after |
|---|---|---|---|---|
| `./trajectories/` | ❌ absent | ✅ 3 files, scoped to parent minibatch | ✅ | ✅ |
| `./guidance/<cap>/` | ❌ absent | ✅ `system-prompt` | ✅ | ✅ |
| `./guidance/diagnose/` | ❌ absent | ✅ | ✅ | ✅ |
| `./guidance/sources/` | ❌ absent | ✅ | ❌ (flag dropped) | ✅ |
| `./guidance/optimizer/<name>.md` | ❌ absent | ✅ | ❌ | ✅ |
| native skills (`.claude/skills/`) + `CLAUDE.md` | ❌ absent | ✅ | ❌ | ✅ |
| `CAP_BRIEF` (allowed edit space) | ❌ **empty** | ✅ | ❌ **empty** | ✅ |
| `BENCH_REPO` pointer | ❌ | ✅ | ❌ | ✅ |
| `PARALLEL_NOTE` fan-out | ❌ | ✅ | ❌ sequential (wrong) | ✅ |
| `{{TARGET_READER}}` consuming-LLM brief | ❌ | ✅ | ❌ | ✅ |
| intake-authored `--instructions-file` template | ❌ ignored | ✅ honored | ❌ ignored | ✅ honored |
| `target_profile` run event | ❌ never logged | ✅ | ❌ | ✅ |
| **rendered prompt size** (built-in default template) | **1,460 chars** | **22,770 chars** | 20,473 | 21,391 |
| **rendered prompt size** (configured run, intake template — the realistic case) | **1,474 B** | **4,745 B** | 20,648 B | 4,264 B |
| algorithm's own block preserved | `REFLECTION.md`/`FOCUS.md` | ✅ still there | L-budget buffer | ✅ still there |

> **Corrected in review (finding 7):** the 1,460 → 22,770 figures are from the *built-in default* template path, not a configured run — a reader would wrongly infer 22 KB prompts. The second row is the same spec with an intake-authored `optimizer_instructions_file`, which is what a real run uses: GEPA 1,474 → 4,745 B (landing *at* hill-climb's 3,736 B, which is the point) and SkillOpt actually **shrinks** 20,648 → 4,264 B because it now renders the configured template instead of falling through to the verbose default. The assembled prompt is now also globally capped at `optimizer_context.MAX_INSTRUCTIONS_CHARS` (60,000).

SkillOpt's **epoch-boundary slow/meta update** had the same gap (a bare `_slow_update_instructions` string) and now also renders through the seam.

## Flags that were parsed but silently dropped, and now work

For **both** `--algorithm gepa` and `--algorithm skillopt`:

`--capabilities` · `--instructions-file` · `--bench-repo` · `--optimizer-name` · `--capability-sources` · `--target-model` · `--target-profile-file`

`cli.py` no longer branches per flag. It emits them via one helper for every algorithm in `_OPTIMIZER_CONTEXT_ALGORITHMS = ("hill-climb", "gepa", "skillopt")`. The agent-driven algorithms (`evograph`, `agent-optimize`) are excluded **explicitly** — they have no deterministic loop — rather than each flag being dropped invisibly.

## The shared seam (for downstream issues)

**`core/cap_evolve/optimizer_context.py`** — also exported as `from cap_evolve import OptimizerContext`.

```python
@dataclass
class OptimizerContext:
    capabilities: list[str] = []          # accepts a list OR a comma-separated string
    optimizer_name: str | None = None
    instructions_file: str | None = None
    bench_repo: str | None = None
    capability_sources: list[str] = []
    project_dir: Path | None = None
    target_model: str = ""
    target_profile_file: str | None = None

    @classmethod
    def from_args(cls, args) -> OptimizerContext        # argparse namespace -> ctx
    @staticmethod
    def add_arguments(parser) -> None                    # declare the 7 shared flags
    def profile(self)                                    # resolved TargetProfile (cached)
    def target_reader(self) -> str                        # {{TARGET_READER}} block (cached)
    def log_profile(self, run_dir: RunDir) -> None        # the target_profile event

# FILE side — everything copied into the optimizer's workdir
def inject(adapter, run_dir: RunDir, workdir: Path, *, split: str,
           ctx: OptimizerContext | None = None, tag: str | None = None) -> None

# PROMPT side — the rendered per-iteration INSTRUCTIONS
def render_instructions(current: SplitResult, focus_ids, label: str, *,
                        ctx: OptimizerContext | None = None,
                        algorithm: str = "hill-climb",
                        run_dir: RunDir | None = None,
                        parent_id: str | None = None,
                        extra: str = "") -> str

INJECTED_DIRS:  tuple[str, ...]   # trajectories, guidance, prior_iterations, .claude, …
INJECTED_NAMES: tuple[str, ...]   # CLAUDE.md, AGENTS.md, GEMINI.md
```

All three loops (`hill_climb_loop`, `gepa_loop`, `skillopt_loop`) and `run_step` take `ctx=`. The per-field kwargs stay on `hill_climb_loop`/`run_step` for direct callers and build a ctx when none is passed, so nothing external breaks.

**Extend it here, once:**
- a new **injected artifact** → `inject()` (all three algorithms get it) and add its name to `INJECTED_DIRS`/`INJECTED_NAMES`.
- a new **prompt block** → `render_instructions()` (or pass it as `extra=` if it is algorithm-specific).
- a new **flag** → `OptimizerContext` field + `add_arguments` + `cli._optimizer_context_flags`.

`INJECTED_DIRS`/`INJECTED_NAMES` is a single definition consumed by three places that previously each hardcoded their own list: `harness._SNAPSHOT_IGNORE`, `gepa._components` (so injected read-context can't become an "editable component") and `cache.hash_candidate_dir` (so it can't bust the eval cache).

GEPA additionally passes `tag=f"mb_p_{n:04d}"` so `./trajectories/` holds the **verbatim, untruncated** rollouts that `REFLECTION.md` only excerpts at 800 chars.

## Verification

Full suite (baseline on `origin/main` is **178 passed, 1 failed**; the one failure is a pre-existing environmental port collision in `test_dashboard_launch.py` — a live dashboard occupies 7878 on this machine, so `_free_port` bumps it):

```
$ PYTHONPATH=/tmp/wt-109/core python -m pytest core/tests -q
FAILED core/tests/test_dashboard_launch.py::test_maybe_launch_spawns_when_available
1 failed, 191 passed in 67.76s (0:01:07)
```

178 → **191 passed** = the 13 new tests in `core/tests/test_optimizer_context_parity.py`. All 13 **fail before** the source change and pass after (proof in the Evidence comment).

```
$ python -m compileall -q core skills
COMPILEALL CLEAN
```

Real end-to-end `cap-evolve run` on the bundled `examples/toy_calc` with the `mock` optimizer (zero API cost), for **both** algorithms plus hill-climb as the regression control — each with the previously-dropped flags configured in the spec:

```
gepa:        baseline_val 0.0 -> test_reward 1.0 (test_delta 1.0), 3 iterations
skillopt:    baseline_val 0.0 -> test_reward 1.0 (test_delta 1.0), 3 iterations
hill-climb:  baseline_val 0.0 -> test_reward 1.0 (test_delta 1.0), 3 iterations
```

Run-dir proof that the flags reach the optimizer prompt (gepa):

```
$ ls -1 work/gepa_0001/guidance         $ ls -1 work/gepa_0001/trajectories
diagnose                                a2__mb_p_0000__t0.json
optimizer                               a3__mb_p_0000__t0.json
sources                                 a5__mb_p_0000__t0.json
system-prompt                           a6__mb_p_0000__t0.json

INTAKE-AUTHORED-TEMPLATE-MARKER            1   <- --instructions-file honored
allowed edit space                         1   <- --capabilities / CAP_BRIEF
examples/toy_calc                          1   <- --bench-repo
guidance/system-prompt/SKILL.md            1
GEPA reflective optimization step          1   <- GEPA's own block preserved
weaker                                     2   <- --target-model reader brief
```

Full command output, the fail-before/pass-after transcript and the skillopt + slow-update excerpts are in the **🔬 Evidence** comment.

## House rules
- Zero new runtime deps (stdlib only: `dataclasses`, `pathlib`).
- Core change covered by a new test in `core/tests/`.
- Honesty logic untouched — no change to splits, gate, seal, or the val-only acceptance path.

