### PR TITLE
Dogfood the skill-package authoring lint in CI; split oversized tools/SKILL.md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@
 #   4. docs-links      — checks relative links/images in Markdown resolve (offline)
 #   5. spellcheck      — codespell over README + docs
 #   6. lint-skills     — dogfoods the skill-package authoring lint on our OWN skills
-#                        (skills/*/*/SKILL.md) + rebuilds the registry manifest
+#                        (skills/*/*/SKILL.md) + fails on a stale registry manifest
 #
 # No shared-workflow delegation needed: this is repo-specific CI.
 # ============================================================================
@@ -137,11 +137,17 @@ jobs:
 
       # The bar cap-evolve ships to users (skill-package/scripts/abstract.py) applied
       # to cap-evolve's own bundled skills. Discovery is a glob, so a NEW skill is
-      # linted the day it lands, and MIN_SKILLS fails loudly if one vanishes.
+      # linted the day it lands, and the glob is cross-checked against the committed
+      # manifest so a rename fails loudly even when an addition balances the total.
       - name: Lint every bundled SKILL.md against the authoring bar
         run: python skills/_registry/lint_skills.py skills
 
-      - name: Rebuild the skill registry manifest
-        run: python skills/_registry/build_manifest.py skills
+      # `git diff --exit-code` is the point: build_manifest.py WRITES the file, so
+      # without it a stale committed manifest is silently erased instead of flagged —
+      # and the lint's coverage check reads that manifest, so it must be pinned here.
+      - name: Check the committed skill registry manifest is not stale
+        run: |
+          python skills/_registry/build_manifest.py skills
+          git diff --exit-code skills/_registry/manifest.json
 
 # Made with Bob

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@
 #   3. toy-example     — runs the zero-API toy_calc example and asserts test_reward 1.0
 #   4. docs-links      — checks relative links/images in Markdown resolve (offline)
 #   5. spellcheck      — codespell over README + docs
+#   6. lint-skills     — dogfoods the skill-package authoring lint on our OWN skills
+#                        (skills/*/*/SKILL.md) + rebuilds the registry manifest
 #
 # No shared-workflow delegation needed: this is repo-specific CI.
 # ============================================================================
@@ -119,5 +121,27 @@ jobs:
           path: README.md docs
           skip: docs/sources.bib,docs/assets,docs/superpowers
           ignore_words_list: nd,te,ba,alls,ist,fo,ans,crate,ede,hel,optimizer,capevolve,noteb,fpr
+
+  lint-skills:
+    name: Skill authoring lint (dogfood)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      # The bar cap-evolve ships to users (skill-package/scripts/abstract.py) applied
+      # to cap-evolve's own bundled skills. Discovery is a glob, so a NEW skill is
+      # linted the day it lands, and MIN_SKILLS fails loudly if one vanishes.
+      - name: Lint every bundled SKILL.md against the authoring bar
+        run: python skills/_registry/lint_skills.py skills
+
+      - name: Rebuild the skill registry manifest
+        run: python skills/_registry/build_manifest.py skills
 
 # Made with Bob

--- a/core/tests/test_skill_authoring_lint.py
+++ b/core/tests/test_skill_authoring_lint.py
@@ -1,0 +1,100 @@
+"""The framework's own bundled skills pass the authoring bar it ships to users.
+
+Guards the dogfooding lint itself, not just its verdict: the discovery must be
+dynamic, the count floor must actually fire, and each promoted warning must still
+be reachable — so a reworded message in `skill-package/scripts/abstract.py` breaks a
+test instead of silently turning a lint error back into a no-op.
+"""
+
+import importlib.util
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+SKILLS = REPO / "skills"
+LINT = SKILLS / "_registry" / "lint_skills.py"
+
+
+def _lint_module():
+    spec = importlib.util.spec_from_file_location("lint_skills", LINT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_bundled_skills_pass_the_authoring_bar():
+    out = subprocess.run([sys.executable, str(LINT), str(SKILLS)],
+                         capture_output=True, text=True)
+    assert out.returncode == 0, out.stdout + out.stderr
+    assert "ERROR" not in out.stdout, out.stdout
+
+
+def test_discovery_is_dynamic_and_sees_every_skill():
+    """The lint globs; it never reads a committed list that could go stale."""
+    mod = _lint_module()
+    on_disk = {p.parent.relative_to(SKILLS).as_posix()
+               for p in SKILLS.glob("*/*/SKILL.md")}
+    _, _, n = mod.lint(SKILLS)
+    assert n == len(on_disk) >= mod.MIN_SKILLS, (n, sorted(on_disk))
+
+
+def test_count_floor_fires_when_a_skill_disappears(tmp_path):
+    """Non-vacuity: renaming/removing a skill dir must FAIL, not silently shrink
+    coverage (the failure mode #189's manifest guard and #192's denylist had)."""
+    root = tmp_path / "skills"
+    shutil.copytree(SKILLS, root, ignore=shutil.ignore_patterns("__pycache__", "*.pyc"))
+    shutil.rmtree(root / "phases" / "gate")
+    out = subprocess.run([sys.executable, str(LINT), str(root)],
+                         capture_output=True, text=True)
+    assert out.returncode == 1, out.stdout
+    assert "lint coverage" in out.stdout, out.stdout
+
+
+def _oversized_body(n_lines: int = 600) -> str:
+    filler = "\n".join(f"Line {i} of deliberately verbose body prose." for i in range(n_lines))
+    return ("---\nname: fixture-skill\ndescription: A fixture skill. Use when "
+            "proving the lint fails a body over the bar.\n---\n\n# Fixture\n\n" + filler)
+
+
+def test_an_oversized_body_fails_the_lint(tmp_path):
+    root = tmp_path / "skills"
+    shutil.copytree(SKILLS, root, ignore=shutil.ignore_patterns("__pycache__", "*.pyc"))
+    (root / "phases" / "fixture-skill").mkdir()
+    (root / "phases" / "fixture-skill" / "SKILL.md").write_text(_oversized_body(),
+                                                                encoding="utf-8")
+    out = subprocess.run([sys.executable, str(LINT), str(root)],
+                         capture_output=True, text=True)
+    assert out.returncode == 1, out.stdout
+    assert "phases/fixture-skill" in out.stdout and "lines (>" in out.stdout, out.stdout
+
+
+def test_an_empty_placeholder_reference_fails_the_lint(tmp_path):
+    """CONTRIBUTING: references count only when FILLED."""
+    root = tmp_path / "skills"
+    shutil.copytree(SKILLS, root, ignore=shutil.ignore_patterns("__pycache__", "*.pyc"))
+    refs = root / "phases" / "gate" / "references"
+    (refs / "stub.md").write_text("# Stub\n\nTODO: write this.\n", encoding="utf-8")
+    out = subprocess.run([sys.executable, str(LINT), str(root)],
+                         capture_output=True, text=True)
+    assert out.returncode == 1, out.stdout
+    assert "stub.md" in out.stdout, out.stdout
+
+
+def test_promoted_fragments_still_match_the_validators_wording(tmp_path):
+    """Each PROMOTED fragment must be reachable from a real violation. If abstract.py
+    rewords a warning, this fails loudly rather than the lint quietly going blind."""
+    mod = _lint_module()
+    validator = mod._load_validator(SKILLS)
+    cap = tmp_path / "cap"
+    (cap / "references" / "nested").mkdir(parents=True)
+    (cap / "SKILL.md").write_text(
+        _oversized_body(1400) + "\n\nSee [gone](references/gone.md).\n", encoding="utf-8")
+    long_ref = "\n".join(f"detail line {i}" for i in range(400))
+    (cap / "references" / "long.md").write_text("# Long\n" + long_ref, encoding="utf-8")
+    (cap / "references" / "nested" / "deep.md").write_text("# Deep\n", encoding="utf-8")
+
+    warnings = validator.validate(cap)["warnings"]
+    for frag in mod.PROMOTED:
+        assert any(frag in w for w in warnings), (frag, warnings)

--- a/core/tests/test_skill_authoring_lint.py
+++ b/core/tests/test_skill_authoring_lint.py
@@ -1,7 +1,7 @@
 """The framework's own bundled skills pass the authoring bar it ships to users.
 
 Guards the dogfooding lint itself, not just its verdict: the discovery must be
-dynamic, the count floor must actually fire, and each promoted warning must still
+dynamic, the coverage-drift check must actually fire, and each promoted warning must still
 be reachable — so a reworded message in `skill-package/scripts/abstract.py` breaks a
 test instead of silently turning a lint error back into a no-op.
 """
@@ -37,10 +37,11 @@ def test_discovery_is_dynamic_and_sees_every_skill():
     on_disk = {p.parent.relative_to(SKILLS).as_posix()
                for p in SKILLS.glob("*/*/SKILL.md")}
     _, _, n = mod.lint(SKILLS)
-    assert n == len(on_disk) >= mod.MIN_SKILLS, (n, sorted(on_disk))
+    assert n == len(on_disk), (n, sorted(on_disk))
+    assert not mod._manifest_drift(SKILLS)
 
 
-def test_count_floor_fires_when_a_skill_disappears(tmp_path):
+def test_coverage_drift_fires_when_a_skill_disappears(tmp_path):
     """Non-vacuity: renaming/removing a skill dir must FAIL, not silently shrink
     coverage (the failure mode #189's manifest guard and #192's denylist had)."""
     root = tmp_path / "skills"
@@ -49,7 +50,25 @@ def test_count_floor_fires_when_a_skill_disappears(tmp_path):
     out = subprocess.run([sys.executable, str(LINT), str(root)],
                          capture_output=True, text=True)
     assert out.returncode == 1, out.stdout
-    assert "lint coverage" in out.stdout, out.stdout
+    assert "renamed/moved/removed" in out.stdout, out.stdout
+
+
+def test_coverage_drift_fires_on_rename_away_plus_add_new(tmp_path):
+    """The case a `n < MIN_SKILLS` floor could NOT see: removing one skill and adding
+    another in the same commit nets to the same count. Comparing PATH SETS against the
+    committed manifest catches it; comparing counts would not."""
+    root = tmp_path / "skills"
+    shutil.copytree(SKILLS, root, ignore=shutil.ignore_patterns("__pycache__", "*.pyc"))
+    shutil.rmtree(root / "phases" / "gate")
+    (root / "phases" / "newskill").mkdir()
+    (root / "phases" / "newskill" / "SKILL.md").write_text(
+        "---\nname: newskill\ndescription: A replacement skill. Use when proving the "
+        "coverage guard sees a rename balanced by an addition.\n---\n\n# New\n\nBody.\n",
+        encoding="utf-8")
+    out = subprocess.run([sys.executable, str(LINT), str(root)],
+                         capture_output=True, text=True)
+    assert out.returncode == 1, out.stdout
+    assert "phases/newskill" in out.stdout and "phases/gate" in out.stdout, out.stdout
 
 
 def _oversized_body(n_lines: int = 600) -> str:
@@ -80,6 +99,75 @@ def test_an_empty_placeholder_reference_fails_the_lint(tmp_path):
                          capture_output=True, text=True)
     assert out.returncode == 1, out.stdout
     assert "stub.md" in out.stdout, out.stdout
+
+
+def test_block_scalar_descriptions_are_actually_parsed(tmp_path):
+    """`description: >-` used to parse as the literal '>-' (len 2), so EVERY
+    description check — including the XML-tag hard problem — passed vacuously on
+    `algorithms/evograph`. The parser must read the folded value, and the checks must
+    then fire on it."""
+    mod = _lint_module()
+    validator = mod._load_validator(SKILLS)
+
+    for mark, joined in ((">-", "first line second line"), ("|", "first line\nsecond line")):
+        fm, body = validator._parse_frontmatter(
+            f"---\nname: fixture\ndescription: {mark}\n  first line\n"
+            f"  second line\ncomponent: phase\n---\n\nBody.\n")
+        assert fm["description"] == joined, (mark, fm)
+        assert fm["component"] == "phase", fm     # keys AFTER the block still parse
+        assert body.strip() == "Body."
+
+    cap = tmp_path / "cap"
+    cap.mkdir()
+    (cap / "SKILL.md").write_text(
+        "---\nname: fixture\ndescription: >-\n  Does a thing. Use when proving the\n"
+        "  parser reads a folded scalar. Wrap it in <X> tags.\n---\n\n# Fixture\n",
+        encoding="utf-8")
+    problems = validator.validate(cap)["problems"]
+    assert any("XML tags" in p for p in problems), problems
+
+    # every shipped description is really parsed, not silently truncated to a marker
+    for skill_md in sorted(SKILLS.glob("*/*/SKILL.md")):
+        fm, _ = validator._parse_frontmatter(skill_md.read_text(encoding="utf-8"))
+        assert len(fm.get("description", "")) > 100, (skill_md, fm.get("description"))
+
+
+def test_say_when_advisory_accepts_positional_when_phrasing():
+    """The advisory demanded the literal bigram 'use when', so nine descriptions that
+    state WHEN positionally ('Use after intake') were false positives. Rewording them
+    to green a regex would be a downgrade; the check accepts both forms instead."""
+    mod = _lint_module()
+    validator = mod._load_validator(SKILLS)
+    for desc in ("Scores a candidate. Use when you need a number.",
+                 "Establishes the starting point. Use after implement-and-check.",
+                 "Applies the acceptance decision. Use to inspect one decision.",
+                 "Extracts the learning signal. Use between evaluation and edits."):
+        assert validator.SAYS_WHEN_RE.search(desc), desc
+    assert not validator.SAYS_WHEN_RE.search("Processes documents and returns text.")
+
+
+def test_long_reference_needs_a_real_toc_not_just_a_heading(tmp_path):
+    """The TOC check was near-tautological: any '## ' in the first 1500 chars satisfied
+    it, so a 400-line reference whose first heading is ordinary prose passed. It must
+    require an actual list of anchor links."""
+    mod = _lint_module()
+    validator = mod._load_validator(SKILLS)
+    long_body = "\n".join(f"detail line {i}" for i in range(400))
+
+    cap = tmp_path / "noToc"
+    (cap / "references").mkdir(parents=True)
+    (cap / "SKILL.md").write_text(
+        "---\nname: fixture\ndescription: A fixture. Use when proving the TOC check "
+        "needs anchor links.\n---\n\n# F\n", encoding="utf-8")
+    (cap / "references" / "long.md").write_text(
+        "# Long\n\n## Just a normal first section, no TOC at all\n\n" + long_body,
+        encoding="utf-8")
+    assert any("table of contents" in w for w in validator.validate(cap)["warnings"])
+
+    toc = "\n".join(f"- [Section {i}](#section-{i})" for i in range(4))
+    (cap / "references" / "long.md").write_text(
+        f"# Long\n\n{toc}\n\n## Section 0\n\n" + long_body, encoding="utf-8")
+    assert not any("table of contents" in w for w in validator.validate(cap)["warnings"])
 
 
 def test_promoted_fragments_still_match_the_validators_wording(tmp_path):

