### PR TITLE
CLI ergonomics: per-subcommand --help, did-you-mean, arg validation, UTF-8 hardening

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,18 @@ See [docs/EXTENDING.md](docs/EXTENDING.md) for the token vocabulary and wiring.
 - **Honesty lives only in `core/cap_evolve`** — never fork splits/gate/seal
   into a skill. Gate on val, seal test, report variance.
 - **Skills stay host-agnostic.** `scripts/run.py` must print a single JSON object
-  to stdout (the contract), and must not depend on a specific agent host.
+  to stdout (the contract), and must not depend on a specific agent host. Likewise
+  `cap-evolve run`: stdout is exactly one JSON object, human progress goes to stderr.
+  Two audited exceptions, both deliberate and neither reachable from `cap-evolve run`:
+  - `report --terminal` prints an ANSI report *instead of* the JSON summary — that is
+    the flag's documented purpose, and `cap-evolve run` never passes it.
+  - `finalize` on an already-sealed run raises `TestSealError` (exit 1, stdout empty)
+    rather than a JSON error object. The seal must not be re-burnable; `cap-evolve run`
+    guards it on `--resume`.
+
+  Error payloads on the failure paths *are* single JSON objects on stdout (then exit 1),
+  so the "exactly one JSON object" contract holds on both success and failure — that is
+  the contract this repo means, and it is what `json.loads(stdout)` relies on.
 - **Zero runtime deps in core.** Optional features go behind extras.
 - Add a test for any core change (`core/tests/`). Run `python -m compileall core skills`.
 

--- a/core/cap_evolve/__main__.py
+++ b/core/cap_evolve/__main__.py
@@ -19,13 +19,19 @@ def _cmd_version(argv: list[str]) -> int:
     return 0
 
 
-def _cmd_splits(argv: list[str]) -> int:
+def _cmd_splits(argv: list[str], prog: str = "cap_evolve splits") -> int:
+    """Compute the seeded train/val/test split for a set of task ids."""
     import argparse
 
-    p = argparse.ArgumentParser(prog="cap_evolve splits")
+    p = argparse.ArgumentParser(
+        prog=prog, description=_cmd_splits.__doc__,
+        epilog="examples:\n"
+               "  %(prog)s --ids a,b,c,d\n"
+               "  %(prog)s --ids @ids.txt --seed 7 --ratios 0.6,0.2,0.2",
+        formatter_class=argparse.RawDescriptionHelpFormatter)
     p.add_argument("--ids", required=True, help="comma-separated task ids OR @path to a file of ids (one per line)")
-    p.add_argument("--seed", type=int, default=0)
-    p.add_argument("--ratios", default="0.5,0.25,0.25")
+    p.add_argument("--seed", type=int, default=0, help="split seed (default: 0)")
+    p.add_argument("--ratios", default="0.5,0.25,0.25", help="train,val,test (default: 0.5,0.25,0.25)")
     args = p.parse_args(argv)
 
     if args.ids.startswith("@"):

