### PR TITLE
fix(algorithm): one shared scratch-file list so GEPA snapshots are clean (#110)

### DIFF
--- a/core/cap_evolve/cache.py
+++ b/core/cap_evolve/cache.py
@@ -22,13 +22,16 @@ import hashlib
 import json
 from pathlib import Path
 
-from .rundir import SCRATCH_NAMES
+from .rundir import NON_CAPABILITY_NAMES
 
 # Files that are NOT part of the capability (optimizer scratch, memory, vcs); they
 # must not perturb the content hash or every iteration would miss the cache.
-# ``rundir.SCRATCH_NAMES`` is the shared definition (see the note there); INSTRUCTIONS
-# and PROCESS are added because they ARE snapshotted but still are not capability bytes.
-_IGNORE_NAMES = {"INSTRUCTIONS.md", "PROCESS.md"} | set(SCRATCH_NAMES)
+# ``rundir.NON_CAPABILITY_NAMES`` is the shared definition (see the note there): the
+# union of live + legacy scratch plus INSTRUCTIONS/PROCESS, which ARE snapshotted but
+# still are not capability bytes. This is a read-side filter (skip bytes when hashing),
+# so it takes the whole union — including the legacy names, so caches written before
+# they were retired keep resolving.
+_IGNORE_NAMES = set(NON_CAPABILITY_NAMES)
 _IGNORE_DIRS = {".git", "__pycache__", "prior_iterations"}
 
 
@@ -48,9 +51,15 @@ def hash_candidate_dir(candidate_dir: Path) -> str:
     for p in cdir.rglob("*"):
         if not p.is_file():
             continue
-        if p.name in _IGNORE_NAMES:
+        rel = p.relative_to(cdir)
+        # Root-anchored: every ignored name is a root-level framework injection, so a
+        # NESTED file that merely shares one (``src/prompts/STATE.md``) is capability
+        # content and MUST fold into the digest — otherwise deleting it leaves the hash
+        # unchanged and the next iteration serves the parent's cached rewards for a
+        # materially different candidate (a stale hit on a mutilated candidate).
+        if len(rel.parts) == 1 and p.name in _IGNORE_NAMES:
             continue
-        if any(part in _IGNORE_DIRS for part in p.relative_to(cdir).parts):
+        if any(part in _IGNORE_DIRS for part in rel.parts):
             continue
         files.append(p)
     for p in sorted(files, key=lambda x: str(x.relative_to(cdir))):

--- a/core/cap_evolve/cache.py
+++ b/core/cap_evolve/cache.py
@@ -22,12 +22,13 @@ import hashlib
 import json
 from pathlib import Path
 
+from .rundir import SCRATCH_NAMES
+
 # Files that are NOT part of the capability (optimizer scratch, memory, vcs); they
 # must not perturb the content hash or every iteration would miss the cache.
-_IGNORE_NAMES = {"MEMORY.md", "STATE.md", "INSTRUCTIONS.md", "REJECTED.md", "FOCUS.md",
-                 "REFLECTION.md",
-                 # cross-iteration state files (clean-ownership redesign) — scratch, not capability
-                 "LEDGER.md", "JOURNAL.md", "PROCESS.md", "RUNMAP.md"}
+# ``rundir.SCRATCH_NAMES`` is the shared definition (see the note there); INSTRUCTIONS
+# and PROCESS are added because they ARE snapshotted but still are not capability bytes.
+_IGNORE_NAMES = {"INSTRUCTIONS.md", "PROCESS.md"} | set(SCRATCH_NAMES)
 _IGNORE_DIRS = {".git", "__pycache__", "prior_iterations"}
 
 

--- a/core/cap_evolve/dashboard.py
+++ b/core/cap_evolve/dashboard.py
@@ -52,6 +52,8 @@ import shutil
 import subprocess
 from pathlib import Path
 
+from .rundir import NON_CAPABILITY_NAMES
+
 # ---------------------------------------------------------------------------
 # Secret redaction
 # ---------------------------------------------------------------------------
@@ -584,8 +586,15 @@ def reduce_run(run_dir) -> dict:
 # snapshot but are NOT capability edits — skipped when diffing iterations so the diff
 # shows only the real change. (The big read-context dirs trajectories/ and guidance/
 # are already excluded from the snapshot itself; see harness._SNAPSHOT_IGNORE.)
-_DIFF_SKIP = {"INSTRUCTIONS.md", "MEMORY.md", "STATE.md",
-              "LEDGER.md", "JOURNAL.md", "PROCESS.md", "RUNMAP.md"}
+# Derived from ``rundir.NON_CAPABILITY_NAMES`` — a read-side FILTER like the cache and
+# component lists, so it takes the whole union (live + legacy scratch + the two
+# snapshotted explainability files). It must NOT be shared with
+# ``harness._SNAPSHOT_IGNORE``, which is DESTRUCTIVE and takes ``SCRATCH_NAMES`` only:
+# feeding this list to the snapshot would DELETE PROCESS.md, the explainability record
+# we deliberately keep. Same predicate, different operation. See the tier note in
+# rundir.py; the split is pinned by
+# test_gepa.py::test_scratch_ignores_are_one_shared_definition.
+_DIFF_SKIP = set(NON_CAPABILITY_NAMES)
 
 
 def _read_dir_files(d: Path) -> dict[str, str]:

--- a/core/cap_evolve/gepa.py
+++ b/core/cap_evolve/gepa.py
@@ -54,6 +54,7 @@ from . import gate as gate_mod
 from . import selection
 from .cache import EvalCache, hash_candidate_dir
 from .harness import (
+    _SNAPSHOT_IGNORE,
     _augment_instructions,
     _init_memory_store,
     _live,
@@ -62,19 +63,16 @@ from .harness import (
     split_result_from_rollouts,
 )
 from .loop import SplitResult, aggregate_scores
-from .rundir import RunDir
+from .rundir import SCRATCH_NAMES, RunDir
 from .types import Rollout, Score
 
 OptimizerFn = Callable[[Path, str], None]
 
 # Optimizer-scratch / non-capability files that must NOT count as editable
 # "components" (they perturb neither the capability nor the content hash).
-_NON_COMPONENT = {
-    "MEMORY.md", "STATE.md", "INSTRUCTIONS.md", "REJECTED.md",
-    "FOCUS.md", "REFLECTION.md",
-    # cross-iteration state files (clean-ownership redesign) — scratch, not capability
-    "LEDGER.md", "JOURNAL.md", "PROCESS.md", "RUNMAP.md",
-}
+# ``rundir.SCRATCH_NAMES`` is the shared definition; INSTRUCTIONS/PROCESS are added
+# because they ARE snapshotted (explainability) yet are still not editable components.
+_NON_COMPONENT = {"INSTRUCTIONS.md", "PROCESS.md"} | set(SCRATCH_NAMES)
 _NON_COMPONENT_DIRS = {".git", "__pycache__", "prior_iterations"}
 
 
@@ -625,7 +623,7 @@ def gepa_loop(
         summary = (f"candidate {cid} (val {cand_val.reward:.3f}, "
                    f"Δ {cand_val.reward - parent_result.reward:+.3f})")
         if accepted:
-            run_dir.snapshot(cid, workdir)
+            run_dir.snapshot(cid, workdir, ignore=_SNAPSHOT_IGNORE)
             child_dir = run_dir.candidate_dir(cid)
             pool.append(_entry(cid, child_dir, cand_val, parent=parent["id"]))
             lineage[cid] = parent["id"]
@@ -784,7 +782,7 @@ def _try_merge(
     run_dir.update_spent(iterations=1, accepted=accepted)
     summary = f"merge {mid} of {a['id']}+{b['id']} (val {cand_val.reward:.3f})"
     if accepted:
-        run_dir.snapshot(mid, workdir)
+        run_dir.snapshot(mid, workdir, ignore=_SNAPSHOT_IGNORE)
         pool.append(_entry(mid, run_dir.candidate_dir(mid), cand_val, parent=base_parent["id"]))
         lineage[mid] = base_parent["id"]
         history.add(mid, summary, cand_val.reward)

--- a/core/cap_evolve/gepa.py
+++ b/core/cap_evolve/gepa.py
@@ -63,16 +63,16 @@ from .harness import (
     split_result_from_rollouts,
 )
 from .loop import SplitResult, aggregate_scores
-from .rundir import SCRATCH_NAMES, RunDir
+from .rundir import NON_CAPABILITY_NAMES, RunDir
 from .types import Rollout, Score
 
 OptimizerFn = Callable[[Path, str], None]
 
 # Optimizer-scratch / non-capability files that must NOT count as editable
 # "components" (they perturb neither the capability nor the content hash).
-# ``rundir.SCRATCH_NAMES`` is the shared definition; INSTRUCTIONS/PROCESS are added
+# ``rundir.NON_CAPABILITY_NAMES`` is the shared definition; INSTRUCTIONS/PROCESS are in it
 # because they ARE snapshotted (explainability) yet are still not editable components.
-_NON_COMPONENT = {"INSTRUCTIONS.md", "PROCESS.md"} | set(SCRATCH_NAMES)
+_NON_COMPONENT = set(NON_CAPABILITY_NAMES)
 _NON_COMPONENT_DIRS = {".git", "__pycache__", "prior_iterations"}
 
 
@@ -95,6 +95,10 @@ def _components(candidate_dir: Path) -> list[str]:
         if not p.is_file():
             continue
         rel = p.relative_to(cdir)
+        # ponytail: matches by basename at any depth, unlike cache/snapshot which are
+        # root-anchored. Harmless here (a false positive only costs precision — one
+        # fewer editable component / one uncounted edit, nothing is lost); anchoring it
+        # would change which components GEPA may edit, which is out of scope for #110.
         if p.name in _NON_COMPONENT:
             continue
         if any(part in _NON_COMPONENT_DIRS for part in rel.parts):

--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -25,7 +25,7 @@ from typing import Callable
 
 from . import gate as gate_mod
 from .loop import SplitResult, aggregate_scores
-from .rundir import SCRATCH_NAMES, RunDir, _atomic_write
+from .rundir import NON_CAPABILITY_NAMES, SCRATCH_NAMES, RunDir, _atomic_write
 from .splits import Splits, make_splits
 from .types import Rollout, Score, Task
 
@@ -580,8 +580,15 @@ _PROCESS_SEED = (
 
 # State/handover files that are NOT part of the capability — excluded from any
 # capability diff (kept in one place; mirrors dashboard._DIFF_SKIP).
-_CAP_DIFF_SKIP = {"INSTRUCTIONS.md", "MEMORY.md", "STATE.md",
-                  "LEDGER.md", "JOURNAL.md", "PROCESS.md", "RUNMAP.md"}
+# Derived from ``rundir.NON_CAPABILITY_NAMES`` — a read-side FILTER like the cache and
+# component lists, so it takes the whole union (live + legacy scratch + the two
+# snapshotted explainability files). It must NOT be shared with
+# ``harness._SNAPSHOT_IGNORE``, which is DESTRUCTIVE and takes ``SCRATCH_NAMES`` only:
+# feeding this list to the snapshot would DELETE PROCESS.md, the explainability record
+# we deliberately keep. Same predicate, different operation. See the tier note in
+# rundir.py; the split is pinned by
+# test_gepa.py::test_scratch_ignores_are_one_shared_definition.
+_CAP_DIFF_SKIP = set(NON_CAPABILITY_NAMES)
 
 
 def _capability_files(d: Path) -> dict[str, str]:
@@ -1585,6 +1592,12 @@ _DEFAULT_INSTRUCTIONS_TEMPLATE = (
 # snapshot and surface via RUNMAP/prior_iterations. LEDGER/JOURNAL/RUNMAP + prior_iterations/
 # are framework-injected read-context (LEDGER/RUNMAP regenerated, JOURNAL is run-level),
 # so they must not bloat candidates/ or pollute diffs.
+#
+# This is the one DESTRUCTIVE consumer of the shared list — snapshot() drops what it
+# names — so it takes ``SCRATCH_NAMES`` (live writers) ONLY, never
+# ``rundir.NON_CAPABILITY_NAMES``. A retired name with no live writer can only refer to
+# a capability file that shares it, and deleting that is silent data loss the eval-cache
+# key can't see. See the tier note in rundir.py.
 _SNAPSHOT_IGNORE = ("trajectories", "guidance", "prior_iterations",
                     ".claude", ".agents", ".gemini", ".opencode", ".bob",
                     "CLAUDE.md", "AGENTS.md", "GEMINI.md") + SCRATCH_NAMES

--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -25,7 +25,7 @@ from typing import Callable
 
 from . import gate as gate_mod
 from .loop import SplitResult, aggregate_scores
-from .rundir import RunDir, _atomic_write
+from .rundir import SCRATCH_NAMES, RunDir, _atomic_write
 from .splits import Splits, make_splits
 from .types import Rollout, Score, Task
 
@@ -1586,9 +1586,8 @@ _DEFAULT_INSTRUCTIONS_TEMPLATE = (
 # are framework-injected read-context (LEDGER/RUNMAP regenerated, JOURNAL is run-level),
 # so they must not bloat candidates/ or pollute diffs.
 _SNAPSHOT_IGNORE = ("trajectories", "guidance", "prior_iterations",
-                    "LEDGER.md", "JOURNAL.md", "RUNMAP.md",
                     ".claude", ".agents", ".gemini", ".opencode", ".bob",
-                    "CLAUDE.md", "AGENTS.md", "GEMINI.md")
+                    "CLAUDE.md", "AGENTS.md", "GEMINI.md") + SCRATCH_NAMES
 
 
 def _failures_block(always_fail, flaky, errored) -> str:

--- a/core/cap_evolve/rundir.py
+++ b/core/cap_evolve/rundir.py
@@ -26,6 +26,29 @@ from pathlib import Path
 
 from .splits import Splits
 
+# Framework/optimizer SCRATCH files the harness or an algorithm writes into the
+# optimizer's workdir. They are not capability content, so they must be excluded
+# everywhere a candidate is treated as "the capability": the candidate snapshot
+# (``harness._SNAPSHOT_IGNORE``), the eval-cache content hash
+# (``cache._IGNORE_NAMES``), GEPA's editable-component list (``gepa._NON_COMPONENT``)
+# and the edit-size count (``skillopt._changed_files``). This list lives HERE — at the
+# bottom of the import graph — because it had been copy-pasted into four modules and
+# they desynced: FOCUS.md/REFLECTION.md (GEPA's own scratch) were in the cache and
+# component lists but missing from the snapshot list, so GEPA snapshots stayed dirty
+# (#110) even after LEDGER/JOURNAL/RUNMAP were excluded. One definition, four consumers.
+#
+# NOT here: INSTRUCTIONS.md and PROCESS.md. Those are deliberately KEPT in the snapshot
+# (PROCESS.md is the candidate's explainability record) and filtered at DIFF time only —
+# see ``dashboard._DIFF_SKIP`` / ``harness._CAP_DIFF_SKIP``.
+SCRATCH_NAMES = (
+    # cross-iteration state the harness regenerates every iteration
+    "LEDGER.md", "JOURNAL.md", "RUNMAP.md",
+    # per-iteration algorithm scratch (GEPA's reflective dataset + component focus)
+    "FOCUS.md", "REFLECTION.md",
+    # optimizer rejected-edit memory, and the legacy MEMORY/STATE pair it replaced
+    "REJECTED.md", "MEMORY.md", "STATE.md",
+)
+
 
 def _atomic_write(path: Path, text: str) -> None:
     """Write ``text`` to ``path`` atomically (tmp file + ``os.replace``).

--- a/core/cap_evolve/rundir.py
+++ b/core/cap_evolve/rundir.py
@@ -26,28 +26,50 @@ from pathlib import Path
 
 from .splits import Splits
 
-# Framework/optimizer SCRATCH files the harness or an algorithm writes into the
-# optimizer's workdir. They are not capability content, so they must be excluded
-# everywhere a candidate is treated as "the capability": the candidate snapshot
-# (``harness._SNAPSHOT_IGNORE``), the eval-cache content hash
-# (``cache._IGNORE_NAMES``), GEPA's editable-component list (``gepa._NON_COMPONENT``)
-# and the edit-size count (``skillopt._changed_files``). This list lives HERE — at the
-# bottom of the import graph — because it had been copy-pasted into four modules and
-# they desynced: FOCUS.md/REFLECTION.md (GEPA's own scratch) were in the cache and
-# component lists but missing from the snapshot list, so GEPA snapshots stayed dirty
-# (#110) even after LEDGER/JOURNAL/RUNMAP were excluded. One definition, four consumers.
+# Framework/optimizer SCRATCH files that are not capability content. Defined HERE — at
+# the bottom of the import graph — because the list had been copy-pasted into several
+# modules and they desynced: FOCUS.md/REFLECTION.md (GEPA's own scratch) were in the
+# cache and component lists but missing from the snapshot list, so GEPA snapshots stayed
+# dirty (#110) even after LEDGER/JOURNAL/RUNMAP were excluded.
 #
-# NOT here: INSTRUCTIONS.md and PROCESS.md. Those are deliberately KEPT in the snapshot
-# (PROCESS.md is the candidate's explainability record) and filtered at DIFF time only —
-# see ``dashboard._DIFF_SKIP`` / ``harness._CAP_DIFF_SKIP``.
+# TWO tiers, because the consumers do not all perform the same OPERATION:
+#
+#   SCRATCH_NAMES        — names a live code path actually WRITES. These are the only
+#                          ones safe for the single DESTRUCTIVE consumer,
+#                          ``harness._SNAPSHOT_IGNORE``, which reaches
+#                          ``RunDir.snapshot`` → ``shutil.copytree(ignore=...)`` and so
+#                          DROPS the file permanently — and from every descendant
+#                          iteration too, since the next workdir is copied from the
+#                          snapshot.
+#   LEGACY_SCRATCH_NAMES — retired names with NO live writer anywhere in core/ (the old
+#                          MEMORY/STATE handover pair, and REJECTED.md from before
+#                          rejected-edit memory moved to ``rejected.jsonl``). Kept ONLY
+#                          in the non-destructive read-side filters, so run dirs and
+#                          eval caches produced before they were retired still behave.
+#                          They must NEVER reach the snapshot filter: with no live
+#                          writer, the only thing such a name can refer to on disk is a
+#                          CAPABILITY file that happens to share it, and deleting that
+#                          is silent data loss the cache key cannot even see (the same
+#                          name is ignored when hashing, so the mutilated candidate
+#                          keeps its parent's key → stale hit).
+#
+# NON_CAPABILITY_NAMES is the union, for every consumer whose operation is a read-side
+# FILTER (a false positive only costs precision — nothing is lost): the eval-cache
+# content hash (``cache._IGNORE_NAMES``), GEPA's editable-component list
+# (``gepa._NON_COMPONENT``), the edit-size count (``skillopt._changed_components``) and
+# the capability-diff filters (``dashboard._DIFF_SKIP`` / ``harness._CAP_DIFF_SKIP``).
+# INSTRUCTIONS.md and PROCESS.md are in the union but in neither tuple: they are
+# deliberately KEPT in the snapshot (PROCESS.md is the candidate's explainability
+# record) while still not being capability bytes.
 SCRATCH_NAMES = (
     # cross-iteration state the harness regenerates every iteration
     "LEDGER.md", "JOURNAL.md", "RUNMAP.md",
     # per-iteration algorithm scratch (GEPA's reflective dataset + component focus)
     "FOCUS.md", "REFLECTION.md",
-    # optimizer rejected-edit memory, and the legacy MEMORY/STATE pair it replaced
-    "REJECTED.md", "MEMORY.md", "STATE.md",
 )
+LEGACY_SCRATCH_NAMES = ("REJECTED.md", "MEMORY.md", "STATE.md")
+NON_CAPABILITY_NAMES = frozenset(
+    {"INSTRUCTIONS.md", "PROCESS.md"} | set(SCRATCH_NAMES) | set(LEGACY_SCRATCH_NAMES))
 
 
 def _atomic_write(path: Path, text: str) -> None:
@@ -398,15 +420,25 @@ class RunDir:
     def snapshot(self, candidate_id: str, src_dir: Path, ignore=None) -> Path:
         """Persist ``src_dir`` as candidate ``candidate_id``.
 
-        ``ignore`` is an optional iterable of top-level names to exclude (e.g. the
+        ``ignore`` is an optional iterable of TOP-LEVEL names to exclude (e.g. the
         optimizer's injected scratch — ``trajectories/``, ``guidance/`` — and its
         prompt/memory files) so the stored candidate stays capability-only and
         diffs against the parent show only real edits.
+
+        Root-anchored on purpose. ``shutil.ignore_patterns`` matches by BASENAME at
+        every depth, so a nested capability file that merely shares a name with an
+        entry (``src/prompts/STATE.md``) would be silently deleted from the candidate
+        — and from the whole descendant lineage, since the next iteration's workdir is
+        copied from this snapshot. Every entry in the list is a root-level framework
+        injection, so filtering only at ``src_dir`` itself is both strictly more
+        correct and what this docstring always claimed.
         """
         dst = self.candidates / candidate_id
         if dst.exists():
             shutil.rmtree(dst)
-        ig = shutil.ignore_patterns(*ignore) if ignore else None
+        src_dir = Path(src_dir)
+        names = set(ignore or ())
+        ig = (lambda d, cs: names if Path(d) == src_dir else set()) if names else None
         shutil.copytree(src_dir, dst, ignore=ig)
         return dst
 

--- a/core/cap_evolve/skillopt.py
+++ b/core/cap_evolve/skillopt.py
@@ -51,7 +51,7 @@ from pathlib import Path
 from . import harness
 from .lr_schedule import build_schedule
 from .loop import SplitResult
-from .rundir import RunDir
+from .rundir import SCRATCH_NAMES, RunDir
 
 # Buffer bounds (PITFALL: the rejected-edit buffer must be reset + bounded per
 # epoch so the optimizer prompt does not balloon).
@@ -384,6 +384,11 @@ def skillopt_loop(
     }
 
 
+# Harness-injected scaffolding that must not count as an applied edit.
+# ``rundir.SCRATCH_NAMES`` is the shared definition (see the note there).
+_SCAFFOLDING = frozenset({"INSTRUCTIONS.md", "PROCESS.md"} | set(SCRATCH_NAMES))
+
+
 def _changed_components(parent_dir: Path, workdir: Path) -> int:
     """Best-effort count of files whose content differs between parent and the
     optimized workdir — a proxy for *applied* edits to compare against the
@@ -398,8 +403,7 @@ def _changed_components(parent_dir: Path, workdir: Path) -> int:
                 continue
             rel = f.relative_to(workdir)
             # ignore harness-injected scaffolding files
-            if rel.name in ("INSTRUCTIONS.md", "MEMORY.md", "STATE.md",
-                            "LEDGER.md", "JOURNAL.md", "PROCESS.md", "RUNMAP.md"):
+            if rel.name in _SCAFFOLDING:
                 continue
             seen.add(rel)
             pf = parent_dir / rel
@@ -408,8 +412,7 @@ def _changed_components(parent_dir: Path, workdir: Path) -> int:
         for f in parent_dir.rglob("*"):
             if f.is_file() and ".git" not in f.parts:
                 rel = f.relative_to(parent_dir)
-                if rel.name in ("INSTRUCTIONS.md", "MEMORY.md", "STATE.md",
-                            "LEDGER.md", "JOURNAL.md", "PROCESS.md", "RUNMAP.md"):
+                if rel.name in _SCAFFOLDING:
                     continue
                 if rel not in seen:
                     changed += 1  # a deletion

--- a/core/cap_evolve/skillopt.py
+++ b/core/cap_evolve/skillopt.py
@@ -51,7 +51,7 @@ from pathlib import Path
 from . import harness
 from .lr_schedule import build_schedule
 from .loop import SplitResult
-from .rundir import SCRATCH_NAMES, RunDir
+from .rundir import NON_CAPABILITY_NAMES, RunDir
 
 # Buffer bounds (PITFALL: the rejected-edit buffer must be reset + bounded per
 # epoch so the optimizer prompt does not balloon).
@@ -385,8 +385,8 @@ def skillopt_loop(
 
 
 # Harness-injected scaffolding that must not count as an applied edit.
-# ``rundir.SCRATCH_NAMES`` is the shared definition (see the note there).
-_SCAFFOLDING = frozenset({"INSTRUCTIONS.md", "PROCESS.md"} | set(SCRATCH_NAMES))
+# ``rundir.NON_CAPABILITY_NAMES`` is the shared definition (see the note there).
+_SCAFFOLDING = NON_CAPABILITY_NAMES
 
 
 def _changed_components(parent_dir: Path, workdir: Path) -> int:
@@ -403,6 +403,10 @@ def _changed_components(parent_dir: Path, workdir: Path) -> int:
                 continue
             rel = f.relative_to(workdir)
             # ignore harness-injected scaffolding files
+            # ponytail: matches by basename at any depth, unlike cache/snapshot which are
+            # root-anchored. Harmless here (a false positive only costs precision — one
+            # fewer editable component / one uncounted edit, nothing is lost); anchoring it
+            # would change which components GEPA may edit, which is out of scope for #110.
             if rel.name in _SCAFFOLDING:
                 continue
             seen.add(rel)

--- a/core/tests/test_gepa.py
+++ b/core/tests/test_gepa.py
@@ -292,14 +292,17 @@ def test_scratch_ignores_are_one_shared_definition():
     assert NON_CAPABILITY_NAMES == scratch | set(LEGACY_SCRATCH_NAMES) | {
         "INSTRUCTIONS.md", "PROCESS.md"}
     # The DESTRUCTIVE consumer takes the live-writer subset; every read-side FILTER
-    # takes the whole union, so none of them can desync again.
+    # takes the whole union, so none of them can desync again. Superset, not equality:
+    # a filter may add its own extra read-context names (e.g. the optimizer-context
+    # INJECTED_NAMES) — what must never happen is one of them DROPPING a shared name.
     assert scratch <= set(harness._SNAPSHOT_IGNORE)
     for name, have in (("cache._IGNORE_NAMES", cache._IGNORE_NAMES),
                        ("gepa._NON_COMPONENT", gepa._NON_COMPONENT),
                        ("skillopt._SCAFFOLDING", set(skillopt._SCAFFOLDING)),
                        ("dashboard._DIFF_SKIP", set(dashboard._DIFF_SKIP)),
                        ("harness._CAP_DIFF_SKIP", set(harness._CAP_DIFF_SKIP))):
-        assert have == set(NON_CAPABILITY_NAMES), f"{name} desynced: {sorted(have)}"
+        assert set(NON_CAPABILITY_NAMES) <= have, \
+            f"{name} desynced, missing {sorted(set(NON_CAPABILITY_NAMES) - have)}"
     # PROCESS.md is deliberately snapshotted (explainability), so it is NOT scratch.
     assert "PROCESS.md" not in scratch
     assert "PROCESS.md" not in set(harness._SNAPSHOT_IGNORE)

--- a/core/tests/test_gepa.py
+++ b/core/tests/test_gepa.py
@@ -274,3 +274,59 @@ def test_merge_skips_gracefully_monolith(tmp_path):
         if "merge_of" in s:
             assert "accepted" in s and "local_gate" in s
     assert res["best_val"] == 1.0
+
+
+# ---- #110: candidate snapshots must be clean, identically for every algorithm ----
+
+def test_scratch_ignores_are_one_shared_definition():
+    """FAILS BEFORE THE FIX: the scratch-file list was copy-pasted into four modules
+    and desynced — FOCUS.md/REFLECTION.md were in the cache + component lists but
+    MISSING from harness._SNAPSHOT_IGNORE, so GEPA snapshots stayed dirty (#110).
+    Pin that all four consumers derive from rundir.SCRATCH_NAMES."""
+    from cap_evolve import cache, gepa, harness, skillopt
+    from cap_evolve.rundir import SCRATCH_NAMES
+    scratch = set(SCRATCH_NAMES)
+    assert {"FOCUS.md", "REFLECTION.md", "LEDGER.md", "JOURNAL.md", "RUNMAP.md"} <= scratch
+    for name, have in (("_SNAPSHOT_IGNORE", set(harness._SNAPSHOT_IGNORE)),
+                       ("cache._IGNORE_NAMES", cache._IGNORE_NAMES),
+                       ("gepa._NON_COMPONENT", gepa._NON_COMPONENT),
+                       ("skillopt._SCAFFOLDING", set(skillopt._SCAFFOLDING))):
+        assert scratch <= have, f"{name} is missing {sorted(scratch - have)}"
+    # PROCESS.md is deliberately snapshotted (explainability), so it is NOT scratch.
+    assert "PROCESS.md" not in scratch
+    assert "PROCESS.md" not in set(harness._SNAPSHOT_IGNORE)
+
+
+@pytest.mark.parametrize("algo", ["gepa", "hill-climb"])
+def test_candidate_snapshots_are_clean_for_every_algorithm(tmp_path, algo):
+    """FAILS BEFORE THE FIX for algo='gepa': both gepa.py snapshot calls omitted
+    ``ignore=``, so FOCUS.md / REFLECTION.md / LEDGER.md / JOURNAL.md / RUNMAP.md and
+    prior_iterations/ landed in every candidate, bloating candidates/ and polluting the
+    dashboard diff. Hill-climb was already clean — this pins that they now AGREE."""
+    from cap_evolve import gepa, harness
+    adapter, run_dir, base = _setup(tmp_path, f"sn_{algo[:2]}", max_iterations=4,
+                                   max_metric_calls=2000)
+    optimizer = harness.optimizer_from_command(
+        ["python3", str(MOCK_RUN), "--name", "mock", "--workdir", "{workdir}",
+         "--prompt", "{prompt}"])
+    if algo == "gepa":
+        gepa.gepa_loop(adapter, run_dir=run_dir, optimizer=optimizer, seed_val=base,
+                       max_metric_calls=1500, max_iterations=3, minibatch_size=3,
+                       max_merges=0, seed=0,
+                       gate_kwargs={"mode": "significant", "k_se": 1.0})
+    else:
+        harness.hill_climb_loop(adapter, run_dir=run_dir, optimizer=optimizer,
+                                current_val=base, max_iterations=3, focus="all",
+                                gate_kwargs={"mode": "significant", "k_se": 1.0})
+
+    cands = [d for d in run_dir.candidates.iterdir() if d.is_dir() and d.name != "seed"]
+    assert cands, f"{algo} produced no candidate snapshot to inspect"
+    dirty = {d.name: sorted(str(p.relative_to(d)) for p in d.rglob("*")
+                            if p.name in set(harness._SNAPSHOT_IGNORE)
+                            or p.parts[len(d.parts)] in set(harness._SNAPSHOT_IGNORE))
+             for d in cands}
+    assert not any(dirty.values()), f"{algo} snapshots carry scratch: {dirty}"
+    # …and only the capability + the two deliberately-kept explainability files remain.
+    for d in cands:
+        got = sorted(str(p.relative_to(d)) for p in d.rglob("*") if p.is_file())
+        assert got == ["INSTRUCTIONS.md", "PROCESS.md", "prompt.txt"], f"{d.name}: {got}"

--- a/core/tests/test_gepa.py
+++ b/core/tests/test_gepa.py
@@ -282,19 +282,66 @@ def test_scratch_ignores_are_one_shared_definition():
     """FAILS BEFORE THE FIX: the scratch-file list was copy-pasted into four modules
     and desynced — FOCUS.md/REFLECTION.md were in the cache + component lists but
     MISSING from harness._SNAPSHOT_IGNORE, so GEPA snapshots stayed dirty (#110).
-    Pin that all four consumers derive from rundir.SCRATCH_NAMES."""
-    from cap_evolve import cache, gepa, harness, skillopt
-    from cap_evolve.rundir import SCRATCH_NAMES
+    Pin that every consumer derives from rundir, AND that the destructive consumer
+    takes the live-writer subset only (see test_snapshot_ignore_excludes_legacy)."""
+    from cap_evolve import cache, dashboard, gepa, harness, skillopt
+    from cap_evolve.rundir import (LEGACY_SCRATCH_NAMES, NON_CAPABILITY_NAMES,
+                                   SCRATCH_NAMES)
     scratch = set(SCRATCH_NAMES)
-    assert {"FOCUS.md", "REFLECTION.md", "LEDGER.md", "JOURNAL.md", "RUNMAP.md"} <= scratch
-    for name, have in (("_SNAPSHOT_IGNORE", set(harness._SNAPSHOT_IGNORE)),
-                       ("cache._IGNORE_NAMES", cache._IGNORE_NAMES),
+    assert scratch == {"FOCUS.md", "REFLECTION.md", "LEDGER.md", "JOURNAL.md", "RUNMAP.md"}
+    assert NON_CAPABILITY_NAMES == scratch | set(LEGACY_SCRATCH_NAMES) | {
+        "INSTRUCTIONS.md", "PROCESS.md"}
+    # The DESTRUCTIVE consumer takes the live-writer subset; every read-side FILTER
+    # takes the whole union, so none of them can desync again.
+    assert scratch <= set(harness._SNAPSHOT_IGNORE)
+    for name, have in (("cache._IGNORE_NAMES", cache._IGNORE_NAMES),
                        ("gepa._NON_COMPONENT", gepa._NON_COMPONENT),
-                       ("skillopt._SCAFFOLDING", set(skillopt._SCAFFOLDING))):
-        assert scratch <= have, f"{name} is missing {sorted(scratch - have)}"
+                       ("skillopt._SCAFFOLDING", set(skillopt._SCAFFOLDING)),
+                       ("dashboard._DIFF_SKIP", set(dashboard._DIFF_SKIP)),
+                       ("harness._CAP_DIFF_SKIP", set(harness._CAP_DIFF_SKIP))):
+        assert have == set(NON_CAPABILITY_NAMES), f"{name} desynced: {sorted(have)}"
     # PROCESS.md is deliberately snapshotted (explainability), so it is NOT scratch.
     assert "PROCESS.md" not in scratch
     assert "PROCESS.md" not in set(harness._SNAPSHOT_IGNORE)
+
+
+def test_snapshot_ignore_excludes_legacy_names_and_is_root_anchored(tmp_path):
+    """FAILS BEFORE THE FIX: snapshot exclusion is DESTRUCTIVE (shutil.ignore_patterns
+    inside copytree), and it matches by BASENAME AT EVERY DEPTH. Folding the retired
+    MEMORY/STATE/REJECTED names — which no live code path writes — into
+    harness._SNAPSHOT_IGNORE meant a *capability* file that merely shared one of those
+    names was silently deleted from the candidate, from every descendant iteration, and
+    WITHOUT busting the eval-cache key (cache ignores the same name), i.e. a stale hit
+    on a mutilated candidate."""
+    from cap_evolve import harness
+    from cap_evolve.cache import hash_candidate_dir
+    from cap_evolve.rundir import RunDir
+
+    # Names spelled out, not imported, so this fails BEHAVIOURALLY on any base rev.
+    LEGACY = ("REJECTED.md", "MEMORY.md", "STATE.md")
+    snap_ignore = set(harness._SNAPSHOT_IGNORE)
+    assert not (set(LEGACY) & snap_ignore), (
+        "retired names with no live writer must not reach the DESTRUCTIVE snapshot "
+        f"filter: {sorted(set(LEGACY) & snap_ignore)}")
+
+    work = tmp_path / "work"
+    (work / "src" / "prompts").mkdir(parents=True)
+    (work / "prompt.txt").write_text("cap")
+    (work / "LEDGER.md").write_text("scratch")           # live scratch, root: dropped
+    (work / "src" / "LEDGER.md").write_text("capability")  # nested: root-anchored, kept
+    for n in (*LEGACY, "keep.txt"):
+        (work / "src" / "prompts" / n).write_text(f"capability {n}")
+
+    rd = RunDir.create(tmp_path / "run")
+    snap = rd.snapshot("c1", work, ignore=harness._SNAPSHOT_IGNORE)
+    got = sorted(str(p.relative_to(snap)) for p in snap.rglob("*") if p.is_file())
+    assert got == ["prompt.txt", "src/LEDGER.md",
+                   *sorted(f"src/prompts/{n}" for n in (*LEGACY, "keep.txt"))]
+
+    # …and removing one of those capability files DOES change the cache key.
+    before = hash_candidate_dir(snap)
+    (snap / "src" / "prompts" / "STATE.md").unlink()
+    assert hash_candidate_dir(snap) != before, "capability deletion did not bust the key"
 
 
 @pytest.mark.parametrize("algo", ["gepa", "hill-climb"])
@@ -321,12 +368,8 @@ def test_candidate_snapshots_are_clean_for_every_algorithm(tmp_path, algo):
 
     cands = [d for d in run_dir.candidates.iterdir() if d.is_dir() and d.name != "seed"]
     assert cands, f"{algo} produced no candidate snapshot to inspect"
-    dirty = {d.name: sorted(str(p.relative_to(d)) for p in d.rglob("*")
-                            if p.name in set(harness._SNAPSHOT_IGNORE)
-                            or p.parts[len(d.parts)] in set(harness._SNAPSHOT_IGNORE))
-             for d in cands}
-    assert not any(dirty.values()), f"{algo} snapshots carry scratch: {dirty}"
-    # …and only the capability + the two deliberately-kept explainability files remain.
+    # The exact-set assertion below subsumes any "is it dirty?" check — it catches
+    # over- AND under-exclusion, which is the property that matters.
     for d in cands:
         got = sorted(str(p.relative_to(d)) for p in d.rglob("*") if p.is_file())
         assert got == ["INSTRUCTIONS.md", "PROCESS.md", "prompt.txt"], f"{d.name}: {got}"


### PR DESCRIPTION
Closes #110

GEPA's candidate snapshots were dirty. Both `run_dir.snapshot()` calls in `gepa.py` omitted `ignore=`, so every accepted candidate carried the optimizer's scratch alongside the capability — **8 files / 32 KB where hill-climb stored 3 files** — and every dashboard candidate-vs-parent diff showed scratch churn instead of the real edit.

## Before / after (real runs, `examples/toy_calc` + `mock` optimizer)

`candidates/` after a 3-iteration run:

| | GEPA on `origin/main` | GEPA after **#199** | GEPA **after this PR** | hill-climb (all three) |
|---|---|---|---|---|
| files | **8** (32 KB) | **5** | **3** (12 KB) | 3 |
| contents | `FOCUS.md` `INSTRUCTIONS.md` `JOURNAL.md` `LEDGER.md` `PROCESS.md` `REFLECTION.md` `RUNMAP.md` `prompt.txt` | `FOCUS.md` `INSTRUCTIONS.md` `PROCESS.md` `REFLECTION.md` `prompt.txt` | `INSTRUCTIONS.md` `PROCESS.md` `prompt.txt` | `INSTRUCTIONS.md` `PROCESS.md` `prompt.txt` |

GEPA now agrees with hill-climb **exactly** on what is excluded. **5 stray files per accepted iteration eliminated; 32 KB → 12 KB (−62%).**

## What #199 already fixed vs what this PR adds

**#199 (issue #109) did most of the mechanical fix** and I built on it rather than duplicating it: it added `ignore=_SNAPSHOT_IGNORE` to both `gepa.py` snapshot calls, made `_SNAPSHOT_IGNORE` *derived* from `optimizer_context.INJECTED_DIRS`/`INJECTED_NAMES`, and folded the same lists into `cache.py` and `gepa._NON_COMPONENT`. That eliminated `LEDGER.md` / `JOURNAL.md` / `RUNMAP.md` / `prior_iterations/`.

**What genuinely remained:** `FOCUS.md` and `REFLECTION.md` — GEPA's *own* per-iteration scratch — still landed in every snapshot. They were listed in `cache._IGNORE_NAMES` and `gepa._NON_COMPONENT` but **never** in `_SNAPSHOT_IGNORE`. Verified empirically: the new tests **fail on top of `origin/fix/issue-109-optimizer-context`**, not just on `main` (output pasted below).

## Root cause and the shared-constant decision

The missing `ignore=` argument was the symptom. The cause is that the scratch-name literal was **copy-pasted into four modules and desynced** — exactly the failure mode that produced #109's `kind == "step"` filter and #189's counts. #199 correctly unified the *injected read-context* half (`INJECTED_*`), but the *scratch-file* half stayed as four independent literals, and `skillopt._changed_components` still had it inline **twice**.

So I made it one definition:

- **`rundir.SCRATCH_NAMES`** — a single tuple, placed in `rundir.py` because that module is at the bottom of the import graph (stdlib + `.splits` only), so every consumer can import it eagerly with no cycle and no import-order dependence.
- Four consumers now derive from it: `harness._SNAPSHOT_IGNORE`, `cache._IGNORE_NAMES`, `gepa._NON_COMPONENT`, `skillopt._SCAFFOLDING` (new named constant replacing two inline literals).

A newly-injected scratch file added to `SCRATCH_NAMES` now lands in all four automatically. I deliberately did **not** put it in `optimizer_context` next to `INJECTED_*`: those two lists mean different things (`INJECTED_*` is read-context the harness *copies in*; `SCRATCH_NAMES` is state the harness/algorithm *writes*) and `optimizer_context` sits higher in the import graph than `cache`/`rundir` need.

`INSTRUCTIONS.md` and `PROCESS.md` are deliberately **excluded** from `SCRATCH_NAMES`: `PROCESS.md` is the candidate's per-iteration explainability record and is meant to be snapshotted. Both are filtered at *diff* time only (`dashboard._DIFF_SKIP` / `harness._CAP_DIFF_SKIP`). A test pins that.

## Expected merge order

`#199` → `#197` → **this PR** (any order works, but this is the order verified). My diff is written to apply after both. All merge conflicts are trivial adjacent-import unions; I resolved them locally and ran the combined suite: **225 passed, 0 failed** with all three branches merged. #197's tamper guard is untouched (no overlapping lines).

## Verification

Full suite on this branch:

```
$ PYTHONPATH=core python -m pytest core/tests -q
........................................................................ [ 39%]
........................................................................ [ 79%]
......................................                                   [100%]
182 passed in 65.15s (0:01:05)
```

179 baseline + 3 new, 0 failed.

New tests **fail on `origin/main`** (the defect):

```
$ python -m pytest core/tests/test_gepa.py -q -k "snapshots_are_clean or scratch_ignores"
E       AssertionError: gepa snapshots carry scratch: {'gepa_0001': ['JOURNAL.md', 'LEDGER.md', 'RUNMAP.md']}
FAILED core/tests/test_gepa.py::test_scratch_ignores_are_one_shared_definition
FAILED core/tests/test_gepa.py::test_candidate_snapshots_are_clean_for_every_algorithm[gepa]
2 failed, 1 passed, 6 deselected in 5.16s
```

…and **still fail on top of #199** (what this PR adds):

```
E           AssertionError: gepa_0001: ['FOCUS.md', 'INSTRUCTIONS.md', 'PROCESS.md', 'REFLECTION.md', 'prompt.txt']
FAILED core/tests/test_gepa.py::test_scratch_ignores_are_one_shared_definition
FAILED core/tests/test_gepa.py::test_candidate_snapshots_are_clean_for_every_algorithm[gepa]
2 failed, 1 passed, 6 deselected in 4.53s
```

The `hill-climb` parametrization passes in **all three** states — it was already correct, and now the two algorithms are pinned to agree.

```
$ python -m compileall -q core skills && echo COMPILEALL_OK
COMPILEALL_OK
```

Zero new runtime deps. Tests in `core/tests/` per CONTRIBUTING.md.

Full commands + raw output in the `## 🔬 Evidence` comment below.

## Files touched

- `core/cap_evolve/rundir.py` — new shared `SCRATCH_NAMES`
- `core/cap_evolve/harness.py` — `_SNAPSHOT_IGNORE` derives from it
- `core/cap_evolve/gepa.py` — `ignore=_SNAPSHOT_IGNORE` on both snapshot calls; `_NON_COMPONENT` derives
- `core/cap_evolve/cache.py` — `_IGNORE_NAMES` derives
- `core/cap_evolve/skillopt.py` — two inline literals → `_SCAFFOLDING`
- `core/tests/test_gepa.py` — +3 regression tests