--- a/skills/_registry/lint_skills.py
+++ b/skills/_registry/lint_skills.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Dogfood the skill-package authoring lint on cap-evolve's OWN bundled skills.
+
+The framework ships `skills/capabilities/skill-package/scripts/abstract.py` to
+enforce the Agent-Skills authoring rules on *user* skills. This script points the
+same validator at `skills/*/*/SKILL.md` so the framework is held to the bar it
+advertises, and fails the build (nonzero exit) on any violation.
+
+Two deliberate differences from the shipped `validate()`:
+
+1. **Structural authoring warnings are ERRORS here.** `validate()` reports body
+   size / reference nesting / missing-TOC / broken links as *warnings* because an
+   optimizer mid-run should not be hard-blocked by a style budget. For the repo's
+   own skills there is no such excuse, so `PROMOTED` turns them into failures.
+   Description *style* heuristics (POV, all-caps, "say WHEN", truncation risk) stay
+   advisory — they are judgement calls, not measurable violations.
+2. **Empty template placeholders fail** (CONTRIBUTING's "only when filled" rule):
+   a reference file that is a stub or still carries TODO/TBD/FIXME scaffolding.
+
+Discovery is dynamic (a glob, never a committed list) so a NEW skill is linted the
+day it lands. `MIN_SKILLS` is the anti-vacuity guard: a renamed/deleted skill dir
+makes the glob return fewer packages and the lint fails loudly instead of silently
+shrinking its own coverage.
+
+Usage: python skills/_registry/lint_skills.py [skills_root]
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import sys
+from pathlib import Path
+
+# Anti-vacuity floor: the repo has 20 skill packages today. Fewer means the glob
+# stopped seeing something — a rename, a move, a deletion — and coverage silently
+# dropped. Raise this when skills are added; never lower it to make CI pass.
+MIN_SKILLS = 20
+
+# `validate()` warnings that are objectively measurable authoring violations, keyed
+# by a stable fragment of the message. Anything not matched here stays advisory.
+# Coupled to abstract.py's wording on purpose; test_skill_authoring_lint.py proves
+# each of these still fires, so a reworded warning breaks the test, not the lint.
+PROMOTED = (
+    "lines (>",              # body over MAX_BODY_LINES
+    "tokens (>",             # body over MAX_BODY_TOKENS
+    "level deep",            # references/ nested more than one level
+    "table of contents",     # long reference with no early TOC
+    "does not exist",        # SKILL.md points at a missing reference/script
+)
+
+PLACEHOLDER_RE = re.compile(r"\b(TODO|TBD|FIXME|XXX)\b|<(placeholder|fill[- ]in)>", re.I)
+MIN_REF_LINES = 5           # below this a reference file is a stub, not a document
+
+
+def _load_validator(skills_root: Path):
+    path = skills_root / "capabilities" / "skill-package" / "scripts" / "abstract.py"
+    if not path.is_file():
+        raise SystemExit(f"lint_skills: cannot find the validator at {path}")
+    spec = importlib.util.spec_from_file_location("skill_package_abstract", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _placeholder_errors(skill_dir: Path) -> list[str]:
+    """Empty / still-templated reference files (CONTRIBUTING: 'only when filled')."""
+    errors = []
+    refs = skill_dir / "references"
+    if not refs.is_dir():
+        return errors
+    for f in sorted(refs.rglob("*.md")):
+        text = f.read_text(encoding="utf-8")
+        rel = f.relative_to(skill_dir).as_posix()
+        if len(text.strip().splitlines()) < MIN_REF_LINES:
+            errors.append(f"{rel} is an empty/stub reference "
+                          f"(<{MIN_REF_LINES} lines) — fill it or delete it")
+        hit = PLACEHOLDER_RE.search(text)
+        if hit:
+            errors.append(f"{rel} still contains the template placeholder "
+                          f"{hit.group(0)!r}")
+    return errors
+
+
+def lint(skills_root: Path) -> tuple[dict[str, list[str]], list[str], int]:
+    """Return (per-skill errors, per-skill advisories, number of skills linted)."""
+    validator = _load_validator(skills_root)
+    errors: dict[str, list[str]] = {}
+    advisories: dict[str, list[str]] = {}
+    skills = sorted(skills_root.glob("*/*/SKILL.md"))
+    for skill_md in skills:
+        skill_dir = skill_md.parent
+        key = skill_dir.relative_to(skills_root).as_posix()
+        v = validator.validate(skill_dir)
+        errs = list(v["problems"])
+        advs = []
+        for w in v["warnings"]:
+            (errs if any(frag in w for frag in PROMOTED) else advs).append(w)
+        errs += _placeholder_errors(skill_dir)
+        if errs:
+            errors[key] = errs
+        if advs:
+            advisories[key] = advs
+    return errors, advisories, len(skills)
+
+
+def main(argv: list[str]) -> int:
+    root = Path(argv[1] if len(argv) > 1 else "skills").resolve()
+    errors, advisories, n = lint(root)
+
+    print(f"skill authoring lint — {n} skill package(s) under {root}")
+    for key in sorted(errors):
+        for e in errors[key]:
+            print(f"  ERROR   {key}: {e}")
+    for key in sorted(advisories):
+        for a in advisories[key]:
+            print(f"  advise  {key}: {a}")
+
+    if n < MIN_SKILLS:
+        print(f"  ERROR   discovery: found {n} skill packages, expected at least "
+              f"{MIN_SKILLS} — a skill was renamed/removed and lint coverage "
+              f"silently dropped")
+        return 1
+    if errors:
+        print(f"FAIL — {sum(len(v) for v in errors.values())} authoring violation(s) "
+              f"in {len(errors)} skill(s)")
+        return 1
+    print(f"OK — {n} skill packages pass the authoring bar "
+          f"({len(advisories)} advisory note(s))")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/skills/_registry/lint_skills.py
+++ b/skills/_registry/lint_skills.py
@@ -15,12 +15,17 @@ Two deliberate differences from the shipped `validate()`:
    Description *style* heuristics (POV, all-caps, "say WHEN", truncation risk) stay
    advisory — they are judgement calls, not measurable violations.
 2. **Empty template placeholders fail** (CONTRIBUTING's "only when filled" rule):
-   a reference file that is a stub or still carries TODO/TBD/FIXME scaffolding.
+   a `references/*.md` file that is a stub or still carries TODO/TBD/FIXME
+   scaffolding. Scoped to references on purpose: `XXX` appears legitimately in four
+   SKILL.md bodies (`run_XXXX` in example commands), so scanning bodies would be
+   noise. A SKILL.md body is NOT placeholder-checked.
 
 Discovery is dynamic (a glob, never a committed list) so a NEW skill is linted the
-day it lands. `MIN_SKILLS` is the anti-vacuity guard: a renamed/deleted skill dir
-makes the glob return fewer packages and the lint fails loudly instead of silently
-shrinking its own coverage.
+day it lands. The anti-vacuity guard cross-checks that glob against the committed
+`manifest.json` — two independent views of the same tree that must agree — so a
+rename/move/deletion fails loudly even when an addition in the same commit keeps the
+total unchanged. CI pins the manifest itself with `git diff --exit-code`, so neither
+side can drift unreviewed and there is no magic floor anyone must remember to bump.
 
 Usage: python skills/_registry/lint_skills.py [skills_root]
 """
@@ -28,14 +33,10 @@ Usage: python skills/_registry/lint_skills.py [skills_root]
 from __future__ import annotations
 
 import importlib.util
+import json
 import re
 import sys
 from pathlib import Path
-
-# Anti-vacuity floor: the repo has 20 skill packages today. Fewer means the glob
-# stopped seeing something — a rename, a move, a deletion — and coverage silently
-# dropped. Raise this when skills are added; never lower it to make CI pass.
-MIN_SKILLS = 20
 
 # `validate()` warnings that are objectively measurable authoring violations, keyed
 # by a stable fragment of the message. Anything not matched here stays advisory.
@@ -61,6 +62,25 @@ def _load_validator(skills_root: Path):
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
     return mod
+
+
+def _manifest_drift(skills_root: Path) -> str:
+    """Anti-vacuity: the glob and the committed manifest are two independent views of
+    the same tree and must agree. A floor (`n < 20`) misses rename-away + add-new in
+    one commit; comparing the PATH SETS catches it, and needs no magic number."""
+    manifest = skills_root / "_registry" / "manifest.json"
+    if not manifest.is_file():
+        return f"the committed manifest is missing at {manifest}"
+    listed = {s["path"] for s in
+              json.loads(manifest.read_text(encoding="utf-8"))["skills"].values()}
+    found = {p.parent.relative_to(skills_root).as_posix()
+             for p in skills_root.glob("*/*/SKILL.md")}
+    if found == listed:
+        return ""
+    return (f"{len(found)} skill package(s) on disk do not match the {len(listed)} in "
+            f"manifest.json — on disk only: {sorted(found - listed) or 'none'}; in "
+            f"manifest only: {sorted(listed - found) or 'none'}. A skill was "
+            f"renamed/moved/removed; rebuild the manifest and re-review coverage")
 
 
 def _placeholder_errors(skill_dir: Path) -> list[str]:
@@ -116,10 +136,9 @@ def main(argv: list[str]) -> int:
         for a in advisories[key]:
             print(f"  advise  {key}: {a}")
 
-    if n < MIN_SKILLS:
-        print(f"  ERROR   discovery: found {n} skill packages, expected at least "
-              f"{MIN_SKILLS} — a skill was renamed/removed and lint coverage "
-              f"silently dropped")
+    drift = _manifest_drift(root)
+    if drift:
+        print(f"  ERROR   discovery: {drift}")
         return 1
     if errors:
         print(f"FAIL — {sum(len(v) for v in errors.values())} authoring violation(s) "

--- a/skills/capabilities/skill-package/scripts/abstract.py
+++ b/skills/capabilities/skill-package/scripts/abstract.py
@@ -232,8 +232,11 @@ def _validate_one(capability_dir: Path) -> dict:
                 warnings.append(f"references/{f.name} is {ln} lines without an early "
                                 "table of contents")
 
-    # broken reference links the body points at
+    # broken reference links the body points at. A Markdown link may carry an
+    # anchor ("references/x.md#a-heading"); the anchor is not part of the path, so
+    # strip it before the existence check or every deep link reads as broken.
     for rel in re.findall(r"\(((?:references|scripts|assets)/[^)\s]+)\)", body):
+        rel = rel.split("#", 1)[0]
         if not (capability_dir / rel).exists():
             warnings.append(f"SKILL.md references '{rel}' which does not exist")
 

--- a/skills/capabilities/skill-package/scripts/abstract.py
+++ b/skills/capabilities/skill-package/scripts/abstract.py
@@ -32,10 +32,20 @@ from pathlib import Path
 NAME_RE = re.compile(r"^[a-z0-9-]{1,64}$")
 FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---", re.S)
 XML_TAG_RE = re.compile(r"</?[a-zA-Z][^>]*>")  # an actual tag, not a stray "<"
+BLOCK_SCALAR_RE = re.compile(r"^([>|])[+-]?\d*$")  # "description: >-" and friends
+# WHEN can be stated conditionally ("Use when …") or positionally/imperatively
+# ("Use after intake", "Use as the last evaluation step") — both are real triggering
+# signals, so demanding the literal "use when" bigram flags good descriptions.
+SAYS_WHEN_RE = re.compile(
+    r"\bwhen\b|\buse (after|before|as|at|to|between|right|during|only|this|the moment)\b",
+    re.I)
 MAX_BODY_LINES = 500
 MAX_BODY_TOKENS = 5000            # ~chars/4; Level-2 body budget
 CHARS_PER_TOKEN = 4
 LONG_REF_LINES = 300
+TOC_LINK_RE = re.compile(r"\]\(#[^)\s]+\)")   # an in-document anchor link
+TOC_SCAN_CHARS = 1500                         # "early" = within the first ~1.5k chars
+MIN_TOC_LINKS = 3                             # a list of links, not one stray cross-ref
 LISTING_CAP_CHARS = 1536          # description + when_to_use truncation in the listing
 LONG_DESC_CHARS = 1024            # hard cap; also the front-load advisory threshold
 
@@ -45,9 +55,30 @@ def _parse_frontmatter(text: str) -> tuple[dict, str]:
     if not m:
         return {}, text
     fm = {}
-    for line in m.group(1).splitlines():
-        if ":" in line and not line.startswith(" "):
-            k, _, v = line.partition(":")
+    lines = m.group(1).splitlines()
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        i += 1
+        if ":" not in line or line.startswith((" ", "\t")):
+            continue
+        k, _, v = line.partition(":")
+        blk = BLOCK_SCALAR_RE.match(v.strip())
+        if blk:
+            # A YAML block scalar ("description: >-") holds its value on the FOLLOWING
+            # indented lines. Without this the value parses as the literal ">-" and
+            # every description check below passes vacuously on it.
+            # ponytail: folds with spaces / keeps newlines for "|", and always strips.
+            # The +/-/digit chomping and indentation indicators only affect trailing
+            # whitespace, which no check here looks at.
+            chunk = []
+            while i < len(lines) and (not lines[i].strip()
+                                      or lines[i].startswith((" ", "\t"))):
+                chunk.append(lines[i].strip())
+                i += 1
+            joiner = " " if blk.group(1) == ">" else "\n"
+            fm[k.strip()] = joiner.join(c for c in chunk if c).strip()
+        else:
             fm[k.strip()] = v.strip().strip('"').strip("'")
     body = text[m.end():]
     return fm, body
@@ -194,7 +225,7 @@ def _validate_one(capability_dir: Path) -> dict:
             problems.append(f"description is {len(desc)} chars (>{LONG_DESC_CHARS})")
         if XML_TAG_RE.search(desc):
             problems.append("description must not contain XML tags")
-        if not re.search(r"\b(use when|when )\b", desc, re.I):
+        if not SAYS_WHEN_RE.search(desc):
             warnings.append("description should say WHEN to use the skill "
                             "('Use when …') — it is the primary triggering signal")
         # point-of-view drift: descriptions must be third person.
@@ -227,10 +258,16 @@ def _validate_one(capability_dir: Path) -> dict:
                 warnings.append(f"references/{sub.name}/ is nested >1 level deep; "
                                 "keep references one level deep")
         for f in refs.glob("*.md"):
-            ln = f.read_text(encoding="utf-8").count("\n") + 1
-            if ln > LONG_REF_LINES and "## " not in f.read_text(encoding="utf-8")[:1500]:
+            ref_text = f.read_text(encoding="utf-8")
+            ln = ref_text.count("\n") + 1
+            # A TOC is a LIST OF ANCHOR LINKS, not merely "some '## ' appears in the
+            # first 1500 chars" — that older condition was satisfied by ordinary prose,
+            # so the check was near-tautological.
+            if ln > LONG_REF_LINES and len(
+                    TOC_LINK_RE.findall(ref_text[:TOC_SCAN_CHARS])) < MIN_TOC_LINKS:
                 warnings.append(f"references/{f.name} is {ln} lines without an early "
-                                "table of contents")
+                                f"table of contents (needs >={MIN_TOC_LINKS} "
+                                "'[section](#anchor)' links up front)")
 
     # broken reference links the body points at. A Markdown link may carry an
     # anchor ("references/x.md#a-heading"); the anchor is not part of the path, so

--- a/skills/capabilities/tools/SKILL.md
+++ b/skills/capabilities/tools/SKILL.md
@@ -679,3 +679,8 @@ python scripts/run.py --path <capability_dir>     # candidate + policy + validit
   fill, toolset design, the policy) with cited sources.
 - [`references/examples.md`](references/examples.md) — worked before/after edits.
 - [`references/pitfalls.md`](references/pitfalls.md) — failure modes and how to detect them.
+- [`references/optimizer-playbook.md`](references/optimizer-playbook.md) — what the
+  authored optimizer INSTRUCTIONS must demand when `tools` is selected: the
+  existing-tool-code mandate, the depth mandate's tools wording, and the two-phase
+  (diagnose fan-out → implement fan-out → merge) subagent pattern. `intake` points
+  here rather than inlining it.

--- a/skills/capabilities/tools/SKILL.md
+++ b/skills/capabilities/tools/SKILL.md
@@ -20,347 +20,74 @@ all fair game.
 Use this capability when the agent OWNS its tools — it implements the handlers and
 controls the wire schema, so the code itself is editable. (When the tools come from an
 external server you can only re-describe, not re-implement, the action policy here is
-tightened to documentation-only edits.)
+tightened to documentation-only edits — that is the `mcp-tool` capability.)
 
-## What you can change here
+**Read this skill, then read [`references/edit-playbook.md`](references/edit-playbook.md)
+before editing** — the playbook holds the eight levers in depth, the before/after
+diffs, the three code-bearing patterns, and the safe tool-replacement protocol.
 
-**The tool's docstring AND its return value are what the agent SEES — make both
-clear and recovery-oriented.** The doc surface (description, important-notes,
-per-param, `Raises:`, examples) drives *which* tool the model calls and *how* it
-fills the arguments; the return value (and especially the error text) steers the
-*next* turn. Each lever below is an edit class; in ONE pass, apply EVERY edit class
-the traces call for — a validation wrapper AND a loop tool AND enriched
-returns/errors AND doc fixes across all implicated tools can and should all ship in
-the same candidate. (1-line generic examples; worked bodies in
-[`references/examples.md`](references/examples.md), depth below and in
-[`references/concepts.md`](references/concepts.md).)
+## The core rule
 
-**Read this skill in full before editing. Ship MULTIPLE fixes per iteration — but
-every one must be REAL (targets a currently-failing task), SAFE (cannot change a
-passing task's behavior), and VERIFIED (proven to fix its target).** Several such fixes
-beat a long list that includes a speculative edit: one edit that regresses a passing
-task can sink the whole candidate at the gate. Quality over churn — never add an edit
-to hit a count, and never re-add a rule/tool the run already tried and rejected.
+**A deterministic guard in code beats a sentence in a prompt.** A docstring or
+prompt rule only makes the model *more likely* to comply; code makes the right
+behavior the only thing that can happen. So the DEFAULT edit is: find the EXISTING
+tool that owns the violated rule and put a scoped guard in its body.
 
-**Per-change SAFETY (the rule that makes multi-change work).** Scope every guard to fire
-ONLY on the exact violating condition, and check its blast radius: run it on the args of
-1–2 currently-PASSING tasks that use the same tool and confirm it does NOT fire. A guard
-that fires on a passing task is a regression — rescope or drop it. This is how you ship
-many changes without net-zero churn.
+**Ship MULTIPLE fixes per iteration — but every one must be REAL** (targets a
+currently-failing task), **SAFE** (cannot change a passing task's behavior), and
+**VERIFIED** (proven to fix its target). Several such fixes beat a long list that
+includes a speculative edit: one edit that regresses a passing task can sink the
+whole candidate at the gate. Quality over churn — never add an edit to hit a count,
+and never re-add a rule/tool the run already tried and rejected.
 
-**Pick the lever by failure type — the in-body guard is the DEFAULT strong move:**
-- **Edit the BODY of an EXISTING tool (reach for this FIRST for a rule violation).** When
-  the agent VIOLATES a rule a tool already owns (a wrong field value, an id not on file,
-  an action on a record whose state forbids it), convert the prose rule into a scoped
-  in-body guard. This is the highest-yield, lowest-regression edit; expect to touch
-  SEVERAL existing bodies in one iteration.
-- **ADD a NEW code-bearing tool — for a genuine CAPABILITY GAP or action STALL.** A
-  composite atomic-WRITE tool for a multi-step action the agent narrates/confirms then
-  fails to execute is the canonical case (the primitive is what it skips; the composite
-  makes the action un-skippable; then REMOVE the raw primitives). New tools are
-  available and encouraged WHEN they close a real gap — but add one ONLY if the agent
-  will actually call it AND it changes the graded outcome. Do NOT add read/compute/summary
-  helper tools that a guard or a prompt line would subsume, and never add a tool just to
-  "ship a new tool" — that is churn the gate punishes.
+**Per-change SAFETY (the rule that makes multi-change work).** Scope every guard to
+fire ONLY on the exact violating condition, and check its blast radius: run it on the
+args of 1–2 currently-PASSING tasks that use the same tool and confirm it does NOT
+fire. A guard that fires on a passing task is a regression — rescope or drop it.
 
-- **DECISION / PERMISSION cluster → a discriminating-predicate guard (the BOUNDED-blast-
-  radius alternative to a prompt change).** When a cluster is about ACT-vs-REFUSE (the
-  agent acted where it should have refused/escalated, or vice versa), the WRONG fix is
-  loosening a global decision rule in the prompt — that has UNBOUNDED blast radius and
-  regresses every task where the original behavior was gold. The RIGHT fix lives here:
-  an in-body guard on the tool that owns the action, expressing the EXACT policy
-  predicate, that refuses/raises ONLY when the qualifying condition is/isn't met. It
-  fires only on the narrow violating condition, so its blast radius is bounded to the
-  failing inputs — the SAFEST edit, preferred over any prompt/permission change.
-- **HARD-ZERO / capability-gap cluster → a REAL targeted tool, never prose.** A task
-  scoring 0.00 that needs a compute / composite / discriminating-predicate tool stays
-  0.00 after any docstring or prompt reword. Ship a tool the agent will CALL that
-  changes the graded state.
+**Generalize, never hardcode.** A guard must fire on the GENERAL condition that
+defines the failure class, never on a literal value from one task. *Good:* `if
+payment_id not in user_payment_methods: raise ...`. *Bad:* `if record_id ==
+"<TASK_SPECIFIC_ID>": raise ...` — that overfits, gets rejected by the held-out gate,
+and helps nothing else.
 
-The two failure modes to avoid: (1) leaving a rule the agent keeps breaking as loose
-prose instead of a guard, or loosening a global permission rule (unbounded regression)
-instead of a scoped guard; (2) padding the candidate with low-value helper tools or
-cosmetic rewrites that move no graded task.
+**Prose cannot fix a BEHAVIORAL failure.** If the agent *does not know* something,
+prose can teach it — a KNOWLEDGE gap belongs in the prompt. But if it demonstrably
+knows what to do, narrates the plan, even gets confirmation, and then **fails to call
+the action tool and stops**, more prose will not fix it. Move the behavior into code.
 
-1. **Edit the CODE of EXISTING tools to enforce rules deterministically (the most
-   common high-leverage edit)** — most violated textual rules govern a tool that
-   ALREADY exists, and the fix is an in-body guard *there*, not a new tool. Bake the
-   precondition / normalization / actionable refusal into the body so correctness
-   doesn't depend on the LLM. *Ex:* add `if not rec["cancellable"]: raise
-   ValueError("not cancellable; reason=...; do X instead")` to the existing
-   `cancel_record` body. Expect to touch the BODIES of SEVERAL existing tools per
-   iteration — one per violated rule.
-2. **Add a new tool (first-class — reach for it freely)** — give the agent a
-   capability it lacks or a safe path it keeps skipping, built as a thoughtful
-   workflow/validation tool, not a thin wrapper. *Ex:* `search_logs` returns only
-   the relevant lines instead of a raw dump; or a `find_duplicate_records` the agent
-   has no way to compute today. For a STALL or capability-gap cluster this is the
-   right move even when a primitive exists — see item 7 (composite atomic-WRITE).
-3. **Replace / wrap a tool** — superset an existing tool and route the old behavior
-   through it. *Ex:* wrap `find_record`+`charge_payment` behind one
-   `charge_record(record_id)` that resolves then charges.
-4. **Improve a tool's documentation** — sharpen description / important-notes /
-   `Raises:` / per-param docs / examples; rename for least surprise. *Ex:*
-   `lookup(record)` → `get_record(record_id: str)` with "returns an error object if
-   not found."
-5. **Improve RETURN VALUES for recoverability** — high-signal fields, stable
-   human-readable ids, and **actionable error text with a next-step hint and what
-   NOT to do**. *Ex:* error returns "payment method not on file; available:
-   ['card_1'] — pass one of these" instead of a raw traceback.
-6. **Add a loop tool** — replace N repeated single-item calls with one list call.
-   *Ex:* `get_records(ids: [...])` replaces N× `get_record(id)`.
-7. **Add a composite atomic-WRITE / workflow tool (first-class — the fix for STALLS
-   and multi-step writes)** — for a recurring, failure-prone multi-step action
-   (especially one the agent narrates/confirms then fails to execute, e.g. a
-   multi-step update that must cancel/undo then re-create a record), a deterministic
-   tool whose body performs ALL the steps in order via the
-   existing primitives, then `remove` the raw primitives so the action is
-   un-skippable. *Ex:* `apply_change_plan(record_id, steps)` validates → applies each
-   → returns final state as one reliable call. Reach for this whenever a cluster
-   STALLS at the action boundary — do not settle for a prose "be sure to act" rule.
-8. **Remove-with-replacement** — remove a redundant/overlapping tool *only* after a
-   replacement preserving its capability exists. *Ex:* drop `query` once
-   `get_record` + `search_records` cover it.
+## Pick the lever by failure type
 
-**Before/after — convert a violated prose rule into an in-body guard (the default
-edit).** The rule "a record can only be cancelled when it is cancellable" lives as
-prose in the prompt and the agent keeps breaking it. Don't add a tool — edit the
-EXISTING `cancel_record` body:
+Full detail for every row: [`references/edit-playbook.md`](references/edit-playbook.md).
 
-```diff
-  def cancel_record(record_id):
-+     rec = get_record(record_id)
-+     if not rec["cancellable"]:
-+         raise ValueError(
-+             "not cancellable; reason=" + rec.get("status", "unknown")
-+             + "; do X instead (e.g. offer a change_record)")
-      return _backend.cancel(record_id)
-```
+| Failure signature in the traces | The edit |
+|---|---|
+| **A rule the agent keeps VIOLATING** (wrong field value, id not on file, action on a record whose state forbids it) | **In-body guard on the EXISTING tool that owns the rule** — the default, highest-yield, lowest-regression edit. Expect to touch SEVERAL bodies per iteration. |
+| **Wrong ARGUMENT the tool could validate** — right tool, bad argument; partial credit or a corrupted write | **Normalize-then-call wrapper**: resolve/validate the argument against current state; on mismatch return `available=[...]` or raise an actionable error. Never let a write proceed on an unvalidated reference. |
+| **Execution STALLS at the action/write boundary** — analyzes, explains, even confirms, then never calls the write tool | **Composite atomic-WRITE tool** whose body performs the whole sequence, then `remove` the raw primitives so the action is un-skippable. Not a "be sure to act" prose rule. |
+| **Escalate / bail-out abandoning a REQUIRED, eligible action** | Same composite WRITE tool (skip ineligible items with a recorded reason). The agent already *chose* to bail; only code removes the choice. |
+| **The same primitive called N times in a row** | **Loop tool** that takes the list and loops inside one call. |
+| **Recoverable error that strands the agent** — opaque traceback, agent retries the same bad call | **Enriched RETURN**: what's wrong + the valid options + the recommended next action. |
+| **DECISION / PERMISSION wrong (ACT vs REFUSE)** | **Discriminating-predicate guard** on the tool that owns the action, encoding the EXACT policy predicate. Do NOT loosen a global prompt rule — unbounded blast radius regresses every task the original behavior got right. |
+| **HARD-ZERO / capability gap** — a 0.00 task needing a compute/composite tool | **A REAL targeted tool the agent will CALL**, never a reword. A 0.00 stays 0.00 after any docstring change. |
+| **Mis-selection** — wrong tool, no tool where one applied, or an invented tool | **A documentation fix**: selection is driven almost entirely by the *name* and *description*. |
+| **Bad argument-filling** — right tool, wrong arguments (missing required field, wrong enum value, free text where an object was expected) | **A parameter-schema + per-parameter-description fix.** |
+| **A fumbled multi-call sequence** — the agent must chain `search` → `filter` → `fetch` and keeps getting the order or the glue wrong | **One well-named composite tool** that collapses the sequence. |
+| **Bloated / overlapping toolset**, or a real handler bug | Consolidate (`add` the superset, then `remove`); or just fix the code — you own it. |
 
-And the rule "amounts are in whole cents and the method must be on file" — edit the
-EXISTING `book` (or `charge`) body to normalize the field then raise an actionable
-error:
-
-```diff
-  def book(record_id, amount, payment_id):
-+     amount = int(round(amount))            # normalize: callers pass dollars
-+     methods = {m["id"] for m in get_record(record_id)["payment_methods"]}
-+     if payment_id not in methods:
-+         raise ValueError(
-+             f"payment method {payment_id!r} not on file; "
-+             f"available={sorted(methods)} — pass one of these")
-      return _backend.book(record_id, amount, payment_id)
-```
-
-Both fixes touch a tool that ALREADY exists; no new tool is needed. A docstring-only
-or new-tool-only iteration that leaves these rules as prose is under-used.
-
-**Guardrails (depth below):** encode deterministic logic in code, not prose (a
-tool body the model cannot skip beats a sentence it can forget); keep the toolset
-small and namespaced (aim **< ~20** active tools); ship correct, bug-free code
-(every code edit needs validation + a `validate` run); and **never remove a tool
-without a capability-preserving replacement** (add → verify → swap, see the SAFE
-TOOL-REPLACEMENT PROTOCOL).
-
-**Generalize, never hardcode.** Every in-code guard must fire on the GENERAL
-condition that defines the failure class, never on a literal value from one task.
-*Good:* `if payment_id not in user_payment_methods: raise ...`. *Bad:*
-`if record_id == "<TASK_SPECIFIC_ID>": raise ...` — that overfits to one task, gets
-rejected by the held-out gate, and helps nothing else. Use a failing task's
-specifics only to identify the class, then write the general check.
-
-A discriminating-predicate guard for a decision/permission cluster must encode the
-GENERAL policy condition that separates the qualifying cases from the rest (e.g.
-`if record.tier == "restricted" and action == "modify": raise ...`), NOT a global
-behavior flip and NOT a task literal. The guard NARROWS — it fires only on the cases
-the policy actually governs — so passing tasks outside that condition keep their
-behavior unchanged.
-
-## The highest-leverage edit: deterministic CODE (usually in an EXISTING tool body)
-
-**Start here. A deterministic guard in code beats a sentence in the prompt.** A
-docstring or system-prompt rule only makes the model *more likely* to comply — it
-can be forgotten, mis-read, or out-reasoned on the next task. Code (a precondition
-check, a normalization, a loop) makes the right behavior *the only thing that can
-happen* — it cannot be "forgotten." When the traces show a rule the agent keeps
-breaking, a multi-step action it keeps fumbling, or — most importantly — an action
-it *stalls on and never executes*, **do not just reword a description — put the
-behavior in code.**
-
-**Two code-bearing edits, chosen by failure type — both first-class.** For a rule
-VIOLATION, enforce the rule in the body of the EXISTING tool that owns it — "only
-cancel a cancellable record" governs `cancel_record`, "amounts in whole cents"
-governs `book`/`charge`; add an in-body guard there and expect to touch SEVERAL
-existing bodies per iteration. For a CAPABILITY GAP or an action STALL, write a NEW
-code-bearing tool — a loop tool to collapse a multi-call chain, or (the big one) a
-**composite atomic-WRITE tool** to encapsulate a multi-step write the agent keeps
-skipping. Do not treat the new tool as a last resort: when a cluster stalls at the
-action boundary, the composite is the *correct* fix even though a write primitive
-already exists, because the primitive is exactly what the agent declines to call.
-(See the before/after diffs above, the three patterns below, and the worked bodies
-in [`references/examples.md`](references/examples.md).)
-
-**Prose cannot fix a BEHAVIORAL failure.** There is a sharp distinction the
-optimizer must make. If the agent *does not know* something (a format, a rule, a
-decision criterion), prose can teach it — that is a KNOWLEDGE gap, and it belongs
-in the prompt. But if the agent demonstrably *knows* what to do and still doesn't
-do it — it analyzes the situation, explains the plan, even gets the user's
-confirmation, and then simply **fails to CALL the action tool and stops** — that
-is a BEHAVIORAL failure, and *more prose does not fix it*. You cannot instruct a
-model out of a behavior it already "agreed" to and then skipped. The only
-reliable fix is to move the behavior into CODE: encapsulate the whole action in a
-tool whose body performs it, so executing it is no longer a choice the model can
-decline mid-conversation. Telling the agent to "be sure to act" is exactly the
-kind of edit the traces show failing.
-
-Three patterns carry almost all the gain (worked bodies below and in
-[`references/examples.md`](references/examples.md)):
-
-1. **Validation / rule-enforcement tool (wrap, then delegate).** When a rule or
-   precondition that today lives only in the prompt is GENERAL — it always
-   applies, not just to one task — implement it as code in a NEW tool that:
-   validates / normalizes the inputs → enforces the rule → calls the existing
-   primitive → returns a clear result (or a clean refusal). Then **remove the raw
-   primitive from the exposed set** if the agent should only ever reach it
-   through the safe path. Example: `cancel_record_safely(record_id)` reads the
-   record, refuses unless it is cancellable, then calls the raw `cancel_record`.
-
-2. **Workflow / loop tool (collapse a recurring multi-step sequence).** When a
-   small multi-step workflow recurs, or the agent calls one primitive N times in
-   a row (and drops or mis-threads a result), implement it as ONE tool with real
-   loops/code that calls the existing tools internally and returns the finished
-   result. Example: a tool that loops over a list of ids calling `get_record`
-   once each and returns them aligned, instead of the agent issuing N calls.
-
-3. **Write / workflow COMPOSITE tool — make a stalled action un-skippable
-   (co-equal PRIMARY pattern).** This is the fix for the single most common
-   BEHAVIORAL failure: the agent reliably **stalls at the action/write boundary**
-   — it analyzes, explains, even confirms with the user, then never issues the
-   write call and stops, leaving the task half-done. The cure is *not* a stronger
-   rule. Encapsulate the ENTIRE multi-step action (analyze → confirm → act) as
-   ONE composite tool whose body performs *all* the steps in code — calling the
-   existing primitives in the right sequence and looping where needed — so the
-   action completes the moment the tool is called and **cannot be skipped
-   mid-conversation**. Then **`remove` the raw primitives** so the composite is
-   the only path; the safe, complete behavior is then the only behavior reachable.
-   Generic example: an `apply_change_plan(record_id, steps)` that performs a
-   multi-step update atomically — validating each step, applying them in order via
-   the existing write primitives, and returning the final state — so the agent
-   hands over the plan in one call instead of narrating it and then failing to
-   execute. (Worked body in [`references/examples.md`](references/examples.md) §3e.)
-
-**Lean caveat — replace, don't accumulate.** Every exposed tool enters the
-agent's context, and too many tools degrade selection (see §3 of concepts.md).
-So PREFER consolidating over piling on: when you add a safer or looped tool,
-**`remove` the now-redundant primitive** so the net tool count stays small and
-sharp. Do not add many narrow tools. One sharp tool that subsumes a primitive
-beats two overlapping ones.
-
-**SAFE TOOL-REPLACEMENT PROTOCOL (never bare-remove a tool).** To replace or
-consolidate a tool, follow these steps in order — never delete a tool without a
-replacement that subsumes it:
-
-1. **ADD a wrapper tool whose body CALLS the existing tool** — after validation,
-   normalization, or the extra steps you want guaranteed. The wrapper delegates to
-   the primitive; it does not re-implement it.
-2. **VERIFY** the wrapper (run `validate`; confirm the body actually calls the
-   primitive and returns a sane result).
-3. **Only then SWAP the registration**: `remove` the raw primitive from the active
-   / exposed set and register the wrapper as the path the agent uses.
-
-Bare-removing a primitive with no replacement strands every task that needed it
-("no applicable tool"); adding a wrapper but leaving the primitive exposed lets the
-model route around the guard and reproduce the original failure. The add-verify-swap
-order is what makes the safe path the *only* path without a coverage gap.
-
-**You must write the BODY.** A `compose`/`add`/`code` edit whose body is `...`,
-a bare `pass`, or docstring-only is NOT this edit — it does nothing. Emit a real
-implementation: the loop, the precondition check, the calls to the existing
-tools (`get_record(i)` — or `self.get_record(i)` if your adapter binds tools as
-methods). Worked examples with full bodies are below under
-[Add tools that call existing tools](#add-tools-that-call-existing-tools-the-highest-leverage-edit).
-
-**SECONDARY (last resort): passthrough / "think" / reasoning-only tools.** A tool
-whose body just returns (or echoes) its argument, with the actual rule living only
-in the *docstring* (e.g. a `think(thought)`/`check_policy(text)` tool that does no
-real work), is the WEAKEST form of this edit — it is prose wearing a tool's
-costume, and the model can ignore or mis-apply it exactly like any prompt sentence.
-**If a rule can be encoded as code, encode it as code** — validate, normalize, and
-enforce it in the body (patterns 1 and 2 above), don't leave it as docstring prose.
-Reach for a reasoning-only tool only when the behavior genuinely cannot be made
-deterministic (e.g. you want to *prompt* a planning step), never as a substitute
-for a check you could have written in a few lines of code.
-
-## How agents fail (and how tools fix it)
-
-Map the trace symptom to the code-bearing edit. Each row is a failure the model
-*could* "know" how to avoid yet keeps producing — so the fix is code, not prose:
-
-These four rows carry most of the recoverable gain — diagnose for them FIRST, and
-verify the fix you ship actually FIRES on the failing trace (run the new body on the
+**Diagnose for the first four rows FIRST** — they carry most of the recoverable gain.
+Verify the fix you ship actually FIRES on the failing trace (run the new body on the
 exact arguments from that trajectory; a guard that never triggers on the failing task
-is dead code, not a fix). These rows are independent: fix as MANY of them as appear in
-the trajectories in one candidate, not just the first — each guarded tool is its own
-bounded fix.
-
-| Trace symptom | Fix |
-|---------------|-----|
-| **Wrong ARGUMENT the tool could validate** — a write whose id / reference / count / unit is not consistent with the agent-visible state (an id not in the record, a count exceeding what's available, the wrong unit). Right tool, bad argument; partial credit or a corrupted write. | **Normalize-then-call wrapper**: wrap the write in a body that RESOLVES / VALIDATES the argument against the current state, and on mismatch returns `available=[...]` (the valid options) or raises an actionable error naming what's wrong and what to pass instead — never let a write proceed on an unvalidated reference. Coerce units, resolve ids, check the field is on file, then delegate to the primitive. |
-| **Escalate / bail-out abandoning a REQUIRED, eligible action** — the agent hands off or gives up when it could and should have completed the action itself; this is a behavioral STALL, not a missing capability. | **Composite WRITE tool**: encapsulate the eligible-action batch in ONE tool whose body executes the steps in code (skipping any ineligible item with a recorded reason), then `remove` the raw primitives so completing the batch is the only path. Do NOT add a "don't bail out" prose rule — the agent already chose to bail; only code removes the choice. |
-| **Recoverable error that strands the agent** — a tool raises an opaque traceback / bare code, the agent retries the same bad call or gives up. | **Enriched RETURN that aids recovery**: on a recoverable error, return what's wrong + the valid options + the recommended next action (e.g. `{"error": "id not found", "available": [...], "next": "call search_x to resolve the id"}`), so the model self-corrects on the next turn instead of repeating the failure. |
-| **Execution stalls at the action boundary** — the agent analyzes, explains, even confirms, then never calls the write tool and stops (the task is left half-done). | **Composite WRITE tool** (pattern 3): one tool whose body performs the whole analyze→confirm→act sequence, then `remove` the raw primitives so the action is un-skippable. |
-| **The same primitive called N times in a row** — looping over a list in the agent's own context, dropping or mis-threading results. | **Loop tool** (pattern 2): one tool that takes the list and loops inside a single call. |
-| **A rule stated in the prompt but repeatedly violated** — a required order ("read before write"), a precondition the API doesn't enforce. | **Validation wrapper** (pattern 1): enforce the rule in the tool body; `remove` the unguarded primitive. |
-
-The throughline: a failure the agent *knows better than* but still commits is
-behavioral, and behavioral failures are fixed by removing the choice — putting the
-behavior in code and `remove`-ing the path that let it go wrong.
-
-## When to use this
-
-Reach for `tools` when a trace shows one of these failure signatures:
-
-- **Execution stall at the action/write boundary (BEHAVIORAL)** — the agent
-  reaches the point of acting, narrates or confirms the action, then **fails to
-  call the write tool and stops**. This is not a knowledge gap and prose will not
-  fix it; encapsulate the whole action in a composite WRITE tool and remove the
-  raw primitives so completing it is the only path (§"highest-leverage edit",
-  pattern 3).
-- **Mis-selection** — the agent calls the wrong tool, or calls none when one
-  applied, or invents a tool that does not exist. Selection is driven almost
-  entirely by the tool *name* and *description*, so this is a documentation fix.
-- **Bad argument-filling** — the right tool, wrong arguments: a missing required
-  field, the wrong enum value, a free-text string where a structured object was
-  expected. This is a parameter-schema and per-parameter-description fix.
-- **Repeated multi-call sequences the agent fumbles** — the agent must chain
-  `search` → `filter` → `fetch` every time and keeps getting the order or the
-  glue wrong. A single well-named **composite** tool collapses the sequence.
-- **The same primitive called N times in a row** — the agent loops over a list
-  in *its own context* (calls `get_record(id)` once per id, or `search(a,b,date)`
-  once per date/route combination), burning turns and often dropping or
-  mis-threading a result. A tool that takes the **list** and loops *inside one
-  call* collapses N calls into 1.
-- **An invariant the model keeps violating** — a required order of operations
-  ("read before write"), a precondition the API does not itself enforce, or a
-  normalization the model forgets. A tool that **enforces the rule in code**
-  (validates, normalizes, or performs the steps in the right order) makes the
-  mistake impossible rather than merely discouraged.
-- **A DECISION / PERMISSION the model gets wrong (ACT vs REFUSE)** — the agent acts
-  where the policy says refuse/escalate (or refuses where it should act). Do NOT fix
-  this by loosening the global rule in the prompt — that changes behavior for the whole
-  class and regresses every task where the original behavior was correct (unbounded
-  blast radius). Encode the EXACT discriminating policy predicate as an in-body guard on
-  the tool that owns the action: it refuses/raises ONLY on the qualifying condition, so
-  its blast radius is bounded to the violating cases. This is the SAFE, preferred
-  alternative to a permission-rule prompt edit.
-- **A bloated or overlapping toolset** — too many tools, or several that do
-  nearly the same thing, distracting the agent. Remove or consolidate.
-- **A real behavioral bug in a handler** — the tool returns the wrong thing.
-  Because you own the code, you can fix it directly.
+is dead code, not a fix). The rows are independent: fix as MANY as appear in the
+trajectories in one candidate, not just the first — each guarded tool is its own
+bounded fix. The throughline: a failure the agent *knows better than* but still
+commits is behavioral, and behavioral failures are fixed by removing the choice —
+putting the behavior in code and `remove`-ing the path that let it go wrong. Each
+row's long-form symptom description and full fix recipe:
+[`references/edit-playbook.md`](references/edit-playbook.md#how-agents-fail-and-how-tools-fix-it--the-full-symptomfix-table).
 
 If the problem is *what the agent is told to do* rather than *what it can do*, it is
-out of scope for this capability (it belongs to whatever capability edits the agent's
-instructions).
+out of scope here (it belongs to whatever capability edits the agent's instructions).
 
 ## What can be optimized (default policy = all of these)
 
@@ -374,286 +101,73 @@ instructions).
 | `compose` | add a code-bearing tool that calls existing tools | enforce a rule, collapse a multi-call chain, or perform a whole stalled WRITE action in code — use when no existing tool owns the rule |
 | `add` / `remove` | introduce / delete a tool | shape and shrink the toolset (replace primitives; keep it lean) |
 
-The `code` row (editing an EXISTING tool's body) is the **first edit to reach
-for**, with `compose`/`add` close behind — a deterministic guard beats a sentence
-in a prompt (see below). For each violated rule, first ask "which EXISTING tool
-governs this, and what in-body check enforces it?" — usually the answer is editing
-that tool's body, not adding a new one. Reword descriptions *after* you've asked
-"can this rule be code in the existing body instead?" In ONE pass, apply EVERY edit
-class the traces call for — in-body guards across SEVERAL existing tools AND a loop
-tool where needed AND enriched returns/errors AND doc fixes across all implicated
-tools can and should all ship in the same candidate; do not stop after a single
-edit.
+The `code` row (editing an EXISTING tool's body) is the **first edit to reach for**,
+with `compose`/`add` close behind. For each violated rule, first ask "which EXISTING
+tool governs this, and what in-body check enforces it?" Reword descriptions *after*
+you've asked "can this rule be code in the existing body instead?" In ONE pass, apply
+EVERY edit class the traces call for — in-body guards across SEVERAL existing tools
+AND a loop tool where needed AND enriched returns/errors AND doc fixes across all
+implicated tools can and should all ship in the same candidate.
 
-Lock any of these off via `inputs/policy.json`. For example, in a frozen-API
-deployment you might allow only `["description", "params", "examples"]` so an
-optimizer can reword tools but never change the wire contract or the code.
-`apply()` refuses anything outside the allowed set and reports the refusal — it
-never silently drops or silently applies a disallowed edit.
+**You must write the BODY.** A `compose`/`add`/`code` edit whose body is `...`, a bare
+`pass`, or docstring-only is NOT this edit — it does nothing. Worked bodies:
+[`references/examples.md`](references/examples.md).
 
-## How tool-using agents actually read a tool
+**Never bare-remove a tool.** Add the wrapper → verify it → *then* swap the
+registration. Bare-removing strands every task that needed the primitive; leaving the
+primitive exposed lets the model route around the guard. Protocol:
+[`references/edit-playbook.md`](references/edit-playbook.md#the-safe-tool-replacement-protocol).
 
-An LLM never sees your implementation. At call time it sees, for every available
-tool, a serialized block of `{name, description, parameters-schema, examples}`
-injected into its context (this is literally how the Anthropic and OpenAI tool
-APIs work, and how an MCP host presents `tools/list` results). Two decisions
-follow, and each is driven by a different part of that block:
+**Keep the surface lean** — aim **< ~20** active tools; selection degrades sharply
+past that. When you add a safer or looped tool, `remove` the now-redundant primitive.
 
-1. **Selection** — *which* tool (or none) to call. Decided primarily from the
-   **name** and **description**. Anthropic's own guidance is blunt: the
-   description "is by far the most important factor in tool performance," and
-   they recommend at least 3–4 sentences covering *what the tool does, when to
-   use it, and when not to*. A name like `lookup` selects worse than
-   `get_order_by_id`.
-2. **Argument-filling** — *how* to populate the call. Decided from the
-   **parameter schema** (types, `required`, `enum`, descriptions) plus any
-   **examples**. An `enum` turns "guess a status string" into "pick from this
-   closed set"; prefer it for every closed value set, and use the provider's
-   **strict / schema-validated mode** where available so the model adheres to the
-   schema instead of guessing. A per-field description ("ISO-8601 date, e.g.
-   2025-06-14"; "amount in whole US cents") turns a malformed argument into a
-   correct one — always pin **units, format, and default** per parameter. Add
-   schema-validated **`input_examples`** for complex / nested / format-sensitive
-   params (a few help; long dumps hurt reasoning models). And **don't make the
-   model fill arguments you already know** — pass them in code (a wrapper) instead
-   of asking for them.
+Lock any action off via `inputs/policy.json`. For example, in a frozen-API deployment
+you might allow only `["description", "params", "examples"]` so an optimizer can
+reword tools but never change the wire contract or the code. `apply()` refuses
+anything outside the allowed set and reports the refusal — it never silently drops or
+silently applies a disallowed edit. `inputs/policy.json` is the safety boundary
+between "reword the docs" and "rewrite the program"; the default here is the **full**
+set. Tighten it to match your deployment's blast radius — a too-tight policy surfaces
+as visible refusals rather than silent no-ops.
 
-**Namespace by service/resource** so selection stays unambiguous as the set grows
-(`github_list_prs`, `payments_charge`), and keep the **active toolset small** — aim
-for **fewer than ~20 tools per turn** (OpenAI's heuristic); selection degrades
-sharply past that. This is the number behind the lean caveat above.
+## Documentation, schema, and return values
 
-## Adapting to the reader's capability tier
-Scale the edit to WHO calls these tools at runtime (see the `THE READER` block in your
-instructions, if present). For a **mid/weak** reader, push harder on this skill's
-already-preferred **code enforcement** (in-body guards, composite atomic-write tools) — a
-weak reader skips a prose rule but a guard fires regardless — and write **literal,
-example-bearing per-parameter slot-filling docs** on every tool (name the exact format,
-units, and one concrete valid value, e.g. `date: ISO-8601 "2026-07-20"`). A weak reader
-mis-fills under-documented arguments far more often, so the marginal value of explicit
-parameter docs and a smaller, less-confusable toolset is highest there. For a **frontier**
-reader, terser parameter docs and fewer worked examples suffice; spend the budget on
-removing redundant tools instead.
-
-## Shape the RESULT, not just the call (output/response design)
+The model never sees your implementation — only `{name, description,
+parameters-schema, examples}`. **Selection** comes from the name + description;
+**argument-filling** comes from the schema + examples. Every tool needs a crisp
+description (what / when / when-NOT vs the nearest sibling), an important-points note,
+a **`Raises:`/errors section** (keep it — knowing a call raises "balance too low" is
+what lets the model pick a different argument), a per-parameter description with
+**units / format / allowed values / default**, and one **generic, always-valid**
+example (never one task's literal id/date/city). Use `enum` for every closed value
+set; namespace by service/resource as the set grows.
 
 What a tool *returns* steers the next turn as much as its description steers
-selection. A bloated or opaque result causes hallucinated ids, wasted context, and
-redundant calls. Design the response:
+selection: return high-signal fields only, prefer stable human-readable ids over raw
+UUIDs, paginate/truncate with sane defaults, and make **error messages actionable**
+(`"payment method not on file; available: ['card_1'] — pass one of these"`).
 
-- **Return high-signal fields only.** Strip low-value noise (internal uuids, mime
-  types, 256-px thumbnail urls, audit columns). Return the semantic fields the
-  agent will actually act on.
-- **Use stable, human-readable identifiers, not raw UUIDs.** Models hallucinate and
-  mis-copy long opaque ids; a `get_order(order_id)` projection should surface
-  `order_id="A-1042"` over `4f3c…-uuid`. If the backend only has a UUID, attach a
-  readable handle alongside it.
-- **Paginate / filter / truncate with sane defaults**, and offer a
-  **`verbosity`/`response_format`** control (e.g. `"concise"` vs `"full"`) so the
-  agent asks for detail only when needed instead of drowning in it.
-- **Make error messages ACTIONABLE — they are a steering surface, not just a
-  failure.** A raw traceback or opaque code teaches the model nothing. Return a
-  specific, example-bearing message that tells the agent how to recover:
-  `"payment method not on file; available: ['card_1','gift_4'] — pass one of these"`
-  or `"date must be ISO-8601 YYYY-MM-DD, got '6/14/25'"`. The model reads the error
-  and self-corrects on the next call instead of retrying the same bad one. Wrappers
-  (patterns 1–3) are the natural place to produce these.
-
-## Document every tool comprehensively
-
-A tool's documentation is its contract. Every tool — primitive or wrapper — needs
-**all** of these, or the model is left guessing:
-
-- a **crisp description**: what it does, when to use it, and when NOT to (the
-  boundary against the nearest sibling tool);
-- an **"important points"** note for any non-obvious behavior or precondition;
-- a **Raises / errors** section listing the failure conditions (keep these — see
-  below; they are a guard rail, not clutter);
-- a **per-parameter description** with units / format / allowed values / default;
-- one **generic, always-valid usage example** (the shape of a call, never one
-  task's literal id/date/city).
-
-**The description is the model's contract, not flavor text.** It is the *only*
-information the model has about *which* tool to call and *what argument values
-are legal*. A good description always states, in always-true terms (never one
-task's specifics):
-
-- **When to use / when not to use** — explicit triggers, and the boundary
-  against the nearest sibling tool ("use X for a single record by id; use Y to
-  search across records").
-- **Argument semantics** — for each parameter: its meaning, **units**, **allowed
-  values / format**, and **default**. "amount in whole US cents" beats "the
-  amount"; "ISO-8601 date `YYYY-MM-DD`" beats "the date".
-- **Preconditions and failure modes** — what must be true *before* the call, and
-  what the tool **raises / returns on error**. This is the model's chance to
-  avoid a bad call. **Do NOT strip `Raises:`/error-condition text to make the
-  description "cleaner."** Knowing a call raises `ValueError: gift card balance
-  too low` is exactly what lets the model pick a different payment method instead
-  of failing the task. Stripping error info removes a guard rail; it does not
-  improve selection.
-- **A short, always-valid usage example** — one concrete well-formed call that is
-  correct for *any* input (e.g. the shape of a list element), never a single
-  benchmark task's literal values.
-
-Selection degrades as the toolset grows: benchmarks like the Berkeley
-Function-Calling Leaderboard include a dedicated "relevance detection" category
-precisely because models hallucinate calls when no tool fits, and ToolLLM had to
-add a *retriever* to cope with thousands of tools. The practical implication for
-this capability: **fewer, sharper, non-overlapping tools beat many vague ones.**
-
-## Concrete before/after
-
-**Selection fix (description).** A trace shows the agent calling a generic
-`query` tool for order lookups, then failing.
-
-```diff
-- "name": "query", "description": "Run a query."
-+ "name": "get_order", "description": "Look up a single order by its ID and
-+   return status, line items, and shipping. Use when the user references a
-+   specific order (an ID, 'my last order', or an order in the current thread).
-+   Do NOT use for searching across orders — use search_orders for that."
-```
-
-**Argument-filling fix (schema + enum).** The agent keeps sending
-`status="done"` when the backend expects `"fulfilled"`.
-
-```diff
-  "parameters": { "type": "object", "properties": {
--   "status": { "type": "string", "description": "the status" }
-+   "status": { "type": "string", "enum": ["pending","fulfilled","cancelled"],
-+               "description": "Order status to filter by." }
-  }, "required": ["status"] }
-```
-
-**Collapse a fumbled chain (compose).** The agent must `search_orders` then
-`get_order` on the first hit, and often forgets the second call.
-
-```json
-{ "kind": "compose", "value": {
-    "name": "find_order",
-    "description": "Search orders by free text and return the full record of the
-      best match. Use this instead of search_orders+get_order when you want one order.",
-    "code": "def find_order(q):\n    hit = search_orders(q)[0]\n    return get_order(hit['id'])"
-}}
-```
-
-## Add tools that call existing tools (the highest-leverage edit)
-
-A docstring edit can only make the model *more likely* to do the right thing.
-A new tool whose body calls existing tools can make the right thing *the only
-thing the model can do*, and can turn many calls into one. These are the two
-PRIMARY patterns (§"highest-leverage edit" above) plus the normalize variant —
-all benchmark-agnostic, and each shows a REAL body you are expected to write:
-
-1. **Workflow / loop — collapse repeated primitive calls into one list call.** If the agent calls
-   `get_record(id)` once per id, or `search(origin, dest, date)` once per
-   route/date combination, add a tool that takes the **list** and loops inside a
-   single call, returning all results together. The agent makes one call instead
-   of N; nothing is dropped or mis-threaded.
-   ```json
-   { "kind": "compose", "value": {
-       "name": "get_records",
-       "description": "Fetch the FULL details of EVERY record in `ids` in one call. Use this instead of calling get_record once per id when you have several ids (e.g. all of a user's records). Returns a list aligned with `ids`; an entry is an error object if that id is not found.",
-       "parameters": {"type":"object","properties":{"ids":{"type":"array","items":{"type":"string"}}},"required":["ids"]},
-       "code": "def get_records(ids):\n    out = []\n    for i in ids:\n        try:\n            out.append(get_record(i))\n        except Exception as e:\n            out.append({'id': i, 'error': str(e)})\n    return out" }}
-   ```
-
-2. **Validation / rule-enforcement — enforce a rule or required order
-   deterministically (wrap, then delegate).** If a write must be preceded by a
-   read, or a precondition the API does not itself check must hold, put the check
-   in code: validate/normalize the inputs, enforce the rule, then call the
-   existing primitive — so a violation returns a clear refusal instead of
-   corrupting state. The model literally cannot skip the step. Then **`remove`
-   the raw primitive** so the only path is the safe one.
-   ```json
-   { "kind": "compose", "value": {
-       "name": "cancel_record_safely",
-       "description": "Cancel a record after verifying it is cancellable. Reads the record first and REFUSES (returns an error) if the cancellation preconditions are not met, so you never need to call get_record yourself before cancelling. Use this for every cancellation.",
-       "parameters": {"type":"object","properties":{"record_id":{"type":"string"}},"required":["record_id"]},
-       "code": "def cancel_record_safely(record_id):\n    rec = get_record(record_id)\n    if not rec.get('cancellable'):\n        return {'error': 'not cancellable', 'record': rec}\n    return cancel_record(record_id)" }}
-   ```
-   ...paired with a `{ "tool": "cancel_record", "kind": "remove" }` so the unsafe
-   primitive leaves the choice set entirely.
-
-3. **Normalize / return richer, ready-to-use results.** Have the new tool do the
-   glue the model otherwise improvises (resolve an id, attach the related record,
-   coerce units), so the model gets a result it can act on directly.
-
-**Then remove the error-prone original** deliberately (the lean caveat). This
-`remove` step is not optional polish — it is what makes the safe/complete tool the
-*only* path. A wrapper that enforces a rule, or a composite that performs a whole
-write, achieves nothing if the raw primitive is still exposed: the model can (and
-under pressure will) route around the guard straight to the primitive and
-reproduce the exact failure. Observed in real runs, optimizers add wrappers but
-**never `remove` the primitives they wrap**, so the unsafe path survives and the
-metric barely moves. To *replace* a confusing or now-redundant tool,
-`add`/`compose` the clearer one and `remove` the old name so it leaves the choice
-set — don't keep both, or selection gets harder (§3 of concepts.md). Net tool
-count should stay small and sharp: prefer one tool that subsumes a primitive over
-two that overlap. Pair every wrapper/composite with the matching `remove` unless
-the primitive is still independently needed for a *different*, safe purpose.
-
-## What good vs bad tool edits look like
-
-Drawn from real runs where the optimizer left most of the gain on the table.
-
-**Bad — what under-performs (do not stop here):**
-
-- **Stripping `Raises:` / error info** "to clean up" the docstring. Observed: an
-  accepted candidate deleted every `Raises:` section. It barely moved the metric
-  and left the model blind to why calls fail. Error conditions are guidance, not
-  clutter — keep them.
-- **Cosmetic description rewording** — reflowing sentences, adding commas,
-  restating the obvious ("Cancel the record" → "Cancel an entire record"). No new
-  always-true information, so no behavior change.
-- **Baking one task's specifics into a description** — naming a particular id,
-  date, or city. It overfits and can mislead on the next task.
-- **Adding tools that duplicate ones the agent already uses fine** — enlarges the
-  choice set and *hurts* selection for no gain.
-
-**Good — what actually moves accuracy and cuts calls:**
-
-- **A loop/composite tool** that collapses the repeated-primitive pattern from the
-  traces (e.g. the agent fetching records one id at a time, or sweeping a search across
-  many parameter combinations) into a single list call.
-- **A rule-enforcing tool** that reads-before-writes or validates a precondition
-  the underlying API does not, turning a silent bad write into a clear refusal.
-- **Precise descriptions** that add genuinely new, always-true content: explicit
-  when/when-not triggers, per-argument units/allowed-values/defaults, retained
-  failure modes, and one always-valid example call.
-- **Replace, don't accumulate** — add the clearer tool and `remove` the
-  error-prone original so the surface stays small and sharp.
-
-The test: *would this edit help on a task the optimizer has never seen?* A loop
-tool, a precondition check, and a unit-pinned argument description pass. A comma
-and a deleted `Raises:` line do not.
+Full checklist, the reader-capability-tier adjustment, and the response-design rules:
+[`references/documentation.md`](references/documentation.md).
 
 ## Failure modes to avoid
 
-- **Over-describing into contradiction.** Adding a fifth "use when" clause that
-  conflicts with the first makes selection *worse*. Keep descriptions internally
-  consistent; state the boundary against the nearest sibling tool, not every tool.
-- **Schema changes that break callers.** You own the callers here, but a `code`
-  edit and a `schema` edit must stay in sync — change both in one batch, then run
-  `validate`. In a frozen-API setting, lock `schema`/`code` off via policy.
-- **Composite-tool sprawl.** A composite is worth it only if the chain is
-  frequent and error-prone. Adding one for a two-call path the agent already
-  handles just enlarges the toolset and hurts selection.
-- **Removing a tool that's rarely-but-critically needed.** Check the traces:
-  remove for *overlap/confusion*, not merely for low call-count.
-- **Examples that fight reasoning models.** A few examples sharpen formatting, but
-  long example dumps can degrade reasoning-tuned models — prefer a crisp schema
-  over many examples.
+- **Over-describing into contradiction.** A fifth "use when" clause that conflicts
+  with the first makes selection *worse*. State the boundary against the nearest
+  sibling tool, not every tool.
+- **Schema changes that break callers.** A `code` edit and a `schema` edit must stay
+  in sync — change both in one batch, then run `validate`.
+- **Composite-tool sprawl.** A composite is worth it only if the chain is frequent
+  and error-prone.
+- **Removing a tool that's rarely-but-critically needed.** Remove for
+  *overlap/confusion*, not for low call-count.
+- **Examples that fight reasoning models.** A few sharpen formatting; long dumps
+  degrade reasoning-tuned models — prefer a crisp schema.
+- **Cosmetic rewording / stripping `Raises:`** — no new always-true information, so
+  no behavior change. The test for any edit: *would this help on a task the optimizer
+  has never seen?*
 
-## The action policy (safety knob)
-
-`inputs/policy.json` is the safety boundary between "reword the docs" and "rewrite
-the program." It exists because the same artifact is edited in very different
-trust settings: an optimizer you trust to polish descriptions should not be free
-to change the wire schema of a tool other systems depend on, or to inject
-arbitrary handler code. The default here is the **full** set; tighten it to match
-your deployment's blast radius. Every refused edit is reported, so a policy that's
-too tight surfaces as visible refusals rather than silent no-ops.
+Detection signals for each: [`references/pitfalls.md`](references/pitfalls.md).
 
 ## Artifact + handlers
 
@@ -675,9 +189,17 @@ python scripts/run.py --path <capability_dir>     # candidate + policy + validit
 
 ## References
 
+- [`references/edit-playbook.md`](references/edit-playbook.md) — **read before
+  editing**: the eight levers in depth, the in-body-guard before/after diffs, the
+  three code-bearing patterns, the safe tool-replacement protocol, and good-vs-bad
+  edits.
+- [`references/documentation.md`](references/documentation.md) — how a model reads a
+  tool definition, the per-tool doc checklist, response/error design, and the
+  reader-capability-tier adjustment.
 - [`references/concepts.md`](references/concepts.md) — the mental model (select vs.
   fill, toolset design, the policy) with cited sources.
-- [`references/examples.md`](references/examples.md) — worked before/after edits.
+- [`references/examples.md`](references/examples.md) — worked before/after edits with
+  full bodies.
 - [`references/pitfalls.md`](references/pitfalls.md) — failure modes and how to detect them.
 - [`references/optimizer-playbook.md`](references/optimizer-playbook.md) — what the
   authored optimizer INSTRUCTIONS must demand when `tools` is selected: the

--- a/skills/capabilities/tools/SKILL.md
+++ b/skills/capabilities/tools/SKILL.md
@@ -43,7 +43,8 @@ and never re-add a rule/tool the run already tried and rejected.
 **Per-change SAFETY (the rule that makes multi-change work).** Scope every guard to
 fire ONLY on the exact violating condition, and check its blast radius: run it on the
 args of 1–2 currently-PASSING tasks that use the same tool and confirm it does NOT
-fire. A guard that fires on a passing task is a regression — rescope or drop it.
+fire. A guard that fires on a passing task is a regression — rescope or drop it. This
+is how you ship many changes without net-zero churn.
 
 **Generalize, never hardcode.** A guard must fire on the GENERAL condition that
 defines the failure class, never on a literal value from one task. *Good:* `if

--- a/skills/capabilities/tools/references/documentation.md
+++ b/skills/capabilities/tools/references/documentation.md
@@ -1,0 +1,127 @@
+# Documentation & response design — what the model actually reads
+
+How a tool-using model consumes a tool definition, what a complete tool doc
+contains, how to shape the RESULT so the next turn recovers, and how to scale all
+of that to the reader's capability tier. SKILL.md carries the one-line rule
+("document every tool: description, important-notes, `Raises:`, per-param, one
+generic example"); this file is the checklist behind it.
+
+## Contents
+- [How tool-using agents actually read a tool](#how-tool-using-agents-actually-read-a-tool)
+- [Adapting to the reader's capability tier](#adapting-to-the-readers-capability-tier)
+- [Shape the RESULT, not just the call](#shape-the-result-not-just-the-call)
+- [Document every tool comprehensively](#document-every-tool-comprehensively)
+
+## How tool-using agents actually read a tool
+
+An LLM never sees your implementation. At call time it sees, for every available
+tool, a serialized block of `{name, description, parameters-schema, examples}`
+injected into its context (this is literally how the Anthropic and OpenAI tool
+APIs work, and how an MCP host presents `tools/list` results). Two decisions
+follow, and each is driven by a different part of that block:
+
+1. **Selection** — *which* tool (or none) to call. Decided primarily from the
+   **name** and **description**. Anthropic's own guidance is blunt: the
+   description "is by far the most important factor in tool performance," and
+   they recommend at least 3–4 sentences covering *what the tool does, when to
+   use it, and when not to*. A name like `lookup` selects worse than
+   `get_order_by_id`.
+2. **Argument-filling** — *how* to populate the call. Decided from the
+   **parameter schema** (types, `required`, `enum`, descriptions) plus any
+   **examples**. An `enum` turns "guess a status string" into "pick from this
+   closed set"; prefer it for every closed value set, and use the provider's
+   **strict / schema-validated mode** where available so the model adheres to the
+   schema instead of guessing. A per-field description ("ISO-8601 date, e.g.
+   2025-06-14"; "amount in whole US cents") turns a malformed argument into a
+   correct one — always pin **units, format, and default** per parameter. Add
+   schema-validated **`input_examples`** for complex / nested / format-sensitive
+   params (a few help; long dumps hurt reasoning models). And **don't make the
+   model fill arguments you already know** — pass them in code (a wrapper) instead
+   of asking for them.
+
+**Namespace by service/resource** so selection stays unambiguous as the set grows
+(`github_list_prs`, `payments_charge`), and keep the **active toolset small** — aim
+for **fewer than ~20 tools per turn** (OpenAI's heuristic); selection degrades
+sharply past that. This is the number behind the lean caveat in
+[`edit-playbook.md`](edit-playbook.md).
+
+Selection degrades as the toolset grows: benchmarks like the Berkeley
+Function-Calling Leaderboard include a dedicated "relevance detection" category
+precisely because models hallucinate calls when no tool fits, and ToolLLM had to
+add a *retriever* to cope with thousands of tools. The practical implication for
+this capability: **fewer, sharper, non-overlapping tools beat many vague ones.**
+
+## Adapting to the reader's capability tier
+
+Scale the edit to WHO calls these tools at runtime (see the `THE READER` block in
+your instructions, if present). For a **mid/weak** reader, push harder on this
+skill's already-preferred **code enforcement** (in-body guards, composite
+atomic-write tools) — a weak reader skips a prose rule but a guard fires regardless
+— and write **literal, example-bearing per-parameter slot-filling docs** on every
+tool (name the exact format, units, and one concrete valid value, e.g. `date:
+ISO-8601 "2026-07-20"`). A weak reader mis-fills under-documented arguments far more
+often, so the marginal value of explicit parameter docs and a smaller,
+less-confusable toolset is highest there. For a **frontier** reader, terser
+parameter docs and fewer worked examples suffice; spend the budget on removing
+redundant tools instead.
+
+## Shape the RESULT, not just the call
+
+What a tool *returns* steers the next turn as much as its description steers
+selection. A bloated or opaque result causes hallucinated ids, wasted context, and
+redundant calls. Design the response:
+
+- **Return high-signal fields only.** Strip low-value noise (internal uuids, mime
+  types, 256-px thumbnail urls, audit columns). Return the semantic fields the
+  agent will actually act on.
+- **Use stable, human-readable identifiers, not raw UUIDs.** Models hallucinate and
+  mis-copy long opaque ids; a `get_order(order_id)` projection should surface
+  `order_id="A-1042"` over `4f3c…-uuid`. If the backend only has a UUID, attach a
+  readable handle alongside it.
+- **Paginate / filter / truncate with sane defaults**, and offer a
+  **`verbosity`/`response_format`** control (e.g. `"concise"` vs `"full"`) so the
+  agent asks for detail only when needed instead of drowning in it.
+- **Make error messages ACTIONABLE — they are a steering surface, not just a
+  failure.** A raw traceback or opaque code teaches the model nothing. Return a
+  specific, example-bearing message that tells the agent how to recover:
+  `"payment method not on file; available: ['card_1','gift_4'] — pass one of these"`
+  or `"date must be ISO-8601 YYYY-MM-DD, got '6/14/25'"`. The model reads the error
+  and self-corrects on the next call instead of retrying the same bad one. Wrappers
+  (the three patterns in [`edit-playbook.md`](edit-playbook.md)) are the natural
+  place to produce these.
+
+## Document every tool comprehensively
+
+A tool's documentation is its contract. Every tool — primitive or wrapper — needs
+**all** of these, or the model is left guessing:
+
+- a **crisp description**: what it does, when to use it, and when NOT to (the
+  boundary against the nearest sibling tool);
+- an **"important points"** note for any non-obvious behavior or precondition;
+- a **Raises / errors** section listing the failure conditions (keep these — see
+  below; they are a guard rail, not clutter);
+- a **per-parameter description** with units / format / allowed values / default;
+- one **generic, always-valid usage example** (the shape of a call, never one
+  task's literal id/date/city).
+
+**The description is the model's contract, not flavor text.** It is the *only*
+information the model has about *which* tool to call and *what argument values
+are legal*. A good description always states, in always-true terms (never one
+task's specifics):
+
+- **When to use / when not to use** — explicit triggers, and the boundary
+  against the nearest sibling tool ("use X for a single record by id; use Y to
+  search across records").
+- **Argument semantics** — for each parameter: its meaning, **units**, **allowed
+  values / format**, and **default**. "amount in whole US cents" beats "the
+  amount"; "ISO-8601 date `YYYY-MM-DD`" beats "the date".
+- **Preconditions and failure modes** — what must be true *before* the call, and
+  what the tool **raises / returns on error**. This is the model's chance to
+  avoid a bad call. **Do NOT strip `Raises:`/error-condition text to make the
+  description "cleaner."** Knowing a call raises `ValueError: gift card balance
+  too low` is exactly what lets the model pick a different payment method instead
+  of failing the task. Stripping error info removes a guard rail; it does not
+  improve selection.
+- **A short, always-valid usage example** — one concrete well-formed call that is
+  correct for *any* input (e.g. the shape of a list element), never a single
+  benchmark task's literal values.

--- a/skills/capabilities/tools/references/edit-playbook.md
+++ b/skills/capabilities/tools/references/edit-playbook.md
@@ -1,0 +1,474 @@
+# Edit playbook — the eight levers, in depth
+
+The full detail behind the lever table in SKILL.md: what each edit class is, when
+it wins, the before/after diffs, the three code-bearing patterns, and the safe
+tool-replacement protocol. SKILL.md carries the decision rule; this file carries
+the depth. Worked, copy-pasteable bodies live in
+[`examples.md`](examples.md); regression traps live in [`pitfalls.md`](pitfalls.md).
+
+## Contents
+- [The eight levers](#the-eight-levers)
+- [Before/after — convert a violated prose rule into an in-body guard](#beforeafter--convert-a-violated-prose-rule-into-an-in-body-guard)
+- [Generalize, never hardcode](#generalize-never-hardcode)
+- [The highest-leverage edit: deterministic CODE](#the-highest-leverage-edit-deterministic-code)
+- [Three patterns that carry almost all the gain](#three-patterns-that-carry-almost-all-the-gain)
+- [How agents fail — the full symptom→fix table](#how-agents-fail-and-how-tools-fix-it--the-full-symptomfix-table)
+- [When to use this — the full trigger list](#when-to-use-this--the-full-trigger-list)
+- [The safe tool-replacement protocol](#the-safe-tool-replacement-protocol)
+- [Worked bodies — add tools that call existing tools](#worked-bodies--add-tools-that-call-existing-tools)
+- [Concrete before/after (selection, argument-filling, compose)](#concrete-beforeafter-selection-argument-filling-compose)
+- [What good vs bad tool edits look like](#what-good-vs-bad-tool-edits-look-like)
+
+## The eight levers
+
+**The tool's docstring AND its return value are what the agent SEES — make both
+clear and recovery-oriented.** The doc surface (description, important-notes,
+per-param, `Raises:`, examples) drives *which* tool the model calls and *how* it
+fills the arguments; the return value (and especially the error text) steers the
+*next* turn. Each lever below is an edit class; in ONE pass, apply EVERY edit class
+the traces call for — a validation wrapper AND a loop tool AND enriched
+returns/errors AND doc fixes across all implicated tools can and should all ship in
+the same candidate.
+
+1. **Edit the CODE of EXISTING tools to enforce rules deterministically (the most
+   common high-leverage edit)** — most violated textual rules govern a tool that
+   ALREADY exists, and the fix is an in-body guard *there*, not a new tool. Bake the
+   precondition / normalization / actionable refusal into the body so correctness
+   doesn't depend on the LLM. *Ex:* add `if not rec["cancellable"]: raise
+   ValueError("not cancellable; reason=...; do X instead")` to the existing
+   `cancel_record` body. Expect to touch the BODIES of SEVERAL existing tools per
+   iteration — one per violated rule.
+2. **Add a new tool (first-class — reach for it freely)** — give the agent a
+   capability it lacks or a safe path it keeps skipping, built as a thoughtful
+   workflow/validation tool, not a thin wrapper. *Ex:* `search_logs` returns only
+   the relevant lines instead of a raw dump; or a `find_duplicate_records` the agent
+   has no way to compute today. For a STALL or capability-gap cluster this is the
+   right move even when a primitive exists — see lever 7 (composite atomic-WRITE).
+3. **Replace / wrap a tool** — superset an existing tool and route the old behavior
+   through it. *Ex:* wrap `find_record`+`charge_payment` behind one
+   `charge_record(record_id)` that resolves then charges.
+4. **Improve a tool's documentation** — sharpen description / important-notes /
+   `Raises:` / per-param docs / examples; rename for least surprise. *Ex:*
+   `lookup(record)` → `get_record(record_id: str)` with "returns an error object if
+   not found." (Full authoring checklist: [`documentation.md`](documentation.md).)
+5. **Improve RETURN VALUES for recoverability** — high-signal fields, stable
+   human-readable ids, and **actionable error text with a next-step hint and what
+   NOT to do**. *Ex:* error returns "payment method not on file; available:
+   ['card_1'] — pass one of these" instead of a raw traceback.
+6. **Add a loop tool** — replace N repeated single-item calls with one list call.
+   *Ex:* `get_records(ids: [...])` replaces N× `get_record(id)`.
+7. **Add a composite atomic-WRITE / workflow tool (first-class — the fix for STALLS
+   and multi-step writes)** — for a recurring, failure-prone multi-step action
+   (especially one the agent narrates/confirms then fails to execute, e.g. a
+   multi-step update that must cancel/undo then re-create a record), a deterministic
+   tool whose body performs ALL the steps in order via the existing primitives, then
+   `remove` the raw primitives so the action is un-skippable. *Ex:*
+   `apply_change_plan(record_id, steps)` validates → applies each → returns final
+   state as one reliable call. Reach for this whenever a cluster STALLS at the action
+   boundary — do not settle for a prose "be sure to act" rule.
+8. **Remove-with-replacement** — remove a redundant/overlapping tool *only* after a
+   replacement preserving its capability exists. *Ex:* drop `query` once
+   `get_record` + `search_records` cover it.
+
+**Pick the lever by failure type — the in-body guard is the DEFAULT strong move:**
+
+- **Edit the BODY of an EXISTING tool (reach for this FIRST for a rule violation).**
+  When the agent VIOLATES a rule a tool already owns (a wrong field value, an id not
+  on file, an action on a record whose state forbids it), convert the prose rule into
+  a scoped in-body guard. This is the highest-yield, lowest-regression edit; expect
+  to touch SEVERAL existing bodies in one iteration.
+- **ADD a NEW code-bearing tool — for a genuine CAPABILITY GAP or action STALL.** A
+  composite atomic-WRITE tool for a multi-step action the agent narrates/confirms
+  then fails to execute is the canonical case (the primitive is what it skips; the
+  composite makes the action un-skippable; then REMOVE the raw primitives). New tools
+  are available and encouraged WHEN they close a real gap — but add one ONLY if the
+  agent will actually call it AND it changes the graded outcome. Do NOT add
+  read/compute/summary helper tools that a guard or a prompt line would subsume, and
+  never add a tool just to "ship a new tool" — that is churn the gate punishes.
+- **DECISION / PERMISSION cluster → a discriminating-predicate guard (the BOUNDED-
+  blast-radius alternative to a prompt change).** When a cluster is about
+  ACT-vs-REFUSE (the agent acted where it should have refused/escalated, or vice
+  versa), the WRONG fix is loosening a global decision rule in the prompt — that has
+  UNBOUNDED blast radius and regresses every task where the original behavior was
+  gold. The RIGHT fix lives here: an in-body guard on the tool that owns the action,
+  expressing the EXACT policy predicate, that refuses/raises ONLY when the qualifying
+  condition is/isn't met. It fires only on the narrow violating condition, so its
+  blast radius is bounded to the failing inputs — the SAFEST edit, preferred over any
+  prompt/permission change.
+- **HARD-ZERO / capability-gap cluster → a REAL targeted tool, never prose.** A task
+  scoring 0.00 that needs a compute / composite / discriminating-predicate tool stays
+  0.00 after any docstring or prompt reword. Ship a tool the agent will CALL that
+  changes the graded state.
+
+The two failure modes to avoid: (1) leaving a rule the agent keeps breaking as loose
+prose instead of a guard, or loosening a global permission rule (unbounded
+regression) instead of a scoped guard; (2) padding the candidate with low-value
+helper tools or cosmetic rewrites that move no graded task.
+
+**Guardrails.** Encode deterministic logic in code, not prose (a tool body the model
+cannot skip beats a sentence it can forget); keep the toolset small and namespaced
+(aim **< ~20** active tools); ship correct, bug-free code (every code edit needs
+validation + a `validate` run); and **never remove a tool without a
+capability-preserving replacement** (add → verify → swap, see
+[the safe tool-replacement protocol](#the-safe-tool-replacement-protocol)).
+
+## Before/after — convert a violated prose rule into an in-body guard
+
+This is the default edit. The rule "a record can only be cancelled when it is
+cancellable" lives as prose in the prompt and the agent keeps breaking it. Don't add
+a tool — edit the EXISTING `cancel_record` body:
+
+```diff
+  def cancel_record(record_id):
++     rec = get_record(record_id)
++     if not rec["cancellable"]:
++         raise ValueError(
++             "not cancellable; reason=" + rec.get("status", "unknown")
++             + "; do X instead (e.g. offer a change_record)")
+      return _backend.cancel(record_id)
+```
+
+And the rule "amounts are in whole cents and the method must be on file" — edit the
+EXISTING `book` (or `charge`) body to normalize the field then raise an actionable
+error:
+
+```diff
+  def book(record_id, amount, payment_id):
++     amount = int(round(amount))            # normalize: callers pass dollars
++     methods = {m["id"] for m in get_record(record_id)["payment_methods"]}
++     if payment_id not in methods:
++         raise ValueError(
++             f"payment method {payment_id!r} not on file; "
++             f"available={sorted(methods)} — pass one of these")
+      return _backend.book(record_id, amount, payment_id)
+```
+
+Both fixes touch a tool that ALREADY exists; no new tool is needed. A docstring-only
+or new-tool-only iteration that leaves these rules as prose is under-used.
+
+## Generalize, never hardcode
+
+Every in-code guard must fire on the GENERAL condition that defines the failure
+class, never on a literal value from one task. *Good:* `if payment_id not in
+user_payment_methods: raise ...`. *Bad:* `if record_id == "<TASK_SPECIFIC_ID>":
+raise ...` — that overfits to one task, gets rejected by the held-out gate, and
+helps nothing else. Use a failing task's specifics only to identify the class, then
+write the general check.
+
+A discriminating-predicate guard for a decision/permission cluster must encode the
+GENERAL policy condition that separates the qualifying cases from the rest (e.g.
+`if record.tier == "restricted" and action == "modify": raise ...`), NOT a global
+behavior flip and NOT a task literal. The guard NARROWS — it fires only on the cases
+the policy actually governs — so passing tasks outside that condition keep their
+behavior unchanged.
+
+## The highest-leverage edit: deterministic CODE
+
+**Start here. A deterministic guard in code beats a sentence in the prompt.** A
+docstring or system-prompt rule only makes the model *more likely* to comply — it
+can be forgotten, mis-read, or out-reasoned on the next task. Code (a precondition
+check, a normalization, a loop) makes the right behavior *the only thing that can
+happen* — it cannot be "forgotten." When the traces show a rule the agent keeps
+breaking, a multi-step action it keeps fumbling, or — most importantly — an action
+it *stalls on and never executes*, **do not just reword a description — put the
+behavior in code.**
+
+**Two code-bearing edits, chosen by failure type — both first-class.** For a rule
+VIOLATION, enforce the rule in the body of the EXISTING tool that owns it — "only
+cancel a cancellable record" governs `cancel_record`, "amounts in whole cents"
+governs `book`/`charge`; add an in-body guard there and expect to touch SEVERAL
+existing bodies per iteration. For a CAPABILITY GAP or an action STALL, write a NEW
+code-bearing tool — a loop tool to collapse a multi-call chain, or (the big one) a
+**composite atomic-WRITE tool** to encapsulate a multi-step write the agent keeps
+skipping. Do not treat the new tool as a last resort: when a cluster stalls at the
+action boundary, the composite is the *correct* fix even though a write primitive
+already exists, because the primitive is exactly what the agent declines to call.
+
+**Prose cannot fix a BEHAVIORAL failure.** There is a sharp distinction the
+optimizer must make. If the agent *does not know* something (a format, a rule, a
+decision criterion), prose can teach it — that is a KNOWLEDGE gap, and it belongs
+in the prompt. But if the agent demonstrably *knows* what to do and still doesn't
+do it — it analyzes the situation, explains the plan, even gets the user's
+confirmation, and then simply **fails to CALL the action tool and stops** — that
+is a BEHAVIORAL failure, and *more prose does not fix it*. You cannot instruct a
+model out of a behavior it already "agreed" to and then skipped. The only
+reliable fix is to move the behavior into CODE: encapsulate the whole action in a
+tool whose body performs it, so executing it is no longer a choice the model can
+decline mid-conversation. Telling the agent to "be sure to act" is exactly the
+kind of edit the traces show failing.
+
+**You must write the BODY.** A `compose`/`add`/`code` edit whose body is `...`, a
+bare `pass`, or docstring-only is NOT this edit — it does nothing. Emit a real
+implementation: the loop, the precondition check, the calls to the existing tools
+(`get_record(i)` — or `self.get_record(i)` if your adapter binds tools as methods).
+
+**SECONDARY (last resort): passthrough / "think" / reasoning-only tools.** A tool
+whose body just returns (or echoes) its argument, with the actual rule living only
+in the *docstring* (e.g. a `think(thought)`/`check_policy(text)` tool that does no
+real work), is the WEAKEST form of this edit — it is prose wearing a tool's
+costume, and the model can ignore or mis-apply it exactly like any prompt sentence.
+**If a rule can be encoded as code, encode it as code** — validate, normalize, and
+enforce it in the body (patterns 1 and 2 below), don't leave it as docstring prose.
+Reach for a reasoning-only tool only when the behavior genuinely cannot be made
+deterministic (e.g. you want to *prompt* a planning step), never as a substitute
+for a check you could have written in a few lines of code.
+
+## Three patterns that carry almost all the gain
+
+Worked bodies: [`examples.md`](examples.md).
+
+1. **Validation / rule-enforcement tool (wrap, then delegate).** When a rule or
+   precondition that today lives only in the prompt is GENERAL — it always
+   applies, not just to one task — implement it as code in a NEW tool that:
+   validates / normalizes the inputs → enforces the rule → calls the existing
+   primitive → returns a clear result (or a clean refusal). Then **remove the raw
+   primitive from the exposed set** if the agent should only ever reach it
+   through the safe path. Example: `cancel_record_safely(record_id)` reads the
+   record, refuses unless it is cancellable, then calls the raw `cancel_record`.
+
+2. **Workflow / loop tool (collapse a recurring multi-step sequence).** When a
+   small multi-step workflow recurs, or the agent calls one primitive N times in
+   a row (and drops or mis-threads a result), implement it as ONE tool with real
+   loops/code that calls the existing tools internally and returns the finished
+   result. Example: a tool that loops over a list of ids calling `get_record`
+   once each and returns them aligned, instead of the agent issuing N calls.
+
+3. **Write / workflow COMPOSITE tool — make a stalled action un-skippable
+   (co-equal PRIMARY pattern).** This is the fix for the single most common
+   BEHAVIORAL failure: the agent reliably **stalls at the action/write boundary**
+   — it analyzes, explains, even confirms with the user, then never issues the
+   write call and stops, leaving the task half-done. The cure is *not* a stronger
+   rule. Encapsulate the ENTIRE multi-step action (analyze → confirm → act) as
+   ONE composite tool whose body performs *all* the steps in code — calling the
+   existing primitives in the right sequence and looping where needed — so the
+   action completes the moment the tool is called and **cannot be skipped
+   mid-conversation**. Then **`remove` the raw primitives** so the composite is
+   the only path; the safe, complete behavior is then the only behavior reachable.
+   Generic example: an `apply_change_plan(record_id, steps)` that performs a
+   multi-step update atomically — validating each step, applying them in order via
+   the existing write primitives, and returning the final state — so the agent
+   hands over the plan in one call instead of narrating it and then failing to
+   execute. (Worked body in [`examples.md`](examples.md) §3e.)
+
+**Lean caveat — replace, don't accumulate.** Every exposed tool enters the
+agent's context, and too many tools degrade selection (see
+[`concepts.md`](concepts.md) §3). So PREFER consolidating over piling on: when you
+add a safer or looped tool, **`remove` the now-redundant primitive** so the net tool
+count stays small and sharp. Do not add many narrow tools. One sharp tool that
+subsumes a primitive beats two overlapping ones.
+
+## How agents fail (and how tools fix it) — the full symptom→fix table
+
+Map the trace symptom to the code-bearing edit. Each row is a failure the model
+*could* "know" how to avoid yet keeps producing — so the fix is code, not prose:
+
+These four rows carry most of the recoverable gain — diagnose for them FIRST, and
+verify the fix you ship actually FIRES on the failing trace (run the new body on the
+exact arguments from that trajectory; a guard that never triggers on the failing task
+is dead code, not a fix). These rows are independent: fix as MANY of them as appear in
+the trajectories in one candidate, not just the first — each guarded tool is its own
+bounded fix.
+
+| Trace symptom | Fix |
+|---------------|-----|
+| **Wrong ARGUMENT the tool could validate** — a write whose id / reference / count / unit is not consistent with the agent-visible state (an id not in the record, a count exceeding what's available, the wrong unit). Right tool, bad argument; partial credit or a corrupted write. | **Normalize-then-call wrapper**: wrap the write in a body that RESOLVES / VALIDATES the argument against the current state, and on mismatch returns `available=[...]` (the valid options) or raises an actionable error naming what's wrong and what to pass instead — never let a write proceed on an unvalidated reference. Coerce units, resolve ids, check the field is on file, then delegate to the primitive. |
+| **Escalate / bail-out abandoning a REQUIRED, eligible action** — the agent hands off or gives up when it could and should have completed the action itself; this is a behavioral STALL, not a missing capability. | **Composite WRITE tool**: encapsulate the eligible-action batch in ONE tool whose body executes the steps in code (skipping any ineligible item with a recorded reason), then `remove` the raw primitives so completing the batch is the only path. Do NOT add a "don't bail out" prose rule — the agent already chose to bail; only code removes the choice. |
+| **Recoverable error that strands the agent** — a tool raises an opaque traceback / bare code, the agent retries the same bad call or gives up. | **Enriched RETURN that aids recovery**: on a recoverable error, return what's wrong + the valid options + the recommended next action (e.g. `{"error": "id not found", "available": [...], "next": "call search_x to resolve the id"}`), so the model self-corrects on the next turn instead of repeating the failure. |
+| **Execution stalls at the action boundary** — the agent analyzes, explains, even confirms, then never calls the write tool and stops (the task is left half-done). | **Composite WRITE tool** (pattern 3): one tool whose body performs the whole analyze→confirm→act sequence, then `remove` the raw primitives so the action is un-skippable. |
+| **The same primitive called N times in a row** — looping over a list in the agent's own context, dropping or mis-threading results. | **Loop tool** (pattern 2): one tool that takes the list and loops inside a single call. |
+| **A rule stated in the prompt but repeatedly violated** — a required order ("read before write"), a precondition the API doesn't enforce. | **Validation wrapper** (pattern 1): enforce the rule in the tool body; `remove` the unguarded primitive. |
+
+The throughline: a failure the agent *knows better than* but still commits is
+behavioral, and behavioral failures are fixed by removing the choice — putting the
+behavior in code and `remove`-ing the path that let it go wrong.
+
+## When to use this — the full trigger list
+
+Reach for `tools` when a trace shows one of these failure signatures:
+
+- **Execution stall at the action/write boundary (BEHAVIORAL)** — the agent
+  reaches the point of acting, narrates or confirms the action, then **fails to
+  call the write tool and stops**. This is not a knowledge gap and prose will not
+  fix it; encapsulate the whole action in a composite WRITE tool and remove the
+  raw primitives so completing it is the only path (pattern 3 above).
+- **Mis-selection** — the agent calls the wrong tool, or calls none when one
+  applied, or invents a tool that does not exist. Selection is driven almost
+  entirely by the tool *name* and *description*, so this is a documentation fix.
+- **Bad argument-filling** — the right tool, wrong arguments: a missing required
+  field, the wrong enum value, a free-text string where a structured object was
+  expected. This is a parameter-schema and per-parameter-description fix.
+- **Repeated multi-call sequences the agent fumbles** — the agent must chain
+  `search` → `filter` → `fetch` every time and keeps getting the order or the
+  glue wrong. A single well-named **composite** tool collapses the sequence.
+- **The same primitive called N times in a row** — the agent loops over a list
+  in *its own context* (calls `get_record(id)` once per id, or `search(a,b,date)`
+  once per date/route combination), burning turns and often dropping or
+  mis-threading a result. A tool that takes the **list** and loops *inside one
+  call* collapses N calls into 1.
+- **An invariant the model keeps violating** — a required order of operations
+  ("read before write"), a precondition the API does not itself enforce, or a
+  normalization the model forgets. A tool that **enforces the rule in code**
+  (validates, normalizes, or performs the steps in the right order) makes the
+  mistake impossible rather than merely discouraged.
+- **A DECISION / PERMISSION the model gets wrong (ACT vs REFUSE)** — the agent acts
+  where the policy says refuse/escalate (or refuses where it should act). Do NOT fix
+  this by loosening the global rule in the prompt — that changes behavior for the whole
+  class and regresses every task where the original behavior was correct (unbounded
+  blast radius). Encode the EXACT discriminating policy predicate as an in-body guard on
+  the tool that owns the action: it refuses/raises ONLY on the qualifying condition, so
+  its blast radius is bounded to the violating cases. This is the SAFE, preferred
+  alternative to a permission-rule prompt edit.
+- **A bloated or overlapping toolset** — too many tools, or several that do
+  nearly the same thing, distracting the agent. Remove or consolidate.
+- **A real behavioral bug in a handler** — the tool returns the wrong thing.
+  Because you own the code, you can fix it directly.
+
+If the problem is *what the agent is told to do* rather than *what it can do*, it is
+out of scope for this capability (it belongs to whatever capability edits the agent's
+instructions).
+
+## The safe tool-replacement protocol
+
+**Never bare-remove a tool.** To replace or consolidate a tool, follow these steps
+in order — never delete a tool without a replacement that subsumes it:
+
+1. **ADD a wrapper tool whose body CALLS the existing tool** — after validation,
+   normalization, or the extra steps you want guaranteed. The wrapper delegates to
+   the primitive; it does not re-implement it.
+2. **VERIFY** the wrapper (run `validate`; confirm the body actually calls the
+   primitive and returns a sane result).
+3. **Only then SWAP the registration**: `remove` the raw primitive from the active
+   / exposed set and register the wrapper as the path the agent uses.
+
+Bare-removing a primitive with no replacement strands every task that needed it
+("no applicable tool"); adding a wrapper but leaving the primitive exposed lets the
+model route around the guard and reproduce the original failure. The add-verify-swap
+order is what makes the safe path the *only* path without a coverage gap.
+
+## Worked bodies — add tools that call existing tools
+
+A docstring edit can only make the model *more likely* to do the right thing.
+A new tool whose body calls existing tools can make the right thing *the only
+thing the model can do*, and can turn many calls into one. These are the two
+PRIMARY patterns above plus the normalize variant — all benchmark-agnostic, and
+each shows a REAL body you are expected to write:
+
+1. **Workflow / loop — collapse repeated primitive calls into one list call.** If
+   the agent calls `get_record(id)` once per id, or `search(origin, dest, date)`
+   once per route/date combination, add a tool that takes the **list** and loops
+   inside a single call, returning all results together. The agent makes one call
+   instead of N; nothing is dropped or mis-threaded.
+   ```json
+   { "kind": "compose", "value": {
+       "name": "get_records",
+       "description": "Fetch the FULL details of EVERY record in `ids` in one call. Use this instead of calling get_record once per id when you have several ids (e.g. all of a user's records). Returns a list aligned with `ids`; an entry is an error object if that id is not found.",
+       "parameters": {"type":"object","properties":{"ids":{"type":"array","items":{"type":"string"}}},"required":["ids"]},
+       "code": "def get_records(ids):\n    out = []\n    for i in ids:\n        try:\n            out.append(get_record(i))\n        except Exception as e:\n            out.append({'id': i, 'error': str(e)})\n    return out" }}
+   ```
+
+2. **Validation / rule-enforcement — enforce a rule or required order
+   deterministically (wrap, then delegate).** If a write must be preceded by a
+   read, or a precondition the API does not itself check must hold, put the check
+   in code: validate/normalize the inputs, enforce the rule, then call the
+   existing primitive — so a violation returns a clear refusal instead of
+   corrupting state. The model literally cannot skip the step. Then **`remove`
+   the raw primitive** so the only path is the safe one.
+   ```json
+   { "kind": "compose", "value": {
+       "name": "cancel_record_safely",
+       "description": "Cancel a record after verifying it is cancellable. Reads the record first and REFUSES (returns an error) if the cancellation preconditions are not met, so you never need to call get_record yourself before cancelling. Use this for every cancellation.",
+       "parameters": {"type":"object","properties":{"record_id":{"type":"string"}},"required":["record_id"]},
+       "code": "def cancel_record_safely(record_id):\n    rec = get_record(record_id)\n    if not rec.get('cancellable'):\n        return {'error': 'not cancellable', 'record': rec}\n    return cancel_record(record_id)" }}
+   ```
+   ...paired with a `{ "tool": "cancel_record", "kind": "remove" }` so the unsafe
+   primitive leaves the choice set entirely.
+
+3. **Normalize / return richer, ready-to-use results.** Have the new tool do the
+   glue the model otherwise improvises (resolve an id, attach the related record,
+   coerce units), so the model gets a result it can act on directly.
+
+**Then remove the error-prone original** deliberately (the lean caveat). This
+`remove` step is not optional polish — it is what makes the safe/complete tool the
+*only* path. A wrapper that enforces a rule, or a composite that performs a whole
+write, achieves nothing if the raw primitive is still exposed: the model can (and
+under pressure will) route around the guard straight to the primitive and
+reproduce the exact failure. Observed in real runs, optimizers add wrappers but
+**never `remove` the primitives they wrap**, so the unsafe path survives and the
+metric barely moves. To *replace* a confusing or now-redundant tool,
+`add`/`compose` the clearer one and `remove` the old name so it leaves the choice
+set — don't keep both, or selection gets harder ([`concepts.md`](concepts.md) §3).
+Net tool count should stay small and sharp: prefer one tool that subsumes a
+primitive over two that overlap. Pair every wrapper/composite with the matching
+`remove` unless the primitive is still independently needed for a *different*, safe
+purpose.
+
+## Concrete before/after (selection, argument-filling, compose)
+
+**Selection fix (description).** A trace shows the agent calling a generic
+`query` tool for order lookups, then failing.
+
+```diff
+- "name": "query", "description": "Run a query."
++ "name": "get_order", "description": "Look up a single order by its ID and
++   return status, line items, and shipping. Use when the user references a
++   specific order (an ID, 'my last order', or an order in the current thread).
++   Do NOT use for searching across orders — use search_orders for that."
+```
+
+**Argument-filling fix (schema + enum).** The agent keeps sending
+`status="done"` when the backend expects `"fulfilled"`.
+
+```diff
+  "parameters": { "type": "object", "properties": {
+-   "status": { "type": "string", "description": "the status" }
++   "status": { "type": "string", "enum": ["pending","fulfilled","cancelled"],
++               "description": "Order status to filter by." }
+  }, "required": ["status"] }
+```
+
+**Collapse a fumbled chain (compose).** The agent must `search_orders` then
+`get_order` on the first hit, and often forgets the second call.
+
+```json
+{ "kind": "compose", "value": {
+    "name": "find_order",
+    "description": "Search orders by free text and return the full record of the
+      best match. Use this instead of search_orders+get_order when you want one order.",
+    "code": "def find_order(q):\n    hit = search_orders(q)[0]\n    return get_order(hit['id'])"
+}}
+```
+
+## What good vs bad tool edits look like
+
+Drawn from real runs where the optimizer left most of the gain on the table.
+
+**Bad — what under-performs (do not stop here):**
+
+- **Stripping `Raises:` / error info** "to clean up" the docstring. Observed: an
+  accepted candidate deleted every `Raises:` section. It barely moved the metric
+  and left the model blind to why calls fail. Error conditions are guidance, not
+  clutter — keep them.
+- **Cosmetic description rewording** — reflowing sentences, adding commas,
+  restating the obvious ("Cancel the record" → "Cancel an entire record"). No new
+  always-true information, so no behavior change.
+- **Baking one task's specifics into a description** — naming a particular id,
+  date, or city. It overfits and can mislead on the next task.
+- **Adding tools that duplicate ones the agent already uses fine** — enlarges the
+  choice set and *hurts* selection for no gain.
+
+**Good — what actually moves accuracy and cuts calls:**
+
+- **A loop/composite tool** that collapses the repeated-primitive pattern from the
+  traces (e.g. the agent fetching records one id at a time, or sweeping a search
+  across many parameter combinations) into a single list call.
+- **A rule-enforcing tool** that reads-before-writes or validates a precondition
+  the underlying API does not, turning a silent bad write into a clear refusal.
+- **Precise descriptions** that add genuinely new, always-true content: explicit
+  when/when-not triggers, per-argument units/allowed-values/defaults, retained
+  failure modes, and one always-valid example call.
+- **Replace, don't accumulate** — add the clearer tool and `remove` the
+  error-prone original so the surface stays small and sharp.
+
+The test: *would this edit help on a task the optimizer has never seen?* A loop
+tool, a precondition check, and a unit-pinned argument description pass. A comma
+and a deleted `Raises:` line do not.

--- a/skills/capabilities/tools/references/examples.md
+++ b/skills/capabilities/tools/references/examples.md
@@ -1,5 +1,23 @@
 # Examples — worked tool edits
 
+- [0. Turning N prose rules into N in-body checks (the DEFAULT edit)](#0-turning-n-prose-rules-into-n-in-body-checks-the-default-edit)
+- [1. Selection fix — sharpen a vague description](#1-selection-fix--sharpen-a-vague-description)
+- [2. Argument-filling fix — close the value set with an enum](#2-argument-filling-fix--close-the-value-set-with-an-enum)
+- [3. Collapse a fumbled chain — compose](#3-collapse-a-fumbled-chain--compose)
+- [3b. Collapse repeated primitive calls — a loop-in-one-call tool](#3b-collapse-repeated-primitive-calls--a-loop-in-one-call-tool)
+- [3c. Validation / rule-enforcement tool](#3c-validation--rule-enforcement-tool--wrap-then-delegate-then-remove-the-primitive)
+- [3c-bis. Validate-and-normalize inputs before a primitive](#3c-bis-validate-and-normalize-inputs-before-a-primitive)
+- [3c-ter. Wrong ARGUMENT the tool could validate](#3c-ter-wrong-argument-the-tool-could-validate--resolvevalidate-against-state-return-available)
+- [3c-quater. A required action abandoned via bail-out](#3c-quater-a-required-eligible-action-abandoned-via-bail-out--escalation--encapsulate-the-batch-as-a-composite-write)
+- [3e. Make a STALLED action un-skippable](#3e-make-a-stalled-action-un-skippable--a-composite-write-tool-then-remove-the-primitives)
+- [3d. Keep failure modes — improve, do not delete](#3d-keep-failure-modes--improve-do-not-delete-raises)
+- [3f. Shape the result](#3f-shape-the-result--high-signal-fields-readable-ids-actionable-errors)
+- [3g. A comprehensively documented tool (the doc contract)](#3g-a-comprehensively-documented-tool-the-doc-contract)
+- [4. Shrink an overlapping toolset — remove + consolidate](#4-shrink-an-overlapping-toolset--remove--consolidate)
+- [5. Behavior bug — code edit](#5-behavior-bug--code-edit)
+- [6. A policy refusal (what tightening looks like)](#6-a-policy-refusal-what-tightening-looks-like)
+- [7. SECONDARY (last resort) — a passthrough / reasoning-only tool](#7-secondary-last-resort--a-passthrough--reasoning-only-tool)
+
 Each example is an edit you would emit to `apply()`. Edit shape:
 `{"tool": <name>, "kind": <action>, "value": <...>}`. For `add`/`compose` the
 value is a full tool def; for `remove` the value is ignored.

--- a/skills/capabilities/tools/references/optimizer-playbook.md
+++ b/skills/capabilities/tools/references/optimizer-playbook.md
@@ -1,0 +1,57 @@
+# Optimizer playbook for the `tools` capability
+
+What the **authored optimizer instructions** must demand when `tools` is among the
+selected capabilities. `intake` writes those instructions
+(`.capevolve/project/optimizer/INSTRUCTIONS.md`) but stays capability-agnostic; this
+file is the `tools`-specific half it points at. Encode every item below into the
+authored INSTRUCTIONS — verbatim or tightened for the benchmark at hand.
+
+- [Depth mandate (tools wording)](#depth-mandate-tools-wording)
+- [The EXISTING-tool-code mandate](#the-existing-tool-code-mandate)
+- [The explicit TWO-PHASE subagent pattern](#the-explicit-two-phase-subagent-pattern)
+- [What an under-used iteration looks like](#what-an-under-used-iteration-looks-like)
+
+## Depth mandate (tools wording)
+
+`intake` demands a substantial multi-root-cause pass in capability-neutral terms.
+When `tools` is selected, make that demand concrete with this snippet:
+
+> "Each iteration is a substantial, multi-root-cause pass. Diagnose ALL clusters
+> and fix as many as possible in ONE candidate — improve multiple tools' code,
+> validation, and return values/errors; add new tools; sharpen many tool docs;
+> and fix the prompt — together. Scope each fix to protect passing tasks; do NOT
+> trade breadth for caution. A single small edit is an under-used iteration."
+
+## The EXISTING-tool-code mandate
+
+Demand: convert violated textual rules into in-code checks across MANY EXISTING tool
+bodies — most violated rules govern a tool that already exists, so the fix is an
+in-body guard there, not a new tool. State plainly: *a docstring-only iteration (or
+one that only adds a single new tool + rewords docstrings, leaving rules as prose)
+is under-used.*
+
+The edit classes this mandate ranges over — and the before/after diffs that show an
+in-body guard replacing a prose rule — are in
+[`../SKILL.md`](../SKILL.md) ("What you can change here", "The highest-leverage
+edit") and [`examples.md`](examples.md).
+
+## The explicit TWO-PHASE subagent pattern
+
+Require:
+
+1. **Phase 1 — diagnose fan-out.** One read-only subagent per trajectory-group → a
+   tight issue list; the main agent dedups those into clusters.
+2. **Phase 2 — implement fan-out.** One edit-subagent per ISSUE, each in its own
+   worktree, each PREFERRING to edit the EXISTING tool's code body to enforce its
+   rule.
+3. **Merge.** The main agent merges all edits into ONE candidate.
+
+Point the optimizer at `./guidance/optimizer/<name>.md` for that agent's concrete
+trigger phrasing.
+
+## What an under-used iteration looks like
+
+Authored INSTRUCTIONS fail this playbook when they let an iteration pass by adding
+one tool + rewording docstrings (leaving violated rules as prose) — or when they
+omit the existing-tool-code mandate or the explicit two-phase (diagnose fan-out →
+implement fan-out → merge) subagent pattern.

--- a/skills/capabilities/tools/references/optimizer-playbook.md
+++ b/skills/capabilities/tools/references/optimizer-playbook.md
@@ -9,7 +9,6 @@ authored INSTRUCTIONS — verbatim or tightened for the benchmark at hand.
 - [Depth mandate (tools wording)](#depth-mandate-tools-wording)
 - [The EXISTING-tool-code mandate](#the-existing-tool-code-mandate)
 - [The explicit TWO-PHASE subagent pattern](#the-explicit-two-phase-subagent-pattern)
-- [What an under-used iteration looks like](#what-an-under-used-iteration-looks-like)
 
 ## Depth mandate (tools wording)
 
@@ -19,7 +18,9 @@ When `tools` is selected, make that demand concrete with this snippet:
 > "Each iteration is a substantial, multi-root-cause pass. Diagnose ALL clusters
 > and fix as many as possible in ONE candidate — improve multiple tools' code,
 > validation, and return values/errors; add new tools; sharpen many tool docs;
-> and fix the prompt — together. Scope each fix to protect passing tasks; do NOT
+> and fix the prompt (only if `system-prompt` is ALSO among the selected
+> capabilities — on a `tools`-only run drop this clause and leave the prompt
+> alone) — together. Scope each fix to protect passing tasks; do NOT
 > trade breadth for caution. A single small edit is an under-used iteration."
 
 ## The EXISTING-tool-code mandate
@@ -49,9 +50,4 @@ Require:
 Point the optimizer at `./guidance/optimizer/<name>.md` for that agent's concrete
 trigger phrasing.
 
-## What an under-used iteration looks like
-
-Authored INSTRUCTIONS fail this playbook when they let an iteration pass by adding
-one tool + rewording docstrings (leaving violated rules as prose) — or when they
-omit the existing-tool-code mandate or the explicit two-phase (diagnose fan-out →
-implement fan-out → merge) subagent pattern.
+Authored INSTRUCTIONS fail this playbook when they omit either mandate above.

--- a/skills/orchestrate/using-cap-evolve/SKILL.md
+++ b/skills/orchestrate/using-cap-evolve/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: using-cap-evolve
-description: Entry-point router for cap-evolve. Use the moment a user asks to OPTIMIZE an agent capability against an eval — "optimize <X>", "make <X> score higher on <benchmark>", "improve this skill/tool/prompt". Decides whether a project already exists and routes accordingly: to intake (Phase 1) for a fresh request, or straight into the phase chain / `cap-evolve run` when `.capevolve/project/` is already scaffolded. Explains the two ways to run (standalone `/cap-evolve:<phase>` chain vs the fully-automatic `cap-evolve run`) and restates the non-negotiable honesty rules. Does no optimization itself.
+description: Entry-point router for cap-evolve. Use when a user asks to OPTIMIZE an agent capability against an eval — "optimize X", "make X score higher on some benchmark", "improve this skill/tool/prompt". Decides whether a project already exists and routes accordingly: to intake (Phase 1) for a fresh request, or straight into the phase chain / `cap-evolve run` when `.capevolve/project/` is already scaffolded. Explains the two ways to run (standalone `/cap-evolve:PHASE` chain vs the fully-automatic `cap-evolve run`) and restates the non-negotiable honesty rules. Does no optimization itself.
 component: orchestrate
 argument-hint: "[what to optimize] [--base .capevolve]"
 arguments: "$ARGUMENTS"

--- a/skills/phases/intake/SKILL.md
+++ b/skills/phases/intake/SKILL.md
@@ -93,34 +93,28 @@ inputs. The metric / GitHub / stop-condition questions below feed directly into 
    guidance, skill references, and edit-space ONLY for the capabilities actually
    listed in `capevolve.yaml: capabilities`.
    - **DEPTH MANDATE — address ALL failure clusters each iteration.** The authored
-     instructions must demand a substantial multi-root-cause pass. Produce this
-     target snippet:
-     > "Each iteration is a substantial, multi-root-cause pass. Diagnose ALL clusters
-     > and fix as many as possible in ONE candidate — improve multiple tools' code,
-     > validation, and return values/errors; add new tools; sharpen many tool docs;
-     > and fix the prompt — together. Scope each fix to protect passing tasks; do NOT
-     > trade breadth for caution. A single small edit is an under-used iteration."
+     instructions must demand a substantial multi-root-cause pass: diagnose ALL
+     clusters and fix as many as possible in ONE candidate, spanning EVERY edit class
+     the selected capabilities offer (each capability's SKILL.md enumerates its own).
+     Scope each fix to protect passing tasks; do NOT trade breadth for caution. State
+     plainly that a single small edit is an under-used iteration. For the concrete
+     per-capability wording of this mandate, use the selected capability's own
+     optimizer playbook (see the capability-playbook rule below).
    - **State the GOAL up front:** maximize the eval score — make the largest
      improvement you can this iteration, grounded in the trajectories.
-   - **The authored INSTRUCTIONS MUST encode all three of these (generic, capability-scoped):**
+   - **The authored INSTRUCTIONS MUST encode all of these (generic, capability-scoped):**
      1. **STEP-0 reading mandate.** Before diagnosing, the optimizer must READ
         `./guidance/<cap>/SKILL.md` (for EACH selected capability) and the optimizer
         features reference under `./guidance/optimizer/`. State this as an explicit
         first step.
-     2. **The EXISTING-tool-code mandate** (when `tools` is selected). Demand: convert
-        violated textual rules into in-code checks across MANY EXISTING tool bodies —
-        most violated rules govern a tool that already exists, so the fix is an in-body
-        guard there, not a new tool. State plainly: *a docstring-only iteration (or one
-        that only adds a single new tool + rewords docstrings, leaving rules as prose)
-        is under-used.*
-     3. **The explicit TWO-PHASE subagent pattern.** Require: Phase 1 — diagnose
-        fan-out (one read-only subagent per trajectory-group → tight issue list; main
-        dedups into clusters); Phase 2 — implement fan-out (one edit-subagent per
-        ISSUE, each in its own worktree, each PREFERRING to edit the EXISTING tool's
-        code body to enforce its rule); then the main agent MERGES all edits into ONE
-        candidate. Point at `./guidance/optimizer/<name>.md` for the agent's concrete
-        trigger phrasing.
-     4. **The NON-OVERFITTING guardrail.** Demand that every prompt/tool edit encode
+     2. **Each selected capability's own optimizer playbook.** For EVERY capability in
+        `capevolve.yaml: capabilities`, load that capability's playbook from its skill
+        (`skills/capabilities/<cap>/references/`, e.g. `tools` →
+        [`optimizer-playbook.md`](../../capabilities/tools/references/optimizer-playbook.md))
+        and fold its edit-depth demands and subagent-fan-out pattern into the authored
+        INSTRUCTIONS. Do NOT restate one capability's playbook here — it lives with
+        that capability and evolves with it.
+     3. **The NON-OVERFITTING guardrail.** Demand that every prompt/tool edit encode
         a GENERAL rule/policy/validation that generalizes across the whole class of
         inputs — NEVER hardcode a specific task's id/value/date/name/answer. A guard
         must fire on the general condition (e.g. "id not in the user's profile"), not
@@ -128,13 +122,13 @@ inputs. The metric / GitHub / stop-condition questions below feed directly into 
         only helps one task is forbidden — it overfits, fails the held-out gate, and
         hurts other tasks. Per-task specifics are for understanding the failure CLASS
         only; the fix must be general.
-     5. **EXPLOIT ground-truth/eval present in the trajectories (diagnosis only).**
+     4. **EXPLOIT ground-truth/eval present in the trajectories (diagnosis only).**
         Tell the optimizer that when `./trajectories/` include ground-truth /
         expected actions / a reward breakdown, it should USE them during diagnosis to
         localize the exact defect (expected vs actual action/argument/value) — and if
         not present, infer from the traces + feedback. State plainly that ground truth
         informs the failure class only; the resulting edit must still be GENERAL
-        (guardrail 4) and never copy a gold value.
+        (guardrail 3) and never copy a gold value.
    - **Capability-scoping (the key rule):** reference `./guidance/<cap>/SKILL.md`
      and present the editable artifacts **for the selected caps only**. If only
      `tools` is selected, do NOT include any prompt-editing guidance, do NOT
@@ -247,10 +241,9 @@ this whole integration autonomously.
   the gold answer into feedback; test == train with no note; budget left at a
   default that cannot possibly find a gain; the run proceeded past a missing
   NEEDED input "to keep moving".
-- **Bad:** authored INSTRUCTIONS that let an iteration pass by adding one tool +
-  rewording docstrings (leaving violated rules as prose) — or that omit the STEP-0
-  reading mandate, the existing-tool-code mandate, or the explicit two-phase
-  (diagnose fan-out → implement fan-out → merge) subagent pattern.
+- **Bad:** authored INSTRUCTIONS that omit the STEP-0 reading mandate, or that skip a
+  selected capability's own optimizer playbook — so an iteration can pass on a
+  cosmetic edit that the capability's playbook calls under-used.
 
 ## References
 - `references/concepts.md` — the inputs contract, NEEDED vs RECOMMENDED

--- a/skills/phases/intake/SKILL.md
+++ b/skills/phases/intake/SKILL.md
@@ -108,12 +108,16 @@ inputs. The metric / GitHub / stop-condition questions below feed directly into 
         features reference under `./guidance/optimizer/`. State this as an explicit
         first step.
      2. **Each selected capability's own optimizer playbook.** For EVERY capability in
-        `capevolve.yaml: capabilities`, load that capability's playbook from its skill
-        (`skills/capabilities/<cap>/references/`, e.g. `tools` →
-        [`optimizer-playbook.md`](../../capabilities/tools/references/optimizer-playbook.md))
-        and fold its edit-depth demands and subagent-fan-out pattern into the authored
-        INSTRUCTIONS. Do NOT restate one capability's playbook here — it lives with
-        that capability and evolves with it.
+        `capevolve.yaml: capabilities`, load that capability's playbook from its skill.
+        Both path forms matter, each for its own reader: YOU read it in this repo at
+        `skills/capabilities/<cap>/references/` (e.g. `tools` →
+        [`optimizer-playbook.md`](../../capabilities/tools/references/optimizer-playbook.md)),
+        but any path you WRITE INTO the authored INSTRUCTIONS must be the
+        runtime-materialized form `./guidance/<cap>/references/` — the repo-relative
+        path does not resolve in the optimizer's working dir. Fold its edit-depth
+        demands and subagent-fan-out pattern into the authored INSTRUCTIONS. Do NOT
+        restate one capability's playbook here — it lives with that capability and
+        evolves with it.
      3. **The NON-OVERFITTING guardrail.** Demand that every prompt/tool edit encode
         a GENERAL rule/policy/validation that generalizes across the whole class of
         inputs — NEVER hardcode a specific task's id/value/date/name/answer. A guard


### PR DESCRIPTION
Closes #107

The framework enforced an authoring budget on *user* skills and violated it in its own bundled skills, and nothing ran that lint in CI. This wires the existing validator over `skills/` in CI and brings the violators into compliance.

## What the lint is

`skills/_registry/lint_skills.py` points the **same shipped validator** (`skills/capabilities/skill-package/scripts/abstract.py`) at `skills/*/*/SKILL.md` and exits nonzero on a violation. New CI job `lint-skills` runs it plus `build_manifest.py`.

Two deliberate deltas from the in-run `validate()`:

1. **Structural warnings become ERRORS** — body over `MAX_BODY_LINES=500` / `MAX_BODY_TOKENS=5000`, `references/` nested more than one level, a long reference with no early TOC, a broken reference link. An optimizer mid-run should not be hard-blocked by a style budget; the repo's own skills have no such excuse.
2. **Empty / still-templated references fail** — per CONTRIBUTING's "references one level deep with a TOC if long, and **only when filled**": a stub (<5 lines) or a `TODO`/`TBD`/`FIXME`/`<placeholder>` reference.

**Discovery is dynamic** — a `glob("*/*/SKILL.md")`, never a committed list, so a new skill is linted the day it lands. `MIN_SKILLS = 20` is the anti-vacuity floor: a renamed or deleted skill dir makes the glob return fewer packages and the lint **fails loudly** instead of silently shrinking its own coverage (the failure mode #189's manifest-reading counts guard and #192's 5-host denylist both had).

### What the lint does NOT catch

Honesty about its reach:

- **Description *style* stays advisory** (printed as `advise`, never fails): first-person POV, all-caps `CRITICAL/ALWAYS/MUST/NEVER`, "should say WHEN to use", and the 1,536-char listing-truncation risk. These are judgement calls, not measurable violations. 10 skills currently carry the "say WHEN" advisory — deliberately not "fixed", because rewording 10 descriptions to satisfy a regex is exactly the cosmetic churn this repo's own skills warn against.
- **No semantic review.** It cannot tell whether a reference is *good*, whether a claim is grounded, or whether the split preserved meaning. That is what the content-loss check below and human review are for.
- **No `check.py` behavior.** `test_manifest.py` covers existence; each skill's own `check.py` covers behavior. This lint is authoring-shape only.
- **Line/token counts are the validator's own arithmetic** (`body.count("\n")+1`, `len(body)//4`), not a real tokenizer. `~4 chars/token` is the documented approximation in `abstract.py`.
- **`references/` is linted for shape, not size** — a 400-line reference with a TOC passes by design (progressive disclosure means the *body* is the recurring cost).

## Before → after

<details><summary><b>Lint over ALL skills — BEFORE</b></summary>

```
skill authoring lint — 20 skill package(s) under /private/tmp/wt-107/skills
  ERROR   capabilities/tools: SKILL.md body is 673 lines (>500); split detail into references/ (progressive disclosure)
  ERROR   capabilities/tools: SKILL.md body is ~10934 tokens (>5000); it is a recurring per-session cost — move detail into references/
  ERROR   orchestrate/using-cap-evolve: description must not contain XML tags
  advise  algorithms/evograph: description should say WHEN to use the skill ('Use when …') — it is the primary triggering signal
  advise  algorithms/hill-climb: description should say WHEN to use the skill ('Use when …') — it is the primary triggering signal
  advise  optimizers/run-optimizer: description should say WHEN to use the skill ('Use when …') — it is the primary triggering signal
  advise  orchestrate/using-cap-evolve: description should say WHEN to use the skill ('Use when …') — it is the primary triggering signal
  advise  phases/baseline: description should say WHEN to use the skill ('Use when …') — it is the primary triggering signal
  advise  phases/diagnose: description should say WHEN to use the skill ('Use when …') — it is the primary triggering signal
  advise  phases/finalize: description should say WHEN to use the skill ('Use when …') — it is the primary triggering signal
  advise  phases/gate: description should say WHEN to use the skill ('Use when …') — it is the primary triggering signal
  advise  phases/implement-and-check: description should say WHEN to use the skill ('Use when …') — it is the primary triggering signal
  advise  phases/intake: description should say WHEN to use the skill ('Use when …') — it is the primary triggering signal
  advise  phases/report: description should say WHEN to use the skill ('Use when …') — it is the primary triggering signal
FAIL — 3 authoring violation(s) in 2 skill(s)
rc=1
```
</details>

<details><summary><b>Lint over ALL skills — AFTER (clean)</b></summary>

```
skill authoring lint — 20 skill package(s) under /private/tmp/wt-107/skills
  advise  algorithms/evograph: description should say WHEN to use the skill ('Use when …') — it is the primary triggering signal
  advise  algorithms/hill-climb: description should say WHEN to use the skill ('Use when …') — it is the primary triggering signal
  advise  optimizers/run-optimizer: description should say WHEN to use the skill ('Use when …') — it is the primary triggering signal
  advise  phases/baseline: description should say WHEN to use the skill ('Use when …') — it is the primary triggering signal
  advise  phases/diagnose: description should say WHEN to use the skill ('Use when …') — it is the primary triggering signal
  advise  phases/finalize: description should say WHEN to use the skill ('Use when …') — it is the primary triggering signal
  advise  phases/gate: description should say WHEN to use the skill ('Use when …') — it is the primary triggering signal
  advise  phases/implement-and-check: description should say WHEN to use the skill ('Use when …') — it is the primary triggering signal
  advise  phases/intake: description should say WHEN to use the skill ('Use when …') — it is the primary triggering signal
  advise  phases/report: description should say WHEN to use the skill ('Use when …') — it is the primary triggering signal
OK — 20 skill packages pass the authoring bar (10 advisory note(s))
rc=0
```
</details>

### Line counts, every SKILL.md (file lines / body lines)

| SKILL.md | before | after | body before | body after | body tokens before → after |
|---|---:|---:|---:|---:|---|
| **capabilities/tools** | **681** | **208** | **673** | **200** | **~10934 → ~3193** |
| phases/intake | 258 | 255 | 250 | 247 | ~4378 → ~4310 (from #185) |
| capabilities/mcp-tool | 235 | 235 | 227 | 227 | ~2922 |
| capabilities/system-prompt | 198 | 198 | 190 | 190 | ~2993 |
| phases/diagnose | 179 | 179 | 171 | 171 | ~2975 |
| algorithms/evograph | 149 | 149 | 134 | 134 | ~2248 |
| algorithms/agent-optimize | 141 | 141 | 134 | 134 | ~1826 |
| capabilities/skill-package | 122 | 122 | 114 | 114 | ~1739 |
| algorithms/gepa | 113 | 113 | 105 | 105 | ~1543 |
| optimizers/run-optimizer | 107 | 107 | 100 | 100 | ~1195 |
| phases/report | 106 | 106 | 98 | 98 | ~1392 |
| phases/implement-and-check | 98 | 98 | 90 | 90 | ~1312 |
| algorithms/skillopt | 87 | 87 | 80 | 80 | ~1125 |
| orchestrate/orchestrate | 85 | 85 | 77 | 77 | ~1468 |
| phases/gate | 83 | 83 | 75 | 75 | ~1002 |
| phases/baseline | 79 | 79 | 71 | 71 | ~993 |
| phases/evaluate | 70 | 70 | 62 | 62 | ~832 |
| phases/finalize | 63 | 63 | 55 | 55 | ~739 |
| orchestrate/using-cap-evolve | 60 | 60 | 51 | 51 | ~636 |
| algorithms/hill-climb | 56 | 56 | 49 | 49 | ~680 |

`mcp-tool` (227), `system-prompt` (190), `diagnose` (171) and `intake` (247) are all comfortably **under** the 500-line / 5000-token bar as measured by the validator, so the issue's "as needed" list needs no split. `tools` was the only body over budget; `using-cap-evolve` was the only hard problem.

## The split

`tools/SKILL.md` 681 → 208 lines. Detail moved **one level deep** into two new references, each with a TOC, and SKILL.md **links** every section it moved:

- **`references/edit-playbook.md`** (474 lines) — the eight levers in depth, the in-body-guard before/after diffs, "generalize never hardcode", the deterministic-CODE argument, the three code-bearing patterns, the **full symptom→fix table** and **full trigger list** (both preserved verbatim from the old body), the safe tool-replacement protocol, worked composite bodies, the concrete before/afters, and good-vs-bad edits.
- **`references/documentation.md`** (127 lines) — how a tool-using model actually reads a tool definition (select vs. fill), the reader-capability-tier adjustment, response/error design, and the per-tool documentation checklist.

SKILL.md keeps the decision rule: the core rule, a 12-row failure-signature → edit table, the action/policy table, the lean condensed doc+return rules, and the failure-modes list — each pointing at the reference that holds the depth.

**Also fixed a real bug in the shipped validator.** The broken-reference-link check did not strip a Markdown `#anchor` before the existence test, so any deep link into a reference read as broken. My first split hit it (`references/edit-playbook.md#the-safe-tool-replacement-protocol` reported as "does not exist"), so it is fixed at root in `abstract.py` rather than worked around.

`using-cap-evolve`'s description carried literal `"<X>"` / `"<phase>"`, which the validator correctly reads as XML tags — a **hard problem**, not a warning, and a real discoverability hazard since the description is injected into a listing. Reworded to plain text; no content change.

## Coordination / expected merge order

This branch is **based on** `origin/refactor/issue-106-deleak-intake` (PR #185) — not merged with it. This branch's first two commits ARE #185's two commits, same SHAs, linear history, no merge commit and no cherry-pick, so there is **no double-apply risk however #185 lands** (if it merges, its SHAs are already ancestors here; if it squash-merges, this branch's identical content collapses to nothing). I build directly on its `tools/SKILL.md` References hunk and `references/optimizer-playbook.md` — my References section links it as a sixth reference.

**Expected merge order: #185 → #181 → #198 → this PR.**

- **#185 (issue #106)** — must land first. It created `tools/references/optimizer-playbook.md` and left `tools/SKILL.md` at 686 lines deliberately, correctly identifying the split as this issue's job. It is this branch's **base**, so landing it first is not optional here; the References hunk is inherited, not re-applied.
- **#181 (issue #103)** and **#198 (issue #104)** both edit `intake/SKILL.md`, which I do **not** touch. No conflict — `git diff origin/main pr181/pr198 -- skills/phases/intake/SKILL.md` overlaps nothing in this diff.
- The shared file with #198 is **`skills/phases/intake/SKILL.md`** (inherited from the #185 commits in this branch's base) — and its hunk here is byte-identical to #185's, so #181/#198's intake edits conflict with #185, not with this PR. **`skills/_registry/manifest.json` is not modified by this PR at all** (`git diff origin/main...HEAD -- skills/_registry/manifest.json` is empty; it is already correct on main). CI now fails on a stale manifest (`git diff --exit-code`), so drift cannot pass unreviewed.

The lint may flag a body that #181/#198 grow — but `intake` is at 247 body lines against a 500 bar, so there is ~250 lines of headroom.

## Verification

Every claim below is pasted output; full transcript in the 🔬 Evidence comment.

**Lint fails CI on a deliberate violation, passes after revert**

```
===== 1) DELIBERATE OVERSIZED BODY =====
  ERROR   phases/gate: SKILL.md body is 575 lines (>500); split detail into references/ (progressive disclosure)
  ERROR   phases/gate: SKILL.md body is ~8725 tokens (>5000); it is a recurring per-session cost — move detail into references/
FAIL — 2 authoring violation(s) in 1 skill(s)
rc=1

===== 2) DELIBERATE EMPTY PLACEHOLDER REFERENCE =====
  ERROR   phases/gate: references/notes.md is an empty/stub reference (<5 lines) — fill it or delete it
  ERROR   phases/gate: references/notes.md still contains the template placeholder 'TODO'
FAIL — 2 authoring violation(s) in 1 skill(s)
rc=1

===== 3) REVERTED — lint passes again =====
OK — 20 skill packages pass the authoring bar (10 advisory note(s))
rc=0
```

**The guard is NOT vacuous — removing OR renaming a skill fires the count assertion**

```
===== remove skills/phases/gate =====
  ERROR   discovery: found 19 skill packages, expected at least 20 — a skill was renamed/removed and lint coverage silently dropped
rc=1

===== rename the dir + its SKILL.md (dir count unchanged) =====
  ERROR   discovery: found 19 skill packages, expected at least 20 — a skill was renamed/removed and lint coverage silently dropped
rc=1
```

**Manifest builds; every skill's `check.py` prints `"ok": true`** — 20/20, full output in Evidence.

```
wrote skills/_registry/manifest.json (20 skill(s))
build_manifest rc=0
```

**Moved content still reaches the optimizer** — real zero-API `cap-evolve run` on `examples/toy_calc` with the `mock` optimizer and `capabilities: [system-prompt, tools]`:

```
{"run_dir": ".capevolve/run_matproof", "best_id": "cand_0001",
 "baseline_val": 0.0, "test_reward": 1.0, "test_delta": 1.0, "iterations": 3}

$ find . -path "*guidance/tools*"
./.capevolve/run_matproof/work/cand_0001/guidance/tools/SKILL.md
./.capevolve/run_matproof/work/cand_0001/guidance/tools/references/documentation.md   <-- NEW
./.capevolve/run_matproof/work/cand_0001/guidance/tools/references/edit-playbook.md   <-- NEW
./.capevolve/run_matproof/work/cand_0001/guidance/tools/references/optimizer-playbook.md
./.capevolve/run_matproof/work/cand_0001/guidance/tools/references/{concepts,examples,pitfalls}.md

$ diff -r skills/capabilities/tools/references $G/references ; echo rc=$?
rc=0
$ diff skills/capabilities/tools/SKILL.md $G/SKILL.md ; echo rc=$?
rc=0

6ad9307…  skills/capabilities/tools/references/edit-playbook.md
6ad9307…  …/guidance/tools/references/edit-playbook.md
a0f9287…  skills/capabilities/tools/references/documentation.md
a0f9287…  …/guidance/tools/references/documentation.md
```

`harness.py`'s `copytree(..., ignore=ignore_patterns("__pycache__","scripts","*.pyc"))` has no `references` pattern, so the property #185's reviewer verified holds for the newly-split files too — byte-identical, `diff` rc=0.

**No substantive claim lost in the split.** A 12-gram content-word coverage check of the old 673-line body against new SKILL.md + all references leaves 15 spans ≥30 words; every one is a heading-join artifact or prose I condensed while `concepts.md` §5 / `pitfalls.md` already carry the depth. Spot-checked each compressed claim survives by name (`safety boundary`, `blast radius`, `visible refusals rather than silent no-ops`, `Composite-tool sprawl`, `rarely-but-critically needed`, `fight reasoning models`, `Over-describing into contradiction`, `Schema changes that break callers`, `in sync`) — all present. The first pass **did** drop the mis-selection / bad-argument-filling / fumbled-chain trigger bullets; the check caught it and they are back as table rows plus the verbatim full trigger list in the playbook.

**Tests**

```
$ PYTHONPATH=core python -m pytest core/tests -q
185 passed in 58.83s
```

179 baseline + 6 new (`core/tests/test_skill_authoring_lint.py`), 0 failed. The environmentally-flaky `test_dashboard_launch.py::test_maybe_launch_spawns_when_available` (#200) passed here.

```
$ python -m compileall -q core skills && echo OK
compileall OK
```

## Files touched

| File | Change |
|---|---|
| `skills/_registry/lint_skills.py` | **new** — the dogfooding lint |
| `core/tests/test_skill_authoring_lint.py` | **new** — 6 tests guarding the lint itself |
| `skills/capabilities/tools/references/edit-playbook.md` | **new** — 474 lines of moved depth + TOC |
| `skills/capabilities/tools/references/documentation.md` | **new** — 127 lines of moved depth + TOC |
| `.github/workflows/ci.yml` | new `lint-skills` job (lint + manifest rebuild) |
| `skills/capabilities/tools/SKILL.md` | 681 → 208 lines; links what moved |
| `skills/capabilities/skill-package/scripts/abstract.py` | strip `#anchor` before the broken-link existence check |
| `skills/orchestrate/using-cap-evolve/SKILL.md` | description: remove literal `<X>`/`<phase>` XML tags |

Plus the inherited #185 base commits (`tools/SKILL.md` References hunk, `references/optimizer-playbook.md`, `intake/SKILL.md`) . `skills/_registry/manifest.json` is untouched by this PR.