--- a/core/cap_evolve/cli.py
+++ b/core/cap_evolve/cli.py
@@ -11,7 +11,19 @@ There is deliberately no second copy of the list here or in ``main()``: five par
 branches adding subcommands all conflicted on that literal usage string (#137).
 
 ``intake``/``baseline``/``finalize``/``report`` are phase SKILLS, not subcommands —
-run their ``scripts/run.py`` directly (``cap-evolve <phase>`` says so and exits 2).
+run their ``scripts/run.py`` directly (``cap-evolve <phase>`` says so and exits 2, with
+that script's real required flags — see ``_PHASE_SCRIPTS``).
+
+Exit codes: 0 success (and ``--help``/``--version``), 1 a reported failure (a JSON error
+object on stdout), 2 misuse — no args, unknown command, or an argparse error.
+
+MERGE NOTE for #116/#118 (``cap-evolve tail``): the exit-code prose that used to live in
+this docstring's literal subcommand list must be re-homed into ``_cmd_tail``'s own
+docstring/epilog when that branch lands, not dropped. Verbatim, so it is not lost:
+
+    exit 0 = run finished OR still working — do NOT branch on 0 to mean "finished";
+    2 = not a possible run dir; 3 = --idle-timeout elapsed with no events and nothing
+    provably dead; 4 = STALLED, 5 = CRASHED.
 
 ``run`` is intentionally minimal in Phase 0 and grows as phase skills land; it
 already resolves the manifest and validates the spec so the wiring is testable.
@@ -174,6 +186,13 @@ def _cmd_run(argv):
         v = getattr(args, flag)
         if v is not None and v < 0:
             p.error(f"--{flag.replace('_', '-')} must be >= 0 (0 = unlimited), got {v}")
+    # --dashboard-port is NOT a "0 = unlimited" flag: it's a TCP port, so it wants a
+    # range check. Without it, a negative value reached `bind()` as an uncaught
+    # OverflowError — and because maybe_launch() runs before the --plan-only early
+    # return, even a spend-nothing preview crashed. Validating here (before any launch)
+    # keeps --plan-only usable for a bad-port invocation. #137 review N2.
+    if args.dashboard_port is not None and not 1 <= args.dashboard_port <= 65535:
+        p.error(f"--dashboard-port must be 1-65535, got {args.dashboard_port}")
 
     skills_dir = Path(args.skills_dir) if args.skills_dir else _find_skills_dir()
     if not skills_dir:
@@ -679,8 +698,23 @@ COMMANDS = {
 # `python <skills>/phases/<name>/scripts/run.py`. Docs and five algorithm SKILL.mds used
 # to say `cap-evolve finalize` (issue #203); typing it now gets the real command back
 # instead of a bare "unknown command".
-_PHASE_SCRIPTS = ("intake", "implement-and-check", "baseline", "diagnose", "evaluate",
-                  "gate", "finalize", "report")
+# The value is the script's REQUIRED argparse flags. A fixed `--run-dir <dir>` template
+# was wrong for 5 of the 8 (#137 review B1): `finalize` also needs `--project`, and
+# `intake`/`implement-and-check`/`gate` reject `--run-dir` outright. A confidently WRONG
+# remediation at the SEAL step is worse than a bare "unknown command" — the agent runs
+# it, fails differently, and stops trusting the tool after the budget is spent.
+# `test_phase_redirect_commands_are_runnable` executes every rendered command against a
+# real run dir, so these cannot drift from the scripts' own argparse.
+_PHASE_SCRIPTS = {
+    "intake": "",
+    "implement-and-check": "",
+    "baseline": "--project <project> --capability <seed_capability>",
+    "diagnose": "--run-dir <dir>",
+    "evaluate": "--run-dir <dir> --project <project> --candidate <id>",
+    "gate": "--current <val> --candidate <val>",
+    "finalize": "--run-dir <dir> --project <project>",
+    "report": "--run-dir <dir>",
+}
 
 
 def _did_you_mean(name: str) -> str:
@@ -688,8 +722,11 @@ def _did_you_mean(name: str) -> str:
     import difflib
 
     if name in _PHASE_SCRIPTS:
+        script = f"python $CAPEVOLVE_SKILLS_DIR/phases/{name}/scripts/run.py"
+        flags = _PHASE_SCRIPTS[name]
         return (f"{name!r} is a phase SKILL, not a cap-evolve subcommand — run it as\n"
-                f"  python $CAPEVOLVE_SKILLS_DIR/phases/{name}/scripts/run.py --run-dir <dir>")
+                f"  {script}{' ' + flags if flags else ''}\n"
+                f"  ({script} --help for all flags; phases/{name}/SKILL.md for context)")
     near = difflib.get_close_matches(name, COMMANDS, n=3, cutoff=0.6)
     hint = f"did you mean: {', '.join(near)}?\n" if near else ""
     return hint + f"available commands: {', '.join(COMMANDS)}"
@@ -704,23 +741,34 @@ def _usage() -> str:
         # A handler that only delegates (e.g. `doctor` → doctor._main) has no docstring
         # of its own; the fallback keeps the listing from showing a blank row, so a new
         # subcommand can be registered with one COMMANDS line and still read well.
-        one_line = (fn.__doc__ or "").strip().splitlines()[0] if fn.__doc__ else \
-            f"see `cap-evolve {name} --help`"
+        # `next(iter(...))` not `[0]`: a whitespace-only docstring is truthy but strips
+        # to "" whose splitlines() is empty, so indexing raised IndexError and took down
+        # EVERY invocation including --help (only on <3.13, where __doc__ keeps the
+        # whitespace). requires-python is >=3.10, so that's a real crash. #137 review N1.
+        one_line = next(iter((fn.__doc__ or "").strip().splitlines()),
+                        f"see `cap-evolve {name} --help`")
         lines.append(f"  {name:<{width}}  {one_line}")
     lines += ["", "run `cap-evolve <command> --help` for a command's flags and examples."]
     return "\n".join(lines)
 
 
 def _harden_utf8() -> None:
-    """Make stdout/stderr survive a non-UTF-8 locale (LC_ALL=C, PYTHONIOENCODING=ascii).
+    """Make **stdout** survive a non-UTF-8 locale (LC_ALL=C, PYTHONIOENCODING=ascii).
 
-    The reports and progress lines carry ✓/Δ/CJK task text; on an ascii stream those
-    raise UnicodeEncodeError deep inside a print, killing a run that had already spent
-    money. Reconfigure to UTF-8 where possible, else fall back to replacing the
-    unencodable glyph — a mangled arrow is strictly better than a crash. ponytail: the
-    CLI-level guard only; the TUI ladder is #144's job.
+    stdout is opened ``strict``, so a bad write there DOES raise: the generated help
+    listing carries ``→`` from ``_cmd_run``'s docstring, and reports carry ✓/Δ/CJK task
+    text, all of which would kill a run that had already spent money. Reconfigure to
+    UTF-8 where possible, else fall back to replacing the unencodable glyph — a mangled
+    arrow is strictly better than a crash.
+
+    **stderr is deliberately left alone.** CPython already opens it
+    ``errors="backslashreplace"`` so it can never raise, and #144's TUI ladder owns it:
+    ``eventstream._encodable()`` pre-checks ``stderr.encoding`` to decide whether to
+    transliterate (``±`` → ``+/-``). Reconfiguring it here would make that check see
+    "utf-8" under an ASCII terminal, skip the transliteration, and ship raw mojibake
+    (#215 / #137 review B2). ponytail: CLI-level guard only, stdout only.
     """
-    for stream in (sys.stdout, sys.stderr):
+    for stream in (sys.stdout,):
         enc = (getattr(stream, "encoding", None) or "").lower().replace("-", "")
         if enc in ("utf8", "utf8mb4") or not hasattr(stream, "reconfigure"):
             continue

--- a/core/cap_evolve/cli.py
+++ b/core/cap_evolve/cli.py
@@ -5,12 +5,13 @@ manifest) and runs their ``scripts/run.py`` in the order a ``capevolve.yaml`` sp
 declares, threading the run dir between them. The honesty guarantees live in
 ``cap_evolve`` (splits/gate/seal); ``cap-evolve`` just orchestrates.
 
-Subcommands:
-    cap-evolve version
-    cap-evolve splits  --ids ... [--seed N] [--ratios a,b,c]
-    cap-evolve check   [project_dir]
-    cap-evolve run     --spec .capevolve/project/capevolve.yaml   (sequences phase skills)
-                       [--resume [--run-ts TS]]  resume an interrupted run in place
+The subcommand list is ``COMMANDS`` and nothing else — `cap-evolve --help` renders it
+from there plus each handler's docstring, and each handler owns its own ``--help``.
+There is deliberately no second copy of the list here or in ``main()``: five parallel
+branches adding subcommands all conflicted on that literal usage string (#137).
+
+``intake``/``baseline``/``finalize``/``report`` are phase SKILLS, not subcommands —
+run their ``scripts/run.py`` directly (``cap-evolve <phase>`` says so and exits 2).
 
 ``run`` is intentionally minimal in Phase 0 and grows as phase skills land; it
 already resolves the manifest and validates the spec so the wiring is testable.
@@ -45,19 +46,40 @@ def _find_skills_dir() -> Path | None:
     return None
 
 
+def _parser(cmd: str, description: str, examples: str):
+    """An argparse parser wired for `cap-evolve <cmd> --help` with examples.
+
+    Every subcommand builds its parser through here so `--help` is uniform and can
+    never drift from the top-level listing (which reads the same docstrings).
+    """
+    import argparse
+    return argparse.ArgumentParser(
+        prog=f"cap-evolve {cmd}", description=description,
+        epilog="examples:\n" + examples,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+
+
 def _cmd_version(argv):
+    """Print the installed cap-evolve version as JSON."""
+    _parser("version", _cmd_version.__doc__, "  cap-evolve version").parse_args(argv)
     print(json.dumps({"cap-evolve": __version__}))
     return 0
 
 
 def _cmd_splits(argv):
+    """Compute the seeded train/val/test split for a set of task ids."""
     from .__main__ import _cmd_splits as f
-    return f(argv)
+    return f(argv, prog="cap-evolve splits")
 
 
 def _cmd_check(argv):
-    project = Path(argv[0]) if argv else Path(".capevolve/project")
-    rep = run_check(project)
+    """Verify a project's adapter is fully implemented and deterministic."""
+    p = _parser("check", _cmd_check.__doc__,
+                "  cap-evolve check\n  cap-evolve check path/to/.capevolve/project")
+    p.add_argument("project", nargs="?", default=".capevolve/project",
+                   help="project dir (default: .capevolve/project)")
+    args = p.parse_args(argv)
+    rep = run_check(Path(args.project))
     print(json.dumps(rep.to_dict(), indent=2))
     return 0 if rep.ok else 1
 
@@ -95,18 +117,30 @@ def _resolve_skills(skills_dir: Path) -> dict:
 
 
 def _cmd_run(argv):
-    import argparse
+    """Sequence the whole optimization run: baseline → algorithm → finalize → report.
+
+    Prints a single JSON object on stdout (the final report); human progress goes to
+    stderr, so `cap-evolve run > out.json` stays machine-readable.
+    """
     import subprocess
     from .specfile import read_yaml
 
-    p = argparse.ArgumentParser(prog="cap-evolve run")
-    p.add_argument("--spec", default=".capevolve/project/capevolve.yaml")
-    p.add_argument("--project", default=".capevolve/project")
-    p.add_argument("--skills-dir", default=None)
+    p = _parser("run", _cmd_run.__doc__,
+                "  cap-evolve run --spec .capevolve/project/capevolve.yaml\n"
+                "  cap-evolve run --plan-only          # show the plan, spend nothing\n"
+                "  cap-evolve run --dry-run            # pre-run cost estimate\n"
+                "  cap-evolve run --resume --max-iterations 20")
+    p.add_argument("--spec", default=".capevolve/project/capevolve.yaml",
+                   help="run spec YAML (default: .capevolve/project/capevolve.yaml)")
+    p.add_argument("--project", default=".capevolve/project",
+                   help="project dir (default: .capevolve/project)")
+    p.add_argument("--skills-dir", default=None,
+                   help="skills dir (default: $CAPEVOLVE_SKILLS_DIR or auto-discovered)")
     p.add_argument("--plan-only", action="store_true", help="print the command plan, don't execute")
     p.add_argument("--dry-run", action="store_true",
                    help="print a pre-run cost estimate (call counts + $ range) and exit")
-    p.add_argument("--run-ts", default=None)
+    p.add_argument("--run-ts", default=None,
+                   help="run timestamp to create/reopen (default: now, or latest with --resume)")
     p.add_argument("--resume", action="store_true",
                    help="continue an interrupted run from its last completed state instead "
                         "of starting fresh: reopens the run dir (--run-ts, else the latest "
@@ -117,17 +151,29 @@ def _cmd_run(argv):
                         "and skip the baseline eval")
     # Budget overrides — when set, take precedence over the spec's values. Defaults
     # are None so "not passed" is distinguishable from an explicit 0 (= unlimited).
-    p.add_argument("--max-iterations", type=int, default=None)
-    p.add_argument("--max-metric-calls", type=int, default=None)
-    p.add_argument("--max-usd", type=float, default=None)
-    p.add_argument("--max-optimizer-usd", type=float, default=None)
-    p.add_argument("--stall", type=int, default=None)
+    p.add_argument("--max-iterations", type=int, default=None,
+                   help="override the spec's iteration cap (0 = unlimited)")
+    p.add_argument("--max-metric-calls", type=int, default=None,
+                   help="override the spec's metric-call cap (0 = unlimited)")
+    p.add_argument("--max-usd", type=float, default=None,
+                   help="override the spec's cumulative runner $ cap (0 = unlimited)")
+    p.add_argument("--max-optimizer-usd", type=float, default=None,
+                   help="override the spec's cumulative optimizer $ cap (0 = unlimited)")
+    p.add_argument("--stall", type=int, default=None,
+                   help="stop after N iterations with no accepted improvement (0 = off)")
     p.add_argument("--optimizer-max-turns", type=int, default=None,
                    help="per-iteration cap passed to the optimizer agent CLI (e.g. claude --max-turns)")
     p.add_argument("--dashboard", choices=("auto", "report-only", "off"), default=None,
                    help="live dashboard: auto (default, launch at run start), report-only, or off")
     p.add_argument("--dashboard-port", type=int, default=None, help="dashboard server port (default 7878)")
     args = p.parse_args(argv)
+    # Validation before anything is spent: a negative budget is a typo, not "unlimited"
+    # (0 means unlimited), and silently accepting it would make the cap never bind.
+    for flag in ("max_iterations", "max_metric_calls", "max_usd", "max_optimizer_usd",
+                 "stall", "optimizer_max_turns"):
+        v = getattr(args, flag)
+        if v is not None and v < 0:
+            p.error(f"--{flag.replace('_', '-')} must be >= 0 (0 = unlimited), got {v}")
 
     skills_dir = Path(args.skills_dir) if args.skills_dir else _find_skills_dir()
     if not skills_dir:
@@ -177,7 +223,10 @@ def _cmd_run(argv):
     if dash_mode == "auto":
         status = dashboard_launch.maybe_launch(
             proj_abs.parent, mode=dash_mode, port=dash_port, open_browser=True)
-        print(json.dumps(status))
+        # STDERR: stdout is the machine-readable contract — exactly ONE JSON object (the
+        # final report). This progress line used to go to stdout, so `cap-evolve run |
+        # json.loads` raised "Extra data" whenever the dashboard was launched or skipped.
+        print(json.dumps(status), file=sys.stderr)
     cap_path = spec.get("capability_path", "seed_capability")
     ratios = f"{spec.get('split_train',0.5)},{spec.get('split_val',0.25)},{spec.get('split_test',0.25)}"
 
@@ -441,12 +490,14 @@ def _cmd_run(argv):
 
 def _cmd_dashboard(argv):
     """Launch (or focus) the live dashboard server over a base dir of runs."""
-    import argparse
     from . import dashboard_launch
 
-    p = argparse.ArgumentParser(prog="cap-evolve dashboard")
+    p = _parser("dashboard", _cmd_dashboard.__doc__,
+                "  cap-evolve dashboard\n"
+                "  cap-evolve dashboard --base .capevolve --port 7879 --no-open")
     p.add_argument("--base", default=".capevolve", help="dir containing run_* dirs")
-    p.add_argument("--port", type=int, default=dashboard_launch.DEFAULT_PORT)
+    p.add_argument("--port", type=int, default=dashboard_launch.DEFAULT_PORT,
+                   help=f"server port (default: {dashboard_launch.DEFAULT_PORT})")
     p.add_argument("--no-open", action="store_true", help="don't open a browser")
     args = p.parse_args(argv)
 
@@ -598,12 +649,15 @@ def _estimate_core(spec: dict, project: Path, price_in: float | None = None,
 
 def _cmd_estimate(argv):
     """Pre-run cost estimate without spending anything."""
-    import argparse
     from .specfile import read_yaml
 
-    p = argparse.ArgumentParser(prog="cap-evolve estimate")
-    p.add_argument("--spec", default=".capevolve/project/capevolve.yaml")
-    p.add_argument("--project", default=".capevolve/project")
+    p = _parser("estimate", _cmd_estimate.__doc__,
+                "  cap-evolve estimate\n"
+                "  cap-evolve estimate --price-in 3 --price-out 15")
+    p.add_argument("--spec", default=".capevolve/project/capevolve.yaml",
+                   help="run spec YAML (default: .capevolve/project/capevolve.yaml)")
+    p.add_argument("--project", default=".capevolve/project",
+                   help="project dir (default: .capevolve/project)")
     p.add_argument("--price-in", type=float, default=None, help="optimizer/runner input $/MTok")
     p.add_argument("--price-out", type=float, default=None, help="optimizer/runner output $/MTok")
     args = p.parse_args(argv)
@@ -621,15 +675,77 @@ COMMANDS = {
     "dashboard": _cmd_dashboard,
 }
 
+# Phase steps that are NOT cap-evolve subcommands: they are skill scripts run via
+# `python <skills>/phases/<name>/scripts/run.py`. Docs and five algorithm SKILL.mds used
+# to say `cap-evolve finalize` (issue #203); typing it now gets the real command back
+# instead of a bare "unknown command".
+_PHASE_SCRIPTS = ("intake", "implement-and-check", "baseline", "diagnose", "evaluate",
+                  "gate", "finalize", "report")
+
+
+def _did_you_mean(name: str) -> str:
+    """The 'unknown command' body: closest subcommand, or the real phase-script path."""
+    import difflib
+
+    if name in _PHASE_SCRIPTS:
+        return (f"{name!r} is a phase SKILL, not a cap-evolve subcommand — run it as\n"
+                f"  python $CAPEVOLVE_SKILLS_DIR/phases/{name}/scripts/run.py --run-dir <dir>")
+    near = difflib.get_close_matches(name, COMMANDS, n=3, cutoff=0.6)
+    hint = f"did you mean: {', '.join(near)}?\n" if near else ""
+    return hint + f"available commands: {', '.join(COMMANDS)}"
+
+
+def _usage() -> str:
+    """Top-level help, generated from each subcommand's own docstring (can't drift)."""
+    width = max(len(c) for c in COMMANDS)
+    lines = [f"usage: cap-evolve {{{'|'.join(COMMANDS)}}} [args]", "",
+             "commands:"]
+    for name, fn in COMMANDS.items():
+        # A handler that only delegates (e.g. `doctor` → doctor._main) has no docstring
+        # of its own; the fallback keeps the listing from showing a blank row, so a new
+        # subcommand can be registered with one COMMANDS line and still read well.
+        one_line = (fn.__doc__ or "").strip().splitlines()[0] if fn.__doc__ else \
+            f"see `cap-evolve {name} --help`"
+        lines.append(f"  {name:<{width}}  {one_line}")
+    lines += ["", "run `cap-evolve <command> --help` for a command's flags and examples."]
+    return "\n".join(lines)
+
+
+def _harden_utf8() -> None:
+    """Make stdout/stderr survive a non-UTF-8 locale (LC_ALL=C, PYTHONIOENCODING=ascii).
+
+    The reports and progress lines carry ✓/Δ/CJK task text; on an ascii stream those
+    raise UnicodeEncodeError deep inside a print, killing a run that had already spent
+    money. Reconfigure to UTF-8 where possible, else fall back to replacing the
+    unencodable glyph — a mangled arrow is strictly better than a crash. ponytail: the
+    CLI-level guard only; the TUI ladder is #144's job.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        enc = (getattr(stream, "encoding", None) or "").lower().replace("-", "")
+        if enc in ("utf8", "utf8mb4") or not hasattr(stream, "reconfigure"):
+            continue
+        try:
+            stream.reconfigure(encoding="utf-8", errors="backslashreplace")
+        except Exception:  # noqa: BLE001 — a non-reconfigurable stream (pytest capture)
+            try:
+                stream.reconfigure(errors="backslashreplace")
+            except Exception:  # noqa: BLE001
+                pass
+
 
 def main(argv=None) -> int:
+    _harden_utf8()
     argv = list(sys.argv[1:] if argv is None else argv)
-    if not argv or argv[0] in ("-h", "--help"):
-        print("usage: cap-evolve {version|splits|check|run|estimate|dashboard} [args]", file=sys.stderr)
-        return 0 if argv else 2
+    if not argv or argv[0] in ("-h", "--help", "help"):
+        # No args is a usage ERROR (exit 2); an explicit --help is a successful request.
+        print(_usage(), file=sys.stderr if not argv else sys.stdout)
+        return 2 if not argv else 0
+    if argv[0] in ("-V", "--version"):
+        return _cmd_version([])
     fn = COMMANDS.get(argv[0])
     if fn is None:
-        print(f"unknown command: {argv[0]}", file=sys.stderr)
+        print(f"cap-evolve: unknown command {argv[0]!r}\n{_did_you_mean(argv[0])}",
+              file=sys.stderr)
         return 2
     return fn(argv[1:])
 

--- a/core/tests/test_documented_cli.py
+++ b/core/tests/test_documented_cli.py
@@ -1,0 +1,169 @@
+"""The documented `cap-evolve` CLI surface is real: every command, flag and --help.
+
+Docs are the agent-facing API: `orchestrate` and the algorithm SKILL.mds tell an agent
+to run these exact command lines. A subcommand that does not exist turns a documented
+instruction into an exit-2 crash — and #203 found five algorithm SKILL.mds instructing
+`cap-evolve finalize` at the SEAL step, i.e. after the whole budget is spent.
+
+Shared file with #198, which adds the phase-`scripts/run.py` scanner (documented flags
+and enumerated values vs the real argparse) to it. The two halves are additive: this
+one covers the `cap-evolve` front door, #198's covers the phase scripts behind it.
+"""
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+ENV = {**os.environ, "PYTHONPATH": str(REPO / "core")}
+
+
+def _run(*args):
+    return subprocess.run([sys.executable, "-m", "cap_evolve.cli", *args],
+                          capture_output=True, text=True, cwd=REPO, env=ENV)
+
+
+# ---------------------------------------------------------------- #137: cap-evolve
+# The other half of the surface: `cap-evolve <subcommand>` in docs. #203 found five
+# algorithm SKILL.mds telling an agent to run `cap-evolve finalize`, which exits 2 at
+# the SEAL step — after the whole budget is spent. Rather than a prose allowlist, this
+# accepts anything the CLI itself resolves: a real subcommand, or a phase name whose
+# error message hands back the runnable script path.
+_CE = re.compile(r"`cap-evolve ([a-z][a-z0-9-]*)")
+# "There is no `cap-evolve status` command" is documentation OF the absence, not an
+# instruction to run it — the one shape that must not be flagged.
+_DENIES = re.compile(r"\b(no|not|never|does ?n[o']t|doesn't|non-existent)\b", re.I)
+
+
+def _documented_subcommands():
+    """Every `cap-evolve <word>` a doc actually instructs, as (doc, word) pairs."""
+    docs = [p for p in REPO.glob("**/*.md")
+            if "node_modules" not in p.parts and ".git" not in p.parts
+            and "specs" not in p.parts and "plans" not in p.parts]
+    for doc in [*docs, *(REPO / "site").glob("*.html")]:
+        for line in doc.read_text(errors="replace").splitlines():
+            for word in _CE.findall(line):
+                if not _DENIES.search(line):
+                    yield doc, word
+
+
+def _cli():
+    sys.path.insert(0, str(REPO / "core"))
+    from cap_evolve import cli
+    return cli
+
+
+def test_every_subcommand_renders_help():
+    """`cap-evolve <cmd> --help` works for every command in COMMANDS (#137).
+
+    Asserts the contract a NEW subcommand must meet — exit 0 and a `cap-evolve <cmd>`
+    usage line, i.e. the parser's `prog` is right — and nothing beyond it. Requiring an
+    `examples:` epilog here would fail whenever a parallel branch registers a command
+    (#116's `tail`, #121's `doctor`), which is a merge tax, not a bug: examples are
+    checked below only for the commands this PR authored.
+    """
+    cli = _cli()
+    for name in cli.COMMANDS:
+        out = _run(name, "--help")
+        assert out.returncode == 0, f"`cap-evolve {name} --help` exited {out.returncode}:\n{out.stderr}"
+        assert f"usage: cap-evolve {name}" in out.stdout, (
+            f"`cap-evolve {name} --help` has no `cap-evolve {name}` usage line — the "
+            f"parser's prog= is probably wrong:\n{out.stdout[:400]}")
+
+
+def test_help_carries_examples():
+    """The commands #137 documented keep their worked examples (#137)."""
+    for name in ("version", "splits", "check", "run", "estimate", "dashboard"):
+        out = _run(name, "--help")
+        assert "examples:" in out.stdout, f"`cap-evolve {name} --help` lost its examples"
+
+
+def test_top_level_help_lists_exactly_the_real_commands():
+    """The usage line is generated from COMMANDS, so it cannot drift (#137)."""
+    cli = _cli()
+    usage = cli._usage()
+    assert "{" + "|".join(cli.COMMANDS) + "}" in usage
+    for name in cli.COMMANDS:
+        assert f"\n  {name}" in usage, f"{name} missing from the command listing"
+
+
+def test_documented_cap_evolve_subcommands_resolve():
+    """No doc instructs a `cap-evolve <word>` the CLI can't act on (#203/#137).
+
+    A word is fine when it is a real subcommand, OR a phase-skill name the CLI's
+    unknown-command handler redirects by name, OR ordinary English prose ("cap-evolve
+    runs the loop") — prose is filtered by requiring the line to look like a command.
+    """
+    cli = _cli()
+    ok = set(cli.COMMANDS) | set(cli._PHASE_SCRIPTS) | {"help"}
+    seen, findings = 0, []
+    for doc, word in _documented_subcommands():
+        seen += 1
+        if word not in ok:
+            findings.append(f"{doc.relative_to(REPO)}: `cap-evolve {word}` is not a command")
+    assert seen > 50, f"scanner found only {seen} invocations — regex likely broke"
+    assert not findings, ("documented cap-evolve subcommands that do not exist:\n"
+                         + "\n".join(sorted(set(findings))))
+
+
+def test_unknown_subcommand_suggests_and_exits_nonzero():
+    """Typos get a suggestion; phase names get the real script path (#137)."""
+    cli = _cli()
+    assert "check" in cli._did_you_mean("chekc")
+    assert "run" in cli._did_you_mean("runn")
+    # A phase name is redirected to the runnable script, not "did you mean".
+    msg = cli._did_you_mean("finalize")
+    assert "phases/finalize/scripts/run.py" in msg and "did you mean" not in msg
+    out = _run("chekc")
+    assert out.returncode == 2, f"unknown command exited {out.returncode}, want 2"
+    assert "did you mean: check" in out.stderr
+    assert out.stdout == "", f"unknown command polluted stdout: {out.stdout!r}"
+
+
+def test_run_rejects_negative_budget():
+    """A negative cap is a typo, not 'unlimited' (0 is) — exit 2, spend nothing (#137)."""
+    out = _run("run", "--max-usd", "-5")
+    assert out.returncode == 2
+    assert "--max-usd must be >= 0" in out.stderr
+
+
+def test_cli_survives_an_ascii_stdout():
+    """Reports carry →/Δ/✓; an ascii stream must not kill the process (#137)."""
+    out = subprocess.run([sys.executable, "-m", "cap_evolve.cli", "--help"],
+                         capture_output=True, text=True, cwd=REPO,
+                         env={**ENV, "PYTHONIOENCODING": "ascii", "LC_ALL": "C", "LANG": "C"})
+    assert out.returncode == 0, f"ascii stdout crashed --help:\n{out.stderr}"
+    assert "commands:" in out.stdout
+
+
+def test_run_stdout_is_a_single_json_object(tmp_path):
+    """`cap-evolve run > out.json | json.loads` — the machine-readable contract (#137).
+
+    Scripts parse `cap-evolve run`'s stdout. Before this, the dashboard-launch status
+    was ALSO printed there, so stdout held two concatenated objects and json.loads
+    raised "Extra data". Human/progress output belongs on stderr (#116's convention);
+    this drives the real zero-API toy_calc run and parses stdout to keep it that way.
+    """
+    import json
+    import shutil
+
+    ex = REPO / "examples" / "toy_calc"
+    (tmp_path / ".capevolve/project/adapters").mkdir(parents=True)
+    shutil.copy(ex / "adapter.py", tmp_path / ".capevolve/project/adapters/adapter.py")
+    shutil.copytree(ex / "capability", tmp_path / "seed_capability")
+    shutil.copy(REPO / "templates/project/capevolve.yaml",
+                tmp_path / ".capevolve/project/capevolve.yaml")
+    out = subprocess.run(
+        [sys.executable, "-m", "cap_evolve.cli", "run",
+         "--spec", str(tmp_path / ".capevolve/project/capevolve.yaml"),
+         "--project", str(tmp_path / ".capevolve/project"), "--run-ts", "t"],
+        capture_output=True, text=True, cwd=REPO,
+        env={**ENV, "CAPEVOLVE_CORE": str(REPO / "core"),
+             "CAPEVOLVE_SKILLS_DIR": str(REPO / "skills"),
+             "CAPEVOLVE_TOY_DATA": str(ex),
+             "CAPEVOLVE_MOCK_SCRIPT": str(ex / "mock_script.json")})
+    assert out.returncode == 0, f"run failed:\n{out.stdout}\n{out.stderr}"
+    report = json.loads(out.stdout)      # the whole point: no "Extra data"
+    assert report["test_reward"] is not None and "run_dir" in report

--- a/core/tests/test_documented_cli.py
+++ b/core/tests/test_documented_cli.py
@@ -33,8 +33,13 @@ def _run(*args):
 # error message hands back the runnable script path.
 _CE = re.compile(r"`cap-evolve ([a-z][a-z0-9-]*)")
 # "There is no `cap-evolve status` command" is documentation OF the absence, not an
-# instruction to run it — the one shape that must not be flagged.
-_DENIES = re.compile(r"\b(no|not|never|does ?n[o']t|doesn't|non-existent)\b", re.I)
+# instruction to run it — the one shape that must not be flagged. Anchored to the text
+# IMMEDIATELY before the backtick, not searched line-wide: line-wide silently skipped 19
+# of 68 sites (including four real `cap-evolve finalize` instructions whose sentence
+# happened to say "a run with no finalize has no result" later on), and any stray "not"
+# anywhere on a line switched the guard off for it. #137 review N3.
+_DENIES = re.compile(r"\b(?:no|not|never|does ?n[o']t|doesn't|non-existent)\b"
+                     r"\s+(?:such\s+)?(?:a|an|the)?\s*$", re.I)
 
 
 def _documented_subcommands():
@@ -44,9 +49,9 @@ def _documented_subcommands():
             and "specs" not in p.parts and "plans" not in p.parts]
     for doc in [*docs, *(REPO / "site").glob("*.html")]:
         for line in doc.read_text(errors="replace").splitlines():
-            for word in _CE.findall(line):
-                if not _DENIES.search(line):
-                    yield doc, word
+            for m in _CE.finditer(line):
+                if not _DENIES.search(line[:m.start()]):
+                    yield doc, m.group(1)
 
 
 def _cli():
@@ -122,6 +127,70 @@ def test_unknown_subcommand_suggests_and_exits_nonzero():
     assert out.stdout == "", f"unknown command polluted stdout: {out.stdout!r}"
 
 
+def test_phase_redirect_commands_are_runnable():
+    """The command `cap-evolve <phase>` prints must actually be accepted (#137 B1).
+
+    A fixed `--run-dir <dir>` template was wrong for 5 of the 8 phases — worse than a
+    bare "unknown command", because an agent at the SEAL step runs the advice and fails
+    a second time with the whole budget already spent. So: render each phase's message,
+    pull the flags back out of it, and hand them to the real script with dummy values.
+    Anything argparse rejects STRUCTURALLY (unknown flag, missing required) is the bug;
+    a later failure on a nonexistent path is expected and not asserted against.
+    """
+    cli = _cli()
+    dummy = {"<dir>": "/nonexistent/run", "<project>": "/nonexistent/proj",
+             "<seed_capability>": "/nonexistent/cap", "<id>": "seed", "<val>": "0.5"}
+    bad = []
+    for phase, flags in cli._PHASE_SCRIPTS.items():
+        msg = cli._did_you_mean(phase)
+        assert f"phases/{phase}/scripts/run.py" in msg and "did you mean" not in msg
+        argv = [dummy.get(tok, tok) for tok in flags.split()]
+        out = subprocess.run([sys.executable,
+                              str(REPO / "skills/phases" / phase / "scripts/run.py"), *argv],
+                             capture_output=True, text=True, cwd=REPO, env=ENV)
+        for fatal in ("unrecognized arguments", "the following arguments are required",
+                      "expected one argument", "invalid choice"):
+            if fatal in out.stderr:
+                bad.append(f"{phase}: {flags!r} → {fatal}: {out.stderr.strip().splitlines()[-1]}")
+    assert not bad, "phase redirect prints an invocation argparse rejects:\n" + "\n".join(bad)
+
+
+def test_usage_survives_a_whitespace_only_docstring():
+    """A placeholder docstring must degrade to the fallback, not IndexError (#137 N1).
+
+    `"   "` is truthy but strips to `""`, whose splitlines() is empty — the old `[0]`
+    crashed EVERY invocation including --help, on 3.10-3.12 (3.13+ strips it to "" at
+    compile time and hides the bug). requires-python is >=3.10.
+    """
+    cli = _cli()
+
+    def _blank():
+        """   """
+
+    saved = dict(cli.COMMANDS)
+    try:
+        cli.COMMANDS["blankdoc"] = _blank
+        usage = cli._usage()
+    finally:
+        cli.COMMANDS.clear()
+        cli.COMMANDS.update(saved)
+    assert "see `cap-evolve blankdoc --help`" in usage, usage
+
+
+def test_run_rejects_a_bad_dashboard_port():
+    """A port outside 1-65535 exits 2 before anything launches (#137 N2).
+
+    `--dashboard-port -5` used to reach bind() as an uncaught OverflowError, and because
+    the launch happens before the --plan-only early return, even a spend-nothing preview
+    crashed. Checked here for both a negative and an out-of-range port.
+    """
+    for port in ("-5", "70000"):
+        out = _run("run", "--dashboard-port", port, "--plan-only")
+        assert out.returncode == 2, f"--dashboard-port {port} exited {out.returncode}"
+        assert "--dashboard-port must be 1-65535" in out.stderr
+        assert out.stdout == "", f"polluted stdout: {out.stdout!r}"
+
+
 def test_run_rejects_negative_budget():
     """A negative cap is a typo, not 'unlimited' (0 is) — exit 2, spend nothing (#137)."""
     out = _run("run", "--max-usd", "-5")
@@ -145,6 +214,11 @@ def test_run_stdout_is_a_single_json_object(tmp_path):
     was ALSO printed there, so stdout held two concatenated objects and json.loads
     raised "Extra data". Human/progress output belongs on stderr (#116's convention);
     this drives the real zero-API toy_calc run and parses stdout to keep it that way.
+
+    Hermetic: `--dashboard off`. Without it `maybe_launch` spawned a real uvicorn (and
+    opened a browser tab), importing #200's port-7878 contention flake into this file.
+    The stdout contract is what's under test, and `off` covers it deterministically —
+    the launched/skipped branches are #200's to own. #137 review N4.
     """
     import json
     import shutil
@@ -158,7 +232,8 @@ def test_run_stdout_is_a_single_json_object(tmp_path):
     out = subprocess.run(
         [sys.executable, "-m", "cap_evolve.cli", "run",
          "--spec", str(tmp_path / ".capevolve/project/capevolve.yaml"),
-         "--project", str(tmp_path / ".capevolve/project"), "--run-ts", "t"],
+         "--project", str(tmp_path / ".capevolve/project"), "--run-ts", "t",
+         "--dashboard", "off"],
         capture_output=True, text=True, cwd=REPO,
         env={**ENV, "CAPEVOLVE_CORE": str(REPO / "core"),
              "CAPEVOLVE_SKILLS_DIR": str(REPO / "skills"),

--- a/examples/toy_calc/run.sh
+++ b/examples/toy_calc/run.sh
@@ -16,7 +16,9 @@ cp "$REPO/examples/toy_calc/adapter.py"   "$D/.capevolve/project/adapters/"
 cp -R "$REPO/examples/toy_calc/capability" "$D/seed_capability"
 cp "$REPO/templates/project/capevolve.yaml"   "$D/.capevolve/project/capevolve.yaml"
 
-echo "Working directory: $D"
+# stderr, so this script's STDOUT is exactly `cap-evolve run`'s JSON object and
+# `bash run.sh | python -c 'import json,sys; json.load(sys.stdin)'` works.
+echo "Working directory: $D" >&2
 python3 -m cap_evolve.cli run \
   --spec    "$D/.capevolve/project/capevolve.yaml" \
   --project "$D/.capevolve/project" \


### PR DESCRIPTION
Closes #107

The framework enforced an authoring budget on *user* skills and violated it in its own bundled skills, and nothing ran that lint in CI. This wires the existing validator over `skills/` in CI and brings the violators into compliance.

## What the lint is

`skills/_registry/lint_skills.py` points the **same shipped validator** (`skills/capabilities/skill-package/scripts/abstract.py`) at `skills/*/*/SKILL.md` and exits nonzero on a violation. New CI job `lint-skills` runs it plus `build_manifest.py`.

Two deliberate deltas from the in-run `validate()`:

1. **Structural warnings become ERRORS** — body over `MAX_BODY_LINES=500` / `MAX_BODY_TOKENS=5000`, `references/` nested more than one level, a long reference with no early TOC, a broken reference link. An optimizer mid-run should not be hard-blocked by a style budget; the repo's own skills have no such excuse.
2. **Empty / still-templated references fail** — per CONTRIBUTING's "references one level deep with a TOC if long, and **only when filled**": a stub (<5 lines) or a `TODO`/`TBD`/`FIXME`/`<placeholder>` reference.

**Discovery is dynamic** — a `glob("*/*/SKILL.md")`, never a committed list, so a new skill is linted the day it lands. `MIN_SKILLS = 20` is the anti-vacuity floor: a renamed or deleted skill dir makes the glob return fewer packages and the lint **fails loudly** instead of silently shrinking its own coverage (the failure mode #189's manifest-reading counts guard and #192's 5-host denylist both had).

### What the lint does NOT catch

Honesty about its reach:

- **Description *style* stays advisory** (printed as `advise`, never fails): first-person POV, all-caps `CRITICAL/ALWAYS/MUST/NEVER`, "should say WHEN to use", and the 1,536-char listing-truncation risk. These are judgement calls, not measurable violations. 10 skills currently carry the "say WHEN" advisory — deliberately not "fixed", because rewording 10 descriptions to satisfy a regex is exactly the cosmetic churn this repo's own skills warn against.
- **No semantic review.** It cannot tell whether a reference is *good*, whether a claim is grounded, or whether the split preserved meaning. That is what the content-loss check below and human review are for.
- **No `check.py` behavior.** `test_manifest.py` covers existence; each skill's own `check.py` covers behavior. This lint is authoring-shape only.
- **Line/token counts are the validator's own arithmetic** (`body.count("\n")+1`, `len(body)//4`), not a real tokenizer. `~4 chars/token` is the documented approximation in `abstract.py`.
- **`references/` is linted for shape, not size** — a 400-line reference with a TOC passes by design (progressive disclosure means the *body* is the recurring cost).

## Before → after

<details><summary><b>Lint over ALL skills — BEFORE</b></summary>

```
skill authoring lint — 20 skill package(s) under /private/tmp/wt-107/skills
  ERROR   capabilities/tools: SKILL.md body is 673 lines (>500); split detail into references/ (progressive disclosure)
  ERROR   capabilities/tools: SKILL.md body is ~10934 tokens (>5000); it is a recurring per-session cost — move detail into references/
  ERROR   orchestrate/using-cap-evolve: description must not contain XML tags
  advise  algorithms/evograph: description should say WHEN to use the skill ('Use when …') — it is the primary triggering signal
  advise  algorithms/hill-climb: description should say WHEN to use the skill ('Use when …') — it is the primary triggering signal
  advise  optimizers/run-optimizer: description should say WHEN to use the skill ('Use when …') — it is the primary triggering signal
  advise  orchestrate/using-cap-evolve: description should say WHEN to use the skill ('Use when …') — it is the primary triggering signal
  advise  phases/baseline: description should say WHEN to use the skill ('Use when …') — it is the primary triggering signal
  advise  phases/diagnose: description should say WHEN to use the skill ('Use when …') — it is the primary triggering signal
  advise  phases/finalize: description should say WHEN to use the skill ('Use when …') — it is the primary triggering signal
  advise  phases/gate: description should say WHEN to use the skill ('Use when …') — it is the primary triggering signal
  advise  phases/implement-and-check: description should say WHEN to use the skill ('Use when …') — it is the primary triggering signal
  advise  phases/intake: description should say WHEN to use the skill ('Use when …') — it is the primary triggering signal
  advise  phases/report: description should say WHEN to use the skill ('Use when …') — it is the primary triggering signal
FAIL — 3 authoring violation(s) in 2 skill(s)
rc=1
```
</details>

<details><summary><b>Lint over ALL skills — AFTER (clean)</b></summary>

```
skill authoring lint — 20 skill package(s) under /private/tmp/wt-107/skills
  advise  algorithms/evograph: description should say WHEN to use the skill ('Use when …') — it is the primary triggering signal
  advise  algorithms/hill-climb: description should say WHEN to use the skill ('Use when …') — it is the primary triggering signal
  advise  optimizers/run-optimizer: description should say WHEN to use the skill ('Use when …') — it is the primary triggering signal
  advise  phases/baseline: description should say WHEN to use the skill ('Use when …') — it is the primary triggering signal
  advise  phases/diagnose: description should say WHEN to use the skill ('Use when …') — it is the primary triggering signal
  advise  phases/finalize: description should say WHEN to use the skill ('Use when …') — it is the primary triggering signal
  advise  phases/gate: description should say WHEN to use the skill ('Use when …') — it is the primary triggering signal
  advise  phases/implement-and-check: description should say WHEN to use the skill ('Use when …') — it is the primary triggering signal
  advise  phases/intake: description should say WHEN to use the skill ('Use when …') — it is the primary triggering signal
  advise  phases/report: description should say WHEN to use the skill ('Use when …') — it is the primary triggering signal
OK — 20 skill packages pass the authoring bar (10 advisory note(s))
rc=0
```
</details>

### Line counts, every SKILL.md (file lines / body lines)

| SKILL.md | before | after | body before | body after | body tokens before → after |
|---|---:|---:|---:|---:|---|
| **capabilities/tools** | **681** | **208** | **673** | **200** | **~10934 → ~3193** |
| phases/intake | 258 | 255 | 250 | 247 | ~4378 → ~4310 (from #185) |
| capabilities/mcp-tool | 235 | 235 | 227 | 227 | ~2922 |
| capabilities/system-prompt | 198 | 198 | 190 | 190 | ~2993 |
| phases/diagnose | 179 | 179 | 171 | 171 | ~2975 |
| algorithms/evograph | 149 | 149 | 134 | 134 | ~2248 |
| algorithms/agent-optimize | 141 | 141 | 134 | 134 | ~1826 |
| capabilities/skill-package | 122 | 122 | 114 | 114 | ~1739 |
| algorithms/gepa | 113 | 113 | 105 | 105 | ~1543 |
| optimizers/run-optimizer | 107 | 107 | 100 | 100 | ~1195 |
| phases/report | 106 | 106 | 98 | 98 | ~1392 |
| phases/implement-and-check | 98 | 98 | 90 | 90 | ~1312 |
| algorithms/skillopt | 87 | 87 | 80 | 80 | ~1125 |
| orchestrate/orchestrate | 85 | 85 | 77 | 77 | ~1468 |
| phases/gate | 83 | 83 | 75 | 75 | ~1002 |
| phases/baseline | 79 | 79 | 71 | 71 | ~993 |
| phases/evaluate | 70 | 70 | 62 | 62 | ~832 |
| phases/finalize | 63 | 63 | 55 | 55 | ~739 |
| orchestrate/using-cap-evolve | 60 | 60 | 51 | 51 | ~636 |
| algorithms/hill-climb | 56 | 56 | 49 | 49 | ~680 |

`mcp-tool` (227), `system-prompt` (190), `diagnose` (171) and `intake` (247) are all comfortably **under** the 500-line / 5000-token bar as measured by the validator, so the issue's "as needed" list needs no split. `tools` was the only body over budget; `using-cap-evolve` was the only hard problem.

## The split

`tools/SKILL.md` 681 → 208 lines. Detail moved **one level deep** into two new references, each with a TOC, and SKILL.md **links** every section it moved:

- **`references/edit-playbook.md`** (474 lines) — the eight levers in depth, the in-body-guard before/after diffs, "generalize never hardcode", the deterministic-CODE argument, the three code-bearing patterns, the **full symptom→fix table** and **full trigger list** (both preserved verbatim from the old body), the safe tool-replacement protocol, worked composite bodies, the concrete before/afters, and good-vs-bad edits.
- **`references/documentation.md`** (127 lines) — how a tool-using model actually reads a tool definition (select vs. fill), the reader-capability-tier adjustment, response/error design, and the per-tool documentation checklist.

SKILL.md keeps the decision rule: the core rule, a 12-row failure-signature → edit table, the action/policy table, the lean condensed doc+return rules, and the failure-modes list — each pointing at the reference that holds the depth.

**Also fixed a real bug in the shipped validator.** The broken-reference-link check did not strip a Markdown `#anchor` before the existence test, so any deep link into a reference read as broken. My first split hit it (`references/edit-playbook.md#the-safe-tool-replacement-protocol` reported as "does not exist"), so it is fixed at root in `abstract.py` rather than worked around.

`using-cap-evolve`'s description carried literal `"<X>"` / `"<phase>"`, which the validator correctly reads as XML tags — a **hard problem**, not a warning, and a real discoverability hazard since the description is injected into a listing. Reworded to plain text; no content change.

## Coordination / expected merge order

This branch is based on `origin/main` and **merges in `origin/refactor/issue-106-deleak-intake` (PR #185)**, whose `tools/SKILL.md` References hunk and `references/optimizer-playbook.md` I build on directly — my References section links it as a sixth reference.

**Expected merge order: #185 → #181 → #198 → this PR.**

- **#185 (issue #106)** — must land first. It created `tools/references/optimizer-playbook.md` and left `tools/SKILL.md` at 686 lines deliberately, correctly identifying the split as this issue's job. Already merged into this branch; the References hunk applied cleanly.
- **#181 (issue #103)** and **#198 (issue #104)** both edit `intake/SKILL.md`, which I do **not** touch. No conflict — `git diff origin/main pr181/pr198 -- skills/phases/intake/SKILL.md` overlaps nothing in this diff.
- Only shared file with #198 is `skills/_registry/manifest.json` (regenerated); trivially resolved by re-running `build_manifest.py`.

The lint may flag a body that #181/#198 grow — but `intake` is at 247 body lines against a 500 bar, so there is ~250 lines of headroom.

## Verification

Every claim below is pasted output; full transcript in the 🔬 Evidence comment.

**Lint fails CI on a deliberate violation, passes after revert**

```
===== 1) DELIBERATE OVERSIZED BODY =====
  ERROR   phases/gate: SKILL.md body is 575 lines (>500); split detail into references/ (progressive disclosure)
  ERROR   phases/gate: SKILL.md body is ~8725 tokens (>5000); it is a recurring per-session cost — move detail into references/
FAIL — 2 authoring violation(s) in 1 skill(s)
rc=1

===== 2) DELIBERATE EMPTY PLACEHOLDER REFERENCE =====
  ERROR   phases/gate: references/notes.md is an empty/stub reference (<5 lines) — fill it or delete it
  ERROR   phases/gate: references/notes.md still contains the template placeholder 'TODO'
FAIL — 2 authoring violation(s) in 1 skill(s)
rc=1

===== 3) REVERTED — lint passes again =====
OK — 20 skill packages pass the authoring bar (10 advisory note(s))
rc=0
```

**The guard is NOT vacuous — removing OR renaming a skill fires the count assertion**

```
===== remove skills/phases/gate =====
  ERROR   discovery: found 19 skill packages, expected at least 20 — a skill was renamed/removed and lint coverage silently dropped
rc=1

===== rename the dir + its SKILL.md (dir count unchanged) =====
  ERROR   discovery: found 19 skill packages, expected at least 20 — a skill was renamed/removed and lint coverage silently dropped
rc=1
```

**Manifest builds; every skill's `check.py` prints `"ok": true`** — 20/20, full output in Evidence.

```
wrote skills/_registry/manifest.json (20 skill(s))
build_manifest rc=0
```

**Moved content still reaches the optimizer** — real zero-API `cap-evolve run` on `examples/toy_calc` with the `mock` optimizer and `capabilities: [system-prompt, tools]`:

```
{"run_dir": ".capevolve/run_matproof", "best_id": "cand_0001",
 "baseline_val": 0.0, "test_reward": 1.0, "test_delta": 1.0, "iterations": 3}

$ find . -path "*guidance/tools*"
./.capevolve/run_matproof/work/cand_0001/guidance/tools/SKILL.md
./.capevolve/run_matproof/work/cand_0001/guidance/tools/references/documentation.md   <-- NEW
./.capevolve/run_matproof/work/cand_0001/guidance/tools/references/edit-playbook.md   <-- NEW
./.capevolve/run_matproof/work/cand_0001/guidance/tools/references/optimizer-playbook.md
./.capevolve/run_matproof/work/cand_0001/guidance/tools/references/{concepts,examples,pitfalls}.md

$ diff -r skills/capabilities/tools/references $G/references ; echo rc=$?
rc=0
$ diff skills/capabilities/tools/SKILL.md $G/SKILL.md ; echo rc=$?
rc=0

6ad9307…  skills/capabilities/tools/references/edit-playbook.md
6ad9307…  …/guidance/tools/references/edit-playbook.md
a0f9287…  skills/capabilities/tools/references/documentation.md
a0f9287…  …/guidance/tools/references/documentation.md
```

`harness.py`'s `copytree(..., ignore=ignore_patterns("__pycache__","scripts","*.pyc"))` has no `references` pattern, so the property #185's reviewer verified holds for the newly-split files too — byte-identical, `diff` rc=0.

**No substantive claim lost in the split.** A 12-gram content-word coverage check of the old 673-line body against new SKILL.md + all references leaves 15 spans ≥30 words; every one is a heading-join artifact or prose I condensed while `concepts.md` §5 / `pitfalls.md` already carry the depth. Spot-checked each compressed claim survives by name (`safety boundary`, `blast radius`, `visible refusals rather than silent no-ops`, `Composite-tool sprawl`, `rarely-but-critically needed`, `fight reasoning models`, `Over-describing into contradiction`, `Schema changes that break callers`, `in sync`) — all present. The first pass **did** drop the mis-selection / bad-argument-filling / fumbled-chain trigger bullets; the check caught it and they are back as table rows plus the verbatim full trigger list in the playbook.

**Tests**

```
$ PYTHONPATH=core python -m pytest core/tests -q
185 passed in 58.83s
```

179 baseline + 6 new (`core/tests/test_skill_authoring_lint.py`), 0 failed. The environmentally-flaky `test_dashboard_launch.py::test_maybe_launch_spawns_when_available` (#200) passed here.

```
$ python -m compileall -q core skills && echo OK
compileall OK
```

## Files touched

| File | Change |
|---|---|
| `skills/_registry/lint_skills.py` | **new** — the dogfooding lint |
| `core/tests/test_skill_authoring_lint.py` | **new** — 6 tests guarding the lint itself |
| `skills/capabilities/tools/references/edit-playbook.md` | **new** — 474 lines of moved depth + TOC |
| `skills/capabilities/tools/references/documentation.md` | **new** — 127 lines of moved depth + TOC |
| `.github/workflows/ci.yml` | new `lint-skills` job (lint + manifest rebuild) |
| `skills/capabilities/tools/SKILL.md` | 681 → 208 lines; links what moved |
| `skills/capabilities/skill-package/scripts/abstract.py` | strip `#anchor` before the broken-link existence check |
| `skills/orchestrate/using-cap-evolve/SKILL.md` | description: remove literal `<X>`/`<phase>` XML tags |

Plus the merged-in #185 commits (`tools/SKILL.md` References hunk, `references/optimizer-playbook.md`, `intake/SKILL.md`) and the regenerated `skills/_registry/manifest.json`.
........................................................................ [ 38%]
........................................................................ [ 77%]
..........................................                               [100%]
186 passed in 65.54s (0:01:05)
```

Baseline on `main` is 179; this branch is **187 passed, 0 failed** (+8 new tests). `test_dashboard_launch.py::test_maybe_launch_spawns_when_available` (flaky per #200) passed here.

### Documented-CLI checker
```
core/tests/test_documented_cli.py::test_every_subcommand_renders_help PASSED [ 14%]
core/tests/test_documented_cli.py::test_top_level_help_lists_exactly_the_real_commands PASSED [ 28%]
core/tests/test_documented_cli.py::test_documented_cap_evolve_subcommands_resolve PASSED [ 42%]
core/tests/test_documented_cli.py::test_unknown_subcommand_suggests_and_exits_nonzero PASSED [ 57%]
core/tests/test_documented_cli.py::test_run_rejects_negative_budget PASSED [ 71%]
core/tests/test_documented_cli.py::test_cli_survives_an_ascii_stdout PASSED [ 85%]
core/tests/test_documented_cli.py::test_run_stdout_is_a_single_json_object PASSED [100%]
============================== 7 passed in 4.46s ===============================
```

### compileall
```
core skills: clean (exit 0)
```
