### PR TITLE
refactor(core): drop dead optimizer-memory API + unused params; fix misleading cache docstring

### DIFF
--- a/core/cap_evolve/__init__.py
+++ b/core/cap_evolve/__init__.py
@@ -4,7 +4,7 @@ This is the *only* shipped code in cap-evolve. Everything user-facing is an
 Agent Skill; those skills' ``run.py`` scripts call into here for the things that
 must be consistent and honest across every run: task/score types, seeded splits
 with a sealed test set, variance-aware statistics, the acceptance gate,
-optimizer memory, the run directory, and the adapter contract.
+the run directory, and the adapter contract.
 
 Import it directly when Python is available, or invoke ``python -m
 cap_evolve <command>`` and parse the JSON it prints.

--- a/core/cap_evolve/cache.py
+++ b/core/cap_evolve/cache.py
@@ -1,16 +1,18 @@
 """Eval cache — skip a rollout when the same candidate was already scored on a task.
 
 Keyed by ``(hash of the candidate's editable files, task_id) -> {reward, feedback}``
-and persisted in the run dir. The hash is over file CONTENTS, so two byte-identical
-candidates share cache entries even under different ids.
+and persisted in the run dir, so re-evaluating an identical candidate (e.g. a parent
+re-sampled in GEPA, or a resumed run) costs nothing. The hash is over file CONTENTS,
+so two byte-identical candidates share cache entries even under different ids.
 
-**Scope: GEPA only.** The single consumer is ``gepa._eval_minibatch``, where the same
-parent is re-sampled from the Pareto frontier across iterations and re-scored on
-overlapping minibatches — that repetition is what the cache pays for.
-``harness.evaluate_candidate`` (every full-val and sealed-test eval, in every algorithm)
-does NOT consult it and always pays full price, so re-scoring an identical candidate on
-full val — common on ``--resume`` or a seed re-eval — is not deduplicated. Wiring it in
-there is a possible perf win, not existing behavior; there is no flag for it today.
+**Scope: GEPA only** — which bounds the "costs nothing" above. The single consumer is
+``gepa._eval_minibatch``, where the same parent is re-sampled from the Pareto frontier
+across iterations and re-scored on overlapping minibatches; that repetition is what the
+cache pays for. ``harness.evaluate_candidate`` (every full-val and sealed-test eval, in
+every algorithm) does NOT consult it and always pays full price, so re-scoring an
+identical candidate on full val — including on ``--resume`` or a seed re-eval — is NOT
+deduplicated. Wiring it in there is a possible perf win, not existing behavior, and
+there is no flag for it today (``test_w1_engine.py`` guards that claim).
 
 Honesty notes:
   * The cache stores only the SCORE (reward + feedback), never gold answers.

--- a/core/cap_evolve/cache.py
+++ b/core/cap_evolve/cache.py
@@ -1,17 +1,23 @@
 """Eval cache — skip a rollout when the same candidate was already scored on a task.
 
 Keyed by ``(hash of the candidate's editable files, task_id) -> {reward, feedback}``
-and persisted in the run dir, so re-evaluating an identical candidate (e.g. a parent
-re-sampled in GEPA, or a resumed run) costs nothing. The hash is over file CONTENTS,
-so two byte-identical candidates share cache entries even under different ids.
+and persisted in the run dir. The hash is over file CONTENTS, so two byte-identical
+candidates share cache entries even under different ids.
+
+**Scope: GEPA only.** The single consumer is ``gepa._eval_minibatch``, where the same
+parent is re-sampled from the Pareto frontier across iterations and re-scored on
+overlapping minibatches — that repetition is what the cache pays for.
+``harness.evaluate_candidate`` (every full-val and sealed-test eval, in every algorithm)
+does NOT consult it and always pays full price, so re-scoring an identical candidate on
+full val — common on ``--resume`` or a seed re-eval — is not deduplicated. Wiring it in
+there is a possible perf win, not existing behavior; there is no flag for it today.
 
 Honesty notes:
   * The cache stores only the SCORE (reward + feedback), never gold answers.
   * It is keyed on candidate-file content, so an edit (even whitespace) busts the
     key — a stale score can never be served for changed files.
   * It is an optimization, not a source of truth: ``events.jsonl`` still records
-    every evaluation. Wiring into ``evaluate_candidate`` is OFF by default and gated
-    behind a flag (see ``maybe_cached_score``) so it cannot silently change behavior.
+    every evaluation.
 
 Pure stdlib (hashlib + json).
 """

--- a/core/cap_evolve/gepa.py
+++ b/core/cap_evolve/gepa.py
@@ -566,7 +566,7 @@ def gepa_loop(
         refl_summary = _write_reflection(workdir, parent_mb)
         focus_label = _write_focus(workdir, comps, focus)
         instructions = _instructions(refl_summary, focus_label, mb)
-        instructions = _augment_instructions(instructions, workdir, run_dir, rejected, history)
+        instructions = _augment_instructions(instructions, workdir, run_dir)
 
         opt_error = None
         opt_cost_usd, opt_tokens = 0.0, 0

--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -713,18 +713,7 @@ def _journal_tail(workdir: Path) -> str:
     return tail.replace(_JOURNAL_MARK, "").strip()
 
 
-def _latest_journal_note(workdir: Path, *, max_chars: int = 900) -> str | None:
-    """The newest journal entry, capped — stored in the factual ledger as the candidate's
-    one-line lineage note. Returns ``None`` when the optimizer appended nothing."""
-    tail = _journal_tail(workdir)
-    if not tail:
-        return None
-    if len(tail) > max_chars:
-        tail = tail[:max_chars].rstrip() + " …"
-    return tail
-
-
-def _build_ledger(workdir: Path, run_dir: RunDir, rejected, history) -> None:
+def _build_ledger(workdir: Path, run_dir: RunDir) -> None:
     """Write the FACTUAL, framework-owned LEDGER.md: one row per prior iteration with
     its outcome + the exact tasks it broke/fixed. Deterministic — the objective record;
     the optimizer's own narrative lives in JOURNAL.md."""
@@ -898,8 +887,7 @@ def _build_runmap(workdir: Path, run_dir: RunDir) -> None:
     (workdir / "RUNMAP.md").write_text(text, encoding="utf-8")
 
 
-def _augment_instructions(instructions: str, workdir: Path, run_dir: RunDir,
-                          rejected, history) -> str:
+def _augment_instructions(instructions: str, workdir: Path, run_dir: RunDir) -> str:
     """Give the optimizer its four cross-iteration files + a prompt pointer to each.
 
     Clean ownership (see the file-header comment near ``_JOURNAL_SEED``):
@@ -909,7 +897,7 @@ def _augment_instructions(instructions: str, workdir: Path, run_dir: RunDir,
       - RUNMAP.md + prior_iterations/ — framework manifest + copies of every prior
         iteration's PROCESS.md and capability diff (real prior-work-dir access).
     """
-    _build_ledger(workdir, run_dir, rejected, history)
+    _build_ledger(workdir, run_dir)
     _seed_journal(workdir, run_dir)
     if not (workdir / "PROCESS.md").exists():
         (workdir / "PROCESS.md").write_text(_PROCESS_SEED, encoding="utf-8")
@@ -1253,7 +1241,7 @@ def run_step(
                               capabilities=capabilities, optimizer_name=optimizer_name,
                               capability_sources=capability_sources, project_dir=project_dir)
 
-    instructions = _augment_instructions(instructions, workdir, run_dir, rejected, history)
+    instructions = _augment_instructions(instructions, workdir, run_dir)
 
     optimizer_error = None
     opt_cost_usd, opt_tokens = 0.0, 0
@@ -1328,30 +1316,22 @@ def run_step(
                       opt_cost_usd=round(opt_cost_usd, 6), opt_tokens=opt_tokens)
     run_dir.record_spend_warnings()
 
-    # update optimizer memory + commit the iteration to the version store so the
-    # whole process stays inspectable (git log / LEDGER / JOURNAL). The `note` is the
-    # optimizer's own handover (its approach + lesson), taken from the entry it appended
-    # to JOURNAL.md this iteration so the lineage record carries what was tried, not just Δ/SE.
+    # Record the iteration for the dashboard's Memory/Insights panels + commit it to the
+    # version store, so the whole process stays inspectable (git log / LEDGER / JOURNAL).
     delta = cand_val.reward - current_val.reward
     summary = f"candidate {cid} (val {cand_val.reward:.3f}, Δ {delta:+.3f})"
     # Fold the optimizer's appended JOURNAL entry into the run-level append-only journal
-    # (so handover accumulates across accepted AND rejected iterations), and reuse it as
-    # the candidate's lineage note in the factual ledger.
+    # (so handover accumulates across accepted AND rejected iterations). This is the
+    # channel the NEXT iteration actually reads; _reconcile_journal stamps the objective
+    # outcome + the exact tasks broken/fixed into it.
     _reconcile_journal(workdir, run_dir, cid, accepted=accepted,
                        val=cand_val.reward, delta=delta)
-    note = _latest_journal_note(workdir)
-    # Per-task broke/fixed lists vs the parent (from the rollouts just persisted), so
-    # MEMORY records the SPECIFIC tasks a candidate broke — not just a category — and
-    # the next iteration won't retry the regression. Best-effort; None when not
-    # comparable (e.g. parent rollouts absent).
-    impact = _candidate_task_impact(run_dir, cid, "val",
-                                    parent_of={cid: parent_id})
     if accepted:
         if history is not None:
-            history.add(cid, summary, cand_val.reward, note=note, impact=impact)
+            history.add(cid, summary, cand_val.reward)
     else:
         if rejected is not None:
-            rejected.add(cid, summary, decision.reason, cand_val.reward, note=note, impact=impact)
+            rejected.add(cid, summary, decision.reason, cand_val.reward)
     if store is not None:
         store.commit(f"iter {run_dir.spent.iterations}: "
                      f"{'ACCEPT' if accepted else 'reject'} {summary}",

--- a/core/cap_evolve/memory.py
+++ b/core/cap_evolve/memory.py
@@ -1,16 +1,23 @@
-"""Optimizer memory: rejected approaches + accepted history.
+"""Optimizer memory: append-only jsonl records of rejected + accepted candidates.
 
-Two append-only records that survive across iterations:
+These are **audit/UI records, not optimizer input.** Two append-only files in the run
+dir, one line per candidate:
 
-- ``RejectedMemory`` — every candidate the gate rejected, with the reason. Its
-  ``render()`` produces a markdown block fed into the *next* proposal prompt as
-  STEERING: don't re-submit a regressed edit verbatim, but a better-designed version
-  of the same idea may still work — so a high-value cluster is not permanently
-  abandoned (prior agent-optimization work's RejectedMemory / evo-graph's Rejected Memory Store).
-- ``History`` — every accepted candidate, so the loop can show the optimizer
-  what worked and reconstruct the best-so-far lineage.
+- ``RejectedMemory`` (``rejected.jsonl``) — every candidate the gate rejected, with the
+  reason.
+- ``History`` (``history.jsonl``) — every accepted candidate.
 
-Backed by jsonl files in the run dir; pure stdlib.
+Their only consumer is the dashboard: ``GET /api/runs/{id}/memory``
+(``dashboard/backend/capevolve_dashboard/memory.py``) serves them to the Memory panel
+and to the Insights "dead ends" grouping, which read exactly
+``{candidate_id, summary, val, reason}`` — nothing else.
+
+They are NOT fed back into any proposal prompt: the framework-owned LEDGER.md /
+JOURNAL.md / RUNMAP.md files (see ``harness._augment_instructions``) are the sole
+cross-iteration channel the optimizer actually reads. Do not add a ``render()`` here
+expecting it to reach a prompt — wire it through ``_augment_instructions`` instead.
+
+Pure stdlib.
 """
 
 from __future__ import annotations
@@ -20,35 +27,9 @@ from pathlib import Path
 from typing import Optional
 
 
-def _store_impact(rec: dict, impact: Optional[dict]) -> None:
-    """Attach a candidate's per-task broke/fixed lists to its memory record.
-
-    ``impact`` is the dict produced by ``harness._candidate_task_impact``
-    (``{"broke": [...], "fixed": [...], ...}``). Only the non-empty broke/fixed
-    lists are stored, so old records (impact=None) stay byte-identical and the
-    memory file is not bloated when there was no per-task movement."""
-    if not impact:
-        return
-    broke = [str(t) for t in (impact.get("broke") or [])]
-    fixed = [str(t) for t in (impact.get("fixed") or [])]
-    if broke:
-        rec["broke"] = broke
-    if fixed:
-        rec["fixed"] = fixed
-
-
-def _render_impact(e: dict) -> Optional[str]:
-    """One-line per-task impact for a memory entry, or None when there is none."""
-    broke = e.get("broke") or []
-    fixed = e.get("fixed") or []
-    if not broke and not fixed:
-        return None
-    parts = []
-    if broke:
-        parts.append("broke {" + ", ".join(str(t) for t in broke) + "}")
-    if fixed:
-        parts.append("fixed {" + ", ".join(str(t) for t in fixed) + "}")
-    return "per-task impact: " + "; ".join(parts)
+def _append(path: Path, rec: dict) -> None:
+    with path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(rec) + "\n")
 
 
 class RejectedMemory:
@@ -56,53 +37,10 @@ class RejectedMemory:
         self.path = Path(path)
         self.path.parent.mkdir(parents=True, exist_ok=True)
 
-    def add(self, candidate_id: str, summary: str, reason: str, val: Optional[float] = None,
-            note: Optional[str] = None, impact: Optional[dict] = None) -> None:
-        rec = {
-            "candidate_id": candidate_id,
-            "summary": summary.strip(),
-            "reason": reason.strip(),
-            "val": val,
-        }
-        if note and note.strip():
-            rec["note"] = note.strip()
-        _store_impact(rec, impact)
-        with self.path.open("a", encoding="utf-8") as f:
-            f.write(json.dumps(rec) + "\n")
-
-    def entries(self) -> list[dict]:
-        if not self.path.exists():
-            return []
-        out = []
-        for line in self.path.read_text(encoding="utf-8").splitlines():
-            line = line.strip()
-            if line:
-                out.append(json.loads(line))
-        return out
-
-    def render(self, limit: int = 20) -> str:
-        """Markdown block for the proposal prompt: approaches that regressed AS
-        IMPLEMENTED — steering, not a permanent ban-list."""
-        items = self.entries()[-limit:]
-        if not items:
-            return "_No regressed approaches yet._"
-        lines = [
-            "## Approaches that regressed AS IMPLEMENTED",
-            "These exact edits were rejected by the gate. Don't re-submit them verbatim — "
-            "but a better-designed version of the same idea MAY still work, so don't "
-            "permanently abandon a high-value cluster. Each shows its reject reason "
-            "(and per-task impact) so you can redesign rather than repeat.",
-        ]
-        for e in items:
-            v = f" (val={e['val']:.4f})" if e.get("val") is not None else ""
-            lines.append(f"- **{e['summary']}** — rejected: {e['reason']}{v}")
-            note = (e.get("note") or "").strip()
-            if note:
-                lines.append(f"  - approach + lesson: {note}")
-            imp = _render_impact(e)
-            if imp:
-                lines.append(f"  - {imp}")
-        return "\n".join(lines)
+    def add(self, candidate_id: str, summary: str, reason: str,
+            val: Optional[float] = None) -> None:
+        _append(self.path, {"candidate_id": candidate_id, "summary": summary.strip(),
+                            "reason": reason.strip(), "val": val})
 
 
 class History:
@@ -110,36 +48,6 @@ class History:
         self.path = Path(path)
         self.path.parent.mkdir(parents=True, exist_ok=True)
 
-    def add(self, candidate_id: str, summary: str, val: float,
-            note: Optional[str] = None, impact: Optional[dict] = None) -> None:
-        rec = {"candidate_id": candidate_id, "summary": summary.strip(), "val": val}
-        if note and note.strip():
-            rec["note"] = note.strip()
-        _store_impact(rec, impact)
-        with self.path.open("a", encoding="utf-8") as f:
-            f.write(json.dumps(rec) + "\n")
-
-    def entries(self) -> list[dict]:
-        if not self.path.exists():
-            return []
-        out = []
-        for line in self.path.read_text(encoding="utf-8").splitlines():
-            line = line.strip()
-            if line:
-                out.append(json.loads(line))
-        return out
-
-    def render(self, limit: int = 10) -> str:
-        items = self.entries()[-limit:]
-        if not items:
-            return "_No accepted edits yet (this is the baseline)._"
-        lines = ["## Accepted edits so far (what worked)"]
-        for e in items:
-            lines.append(f"- {e['summary']} → val={e['val']:.4f}")
-            note = (e.get("note") or "").strip()
-            if note:
-                lines.append(f"  - approach + lesson: {note}")
-            imp = _render_impact(e)
-            if imp:
-                lines.append(f"  - {imp}")
-        return "\n".join(lines)
+    def add(self, candidate_id: str, summary: str, val: float) -> None:
+        _append(self.path, {"candidate_id": candidate_id, "summary": summary.strip(),
+                            "val": val})

--- a/core/cap_evolve/rundir.py
+++ b/core/cap_evolve/rundir.py
@@ -4,8 +4,8 @@ Layout under ``.capevolve/run_<ts>/``::
 
     state.json          # best candidate id, budget, spent, test_used
     splits.json         # the frozen train/val/test partition (sealed test)
-    rejected.jsonl      # RejectedMemory
-    history.jsonl       # accepted History
+    rejected.jsonl      # rejected candidates (dashboard Memory panel)
+    history.jsonl       # accepted candidates (dashboard Memory panel)
     candidates/<id>/    # snapshot of each candidate's capability dir
     rollouts/<split>/<task>__<cand>__t<k>.json
     events.jsonl        # append-only audit log

--- a/core/cap_evolve/skillopt.py
+++ b/core/cap_evolve/skillopt.py
@@ -34,7 +34,8 @@ adds three things straight out of the deep-learning analogy:
      bypassing the gate to mutate best.
 
 Everything honesty-critical (materialize → optimize → eval-val → gate →
-accept/reject → snapshot/best, RejectedMemory/History, the sealed test) is
+accept/reject → snapshot/best, the write-only rejected/history audit jsonl, the sealed
+test) is
 delegated to ``harness.run_step`` / ``harness.evaluate_candidate``; this module
 only owns the *schedule*, the *buffer*, and the *slow update*. The result-dict
 shape mirrors ``hill_climb_loop`` (plus per-epoch stats + slow-update records).

--- a/core/tests/test_core.py
+++ b/core/tests/test_core.py
@@ -1,7 +1,7 @@
 """Tests for the honest-evaluation substrate.
 
 These encode the non-negotiable guarantees: deterministic splits, a sealed test
-set, the significance gate, pass^k math, and rejected-memory rendering.
+set, the significance gate, pass^k math, and the memory jsonl record shape.
 """
 
 import math
@@ -122,16 +122,29 @@ def test_combined_stderr_zero_for_single_certain_task():
     assert stats.combined_stderr([1.0], [0.0]) == 0.0
 
 
-# ---- rejected memory ------------------------------------------------------
+# ---- memory jsonl records (the dashboard's Memory panel contract) ----------
 
-def test_rejected_memory_roundtrip_and_render(tmp_path):
-    rm = RejectedMemory(tmp_path / "rejected.jsonl")
+def test_memory_jsonl_record_shape_matches_dashboard_contract(tmp_path):
+    """The jsonl records are consumed by the dashboard's ``/api/runs/{id}/memory``
+    (Memory panel + Insights dead-ends), which reads exactly these keys. Writing an
+    extra/renamed key silently breaks that UI, so pin the shape."""
+    import json
+
+    from cap_evolve import History
+
+    rp = tmp_path / "rejected.jsonl"
+    rm = RejectedMemory(rp)
     rm.add("c1", "added verbose preamble", "Δ<=0 on val", val=0.41)
     rm.add("c2", "removed the schema hint", "regressed val", val=0.30)
-    assert len(rm.entries()) == 2
-    rendered = rm.render()
-    assert "added verbose preamble" in rendered
-    # The block is reframed as STEERING (regressed-as-implemented), not a hard ban:
-    # it must still steer the optimizer away from re-submitting the rejected edit.
-    low = rendered.lower()
-    assert "regressed" in low and "re-submit" in low
+    recs = [json.loads(l) for l in rp.read_text().splitlines() if l.strip()]
+    assert len(recs) == 2
+    assert set(recs[0]) == {"candidate_id", "summary", "reason", "val"}
+    assert recs[0] == {"candidate_id": "c1", "summary": "added verbose preamble",
+                       "reason": "Δ<=0 on val", "val": 0.41}
+
+    hp = tmp_path / "history.jsonl"
+    History(hp).add("c3", "tightened the output contract", 0.62)
+    hrec = json.loads(hp.read_text().strip())
+    assert set(hrec) == {"candidate_id", "summary", "val"}
+    assert hrec == {"candidate_id": "c3", "summary": "tightened the output contract",
+                    "val": 0.62}

--- a/core/tests/test_per_task_impact.py
+++ b/core/tests/test_per_task_impact.py
@@ -33,7 +33,6 @@ def test_per_task_impact_lists_broken_task():
     """A candidate that regressed a previously-passing task must be reported in the
     per-task impact block as having BROKEN that task."""
     from cap_evolve import RunDir, harness
-    from cap_evolve.memory import RejectedMemory
     import tempfile
 
     tmp = Path(tempfile.mkdtemp())
@@ -48,15 +47,13 @@ def test_per_task_impact_lists_broken_task():
 
     # Lineage: cand_0001 forked from seed (a step event), and it was rejected.
     rd.log_event("step", candidate="cand_0001", parent="seed", accept=False)
-    rejected = RejectedMemory(rd.rejected_path)
-    rejected.add("cand_0001", "candidate cand_0001 (val 0.667)", "no significant gain", 0.667)
 
     # The per-task broke/fixed signal reaches the optimizer via the framework-owned
     # factual LEDGER.md (built each iteration). Build it into a workdir and assert the
     # broken/fixed task ids are surfaced in cand_0001's row.
     import tempfile as _tf
     workdir = Path(_tf.mkdtemp())
-    harness._build_ledger(workdir, rd, rejected, None)
+    harness._build_ledger(workdir, rd)
     ledger = (workdir / "LEDGER.md").read_text(encoding="utf-8")
     assert "cand_0001" in ledger
     # Row format: | iter | candidate | parent | outcome | val | Δ | broke {..} | fixed {..} |
@@ -64,7 +61,7 @@ def test_per_task_impact_lists_broken_task():
     assert "{2}" in row   # BROKE task 2 (was passing)
     assert "{3}" in row   # FIXED task 3
 
-    # And the memory record carries the localized broke/fixed lists (C4).
+    # And the underlying signal localizes the broke/fixed task ids (C4).
     impact = harness._candidate_task_impact(rd, "cand_0001", "val",
                                             parent_of={"cand_0001": "seed"})
     assert impact["broke"] == ["2"]

--- a/core/tests/test_w1_engine.py
+++ b/core/tests/test_w1_engine.py
@@ -472,3 +472,16 @@ def test_cache_get_put_roundtrip(tmp_path):
     # persisted: a fresh instance reads it back
     c2 = EvalCache(tmp_path / "cache.json")
     assert c2.get("h", "t0")["reward"] == 0.7
+
+
+def test_no_docs_cite_a_nonexistent_cache_flag():
+    """#114: ``cache.py``'s docstring long claimed the cache was gated behind a flag
+    named ``maybe_cached_score`` — a function that exists nowhere. Docs that name
+    fictional symbols mislead readers into wiring against them, so pin the absence
+    repo-wide (a revert of the docstring fix, or a re-add elsewhere, fails here)."""
+    root = Path(__file__).resolve().parents[2]
+    me = Path(__file__).resolve()
+    hits = [str(f) for pat in ("core/**/*.py", "core/**/*.md", "skills/**/*.py", "skills/**/*.md")
+            for f in root.glob(pat)
+            if f.resolve() != me and "maybe_cached_score" in f.read_text(errors="ignore")]
+    assert hits == [], f"docs cite a nonexistent cache flag: {hits}"

--- a/dashboard/frontend/src/components/MemoryPanel.tsx
+++ b/dashboard/frontend/src/components/MemoryPanel.tsx
@@ -7,7 +7,8 @@ import { pct } from '../lib/format'
 import { Card } from './ui/Card'
 import { Skeleton } from './ui/Skeleton'
 
-/** Optimizer memory: accepted history, rejected ("do-not-re-propose"), and the
+/** Run audit records: accepted history, rejected candidates (an audit trail — nothing
+ * re-reads it to avoid re-proposing; see core/cap_evolve/memory.py), and the
  * per-candidate snapshot files (PROCESS.md explainability / INSTRUCTIONS.md / the
  * capability files). */
 export function MemoryPanel({ runId, graph }: { runId: string; graph: RunGraph }) {

--- a/skills/algorithms/skillopt/SKILL.md
+++ b/skills/algorithms/skillopt/SKILL.md
@@ -25,7 +25,8 @@ hill-climb) but adds three things from the DL analogy:
   without breaking stable successes.
 
 Every step calls the shared `run_step` (materialize → optimize → eval-VAL →
-significance gate → accept/reject → snapshot/best, with RejectedMemory/History);
+significance gate → accept/reject → snapshot/best, and writes the dashboard's
+`rejected.jsonl`/`history.jsonl` audit records — write-only, they never reach a prompt);
 this skill only owns the schedule, the buffer, and the slow update. Gated on val;
 test stays sealed (that's `finalize`).
 

--- a/skills/algorithms/skillopt/references/concepts.md
+++ b/skills/algorithms/skillopt/references/concepts.md
@@ -62,8 +62,9 @@ best-effort file-diff count) to surface an optimizer that ignores its budget.
 Two per-epoch, bounded structures injected into the next step's prompt:
 
 - **rejected-edit buffer** — every rejected candidate's id + val Δ, so the
-  optimizer does not re-propose a dead end *this epoch* (the global RejectedMemory
-  in `run_step` still records all rejects across the run).
+  optimizer does not re-propose a dead end *this epoch*. This buffer is the only
+  reject signal that reaches the prompt; `run_step`'s `rejected.jsonl` is an audit
+  record for the dashboard, not prompt input.
 - **failure-pattern block** — the focus tasks' failing feedback clustered by a
   normalized prefix signature (infra-errored tasks excluded via the structured
   `raw.errored` flag), so the prompt carries *patterns* not raw prose.

--- a/skills/algorithms/skillopt/references/concepts.md
+++ b/skills/algorithms/skillopt/references/concepts.md
@@ -35,7 +35,9 @@ without gepa's frontier bookkeeping.
    avoid this epoch, the unsolved failure patterns). Parent is **always the
    current best** (single lineage). Call `harness.run_step(...)` — it materializes
    the parent, runs the optimizer, evaluates on VAL, applies the significance
-   gate, snapshots + sets best on accept, and writes RejectedMemory/History.
+   gate, snapshots + sets best on accept, and writes the dashboard's
+   `rejected.jsonl`/`history.jsonl` audit records (write-only; the only reject signal
+   that reaches the prompt is SkillOpt's own within-epoch buffer, below).
 4. Append a bounded record to `step_buffer`
    (`{step, epoch, accepted, n_fail, failure_patterns, rejected id + val Δ}`),
    capped (≤ 3 task ids per pattern, ≤ ~10 patterns, ≤ 12 steps) and **reset each


### PR DESCRIPTION
Closes #114

## The issue's premise is only PARTLY right — scoped accordingly

#114 says `memory.py` is write-only and the jsonl machinery can go. I checked empirically before deleting, and the issue itself asked to "confirm the `rejected.jsonl`/`history.jsonl` files aren't relied on by the dashboard before removing writes … (the dashboard reads `events.jsonl`, not these — verify)".

**Verified: that parenthetical is wrong.** The jsonl files have a live reader. So I removed only the genuinely-unread surface and **kept the writes**.

### Write-only proof

The prompt-facing API — `render()`, `entries()`, `_render_impact` — has zero callers outside `memory.py` itself:

```
$ grep -rn "\.render()\|\.entries()\|_render_impact" --include="*.py" core/cap_evolve skills examples
core/cap_evolve/memory.py:40:def _render_impact(e: dict) -> Optional[str]:
core/cap_evolve/memory.py:86:        items = self.entries()[-limit:]
core/cap_evolve/memory.py:102:            imp = _render_impact(e)
core/cap_evolve/memory.py:133:        items = self.entries()[-limit:]
core/cap_evolve/memory.py:142:            imp = _render_impact(e)
```

Every hit is `memory.py` calling itself. `LEDGER.md`/`JOURNAL.md`/`RUNMAP.md` (via `_augment_instructions`) fully replaced this as the optimizer's cross-iteration channel. **Dead → removed.**

Same for the per-record `note` / `broke` / `fixed` fields — written on every iteration, read by nobody:

```
$ grep -rn "broke\|fixed" dashboard/frontend/src dashboard/backend --include="*.tsx" --include="*.ts" --include="*.py"
dashboard/frontend/src/test/insights.test.ts:36:  { candidate_id: 'c', summary: '', reason: 'broke correctness gate', val: 0 },
dashboard/frontend/src/components/Trajectories.tsx:115:  <div className="fixed inset-0 z-40 ...
dashboard/frontend/src/lib/api.ts:71: * first snapshot) from a genuinely missing/broken run. */
dashboard/backend/capevolve_dashboard/runs.py:19:  prefixed ``run_`` or lacking ``events.jsonl``. ...
```

Three CSS/prose coincidences, zero real readers. Field-level audit against the dashboard's consumers:

| field | readers in dashboard | verdict |
|---|---|---|
| `candidate_id` | 5 | **live** |
| `summary` | 9 | **live** |
| `val` | 9 | **live** |
| `reason` | 8 | **live** |
| `note` | 0 | dead → removed |
| `broke` | 0 | dead → removed |
| `fixed` | 0 | dead → removed |

### What I did NOT delete, and why

```
$ grep -rn "rejected.jsonl\|history.jsonl" dashboard
dashboard/backend/capevolve_dashboard/memory.py:31:  "history": _read_jsonl(root / "history.jsonl"),
dashboard/backend/capevolve_dashboard/memory.py:32:  "rejected": _read_jsonl(root / "rejected.jsonl"),
```

`read_memory()` is served at `GET /api/runs/{run_id}/memory` (`app.py:60`), consumed by `MemoryPanel.tsx` (the Deep-Dive **Memory** tab) and `insights.ts::deadEnds()` (the Insights "what not to try" grouping), and baked into `export_static.py:83`. Deleting the writes would have blanked two shipped UI panels. **The `.add()` writes and both jsonl files stay** — they are audit/UI records, which is now what the module docstring says they are.

## Deleted

| removed | why |
|---|---|
| `RejectedMemory.render` / `.entries`, `History.render` / `.entries` | zero callers (grep above) |
| `_render_impact`, `_store_impact` | only used by the above |
| `note=` / `impact=` kwargs + `note`/`broke`/`fixed` fields | written, never read |
| `harness._latest_journal_note` | sole caller was the dead `note=` |
| `_candidate_task_impact` call in `run_step` | existed only to fill those dead fields — re-read rollouts from disk **every iteration**. `_build_ledger` and `_reconcile_journal` keep their own computations, so no signal is lost |
| `rejected` / `history` params on `_augment_instructions` + `_build_ledger` | unused in both bodies |

**82 insertions, 177 deletions across 9 files (net −95).** `memory.py`: 145 → 54 lines. No files removed (`memory.py` still carries the two live writers).

## Algorithm-label stamp: preserved, untouched

`_init_memory_store` is **not renamed, moved, or inlined** — my change does not touch it at all, so PR #204's `algorithm` stamp and the dashboard badge are structurally unaffected. Proven on a locally-built `#199 + #204 + this` merge, all three deterministic loops:

```
### run_e2e_hill-climb
{"t": 1785367294.371619, "kind": "algorithm", "name": "hill-climb:all"}
### run_e2e_gepa
{"t": 1785367297.4603388, "kind": "algorithm", "name": "gepa"}
### run_e2e_skillopt
{"t": 1785367300.6982982, "kind": "algorithm", "name": "skillopt"}
```

and the dashboard summary is non-blank for each: `'hill-climb:all'`, `'gepa'`, `'skillopt'`.

## Corrected cache docstring

Was — describing a flag, a wiring, and a function that do not exist:

> It is an optimization, not a source of truth: `events.jsonl` still records every evaluation. Wiring into `evaluate_candidate` is OFF by default and gated behind a flag (see `maybe_cached_score`) so it cannot silently change behavior.

There is no `maybe_cached_score` anywhere in the repo. Now:

> **Scope: GEPA only.** The single consumer is `gepa._eval_minibatch`, where the same parent is re-sampled from the Pareto frontier across iterations and re-scored on overlapping minibatches — that repetition is what the cache pays for. `harness.evaluate_candidate` (every full-val and sealed-test eval, in every algorithm) does NOT consult it and always pays full price, so re-scoring an identical candidate on full val — common on `--resume` or a seed re-eval — is not deduplicated. Wiring it in there is a possible perf win, not existing behavior; there is no flag for it today.

#199's `_IGNORE_DIRS` / `INJECTED_*` change is untouched (it merges clean).

## Note for #128 / #129

Those add a **genuinely-read** memory. Build on **`_augment_instructions`**, not on `memory.py`. That is the only function whose output reaches the optimizer prompt, and it is now 3 params instead of 5 — add one there and every algorithm (hill-climb, gepa, skillopt) picks it up, since all three route through it. `memory.py`'s docstring now says this explicitly so nobody re-adds a `render()` expecting it to reach a prompt. I deliberately built **no** speculative scaffolding for them.

## Expected merge order

**#199 → #204 → this PR.** Based on `origin/main`; #199 and #204 conflict with each other (both edit the `_init_memory_store` call sites) — that is pre-existing and independent of this PR. After both land, this PR conflicts on exactly one hunk in `gepa.py:614` (#199's `render_instructions` vs my 2-arg `_augment_instructions`); resolution is mechanical — keep #199's call, drop `, rejected, history`:

```python
instructions = render_instructions(
    parent_mb, mb, f"GEPA minibatch of {len(mb)} train task(s)", ctx=ctx,
    algorithm="gepa", run_dir=run_dir, parent_id=parent["id"],
    extra=_gepa_block(refl_summary, focus_label, mb, has_trajectories=has_traj))
instructions = _augment_instructions(instructions, workdir, run_dir)
```

I verified that resolution locally: **203 passed** on the merged tree.

## Verification

### Full core suite on this branch (baseline 179)

```
$ PYTHONPATH=core python -m pytest core/tests -q
........................................................................ [ 40%]
........................................................................ [ 80%]
...................................                                      [100%]
179 passed in 59.77s
```

**179 passed, 0 failed — no net test loss.** One test was replaced, not dropped: `test_rejected_memory_roundtrip_and_render` asserted on the removed `render()`, so it could not survive. It is superseded by `test_memory_jsonl_record_shape_matches_dashboard_contract`, which pins the exact key set the dashboard reads (`{candidate_id, summary, reason, val}` / `{candidate_id, summary, val}`) — a stronger guard, since it fails if anyone renames or adds a field and silently breaks the Memory panel.

### Dashboard backend (would have caught a removed write)

```
$ PYTHONPATH=core python -m pytest dashboard/backend/tests -q
42 passed, 1 warning in 1.88s
```

### compileall

```
$ python -m compileall -q core skills && echo CLEAN
COMPILEALL CLEAN
```

### Real e2e, all three deterministic algorithms, zero API cost

Every one reaches the sealed test number **1.0 ± 0.0** and the memory jsonl still round-trips through the real dashboard reader:

| algorithm | sealed test | best_id | dashboard `algorithm` | history / rejected |
|---|---|---|---|---|
| hill-climb | **1.0** (SE 0.0) | `cand_0001` | `hill-climb:all` | 1 / 2 |
| gepa | **1.0** (SE 0.0) | `gepa_0001` | `gepa` | 1 / 2 |
| skillopt | **1.0** (SE 0.0) | `so_e01s01` | `skillopt` | 1 / 2 |

```
--- memory jsonl still written + dashboard-readable ---
history  n=1 [{'candidate_id': 'cand_0001', 'summary': 'candidate cand_0001 (val 1.000, Δ +1.000)', 'val': 1.0}]
rejected n=2 [{'candidate_id': 'cand_0002', 'summary': 'candidate cand_0002 (val 1.000, Δ +0.000)', 'reason': 'paired Δ̄=+0.0000 <= 0 (SE=0 → STRICT fallback, warned; n=2)', 'val': 1.0}]
```

Records carry exactly the four live keys and no dead `note`/`broke`/`fixed` — the deletion is visible on disk.

Zero new runtime deps; tests stay in `core/tests/`.
