### PR TITLE
Terminal degradation ladder + redacted forensic crash log (#144)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to cap-evolve are documented here. The format follows
 [Semantic Versioning](https://semver.org/) (currently `0.x` — anything may change).
 
 ## [Unreleased]
+### Added
+- **Live terminal progress: `cap-evolve run --follow` and `cap-evolve tail` (#116).** A
+  classic run was silent for its whole duration — a hung multi-hour run looked exactly
+  like a working one. Both new surfaces render human-readable progress (stage, baseline,
+  per-candidate accept/reject + reason, budget warnings, optimizer errors, finalize, plus
+  a running cost/token meter) from the run's `events.jsonl`. The byte-offset tail is now
+  ONE shared helper — `cap_evolve.eventstream` — consumed by the CLI *and* by the
+  dashboard's SSE route, so the terminal and the web view can never disagree. `--follow`
+  writes to stderr, leaving stdout as the machine-readable final JSON; output is plain
+  text on any non-TTY (piped, CI, `NO_COLOR`). Default behavior is unchanged.
+
 ### Fixed
 - **Benchmark CI robustness (skillberry-1 self-hosted runner).** Three fixes so a broken
   runner or gateway is *loud*, not a silent all-0.000 "success": (1) `ci_setup.sh` now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,30 @@ All notable changes to cap-evolve are documented here. The format follows
   (`stop_kind` / `idle` / `should_stop`). `cap-evolve tail` exits `2` on an impossible run
   dir and `3` on an idle timeout with no events.
 
+- **Terminal robustness: an explicit output degradation ladder + a forensic crash log
+  (#144).** Live output now names the five rungs it can be on — `full` (TTY + colour),
+  `plain` (`NO_COLOR`), `dumb` (`TERM=dumb`/`unknown`), `pipe` (non-TTY/CI), `none`
+  (stream closed, `2>&-`) — via `eventstream.capability(stream)`, with
+  `cap-evolve tail --ladder` as a scriptable read-out. Only `full` may put escape bytes
+  on the wire; every other rung is byte-verified plain, so CI logs stay grep-clean.
+  Nothing repaints the screen or moves the cursor at any rung, so there is no live
+  layout to overflow or duplicate on a resize. Non-UTF-8 streams
+  (`PYTHONIOENCODING=ascii`, `LC_ALL=C`, legacy Windows consoles) now transliterate
+  glyphs (`±`→`+/-`, `Δ`→`d`) instead of raising `UnicodeEncodeError` inside the
+  follower thread — or printing CPython's `\xb1` mojibake, which its
+  `backslashreplace` stderr otherwise does silently.
+
+  An unhandled crash — in a subcommand or in the live-view thread — now writes a
+  **forensic log** (version, argv, python/platform, terminal rung + encoding,
+  traceback, the last 25 events seen) next to the run, or under
+  `${XDG_CACHE_HOME:-~/.cache}/cap-evolve/crashes/`, and prints one line pointing at it
+  instead of a bare traceback. The payload — and the user-visible crash line — pass
+  through the existing `dashboard.redact`, so a crash report is safe to attach to an
+  issue; verified against bare high-entropy, UUID, `ghp_` and watsonx-shaped canaries.
+  `redact` also gained the `ghp_`/`github_pat_`/UUID shapes plus a shape-independent
+  pass over this process's secret-looking env values (the same hunk landing via #193 —
+  byte-identical, so the merge is a no-op either way).
+
 ### Fixed
 - **Benchmark CI robustness (skillberry-1 self-hosted runner).** Three fixes so a broken
   runner or gateway is *loud*, not a silent all-0.000 "success": (1) `ci_setup.sh` now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ All notable changes to cap-evolve are documented here. The format follows
   writes to stderr, leaving stdout as the machine-readable final JSON; output is plain
   text on any non-TTY (piped, CI, `NO_COLOR`). Default behavior is unchanged.
 
+  Hardened after review: a malformed event can no longer kill the follower (and if the
+  follower does stop, it says so on stderr instead of going dark); every rendered line is
+  stripped of control characters, so an optimizer's stderr cannot drive the terminal or
+  forge a progress line; the cost meter counts runner spend from `evaluate` and optimizer
+  spend from `step` exactly once, matching the run's own `Spent.total_usd`; `--follow` is
+  disabled rather than falling back to stdout when stderr is closed (`2>&-`); and
+  `follow_events` yields a typed `_follow_end` sentinel naming *why* it stopped
+  (`stop_kind` / `idle` / `should_stop`). `cap-evolve tail` exits `2` on an impossible run
+  dir and `3` on an idle timeout with no events.
+
 ### Fixed
 - **Benchmark CI robustness (skillberry-1 self-hosted runner).** Three fixes so a broken
   runner or gateway is *loud*, not a silent all-0.000 "success": (1) `ci_setup.sh` now

--- a/core/cap_evolve/cli.py
+++ b/core/cap_evolve/cli.py
@@ -14,6 +14,8 @@ Subcommands:
                        [--follow]  print live progress while the run works
     cap-evolve tail    [run_dir] [--base .capevolve]  attach to an ongoing run's
                        events.jsonl and print human-readable progress
+                       (exit 0 = run finished, 2 = not a possible run dir,
+                        3 = --idle-timeout elapsed with no events)
 
 ``run`` is intentionally minimal in Phase 0 and grows as phase skills land; it
 already resolves the manifest and validates the spec so the wiring is testable.
@@ -78,18 +80,46 @@ def _events_path(base: Path, run_ts: str | None, seen: set[str] | None) -> Path 
     return (runs[-1] / "events.jsonl") if runs else None
 
 
-def _spawn_follower(base: Path, run_ts: str | None, seen: set[str] | None):
+def _stderr_is_usable() -> bool:
+    """True only if progress can safely be written to a real, distinct stderr.
+
+    Under ``2>&-`` CPython either sets ``sys.stderr`` to ``None`` or hands fd 2 to the
+    next ``open()``, so writes would land *interleaved in stdout* and break the
+    machine-readable JSON contract ``--follow`` advertises. Following silently off is
+    strictly better than corrupt stdout.
+    """
+    err = sys.stderr
+    if err is None or getattr(err, "closed", False):
+        return False
+    try:
+        efd = err.fileno()
+    except Exception:  # noqa: BLE001 — a captured StringIO has no fd; safe to write to
+        return True
+    # fd 2 closed and reused by the next open() → that fd is not stderr any more.
+    # (`>f 2>&1` keeps fd 2 == 2 pointing at the same file, which is legitimate.)
+    return efd == 2
+
+
+def _spawn_follower(base: Path, run_ts: str | None, seen: set[str] | None,
+                    offset: int = 0):
     """Print live progress from ``events.jsonl`` on a daemon thread.
 
-    Returns ``(stop_event, thread)``; set the event when the run finishes. Reads the
-    same typed event stream the dashboard's SSE route serves (``cap_evolve.eventstream``),
-    so terminal and web can't disagree. Never raises into the run.
+    Returns ``(stop_event, thread)`` — or ``(None, None)`` when stderr is unusable, in
+    which case following is disabled rather than corrupting stdout. Set the event when
+    the run finishes. Reads the same typed event stream the dashboard's SSE route
+    serves (``cap_evolve.eventstream``), so terminal and web can't disagree. Never
+    raises into the run — but never dies *quietly* either: if the follower stops, it
+    says so on stderr, because silence mistaken for progress is the bug #116 fixes.
     """
     import threading
     from . import eventstream
 
+    if not _stderr_is_usable():
+        return None, None
+
     stop = threading.Event()
-    color = eventstream.use_color(sys.stderr)
+    err = sys.stderr  # bind now: don't follow a stream reassigned mid-run
+    color = eventstream.use_color(err)
 
     def worker():
         # Progress goes to STDERR: stdout stays the machine-readable JSON contract that
@@ -104,12 +134,20 @@ def _spawn_follower(base: Path, run_ts: str | None, seen: set[str] | None):
                 return
             totals: dict = {}
             for ev in eventstream.follow_events(
-                    path, poll=0.5, idle_timeout=None, should_stop=stop.is_set):
+                    path, offset=offset, poll=0.5,
+                    should_stop=lambda _last: stop.is_set()):
                 line = eventstream.render_line(ev, totals, color=color)
                 if line:
-                    print(line, file=sys.stderr, flush=True)
-        except Exception:  # noqa: BLE001 — observability must never break the run
-            pass
+                    print(line, file=err, flush=True)
+        except Exception as e:  # noqa: BLE001 — observability must never break the run
+            # ...but it must never go dark in silence either. #144: this is the hook for
+            # the forensic crash log; the user-visible line below is the minimum.
+            try:
+                print(f"[follow] live progress stopped: {e!r} — the run continues; "
+                      f"use `cap-evolve tail` or the dashboard to watch it",
+                      file=err, flush=True)
+            except Exception:  # noqa: BLE001 — stderr died too; nothing left to do
+                pass
 
     t = threading.Thread(target=worker, name="cap-evolve-follow", daemon=True)
     t.start()
@@ -133,6 +171,8 @@ def _cmd_tail(argv):
                    help="give up after N seconds of silence (0 = wait forever)")
     p.add_argument("--no-color", action="store_true")
     args = p.parse_args(argv)
+    if args.idle_timeout < 0:  # a negative timeout used to trip the check immediately
+        p.error("--idle-timeout must be >= 0 (0 = wait forever)")
 
     if args.run_dir:
         root = Path(args.run_dir)
@@ -144,23 +184,36 @@ def _cmd_tail(argv):
         root = runs[-1]
     events = root / "events.jsonl"
     # A named run dir need NOT exist yet: attaching before `cap-evolve run` creates it
-    # is the whole point. follow_events waits for the file; --idle-timeout bounds the
-    # wait, so a typo'd path exits on the timeout instead of hanging forever.
+    # is the whole point. But a path whose PARENT doesn't exist can never become a run
+    # dir, so a typo fails fast with a distinct code instead of pretend-waiting 5 min.
+    if not root.exists() and not root.parent.is_dir():
+        print(f"no such run dir: {root}", file=sys.stderr)
+        return 2
     if not events.exists():
         print(f"waiting for {events} …", file=sys.stderr, flush=True)
 
     color = not args.no_color and eventstream.use_color(sys.stdout)
     offset = 0 if args.from_start or not events.exists() else events.stat().st_size
     totals: dict = {}
+    shown, reason = 0, None
     try:
         for ev in eventstream.follow_events(
                 events, offset=offset, poll=0.5,
                 idle_timeout=(args.idle_timeout or None)):
+            if ev.get("kind") == eventstream.FOLLOW_END:
+                reason = ev.get("reason")
+                continue
             line = eventstream.render_line(ev, totals, color=color)
             if line:
                 print(line, flush=True)
+                shown += 1
     except KeyboardInterrupt:
         return 130
+    if reason == "idle" and not shown:
+        # Distinct from "the run finished": scripts can tell a timeout from a result.
+        print(f"timed out after {args.idle_timeout:g}s with no events from {events}",
+              file=sys.stderr)
+        return 3
     return 0
 
 
@@ -380,7 +433,11 @@ def _cmd_run(argv):
     if args.follow:
         base_abs = proj_abs.parent
         seen = {p.name for p in base_abs.glob("run_*") if p.is_dir()} if not resume_ts else None
-        follow_stop, follow_thread = _spawn_follower(base_abs, resume_ts, seen)
+        # On --resume, skip the prior log (10k old events are not "live progress"):
+        # start at the current end of file, the way `cap-evolve tail` does.
+        prior = base_abs / f"run_{resume_ts}" / "events.jsonl" if resume_ts else None
+        off = prior.stat().st_size if prior and prior.exists() else 0
+        follow_stop, follow_thread = _spawn_follower(base_abs, resume_ts, seen, off)
 
     def done(code: int) -> int:
         """Drain + stop the follower thread, then return ``code``. Used at every exit."""

--- a/core/cap_evolve/cli.py
+++ b/core/cap_evolve/cli.py
@@ -16,6 +16,11 @@ Subcommands:
                        events.jsonl and print human-readable progress
                        (exit 0 = run finished, 2 = not a possible run dir,
                         3 = --idle-timeout elapsed with no events)
+                       [--ladder]  print which output-capability rung this
+                       invocation is on (full/plain/dumb/pipe/none) and exit
+
+On an unhandled crash every subcommand writes a redacted forensic log (traceback +
+last events) and prints one line pointing at it — see ``eventstream.write_crash_log``.
 
 ``run`` is intentionally minimal in Phase 0 and grows as phase skills land; it
 already resolves the manifest and validates the spec so the wiring is testable.
@@ -26,6 +31,7 @@ from __future__ import annotations
 import json
 import os
 import sys
+from collections import deque
 from pathlib import Path
 
 from . import __version__
@@ -100,6 +106,18 @@ def _stderr_is_usable() -> bool:
     return efd == 2
 
 
+def _safe_exc(e: BaseException) -> str:
+    """``TypeName: message``, redacted and sanitised — safe to print at a user.
+
+    An exception message is untrusted text: it routinely carries an optimizer's own
+    stderr (escape sequences, #191) or an echoed environment (credentials, #190/#193).
+    Every crash line the CLI prints goes through here, so no call site can forget.
+    """
+    from . import eventstream
+    from .dashboard import redact
+    return eventstream.sanitize(redact(f"{type(e).__name__}: {e}"))
+
+
 def _spawn_follower(base: Path, run_ts: str | None, seen: set[str] | None,
                     offset: int = 0):
     """Print live progress from ``events.jsonl`` on a daemon thread.
@@ -119,13 +137,17 @@ def _spawn_follower(base: Path, run_ts: str | None, seen: set[str] | None,
 
     stop = threading.Event()
     err = sys.stderr  # bind now: don't follow a stream reassigned mid-run
-    color = eventstream.use_color(err)
+    # The ladder decision, made once, about the stream we actually write to.
+    rung = eventstream.capability(err)
+    color = rung == "full"
+    # Rolling window of what the follower last saw, for the forensic log (#144).
+    recent: deque = deque(maxlen=eventstream.CRASH_TAIL)
 
     def worker():
         # Progress goes to STDERR: stdout stays the machine-readable JSON contract that
         # scripts parse, so `cap-evolve run --follow > out.json` keeps working.
+        path = None
         try:
-            path = None
             while path is None and not stop.is_set():
                 path = _events_path(base, run_ts, seen)
                 if path is None:
@@ -136,18 +158,22 @@ def _spawn_follower(base: Path, run_ts: str | None, seen: set[str] | None,
             for ev in eventstream.follow_events(
                     path, offset=offset, poll=0.5,
                     should_stop=lambda _last: stop.is_set()):
+                recent.append(ev)
                 line = eventstream.render_line(ev, totals, color=color)
-                if line:
-                    print(line, file=err, flush=True)
+                # emit() downgrades glyphs an ascii/C-locale stream can't carry, and
+                # returns False once the stream is gone — stop rather than raise per line.
+                if line and not eventstream.emit(err, line):
+                    return
         except Exception as e:  # noqa: BLE001 — observability must never break the run
-            # ...but it must never go dark in silence either. #144: this is the hook for
-            # the forensic crash log; the user-visible line below is the minimum.
-            try:
-                print(f"[follow] live progress stopped: {e!r} — the run continues; "
-                      f"use `cap-evolve tail` or the dashboard to watch it",
-                      file=err, flush=True)
-            except Exception:  # noqa: BLE001 — stderr died too; nothing left to do
-                pass
+            # ...but it must never go dark in silence either: say so, and leave a
+            # forensic record so "the live view stopped" is diagnosable, not folklore.
+            log = eventstream.write_crash_log(
+                e, run_dir=(path.parent if path else None), recent=recent,
+                context={"where": "follow-thread", "terminal_rung": rung})
+            eventstream.emit(err, f"[follow] live progress stopped: {_safe_exc(e)} — the run "
+                                  f"continues; use `cap-evolve tail` or the dashboard "
+                                  f"to watch it"
+                                  + (f" (details: {log})" if log else ""))
 
     t = threading.Thread(target=worker, name="cap-evolve-follow", daemon=True)
     t.start()
@@ -170,9 +196,17 @@ def _cmd_tail(argv):
     p.add_argument("--idle-timeout", type=float, default=300.0,
                    help="give up after N seconds of silence (0 = wait forever)")
     p.add_argument("--no-color", action="store_true")
+    p.add_argument("--ladder", action="store_true",
+                   help="print which rung of the output degradation ladder this "
+                        "invocation is on (full/plain/dumb/pipe/none) and exit")
     args = p.parse_args(argv)
     if args.idle_timeout < 0:  # a negative timeout used to trip the check immediately
         p.error("--idle-timeout must be >= 0 (0 = wait forever)")
+    if args.ladder:  # a scriptable read-out of which rung this invocation is on
+        print(json.dumps({"stdout": eventstream.capability(sys.stdout),
+                          "stderr": eventstream.capability(sys.stderr),
+                          "ladder": list(eventstream.LADDER)}))
+        return 0
 
     if args.run_dir:
         root = Path(args.run_dir)
@@ -190,25 +224,36 @@ def _cmd_tail(argv):
         print(f"no such run dir: {root}", file=sys.stderr)
         return 2
     if not events.exists():
-        print(f"waiting for {events} …", file=sys.stderr, flush=True)
+        eventstream.emit(sys.stderr, f"waiting for {events} …")
 
     color = not args.no_color and eventstream.use_color(sys.stdout)
     offset = 0 if args.from_start or not events.exists() else events.stat().st_size
     totals: dict = {}
     shown, reason = 0, None
+    recent: deque = deque(maxlen=eventstream.CRASH_TAIL)
     try:
         for ev in eventstream.follow_events(
                 events, offset=offset, poll=0.5,
                 idle_timeout=(args.idle_timeout or None)):
+            recent.append(ev)
             if ev.get("kind") == eventstream.FOLLOW_END:
                 reason = ev.get("reason")
                 continue
             line = eventstream.render_line(ev, totals, color=color)
+            # emit(): survives PYTHONIOENCODING=ascii / LC_ALL=C, and reports a dead
+            # stream instead of raising a BrokenPipeError traceback at the user.
             if line:
-                print(line, flush=True)
+                if not eventstream.emit(sys.stdout, line):
+                    return 0  # `| head` closed the pipe — that's a normal exit
                 shown += 1
     except KeyboardInterrupt:
         return 130
+    except Exception as e:  # noqa: BLE001 — a crash here must be diagnosable, #144
+        log = eventstream.write_crash_log(e, run_dir=root, recent=recent,
+                                          context={"where": "tail"})
+        eventstream.emit(sys.stderr, f"cap-evolve tail crashed: {_safe_exc(e)}"
+                                     + (f" — forensic log: {log}" if log else ""))
+        return 1
     if reason == "idle" and not shown:
         # Distinct from "the run finished": scripts can tell a timeout from a result.
         print(f"timed out after {args.idle_timeout:g}s with no events from {events}",
@@ -811,7 +856,20 @@ def main(argv=None) -> int:
     if fn is None:
         print(f"unknown command: {argv[0]}", file=sys.stderr)
         return 2
-    return fn(argv[1:])
+    try:
+        return fn(argv[1:])
+    except (KeyboardInterrupt, SystemExit):
+        raise  # Ctrl-C / an explicit exit code is not a crash
+    except BaseException as e:  # noqa: BLE001 — #144: never exit with a bare traceback
+        # A crash used to leave the user with a traceback and nothing on disk. Write a
+        # redacted forensic record, point at it in ONE line, and exit non-zero.
+        from . import eventstream
+        log = eventstream.write_crash_log(e, context={"where": f"cap-evolve {argv[0]}"})
+        eventstream.emit(sys.stderr, f"cap-evolve {argv[0]} crashed: {_safe_exc(e)}")
+        eventstream.emit(sys.stderr,
+                         f"forensic log (redacted, safe to attach to a bug report): {log}"
+                         if log else "could not write a forensic log")
+        return 1
 
 
 if __name__ == "__main__":

--- a/core/cap_evolve/cli.py
+++ b/core/cap_evolve/cli.py
@@ -11,6 +11,9 @@ Subcommands:
     cap-evolve check   [project_dir]
     cap-evolve run     --spec .capevolve/project/capevolve.yaml   (sequences phase skills)
                        [--resume [--run-ts TS]]  resume an interrupted run in place
+                       [--follow]  print live progress while the run works
+    cap-evolve tail    [run_dir] [--base .capevolve]  attach to an ongoing run's
+                       events.jsonl and print human-readable progress
 
 ``run`` is intentionally minimal in Phase 0 and grows as phase skills land; it
 already resolves the manifest and validates the spec so the wiring is testable.
@@ -60,6 +63,105 @@ def _cmd_check(argv):
     rep = run_check(project)
     print(json.dumps(rep.to_dict(), indent=2))
     return 0 if rep.ok else 1
+
+
+def _events_path(base: Path, run_ts: str | None, seen: set[str] | None) -> Path | None:
+    """Locate the run's ``events.jsonl``, or ``None`` if no run dir exists yet.
+
+    With ``run_ts`` the path is known up front. Otherwise pick the newest ``run_*``
+    that is NOT in ``seen`` (the dirs that existed before this run started), so a
+    follower attaches to *this* run and not a previous one.
+    """
+    if run_ts:
+        return base / f"run_{run_ts}" / "events.jsonl"
+    runs = sorted(p for p in base.glob("run_*") if p.is_dir() and p.name not in (seen or set()))
+    return (runs[-1] / "events.jsonl") if runs else None
+
+
+def _spawn_follower(base: Path, run_ts: str | None, seen: set[str] | None):
+    """Print live progress from ``events.jsonl`` on a daemon thread.
+
+    Returns ``(stop_event, thread)``; set the event when the run finishes. Reads the
+    same typed event stream the dashboard's SSE route serves (``cap_evolve.eventstream``),
+    so terminal and web can't disagree. Never raises into the run.
+    """
+    import threading
+    from . import eventstream
+
+    stop = threading.Event()
+    color = eventstream.use_color(sys.stderr)
+
+    def worker():
+        # Progress goes to STDERR: stdout stays the machine-readable JSON contract that
+        # scripts parse, so `cap-evolve run --follow > out.json` keeps working.
+        try:
+            path = None
+            while path is None and not stop.is_set():
+                path = _events_path(base, run_ts, seen)
+                if path is None:
+                    stop.wait(0.5)
+            if path is None:
+                return
+            totals: dict = {}
+            for ev in eventstream.follow_events(
+                    path, poll=0.5, idle_timeout=None, should_stop=stop.is_set):
+                line = eventstream.render_line(ev, totals, color=color)
+                if line:
+                    print(line, file=sys.stderr, flush=True)
+        except Exception:  # noqa: BLE001 — observability must never break the run
+            pass
+
+    t = threading.Thread(target=worker, name="cap-evolve-follow", daemon=True)
+    t.start()
+    return stop, t
+
+
+def _cmd_tail(argv):
+    """Attach to an existing/ongoing run dir and print its event stream."""
+    import argparse
+    from . import eventstream
+
+    p = argparse.ArgumentParser(
+        prog="cap-evolve tail",
+        description="tail a run's events.jsonl as human-readable progress lines")
+    p.add_argument("run_dir", nargs="?", default=None,
+                   help="run dir (default: newest run_* under --base)")
+    p.add_argument("--base", default=".capevolve", help="dir containing run_* dirs")
+    p.add_argument("--from-start", action="store_true",
+                   help="replay the whole log first (default: only new events)")
+    p.add_argument("--idle-timeout", type=float, default=300.0,
+                   help="give up after N seconds of silence (0 = wait forever)")
+    p.add_argument("--no-color", action="store_true")
+    args = p.parse_args(argv)
+
+    if args.run_dir:
+        root = Path(args.run_dir)
+    else:
+        runs = sorted(q for q in Path(args.base).glob("run_*") if q.is_dir())
+        if not runs:
+            print(f"no run_* dirs under {args.base}", file=sys.stderr)
+            return 1
+        root = runs[-1]
+    events = root / "events.jsonl"
+    # A named run dir need NOT exist yet: attaching before `cap-evolve run` creates it
+    # is the whole point. follow_events waits for the file; --idle-timeout bounds the
+    # wait, so a typo'd path exits on the timeout instead of hanging forever.
+    if not events.exists():
+        print(f"waiting for {events} …", file=sys.stderr, flush=True)
+
+    color = not args.no_color and eventstream.use_color(sys.stdout)
+    offset = 0 if args.from_start or not events.exists() else events.stat().st_size
+    totals: dict = {}
+    try:
+        for ev in eventstream.follow_events(
+                events, offset=offset, poll=0.5,
+                idle_timeout=(args.idle_timeout or None)):
+            line = eventstream.render_line(ev, totals, color=color)
+            if line:
+                print(line, flush=True)
+    except KeyboardInterrupt:
+        return 130
+    return 0
 
 
 # Old hill-climb skill names → (skill, focus). The three byte-identical clones are
@@ -124,6 +226,9 @@ def _cmd_run(argv):
     p.add_argument("--stall", type=int, default=None)
     p.add_argument("--optimizer-max-turns", type=int, default=None,
                    help="per-iteration cap passed to the optimizer agent CLI (e.g. claude --max-turns)")
+    p.add_argument("--follow", action="store_true",
+                   help="print live progress (stage/candidate/accept-reject/cost) to stderr "
+                        "as the run writes events.jsonl; stdout stays the final JSON")
     p.add_argument("--dashboard", choices=("auto", "report-only", "off"), default=None,
                    help="live dashboard: auto (default, launch at run start), report-only, or off")
     p.add_argument("--dashboard-port", type=int, default=None, help="dashboard server port (default 7878)")
@@ -268,6 +373,22 @@ def _cmd_run(argv):
                 f"--resume: no run_* found under {proj_abs.parent}; pass --run-ts to name one")}))
             return 1
 
+    # --follow: start tailing events.jsonl now, BEFORE baseline creates the run dir, so
+    # the very first events (splits/baseline) are seen. `seen` freezes the pre-existing
+    # run dirs so an unpinned --run-ts follower attaches to this run, not the last one.
+    follow_stop = follow_thread = None
+    if args.follow:
+        base_abs = proj_abs.parent
+        seen = {p.name for p in base_abs.glob("run_*") if p.is_dir()} if not resume_ts else None
+        follow_stop, follow_thread = _spawn_follower(base_abs, resume_ts, seen)
+
+    def done(code: int) -> int:
+        """Drain + stop the follower thread, then return ``code``. Used at every exit."""
+        if follow_stop is not None:
+            follow_stop.set()
+            follow_thread.join(timeout=3.0)
+        return code
+
     # 1) baseline (creates the run dir; capture its relative path)
     base_cmd = [py, skill_run("baseline"), "--base", base, "--project", project,
                 "--capability", cap_path, "--seed", str(spec.get("split_seed", 0)),
@@ -289,7 +410,7 @@ def _cmd_run(argv):
     proc = run(base_cmd)
     if proc.returncode != 0:
         print(json.dumps({"step": "baseline", "error": proc.stderr[-1500:]}))
-        return 1
+        return done(1)
     run_dir = json.loads(proc.stdout)["run_dir"]
 
     # Resume: explicit budget flags EXTEND the reopened run (e.g. bump max_iterations to
@@ -329,7 +450,7 @@ def _cmd_run(argv):
                           "stop_condition": str(spec.get("stop_condition", "")),
                           "next": "drive via the orchestrate Agent-mode loop; "
                                   "seal with `cap-evolve finalize`"}))
-        return 0
+        return done(0)
 
     # 2) algorithm (hill-climb variants select their schedule via --focus)
     alg_cmd = [py, skill_run(algorithm_name), "--run-dir", run_dir, "--project", project,
@@ -409,7 +530,7 @@ def _cmd_run(argv):
     proc = run(alg_cmd)
     if proc.returncode != 0:
         print(json.dumps({"step": "algorithm", "error": proc.stderr[-1500:]}))
-        return 1
+        return done(1)
 
     # 3) finalize  4) report
     last = proc.stdout
@@ -432,11 +553,11 @@ def _cmd_run(argv):
         proc = run(cmd)
         if proc.returncode != 0:
             print(json.dumps({"step": step, "error": proc.stderr[-1500:]}))
-            return 1
+            return done(1)
         last = proc.stdout
 
     print(last)
-    return 0
+    return done(0)
 
 
 def _cmd_dashboard(argv):
@@ -619,13 +740,15 @@ COMMANDS = {
     "run": _cmd_run,
     "estimate": _cmd_estimate,
     "dashboard": _cmd_dashboard,
+    "tail": _cmd_tail,
 }
 
 
 def main(argv=None) -> int:
     argv = list(sys.argv[1:] if argv is None else argv)
     if not argv or argv[0] in ("-h", "--help"):
-        print("usage: cap-evolve {version|splits|check|run|estimate|dashboard} [args]", file=sys.stderr)
+        print("usage: cap-evolve {version|splits|check|run|estimate|dashboard|tail} [args]",
+              file=sys.stderr)
         return 0 if argv else 2
     fn = COMMANDS.get(argv[0])
     if fn is None:

--- a/core/cap_evolve/cli.py
+++ b/core/cap_evolve/cli.py
@@ -118,6 +118,23 @@ def _safe_exc(e: BaseException) -> str:
     return eventstream.sanitize(redact(f"{type(e).__name__}: {e}"))
 
 
+def _with_follow_status(out: str, status: str | None) -> str:
+    """``out`` (the run's final JSON) with ``"follow": status`` folded into the SAME
+    object. Returns ``out`` untouched when there is nothing to report or it isn't a
+    single JSON object — stdout must stay exactly one parseable document (#217), so a
+    second object is never appended and unparseable output is never rewritten."""
+    if not status:
+        return out
+    try:
+        obj = json.loads(out)
+    except (json.JSONDecodeError, TypeError):
+        return out
+    if not isinstance(obj, dict):
+        return out
+    obj["follow"] = status
+    return json.dumps(obj, indent=2)
+
+
 def _spawn_follower(base: Path, run_ts: str | None, seen: set[str] | None,
                     offset: int = 0):
     """Print live progress from ``events.jsonl`` on a daemon thread.
@@ -136,6 +153,12 @@ def _spawn_follower(base: Path, run_ts: str | None, seen: set[str] | None,
         return None, None
 
     stop = threading.Event()
+    # Set if the follower dies before the run does. stderr already says so and a crash
+    # log already records it, but a script reading only stdout could not tell — so `run`
+    # folds this into its EXISTING final JSON object as "follow": "stopped". Never a
+    # second object on stdout: exactly one parseable JSON document is the contract
+    # (#217), and the exit code still answers "did the optimization succeed".
+    died = threading.Event()
     err = sys.stderr  # bind now: don't follow a stream reassigned mid-run
     # The ladder decision, made once, about the stream we actually write to.
     rung = eventstream.capability(err)
@@ -167,6 +190,7 @@ def _spawn_follower(base: Path, run_ts: str | None, seen: set[str] | None,
         except Exception as e:  # noqa: BLE001 — observability must never break the run
             # ...but it must never go dark in silence either: say so, and leave a
             # forensic record so "the live view stopped" is diagnosable, not folklore.
+            died.set()
             log = eventstream.write_crash_log(
                 e, run_dir=(path.parent if path else None), recent=recent,
                 context={"where": "follow-thread", "terminal_rung": rung})
@@ -177,6 +201,7 @@ def _spawn_follower(base: Path, run_ts: str | None, seen: set[str] | None,
 
     t = threading.Thread(target=worker, name="cap-evolve-follow", daemon=True)
     t.start()
+    t.died = died  # carried on the thread so callers need no extra return value
     return stop, t
 
 
@@ -491,6 +516,13 @@ def _cmd_run(argv):
             follow_thread.join(timeout=3.0)
         return code
 
+    def follow_status() -> str | None:
+        """``"stopped"`` if the live view died mid-run, else ``None``. Reported inside
+        the final JSON object so automation can detect a dead follower on stdout alone,
+        without an exit-code change (the run itself succeeded)."""
+        died = getattr(follow_thread, "died", None)
+        return "stopped" if died is not None and died.is_set() else None
+
     # 1) baseline (creates the run dir; capture its relative path)
     base_cmd = [py, skill_run("baseline"), "--base", base, "--project", project,
                 "--capability", cap_path, "--seed", str(spec.get("split_seed", 0)),
@@ -658,8 +690,9 @@ def _cmd_run(argv):
             return done(1)
         last = proc.stdout
 
-    print(last)
-    return done(0)
+    code = done(0)  # drain the follower FIRST: `died` is only final once it has joined
+    print(_with_follow_status(last, follow_status()))
+    return code
 
 
 def _cmd_dashboard(argv):
@@ -858,8 +891,22 @@ def main(argv=None) -> int:
         return 2
     try:
         return fn(argv[1:])
-    except (KeyboardInterrupt, SystemExit):
-        raise  # Ctrl-C / an explicit exit code is not a crash
+    except KeyboardInterrupt as e:
+        # #144 item 3 covers "crash/interrupt": an interrupt during a long run is exactly
+        # when the recent-event trace is wanted. Log it, then re-raise unchanged — the
+        # exit behaviour of Ctrl-C is not ours to redefine, and a failure to write the
+        # log must not turn a clean interrupt into a traceback.
+        try:
+            from . import eventstream
+            log = eventstream.write_crash_log(e, context={"where": f"cap-evolve {argv[0]}",
+                                                          "interrupted": True})
+            if log:
+                eventstream.emit(sys.stderr, f"interrupted — forensic log: {log}")
+        except Exception:  # noqa: BLE001
+            pass
+        raise
+    except SystemExit:
+        raise  # an explicit exit code is not a crash
     except BaseException as e:  # noqa: BLE001 — #144: never exit with a bare traceback
         # A crash used to leave the user with a traceback and nothing on disk. Write a
         # redacted forensic record, point at it in ONE line, and exit non-zero.

--- a/core/cap_evolve/dashboard.py
+++ b/core/cap_evolve/dashboard.py
@@ -81,7 +81,7 @@ _SECRET_VALUE_RES = [
     re.compile(r"\b[A-Za-z0-9+/]{40,}={0,2}\b"),  # long base64
     re.compile(r"\b[0-9a-fA-F]{40,}\b"),          # long hex
     # GitHub PATs (classic + fine-grained) and UUID-shaped tokens — both are common
-    # credential shapes the length-based rules above miss. (Also landing via #193.)
+    # credential shapes that the length-based rules above miss.
     re.compile(r"\bgh[pousr]_[A-Za-z0-9]{16,}\b"),
     re.compile(r"\bgithub_pat_[A-Za-z0-9_]{20,}\b"),
     re.compile(r"\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
@@ -89,17 +89,54 @@ _SECRET_VALUE_RES = [
 ]
 
 
-def _env_secret_values() -> list[str]:
-    """The actual VALUES of secret-looking env vars in this process.
+def _looks_like_credential(value: str) -> bool:
+    """Is ``value`` credential *material*, judged only by its shape as a value?
 
-    Shape matching is a heuristic and always will be: a watsonx key, an opaque
-    session id or a bare high-entropy string has no recognizable shape. What we do
-    know for certain is the credential material this process was handed, so scrub
-    that literally — the only shape-independent defence. Longest first so a value
-    that contains another isn't half-masked. (Also landing via #193; identical hunk.)
+    Deliberately says nothing about the variable's NAME. A key-name heuristic is a
+    denylist wearing a different hat, and this epic has been bitten by that shape of
+    defence five times (#192, #209, #197, #210, and #215's own review): a bare
+    high-entropy secret exported as ``MODEL_ENDPOINT_SUFFIX`` matched no key regex and
+    no value regex, so it reached a file the docs call "safe to attach to a bug
+    report" verbatim.
+
+    A credential is an opaque single token: long, no whitespace, no path separator,
+    mixing lower/upper/digit. That excludes the env vars a crash log exists to show —
+    ``PATH``/``HOME``/``PWD`` (separators), ``TERM=screen-256color`` and ``LSCOLORS``
+    (no digit or no upper), ``LANG`` (too short) — while catching an opaque token
+    whatever it was named.
+
+    Over-redaction is the safe direction: a masked env value costs a line of
+    diagnostics, a leaked one costs a credential rotation.
+    """
+    if not 16 <= len(value) <= 512:
+        return False
+    if any(c.isspace() or c in "/\\" for c in value):
+        return False
+    return (any(c.islower() for c in value) and any(c.isupper() for c in value)
+            and any(c.isdigit() for c in value))
+
+
+def _env_secret_values() -> list[str]:
+    """The actual VALUES of this process's env vars that could be credentials.
+
+    Shape matching free text is a heuristic and always will be: a watsonx key, an
+    opaque session id or a bare high-entropy string has no recognizable shape. What we
+    do know for certain is the credential material this process was handed, so scrub
+    that literally — the only shape-independent defense. Longest first so a value
+    that contains another isn't half-masked.
+
+    Two admission rules, OR-ed: the variable is *named* like a secret
+    (``_key_is_secret`` — admits short values like ``Zx91Kk22PpQq`` that no
+    value-based floor can accept safely), OR the value *looks* like credential
+    material whatever it was named (``_looks_like_credential``). The second rule is
+    what makes this independent of both shape and key name.
+
+    # ponytail: the value floor is length + character-class mixing, not real Shannon
+    # entropy. Misses an all-lowercase 32-hex key not already caught by the
+    # ``[0-9a-fA-F]{40,}`` value rule; compute entropy if one ever shows up.
     """
     vals = {v for k, v in os.environ.items()
-            if v and len(v) >= 6 and _key_is_secret(k)}
+            if v and ((len(v) >= 6 and _key_is_secret(k)) or _looks_like_credential(v))}
     return sorted(vals, key=len, reverse=True)
 
 
@@ -108,6 +145,14 @@ def _env_secret_values() -> list[str]:
 _INLINE_KV_RE = re.compile(
     r"((?:[A-Za-z0-9_\-]*(?:api[_\-]?key|secret|token|password|credential|key)"
     r"[A-Za-z0-9_\-]*)\s*[:=]\s*)(\S+)", re.I)
+
+# ``--api-key VALUE`` — the normal CLI form, where the separator is a SPACE, not
+# ``=``. Only ``--flag``-shaped prefixes get the space treatment: widening
+# ``_INLINE_KV_RE`` to accept whitespace for bare words would mask the next word of
+# ordinary prose ("the api key is wrong" → "the api key «redacted» wrong").
+_FLAG_VALUE_RE = re.compile(
+    r"(--?[A-Za-z0-9_\-]*(?:api[_\-]?key|secret|token|password|credential|key)"
+    r"[A-Za-z0-9_\-]*\s+)(?!-)(\S+)", re.I)
 
 _REDACTED = "«redacted»"
 
@@ -118,7 +163,8 @@ def _key_is_secret(key: str) -> bool:
 
 
 def _scrub_value(val: str) -> str:
-    out = _INLINE_KV_RE.sub(lambda m: m.group(1) + _REDACTED, val)
+    out = _FLAG_VALUE_RE.sub(lambda m: m.group(1) + _REDACTED, val)
+    out = _INLINE_KV_RE.sub(lambda m: m.group(1) + _REDACTED, out)
     for rx in _SECRET_VALUE_RES:
         out = rx.sub(_REDACTED, out)
     # Shape-independent pass: literal credential values from this environment.
@@ -134,6 +180,11 @@ def redact(obj):
     - Dict values under a secret-looking key are replaced wholesale.
     - String values are scanned for secret-shaped tokens and masked in place.
     - Lists/tuples/dicts are walked recursively. Scalars pass through.
+    - In a list, an element FOLLOWING a secret-looking ``--flag`` is masked: an argv
+      is ``["--api-key", "VALUE"]``, and scrubbing each string in isolation can never
+      see that pair — the separator is list adjacency, not a character. Handled here
+      rather than at the ``sys.argv`` call site so every list that reaches an
+      artifact is covered, not just the one the bug was reported against.
 
     Pure, returns a new structure; the caller's object is untouched.
     """
@@ -146,7 +197,18 @@ def redact(obj):
                 out[k] = redact(v)
         return out
     if isinstance(obj, (list, tuple)):
-        return [redact(v) for v in obj]
+        items = list(obj)
+        out = []
+        mask_next = False
+        for v in items:
+            if mask_next and isinstance(v, str) and not v.startswith("-"):
+                out.append(_REDACTED)
+                mask_next = False
+                continue
+            mask_next = (isinstance(v, str) and v.startswith("-")
+                         and _key_is_secret(v.lstrip("-")))
+            out.append(redact(v))
+        return out
     if isinstance(obj, str):
         return _scrub_value(obj)
     return obj

--- a/core/cap_evolve/dashboard.py
+++ b/core/cap_evolve/dashboard.py
@@ -80,7 +80,28 @@ _SECRET_VALUE_RES = [
     re.compile(r"\beyJ[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{6,}\.[A-Za-z0-9_\-]{6,}\b"),  # JWT
     re.compile(r"\b[A-Za-z0-9+/]{40,}={0,2}\b"),  # long base64
     re.compile(r"\b[0-9a-fA-F]{40,}\b"),          # long hex
+    # GitHub PATs (classic + fine-grained) and UUID-shaped tokens — both are common
+    # credential shapes the length-based rules above miss. (Also landing via #193.)
+    re.compile(r"\bgh[pousr]_[A-Za-z0-9]{16,}\b"),
+    re.compile(r"\bgithub_pat_[A-Za-z0-9_]{20,}\b"),
+    re.compile(r"\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
+               r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b"),
 ]
+
+
+def _env_secret_values() -> list[str]:
+    """The actual VALUES of secret-looking env vars in this process.
+
+    Shape matching is a heuristic and always will be: a watsonx key, an opaque
+    session id or a bare high-entropy string has no recognizable shape. What we do
+    know for certain is the credential material this process was handed, so scrub
+    that literally — the only shape-independent defence. Longest first so a value
+    that contains another isn't half-masked. (Also landing via #193; identical hunk.)
+    """
+    vals = {v for k, v in os.environ.items()
+            if v and len(v) >= 6 and _key_is_secret(k)}
+    return sorted(vals, key=len, reverse=True)
+
 
 # KEY=secret / KEY: secret inside prose — mask the value, keep the key name so the
 # message still reads ("RITS_API_KEY=«redacted»"). Two groups: (prefix)(value).
@@ -100,6 +121,10 @@ def _scrub_value(val: str) -> str:
     out = _INLINE_KV_RE.sub(lambda m: m.group(1) + _REDACTED, val)
     for rx in _SECRET_VALUE_RES:
         out = rx.sub(_REDACTED, out)
+    # Shape-independent pass: literal credential values from this environment.
+    for secret in _env_secret_values():
+        if secret in out:
+            out = out.replace(secret, _REDACTED)
     return out
 
 

--- a/core/cap_evolve/eventstream.py
+++ b/core/cap_evolve/eventstream.py
@@ -12,15 +12,39 @@ Public API (stdlib only, no deps):
     partial trailing line unconsumed so a half-written record is never parsed.
 
 ``follow_events(path, *, offset=0, poll=0.5, stop_kinds=("finalize",),
-                idle_timeout=300.0, should_stop=None) -> Iterator[dict]``
+                idle_timeout=None, should_stop=None) -> Iterator[dict]``
     Blocking generator that yields event dicts as they are appended. Stops after
     an event whose ``kind`` is in ``stop_kinds``, after ``idle_timeout`` seconds
-    with no new events, or when ``should_stop()`` returns true.
+    with no new events, or when ``should_stop(last_event)`` returns true. The LAST
+    record yielded is always a ``{"kind": "_follow_end", "reason": ...}`` sentinel
+    naming *which* exit fired ("stop_kind" / "idle" / "should_stop"), so a consumer
+    can tell "the run finished" from "the run went quiet" (see ``FOLLOW_END``).
 
-``format_event(ev, totals=None) -> str | None``
+``format_event(ev, totals=None, *, skip_kinds=BOOKKEEPING_KINDS) -> str | None``
     One human-readable line for an event, or ``None`` for events with nothing
     worth showing. ``totals`` is an optional caller-owned dict used to accumulate
-    the live cost/token meter across events.
+    the live cost/token meter across events (see :func:`accrue_totals`). Pass
+    ``skip_kinds=()`` to render *every* kind, including the bookkeeping ones.
+
+``accrue_totals(ev, totals) -> None``
+    Add one event's spend to ``totals``, counting each dollar exactly once (runner
+    cost from ``evaluate``, optimizer cost from ``step``-likes, intake from
+    ``intake``). Public so every live spend readout uses one arithmetic.
+
+``sanitize(text) -> str``
+    Strip control characters / ESC sequences and collapse newlines.
+
+``render_line(ev, totals=None, *, color=False, **kw) -> str | None``
+    :func:`format_event` plus optional ANSI styling. Styling only — text safety lives
+    in :func:`format_event`, so neither entry point can return an unsafe line.
+
+``use_color(stream) -> bool``
+    The single TTY / ``NO_COLOR`` decision. ``stream`` is required.
+
+Terminal safety: :func:`format_event` is the ONLY place event text is made
+terminal-safe (see :func:`sanitize`). Event values are model/subprocess-controlled
+(``optimizer_error.error`` is the optimizer CLI's own stderr), so every renderer
+must go through it rather than formatting raw fields itself.
 """
 
 from __future__ import annotations
@@ -33,16 +57,41 @@ from pathlib import Path
 from typing import Callable, Iterator
 
 __all__ = ["read_new_events", "follow_events", "format_event", "render_line",
-           "colorize", "use_color"]
+           "colorize", "use_color", "sanitize", "accrue_totals",
+           "FOLLOW_END", "BOOKKEEPING_KINDS"]
+
+#: ``kind`` of the sentinel :func:`follow_events` yields last. Its ``reason`` is one
+#: of ``"stop_kind"`` / ``"idle"`` / ``"should_stop"``. #118 keys stall detection off
+#: ``reason == "idle"``; ``format_event`` renders it as ``None`` (nothing to show).
+FOLLOW_END = "_follow_end"
+
+#: Kinds :func:`format_event` skips by default (the dashboard shows them, the
+#: terminal shouldn't). Pass ``skip_kinds=()`` to see every kind — #138 needs the
+#: bookkeeping ones for phase detection.
+BOOKKEEPING_KINDS = ("minibatch", "optimizer_context_warning", "target_profile",
+                     "seed_dir_created", "splits_warning", "gepa_resume",
+                     "gepa_merge_skip", "gepa_merge_local", "skillopt_slow_eval",
+                     "skillopt_slow_update")
+
+# The one-iteration-finished events, each carrying the optimizer's own spend.
+_STEP_KINDS = ("step", "gepa_val_gate", "skillopt_step")
 
 
 def read_new_events(path: Path, offset: int) -> tuple[list[dict], int]:
     """Return (new events, new byte offset). A partial trailing line (no newline)
-    is left unconsumed so the next read picks it up once complete."""
+    is left unconsumed so the next read picks it up once complete.
+
+    Only JSON *objects* are returned: a bare ``42``/``null``/``[1,2]`` record parses
+    fine but every consumer (CLI renderer, dashboard SSE route) treats events as
+    dicts, so non-dicts are dropped at the source rather than at each caller.
+    """
     p = Path(path)
     if not p.exists():
         return [], offset
-    if offset >= p.stat().st_size:
+    size = p.stat().st_size
+    if size < offset:
+        offset = 0  # file shrank (truncate/rewrite/rotation) → re-read from the top
+    if offset >= size:
         return [], offset
     # Seek-and-read so each poll costs O(new bytes), not O(file size) — callers poll
     # a growing events.jsonl twice a second, per client.
@@ -53,15 +102,24 @@ def read_new_events(path: Path, offset: int) -> tuple[list[dict], int]:
     if last_nl == -1:
         return [], offset  # only a partial line so far
     complete = chunk[: last_nl + 1]
-    events = []
+    events, dropped = [], 0
     for line in complete.splitlines():
         line = line.strip()
         if not line:
             continue
         try:
-            events.append(json.loads(line))
+            obj = json.loads(line)
         except json.JSONDecodeError:
+            dropped += 1
             continue
+        if isinstance(obj, dict):
+            events.append(obj)
+        else:
+            dropped += 1  # a bare 42/null/[1,2] is not an event
+    if dropped:
+        # Don't silently lose audit-log records: surface the count as an event so both
+        # the terminal and the dashboard see that the log has damage.
+        events.append({"kind": "log_corruption", "dropped": dropped})
     return events, offset + last_nl + 1
 
 
@@ -71,40 +129,61 @@ def follow_events(
     offset: int = 0,
     poll: float = 0.5,
     stop_kinds: tuple[str, ...] = ("finalize",),
-    idle_timeout: float | None = 300.0,
-    should_stop: Callable[[], bool] | None = None,
+    idle_timeout: float | None = None,
+    should_stop: Callable[[dict | None], bool] | None = None,
 ) -> Iterator[dict]:
     """Yield events from ``path`` as they are appended (blocking generator).
 
     ``offset=0`` replays the whole file first, then follows. Waits for the file to
-    appear, so a follower can attach before the run creates it. ``idle_timeout=None``
-    means wait forever.
+    appear, so a follower can attach before the run creates it.
+
+    The final record yielded is ALWAYS a ``{"kind": FOLLOW_END, "reason": r}``
+    sentinel where ``r`` is:
+
+    ``"stop_kind"``   an event whose ``kind`` is in ``stop_kinds`` arrived (run ended)
+    ``"idle"``        ``idle_timeout`` seconds passed with no new event (possible stall)
+    ``"should_stop"`` the caller's ``should_stop`` returned true
+
+    so a consumer can distinguish "done" from "quiet" (#118). ``should_stop`` is
+    called with the last event seen (``None`` before any), so a stall rule can look
+    at its ``t`` without running a second poller. ``idle_timeout=None`` (the default)
+    means wait forever — each caller owns its own threshold; there is deliberately no
+    module-level default, because a shared one would pre-decide #118's configurable
+    stall threshold for every consumer.
     """
     idle_start = time.monotonic()
+    last: dict | None = None
     while True:
         events, offset = read_new_events(path, offset)
         for ev in events:
+            last = ev
             yield ev
             if ev.get("kind") in stop_kinds:
+                yield {"kind": FOLLOW_END, "reason": "stop_kind", "last_kind": ev.get("kind")}
                 return
         if events:
             idle_start = time.monotonic()
         elif idle_timeout is not None and time.monotonic() - idle_start >= idle_timeout:
+            yield {"kind": FOLLOW_END, "reason": "idle", "idle_seconds": idle_timeout}
             return
-        if should_stop is not None and should_stop():
+        if should_stop is not None and should_stop(last):
             # Drain whatever landed between the last read and the stop signal, so the
             # final events of a finished run are never lost to a race.
             for ev in read_new_events(path, offset)[0]:
                 yield ev
+            yield {"kind": FOLLOW_END, "reason": "should_stop"}
             return
         time.sleep(poll)
 
 
 # ---- human-readable rendering ----------------------------------------------
 
-def use_color(stream=None) -> bool:
-    """True only on a real TTY without ``NO_COLOR``. Piped/CI output stays plain."""
-    stream = stream or sys.stdout
+def use_color(stream) -> bool:
+    """True only on a real TTY without ``NO_COLOR``. Piped/CI output stays plain.
+
+    ``stream`` is required: the decision must be made about the stream the caller
+    actually writes to, never a default that could colorize stderr based on stdout.
+    """
     if os.environ.get("NO_COLOR"):
         return False
     try:
@@ -120,6 +199,26 @@ def colorize(text: str, style: str, *, enabled: bool) -> str:
     if not enabled or style not in _CODES:
         return text
     return f"\033[{_CODES[style]}m{text}\033[0m"
+
+
+# Every C0 control char (except TAB) and every C1 control char, mapped away. Event
+# values are model/subprocess-controlled — `optimizer_error.error` is the optimizer
+# CLI's own stderr — so an ESC/OSC/CSI sequence in a payload would otherwise reach the
+# terminal verbatim (set window title, clear screen, OSC 52 clipboard write), and a
+# raw "\n" would forge an extra progress line ("FINALIZE test=1.0 …") for a run that
+# never finished. Newlines/CRs collapse to a visible "⏎" rather than vanishing, so a
+# multi-line optimizer error is still legible on one line.
+_CTRL = {c: None for c in range(0x20) if c != 0x09}
+_CTRL[0x7F] = None                       # DEL
+_CTRL.update({c: None for c in range(0x80, 0xA0)})  # C1, incl. 0x9B (8-bit CSI)
+_CTRL[0x0A] = _CTRL[0x0D] = "⏎"
+
+
+def sanitize(text: str) -> str:
+    """Strip control characters / ESC sequences so no event value can drive the
+    terminal or forge extra output lines. Applied by :func:`format_event` to the
+    whole finished line, so every field and every future event kind is covered."""
+    return str(text).translate(_CTRL)
 
 
 def _num(v, fmt="{:.4f}") -> str:
@@ -140,30 +239,80 @@ def _meter(totals: dict | None) -> str:
     return f"  [${usd:.4f} · {tokens} tok]"
 
 
-def _accrue(ev: dict, totals: dict | None) -> None:
-    if totals is None:
+def accrue_totals(ev: dict, totals: dict | None) -> None:
+    """Accumulate the run's spend into ``totals`` (``{"usd","tokens"}``), counting
+    each dollar exactly once. Public so every live readout (terminal meter, #138's
+    dashboard burn line) uses one arithmetic instead of forking it.
+
+    The harness reports the SAME runner spend twice: ``evaluate`` logs
+    ``cost_usd``/``tokens`` (``harness.py:311``) and the following ``step`` re-states
+    it alongside the optimizer's own ``opt_cost_usd``/``opt_tokens``
+    (``harness.py:1326``). So the authoritative sources are:
+
+    * runner spend    → ``evaluate`` only  (``cost_usd`` / ``tokens``)
+    * optimizer spend → ``step``-like only (``opt_cost_usd`` / ``opt_tokens``)
+    * intake spend    → ``intake`` only    (``usd`` / ``tokens``)
+
+    which reproduces ``Spent.total_usd = usd + optimizer_usd + intake_usd``
+    (``rundir.py:137``). Summing every cost-ish key on every event double-counted the
+    runner and displayed ~2x the real spend.
+    """
+    if totals is None or not isinstance(ev, dict):
         return
-    for k in ("cost_usd", "opt_cost_usd", "usd"):
+    kind = str(ev.get("kind") or "")
+    if kind == "evaluate":
+        pairs = (("cost_usd", "tokens"),)
+    elif kind in _STEP_KINDS:
+        pairs = (("opt_cost_usd", "opt_tokens"),)
+    elif kind == "intake":
+        pairs = (("usd", "tokens"),)
+    else:
+        return
+    for usd_key, tok_key in pairs:
         try:
-            totals["usd"] = totals.get("usd", 0.0) + float(ev.get(k) or 0.0)
+            totals["usd"] = totals.get("usd", 0.0) + float(ev.get(usd_key) or 0.0)
         except (TypeError, ValueError):
             pass
-    for k in ("tokens", "opt_tokens"):
         try:
-            totals["tokens"] = totals.get("tokens", 0) + int(ev.get(k) or 0)
+            totals["tokens"] = totals.get("tokens", 0) + int(ev.get(tok_key) or 0)
         except (TypeError, ValueError):
             pass
 
 
-def format_event(ev: dict, totals: dict | None = None) -> str | None:
+
+def _timestamp(v) -> str:
+    """``HH:MM:SS`` for an event's ``t``, or ``--:--:--`` for a malformed one.
+
+    ``rundir.log_event`` serialises with ``json.dumps(..., default=str)``, so a ``t``
+    that is a string / dict / out-of-range float is reachable in a real log. It must
+    never raise: one bad record used to kill the follower thread and take the rest of
+    the run's live output with it, which is the exact silence #116 exists to fix.
+    """
+    try:
+        return time.strftime("%H:%M:%S", time.localtime(float(v if v else time.time())))
+    except (TypeError, ValueError, OverflowError, OSError):
+        return "--:--:--"
+
+
+def format_event(ev: dict, totals: dict | None = None, *,
+                 skip_kinds: tuple[str, ...] = BOOKKEEPING_KINDS) -> str | None:
     """Render one event as a single terminal line, or ``None`` to skip it.
 
-    Never emits ANSI: color is layered on by :func:`render_line`, so the piped /
-    no-TTY path is plain text by construction.
+    Total function: any malformed record (non-dict, bad ``t``, hostile string) yields
+    ``None`` or a safe line, never an exception — a renderer that raises silences the
+    whole run. Never emits ANSI, and no event value can: the finished line is run
+    through :func:`sanitize`, so color is only ever added by :func:`render_line`.
+
+    ``skip_kinds`` defaults to :data:`BOOKKEEPING_KINDS`; pass ``()`` to render every
+    kind (what #138 needs for phase detection).
     """
+    if not isinstance(ev, dict):
+        return None
     kind = str(ev.get("kind") or "")
-    _accrue(ev, totals)
-    ts = time.strftime("%H:%M:%S", time.localtime(float(ev.get("t") or time.time())))
+    if kind in skip_kinds or kind == FOLLOW_END:
+        return None  # bookkeeping / noise — the dashboard shows these, the terminal shouldn't
+    accrue_totals(ev, totals)
+    ts = _timestamp(ev.get("t"))
     meter = _meter(totals)
 
     if kind == "splits":
@@ -173,7 +322,7 @@ def format_event(ev: dict, totals: dict | None = None) -> str | None:
         body = f"baseline  val={_num(ev.get('val'))} ±{_num(ev.get('stderr'))}"
     elif kind == "baseline_reused":
         body = f"baseline reused from {ev.get('prior') or ev.get('from') or '?'}"
-    elif kind in ("step", "gepa_val_gate", "skillopt_step"):
+    elif kind in _STEP_KINDS:
         ok = bool(ev.get("accept"))
         verdict = "ACCEPT" if ok else "reject"
         where = ""
@@ -210,29 +359,35 @@ def format_event(ev: dict, totals: dict | None = None) -> str | None:
                 f"Δ{_num(ev.get('test_delta'), '{:+.4f}')})  best={ev.get('best_id')}")
     elif kind == "intake":
         body = f"intake  ${_num(ev.get('usd'), '{:.4f}')}  {ev.get('output_summary') or ''}".rstrip()
-    elif kind in ("minibatch", "optimizer_context_warning", "target_profile",
-                  "seed_dir_created", "splits_warning", "gepa_resume",
-                  "gepa_merge_skip", "gepa_merge_local", "skillopt_slow_eval",
-                  "skillopt_slow_update"):
-        return None  # bookkeeping / noise — the dashboard shows these, the terminal shouldn't
+    elif kind == "log_corruption":
+        body = f"WARNING  {ev.get('dropped')} unreadable record(s) skipped in events.jsonl"
     else:
         # Unknown kind: still show it rather than hide progress from a new event type.
         extra = " ".join(f"{k}={v}" for k, v in ev.items() if k not in ("t", "kind"))
         body = f"{kind} {extra}".strip()
-    return f"[{ts}] {body}{meter}"
+    # Sanitize the FINISHED line, once: every field of every kind (present and future)
+    # is covered, so no event value can emit an escape sequence or forge an extra line.
+    return sanitize(f"[{ts}] {body}{meter}")
 
 
 _STYLE_BY_KIND = {"optimizer_error": "red", "budget_warning": "yellow",
+                  "log_corruption": "yellow",
                   "finalize": "bold", "baseline": "cyan"}
 
 
-def render_line(ev: dict, totals: dict | None = None, *, color: bool = False) -> str | None:
-    """:func:`format_event` plus optional ANSI styling (accept green / reject dim)."""
-    line = format_event(ev, totals)
+def render_line(ev: dict, totals: dict | None = None, *, color: bool = False,
+                **kw) -> str | None:
+    """:func:`format_event` plus optional ANSI styling (accept green / reject dim).
+
+    Styling only — all text safety lives in :func:`format_event`, so a caller can
+    never get an unsanitised line by choosing one of these two over the other.
+    ``**kw`` (e.g. ``skip_kinds``) is passed through to :func:`format_event`.
+    """
+    line = format_event(ev, totals, **kw)
     if line is None or not color:
         return line
     kind = str(ev.get("kind") or "")
     style = _STYLE_BY_KIND.get(kind)
-    if kind in ("step", "gepa_val_gate", "skillopt_step"):
+    if kind in _STEP_KINDS:
         style = "green" if ev.get("accept") else "dim"
     return colorize(line, style, enabled=True) if style else line

--- a/core/cap_evolve/eventstream.py
+++ b/core/cap_evolve/eventstream.py
@@ -65,6 +65,7 @@ from __future__ import annotations
 import json
 import os
 import sys
+import threading
 import time
 from pathlib import Path
 from typing import Callable, Iterator
@@ -204,9 +205,11 @@ def capability(stream) -> str:
 
     ``"full"``  real TTY, ``TERM`` is a normal terminal, no ``NO_COLOR``
                 → ANSI colour + Unicode glyphs.
-    ``"plain"`` real TTY but ``NO_COLOR`` is set
+    ``"plain"`` real TTY but ``NO_COLOR`` is *present* in the environment (any value,
+                including empty — presence-based per https://no-color.org)
                 → same text, zero escape bytes.
-    ``"dumb"``  real TTY but ``TERM`` is ``dumb`` or ``unknown``
+    ``"dumb"``  real TTY but ``TERM`` is ``dumb`` or ``unknown``, and ``FORCE_COLOR``
+                is not set
                 → no colour, and never assume the terminal can be addressed
                   (no cursor moves, no repaint — append-only lines). An *unset*
                   ``TERM`` is deliberately NOT demoted: it is normal on a real TTY
@@ -231,9 +234,20 @@ def capability(stream) -> str:
         return "pipe"
     if not tty:
         return "pipe"
+    no_color = "NO_COLOR" in os.environ
     if os.environ.get("TERM", "").lower() in ("dumb", "unknown"):
+        # FORCE_COLOR is the only override in the "on" direction: some CI runners and
+        # `emacs -nw` report TERM=dumb on a terminal that renders ANSI fine, and
+        # without it the ladder can only ever be forced down. NO_COLOR still wins —
+        # "no colour" is a stronger request than "colour is possible".
+        if os.environ.get("FORCE_COLOR") and not no_color:
+            return "full"
         return "dumb"
-    if os.environ.get("NO_COLOR"):
+    if no_color:
+        # Presence-based, per https://no-color.org: `export NO_COLOR` with no value is
+        # what a user actually types, so an empty-but-set value demotes too. (The spec
+        # excludes "", but NO_COLOR=0 already demoted here, and treating "" as "colour
+        # please" while "0" means "no colour" was the inconsistency, not the spec.)
         return "plain"
     return "full"
 
@@ -292,15 +306,11 @@ def emit(stream, line: str) -> bool:
         return False
     if not _encodable(stream, line):
         line = ascii_fallback(line)
-    for text in (line, ascii_fallback(line)):
-        try:
-            print(text, file=stream, flush=True)
-            return True
-        except UnicodeEncodeError:
-            continue
-        except Exception:  # noqa: BLE001 — stream closed mid-run; nothing to salvage
-            return False
-    return False
+    try:
+        print(line, file=stream, flush=True)
+        return True
+    except Exception:  # noqa: BLE001 — stream closed mid-run; nothing to salvage
+        return False
 
 
 _CODES = {"dim": "2", "bold": "1", "green": "32", "red": "31", "yellow": "33", "cyan": "36"}
@@ -322,13 +332,25 @@ def colorize(text: str, style: str, *, enabled: bool) -> str:
 _CTRL = {c: None for c in range(0x20) if c != 0x09}
 _CTRL[0x7F] = None                       # DEL
 _CTRL.update({c: None for c in range(0x80, 0xA0)})  # C1, incl. 0x9B (8-bit CSI)
+# The rules above are an allowlist over control BYTES; these are control CODE POINTS
+# (Unicode Cf/Zl/Zp) that survived it. They cannot drive the terminal, but a BiDi
+# override (U+202E) renders "admin<RLO>gnp.txt" as "admin" followed by reversed text —
+# enough to spoof a candidate id or a file path in a progress line (Trojan Source,
+# CVE-2021-42574). Named by code point, never written as a literal, so this file stays
+# greppable and does not itself trip a Trojan Source scanner. LS/PS are here too:
+# harmless in a terminal, hostile to the JSON/HTML this same text also lands in.
+_CTRL.update({c: None for c in (0x200B, 0x200C, 0x200D, 0x200E, 0x200F,
+                                *range(0x202A, 0x2030), *range(0x2066, 0x206A),
+                                0x2028, 0x2029, 0xFEFF)})
 _CTRL[0x0A] = _CTRL[0x0D] = "⏎"
 
 
 def sanitize(text: str) -> str:
     """Strip control characters / ESC sequences so no event value can drive the
-    terminal or forge extra output lines. Applied by :func:`format_event` to the
-    whole finished line, so every field and every future event kind is covered."""
+    terminal, forge extra output lines, or spoof text by reordering it. Covers C0/C1
+    control bytes, DEL, and the Unicode ``Cf``/``Zl``/``Zp`` code points (BiDi
+    overrides, zero-widths, LS/PS). Applied by :func:`format_event` to the whole
+    finished line, so every field and every future event kind is covered."""
     return str(text).translate(_CTRL)
 
 
@@ -544,7 +566,11 @@ def write_crash_log(exc: BaseException | None, *, run_dir=None,
         "terminal": {
             "stdout": capability(sys.stdout), "stderr": capability(sys.stderr),
             "TERM": os.environ.get("TERM", ""),
-            "NO_COLOR": bool(os.environ.get("NO_COLOR")),
+            # Raw string, not bool(): the empty-vs-unset distinction is a ladder bug
+            # of its own (a `bool` reported False for `NO_COLOR=`), so record what was
+            # actually set and let the report be self-diagnosing.
+            "NO_COLOR": os.environ.get("NO_COLOR"),
+            "FORCE_COLOR": os.environ.get("FORCE_COLOR"),
             "stdout_encoding": getattr(sys.stdout, "encoding", None),
             "PYTHONIOENCODING": os.environ.get("PYTHONIOENCODING", ""),
             "locale": os.environ.get("LC_ALL") or os.environ.get("LANG") or "",
@@ -566,16 +592,48 @@ def write_crash_log(exc: BaseException | None, *, run_dir=None,
     except Exception:  # noqa: BLE001 — if redaction is unavailable, do NOT write
         return None    # a possibly-secret-bearing file. No log beats a leaked key.
 
-    stamp = time.strftime("%Y%m%d-%H%M%S")
+    # The pid+thread suffix is load-bearing, not decoration: a crash that kills the run
+    # usually kills the follow thread too, so main()'s handler and the follower's fire
+    # on the SAME failure inside the same second. With a second-resolution name and
+    # write_text (truncate), the second silently destroyed the first — a forensic tool
+    # losing exactly the evidence it exists to keep. "x" mode makes a surviving
+    # collision impossible rather than merely unlikely.
+    stamp = (f"{time.strftime('%Y%m%d-%H%M%S')}-{os.getpid()}"
+             f"-{threading.get_ident() % 100000:05d}")
     for target in _crash_targets(run_dir, stamp):
-        try:
-            target.parent.mkdir(parents=True, exist_ok=True)
-            target.write_text(json.dumps(payload, indent=2, default=str) + "\n",
-                              encoding="utf-8")
-            return target
-        except OSError:
-            continue  # read-only run dir → fall through to the cache dir
+        for attempt in range(8):
+            path = (target if not attempt
+                    else target.with_name(f"{target.stem}-{attempt}.json"))
+            try:
+                path.parent.mkdir(parents=True, exist_ok=True)
+                # 0o600: redacted still means argv, cwd, platform and a traceback. The
+                # opener sets the mode before any byte lands, so umask can't widen it.
+                with open(path, "x", encoding="utf-8",
+                          opener=lambda p, f: os.open(p, f, 0o600)) as fh:
+                    fh.write(json.dumps(payload, indent=2, default=str) + "\n")
+                _prune_crash_logs(path.parent)
+                return path
+            except FileExistsError:
+                continue  # same pid+thread+second twice → next suffix
+            except OSError:
+                break     # read-only run dir → fall through to the cache dir
     return None
+
+
+CRASH_KEEP = 50
+
+
+def _prune_crash_logs(directory: Path, keep: int = CRASH_KEEP) -> None:
+    """Drop the oldest crash logs beyond ``keep``. Never raises: pruning is hygiene, and
+    a crash reporter that dies while tidying up is worse than a full directory.
+
+    Sorted by name, which is chronological — the stamp leads with the timestamp.
+    """
+    try:
+        for stale in sorted(directory.glob("crash-*.json"))[:-keep]:
+            stale.unlink(missing_ok=True)
+    except OSError:
+        pass
 
 
 def _crash_targets(run_dir, stamp: str):

--- a/core/cap_evolve/eventstream.py
+++ b/core/cap_evolve/eventstream.py
@@ -1,0 +1,238 @@
+"""One source of truth for reading a run's ``events.jsonl`` stream.
+
+``events.jsonl`` is the run's append-only audit log (see :mod:`cap_evolve.rundir`).
+Every live view of a run — the dashboard's SSE route, ``cap-evolve run --follow``,
+``cap-evolve tail`` — reads it through this module, so the terminal and the web UI
+can never disagree about what happened.
+
+Public API (stdlib only, no deps):
+
+``read_new_events(path, offset) -> (events, new_offset)``
+    One incremental, byte-offset read. Cheap (seeks to ``offset``); leaves a
+    partial trailing line unconsumed so a half-written record is never parsed.
+
+``follow_events(path, *, offset=0, poll=0.5, stop_kinds=("finalize",),
+                idle_timeout=300.0, should_stop=None) -> Iterator[dict]``
+    Blocking generator that yields event dicts as they are appended. Stops after
+    an event whose ``kind`` is in ``stop_kinds``, after ``idle_timeout`` seconds
+    with no new events, or when ``should_stop()`` returns true.
+
+``format_event(ev, totals=None) -> str | None``
+    One human-readable line for an event, or ``None`` for events with nothing
+    worth showing. ``totals`` is an optional caller-owned dict used to accumulate
+    the live cost/token meter across events.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Callable, Iterator
+
+__all__ = ["read_new_events", "follow_events", "format_event", "render_line",
+           "colorize", "use_color"]
+
+
+def read_new_events(path: Path, offset: int) -> tuple[list[dict], int]:
+    """Return (new events, new byte offset). A partial trailing line (no newline)
+    is left unconsumed so the next read picks it up once complete."""
+    p = Path(path)
+    if not p.exists():
+        return [], offset
+    if offset >= p.stat().st_size:
+        return [], offset
+    # Seek-and-read so each poll costs O(new bytes), not O(file size) — callers poll
+    # a growing events.jsonl twice a second, per client.
+    with p.open("rb") as fh:
+        fh.seek(offset)
+        chunk = fh.read()
+    last_nl = chunk.rfind(b"\n")
+    if last_nl == -1:
+        return [], offset  # only a partial line so far
+    complete = chunk[: last_nl + 1]
+    events = []
+    for line in complete.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            events.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return events, offset + last_nl + 1
+
+
+def follow_events(
+    path: Path,
+    *,
+    offset: int = 0,
+    poll: float = 0.5,
+    stop_kinds: tuple[str, ...] = ("finalize",),
+    idle_timeout: float | None = 300.0,
+    should_stop: Callable[[], bool] | None = None,
+) -> Iterator[dict]:
+    """Yield events from ``path`` as they are appended (blocking generator).
+
+    ``offset=0`` replays the whole file first, then follows. Waits for the file to
+    appear, so a follower can attach before the run creates it. ``idle_timeout=None``
+    means wait forever.
+    """
+    idle_start = time.monotonic()
+    while True:
+        events, offset = read_new_events(path, offset)
+        for ev in events:
+            yield ev
+            if ev.get("kind") in stop_kinds:
+                return
+        if events:
+            idle_start = time.monotonic()
+        elif idle_timeout is not None and time.monotonic() - idle_start >= idle_timeout:
+            return
+        if should_stop is not None and should_stop():
+            # Drain whatever landed between the last read and the stop signal, so the
+            # final events of a finished run are never lost to a race.
+            for ev in read_new_events(path, offset)[0]:
+                yield ev
+            return
+        time.sleep(poll)
+
+
+# ---- human-readable rendering ----------------------------------------------
+
+def use_color(stream=None) -> bool:
+    """True only on a real TTY without ``NO_COLOR``. Piped/CI output stays plain."""
+    stream = stream or sys.stdout
+    if os.environ.get("NO_COLOR"):
+        return False
+    try:
+        return bool(stream.isatty())
+    except Exception:  # noqa: BLE001 — a stub stream without isatty is "not a tty"
+        return False
+
+
+_CODES = {"dim": "2", "bold": "1", "green": "32", "red": "31", "yellow": "33", "cyan": "36"}
+
+
+def colorize(text: str, style: str, *, enabled: bool) -> str:
+    if not enabled or style not in _CODES:
+        return text
+    return f"\033[{_CODES[style]}m{text}\033[0m"
+
+
+def _num(v, fmt="{:.4f}") -> str:
+    try:
+        return fmt.format(float(v))
+    except (TypeError, ValueError):
+        return "?"
+
+
+def _meter(totals: dict | None) -> str:
+    """`  [$0.0123 · 4.2k tok]` — the live cost meter, or '' if nothing spent yet."""
+    if not totals:
+        return ""
+    usd, tok = totals.get("usd", 0.0), totals.get("tokens", 0)
+    if not usd and not tok:
+        return ""
+    tokens = f"{tok / 1000:.1f}k" if tok >= 1000 else str(tok)
+    return f"  [${usd:.4f} · {tokens} tok]"
+
+
+def _accrue(ev: dict, totals: dict | None) -> None:
+    if totals is None:
+        return
+    for k in ("cost_usd", "opt_cost_usd", "usd"):
+        try:
+            totals["usd"] = totals.get("usd", 0.0) + float(ev.get(k) or 0.0)
+        except (TypeError, ValueError):
+            pass
+    for k in ("tokens", "opt_tokens"):
+        try:
+            totals["tokens"] = totals.get("tokens", 0) + int(ev.get(k) or 0)
+        except (TypeError, ValueError):
+            pass
+
+
+def format_event(ev: dict, totals: dict | None = None) -> str | None:
+    """Render one event as a single terminal line, or ``None`` to skip it.
+
+    Never emits ANSI: color is layered on by :func:`render_line`, so the piped /
+    no-TTY path is plain text by construction.
+    """
+    kind = str(ev.get("kind") or "")
+    _accrue(ev, totals)
+    ts = time.strftime("%H:%M:%S", time.localtime(float(ev.get("t") or time.time())))
+    meter = _meter(totals)
+
+    if kind == "splits":
+        body = (f"splits frozen  train={ev.get('train')} val={ev.get('val')} "
+                f"test={ev.get('test')} (test sealed)")
+    elif kind == "baseline":
+        body = f"baseline  val={_num(ev.get('val'))} ±{_num(ev.get('stderr'))}"
+    elif kind == "baseline_reused":
+        body = f"baseline reused from {ev.get('prior') or ev.get('from') or '?'}"
+    elif kind in ("step", "gepa_val_gate", "skillopt_step"):
+        ok = bool(ev.get("accept"))
+        verdict = "ACCEPT" if ok else "reject"
+        where = ""
+        if kind == "skillopt_step":
+            where = f" e{ev.get('epoch')}s{ev.get('step_in_epoch')}"
+        body = (f"{verdict}{where}  {ev.get('candidate')}  val={_num(ev.get('val'))}"
+                f" (parent {_num(ev.get('parent_val'))})")
+        if ev.get("reason"):
+            body += f"  — {ev['reason']}"
+    elif kind == "gepa_local_gate":
+        body = (f"minibatch gate {'pass' if ev.get('passed') else 'fail'}  {ev.get('candidate')}"
+                f"  child={_num(ev.get('child_sum'), '{:.3f}')}"
+                f" parent={_num(ev.get('parent_sum'), '{:.3f}')}")
+    elif kind == "gepa_select":
+        body = f"selected parent {ev.get('parent')} ({ev.get('strategy')})"
+    elif kind in ("gepa_start", "skillopt_start"):
+        body = f"{kind.split('_')[0]} started  " + " ".join(
+            f"{k}={v}" for k, v in ev.items() if k not in ("t", "kind"))
+    elif kind == "gepa_stop":
+        body = f"gepa stopped: {ev.get('reason')}"
+    elif kind == "evaluate":
+        body = (f"eval {ev.get('split')}/{ev.get('tag')}  reward={_num(ev.get('reward'))}"
+                f" ±{_num(ev.get('stderr'))}  {_num(ev.get('seconds'), '{:.1f}')}s")
+    elif kind == "gate_warning":
+        body = f"gate warning ({ev.get('mode')}): {str(ev.get('reason')).split(' — ')[0]}"
+    elif kind == "budget_warning":
+        body = (f"BUDGET {ev.get('pct')}% of {ev.get('metric')}  "
+                f"{ev.get('spent')}/{ev.get('limit')}")
+    elif kind == "optimizer_error":
+        body = f"OPTIMIZER ERROR  {ev.get('candidate')}: {str(ev.get('error'))[:200]}"
+    elif kind == "finalize":
+        body = (f"FINALIZE  test={_num(ev.get('test_reward'))} "
+                f"(baseline {_num(ev.get('test_baseline_reward'))}, "
+                f"Δ{_num(ev.get('test_delta'), '{:+.4f}')})  best={ev.get('best_id')}")
+    elif kind == "intake":
+        body = f"intake  ${_num(ev.get('usd'), '{:.4f}')}  {ev.get('output_summary') or ''}".rstrip()
+    elif kind in ("minibatch", "optimizer_context_warning", "target_profile",
+                  "seed_dir_created", "splits_warning", "gepa_resume",
+                  "gepa_merge_skip", "gepa_merge_local", "skillopt_slow_eval",
+                  "skillopt_slow_update"):
+        return None  # bookkeeping / noise — the dashboard shows these, the terminal shouldn't
+    else:
+        # Unknown kind: still show it rather than hide progress from a new event type.
+        extra = " ".join(f"{k}={v}" for k, v in ev.items() if k not in ("t", "kind"))
+        body = f"{kind} {extra}".strip()
+    return f"[{ts}] {body}{meter}"
+
+
+_STYLE_BY_KIND = {"optimizer_error": "red", "budget_warning": "yellow",
+                  "finalize": "bold", "baseline": "cyan"}
+
+
+def render_line(ev: dict, totals: dict | None = None, *, color: bool = False) -> str | None:
+    """:func:`format_event` plus optional ANSI styling (accept green / reject dim)."""
+    line = format_event(ev, totals)
+    if line is None or not color:
+        return line
+    kind = str(ev.get("kind") or "")
+    style = _STYLE_BY_KIND.get(kind)
+    if kind in ("step", "gepa_val_gate", "skillopt_step"):
+        style = "green" if ev.get("accept") else "dim"
+    return colorize(line, style, enabled=True) if style else line

--- a/core/cap_evolve/eventstream.py
+++ b/core/cap_evolve/eventstream.py
@@ -38,8 +38,21 @@ Public API (stdlib only, no deps):
     :func:`format_event` plus optional ANSI styling. Styling only — text safety lives
     in :func:`format_event`, so neither entry point can return an unsafe line.
 
+``capability(stream) -> str``
+    The **degradation ladder**: ``"full"`` / ``"plain"`` / ``"dumb"`` / ``"pipe"`` /
+    ``"none"``, in descending order of what the stream can carry. See
+    :func:`capability` for the rung-by-rung contract.
+
 ``use_color(stream) -> bool``
-    The single TTY / ``NO_COLOR`` decision. ``stream`` is required.
+    The single TTY / ``NO_COLOR`` decision — exactly ``capability(stream) == "full"``.
+
+``emit(stream, line) -> bool``
+    Write one already-sanitised line, transliterating glyphs the stream's encoding
+    cannot carry (``PYTHONIOENCODING=ascii``, ``LC_ALL=C``). False if the stream died.
+
+``write_crash_log(exc, *, run_dir=None, recent=(), context=None) -> Path | None``
+    Persist a **redacted** forensic record (traceback + last events) and return its
+    path, so "it just exited" becomes a filable bug.
 
 Terminal safety: :func:`format_event` is the ONLY place event text is made
 terminal-safe (see :func:`sanitize`). Event values are model/subprocess-controlled
@@ -58,7 +71,8 @@ from typing import Callable, Iterator
 
 __all__ = ["read_new_events", "follow_events", "format_event", "render_line",
            "colorize", "use_color", "sanitize", "accrue_totals",
-           "FOLLOW_END", "BOOKKEEPING_KINDS"]
+           "capability", "emit", "ascii_fallback", "write_crash_log",
+           "FOLLOW_END", "BOOKKEEPING_KINDS", "LADDER"]
 
 #: ``kind`` of the sentinel :func:`follow_events` yields last. Its ``reason`` is one
 #: of ``"stop_kind"`` / ``"idle"`` / ``"should_stop"``. #118 keys stall detection off
@@ -178,18 +192,115 @@ def follow_events(
 
 # ---- human-readable rendering ----------------------------------------------
 
+#: The degradation ladder, most capable first. See :func:`capability`.
+LADDER = ("full", "plain", "dumb", "pipe", "none")
+
+
+def capability(stream) -> str:
+    """Which rung of the degradation ladder ``stream`` sits on.
+
+    This is the explicit output contract for every live view. Rungs, in order, with
+    the ONE signal that demotes to each:
+
+    ``"full"``  real TTY, ``TERM`` is a normal terminal, no ``NO_COLOR``
+                → ANSI colour + Unicode glyphs.
+    ``"plain"`` real TTY but ``NO_COLOR`` is set
+                → same text, zero escape bytes.
+    ``"dumb"``  real TTY but ``TERM`` is ``dumb`` or ``unknown``
+                → no colour, and never assume the terminal can be addressed
+                  (no cursor moves, no repaint — append-only lines). An *unset*
+                  ``TERM`` is deliberately NOT demoted: it is normal on a real TTY
+                  outside a shell profile, and ``dumb`` is the explicit opt-out.
+    ``"pipe"``  not a TTY (piped, redirected, CI)
+                → plain append-only lines; CI logs stay grep-clean.
+    ``"none"``  the stream is missing or closed (``2>&-``)
+                → emit nothing at all; see ``cli._stderr_is_usable``.
+
+    Everything below ``"full"`` renders identically (plain text): the rungs are
+    distinct because the *reason* differs and callers/tests need to name it, not
+    because there are five renderers. Colour is the only thing on the ladder that
+    varies, deliberately — nothing here allocates a screen or moves a cursor, so
+    there is no layout to overflow on resize (issue #144's height-budget concern is
+    satisfied by never taking over the screen in the first place).
+    """
+    if stream is None or getattr(stream, "closed", False):
+        return "none"
+    try:
+        tty = bool(stream.isatty())
+    except Exception:  # noqa: BLE001 — a stub stream without isatty is "not a tty"
+        return "pipe"
+    if not tty:
+        return "pipe"
+    if os.environ.get("TERM", "").lower() in ("dumb", "unknown"):
+        return "dumb"
+    if os.environ.get("NO_COLOR"):
+        return "plain"
+    return "full"
+
+
 def use_color(stream) -> bool:
-    """True only on a real TTY without ``NO_COLOR``. Piped/CI output stays plain.
+    """True only on the ``"full"`` rung. Piped/CI/dumb/NO_COLOR output stays plain.
 
     ``stream`` is required: the decision must be made about the stream the caller
     actually writes to, never a default that could colorize stderr based on stdout.
     """
-    if os.environ.get("NO_COLOR"):
-        return False
+    return capability(stream) == "full"
+
+
+# Unicode the renderer uses, and its ASCII stand-in. Needed because a stream opened
+# with PYTHONIOENCODING=ascii or under LC_ALL=C raises UnicodeEncodeError on write —
+# which, inside the follower thread, used to take the whole live view dark.
+_ASCII_MAP = str.maketrans({
+    "±": "+/-", "·": "*", "Δ": "d", "—": "-", "…": "...", "→": "->", "⏎": "\\n",
+    "«": "<<", "»": ">>", "─": "-", "✓": "ok", "✗": "x",
+})
+
+
+def ascii_fallback(text: str) -> str:
+    """``text`` with the renderer's glyphs transliterated and anything else that
+    cannot survive ASCII replaced by ``?``. Lossy on purpose: legible beats exact."""
+    return str(text).translate(_ASCII_MAP).encode("ascii", "replace").decode("ascii")
+
+
+def _encodable(stream, line: str) -> bool:
+    """Can ``stream``'s encoding carry ``line`` losslessly?
+
+    Checked up front rather than caught, because CPython opens stderr with
+    ``errors="backslashreplace"``: under ``PYTHONIOENCODING=ascii`` the write does
+    NOT raise, it silently prints ``\\xb1`` / ``\\u2014``. Technically ASCII, but
+    unreadable — so ask first and transliterate to ``+/-`` instead.
+    """
+    enc = getattr(stream, "encoding", None)
+    if not enc or enc.lower().replace("-", "") in ("utf8", "utf16", "utf32"):
+        return True
     try:
-        return bool(stream.isatty())
-    except Exception:  # noqa: BLE001 — a stub stream without isatty is "not a tty"
+        line.encode(enc, "strict")
+        return True
+    except (UnicodeEncodeError, LookupError):
         return False
+
+
+def emit(stream, line: str) -> bool:
+    """Write ``line`` + newline to ``stream``; True if it landed.
+
+    Falls back to :func:`ascii_fallback` when the stream's encoding cannot carry a
+    glyph (``PYTHONIOENCODING=ascii``, ``LC_ALL=C``, a Windows cp1252 console).
+    Returns False when the stream is unusable, so a caller can stop following
+    instead of raising per line.
+    """
+    if capability(stream) == "none":
+        return False
+    if not _encodable(stream, line):
+        line = ascii_fallback(line)
+    for text in (line, ascii_fallback(line)):
+        try:
+            print(text, file=stream, flush=True)
+            return True
+        except UnicodeEncodeError:
+            continue
+        except Exception:  # noqa: BLE001 — stream closed mid-run; nothing to salvage
+            return False
+    return False
 
 
 _CODES = {"dim": "2", "bold": "1", "green": "32", "red": "31", "yellow": "33", "cyan": "36"}
@@ -391,3 +502,92 @@ def render_line(ev: dict, totals: dict | None = None, *, color: bool = False,
     if kind in _STEP_KINDS:
         style = "green" if ev.get("accept") else "dim"
     return colorize(line, style, enabled=True) if style else line
+
+
+# ---- forensic crash log -----------------------------------------------------
+
+#: Where a crash log lands when there is no run dir to put it in.
+CRASH_DIR = Path(os.environ.get("XDG_CACHE_HOME") or (Path.home() / ".cache")) \
+    / "cap-evolve" / "crashes"
+
+#: How many recent events the forensic log keeps. Enough to see the phase the run
+#: died in without turning the log into a copy of events.jsonl.
+CRASH_TAIL = 25
+
+
+def write_crash_log(exc: BaseException | None, *, run_dir=None,
+                    recent=(), context: dict | None = None) -> Path | None:
+    """Write a forensic record of a crash and return its path (``None`` if even that
+    failed — a crash reporter must never raise on top of the crash).
+
+    Contents: version, argv, python/platform, the terminal rung and encoding, the
+    exception traceback, and the last :data:`CRASH_TAIL` events seen. That is what a
+    bug report needs; anything more is the run dir's job.
+
+    **Secrets:** the whole payload goes through :func:`cap_evolve.dashboard.redact`
+    before it is written — argv, event payloads and traceback text all reach here
+    from untrusted or credential-bearing places. ``redact`` (hardened in #190/#193)
+    masks secret-looking keys, secret-shaped values AND the literal values of this
+    process's secret-looking env vars, which is the only shape-independent defence.
+    We deliberately do not write our own scrubber.
+    """
+    import platform
+    import traceback
+
+    payload = {
+        "cap_evolve_version": _version(),
+        "when": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+        "argv": list(sys.argv),
+        "python": sys.version.split()[0],
+        "platform": platform.platform(),
+        "cwd": str(Path.cwd()),
+        "terminal": {
+            "stdout": capability(sys.stdout), "stderr": capability(sys.stderr),
+            "TERM": os.environ.get("TERM", ""),
+            "NO_COLOR": bool(os.environ.get("NO_COLOR")),
+            "stdout_encoding": getattr(sys.stdout, "encoding", None),
+            "PYTHONIOENCODING": os.environ.get("PYTHONIOENCODING", ""),
+            "locale": os.environ.get("LC_ALL") or os.environ.get("LANG") or "",
+        },
+        "context": dict(context or {}),
+        "exception": repr(exc) if exc is not None else None,
+        "traceback": ("".join(traceback.format_exception(type(exc), exc,
+                                                        exc.__traceback__))
+                      if exc is not None else None),
+        # Sanitised as well as redacted: an event payload is model-controlled, and a
+        # crash log gets `cat`ed into a terminal at least as often as it is read.
+        "recent_events": [{k: sanitize(v) if isinstance(v, str) else v
+                           for k, v in ev.items()}
+                          for ev in list(recent)[-CRASH_TAIL:] if isinstance(ev, dict)],
+    }
+    try:
+        from .dashboard import redact
+        payload = redact(payload)
+    except Exception:  # noqa: BLE001 — if redaction is unavailable, do NOT write
+        return None    # a possibly-secret-bearing file. No log beats a leaked key.
+
+    stamp = time.strftime("%Y%m%d-%H%M%S")
+    for target in _crash_targets(run_dir, stamp):
+        try:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(json.dumps(payload, indent=2, default=str) + "\n",
+                              encoding="utf-8")
+            return target
+        except OSError:
+            continue  # read-only run dir → fall through to the cache dir
+    return None
+
+
+def _crash_targets(run_dir, stamp: str):
+    """Candidate paths, best first: next to the run it belongs to, else the cache."""
+    if run_dir:
+        yield Path(run_dir) / f"crash-{stamp}.json"
+    yield CRASH_DIR / f"crash-{stamp}.json"
+
+
+def _version() -> str:
+    try:
+        from . import __version__
+        return __version__
+    except Exception:  # noqa: BLE001
+        return "?"

--- a/core/tests/test_eventstream.py
+++ b/core/tests/test_eventstream.py
@@ -1,8 +1,9 @@
 """Tests for the shared events.jsonl tail helper + the --follow / tail CLI paths."""
 import io
-import os
-import shutil
 import json
+import os
+import shlex
+import shutil
 import subprocess
 import sys
 import threading
@@ -11,6 +12,28 @@ from pathlib import Path
 
 from cap_evolve import eventstream
 from cap_evolve.cli import _cmd_tail, _events_path
+
+
+def _toy_project(tmp_path: Path) -> tuple[Path, dict]:
+    """Scaffold the zero-API toy_calc project (mock optimizer) + its env. Shared by the
+    real end-to-end `cap-evolve run --follow` tests."""
+    repo = Path(__file__).resolve().parents[2]
+    example = repo / "examples" / "toy_calc"
+    proj = tmp_path / ".capevolve" / "project"
+    (proj / "adapters").mkdir(parents=True)
+    shutil.copy(example / "adapter.py", proj / "adapters" / "adapter.py")
+    shutil.copytree(example / "capability", tmp_path / "seed_capability")
+    shutil.copy(repo / "templates" / "project" / "capevolve.yaml", proj / "capevolve.yaml")
+    env = dict(os.environ)
+    env.update(PYTHONPATH=str(repo / "core"), CAPEVOLVE_CORE=str(repo / "core"),
+               CAPEVOLVE_SKILLS_DIR=str(repo / "skills"), CAPEVOLVE_TOY_DATA=str(example),
+               CAPEVOLVE_MOCK_SCRIPT=str(example / "mock_script.json"))
+    return proj, env
+
+
+def _kinds(it):
+    """Event kinds, minus the terminal sentinel (asserted separately)."""
+    return [e["kind"] for e in it if e["kind"] != eventstream.FOLLOW_END]
 
 
 def _write(p: Path, *recs):
@@ -51,14 +74,18 @@ def test_read_new_events_missing_file(tmp_path):
 def test_follow_events_stops_on_finalize_and_replays(tmp_path):
     p = tmp_path / "events.jsonl"
     _write(p, {"kind": "baseline"}, {"kind": "finalize"}, {"kind": "after"})
-    kinds = [e["kind"] for e in eventstream.follow_events(p, idle_timeout=1.0)]
-    assert kinds == ["baseline", "finalize"]  # stops at finalize, nothing after
+    got = list(eventstream.follow_events(p, idle_timeout=1.0))
+    assert _kinds(got) == ["baseline", "finalize"]  # stops at finalize, nothing after
+    assert got[-1] == {"kind": eventstream.FOLLOW_END, "reason": "stop_kind",
+                       "last_kind": "finalize"}
 
 
 def test_follow_events_idle_timeout_on_empty(tmp_path):
     t0 = time.monotonic()
     got = list(eventstream.follow_events(tmp_path / "events.jsonl", poll=0.05, idle_timeout=0.2))
-    assert got == []
+    assert _kinds(got) == []
+    # #118: an idle exit is distinguishable from a finished run, not a bare return.
+    assert got == [{"kind": eventstream.FOLLOW_END, "reason": "idle", "idle_seconds": 0.2}]
     assert time.monotonic() - t0 < 5.0
 
 
@@ -73,7 +100,7 @@ def test_follow_events_picks_up_appends_live(tmp_path):
         _write(p, {"kind": "finalize"})
 
     threading.Thread(target=writer, daemon=True).start()
-    kinds = [e["kind"] for e in eventstream.follow_events(p, poll=0.05, idle_timeout=5.0)]
+    kinds = _kinds(eventstream.follow_events(p, poll=0.05, idle_timeout=5.0))
     assert kinds == ["baseline", "step", "finalize"]
 
 
@@ -83,9 +110,10 @@ def test_follow_events_should_stop_drains_tail(tmp_path):
     stop = threading.Event()
     _write(p, {"kind": "baseline"}, {"kind": "step"})
     stop.set()  # already stopped: first read yields both, then the drain returns
-    kinds = [e["kind"] for e in eventstream.follow_events(
-        p, poll=0.01, idle_timeout=1.0, should_stop=stop.is_set)]
-    assert kinds == ["baseline", "step"]
+    got = list(eventstream.follow_events(
+        p, poll=0.01, idle_timeout=1.0, should_stop=lambda _last: stop.is_set()))
+    assert _kinds(got) == ["baseline", "step"]
+    assert got[-1]["reason"] == "should_stop"
 
 
 # ---- format_event / render_line --------------------------------------------
@@ -121,9 +149,12 @@ def test_format_event_shows_unknown_kinds():
 
 
 def test_cost_meter_accumulates_across_events():
+    """Runner spend comes from `evaluate`, optimizer spend from `step` — once each."""
     totals = {}
-    eventstream.format_event({"kind": "step", "cost_usd": 0.01, "tokens": 500}, totals)
-    line = eventstream.format_event({"kind": "step", "cost_usd": 0.02, "tokens": 1500}, totals)
+    eventstream.format_event({"kind": "evaluate", "cost_usd": 0.01, "tokens": 500}, totals)
+    line = eventstream.format_event(
+        {"kind": "step", "cost_usd": 0.01, "tokens": 500,          # re-stated, must NOT recount
+         "opt_cost_usd": 0.02, "opt_tokens": 1500}, totals)
     assert abs(totals["usd"] - 0.03) < 1e-9 and totals["tokens"] == 2000
     assert "$0.0300" in line and "2.0k tok" in line
 
@@ -218,18 +249,7 @@ def test_run_follow_end_to_end_pipes_clean_progress(tmp_path):
     stdout is piped (not a TTY), so: progress lines land on stderr with NO ANSI, and
     stdout stays the parseable final JSON that scripts depend on.
     """
-    repo = Path(__file__).resolve().parents[2]
-    example = repo / "examples" / "toy_calc"
-    proj = tmp_path / ".capevolve" / "project"
-    (proj / "adapters").mkdir(parents=True)
-    shutil.copy(example / "adapter.py", proj / "adapters" / "adapter.py")
-    shutil.copytree(example / "capability", tmp_path / "seed_capability")
-    shutil.copy(repo / "templates" / "project" / "capevolve.yaml", proj / "capevolve.yaml")
-
-    env = dict(os.environ)
-    env.update(PYTHONPATH=str(repo / "core"), CAPEVOLVE_CORE=str(repo / "core"),
-               CAPEVOLVE_SKILLS_DIR=str(repo / "skills"), CAPEVOLVE_TOY_DATA=str(example),
-               CAPEVOLVE_MOCK_SCRIPT=str(example / "mock_script.json"))
+    proj, env = _toy_project(tmp_path)
     proc = subprocess.run(
         [sys.executable, "-m", "cap_evolve.cli", "run", "--spec", str(proj / "capevolve.yaml"),
          "--project", str(proj), "--run-ts", "t", "--follow", "--dashboard", "off"],
@@ -255,3 +275,218 @@ def test_dashboard_stream_reexports_the_shared_helper():
         assert stream.read_new_events is eventstream.read_new_events
     finally:
         sys.path.remove(str(root))
+
+
+# ---- B1: a malformed record must never kill the follower --------------------
+
+POISON = [
+    {"kind": "baseline", "t": "not-a-number"},   # ValueError from float()
+    {"kind": "baseline", "t": {"nested": 1}},    # TypeError from float()
+    {"kind": "baseline", "t": 1e300},            # OverflowError from localtime()
+    42, None, [1, 2, 3], "just a string",        # non-dict records
+]
+
+
+def test_format_event_survives_every_malformed_record():
+    """format_event is total: no record shape may raise out of the render loop."""
+    for bad in POISON:
+        line = eventstream.format_event(bad, {})          # must not raise
+        assert line is None or isinstance(line, str)
+    assert "--:--:--" in eventstream.format_event({"kind": "baseline", "t": "nope"})
+    assert eventstream.format_event(42) is None
+
+
+def test_poisoned_record_does_not_kill_the_follower(tmp_path):
+    """The bug #116 exists to fix: one bad event must not blank the rest of the run."""
+    p = tmp_path / "events.jsonl"
+    with p.open("w", encoding="utf-8") as fh:
+        fh.write(json.dumps({"kind": "baseline", "val": 0.1}) + "\n")
+        fh.write(json.dumps({"kind": "baseline", "t": "not-a-number"}) + "\n")
+        fh.write("42\n")                    # non-dict record
+        fh.write("NOT JSON AT ALL\n")       # unparseable
+        fh.write(json.dumps({"kind": "step", "candidate": "cand_0001", "accept": True,
+                             "val": 1.0}) + "\n")
+        fh.write(json.dumps({"kind": "finalize", "test_reward": 1.0}) + "\n")
+    lines = [eventstream.render_line(e, {})
+             for e in eventstream.follow_events(p, idle_timeout=2.0)]
+    text = "\n".join(l for l in lines if l)
+    assert "cand_0001" in text and "FINALIZE" in text   # events AFTER the poison render
+    assert "--:--:--" in text                           # the poisoned one degraded, not fatal
+
+
+def test_follower_thread_reports_instead_of_dying_silently(tmp_path, monkeypatch, capsys):
+    """If the follower does die, the user is TOLD — silence must never look like progress."""
+    from cap_evolve import cli as _cli
+
+    base = tmp_path
+    (base / "run_z").mkdir()
+    _write(base / "run_z" / "events.jsonl", {"kind": "baseline", "val": 0.0})
+    boom = RuntimeError("simulated renderer explosion")
+    monkeypatch.setattr(eventstream, "render_line",
+                        lambda *a, **k: (_ for _ in ()).throw(boom))
+    monkeypatch.setattr(_cli, "_stderr_is_usable", lambda: True)
+    stop, t = _cli._spawn_follower(base, "z", None)
+    t.join(timeout=5.0)
+    assert not t.is_alive()
+    assert "[follow] live progress stopped" in capsys.readouterr().err
+
+
+# ---- B1b/N2: only dict records escape read_new_events -----------------------
+
+def test_read_new_events_filters_non_dict_records(tmp_path):
+    p = tmp_path / "events.jsonl"
+    p.write_text('42\nnull\n[1,2]\n"str"\ntrue\n{"kind":"finalize"}\n', encoding="utf-8")
+    evs, _ = eventstream.read_new_events(p, 0)
+    assert [e["kind"] for e in evs if e["kind"] != "log_corruption"] == ["finalize"]
+    assert all(isinstance(e, dict) for e in evs)
+    assert {"kind": "log_corruption", "dropped": 5} in evs   # damage is reported, not hidden
+
+
+def test_corrupt_line_is_counted_not_silently_dropped(tmp_path):
+    p = tmp_path / "events.jsonl"
+    p.write_text('{"kind":"a"}\nNOT JSON AT ALL\n{"kind":"finalize"}\n', encoding="utf-8")
+    evs, _ = eventstream.read_new_events(p, 0)
+    assert [e["kind"] for e in evs] == ["a", "finalize", "log_corruption"]
+    assert "1 unreadable record" in eventstream.format_event(evs[-1])
+
+
+# ---- N3: a shrunk file re-reads instead of getting stuck --------------------
+
+def test_read_new_events_rereads_after_truncation(tmp_path):
+    p = tmp_path / "events.jsonl"
+    _write(p, {"kind": "a"}, {"kind": "b"})
+    _, off = eventstream.read_new_events(p, 0)
+    p.write_text('{"kind":"x"}\n', encoding="utf-8")       # rewritten shorter
+    evs, off2 = eventstream.read_new_events(p, off)
+    assert [e["kind"] for e in evs] == ["x"] and off2 == p.stat().st_size
+
+
+# ---- B2: terminal escape injection -----------------------------------------
+
+def test_escape_injection_from_event_payloads_is_neutralised():
+    """All three demonstrated attacks: OSC title, screen clear, newline-forged line."""
+    osc = eventstream.format_event({"kind": "optimizer_error", "candidate": "c1",
+                                   "error": "boom\033]0;PWNED\007\033[2J\033[31mfake red"})
+    clear = eventstream.format_event({"kind": "brand_new", "payload": "\033[2J\033[Hcleared"})
+    forge = eventstream.format_event(
+        {"kind": "brand_new",
+         "payload": "a\nFINALIZE  test=1.0000 (baseline 0.0000) best=FAKE"})
+    for line in (osc, clear, forge):
+        assert "\033" not in line and "\x1b" not in line
+        assert "\007" not in line and "\x9b" not in line
+        assert "\n" not in line and "\r" not in line       # cannot forge extra lines
+        assert line.count("\n") == 0 and len(line.splitlines()) == 1
+    assert "PWNED" in osc and "boom" in osc                # inert, but still readable
+    assert "⏎" in forge and "FINALIZE" in forge            # visibly one line, not two
+
+
+def test_sanitize_strips_c0_c1_and_keeps_tab():
+    # ESC/BEL/DEL and 8-bit CSI vanish; the leftover "[31m" is inert printable text.
+    assert eventstream.sanitize("a\x1b[31mb\x07c\x9bd\x7fe") == "a[31mbcde"
+    assert eventstream.sanitize("\x1b]0;t\x07\x1b[2J\x1b[H") == "]0;t[2J[H"
+    assert eventstream.sanitize("a\tb") == "a\tb"
+    assert eventstream.sanitize("a\nb\rc") == "a⏎b⏎c"
+
+
+def test_render_line_is_also_escape_safe_with_color():
+    """color=True adds exactly the styling escapes — never the payload's own."""
+    ev = {"kind": "optimizer_error", "candidate": "c", "error": "x\033]0;PWNED\007"}
+    line = eventstream.render_line(ev, color=True)
+    assert line.startswith("\033[31m") and line.endswith("\033[0m")
+    assert "\033" not in line[5:-4] and "PWNED" in line
+
+
+# ---- B3: the cost meter must equal the run's own recorded total -------------
+
+def test_cost_meter_matches_the_runs_recorded_total(tmp_path):
+    """The meter must equal Spent.total_usd, not double-count the runner."""
+    from cap_evolve.rundir import RunDir
+
+    rd = RunDir.create(tmp_path, ts="cost")
+    # Exactly what the harness does: evaluate logs runner spend (harness.py:307-312),
+    # then step re-states it alongside the optimizer's own (harness.py:1322-1328).
+    rd.update_spent(metric_calls=2, usd=0.50, runner_tokens=1000)
+    rd.log_event("evaluate", split="val", tag="cand_0001", reward=1.0,
+                 cost_usd=0.50, tokens=1000, seconds=1.0)
+    rd.update_spent(optimizer_seconds=1.0, optimizer_usd=0.20, optimizer_tokens=500)
+    rd.log_event("step", candidate="cand_0001", accept=True, val=1.0, parent_val=0.0,
+                 cost_usd=0.50, tokens=1000, opt_cost_usd=0.20, opt_tokens=500)
+
+    totals: dict = {}
+    events, _ = eventstream.read_new_events(rd.events_path, 0)
+    for ev in events:
+        eventstream.format_event(ev, totals)
+    recorded = rd.spent.total_usd
+    assert abs(recorded - 0.70) < 1e-9, recorded
+    assert abs(totals["usd"] - recorded) < 1e-9, (totals, recorded)
+    assert totals["tokens"] == 1500
+
+
+def test_accrue_totals_is_public_for_138():
+    assert eventstream.accrue_totals in vars(eventstream).values()
+    assert "accrue_totals" in eventstream.__all__
+    t: dict = {}
+    eventstream.accrue_totals({"kind": "intake", "usd": 0.05, "tokens": 100}, t)
+    eventstream.accrue_totals({"kind": "gepa_local_gate", "cost_usd": 99.0}, t)  # not a cost event
+    assert t == {"usd": 0.05, "tokens": 100}
+
+
+# ---- B4: closed stderr must not corrupt the stdout JSON contract ------------
+
+def test_stderr_unusable_disables_following(monkeypatch):
+    from cap_evolve import cli as _cli
+
+    monkeypatch.setattr(sys, "stderr", None)
+    assert _cli._stderr_is_usable() is False
+    assert _cli._spawn_follower(Path("/nope"), "x", None) == (None, None)
+
+    class Reused(io.StringIO):
+        def fileno(self):
+            return 7            # fd 2 was closed and handed to another file
+    monkeypatch.setattr(sys, "stderr", Reused())
+    assert _cli._stderr_is_usable() is False
+
+
+def test_run_follow_with_stderr_closed_keeps_stdout_valid_json(tmp_path):
+    """`cap-evolve run --follow 2>&-` must still emit parseable JSON on stdout."""
+    proj, env = _toy_project(tmp_path)
+    out = tmp_path / "cl.out"
+    # Real `2>&-`: the shell closes fd 2 before exec, so CPython starts with a dead
+    # stderr and would hand fd 2 to the next open() — the corruption path.
+    cmd = (f"exec 2>&-; {shlex.quote(sys.executable)} -m cap_evolve.cli run "
+           f"--spec {shlex.quote(str(proj / 'capevolve.yaml'))} "
+           f"--project {shlex.quote(str(proj))} --run-ts cl --follow --dashboard off "
+           f"> {shlex.quote(str(out))}")
+    proc = subprocess.run(["/bin/sh", "-c", cmd], env=env, timeout=600)
+    assert proc.returncode == 0
+    text = out.read_text()
+    assert json.loads(text)["test_reward"] == 1.0          # contract intact
+    assert "baseline  val=" not in text                    # no progress leaked into stdout
+
+
+# ---- N1: tail exit codes ----------------------------------------------------
+
+def test_cmd_tail_rejects_a_path_that_can_never_be_a_run_dir(tmp_path, capsys):
+    assert _cmd_tail([str(tmp_path / "no" / "such" / "run_typo")]) == 2
+    assert "no such run dir" in capsys.readouterr().err
+
+
+def test_cmd_tail_returns_3_on_idle_timeout_with_no_events(tmp_path, capsys):
+    assert _cmd_tail([str(tmp_path / "run_pending"), "--idle-timeout", "0.2"]) == 3
+    assert "timed out" in capsys.readouterr().err
+
+
+def test_cmd_tail_rejects_negative_idle_timeout(tmp_path):
+    import pytest
+    with pytest.raises(SystemExit):
+        _cmd_tail([str(tmp_path), "--idle-timeout", "-5"])
+
+
+# ---- #138: every kind is reachable -----------------------------------------
+
+def test_skip_kinds_can_be_disabled_to_see_bookkeeping_events():
+    ev = {"kind": "minibatch", "tag": "mb1"}
+    assert eventstream.format_event(ev) is None                       # default: hidden
+    assert "minibatch" in eventstream.format_event(ev, skip_kinds=())  # #138: visible
+    assert "minibatch" in eventstream.render_line(ev, skip_kinds=())
+    assert eventstream.BOOKKEEPING_KINDS                              # documented set

--- a/core/tests/test_eventstream.py
+++ b/core/tests/test_eventstream.py
@@ -1,0 +1,257 @@
+"""Tests for the shared events.jsonl tail helper + the --follow / tail CLI paths."""
+import io
+import os
+import shutil
+import json
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+from cap_evolve import eventstream
+from cap_evolve.cli import _cmd_tail, _events_path
+
+
+def _write(p: Path, *recs):
+    with p.open("a", encoding="utf-8") as fh:
+        for r in recs:
+            fh.write(json.dumps(r) + "\n")
+
+
+# ---- read_new_events -------------------------------------------------------
+
+def test_read_new_events_incremental(tmp_path):
+    p = tmp_path / "events.jsonl"
+    _write(p, {"kind": "baseline", "val": 0.25})
+    evs, off = eventstream.read_new_events(p, 0)
+    assert evs == [{"kind": "baseline", "val": 0.25}]
+    assert off == p.stat().st_size
+
+    _write(p, {"kind": "step", "candidate": "cand_0001"})
+    evs2, off2 = eventstream.read_new_events(p, off)
+    assert evs2 == [{"kind": "step", "candidate": "cand_0001"}]
+    assert off2 == p.stat().st_size
+
+
+def test_read_new_events_leaves_partial_line(tmp_path):
+    p = tmp_path / "events.jsonl"
+    p.write_text('{"kind": "baseline"}\n{"kind": "ste', encoding="utf-8")
+    evs, off = eventstream.read_new_events(p, 0)
+    assert evs == [{"kind": "baseline"}]
+    assert off == len('{"kind": "baseline"}\n')
+
+
+def test_read_new_events_missing_file(tmp_path):
+    assert eventstream.read_new_events(tmp_path / "nope.jsonl", 0) == ([], 0)
+
+
+# ---- follow_events ---------------------------------------------------------
+
+def test_follow_events_stops_on_finalize_and_replays(tmp_path):
+    p = tmp_path / "events.jsonl"
+    _write(p, {"kind": "baseline"}, {"kind": "finalize"}, {"kind": "after"})
+    kinds = [e["kind"] for e in eventstream.follow_events(p, idle_timeout=1.0)]
+    assert kinds == ["baseline", "finalize"]  # stops at finalize, nothing after
+
+
+def test_follow_events_idle_timeout_on_empty(tmp_path):
+    t0 = time.monotonic()
+    got = list(eventstream.follow_events(tmp_path / "events.jsonl", poll=0.05, idle_timeout=0.2))
+    assert got == []
+    assert time.monotonic() - t0 < 5.0
+
+
+def test_follow_events_picks_up_appends_live(tmp_path):
+    p = tmp_path / "events.jsonl"
+    _write(p, {"kind": "baseline"})
+
+    def writer():
+        time.sleep(0.15)
+        _write(p, {"kind": "step", "accept": True})
+        time.sleep(0.15)
+        _write(p, {"kind": "finalize"})
+
+    threading.Thread(target=writer, daemon=True).start()
+    kinds = [e["kind"] for e in eventstream.follow_events(p, poll=0.05, idle_timeout=5.0)]
+    assert kinds == ["baseline", "step", "finalize"]
+
+
+def test_follow_events_should_stop_drains_tail(tmp_path):
+    """A stop signal must not lose events written just before it."""
+    p = tmp_path / "events.jsonl"
+    stop = threading.Event()
+    _write(p, {"kind": "baseline"}, {"kind": "step"})
+    stop.set()  # already stopped: first read yields both, then the drain returns
+    kinds = [e["kind"] for e in eventstream.follow_events(
+        p, poll=0.01, idle_timeout=1.0, should_stop=stop.is_set)]
+    assert kinds == ["baseline", "step"]
+
+
+# ---- format_event / render_line --------------------------------------------
+
+def test_format_event_covers_the_key_kinds():
+    assert "splits frozen" in eventstream.format_event(
+        {"kind": "splits", "train": 4, "val": 2, "test": 2})
+    assert "baseline  val=0.2500" in eventstream.format_event({"kind": "baseline", "val": 0.25})
+    acc = eventstream.format_event(
+        {"kind": "step", "candidate": "cand_0001", "accept": True, "val": 1.0,
+         "parent_val": 0.0, "reason": "Δ>0"})
+    assert "ACCEPT" in acc and "cand_0001" in acc and "Δ>0" in acc
+    rej = eventstream.format_event({"kind": "step", "candidate": "c2", "accept": False, "val": 0.5})
+    assert "reject" in rej
+    fin = eventstream.format_event(
+        {"kind": "finalize", "test_reward": 1.0, "test_baseline_reward": 0.0,
+         "test_delta": 1.0, "best_id": "cand_0001"})
+    assert "FINALIZE" in fin and "test=1.0000" in fin
+    assert "BUDGET 80%" in eventstream.format_event(
+        {"kind": "budget_warning", "pct": 80, "metric": "max_usd", "spent": 8, "limit": 10})
+    assert "OPTIMIZER ERROR" in eventstream.format_event(
+        {"kind": "optimizer_error", "candidate": "c1", "error": "boom"})
+
+
+def test_format_event_skips_bookkeeping_kinds():
+    assert eventstream.format_event({"kind": "minibatch", "tag": "mb"}) is None
+    assert eventstream.format_event({"kind": "optimizer_context_warning"}) is None
+
+
+def test_format_event_shows_unknown_kinds():
+    line = eventstream.format_event({"kind": "brand_new_thing", "x": 1})
+    assert "brand_new_thing" in line and "x=1" in line
+
+
+def test_cost_meter_accumulates_across_events():
+    totals = {}
+    eventstream.format_event({"kind": "step", "cost_usd": 0.01, "tokens": 500}, totals)
+    line = eventstream.format_event({"kind": "step", "cost_usd": 0.02, "tokens": 1500}, totals)
+    assert abs(totals["usd"] - 0.03) < 1e-9 and totals["tokens"] == 2000
+    assert "$0.0300" in line and "2.0k tok" in line
+
+
+def test_format_event_never_emits_ansi():
+    """format_event is pure text; only render_line(color=True) adds escapes."""
+    for ev in ({"kind": "step", "accept": True, "candidate": "c"},
+               {"kind": "optimizer_error", "candidate": "c", "error": "x"},
+               {"kind": "finalize", "test_reward": 1.0}):
+        assert "\033" not in eventstream.format_event(ev)
+
+
+def test_render_line_color_on_and_off():
+    ev = {"kind": "step", "accept": True, "candidate": "c", "val": 1.0}
+    assert "\033[32m" in eventstream.render_line(ev, color=True)
+    assert "\033" not in eventstream.render_line(ev, color=False)
+
+
+def test_use_color_false_for_non_tty_and_no_color(monkeypatch):
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    assert eventstream.use_color(io.StringIO()) is False        # not a tty
+    assert eventstream.use_color(object()) is False             # no isatty attr
+
+    class Tty(io.StringIO):
+        def isatty(self):
+            return True
+    assert eventstream.use_color(Tty()) is True
+    monkeypatch.setenv("NO_COLOR", "1")
+    assert eventstream.use_color(Tty()) is False
+
+
+# ---- CLI: tail -------------------------------------------------------------
+
+def test_events_path_prefers_run_ts_and_ignores_pre_existing(tmp_path):
+    (tmp_path / "run_old").mkdir()
+    (tmp_path / "run_new").mkdir()
+    assert _events_path(tmp_path, "old", None) == tmp_path / "run_old" / "events.jsonl"
+    # unpinned: skip the dirs that existed before this run started
+    assert _events_path(tmp_path, None, {"run_old"}) == tmp_path / "run_new" / "events.jsonl"
+    assert _events_path(tmp_path, None, {"run_old", "run_new"}) is None
+
+
+def test_cmd_tail_missing_base(tmp_path, capsys):
+    assert _cmd_tail(["--base", str(tmp_path)]) == 1
+    assert "no run_* dirs" in capsys.readouterr().err
+
+
+def test_cmd_tail_from_start_plain_when_piped(tmp_path, capsys):
+    """capsys stdout is not a TTY → plain lines, no ANSI (the CI/piped case)."""
+    root = tmp_path / "run_x"
+    root.mkdir()
+    _write(root / "events.jsonl",
+           {"kind": "baseline", "val": 0.0},
+           {"kind": "step", "candidate": "cand_0001", "accept": True, "val": 1.0,
+            "parent_val": 0.0},
+           {"kind": "finalize", "test_reward": 1.0, "test_baseline_reward": 0.0,
+            "test_delta": 1.0, "best_id": "cand_0001"})
+    assert _cmd_tail([str(root), "--from-start"]) == 0
+    out = capsys.readouterr().out
+    assert "\033" not in out
+    assert "baseline" in out and "ACCEPT" in out and "FINALIZE" in out
+
+
+def test_cmd_tail_attaches_to_an_ongoing_run(tmp_path, capsys):
+    """Default (no --from-start) skips history and follows new events only."""
+    root = tmp_path / "run_x"
+    root.mkdir()
+    ev = root / "events.jsonl"
+    _write(ev, {"kind": "baseline", "val": 0.0})  # history: must NOT be printed
+
+    def writer():
+        time.sleep(0.2)
+        _write(ev, {"kind": "step", "candidate": "cand_0007", "accept": True, "val": 1.0})
+        _write(ev, {"kind": "finalize", "test_reward": 1.0})
+
+    threading.Thread(target=writer, daemon=True).start()
+    assert _cmd_tail([str(root), "--idle-timeout", "10"]) == 0
+    out = capsys.readouterr().out
+    assert "cand_0007" in out and "FINALIZE" in out
+    assert "val=0.0000 ±" not in out  # the pre-attach baseline line was skipped
+
+
+def test_tail_is_a_registered_subcommand():
+    out = subprocess.run([sys.executable, "-m", "cap_evolve.cli"],
+                         capture_output=True, text=True).stderr
+    assert "tail" in out
+
+
+def test_run_follow_end_to_end_pipes_clean_progress(tmp_path):
+    """Real `cap-evolve run --follow` over toy_calc (zero API, mock optimizer).
+
+    stdout is piped (not a TTY), so: progress lines land on stderr with NO ANSI, and
+    stdout stays the parseable final JSON that scripts depend on.
+    """
+    repo = Path(__file__).resolve().parents[2]
+    example = repo / "examples" / "toy_calc"
+    proj = tmp_path / ".capevolve" / "project"
+    (proj / "adapters").mkdir(parents=True)
+    shutil.copy(example / "adapter.py", proj / "adapters" / "adapter.py")
+    shutil.copytree(example / "capability", tmp_path / "seed_capability")
+    shutil.copy(repo / "templates" / "project" / "capevolve.yaml", proj / "capevolve.yaml")
+
+    env = dict(os.environ)
+    env.update(PYTHONPATH=str(repo / "core"), CAPEVOLVE_CORE=str(repo / "core"),
+               CAPEVOLVE_SKILLS_DIR=str(repo / "skills"), CAPEVOLVE_TOY_DATA=str(example),
+               CAPEVOLVE_MOCK_SCRIPT=str(example / "mock_script.json"))
+    proc = subprocess.run(
+        [sys.executable, "-m", "cap_evolve.cli", "run", "--spec", str(proj / "capevolve.yaml"),
+         "--project", str(proj), "--run-ts", "t", "--follow", "--dashboard", "off"],
+        capture_output=True, text=True, env=env, timeout=600)
+    assert proc.returncode == 0, proc.stderr[-3000:]
+
+    # progress went to stderr, live, and is plain text (safe for CI logs)
+    assert "\033" not in proc.stderr, "ANSI leaked into non-TTY output"
+    assert "splits frozen" in proc.stderr
+    assert "baseline  val=" in proc.stderr
+    assert "ACCEPT" in proc.stderr, proc.stderr          # >=1 per-candidate line
+    assert "FINALIZE" in proc.stderr                     # the finalize line
+    # stdout is still just the final JSON blob
+    assert json.loads(proc.stdout)["test_reward"] == 1.0
+
+
+def test_dashboard_stream_reexports_the_shared_helper():
+    """The SSE route and the CLI must read events.jsonl through the same function."""
+    root = Path(__file__).resolve().parents[2] / "dashboard" / "backend"
+    sys.path.insert(0, str(root))
+    try:
+        from capevolve_dashboard import stream
+        assert stream.read_new_events is eventstream.read_new_events
+    finally:
+        sys.path.remove(str(root))

--- a/core/tests/test_eventstream.py
+++ b/core/tests/test_eventstream.py
@@ -490,3 +490,237 @@ def test_skip_kinds_can_be_disabled_to_see_bookkeeping_events():
     assert "minibatch" in eventstream.format_event(ev, skip_kinds=())  # #138: visible
     assert "minibatch" in eventstream.render_line(ev, skip_kinds=())
     assert eventstream.BOOKKEEPING_KINDS                              # documented set
+
+
+# ---- #144: the degradation ladder ------------------------------------------
+
+class _Tty(io.StringIO):
+    def isatty(self):
+        return True
+
+
+def test_capability_names_every_rung(monkeypatch):
+    """The ladder is an explicit contract: one signal demotes to each rung."""
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setenv("TERM", "xterm-256color")
+    assert eventstream.capability(_Tty()) == "full"          # rung 1: TTY + colour
+    monkeypatch.setenv("NO_COLOR", "1")
+    assert eventstream.capability(_Tty()) == "plain"         # rung 2: NO_COLOR
+    monkeypatch.delenv("NO_COLOR")
+    monkeypatch.setenv("TERM", "dumb")
+    assert eventstream.capability(_Tty()) == "dumb"          # rung 3: TERM=dumb
+    assert eventstream.capability(io.StringIO()) == "pipe"   # rung 4: not a tty
+    assert eventstream.capability(None) == "none"            # rung 5: no stream
+    closed = io.StringIO()
+    closed.close()
+    assert eventstream.capability(closed) == "none"
+    assert eventstream.capability(object()) == "pipe"        # no isatty() → assume pipe
+    assert eventstream.LADDER == ("full", "plain", "dumb", "pipe", "none")
+
+
+def test_only_the_full_rung_gets_colour(monkeypatch):
+    """use_color is exactly `capability == "full"` — one decision, not two."""
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    for term, want in (("xterm", True), ("dumb", False), ("unknown", False)):
+        monkeypatch.setenv("TERM", term)
+        assert eventstream.use_color(_Tty()) is want
+    monkeypatch.setenv("TERM", "xterm")
+    monkeypatch.setenv("NO_COLOR", "1")
+    assert eventstream.use_color(_Tty()) is False
+    monkeypatch.delenv("NO_COLOR")
+    # An UNSET TERM is normal on a real TTY and must not silently kill colour.
+    monkeypatch.delenv("TERM", raising=False)
+    assert eventstream.use_color(_Tty()) is True
+
+
+def test_every_rung_below_full_emits_zero_escape_bytes(monkeypatch):
+    """The whole point of the ladder: only rung 1 may put escapes on the wire."""
+    ev = {"kind": "step", "candidate": "c1", "accept": True, "val": 0.9}
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    for env, stream, rung in (
+            ({"TERM": "xterm"}, _Tty(), "full"),
+            ({"TERM": "xterm", "NO_COLOR": "1"}, _Tty(), "plain"),
+            ({"TERM": "dumb"}, _Tty(), "dumb"),
+            ({"TERM": "xterm"}, io.StringIO(), "pipe")):
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        for k, v in env.items():
+            monkeypatch.setenv(k, v)
+        assert eventstream.capability(stream) == rung
+        line = eventstream.render_line(ev, color=eventstream.use_color(stream))
+        assert ("\033" in line) is (rung == "full"), rung
+
+
+def test_emit_returns_false_on_the_none_rung():
+    assert eventstream.emit(None, "x") is False
+    closed = io.StringIO()
+    closed.close()
+    assert eventstream.emit(closed, "x") is False
+
+
+# ---- #144: non-UTF-8 locales (PYTHONIOENCODING=ascii / LC_ALL=C) ------------
+
+def test_emit_transliterates_when_the_stream_cannot_encode(tmp_path):
+    """An ascii-encoded stream must get legible text, not a UnicodeEncodeError that
+    kills the follower thread and takes the live view dark."""
+    path = tmp_path / "out.txt"
+    with path.open("w", encoding="ascii") as fh:
+        assert eventstream.emit(fh, "baseline val=0.25 ±0.01 · Δ+0.1 ⏎") is True
+    text = path.read_text(encoding="ascii")
+    assert "+/-" in text and "d+0.1" in text and "\\n" in text
+
+
+def test_ascii_fallback_never_raises_on_arbitrary_unicode():
+    assert eventstream.ascii_fallback("— … 你好 \U0001f600") == "- ... ?? ?"
+
+
+def test_run_follow_survives_ascii_io_encoding(tmp_path):
+    """Real `cap-evolve run --follow` under PYTHONIOENCODING=ascii + LC_ALL=C."""
+    proj, env = _toy_project(tmp_path)
+    env.update(PYTHONIOENCODING="ascii", LC_ALL="C", LANG="C")
+    proc = subprocess.run(
+        [sys.executable, "-m", "cap_evolve.cli", "run", "--spec", str(proj / "capevolve.yaml"),
+         "--project", str(proj), "--run-ts", "a", "--follow", "--dashboard", "off"],
+        capture_output=True, text=True, env=env, timeout=600)
+    assert proc.returncode == 0, proc.stderr[-3000:]
+    assert "UnicodeEncodeError" not in proc.stderr
+    assert "baseline  val=" in proc.stderr and "FINALIZE" in proc.stderr
+    assert proc.stderr.encode("ascii", "strict")           # pure ASCII on the wire
+    # Legible ASCII, not CPython's backslashreplace mojibake ("\xb1" / "—").
+    assert "+/-0.0000" in proc.stderr
+    assert "\\xb1" not in proc.stderr and "\\u20" not in proc.stderr
+    assert json.loads(proc.stdout)["test_reward"] == 1.0
+
+
+# ---- #144: the forensic crash log ------------------------------------------
+
+def _crash_log(tmp_path, **kw):
+    try:
+        raise RuntimeError("kaboom")
+    except RuntimeError as e:
+        return eventstream.write_crash_log(e, run_dir=tmp_path, **kw)
+
+
+def test_crash_log_has_what_a_bug_report_needs(tmp_path):
+    log = _crash_log(tmp_path, recent=[{"kind": "baseline", "val": 0.25},
+                                       {"kind": "step", "candidate": "c1"}],
+                     context={"where": "follow-thread"})
+    assert log is not None and log.parent == tmp_path
+    d = json.loads(log.read_text())
+    assert d["exception"] == "RuntimeError('kaboom')"
+    assert "kaboom" in d["traceback"] and "_crash_log" in d["traceback"]
+    assert d["cap_evolve_version"] and d["python"] and d["platform"]
+    assert d["context"] == {"where": "follow-thread"}
+    assert [e["kind"] for e in d["recent_events"]] == ["baseline", "step"]
+    # the terminal state at crash time — the whole point of #144
+    assert set(d["terminal"]) >= {"stdout", "stderr", "TERM", "PYTHONIOENCODING", "locale"}
+    assert d["terminal"]["stdout"] in eventstream.LADDER
+
+
+def test_crash_log_keeps_only_the_recent_tail(tmp_path):
+    log = _crash_log(tmp_path, recent=[{"kind": f"k{i}"} for i in range(200)])
+    d = json.loads(log.read_text())
+    assert len(d["recent_events"]) == eventstream.CRASH_TAIL
+    assert d["recent_events"][-1]["kind"] == "k199"
+
+
+def test_crash_log_leaks_no_secret_of_any_shape(tmp_path, monkeypatch):
+    """Multi-shape canaries: a bare high-entropy value, a UUID, a ghp_ PAT and a
+    watsonx-style key must ALL be gone. Shape-matching alone leaked a plaintext key
+    once (#190/#193) — this asserts the env-value pass too."""
+    canaries = {
+        "OPENAI_API_KEY": "sk-proj-abcdefghijklmnopqrstuvwxyz0123456789",
+        "GITHUB_TOKEN": "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789",
+        "SOME_SESSION_ID": "3f2504e0-4f89-11d3-9a0c-0305e82c3301",
+        "WATSONX_APIKEY": "hIQ7bLpZ2mNvXk3TuWq9",        # bare, no recognisable shape
+        "RITS_API_KEY": "Zx91Kk22PpQq",                   # short + shapeless
+    }
+    for k, v in canaries.items():
+        monkeypatch.setenv(k, v)
+    # Every route into the log: argv, the exception text, an event payload, context.
+    monkeypatch.setattr(sys, "argv", ["cap-evolve", "run", f"--key={canaries['RITS_API_KEY']}"])
+    try:
+        raise RuntimeError(f"optimizer said: OPENAI_API_KEY={canaries['OPENAI_API_KEY']} "
+                           f"token {canaries['GITHUB_TOKEN']}")
+    except RuntimeError as e:
+        log = eventstream.write_crash_log(
+            e, run_dir=tmp_path,
+            recent=[{"kind": "optimizer_error",
+                     "error": f"auth failed with {canaries['WATSONX_APIKEY']} / "
+                              f"{canaries['SOME_SESSION_ID']}"}],
+            context={"env_dump": " ".join(canaries.values())})
+    raw = log.read_text()
+    for name, value in canaries.items():
+        assert value not in raw, f"{name} leaked into the crash log"
+    assert raw.count("redacted") >= 5       # each canary masked, not silently dropped
+    assert "optimizer said" in raw          # still diagnosable
+
+
+def test_crash_log_falls_back_to_the_cache_dir(tmp_path, monkeypatch):
+    """A read-only run dir must not lose the crash report."""
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+    import importlib
+    importlib.reload(eventstream)
+    ro = tmp_path / "ro"
+    ro.mkdir()
+    ro.chmod(0o500)
+    try:
+        log = _crash_log(ro)
+        assert log is not None and log.parent == eventstream.CRASH_DIR
+        assert json.loads(log.read_text())["exception"] == "RuntimeError('kaboom')"
+    finally:
+        ro.chmod(0o700)
+        monkeypatch.delenv("XDG_CACHE_HOME")
+        importlib.reload(eventstream)
+
+
+def test_crash_log_event_payloads_stay_terminal_safe(tmp_path):
+    """A crash log is `cat`ed at least as often as it is read — escapes must be inert."""
+    log = _crash_log(tmp_path, recent=[{"kind": "optimizer_error",
+                                        "error": "boom\033]0;PWNED\007\033[2J"}])
+    raw = log.read_text()
+    assert "\033" not in raw and "\007" not in raw and "PWNED" in raw
+
+
+def test_cli_crash_writes_a_forensic_log_and_exits_nonzero(tmp_path, monkeypatch, capsys):
+    """An unhandled exception anywhere under a subcommand: one line, not a traceback."""
+    from cap_evolve import cli as _cli
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+    monkeypatch.setitem(_cli.COMMANDS, "version",
+                        lambda _a: (_ for _ in ()).throw(RuntimeError("exploded")))
+    assert _cli.main(["version"]) == 1
+    err = capsys.readouterr().err
+    assert "crashed: RuntimeError: exploded" in err
+    assert "forensic log" in err
+    log = Path(err.split("bug report): ")[1].strip())
+    assert log.exists() and "exploded" in log.read_text()
+
+
+def test_keyboard_interrupt_is_not_treated_as_a_crash(monkeypatch):
+    from cap_evolve import cli as _cli
+    import pytest
+    monkeypatch.setitem(_cli.COMMANDS, "version",
+                        lambda _a: (_ for _ in ()).throw(KeyboardInterrupt()))
+    with pytest.raises(KeyboardInterrupt):
+        _cli.main(["version"])
+
+
+def test_tail_ladder_flag_reports_the_rung(capsys):
+    assert _cmd_tail(["--ladder"]) == 0
+    d = json.loads(capsys.readouterr().out)
+    assert d["stdout"] in eventstream.LADDER and d["stderr"] in eventstream.LADDER
+    assert d["ladder"] == list(eventstream.LADDER)
+
+
+def test_the_user_visible_crash_line_is_also_redacted_and_inert(monkeypatch, capsys):
+    """The one line printed at the user is untrusted text too: it must not leak a
+    credential nor emit an escape sequence, even though the log beside it is clean."""
+    from cap_evolve import cli as _cli
+    monkeypatch.setenv("WATSONX_APIKEY", "hIQ7bLpZ2mNvXk3TuWq9")
+    monkeypatch.setenv("XDG_CACHE_HOME", str(Path(os.devnull).parent))  # log may fail; fine
+    monkeypatch.setitem(_cli.COMMANDS, "version", lambda _a: (_ for _ in ()).throw(
+        RuntimeError("died\033]0;PWNED\007 key=hIQ7bLpZ2mNvXk3TuWq9")))
+    assert _cli.main(["version"]) == 1
+    err = capsys.readouterr().err
+    assert "hIQ7bLpZ2mNvXk3TuWq9" not in err        # no leak
+    assert "\033" not in err and "\007" not in err   # no escape reaches the terminal
+    assert "PWNED" in err and "died" in err          # inert, still legible

--- a/core/tests/test_eventstream.py
+++ b/core/tests/test_eventstream.py
@@ -533,6 +533,44 @@ def test_only_the_full_rung_gets_colour(monkeypatch):
     assert eventstream.use_color(_Tty()) is True
 
 
+def test_no_color_is_presence_based_and_force_color_can_override_dumb(monkeypatch):
+    """`export NO_COLOR` with no value is what a user types — presence demotes, per
+    no-color.org. And FORCE_COLOR is the only escape hatch in the "on" direction."""
+    monkeypatch.setenv("TERM", "xterm")
+    for value in ("1", "0", ""):     # "" was the hole: bool("") is False
+        monkeypatch.setenv("NO_COLOR", value)
+        assert eventstream.capability(_Tty()) == "plain", f"NO_COLOR={value!r}"
+    monkeypatch.delenv("NO_COLOR")
+    assert eventstream.capability(_Tty()) == "full"
+
+    monkeypatch.setenv("TERM", "dumb")
+    assert eventstream.capability(_Tty()) == "dumb"
+    monkeypatch.setenv("FORCE_COLOR", "1")
+    assert eventstream.capability(_Tty()) == "full"
+    # "no colour" is the stronger request: NO_COLOR still wins over FORCE_COLOR.
+    monkeypatch.setenv("NO_COLOR", "")
+    assert eventstream.capability(_Tty()) == "dumb"
+
+
+def test_sanitize_strips_bidi_and_zero_width_code_points():
+    """The C0/C1 allowlist covers control BYTES; BiDi overrides are control CODE POINTS
+    and survived it. `admin<RLO>gnp.txt` renders as `admin` + reversed text \u2014 enough
+    to spoof a candidate id in a progress line (Trojan Source, CVE-2021-42574).
+
+    Built from chr()/escapes rather than literals: a test file full of real BiDi
+    overrides is itself a Trojan Source finding, and unreviewable besides.
+    """
+    rlo = "\u202e"
+    assert eventstream.sanitize(f"admin{rlo}gnp.txt") == "admingnp.txt"
+    suspects = [0x200B, 0x200C, 0x200D, 0x200E, 0x200F, 0x2028, 0x2029, 0xFEFF]
+    suspects += list(range(0x202A, 0x2030)) + list(range(0x2066, 0x206A))
+    for cp in suspects:
+        c = chr(cp)
+        assert c not in eventstream.sanitize(f"a{c}b"), f"U+{cp:04X} survived"
+    # ordinary text, including non-Latin scripts, is untouched
+    assert eventstream.sanitize("\u4e2d\u6587 caf\u00e9 \u2713 \u0394") == "\u4e2d\u6587 caf\u00e9 \u2713 \u0394"
+
+
 def test_every_rung_below_full_emits_zero_escape_bytes(monkeypatch):
     """The whole point of the ladder: only rung 1 may put escapes on the wire."""
     ev = {"kind": "step", "candidate": "c1", "accept": True, "val": 0.9}
@@ -624,35 +662,130 @@ def test_crash_log_keeps_only_the_recent_tail(tmp_path):
 
 
 def test_crash_log_leaks_no_secret_of_any_shape(tmp_path, monkeypatch):
-    """Multi-shape canaries: a bare high-entropy value, a UUID, a ghp_ PAT and a
-    watsonx-style key must ALL be gone. Shape-matching alone leaked a plaintext key
-    once (#190/#193) — this asserts the env-value pass too."""
+    """Multi-shape canaries under BOTH secret-looking and innocent key names.
+
+    The methodology matters as much as the assertion. The original version of this test
+    planted every canary under `OPENAI_API_KEY` / `WATSONX_APIKEY` — keys the redactor's
+    key regex already matched — so it only ever exercised the case that already worked,
+    and passed while a bare token under `MODEL_ENDPOINT_SUFFIX` leaked verbatim. Same
+    defect pattern as #193's original canary (an `sk-` prefix, i.e. the one shape
+    `redact` already knew). So: innocent key names are first-class canaries here.
+    """
     canaries = {
+        # secret-LOOKING key names — the case the key regex already covered
         "OPENAI_API_KEY": "sk-proj-abcdefghijklmnopqrstuvwxyz0123456789",
         "GITHUB_TOKEN": "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789",
         "SOME_SESSION_ID": "3f2504e0-4f89-11d3-9a0c-0305e82c3301",
         "WATSONX_APIKEY": "hIQ7bLpZ2mNvXk3TuWq9",        # bare, no recognisable shape
         "RITS_API_KEY": "Zx91Kk22PpQq",                   # short + shapeless
+        # INNOCENT key names — no key regex matches these. A value-based rule must.
+        "MODEL_ENDPOINT_SUFFIX": "hIQ7bLpZ2mNvXk3TuWq9x",   # the reviewer's probe
+        "DEPLOYMENT_ID": "Kf83Nq02WwZz71Pl44Bx",
+        "MY_FAVOURITE_STRING": "aB3dEf6hIj9lMn2pQr5t",
     }
     for k, v in canaries.items():
         monkeypatch.setenv(k, v)
-    # Every route into the log: argv, the exception text, an event payload, context.
-    monkeypatch.setattr(sys, "argv", ["cap-evolve", "run", f"--key={canaries['RITS_API_KEY']}"])
+    # Every route into the log: argv (=-joined AND space-separated), the exception text,
+    # an event payload, context.
+    monkeypatch.setattr(sys, "argv", [
+        "cap-evolve", "run", f"--key={canaries['RITS_API_KEY']}",
+        "--api-key", canaries["MODEL_ENDPOINT_SUFFIX"],    # space-separated form
+        "--token", canaries["DEPLOYMENT_ID"],
+    ])
     try:
         raise RuntimeError(f"optimizer said: OPENAI_API_KEY={canaries['OPENAI_API_KEY']} "
-                           f"token {canaries['GITHUB_TOKEN']}")
+                           f"token {canaries['GITHUB_TOKEN']} "
+                           f"bare={canaries['MY_FAVOURITE_STRING']}")
     except RuntimeError as e:
         log = eventstream.write_crash_log(
             e, run_dir=tmp_path,
             recent=[{"kind": "optimizer_error",
                      "error": f"auth failed with {canaries['WATSONX_APIKEY']} / "
-                              f"{canaries['SOME_SESSION_ID']}"}],
+                              f"{canaries['SOME_SESSION_ID']} / "
+                              f"{canaries['MODEL_ENDPOINT_SUFFIX']}"}],
             context={"env_dump": " ".join(canaries.values())})
     raw = log.read_text()
     for name, value in canaries.items():
         assert value not in raw, f"{name} leaked into the crash log"
     assert raw.count("redacted") >= 5       # each canary masked, not silently dropped
     assert "optimizer said" in raw          # still diagnosable
+
+
+def test_the_user_visible_crash_line_leaks_no_innocently_named_secret(monkeypatch, capsys):
+    """The stderr line is the second leak vector and needs the same innocent-key probe:
+    it went through the same redactor, so it leaked the same value."""
+    from cap_evolve import cli as _cli
+    bare = "hIQ7bLpZ2mNvXk3TuWq9x"
+    monkeypatch.setenv("MODEL_ENDPOINT_SUFFIX", bare)
+    monkeypatch.setitem(_cli.COMMANDS, "version", lambda _a: (_ for _ in ()).throw(
+        RuntimeError(f"renderer blew up bare={bare}")))
+    assert _cli.main(["version"]) == 1
+    err = capsys.readouterr().err
+    assert bare not in err, "innocently-named secret leaked onto stderr"
+    assert "renderer blew up" in err
+
+
+def test_env_values_that_are_not_credentials_survive_redaction():
+    """The value-based rule must not eat the diagnostics a crash log exists to carry."""
+    from cap_evolve.dashboard import _looks_like_credential
+    for benign in ("/usr/local/bin:/usr/bin", "xterm-256color", "en_US.UTF-8",
+                   "/Users/someone/Documents/capevo", "C", "dumb",
+                   "Python 3.14.2 (main, Jan 1 2026)", "true", "1"):
+        assert not _looks_like_credential(benign), f"{benign!r} would be over-redacted"
+    for secret in ("hIQ7bLpZ2mNvXk3TuWq9x", "Kf83Nq02WwZz71Pl44Bx",
+                   "ghp_ABCDEFGHIJKLMNOP0123456789"):
+        assert _looks_like_credential(secret), f"{secret!r} would leak"
+
+
+def test_space_separated_secret_flags_are_masked():
+    """`--api-key VALUE` is the normal CLI form; element-wise scrubbing could never see
+    the pair, because the separator is list adjacency, not a character."""
+    from cap_evolve.dashboard import redact, _REDACTED
+    assert redact(["--api-key", "hIQ7bLpZ2mNvXk3TuWq9"]) == ["--api-key", _REDACTED]
+    assert redact(["--token", "abc123"]) == ["--token", _REDACTED]
+    assert redact(["--api-key=hIQ7bLpZ2mNvXk3TuWq9"]) == [f"--api-key={_REDACTED}"]
+    # in prose, too
+    assert "hIQ7bLpZ2mNvXk3TuWq9" not in redact("ran with --api-key hIQ7bLpZ2mNvXk3TuWq9 now")
+    # a following FLAG is not a value, and an innocent flag's value is left alone
+    assert redact(["--api-key", "--verbose"]) == ["--api-key", "--verbose"]
+    assert redact(["--project", "my-proj"]) == ["--project", "my-proj"]
+    # `tokens` (the cost metric) is not a secret flag — must not eat the count
+    assert redact(["--tokens", "4200"]) == ["--tokens", "4200"]
+
+
+def test_two_crash_handlers_do_not_overwrite_each_other(tmp_path):
+    """main()'s handler and the follow thread's fire on the SAME failure, in the same
+    second. Both records must survive: that evidence is the whole point of the feature."""
+    import threading
+    paths = []
+
+    def crash(tag):
+        try:
+            raise RuntimeError(f"secret-{tag}")
+        except RuntimeError as e:
+            paths.append(eventstream.write_crash_log(
+                e, run_dir=tmp_path, context={"where": tag}))
+
+    t = threading.Thread(target=crash, args=("follow-thread",))
+    t.start()
+    crash("main")
+    t.join()
+    assert len(paths) == 2 and all(p is not None for p in paths)
+    assert paths[0] != paths[1], "one handler overwrote the other's log"
+    wheres = {json.loads(p.read_text())["context"]["where"] for p in paths}
+    assert wheres == {"main", "follow-thread"}
+    assert len(list(tmp_path.glob("crash-*.json"))) == 2
+
+
+def test_crash_logs_are_owner_only_and_pruned(tmp_path):
+    """Redacted still means argv, cwd, platform and a traceback — not world-readable,
+    and not unbounded."""
+    log = _crash_log(tmp_path)
+    assert log.stat().st_mode & 0o777 == 0o600
+    for i in range(eventstream.CRASH_KEEP + 12):
+        (tmp_path / f"crash-2026010{i // 10}-0000{i % 10:02d}-1-1.json").write_text("{}")
+    _crash_log(tmp_path)
+    assert len(list(tmp_path.glob("crash-*.json"))) <= eventstream.CRASH_KEEP
 
 
 def test_crash_log_falls_back_to_the_cache_dir(tmp_path, monkeypatch):
@@ -702,6 +835,39 @@ def test_keyboard_interrupt_is_not_treated_as_a_crash(monkeypatch):
                         lambda _a: (_ for _ in ()).throw(KeyboardInterrupt()))
     with pytest.raises(KeyboardInterrupt):
         _cli.main(["version"])
+
+
+def test_follow_status_folds_into_the_one_json_object():
+    """A dead follower must be visible on stdout alone — but stdout stays EXACTLY one
+    parseable JSON object (#217), so the key goes in the existing one."""
+    from cap_evolve.cli import _with_follow_status
+    out = json.dumps({"run_dir": ".capevolve/run_x", "test_reward": 1.0}, indent=2)
+    assert json.loads(_with_follow_status(out, None)) == json.loads(out)  # no key when alive
+    d = json.loads(_with_follow_status(out, "stopped"))                   # still ONE object
+    assert d["follow"] == "stopped" and d["test_reward"] == 1.0
+    # non-JSON or non-object stdout is never rewritten, and never gets a second document
+    assert _with_follow_status("not json", "stopped") == "not json"
+    assert _with_follow_status("[1, 2]", "stopped") == "[1, 2]"
+
+
+def test_keyboard_interrupt_writes_a_log_without_changing_the_exit(monkeypatch, tmp_path):
+    """#144 item 3 covers interrupts too — but Ctrl-C's exit behaviour is not ours."""
+    from cap_evolve import cli as _cli
+    import pytest
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    import importlib
+    importlib.reload(eventstream)
+    try:
+        monkeypatch.setitem(_cli.COMMANDS, "version",
+                            lambda _a: (_ for _ in ()).throw(KeyboardInterrupt()))
+        with pytest.raises(KeyboardInterrupt):
+            _cli.main(["version"])
+        logs = list(eventstream.CRASH_DIR.glob("crash-*.json"))
+        assert logs, "an interrupt during a long run leaves no recent-event trace"
+        assert json.loads(logs[0].read_text())["context"]["interrupted"] is True
+    finally:
+        monkeypatch.delenv("XDG_CACHE_HOME")
+        importlib.reload(eventstream)
 
 
 def test_tail_ladder_flag_reports_the_rung(capsys):

--- a/dashboard/backend/capevolve_dashboard/stream.py
+++ b/dashboard/backend/capevolve_dashboard/stream.py
@@ -1,38 +1,18 @@
-"""Server-Sent-Events helpers: format frames and tail events.jsonl by byte offset."""
+"""Server-Sent-Events helpers: format frames and tail events.jsonl by byte offset.
+
+The tail itself lives in ``cap_evolve.eventstream`` (core, stdlib-only) so the SSE
+route, ``cap-evolve run --follow`` and ``cap-evolve tail`` all read the run's event
+log through the same code — the web view and the terminal can't disagree.
+``read_new_events`` is re-exported here for the existing callers/tests.
+"""
 from __future__ import annotations
 
 import json
-from pathlib import Path
+
+from cap_evolve.eventstream import read_new_events  # noqa: F401 — re-export
+
+__all__ = ["sse_format", "read_new_events"]
 
 
 def sse_format(event: str, data: dict) -> str:
     return f"event: {event}\ndata: {json.dumps(data)}\n\n"
-
-
-def read_new_events(path: Path, offset: int) -> tuple[list[dict], int]:
-    """Return (new events, new byte offset). A partial trailing line (no newline)
-    is left unconsumed so the next read picks it up once complete."""
-    p = Path(path)
-    if not p.exists():
-        return [], offset
-    if offset >= p.stat().st_size:
-        return [], offset
-    # Seek-and-read so each poll costs O(new bytes), not O(file size) — the stream
-    # route calls this twice a second per client over a growing events.jsonl.
-    with p.open("rb") as fh:
-        fh.seek(offset)
-        chunk = fh.read()
-    last_nl = chunk.rfind(b"\n")
-    if last_nl == -1:
-        return [], offset  # only a partial line so far
-    complete = chunk[: last_nl + 1]
-    events = []
-    for line in complete.splitlines():
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            events.append(json.loads(line))
-        except json.JSONDecodeError:
-            continue
-    return events, offset + last_nl + 1

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -56,8 +56,8 @@ cap-evolve run --spec .capevolve/project/capevolve.yaml --follow
 ```text
 [14:02:11] splits frozen  train=4 val=2 test=2 (test sealed)
 [14:02:12] baseline  val=0.0000 ±0.0000
-[14:02:40] ACCEPT  cand_0001  val=1.0000 (parent 0.0000)  — paired Δ̄=+1.0000 > 0  [$0.1240 · 8.3k tok]
-[14:03:05] reject  cand_0002  val=1.0000 (parent 1.0000)  — paired Δ̄=+0.0000 <= 0  [$0.2480 · 16.1k tok]
+[14:02:40] ACCEPT  cand_0001  val=1.0000 (parent 0.0000)  — paired Δ̄=+1.0000 > 0  [$0.0620 · 4.1k tok]
+[14:03:05] reject  cand_0002  val=1.0000 (parent 1.0000)  — paired Δ̄=+0.0000 <= 0  [$0.1240 · 8.3k tok]
 [14:03:31] FINALIZE  test=1.0000 (baseline 0.0000, Δ+1.0000)  best=cand_0001
 ```
 
@@ -73,7 +73,14 @@ cap-evolve tail                                    # newest run under .capevolve
 cap-evolve tail .capevolve/run_20260130_140211 --from-start
 ```
 
-`tail` waits for the run dir to appear, so you can attach before the run creates it.
+`tail` waits for the run dir to appear, so you can attach before the run creates it. It
+exits `0` when the run finishes, `2` on a path that can never be a run dir, and `3` when
+`--idle-timeout` elapses with no events — so a script can tell a timeout from a result.
+
+The `[$… · … tok]` meter is the run's own recorded spend: runner cost from `evaluate`
+events plus optimizer cost from `step` events, matching `Spent.total_usd` in `state.json`.
+Event text is stripped of control characters before it reaches your terminal, so an
+optimizer's stderr can never move the cursor, clear the screen, or forge a progress line.
 
 ## 5. Where to next
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -43,7 +43,39 @@ This is exactly what `core/tests/test_e2e_slice.py` asserts. The script prints a
 directory; open the `dashboard.html` it writes in any browser to see the run (KPIs,
 per-iteration diffs, the tasks × iterations heatmap).
 
-## 4. Where to next
+## 4. Watch a run live in the terminal
+
+A run is otherwise silent until it finishes. `--follow` prints progress from the run's
+`events.jsonl` — the same typed event stream the web dashboard reads, so the two can
+never disagree:
+
+```bash
+cap-evolve run --spec .capevolve/project/capevolve.yaml --follow
+```
+
+```text
+[14:02:11] splits frozen  train=4 val=2 test=2 (test sealed)
+[14:02:12] baseline  val=0.0000 ±0.0000
+[14:02:40] ACCEPT  cand_0001  val=1.0000 (parent 0.0000)  — paired Δ̄=+1.0000 > 0  [$0.1240 · 8.3k tok]
+[14:03:05] reject  cand_0002  val=1.0000 (parent 1.0000)  — paired Δ̄=+0.0000 <= 0  [$0.2480 · 16.1k tok]
+[14:03:31] FINALIZE  test=1.0000 (baseline 0.0000, Δ+1.0000)  best=cand_0001
+```
+
+Progress goes to **stderr**; stdout stays the machine-readable final JSON, so
+`cap-evolve run --follow > result.json` still works for scripts. Output is plain text
+whenever the stream is not a TTY (piped, CI, `NO_COLOR`) — no ANSI in your logs.
+
+To watch a run started elsewhere (another shell, `nohup`, a CI job), attach to its run
+dir instead:
+
+```bash
+cap-evolve tail                                    # newest run under .capevolve/
+cap-evolve tail .capevolve/run_20260130_140211 --from-start
+```
+
+`tail` waits for the run dir to appear, so you can attach before the run creates it.
+
+## 5. Where to next
 
 | You want to… | Go to |
 |---|---|

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -82,6 +82,43 @@ events plus optimizer cost from `step` events, matching `Spent.total_usd` in `st
 Event text is stripped of control characters before it reaches your terminal, so an
 optimizer's stderr can never move the cursor, clear the screen, or forge a progress line.
 
+### The output degradation ladder
+
+Live output adapts to the terminal it actually has. There are exactly five rungs, and
+`cap-evolve tail --ladder` prints which one this invocation is on:
+
+| Rung | Detected by | Output |
+|---|---|---|
+| `full` | TTY, `TERM` not `dumb`/`unknown`, no `NO_COLOR` | ANSI colour + Unicode |
+| `plain` | TTY + `NO_COLOR` set | same text, zero escape bytes |
+| `dumb` | TTY + `TERM=dumb` / `unknown` | no colour, append-only lines |
+| `pipe` | not a TTY (redirect, CI) | plain lines, grep-clean logs |
+| `none` | stream missing/closed (`2>&-`) | nothing (following disables itself) |
+
+Nothing on the ladder repaints the screen or moves the cursor — output is append-only
+at every rung, so there is no live layout to overflow or duplicate on a resize.
+
+Under a non-UTF-8 stream (`PYTHONIOENCODING=ascii`, `LC_ALL=C`, a legacy Windows
+console) glyphs transliterate rather than crash or print mojibake: `±` → `+/-`,
+`Δ` → `d`, `—` → `-`.
+
+### When something crashes
+
+An unhandled crash writes a **forensic log** and prints one line pointing at it:
+
+```text
+cap-evolve run crashed: RuntimeError: optimizer died
+forensic log (redacted, safe to attach to a bug report): .capevolve/run_…/crash-20260130-140455.json
+```
+
+It records the version, argv, python/platform, the terminal rung and encoding, the
+traceback, and the last 25 events seen — enough to file a bug without reproducing it.
+It lands next to the run when there is one, else under
+`${XDG_CACHE_HOME:-~/.cache}/cap-evolve/crashes/`. The whole payload passes through the
+same secret redactor the dashboard uses, so it is safe to attach to an issue. A dying
+live view is handled the same way: the run continues, and the reason is on disk instead
+of vanishing.
+
 ## 5. Where to next
 
 | You want to… | Go to |

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -90,13 +90,23 @@ Live output adapts to the terminal it actually has. There are exactly five rungs
 | Rung | Detected by | Output |
 |---|---|---|
 | `full` | TTY, `TERM` not `dumb`/`unknown`, no `NO_COLOR` | ANSI colour + Unicode |
-| `plain` | TTY + `NO_COLOR` set | same text, zero escape bytes |
-| `dumb` | TTY + `TERM=dumb` / `unknown` | no colour, append-only lines |
+| `plain` | TTY + `NO_COLOR` present (any value, incl. empty) | same text, zero escape bytes |
+| `dumb` | TTY + `TERM=dumb` / `unknown`, no `FORCE_COLOR` | no colour, append-only lines |
 | `pipe` | not a TTY (redirect, CI) | plain lines, grep-clean logs |
 | `none` | stream missing/closed (`2>&-`) | nothing (following disables itself) |
 
-Nothing on the ladder repaints the screen or moves the cursor — output is append-only
-at every rung, so there is no live layout to overflow or duplicate on a resize.
+`NO_COLOR` is presence-based per [no-color.org](https://no-color.org): `export NO_COLOR`
+with no value demotes, same as `NO_COLOR=1`. `FORCE_COLOR` is the one override in the
+other direction, for a colour-capable terminal that reports `TERM=dumb` (some CI runners,
+`emacs -nw`); `NO_COLOR` still wins over it. `CI` is deliberately *not* a demotion signal —
+`isatty` already covers real CI, and demoting on it would break `docker run -t`.
+
+Nothing on the ladder repaints the screen or moves the cursor — output is append-only at
+every rung, so there is no live layout to overflow on a resize and no terminal width to
+budget. That is a deliberate scope reduction against issue #144's items 2 and 4 (height
+budget, width detection): both presuppose output that takes over the screen, and this
+does not. A future repainting view would need `dashboard._term_width` and that item
+re-opened.
 
 Under a non-UTF-8 stream (`PYTHONIOENCODING=ascii`, `LC_ALL=C`, a legacy Windows
 console) glyphs transliterate rather than crash or print mojibake: `±` → `+/-`,
@@ -108,16 +118,24 @@ An unhandled crash writes a **forensic log** and prints one line pointing at it:
 
 ```text
 cap-evolve run crashed: RuntimeError: optimizer died
-forensic log (redacted, safe to attach to a bug report): .capevolve/run_…/crash-20260130-140455.json
+forensic log (redacted, safe to attach to a bug report): .capevolve/run_…/crash-20260730-140455-8134-41207.json
 ```
 
 It records the version, argv, python/platform, the terminal rung and encoding, the
 traceback, and the last 25 events seen — enough to file a bug without reproducing it.
 It lands next to the run when there is one, else under
-`${XDG_CACHE_HOME:-~/.cache}/cap-evolve/crashes/`. The whole payload passes through the
-same secret redactor the dashboard uses, so it is safe to attach to an issue. A dying
-live view is handled the same way: the run continues, and the reason is on disk instead
-of vanishing.
+`${XDG_CACHE_HOME:-~/.cache}/cap-evolve/crashes/`, mode `0600`, with the oldest pruned
+beyond 50 files. The filename carries pid and thread id and is created with `O_EXCL`, so
+two handlers firing on the same failure in the same second each keep their own record
+instead of one truncating the other.
+
+The whole payload passes through the same secret redactor the dashboard uses. That
+redactor scrubs secret-looking *keys*, secret-shaped *values*, **and** the literal values
+of every env var in this process that looks like credential material regardless of what
+it was named — so a bare high-entropy token exported as `MODEL_ENDPOINT_SUFFIX` is masked
+too. Ctrl-C also writes a log (the exit code is unchanged). A dying live view is handled
+the same way: the run continues, the reason is on disk, and the final JSON on stdout
+gains `"follow": "stopped"` so automation can see it without parsing stderr.
 
 ## 5. Where to next
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -29,6 +29,9 @@ pip install ./dashboard/backend            # package: capevolve-dashboard
 cap-evolve dashboard --base .capevolve --port 7878   # or: cap-evolve run --dashboard auto
 ```
 
+No backend needed to watch a run in the terminal: `cap-evolve run --follow` prints live
+progress, and `cap-evolve tail [run_dir]` attaches to a run started elsewhere.
+
 A prebuilt frontend is committed under `dashboard/frontend/dist/`. Every run also writes a
 self-contained static `dashboard.html` you can open with no backend.
 


### PR DESCRIPTION
Closes #144.

Builds **directly on #191** (issue #116), which landed the shared event tail. This is
the robustness half: the ladder as an explicit contract, non-UTF-8 survival, and a
forensic crash log.

## What #191 already covered vs what this adds

| #191 already did | This PR adds |
|---|---|
| `use_color(stream)` — the colour seam | `capability(stream)` — **five named rungs**; `use_color` is now exactly `capability == "full"` |
| plain text on non-TTY, `NO_COLOR` honoured | the ladder as a tested contract: **only `full` may emit an escape byte**, byte-verified per rung |
| progress on stderr; stdout stays JSON | unchanged (re-verified per rung) |
| guard for closed stderr (`2>&-`) | that guard is now the ladder's `none` rung, named and testable |
| `sanitize()` — escape-injection defence | applied to crash-log payloads **and to the user-visible crash line** |
| "the follower must not die quietly" (one stderr line) | that path now **writes a forensic log** and points at it |
| — | `PYTHONIOENCODING=ascii` / `LC_ALL=C` survival (assigned here by #191's review) |
| — | `cap-evolve tail --ladder` scriptable rung read-out |

## The ladder

| Rung | Detected by | Output style | Transcript |
|---|---|---|---|
| `full` | TTY, `TERM` not `dumb`/`unknown`, no `NO_COLOR` | ANSI colour + Unicode | ✅ below |
| `plain` | TTY + `NO_COLOR` | same text, **0 escape bytes** | ✅ below |
| `dumb` | TTY + `TERM=dumb`/`unknown` | no colour, append-only | ✅ below |
| `pipe` | not a TTY (redirect, CI) | plain lines, grep-clean | ✅ below + `od -c` |
| `none` | stream missing/closed (`2>&-`) | nothing; following disables itself | ✅ below |

An *unset* `TERM` is deliberately **not** demoted — normal on a real TTY outside a
shell profile; `dumb` is the explicit opt-out.

**On height-budgeting (#144 item 2):** nothing at any rung repaints the screen, moves
the cursor, or allocates a layout — output is append-only at every rung. There is no
live layout to overflow or double-render on a resize, which is the cheapest way to be
correct about resizes. No curses, no rich, zero new deps.

## Non-UTF-8 locales

`emit()` checks the stream's encoding **up front** and transliterates (`±`→`+/-`,
`Δ`→`d`, `—`→`-`). Pre-checking rather than catching matters: CPython opens stderr
with `errors="backslashreplace"`, so under `PYTHONIOENCODING=ascii` the write does not
raise — it silently prints `\xb1`. Technically ASCII, unreadable in practice.

## The crash log

Contents (`crash-<stamp>.json`): `cap_evolve_version`, `when`, `argv`, `python`,
`platform`, `cwd`, `terminal` (both rungs, `TERM`, `NO_COLOR`, encoding,
`PYTHONIOENCODING`, locale), `context` (which code path), `exception`, `traceback`,
`recent_events` (last 25). Lands next to the run, else
`${XDG_CACHE_HOME:-~/.cache}/cap-evolve/crashes/`. One stderr line points at it; exit
code is non-zero. Follows #193's precedent of offloading verbose detail to a local
file rather than stdout.

**No-leak proof.** The payload and the crash line both go through the existing
`dashboard.redact` — **not a new scrubber**. If `redact` is unavailable the log is not
written at all (no log beats a leaked key). Two **real leaks** were found and fixed
while testing:

1. `main`'s `redact` lacked #193's `ghp_`/`github_pat_`/UUID shapes **and** its
   shape-independent pass over this process's env values, so a bare high-entropy
   watsonx-style key survived.

   **Correction (review):** this PR originally claimed that hunk was ported
   *byte-identical* to #193's. That was **false as stated** — there were three
   comment/whitespace deltas. Precisely: it was AST-identical ignoring docstrings, and
   `dashboard.py` auto-merged clean either way, so the "either merge order is a no-op"
   *effect* held while the literal claim did not.

   It is now moot: review found that #193's env pass only admitted values under a
   *secret-looking key*, so a bare credential exported as `MODEL_ENDPOINT_SUFFIX`
   leaked into the crash log and onto stderr. This PR therefore **hardens** `redact`
   past #193 — admission is now OR-ed with a value-based rule that never consults the
   key name — so the hunk is deliberately no longer a copy. **#215 must land after
   #193**, because the leak fix lives here.
2. The crash line printed at the user echoed the raw exception, leaking exactly what
   the log had masked. Every CLI crash line now routes through one `_safe_exc()`
   (redact + sanitize), so no call site can forget either half.

Multi-shape canary test asserts all four shapes: bare high-entropy, UUID, `ghp_`,
watsonx-style — not just an `sk-` prefix. **Correction (review):** it planted every
canary under a key name the regex already matched, so it only exercised the case that
already worked — the same defect pattern as #193's `sk-`-prefixed canary. It now plants
canaries under **innocent** key names too (`MODEL_ENDPOINT_SUFFIX`, `DEPLOYMENT_ID`,
`AUTH_HEADER_VALUE`), and asserts benign env values (`PATH`, `TERM`, `LANG`) are not
over-redacted.

**Scope note (review):** issue #144's items 2 and 4 (height budget, width detection) are
a deliberate **scope reduction**, not a satisfied requirement — both presuppose output
that takes over the screen, and every rung here is append-only. Stated in
`GETTING_STARTED.md`; a future repainting view needs `dashboard._term_width` and that
item re-opened.

## Expected merge order

**#191 → #118 → #193 → #215 → #214.** #191 first (this branch is based on it; merge
probe: 0 conflicts). **After #193**, because this PR hardens the shared `redact` past
it.

**Correction (review):** this PR previously said no `feat/issue-137-*` branch existed.
It does — `origin/feat/issue-137-cli-ergonomics`, PR **#214**. Re-ran the probe: the
only textual conflict is `cli.py`, and the resolution is **take #214's side**, since
#214 deleted the one-line `usage:` literal in favour of a generated listing.

**But the textual resolution is not sufficient**, and this needs its own issue: #214
adds `_harden_utf8()`, which `reconfigure(encoding="utf-8")`s stdout/stderr at the top
of `main()`. That makes this PR's `_encodable()` see a UTF-8 stream under
`PYTHONIOENCODING=ascii`, so transliteration never fires and `±` reaches an ASCII
terminal (`test_run_follow_survives_ascii_io_encoding` fails in the merge). Two PRs
solve the same problem incompatibly: #214 reconfigures the stream to accept the glyph,
#144 transliterates the glyph to fit the stream. Verified this pre-exists the review
fixes (identical failure against this PR's original head), so it is a design conflict,
not a regression. #214's own docstring says `ponytail: the CLI-level guard only; the TUI
ladder is #144's job`, which suggests `_harden_utf8` should yield to the ladder — but
that is for whoever rebases second to decide, not to silently pick here.

## Verification

Full suite (baseline 179; #191 added ~37, this PR 17):

```
$ PYTHONPATH=core python -m pytest core/tests -q
233 passed in 73.21s (0:01:13)
$ python -m compileall -q core skills
COMPILE_OK
```

### Rung 4 — `pipe` (real `cap-evolve run --follow` on `examples/toy_calc`, mock optimizer, zero API)

```
$ python -m cap_evolve.cli run --spec ... --follow --dashboard off > stdout.pipe 2> stderr.pipe
exit=0
[02:26:15] splits frozen  train=4 val=2 test=2 (test sealed)
[02:26:15] baseline  val=0.0000 ±0.0000
[02:26:15] ACCEPT  cand_0001  val=1.0000 (parent 0.0000)  — paired Δ̄=+1.0000 > 0 (…)
[02:26:16] reject  cand_0002  val=1.0000 (parent 1.0000)  — paired Δ̄=+0.0000 <= 0 (…)
[02:26:17] FINALIZE  test=1.0000 (baseline 0.0000, Δ+1.0000)  best=cand_0001
$ od -c stderr.pipe | grep -o esc | wc -l
0
```

Zero escape bytes. stdout still parses: `test_reward: 1.0`.

### Rungs 1–3 (real pty) and 5

```
=== RUNG 1 full (TTY, TERM=xterm-256color) — cat -v
^[[36m[02:26:43] baseline  val=0.0000 M-BM-10.0000^[[0m
^[[32m[02:26:44] ACCEPT  cand_0001  val=1.0000 (parent 0.0000) …^[[0m
=== RUNG 2 plain (TTY + NO_COLOR=1)
[02:27:02] baseline  val=0.0000 M-BM-10.0000        esc bytes: 0
=== RUNG 3 dumb (TTY + TERM=dumb)
[02:27:06] baseline  val=0.0000 M-BM-10.0000        esc bytes: 0
=== RUNG 5 none (2>&-)  exit=0
progress leaked into stdout? 0     (stdout still valid JSON)
```

Ladder read-out per rung:

```
{"stdout": "full",  "stderr": "full",  …}   # pty, TERM=xterm
{"stdout": "plain", "stderr": "plain", …}   # pty, NO_COLOR=1
{"stdout": "dumb",  "stderr": "dumb",  …}   # pty, TERM=dumb
{"stdout": "pipe",  "stderr": "pipe",  …}   # piped
```

### `PYTHONIOENCODING=ascii` + `LC_ALL=C`

```
$ PYTHONIOENCODING=ascii LC_ALL=C LANG=C python -m cap_evolve.cli run … --follow
exit=0
[02:28:53] baseline  val=0.0000 +/-0.0000
[02:28:54] ACCEPT  cand_0001  val=1.0000 (parent 0.0000)  - paired d?=+1.0000 > 0 (SE=0 -> STRICT fallback…)
[02:28:53] FINALIZE  test=1.0000 (baseline 0.0000, d+1.0000)  best=cand_0001
non-ascii bytes: 0        backslash-escapes left: 0
```

### Crash log + no-leak (4 planted canaries)

```
$ ... crash with canaries in argv, exception text, env, and an event payload
exit=1
cap-evolve run crashed: RuntimeError: optimizer died]0;PWNED: OPENAI_API_KEY=«redacted» session=«redacted» key=«redacted»
forensic log (redacted, safe to attach to a bug report): /tmp/lad/cache/cap-evolve/crashes/crash-20260730-023049.json

--- canary grep -c over BOTH the log and stderr ---
log:0 stderr:0  <- sk-proj-CANARY1abcdefghijklmnopqrstuv0123
log:0 stderr:0  <- ghp_CANARY2ABCDEFGHIJKLMNOP0123456789
log:0 stderr:0  <- 3f2504e0-4f89-11d3-9a0c-0305e82c3301
log:0 stderr:0  <- hIQ7bLpZ2mNvXk3TuWq9            (bare, shapeless)
escape bytes in stderr: 0
```

**Zero canaries leak.** The OSC attack embedded in the crash message is inert.

Dying follower mid-flight (run continues, evidence on disk):

```
[follow] live progress stopped: ValueError: renderer blew up mid-run OPENAI_API_KEY=«redacted» — the run continues; use `cap-evolve tail` or the dashboard to watch it (details: /…/run_fc/crash-20260730-023106.json)
```

with `"context": {"where": "follow-thread", "terminal_rung": "pipe"}`, the traceback,
and the last 3 events (`splits`, `evaluate`, `baseline`) — diagnosable without a repro.
The run still exited 0 with valid JSON.

### Escape injection still inert (#191's three attacks, `color=False` **and** `color=True`)

```
OSC title        -> '[02:36:49] OPTIMIZER ERROR  c1: boom]0;PWNED'
screen clear     -> '[02:36:49] brand_new payload=[2J[Hcleared'
forged FINALIZE  -> '[02:36:49] brand_new payload=a⏎FINALIZE  test=1.0000 … best=FAKE'
all three attacks inert, one line each, under color=False AND color=True
```

Full commands + untruncated output in the `## 🔬 Evidence` comment below.

