### PR TITLE
feat(observability): classify a run as working / stalled / crashed / done

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to cap-evolve are documented here. The format follows
 [Semantic Versioning](https://semver.org/) (currently `0.x` — anything may change).
 
 ## [Unreleased]
+### Added
+- **Live terminal progress: `cap-evolve run --follow` and `cap-evolve tail` (#116).** A
+  classic run was silent for its whole duration — a hung multi-hour run looked exactly
+  like a working one. Both new surfaces render human-readable progress (stage, baseline,
+  per-candidate accept/reject + reason, budget warnings, optimizer errors, finalize, plus
+  a running cost/token meter) from the run's `events.jsonl`. The byte-offset tail is now
+  ONE shared helper — `cap_evolve.eventstream` — consumed by the CLI *and* by the
+  dashboard's SSE route, so the terminal and the web view can never disagree. `--follow`
+  writes to stderr, leaving stdout as the machine-readable final JSON; output is plain
+  text on any non-TTY (piped, CI, `NO_COLOR`). Default behavior is unchanged.
+
 ### Fixed
 - **Benchmark CI robustness (skillberry-1 self-hosted runner).** Three fixes so a broken
   runner or gateway is *loud*, not a silent all-0.000 "success": (1) `ci_setup.sh` now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ All notable changes to cap-evolve are documented here. The format follows
 
 ## [Unreleased]
 ### Added
+- **Tell a stalled/hung run from an idle one from a finished one (#118).** A hung run used
+  to masquerade as finished: the dashboard's SSE stream closed after a fixed ~5 idle
+  minutes and the UI flipped to "idle", which reads like completion, while the hub's
+  `_status` left a run that produced one candidate and then crashed as `live` forever.
+  A run is now classified `live` / `stalled` / `crashed` / `done` by one shared
+  classifier — `cap_evolve.eventstream.classify` — used by `cap-evolve tail`,
+  `run --follow`, the hub row, the DeepDive header, and the SSE stream, so the terminal
+  and the web UI cannot disagree about the same run dir.
+
+  **The threshold is derived from the run itself, not a constant.** A fixed 5 minutes is
+  wrong in both directions: a toy run is silent that long only if it is dead, while one
+  τ²-bench rollout can legitimately take 20 minutes. The bar is
+  `max(300s, 3 × the slowest inter-event gap this run has already shown)` — so the run
+  that sets the bar is the run judged by it, and a slow-but-healthy run raises its own
+  bar instead of being reported hung. `CAPEVOLVE_STALL_SECONDS` pins a fixed number for
+  a workload the user knows better than the heuristic does.
+
+  **Liveness is proof-based.** `cap-evolve run` now writes a small `run.pid`
+  (`{pid, host, started}`) into the run dir and never deletes it: after the process exits
+  the pid stops existing, which is what distinguishes "dead" from "alive but quiet". A pid
+  from another host, or no pid file at all (the per-phase skill-chain workflow), reads as
+  *unknown* and is never reported crashed. `done` outranks everything, so a finished run
+  degrades to a clean `done` no matter how long ago it ran.
+
+  `cap-evolve tail` now exits `4` on a stall and `5` on a crash (and prints the verdict
+  with its numbers on stderr) instead of a silence that reads like success;
+  `--no-stall-check` opts out. The SSE route no longer drops the connection after a fixed
+  idle period — it periodically emits a typed `status` frame naming which kind of quiet
+  the run is in, which doubles as the keepalive.
 - **Live terminal progress: `cap-evolve run --follow` and `cap-evolve tail` (#116).** A
   classic run was silent for its whole duration — a hung multi-hour run looked exactly
   like a working one. Both new surfaces render human-readable progress (stage, baseline,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ All notable changes to cap-evolve are documented here. The format follows
   writes to stderr, leaving stdout as the machine-readable final JSON; output is plain
   text on any non-TTY (piped, CI, `NO_COLOR`). Default behavior is unchanged.
 
+  Hardened after review: a malformed event can no longer kill the follower (and if the
+  follower does stop, it says so on stderr instead of going dark); every rendered line is
+  stripped of control characters, so an optimizer's stderr cannot drive the terminal or
+  forge a progress line; the cost meter counts runner spend from `evaluate` and optimizer
+  spend from `step` exactly once, matching the run's own `Spent.total_usd`; `--follow` is
+  disabled rather than falling back to stdout when stderr is closed (`2>&-`); and
+  `follow_events` yields a typed `_follow_end` sentinel naming *why* it stopped
+  (`stop_kind` / `idle` / `should_stop`). `cap-evolve tail` exits `2` on an impossible run
+  dir and `3` on an idle timeout with no events.
+
 ### Fixed
 - **Benchmark CI robustness (skillberry-1 self-hosted runner).** Three fixes so a broken
   runner or gateway is *loud*, not a silent all-0.000 "success": (1) `ci_setup.sh` now

--- a/core/cap_evolve/cli.py
+++ b/core/cap_evolve/cli.py
@@ -14,6 +14,8 @@ Subcommands:
                        [--follow]  print live progress while the run works
     cap-evolve tail    [run_dir] [--base .capevolve]  attach to an ongoing run's
                        events.jsonl and print human-readable progress
+                       (exit 0 = run finished, 2 = not a possible run dir,
+                        3 = --idle-timeout elapsed with no events)
 
 ``run`` is intentionally minimal in Phase 0 and grows as phase skills land; it
 already resolves the manifest and validates the spec so the wiring is testable.
@@ -78,18 +80,46 @@ def _events_path(base: Path, run_ts: str | None, seen: set[str] | None) -> Path 
     return (runs[-1] / "events.jsonl") if runs else None
 
 
-def _spawn_follower(base: Path, run_ts: str | None, seen: set[str] | None):
+def _stderr_is_usable() -> bool:
+    """True only if progress can safely be written to a real, distinct stderr.
+
+    Under ``2>&-`` CPython either sets ``sys.stderr`` to ``None`` or hands fd 2 to the
+    next ``open()``, so writes would land *interleaved in stdout* and break the
+    machine-readable JSON contract ``--follow`` advertises. Following silently off is
+    strictly better than corrupt stdout.
+    """
+    err = sys.stderr
+    if err is None or getattr(err, "closed", False):
+        return False
+    try:
+        efd = err.fileno()
+    except Exception:  # noqa: BLE001 — a captured StringIO has no fd; safe to write to
+        return True
+    # fd 2 closed and reused by the next open() → that fd is not stderr any more.
+    # (`>f 2>&1` keeps fd 2 == 2 pointing at the same file, which is legitimate.)
+    return efd == 2
+
+
+def _spawn_follower(base: Path, run_ts: str | None, seen: set[str] | None,
+                    offset: int = 0):
     """Print live progress from ``events.jsonl`` on a daemon thread.
 
-    Returns ``(stop_event, thread)``; set the event when the run finishes. Reads the
-    same typed event stream the dashboard's SSE route serves (``cap_evolve.eventstream``),
-    so terminal and web can't disagree. Never raises into the run.
+    Returns ``(stop_event, thread)`` — or ``(None, None)`` when stderr is unusable, in
+    which case following is disabled rather than corrupting stdout. Set the event when
+    the run finishes. Reads the same typed event stream the dashboard's SSE route
+    serves (``cap_evolve.eventstream``), so terminal and web can't disagree. Never
+    raises into the run — but never dies *quietly* either: if the follower stops, it
+    says so on stderr, because silence mistaken for progress is the bug #116 fixes.
     """
     import threading
     from . import eventstream
 
+    if not _stderr_is_usable():
+        return None, None
+
     stop = threading.Event()
-    color = eventstream.use_color(sys.stderr)
+    err = sys.stderr  # bind now: don't follow a stream reassigned mid-run
+    color = eventstream.use_color(err)
 
     def worker():
         # Progress goes to STDERR: stdout stays the machine-readable JSON contract that
@@ -104,12 +134,20 @@ def _spawn_follower(base: Path, run_ts: str | None, seen: set[str] | None):
                 return
             totals: dict = {}
             for ev in eventstream.follow_events(
-                    path, poll=0.5, idle_timeout=None, should_stop=stop.is_set):
+                    path, offset=offset, poll=0.5,
+                    should_stop=lambda _last: stop.is_set()):
                 line = eventstream.render_line(ev, totals, color=color)
                 if line:
-                    print(line, file=sys.stderr, flush=True)
-        except Exception:  # noqa: BLE001 — observability must never break the run
-            pass
+                    print(line, file=err, flush=True)
+        except Exception as e:  # noqa: BLE001 — observability must never break the run
+            # ...but it must never go dark in silence either. #144: this is the hook for
+            # the forensic crash log; the user-visible line below is the minimum.
+            try:
+                print(f"[follow] live progress stopped: {e!r} — the run continues; "
+                      f"use `cap-evolve tail` or the dashboard to watch it",
+                      file=err, flush=True)
+            except Exception:  # noqa: BLE001 — stderr died too; nothing left to do
+                pass
 
     t = threading.Thread(target=worker, name="cap-evolve-follow", daemon=True)
     t.start()
@@ -133,6 +171,8 @@ def _cmd_tail(argv):
                    help="give up after N seconds of silence (0 = wait forever)")
     p.add_argument("--no-color", action="store_true")
     args = p.parse_args(argv)
+    if args.idle_timeout < 0:  # a negative timeout used to trip the check immediately
+        p.error("--idle-timeout must be >= 0 (0 = wait forever)")
 
     if args.run_dir:
         root = Path(args.run_dir)
@@ -144,23 +184,36 @@ def _cmd_tail(argv):
         root = runs[-1]
     events = root / "events.jsonl"
     # A named run dir need NOT exist yet: attaching before `cap-evolve run` creates it
-    # is the whole point. follow_events waits for the file; --idle-timeout bounds the
-    # wait, so a typo'd path exits on the timeout instead of hanging forever.
+    # is the whole point. But a path whose PARENT doesn't exist can never become a run
+    # dir, so a typo fails fast with a distinct code instead of pretend-waiting 5 min.
+    if not root.exists() and not root.parent.is_dir():
+        print(f"no such run dir: {root}", file=sys.stderr)
+        return 2
     if not events.exists():
         print(f"waiting for {events} …", file=sys.stderr, flush=True)
 
     color = not args.no_color and eventstream.use_color(sys.stdout)
     offset = 0 if args.from_start or not events.exists() else events.stat().st_size
     totals: dict = {}
+    shown, reason = 0, None
     try:
         for ev in eventstream.follow_events(
                 events, offset=offset, poll=0.5,
                 idle_timeout=(args.idle_timeout or None)):
+            if ev.get("kind") == eventstream.FOLLOW_END:
+                reason = ev.get("reason")
+                continue
             line = eventstream.render_line(ev, totals, color=color)
             if line:
                 print(line, flush=True)
+                shown += 1
     except KeyboardInterrupt:
         return 130
+    if reason == "idle" and not shown:
+        # Distinct from "the run finished": scripts can tell a timeout from a result.
+        print(f"timed out after {args.idle_timeout:g}s with no events from {events}",
+              file=sys.stderr)
+        return 3
     return 0
 
 
@@ -380,7 +433,11 @@ def _cmd_run(argv):
     if args.follow:
         base_abs = proj_abs.parent
         seen = {p.name for p in base_abs.glob("run_*") if p.is_dir()} if not resume_ts else None
-        follow_stop, follow_thread = _spawn_follower(base_abs, resume_ts, seen)
+        # On --resume, skip the prior log (10k old events are not "live progress"):
+        # start at the current end of file, the way `cap-evolve tail` does.
+        prior = base_abs / f"run_{resume_ts}" / "events.jsonl" if resume_ts else None
+        off = prior.stat().st_size if prior and prior.exists() else 0
+        follow_stop, follow_thread = _spawn_follower(base_abs, resume_ts, seen, off)
 
     def done(code: int) -> int:
         """Drain + stop the follower thread, then return ``code``. Used at every exit."""

--- a/core/cap_evolve/cli.py
+++ b/core/cap_evolve/cli.py
@@ -14,8 +14,9 @@ Subcommands:
                        [--follow]  print live progress while the run works
     cap-evolve tail    [run_dir] [--base .capevolve]  attach to an ongoing run's
                        events.jsonl and print human-readable progress
-                       (exit 0 = run finished / still working, 2 = not a possible run
-                        dir, 3 = --idle-timeout elapsed with no events,
+                       (exit 0 = run finished OR still working — do NOT branch on 0 to
+                        mean "finished"; 2 = not a possible run dir; 3 = --idle-timeout
+                        elapsed with no events and nothing provably dead;
                         4 = STALLED, 5 = CRASHED)
 
 ``run`` is intentionally minimal in Phase 0 and grows as phase skills land; it
@@ -32,6 +33,12 @@ from pathlib import Path
 
 from . import __version__
 from .check import run_check
+
+#: How often the liveness probe (#118) runs while watching. Each probe is one log read
+#: plus a ``kill(0)``, so it is throttled well below the 0.5s event poll. `tail` is
+#: interactive and answers fast; `run --follow` owns the run and only needs to warn.
+_STALL_PROBE_SECONDS = 2.0
+_FOLLOW_STALL_PROBE_SECONDS = 30.0
 
 
 def _find_skills_dir() -> Path | None:
@@ -139,12 +146,12 @@ def _spawn_follower(base: Path, run_ts: str | None, seen: set[str] | None,
             # WARN, don't stop: this run is ours and still going, and whether a wedged
             # phase is worth killing is the user's call — the follower's job is to say
             # so, not to give up and leave the terminal silent again.
-            warned, next_check = False, [time.monotonic() + 30.0]
+            warned, next_check = False, [time.monotonic() + _FOLLOW_STALL_PROBE_SECONDS]
 
             def should_stop(last) -> bool:
                 nonlocal warned
                 if last is not None and time.monotonic() >= next_check[0]:
-                    next_check[0] = time.monotonic() + 30.0
+                    next_check[0] = time.monotonic() + _FOLLOW_STALL_PROBE_SECONDS
                     facts = eventstream.liveness_facts(path.parent)
                     if eventstream.classify(facts) == "stalled":
                         if not warned:
@@ -232,16 +239,24 @@ def _cmd_tail(argv):
     next_check = [0.0]
 
     def should_stop(last) -> bool:
-        if last is None:  # nothing yet — only the plain idle timeout applies
-            return bool(first_deadline and time.monotonic() >= first_deadline)
+        timed_out = bool(last is None and first_deadline
+                         and time.monotonic() >= first_deadline)
         if args.no_stall_check or time.monotonic() < next_check[0]:
-            return False
-        next_check[0] = time.monotonic() + 2.0  # one log read + a kill(0), not every poll
+            return timed_out
+        next_check[0] = time.monotonic() + _STALL_PROBE_SECONDS
         facts = eventstream.liveness_facts(root)
-        if eventstream.classify(facts) in ("stalled", "crashed"):
+        status = eventstream.classify(facts)
+        # `crashed` is proof-based — a pid this host no longer has — so it holds whether or
+        # not THIS process happened to see an event. Attaching without --from-start to a
+        # dead run streams nothing, leaving `last` None forever; gating the probe on `last`
+        # meant `--idle-timeout 0` ("wait forever") hung forever on a provably dead run,
+        # and a finite timeout answered the old ambiguous exit 3 instead of the new 5.
+        # `stalled` still needs `last`: it is a guess from silence, and the run may simply
+        # not have started talking yet.
+        if status == "crashed" or (status == "stalled" and last is not None):
             verdict.update(facts)
             return True
-        return False
+        return timed_out
 
     try:
         for ev in eventstream.follow_events(

--- a/core/cap_evolve/cli.py
+++ b/core/cap_evolve/cli.py
@@ -11,6 +11,9 @@ Subcommands:
     cap-evolve check   [project_dir]
     cap-evolve run     --spec .capevolve/project/capevolve.yaml   (sequences phase skills)
                        [--resume [--run-ts TS]]  resume an interrupted run in place
+                       [--follow]  print live progress while the run works
+    cap-evolve tail    [run_dir] [--base .capevolve]  attach to an ongoing run's
+                       events.jsonl and print human-readable progress
 
 ``run`` is intentionally minimal in Phase 0 and grows as phase skills land; it
 already resolves the manifest and validates the spec so the wiring is testable.
@@ -60,6 +63,105 @@ def _cmd_check(argv):
     rep = run_check(project)
     print(json.dumps(rep.to_dict(), indent=2))
     return 0 if rep.ok else 1
+
+
+def _events_path(base: Path, run_ts: str | None, seen: set[str] | None) -> Path | None:
+    """Locate the run's ``events.jsonl``, or ``None`` if no run dir exists yet.
+
+    With ``run_ts`` the path is known up front. Otherwise pick the newest ``run_*``
+    that is NOT in ``seen`` (the dirs that existed before this run started), so a
+    follower attaches to *this* run and not a previous one.
+    """
+    if run_ts:
+        return base / f"run_{run_ts}" / "events.jsonl"
+    runs = sorted(p for p in base.glob("run_*") if p.is_dir() and p.name not in (seen or set()))
+    return (runs[-1] / "events.jsonl") if runs else None
+
+
+def _spawn_follower(base: Path, run_ts: str | None, seen: set[str] | None):
+    """Print live progress from ``events.jsonl`` on a daemon thread.
+
+    Returns ``(stop_event, thread)``; set the event when the run finishes. Reads the
+    same typed event stream the dashboard's SSE route serves (``cap_evolve.eventstream``),
+    so terminal and web can't disagree. Never raises into the run.
+    """
+    import threading
+    from . import eventstream
+
+    stop = threading.Event()
+    color = eventstream.use_color(sys.stderr)
+
+    def worker():
+        # Progress goes to STDERR: stdout stays the machine-readable JSON contract that
+        # scripts parse, so `cap-evolve run --follow > out.json` keeps working.
+        try:
+            path = None
+            while path is None and not stop.is_set():
+                path = _events_path(base, run_ts, seen)
+                if path is None:
+                    stop.wait(0.5)
+            if path is None:
+                return
+            totals: dict = {}
+            for ev in eventstream.follow_events(
+                    path, poll=0.5, idle_timeout=None, should_stop=stop.is_set):
+                line = eventstream.render_line(ev, totals, color=color)
+                if line:
+                    print(line, file=sys.stderr, flush=True)
+        except Exception:  # noqa: BLE001 — observability must never break the run
+            pass
+
+    t = threading.Thread(target=worker, name="cap-evolve-follow", daemon=True)
+    t.start()
+    return stop, t
+
+
+def _cmd_tail(argv):
+    """Attach to an existing/ongoing run dir and print its event stream."""
+    import argparse
+    from . import eventstream
+
+    p = argparse.ArgumentParser(
+        prog="cap-evolve tail",
+        description="tail a run's events.jsonl as human-readable progress lines")
+    p.add_argument("run_dir", nargs="?", default=None,
+                   help="run dir (default: newest run_* under --base)")
+    p.add_argument("--base", default=".capevolve", help="dir containing run_* dirs")
+    p.add_argument("--from-start", action="store_true",
+                   help="replay the whole log first (default: only new events)")
+    p.add_argument("--idle-timeout", type=float, default=300.0,
+                   help="give up after N seconds of silence (0 = wait forever)")
+    p.add_argument("--no-color", action="store_true")
+    args = p.parse_args(argv)
+
+    if args.run_dir:
+        root = Path(args.run_dir)
+    else:
+        runs = sorted(q for q in Path(args.base).glob("run_*") if q.is_dir())
+        if not runs:
+            print(f"no run_* dirs under {args.base}", file=sys.stderr)
+            return 1
+        root = runs[-1]
+    events = root / "events.jsonl"
+    # A named run dir need NOT exist yet: attaching before `cap-evolve run` creates it
+    # is the whole point. follow_events waits for the file; --idle-timeout bounds the
+    # wait, so a typo'd path exits on the timeout instead of hanging forever.
+    if not events.exists():
+        print(f"waiting for {events} …", file=sys.stderr, flush=True)
+
+    color = not args.no_color and eventstream.use_color(sys.stdout)
+    offset = 0 if args.from_start or not events.exists() else events.stat().st_size
+    totals: dict = {}
+    try:
+        for ev in eventstream.follow_events(
+                events, offset=offset, poll=0.5,
+                idle_timeout=(args.idle_timeout or None)):
+            line = eventstream.render_line(ev, totals, color=color)
+            if line:
+                print(line, flush=True)
+    except KeyboardInterrupt:
+        return 130
+    return 0
 
 
 # Old hill-climb skill names → (skill, focus). The three byte-identical clones are
@@ -124,6 +226,9 @@ def _cmd_run(argv):
     p.add_argument("--stall", type=int, default=None)
     p.add_argument("--optimizer-max-turns", type=int, default=None,
                    help="per-iteration cap passed to the optimizer agent CLI (e.g. claude --max-turns)")
+    p.add_argument("--follow", action="store_true",
+                   help="print live progress (stage/candidate/accept-reject/cost) to stderr "
+                        "as the run writes events.jsonl; stdout stays the final JSON")
     p.add_argument("--dashboard", choices=("auto", "report-only", "off"), default=None,
                    help="live dashboard: auto (default, launch at run start), report-only, or off")
     p.add_argument("--dashboard-port", type=int, default=None, help="dashboard server port (default 7878)")
@@ -268,6 +373,22 @@ def _cmd_run(argv):
                 f"--resume: no run_* found under {proj_abs.parent}; pass --run-ts to name one")}))
             return 1
 
+    # --follow: start tailing events.jsonl now, BEFORE baseline creates the run dir, so
+    # the very first events (splits/baseline) are seen. `seen` freezes the pre-existing
+    # run dirs so an unpinned --run-ts follower attaches to this run, not the last one.
+    follow_stop = follow_thread = None
+    if args.follow:
+        base_abs = proj_abs.parent
+        seen = {p.name for p in base_abs.glob("run_*") if p.is_dir()} if not resume_ts else None
+        follow_stop, follow_thread = _spawn_follower(base_abs, resume_ts, seen)
+
+    def done(code: int) -> int:
+        """Drain + stop the follower thread, then return ``code``. Used at every exit."""
+        if follow_stop is not None:
+            follow_stop.set()
+            follow_thread.join(timeout=3.0)
+        return code
+
     # 1) baseline (creates the run dir; capture its relative path)
     base_cmd = [py, skill_run("baseline"), "--base", base, "--project", project,
                 "--capability", cap_path, "--seed", str(spec.get("split_seed", 0)),
@@ -289,7 +410,7 @@ def _cmd_run(argv):
     proc = run(base_cmd)
     if proc.returncode != 0:
         print(json.dumps({"step": "baseline", "error": proc.stderr[-1500:]}))
-        return 1
+        return done(1)
     run_dir = json.loads(proc.stdout)["run_dir"]
 
     # Resume: explicit budget flags EXTEND the reopened run (e.g. bump max_iterations to
@@ -329,7 +450,7 @@ def _cmd_run(argv):
                           "stop_condition": str(spec.get("stop_condition", "")),
                           "next": "drive via the orchestrate Agent-mode loop; "
                                   "seal with `cap-evolve finalize`"}))
-        return 0
+        return done(0)
 
     # 2) algorithm (hill-climb variants select their schedule via --focus)
     alg_cmd = [py, skill_run(algorithm_name), "--run-dir", run_dir, "--project", project,
@@ -409,7 +530,7 @@ def _cmd_run(argv):
     proc = run(alg_cmd)
     if proc.returncode != 0:
         print(json.dumps({"step": "algorithm", "error": proc.stderr[-1500:]}))
-        return 1
+        return done(1)
 
     # 3) finalize  4) report
     last = proc.stdout
@@ -432,11 +553,11 @@ def _cmd_run(argv):
         proc = run(cmd)
         if proc.returncode != 0:
             print(json.dumps({"step": step, "error": proc.stderr[-1500:]}))
-            return 1
+            return done(1)
         last = proc.stdout
 
     print(last)
-    return 0
+    return done(0)
 
 
 def _cmd_dashboard(argv):
@@ -619,13 +740,15 @@ COMMANDS = {
     "run": _cmd_run,
     "estimate": _cmd_estimate,
     "dashboard": _cmd_dashboard,
+    "tail": _cmd_tail,
 }
 
 
 def main(argv=None) -> int:
     argv = list(sys.argv[1:] if argv is None else argv)
     if not argv or argv[0] in ("-h", "--help"):
-        print("usage: cap-evolve {version|splits|check|run|estimate|dashboard} [args]", file=sys.stderr)
+        print("usage: cap-evolve {version|splits|check|run|estimate|dashboard|tail} [args]",
+              file=sys.stderr)
         return 0 if argv else 2
     fn = COMMANDS.get(argv[0])
     if fn is None:

--- a/core/cap_evolve/cli.py
+++ b/core/cap_evolve/cli.py
@@ -14,8 +14,9 @@ Subcommands:
                        [--follow]  print live progress while the run works
     cap-evolve tail    [run_dir] [--base .capevolve]  attach to an ongoing run's
                        events.jsonl and print human-readable progress
-                       (exit 0 = run finished, 2 = not a possible run dir,
-                        3 = --idle-timeout elapsed with no events)
+                       (exit 0 = run finished / still working, 2 = not a possible run
+                        dir, 3 = --idle-timeout elapsed with no events,
+                        4 = STALLED, 5 = CRASHED)
 
 ``run`` is intentionally minimal in Phase 0 and grows as phase skills land; it
 already resolves the manifest and validates the spec so the wiring is testable.
@@ -26,6 +27,7 @@ from __future__ import annotations
 import json
 import os
 import sys
+import time
 from pathlib import Path
 
 from . import __version__
@@ -133,9 +135,28 @@ def _spawn_follower(base: Path, run_ts: str | None, seen: set[str] | None,
             if path is None:
                 return
             totals: dict = {}
+            # #118: warn once when the run goes quieter than its own demonstrated pace.
+            # WARN, don't stop: this run is ours and still going, and whether a wedged
+            # phase is worth killing is the user's call — the follower's job is to say
+            # so, not to give up and leave the terminal silent again.
+            warned, next_check = False, [time.monotonic() + 30.0]
+
+            def should_stop(last) -> bool:
+                nonlocal warned
+                if last is not None and time.monotonic() >= next_check[0]:
+                    next_check[0] = time.monotonic() + 30.0
+                    facts = eventstream.liveness_facts(path.parent)
+                    if eventstream.classify(facts) == "stalled":
+                        if not warned:
+                            warned = True
+                            print(f"[follow] {eventstream.describe_status(facts)}",
+                                  file=err, flush=True)
+                    else:
+                        warned = False  # back within pace: re-arm the warning
+                return stop.is_set()
+
             for ev in eventstream.follow_events(
-                    path, offset=offset, poll=0.5,
-                    should_stop=lambda _last: stop.is_set()):
+                    path, offset=offset, poll=0.5, should_stop=should_stop):
                 line = eventstream.render_line(ev, totals, color=color)
                 if line:
                     print(line, file=err, flush=True)
@@ -168,7 +189,11 @@ def _cmd_tail(argv):
     p.add_argument("--from-start", action="store_true",
                    help="replay the whole log first (default: only new events)")
     p.add_argument("--idle-timeout", type=float, default=300.0,
-                   help="give up after N seconds of silence (0 = wait forever)")
+                   help="give up after N seconds of silence (0 = wait forever). Only "
+                        "bounds the wait BEFORE the first event; once the run has "
+                        "spoken, stall detection takes over (see --no-stall-check)")
+    p.add_argument("--no-stall-check", action="store_true",
+                   help="never stop on a suspected stall; only --idle-timeout applies")
     p.add_argument("--no-color", action="store_true")
     args = p.parse_args(argv)
     if args.idle_timeout < 0:  # a negative timeout used to trip the check immediately
@@ -196,10 +221,31 @@ def _cmd_tail(argv):
     offset = 0 if args.from_start or not events.exists() else events.stat().st_size
     totals: dict = {}
     shown, reason = 0, None
+    # #118: the run's OWN observed pace decides what counts as too much silence, so the
+    # bar is derived from the WHOLE log — not just the events we streamed. Attaching
+    # without --from-start to a run that takes 20 minutes a step would otherwise see no
+    # gaps at all, fall back to the 300s floor, and report a healthy run hung: exactly
+    # the false alarm this issue is about. `--idle-timeout` is left to bound only the
+    # wait for the FIRST event; a fixed timeout after that is the heuristic being replaced.
+    verdict: dict = {}
+    first_deadline = (time.monotonic() + args.idle_timeout) if args.idle_timeout else None
+    next_check = [0.0]
+
+    def should_stop(last) -> bool:
+        if last is None:  # nothing yet — only the plain idle timeout applies
+            return bool(first_deadline and time.monotonic() >= first_deadline)
+        if args.no_stall_check or time.monotonic() < next_check[0]:
+            return False
+        next_check[0] = time.monotonic() + 2.0  # one log read + a kill(0), not every poll
+        facts = eventstream.liveness_facts(root)
+        if eventstream.classify(facts) in ("stalled", "crashed"):
+            verdict.update(facts)
+            return True
+        return False
+
     try:
         for ev in eventstream.follow_events(
-                events, offset=offset, poll=0.5,
-                idle_timeout=(args.idle_timeout or None)):
+                events, offset=offset, poll=0.5, should_stop=should_stop):
             if ev.get("kind") == eventstream.FOLLOW_END:
                 reason = ev.get("reason")
                 continue
@@ -209,11 +255,20 @@ def _cmd_tail(argv):
                 shown += 1
     except KeyboardInterrupt:
         return 130
-    if reason == "idle" and not shown:
+    if verdict:
+        # The whole point of #118: say WHICH kind of quiet this is, with the numbers, and
+        # exit on a code a script can branch on — never a silence that reads like success.
+        status = eventstream.classify(verdict)
+        print(eventstream.describe_status(verdict), file=sys.stderr)
+        return 5 if status == "crashed" else 4
+    if reason == "should_stop" and not shown:
         # Distinct from "the run finished": scripts can tell a timeout from a result.
         print(f"timed out after {args.idle_timeout:g}s with no events from {events}",
               file=sys.stderr)
         return 3
+    if shown:
+        print(eventstream.describe_status(eventstream.liveness_facts(root)),
+              file=sys.stderr)
     return 0
 
 
@@ -469,6 +524,19 @@ def _cmd_run(argv):
         print(json.dumps({"step": "baseline", "error": proc.stderr[-1500:]}))
         return done(1)
     run_dir = json.loads(proc.stdout)["run_dir"]
+
+    # Liveness marker for stall/crash detection (#118). One small file, written once,
+    # NEVER deleted: once this process exits its pid stops existing, and that absence is
+    # exactly the signal that lets a viewer say "crashed" instead of "live forever" for
+    # a run that died without finalizing. Deleting it on exit would erase the evidence.
+    # Best-effort — a run must never fail because a marker could not be written.
+    try:
+        import socket
+        (workdir / run_dir / "run.pid").write_text(
+            json.dumps({"pid": os.getpid(), "host": socket.gethostname(),
+                        "started": time.time()}), encoding="utf-8")
+    except Exception:  # noqa: BLE001 — observability marker, never load-bearing
+        pass
 
     # Resume: explicit budget flags EXTEND the reopened run (e.g. bump max_iterations to
     # keep climbing past the original cap). Without an override the frozen budget stands.

--- a/core/cap_evolve/eventstream.py
+++ b/core/cap_evolve/eventstream.py
@@ -58,7 +58,8 @@ from typing import Callable, Iterator
 
 __all__ = ["read_new_events", "follow_events", "format_event", "render_line",
            "colorize", "use_color", "sanitize", "accrue_totals",
-           "FOLLOW_END", "BOOKKEEPING_KINDS"]
+           "liveness_facts", "classify", "describe_status",
+           "FOLLOW_END", "BOOKKEEPING_KINDS", "STALL_FLOOR_SECONDS", "STALL_SLACK"]
 
 #: ``kind`` of the sentinel :func:`follow_events` yields last. Its ``reason`` is one
 #: of ``"stop_kind"`` / ``"idle"`` / ``"should_stop"``. #118 keys stall detection off
@@ -391,3 +392,195 @@ def render_line(ev: dict, totals: dict | None = None, *, color: bool = False,
     if kind in _STEP_KINDS:
         style = "green" if ev.get("accept") else "dim"
     return colorize(line, style, enabled=True) if style else line
+
+
+# ---- is it working, stalled, crashed, or done? ------------------------------
+#
+# The hard part is NOT noticing silence — it is deciding how much silence is
+# abnormal. A fixed 5-minute idle timeout is wrong in both directions: a toy run
+# is silent for 5 minutes only if it is dead, while one τ²-bench rollout with
+# 50 tool calls can legitimately take 20 minutes, so a constant would report a
+# healthy expensive run as hung. A false "hung" is the worst outcome available
+# here, because the user's reaction is to kill a run that was working.
+#
+# So the expectation is derived from THE SAME RUN: the bar is the slowest gap the
+# run has already demonstrated, times a slack factor, floored. The bar therefore
+# only ever rises as a run proves itself slow, and the run that sets it is the run
+# judged by it — a workload that takes 20 minutes per step raises its own bar to
+# an hour instead of tripping a global constant.
+
+#: Never call a run stalled before this much silence, however fast its events have
+#: been. Keeps a run that produced two events 40ms apart from being declared hung
+#: 120ms later. 300s is the old hard-coded SSE idle close (#118) — demoted from
+#: "the rule" to "the floor".
+STALL_FLOOR_SECONDS = 300.0
+
+#: Multiplier on the slowest gap the run has already shown. 3x is deliberately
+#: generous: the cost of waiting is a slightly late warning, the cost of being
+#: wrong is a killed run.
+STALL_SLACK = 3.0
+
+#: Env override for the derived threshold: a fixed number of seconds, for a user who
+#: knows their workload better than the heuristic does. ``0``/unset = derive.
+STALL_ENV = "CAPEVOLVE_STALL_SECONDS"
+
+
+def _pid_alive(pid, host) -> bool | None:
+    """True / False / ``None`` when it cannot be known.
+
+    ``None`` (unknown) is a first-class answer and the reason this never guesses:
+    a run recorded on another machine, or a pid file we can't parse, must NOT be
+    reported crashed. Only a definite "this pid is gone" produces ``False``.
+
+    ponytail: pid-only liveness, so a recycled pid could read as alive. The window
+    needs ~32k intervening spawns plus the same host, and the failure direction is
+    the safe one (a dead run looks quiet, not a live run looking dead). Upgrade to
+    a pid+start-time pair if that ever matters.
+    """
+    import socket
+    try:
+        pid = int(pid)
+    except (TypeError, ValueError):
+        return None
+    if pid <= 0:
+        return None
+    if host and str(host) != socket.gethostname():
+        return None  # someone else's machine — we cannot see its process table
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True  # exists, owned by another user
+    except OSError:
+        return None
+    return True
+
+
+def _owner_alive(root: Path) -> bool | None:
+    """Read ``run.pid`` (written by ``cap-evolve run``) and probe the owner.
+
+    ``None`` when there is no pid file at all: the per-phase skill-chain workflow
+    (``/cap-evolve:baseline`` … ) has no single long-lived owner, so its runs get the
+    time-based verdict only and are never labelled crashed.
+    """
+    try:
+        info = json.loads((Path(root) / "run.pid").read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(info, dict):
+        return None
+    return _pid_alive(info.get("pid"), info.get("host"))
+
+
+def stall_threshold(gaps) -> float:
+    """Seconds of silence that count as abnormal, derived from ``gaps`` (the run's own
+    observed inter-event intervals). ``max(floor, slack * slowest_gap_so_far)``.
+
+    ``max`` rather than a mean/quantile on purpose: a run that alternates 1s evals with
+    20-minute optimizer calls has a mean of a couple of minutes, so a mean-based bar
+    would fire during every optimizer call. The slowest thing the run has already done
+    is the only defensible estimate of the slowest thing it might do next.
+    """
+    override = os.environ.get(STALL_ENV)
+    if override:
+        try:
+            fixed = float(override)
+            if fixed > 0:
+                return fixed
+        except ValueError:
+            pass
+    slowest = max(gaps, default=0.0)
+    return max(STALL_FLOOR_SECONDS, STALL_SLACK * slowest)
+
+
+def liveness_facts(root, *, events=None, now=None) -> dict:
+    """Everything :func:`classify` needs, gathered from a run dir. Cheap: one
+    ``stat`` plus (unless ``events`` is supplied) one read of ``events.jsonl``.
+
+    ``events`` lets a caller that already has the parsed log — the dashboard reducer
+    does — avoid a second read.
+
+    Silence is measured from the events file's **mtime**, not the last event's ``t``:
+    ``t`` is wall-clock recorded by the writer and can be skewed or malformed, while
+    mtime is the filesystem's own answer to "when did this run last make a noise".
+    """
+    root = Path(root)
+    path = root / "events.jsonl"
+    now = time.time() if now is None else now
+    if events is None:
+        events, _ = read_new_events(path, 0)
+    ts = []
+    finalized = False
+    for ev in events:
+        if not isinstance(ev, dict):
+            continue
+        if ev.get("kind") == "finalize":
+            finalized = True
+        try:
+            ts.append(float(ev.get("t")))
+        except (TypeError, ValueError):
+            continue
+    ts.sort()
+    gaps = [b - a for a, b in zip(ts, ts[1:]) if b >= a]
+    try:
+        silence = max(0.0, now - path.stat().st_mtime)
+    except OSError:
+        silence = None  # no events file yet — the run hasn't spoken at all
+    return {"silence": silence, "threshold": stall_threshold(gaps),
+            "slowest_gap": max(gaps, default=0.0), "events": len(ts),
+            "finalized": finalized, "alive": _owner_alive(root)}
+
+
+def classify(facts: dict) -> str:
+    """One of ``"done"`` / ``"crashed"`` / ``"stalled"`` / ``"live"``.
+
+    Order matters, and it is the whole design:
+
+    ``done``     ``finalize`` sealed the test. Terminal state; nothing about silence
+                 or a departed process can downgrade it, so a finished run degrades
+                 to a clean "done" rather than "its process is gone → crashed".
+    ``crashed``  the owning process is *definitely* gone and the run never finalized.
+                 Needs proof (a pid file naming a pid on this host that no longer
+                 exists) — ``alive is None`` never reaches this branch.
+    ``stalled``  silent for longer than the run's own derived expectation, while its
+                 process is still alive or unknown. "Alive but not talking."
+    ``live``     everything else, including long silences that are still within what
+                 this run has already shown itself capable of.
+    """
+    if facts.get("finalized"):
+        return "done"
+    if facts.get("alive") is False:
+        return "crashed"
+    silence, threshold = facts.get("silence"), facts.get("threshold") or STALL_FLOOR_SECONDS
+    if silence is not None and silence > threshold:
+        return "stalled"
+    return "live"
+
+
+def _mins(s) -> str:
+    if s is None:
+        return "?"
+    return f"{s / 60:.1f}m" if s >= 60 else f"{s:.0f}s"
+
+
+def describe_status(facts: dict) -> str:
+    """One human sentence for the terminal, always naming the numbers behind the
+    verdict — a user deciding whether to kill a run needs the bar, not just the word."""
+    status = classify(facts)
+    silence, thr = facts.get("silence"), facts.get("threshold")
+    bar = (f"threshold {_mins(thr)}"
+           + (f", derived from a slowest gap of {_mins(facts.get('slowest_gap'))}"
+              if (facts.get("slowest_gap") or 0) * STALL_SLACK > STALL_FLOOR_SECONDS else
+              " (floor)"))
+    if status == "done":
+        return "done — finalize sealed the test split"
+    if status == "crashed":
+        return (f"CRASHED — the process that owned this run is gone and it never "
+                f"finalized (last event {_mins(silence)} ago)")
+    if status == "stalled":
+        return (f"STALLED — no events for {_mins(silence)}, over this run's own "
+                f"{bar}. The process is "
+                + ("still alive" if facts.get("alive") else "not reporting a pid")
+                + " — it may be wedged rather than dead.")
+    return (f"working — last event {_mins(silence)} ago, within this run's {bar}")

--- a/core/cap_evolve/eventstream.py
+++ b/core/cap_evolve/eventstream.py
@@ -12,15 +12,39 @@ Public API (stdlib only, no deps):
     partial trailing line unconsumed so a half-written record is never parsed.
 
 ``follow_events(path, *, offset=0, poll=0.5, stop_kinds=("finalize",),
-                idle_timeout=300.0, should_stop=None) -> Iterator[dict]``
+                idle_timeout=None, should_stop=None) -> Iterator[dict]``
     Blocking generator that yields event dicts as they are appended. Stops after
     an event whose ``kind`` is in ``stop_kinds``, after ``idle_timeout`` seconds
-    with no new events, or when ``should_stop()`` returns true.
+    with no new events, or when ``should_stop(last_event)`` returns true. The LAST
+    record yielded is always a ``{"kind": "_follow_end", "reason": ...}`` sentinel
+    naming *which* exit fired ("stop_kind" / "idle" / "should_stop"), so a consumer
+    can tell "the run finished" from "the run went quiet" (see ``FOLLOW_END``).
 
-``format_event(ev, totals=None) -> str | None``
+``format_event(ev, totals=None, *, skip_kinds=BOOKKEEPING_KINDS) -> str | None``
     One human-readable line for an event, or ``None`` for events with nothing
     worth showing. ``totals`` is an optional caller-owned dict used to accumulate
-    the live cost/token meter across events.
+    the live cost/token meter across events (see :func:`accrue_totals`). Pass
+    ``skip_kinds=()`` to render *every* kind, including the bookkeeping ones.
+
+``accrue_totals(ev, totals) -> None``
+    Add one event's spend to ``totals``, counting each dollar exactly once (runner
+    cost from ``evaluate``, optimizer cost from ``step``-likes, intake from
+    ``intake``). Public so every live spend readout uses one arithmetic.
+
+``sanitize(text) -> str``
+    Strip control characters / ESC sequences and collapse newlines.
+
+``render_line(ev, totals=None, *, color=False, **kw) -> str | None``
+    :func:`format_event` plus optional ANSI styling. Styling only — text safety lives
+    in :func:`format_event`, so neither entry point can return an unsafe line.
+
+``use_color(stream) -> bool``
+    The single TTY / ``NO_COLOR`` decision. ``stream`` is required.
+
+Terminal safety: :func:`format_event` is the ONLY place event text is made
+terminal-safe (see :func:`sanitize`). Event values are model/subprocess-controlled
+(``optimizer_error.error`` is the optimizer CLI's own stderr), so every renderer
+must go through it rather than formatting raw fields itself.
 """
 
 from __future__ import annotations
@@ -33,16 +57,41 @@ from pathlib import Path
 from typing import Callable, Iterator
 
 __all__ = ["read_new_events", "follow_events", "format_event", "render_line",
-           "colorize", "use_color"]
+           "colorize", "use_color", "sanitize", "accrue_totals",
+           "FOLLOW_END", "BOOKKEEPING_KINDS"]
+
+#: ``kind`` of the sentinel :func:`follow_events` yields last. Its ``reason`` is one
+#: of ``"stop_kind"`` / ``"idle"`` / ``"should_stop"``. #118 keys stall detection off
+#: ``reason == "idle"``; ``format_event`` renders it as ``None`` (nothing to show).
+FOLLOW_END = "_follow_end"
+
+#: Kinds :func:`format_event` skips by default (the dashboard shows them, the
+#: terminal shouldn't). Pass ``skip_kinds=()`` to see every kind — #138 needs the
+#: bookkeeping ones for phase detection.
+BOOKKEEPING_KINDS = ("minibatch", "optimizer_context_warning", "target_profile",
+                     "seed_dir_created", "splits_warning", "gepa_resume",
+                     "gepa_merge_skip", "gepa_merge_local", "skillopt_slow_eval",
+                     "skillopt_slow_update")
+
+# The one-iteration-finished events, each carrying the optimizer's own spend.
+_STEP_KINDS = ("step", "gepa_val_gate", "skillopt_step")
 
 
 def read_new_events(path: Path, offset: int) -> tuple[list[dict], int]:
     """Return (new events, new byte offset). A partial trailing line (no newline)
-    is left unconsumed so the next read picks it up once complete."""
+    is left unconsumed so the next read picks it up once complete.
+
+    Only JSON *objects* are returned: a bare ``42``/``null``/``[1,2]`` record parses
+    fine but every consumer (CLI renderer, dashboard SSE route) treats events as
+    dicts, so non-dicts are dropped at the source rather than at each caller.
+    """
     p = Path(path)
     if not p.exists():
         return [], offset
-    if offset >= p.stat().st_size:
+    size = p.stat().st_size
+    if size < offset:
+        offset = 0  # file shrank (truncate/rewrite/rotation) → re-read from the top
+    if offset >= size:
         return [], offset
     # Seek-and-read so each poll costs O(new bytes), not O(file size) — callers poll
     # a growing events.jsonl twice a second, per client.
@@ -53,15 +102,24 @@ def read_new_events(path: Path, offset: int) -> tuple[list[dict], int]:
     if last_nl == -1:
         return [], offset  # only a partial line so far
     complete = chunk[: last_nl + 1]
-    events = []
+    events, dropped = [], 0
     for line in complete.splitlines():
         line = line.strip()
         if not line:
             continue
         try:
-            events.append(json.loads(line))
+            obj = json.loads(line)
         except json.JSONDecodeError:
+            dropped += 1
             continue
+        if isinstance(obj, dict):
+            events.append(obj)
+        else:
+            dropped += 1  # a bare 42/null/[1,2] is not an event
+    if dropped:
+        # Don't silently lose audit-log records: surface the count as an event so both
+        # the terminal and the dashboard see that the log has damage.
+        events.append({"kind": "log_corruption", "dropped": dropped})
     return events, offset + last_nl + 1
 
 
@@ -71,40 +129,61 @@ def follow_events(
     offset: int = 0,
     poll: float = 0.5,
     stop_kinds: tuple[str, ...] = ("finalize",),
-    idle_timeout: float | None = 300.0,
-    should_stop: Callable[[], bool] | None = None,
+    idle_timeout: float | None = None,
+    should_stop: Callable[[dict | None], bool] | None = None,
 ) -> Iterator[dict]:
     """Yield events from ``path`` as they are appended (blocking generator).
 
     ``offset=0`` replays the whole file first, then follows. Waits for the file to
-    appear, so a follower can attach before the run creates it. ``idle_timeout=None``
-    means wait forever.
+    appear, so a follower can attach before the run creates it.
+
+    The final record yielded is ALWAYS a ``{"kind": FOLLOW_END, "reason": r}``
+    sentinel where ``r`` is:
+
+    ``"stop_kind"``   an event whose ``kind`` is in ``stop_kinds`` arrived (run ended)
+    ``"idle"``        ``idle_timeout`` seconds passed with no new event (possible stall)
+    ``"should_stop"`` the caller's ``should_stop`` returned true
+
+    so a consumer can distinguish "done" from "quiet" (#118). ``should_stop`` is
+    called with the last event seen (``None`` before any), so a stall rule can look
+    at its ``t`` without running a second poller. ``idle_timeout=None`` (the default)
+    means wait forever — each caller owns its own threshold; there is deliberately no
+    module-level default, because a shared one would pre-decide #118's configurable
+    stall threshold for every consumer.
     """
     idle_start = time.monotonic()
+    last: dict | None = None
     while True:
         events, offset = read_new_events(path, offset)
         for ev in events:
+            last = ev
             yield ev
             if ev.get("kind") in stop_kinds:
+                yield {"kind": FOLLOW_END, "reason": "stop_kind", "last_kind": ev.get("kind")}
                 return
         if events:
             idle_start = time.monotonic()
         elif idle_timeout is not None and time.monotonic() - idle_start >= idle_timeout:
+            yield {"kind": FOLLOW_END, "reason": "idle", "idle_seconds": idle_timeout}
             return
-        if should_stop is not None and should_stop():
+        if should_stop is not None and should_stop(last):
             # Drain whatever landed between the last read and the stop signal, so the
             # final events of a finished run are never lost to a race.
             for ev in read_new_events(path, offset)[0]:
                 yield ev
+            yield {"kind": FOLLOW_END, "reason": "should_stop"}
             return
         time.sleep(poll)
 
 
 # ---- human-readable rendering ----------------------------------------------
 
-def use_color(stream=None) -> bool:
-    """True only on a real TTY without ``NO_COLOR``. Piped/CI output stays plain."""
-    stream = stream or sys.stdout
+def use_color(stream) -> bool:
+    """True only on a real TTY without ``NO_COLOR``. Piped/CI output stays plain.
+
+    ``stream`` is required: the decision must be made about the stream the caller
+    actually writes to, never a default that could colorize stderr based on stdout.
+    """
     if os.environ.get("NO_COLOR"):
         return False
     try:
@@ -120,6 +199,26 @@ def colorize(text: str, style: str, *, enabled: bool) -> str:
     if not enabled or style not in _CODES:
         return text
     return f"\033[{_CODES[style]}m{text}\033[0m"
+
+
+# Every C0 control char (except TAB) and every C1 control char, mapped away. Event
+# values are model/subprocess-controlled — `optimizer_error.error` is the optimizer
+# CLI's own stderr — so an ESC/OSC/CSI sequence in a payload would otherwise reach the
+# terminal verbatim (set window title, clear screen, OSC 52 clipboard write), and a
+# raw "\n" would forge an extra progress line ("FINALIZE test=1.0 …") for a run that
+# never finished. Newlines/CRs collapse to a visible "⏎" rather than vanishing, so a
+# multi-line optimizer error is still legible on one line.
+_CTRL = {c: None for c in range(0x20) if c != 0x09}
+_CTRL[0x7F] = None                       # DEL
+_CTRL.update({c: None for c in range(0x80, 0xA0)})  # C1, incl. 0x9B (8-bit CSI)
+_CTRL[0x0A] = _CTRL[0x0D] = "⏎"
+
+
+def sanitize(text: str) -> str:
+    """Strip control characters / ESC sequences so no event value can drive the
+    terminal or forge extra output lines. Applied by :func:`format_event` to the
+    whole finished line, so every field and every future event kind is covered."""
+    return str(text).translate(_CTRL)
 
 
 def _num(v, fmt="{:.4f}") -> str:
@@ -140,30 +239,80 @@ def _meter(totals: dict | None) -> str:
     return f"  [${usd:.4f} · {tokens} tok]"
 
 
-def _accrue(ev: dict, totals: dict | None) -> None:
-    if totals is None:
+def accrue_totals(ev: dict, totals: dict | None) -> None:
+    """Accumulate the run's spend into ``totals`` (``{"usd","tokens"}``), counting
+    each dollar exactly once. Public so every live readout (terminal meter, #138's
+    dashboard burn line) uses one arithmetic instead of forking it.
+
+    The harness reports the SAME runner spend twice: ``evaluate`` logs
+    ``cost_usd``/``tokens`` (``harness.py:311``) and the following ``step`` re-states
+    it alongside the optimizer's own ``opt_cost_usd``/``opt_tokens``
+    (``harness.py:1326``). So the authoritative sources are:
+
+    * runner spend    → ``evaluate`` only  (``cost_usd`` / ``tokens``)
+    * optimizer spend → ``step``-like only (``opt_cost_usd`` / ``opt_tokens``)
+    * intake spend    → ``intake`` only    (``usd`` / ``tokens``)
+
+    which reproduces ``Spent.total_usd = usd + optimizer_usd + intake_usd``
+    (``rundir.py:137``). Summing every cost-ish key on every event double-counted the
+    runner and displayed ~2x the real spend.
+    """
+    if totals is None or not isinstance(ev, dict):
         return
-    for k in ("cost_usd", "opt_cost_usd", "usd"):
+    kind = str(ev.get("kind") or "")
+    if kind == "evaluate":
+        pairs = (("cost_usd", "tokens"),)
+    elif kind in _STEP_KINDS:
+        pairs = (("opt_cost_usd", "opt_tokens"),)
+    elif kind == "intake":
+        pairs = (("usd", "tokens"),)
+    else:
+        return
+    for usd_key, tok_key in pairs:
         try:
-            totals["usd"] = totals.get("usd", 0.0) + float(ev.get(k) or 0.0)
+            totals["usd"] = totals.get("usd", 0.0) + float(ev.get(usd_key) or 0.0)
         except (TypeError, ValueError):
             pass
-    for k in ("tokens", "opt_tokens"):
         try:
-            totals["tokens"] = totals.get("tokens", 0) + int(ev.get(k) or 0)
+            totals["tokens"] = totals.get("tokens", 0) + int(ev.get(tok_key) or 0)
         except (TypeError, ValueError):
             pass
 
 
-def format_event(ev: dict, totals: dict | None = None) -> str | None:
+
+def _timestamp(v) -> str:
+    """``HH:MM:SS`` for an event's ``t``, or ``--:--:--`` for a malformed one.
+
+    ``rundir.log_event`` serialises with ``json.dumps(..., default=str)``, so a ``t``
+    that is a string / dict / out-of-range float is reachable in a real log. It must
+    never raise: one bad record used to kill the follower thread and take the rest of
+    the run's live output with it, which is the exact silence #116 exists to fix.
+    """
+    try:
+        return time.strftime("%H:%M:%S", time.localtime(float(v if v else time.time())))
+    except (TypeError, ValueError, OverflowError, OSError):
+        return "--:--:--"
+
+
+def format_event(ev: dict, totals: dict | None = None, *,
+                 skip_kinds: tuple[str, ...] = BOOKKEEPING_KINDS) -> str | None:
     """Render one event as a single terminal line, or ``None`` to skip it.
 
-    Never emits ANSI: color is layered on by :func:`render_line`, so the piped /
-    no-TTY path is plain text by construction.
+    Total function: any malformed record (non-dict, bad ``t``, hostile string) yields
+    ``None`` or a safe line, never an exception — a renderer that raises silences the
+    whole run. Never emits ANSI, and no event value can: the finished line is run
+    through :func:`sanitize`, so color is only ever added by :func:`render_line`.
+
+    ``skip_kinds`` defaults to :data:`BOOKKEEPING_KINDS`; pass ``()`` to render every
+    kind (what #138 needs for phase detection).
     """
+    if not isinstance(ev, dict):
+        return None
     kind = str(ev.get("kind") or "")
-    _accrue(ev, totals)
-    ts = time.strftime("%H:%M:%S", time.localtime(float(ev.get("t") or time.time())))
+    if kind in skip_kinds or kind == FOLLOW_END:
+        return None  # bookkeeping / noise — the dashboard shows these, the terminal shouldn't
+    accrue_totals(ev, totals)
+    ts = _timestamp(ev.get("t"))
     meter = _meter(totals)
 
     if kind == "splits":
@@ -173,7 +322,7 @@ def format_event(ev: dict, totals: dict | None = None) -> str | None:
         body = f"baseline  val={_num(ev.get('val'))} ±{_num(ev.get('stderr'))}"
     elif kind == "baseline_reused":
         body = f"baseline reused from {ev.get('prior') or ev.get('from') or '?'}"
-    elif kind in ("step", "gepa_val_gate", "skillopt_step"):
+    elif kind in _STEP_KINDS:
         ok = bool(ev.get("accept"))
         verdict = "ACCEPT" if ok else "reject"
         where = ""
@@ -210,29 +359,35 @@ def format_event(ev: dict, totals: dict | None = None) -> str | None:
                 f"Δ{_num(ev.get('test_delta'), '{:+.4f}')})  best={ev.get('best_id')}")
     elif kind == "intake":
         body = f"intake  ${_num(ev.get('usd'), '{:.4f}')}  {ev.get('output_summary') or ''}".rstrip()
-    elif kind in ("minibatch", "optimizer_context_warning", "target_profile",
-                  "seed_dir_created", "splits_warning", "gepa_resume",
-                  "gepa_merge_skip", "gepa_merge_local", "skillopt_slow_eval",
-                  "skillopt_slow_update"):
-        return None  # bookkeeping / noise — the dashboard shows these, the terminal shouldn't
+    elif kind == "log_corruption":
+        body = f"WARNING  {ev.get('dropped')} unreadable record(s) skipped in events.jsonl"
     else:
         # Unknown kind: still show it rather than hide progress from a new event type.
         extra = " ".join(f"{k}={v}" for k, v in ev.items() if k not in ("t", "kind"))
         body = f"{kind} {extra}".strip()
-    return f"[{ts}] {body}{meter}"
+    # Sanitize the FINISHED line, once: every field of every kind (present and future)
+    # is covered, so no event value can emit an escape sequence or forge an extra line.
+    return sanitize(f"[{ts}] {body}{meter}")
 
 
 _STYLE_BY_KIND = {"optimizer_error": "red", "budget_warning": "yellow",
+                  "log_corruption": "yellow",
                   "finalize": "bold", "baseline": "cyan"}
 
 
-def render_line(ev: dict, totals: dict | None = None, *, color: bool = False) -> str | None:
-    """:func:`format_event` plus optional ANSI styling (accept green / reject dim)."""
-    line = format_event(ev, totals)
+def render_line(ev: dict, totals: dict | None = None, *, color: bool = False,
+                **kw) -> str | None:
+    """:func:`format_event` plus optional ANSI styling (accept green / reject dim).
+
+    Styling only — all text safety lives in :func:`format_event`, so a caller can
+    never get an unsanitised line by choosing one of these two over the other.
+    ``**kw`` (e.g. ``skip_kinds``) is passed through to :func:`format_event`.
+    """
+    line = format_event(ev, totals, **kw)
     if line is None or not color:
         return line
     kind = str(ev.get("kind") or "")
     style = _STYLE_BY_KIND.get(kind)
-    if kind in ("step", "gepa_val_gate", "skillopt_step"):
+    if kind in _STEP_KINDS:
         style = "green" if ev.get("accept") else "dim"
     return colorize(line, style, enabled=True) if style else line

--- a/core/cap_evolve/eventstream.py
+++ b/core/cap_evolve/eventstream.py
@@ -1,0 +1,238 @@
+"""One source of truth for reading a run's ``events.jsonl`` stream.
+
+``events.jsonl`` is the run's append-only audit log (see :mod:`cap_evolve.rundir`).
+Every live view of a run — the dashboard's SSE route, ``cap-evolve run --follow``,
+``cap-evolve tail`` — reads it through this module, so the terminal and the web UI
+can never disagree about what happened.
+
+Public API (stdlib only, no deps):
+
+``read_new_events(path, offset) -> (events, new_offset)``
+    One incremental, byte-offset read. Cheap (seeks to ``offset``); leaves a
+    partial trailing line unconsumed so a half-written record is never parsed.
+
+``follow_events(path, *, offset=0, poll=0.5, stop_kinds=("finalize",),
+                idle_timeout=300.0, should_stop=None) -> Iterator[dict]``
+    Blocking generator that yields event dicts as they are appended. Stops after
+    an event whose ``kind`` is in ``stop_kinds``, after ``idle_timeout`` seconds
+    with no new events, or when ``should_stop()`` returns true.
+
+``format_event(ev, totals=None) -> str | None``
+    One human-readable line for an event, or ``None`` for events with nothing
+    worth showing. ``totals`` is an optional caller-owned dict used to accumulate
+    the live cost/token meter across events.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Callable, Iterator
+
+__all__ = ["read_new_events", "follow_events", "format_event", "render_line",
+           "colorize", "use_color"]
+
+
+def read_new_events(path: Path, offset: int) -> tuple[list[dict], int]:
+    """Return (new events, new byte offset). A partial trailing line (no newline)
+    is left unconsumed so the next read picks it up once complete."""
+    p = Path(path)
+    if not p.exists():
+        return [], offset
+    if offset >= p.stat().st_size:
+        return [], offset
+    # Seek-and-read so each poll costs O(new bytes), not O(file size) — callers poll
+    # a growing events.jsonl twice a second, per client.
+    with p.open("rb") as fh:
+        fh.seek(offset)
+        chunk = fh.read()
+    last_nl = chunk.rfind(b"\n")
+    if last_nl == -1:
+        return [], offset  # only a partial line so far
+    complete = chunk[: last_nl + 1]
+    events = []
+    for line in complete.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            events.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return events, offset + last_nl + 1
+
+
+def follow_events(
+    path: Path,
+    *,
+    offset: int = 0,
+    poll: float = 0.5,
+    stop_kinds: tuple[str, ...] = ("finalize",),
+    idle_timeout: float | None = 300.0,
+    should_stop: Callable[[], bool] | None = None,
+) -> Iterator[dict]:
+    """Yield events from ``path`` as they are appended (blocking generator).
+
+    ``offset=0`` replays the whole file first, then follows. Waits for the file to
+    appear, so a follower can attach before the run creates it. ``idle_timeout=None``
+    means wait forever.
+    """
+    idle_start = time.monotonic()
+    while True:
+        events, offset = read_new_events(path, offset)
+        for ev in events:
+            yield ev
+            if ev.get("kind") in stop_kinds:
+                return
+        if events:
+            idle_start = time.monotonic()
+        elif idle_timeout is not None and time.monotonic() - idle_start >= idle_timeout:
+            return
+        if should_stop is not None and should_stop():
+            # Drain whatever landed between the last read and the stop signal, so the
+            # final events of a finished run are never lost to a race.
+            for ev in read_new_events(path, offset)[0]:
+                yield ev
+            return
+        time.sleep(poll)
+
+
+# ---- human-readable rendering ----------------------------------------------
+
+def use_color(stream=None) -> bool:
+    """True only on a real TTY without ``NO_COLOR``. Piped/CI output stays plain."""
+    stream = stream or sys.stdout
+    if os.environ.get("NO_COLOR"):
+        return False
+    try:
+        return bool(stream.isatty())
+    except Exception:  # noqa: BLE001 — a stub stream without isatty is "not a tty"
+        return False
+
+
+_CODES = {"dim": "2", "bold": "1", "green": "32", "red": "31", "yellow": "33", "cyan": "36"}
+
+
+def colorize(text: str, style: str, *, enabled: bool) -> str:
+    if not enabled or style not in _CODES:
+        return text
+    return f"\033[{_CODES[style]}m{text}\033[0m"
+
+
+def _num(v, fmt="{:.4f}") -> str:
+    try:
+        return fmt.format(float(v))
+    except (TypeError, ValueError):
+        return "?"
+
+
+def _meter(totals: dict | None) -> str:
+    """`  [$0.0123 · 4.2k tok]` — the live cost meter, or '' if nothing spent yet."""
+    if not totals:
+        return ""
+    usd, tok = totals.get("usd", 0.0), totals.get("tokens", 0)
+    if not usd and not tok:
+        return ""
+    tokens = f"{tok / 1000:.1f}k" if tok >= 1000 else str(tok)
+    return f"  [${usd:.4f} · {tokens} tok]"
+
+
+def _accrue(ev: dict, totals: dict | None) -> None:
+    if totals is None:
+        return
+    for k in ("cost_usd", "opt_cost_usd", "usd"):
+        try:
+            totals["usd"] = totals.get("usd", 0.0) + float(ev.get(k) or 0.0)
+        except (TypeError, ValueError):
+            pass
+    for k in ("tokens", "opt_tokens"):
+        try:
+            totals["tokens"] = totals.get("tokens", 0) + int(ev.get(k) or 0)
+        except (TypeError, ValueError):
+            pass
+
+
+def format_event(ev: dict, totals: dict | None = None) -> str | None:
+    """Render one event as a single terminal line, or ``None`` to skip it.
+
+    Never emits ANSI: color is layered on by :func:`render_line`, so the piped /
+    no-TTY path is plain text by construction.
+    """
+    kind = str(ev.get("kind") or "")
+    _accrue(ev, totals)
+    ts = time.strftime("%H:%M:%S", time.localtime(float(ev.get("t") or time.time())))
+    meter = _meter(totals)
+
+    if kind == "splits":
+        body = (f"splits frozen  train={ev.get('train')} val={ev.get('val')} "
+                f"test={ev.get('test')} (test sealed)")
+    elif kind == "baseline":
+        body = f"baseline  val={_num(ev.get('val'))} ±{_num(ev.get('stderr'))}"
+    elif kind == "baseline_reused":
+        body = f"baseline reused from {ev.get('prior') or ev.get('from') or '?'}"
+    elif kind in ("step", "gepa_val_gate", "skillopt_step"):
+        ok = bool(ev.get("accept"))
+        verdict = "ACCEPT" if ok else "reject"
+        where = ""
+        if kind == "skillopt_step":
+            where = f" e{ev.get('epoch')}s{ev.get('step_in_epoch')}"
+        body = (f"{verdict}{where}  {ev.get('candidate')}  val={_num(ev.get('val'))}"
+                f" (parent {_num(ev.get('parent_val'))})")
+        if ev.get("reason"):
+            body += f"  — {ev['reason']}"
+    elif kind == "gepa_local_gate":
+        body = (f"minibatch gate {'pass' if ev.get('passed') else 'fail'}  {ev.get('candidate')}"
+                f"  child={_num(ev.get('child_sum'), '{:.3f}')}"
+                f" parent={_num(ev.get('parent_sum'), '{:.3f}')}")
+    elif kind == "gepa_select":
+        body = f"selected parent {ev.get('parent')} ({ev.get('strategy')})"
+    elif kind in ("gepa_start", "skillopt_start"):
+        body = f"{kind.split('_')[0]} started  " + " ".join(
+            f"{k}={v}" for k, v in ev.items() if k not in ("t", "kind"))
+    elif kind == "gepa_stop":
+        body = f"gepa stopped: {ev.get('reason')}"
+    elif kind == "evaluate":
+        body = (f"eval {ev.get('split')}/{ev.get('tag')}  reward={_num(ev.get('reward'))}"
+                f" ±{_num(ev.get('stderr'))}  {_num(ev.get('seconds'), '{:.1f}')}s")
+    elif kind == "gate_warning":
+        body = f"gate warning ({ev.get('mode')}): {str(ev.get('reason')).split(' — ')[0]}"
+    elif kind == "budget_warning":
+        body = (f"BUDGET {ev.get('pct')}% of {ev.get('metric')}  "
+                f"{ev.get('spent')}/{ev.get('limit')}")
+    elif kind == "optimizer_error":
+        body = f"OPTIMIZER ERROR  {ev.get('candidate')}: {str(ev.get('error'))[:200]}"
+    elif kind == "finalize":
+        body = (f"FINALIZE  test={_num(ev.get('test_reward'))} "
+                f"(baseline {_num(ev.get('test_baseline_reward'))}, "
+                f"Δ{_num(ev.get('test_delta'), '{:+.4f}')})  best={ev.get('best_id')}")
+    elif kind == "intake":
+        body = f"intake  ${_num(ev.get('usd'), '{:.4f}')}  {ev.get('output_summary') or ''}".rstrip()
+    elif kind in ("minibatch", "optimizer_context_warning", "target_profile",
+                  "seed_dir_created", "splits_warning", "gepa_resume",
+                  "gepa_merge_skip", "gepa_merge_local", "skillopt_slow_eval",
+                  "skillopt_slow_update"):
+        return None  # bookkeeping / noise — the dashboard shows these, the terminal shouldn't
+    else:
+        # Unknown kind: still show it rather than hide progress from a new event type.
+        extra = " ".join(f"{k}={v}" for k, v in ev.items() if k not in ("t", "kind"))
+        body = f"{kind} {extra}".strip()
+    return f"[{ts}] {body}{meter}"
+
+
+_STYLE_BY_KIND = {"optimizer_error": "red", "budget_warning": "yellow",
+                  "finalize": "bold", "baseline": "cyan"}
+
+
+def render_line(ev: dict, totals: dict | None = None, *, color: bool = False) -> str | None:
+    """:func:`format_event` plus optional ANSI styling (accept green / reject dim)."""
+    line = format_event(ev, totals)
+    if line is None or not color:
+        return line
+    kind = str(ev.get("kind") or "")
+    style = _STYLE_BY_KIND.get(kind)
+    if kind in ("step", "gepa_val_gate", "skillopt_step"):
+        style = "green" if ev.get("accept") else "dim"
+    return colorize(line, style, enabled=True) if style else line

--- a/core/cap_evolve/eventstream.py
+++ b/core/cap_evolve/eventstream.py
@@ -408,12 +408,48 @@ def render_line(ev: dict, totals: dict | None = None, *, color: bool = False,
 # only ever rises as a run proves itself slow, and the run that sets it is the run
 # judged by it — a workload that takes 20 minutes per step raises its own bar to
 # an hour instead of tripping a global constant.
+#
+# The catch, and the reason the floor is 60 minutes rather than 5: only COMPLETED gaps
+# can be derived from, and a run's slowest step is nearly always the one it is currently
+# INSIDE. A run in its first slow step has demonstrated nothing but its opening burst of
+# sub-second events, so the floor alone judges it — and at 300s that reported `stalled`
+# on healthy runs whose owner was alive in `ps`.
+#
+# Folding the OPEN gap into the derived bar (the obvious fix) does not work, because the
+# bar is what that same silence is compared against: with any slack >= 1 the bar outruns
+# the silence forever and `stalled` becomes unreachable; with slack < 1 the bar collapses
+# onto the floor and the fold does nothing. (Pinned by
+# `test_folding_the_open_gap_into_the_bar_would_never_fire`.) So the uninformed case gets
+# a conservative PRIOR instead — a floor no legitimate first step exceeds — and the
+# derived bar takes over the moment the run completes a slower gap.
+#
+# `crashed` deliberately does not depend on any of this: it needs proof (a departed pid),
+# so the case that most needs a fast answer gets one regardless of the floor.
 
 #: Never call a run stalled before this much silence, however fast its events have
-#: been. Keeps a run that produced two events 40ms apart from being declared hung
-#: 120ms later. 300s is the old hard-coded SSE idle close (#118) — demoted from
-#: "the rule" to "the floor".
-STALL_FLOOR_SECONDS = 300.0
+#: been. This is the bar for a run that has not yet demonstrated a slow step, and it is
+#: deliberately generous, because such a run has told us nothing about its own pace: a
+#: real run opens with a burst of sub-second events (``splits``, ``evaluate val/seed``,
+#: ``baseline`` — all inside the same second) and only then makes its first genuinely
+#: slow optimizer call. Deriving a bar from that opening burst measures the burst, not
+#: the workload, so the floor is the only thing judging the FIRST slow step — and at
+#: 300s it called every run whose first step exceeded five minutes ``stalled`` while its
+#: owner was demonstrably alive in ``ps`` (review of #218: probes A, B, S).
+#:
+#: 3600s = ``STALL_SLACK`` × the ~20-minute τ²-bench step: the same slack the derived bar
+#: applies to a demonstrated gap, applied to the slowest step we consider plausible for a
+#: workload we have not observed yet. One completed gap over 20 minutes and the derived
+#: bar takes over above this.
+#:
+#: What the floor does NOT delay is ``crashed``: a dead run is caught by proof (its pid
+#: is gone), not by silence. So raising the floor costs nothing on the case that matters
+#: most — it only delays the "alive but wedged" guess, where late is the cheap direction
+#: and a false alarm gets a working run killed.
+#:
+#: ponytail: one constant, not a tier on how many gaps the log has, so a genuinely wedged
+#: FAST run is now reported at 60m rather than 5m. Add the tier if minute-scale detection
+#: on cheap runs matters; #118 is about the expensive ones.
+STALL_FLOOR_SECONDS = 3600.0
 
 #: Multiplier on the slowest gap the run has already shown. 3x is deliberately
 #: generous: the cost of waiting is a slightly late warning, the cost of being
@@ -424,18 +460,56 @@ STALL_SLACK = 3.0
 #: knows their workload better than the heuristic does. ``0``/unset = derive.
 STALL_ENV = "CAPEVOLVE_STALL_SECONDS"
 
+#: A log that moved this recently proves SOME process is writing it, which outranks any
+#: marker claiming the owner is dead. Needed because ``run.pid`` is never deleted, so a
+#: reused run dir can hold a dead pid from a previous attempt while the current writer
+#: (the per-phase skill chain writes no marker at all) is actively appending — that read
+#: ``crashed`` on a run with ``silence=0.0s`` (review of #218, probe T). Also covers a
+#: container sharing the host's UTS namespace but not its PID namespace, where the host
+#: check passes and a live pid is simply invisible.
+#:
+#: Small on purpose: a really dead process stops writing instantly, so its silence clears
+#: this within a minute and ``crashed`` still arrives promptly. It only has to be longer
+#: than the interval between two writes of a live run, not longer than a slow step.
+CRASH_MIN_SILENCE_SECONDS = 60.0
 
-def _pid_alive(pid, host) -> bool | None:
+
+def _proc_start_time(pid: int) -> float | None:
+    """Wall-clock epoch seconds at which ``pid`` began, or ``None`` if unknowable.
+
+    ``ps -o lstart=`` is the one answer available on both macOS and Linux without a
+    dependency (``/proc`` is Linux-only, ``psutil`` is a new dep for one field).
+    ``None`` on anything unexpected, so an unparseable answer degrades to the old
+    pid-only behaviour rather than to a guess.
+    """
+    import subprocess
+    try:
+        out = subprocess.run(["ps", "-o", "lstart=", "-p", str(pid)],
+                             capture_output=True, text=True, timeout=5).stdout.strip()
+        # "Thu Jul 30 04:10:04 2026" — the same format on both platforms.
+        return time.mktime(time.strptime(out, "%a %b %d %H:%M:%S %Y")) if out else None
+    except Exception:  # noqa: BLE001 — no ps, odd locale, timeout: unknown, not dead
+        return None
+
+
+#: How far a process's real start time may fall AFTER the marker's ``started`` before we
+#: call it a different process. Slack absorbs `ps` second-granularity and the clock moving
+#: between ``time.time()`` and the write; anything past it is a pid that got reused.
+_PID_START_SLACK = 60.0
+
+
+def _pid_alive(pid, host, started=None) -> bool | None:
     """True / False / ``None`` when it cannot be known.
 
     ``None`` (unknown) is a first-class answer and the reason this never guesses:
     a run recorded on another machine, or a pid file we can't parse, must NOT be
     reported crashed. Only a definite "this pid is gone" produces ``False``.
 
-    ponytail: pid-only liveness, so a recycled pid could read as alive. The window
-    needs ~32k intervening spawns plus the same host, and the failure direction is
-    the safe one (a dead run looks quiet, not a live run looking dead). Upgrade to
-    a pid+start-time pair if that ever matters.
+    ``started`` (the marker's write time) closes pid REUSE: the marker is written after
+    the owner exists, so the owner's real start time can only be *earlier*. A process at
+    this pid that began measurably later is therefore somebody else, and the run it
+    belonged to is gone — ``False``, not a false ``True``. Unknowable start time (no
+    ``ps``, odd output) falls back to pid-only rather than guessing either way.
     """
     import socket
     try:
@@ -454,6 +528,13 @@ def _pid_alive(pid, host) -> bool | None:
         return True  # exists, owned by another user
     except OSError:
         return None
+    try:
+        started = float(started)
+    except (TypeError, ValueError):
+        return True  # old marker with no `started`: pid-only, as before
+    real = _proc_start_time(pid)
+    if real is not None and real > started + _PID_START_SLACK:
+        return False  # same pid, different process — the owner really is gone
     return True
 
 
@@ -470,7 +551,7 @@ def _owner_alive(root: Path) -> bool | None:
         return None
     if not isinstance(info, dict):
         return None
-    return _pid_alive(info.get("pid"), info.get("host"))
+    return _pid_alive(info.get("pid"), info.get("host"), info.get("started"))
 
 
 def stall_threshold(gaps) -> float:
@@ -494,24 +575,10 @@ def stall_threshold(gaps) -> float:
     return max(STALL_FLOOR_SECONDS, STALL_SLACK * slowest)
 
 
-def liveness_facts(root, *, events=None, now=None) -> dict:
-    """Everything :func:`classify` needs, gathered from a run dir. Cheap: one
-    ``stat`` plus (unless ``events`` is supplied) one read of ``events.jsonl``.
-
-    ``events`` lets a caller that already has the parsed log — the dashboard reducer
-    does — avoid a second read.
-
-    Silence is measured from the events file's **mtime**, not the last event's ``t``:
-    ``t`` is wall-clock recorded by the writer and can be skewed or malformed, while
-    mtime is the filesystem's own answer to "when did this run last make a noise".
-    """
-    root = Path(root)
-    path = root / "events.jsonl"
-    now = time.time() if now is None else now
-    if events is None:
-        events, _ = read_new_events(path, 0)
-    ts = []
-    finalized = False
+def _scan(events) -> tuple[list[float], bool]:
+    """``(timestamps, saw_finalize)`` from parsed event dicts. Malformed/absent ``t`` is
+    skipped rather than raising: a half-written log must still produce a verdict."""
+    ts, finalized = [], False
     for ev in events:
         if not isinstance(ev, dict):
             continue
@@ -521,14 +588,84 @@ def liveness_facts(root, *, events=None, now=None) -> dict:
             ts.append(float(ev.get("t")))
         except (TypeError, ValueError):
             continue
-    ts.sort()
-    gaps = [b - a for a, b in zip(ts, ts[1:]) if b >= a]
+    return ts, finalized
+
+
+#: ``str(path) -> (mtime, size, offset, sorted_ts, slowest_gap, n, finalized)``. Bounds the
+#: cost of the periodic probe: the SSE route calls ``liveness()`` every 5s per open
+#: connection, and re-deriving the bar meant re-parsing the WHOLE log each time — 108ms on
+#: a 50k-event / 4.6MB log, 720×/hour/connection (review of #218, non-blocking #6).
+#:
+#: The event-derived facts change only when the file does, so new bytes are folded into the
+#: previous scan and each probe costs O(new bytes) instead of O(file). Silence is NEVER
+#: cached: it changes precisely while nothing on disk changes, which is why liveness sits
+#: outside #194's reduce cache in the first place. A shrunk/replaced file (offset > size)
+#: falls back to a full re-read.
+#:
+#: ponytail: unbounded dict keyed by path, one small tuple per run dir ever probed by this
+#: process, and the log itself is what would have to be re-read anyway. Add an LRU cap if a
+#: process ever watches enough distinct runs for that to show up.
+_FACTS_CACHE: dict = {}
+
+
+def liveness_facts(root, *, events=None, now=None) -> dict:
+    """Everything :func:`classify` needs, gathered from a run dir. Cheap: one ``stat``
+    plus a read of whatever bytes of ``events.jsonl`` are new since the last call.
+
+    ``events`` lets a caller that already has the parsed log — the dashboard reducer
+    does — pass it in and skip the read entirely.
+
+    Silence is measured from the events file's **mtime**, not the last event's ``t``:
+    ``t`` is wall-clock recorded by the writer and can be skewed or malformed, while
+    mtime is the filesystem's own answer to "when did this run last make a noise".
+
+    Note the two quantities come from different clocks — gaps from the writer's ``t``,
+    silence from the filesystem's mtime against the reader's ``now`` — so a machine whose
+    clock is skewed against the writer's gets a correct-by-luck answer (review of #218,
+    non-blocking #7). mtime is still the right pragmatic signal: it is the only one that
+    cannot be forged by a malformed event, and both surfaces read it the same way.
+    """
+    root = Path(root)
+    path = root / "events.jsonl"
+    now = time.time() if now is None else now
+    if events is not None:
+        ts, finalized = _scan(events)
+        ts.sort()
+        gaps = [b - a for a, b in zip(ts, ts[1:]) if b >= a]
+        slowest, n = max(gaps, default=0.0), len(ts)
+    else:
+        try:
+            st = path.stat()
+            stamp = (st.st_mtime, st.st_size)
+        except OSError:
+            stamp = None
+        key = str(path)
+        prev = _FACTS_CACHE.get(key)
+        if prev and stamp and (prev[0], prev[1]) == stamp:
+            _, _, _, ts, slowest, n, finalized = prev
+        else:
+            offset = prev[2] if (prev and stamp and prev[2] <= stamp[1]) else 0
+            ts, slowest, n, finalized = (list(prev[3]), prev[4], prev[5], prev[6]) \
+                if offset else ([], 0.0, 0, False)
+            new, offset = read_new_events(path, offset)
+            fresh, saw_final = _scan(new)
+            finalized = finalized or saw_final
+            n += len(fresh)
+            ts = sorted(ts + fresh)
+            gaps = [b - a for a, b in zip(ts, ts[1:]) if b >= a]
+            slowest = max(gaps, default=0.0)
+            # Only the newest timestamp is needed to extend the max on the next call, but
+            # an out-of-order `t` (two writers, a clock step) must not silently invent a
+            # huge gap, so the sorted list is kept. It is the run's event count, and the
+            # log is on disk anyway.
+            if stamp:
+                _FACTS_CACHE[key] = (stamp[0], stamp[1], offset, ts, slowest, n, finalized)
     try:
         silence = max(0.0, now - path.stat().st_mtime)
     except OSError:
         silence = None  # no events file yet — the run hasn't spoken at all
-    return {"silence": silence, "threshold": stall_threshold(gaps),
-            "slowest_gap": max(gaps, default=0.0), "events": len(ts),
+    return {"silence": silence, "threshold": stall_threshold([slowest]),
+            "slowest_gap": slowest, "events": n,
             "finalized": finalized, "alive": _owner_alive(root)}
 
 
@@ -540,9 +677,12 @@ def classify(facts: dict) -> str:
     ``done``     ``finalize`` sealed the test. Terminal state; nothing about silence
                  or a departed process can downgrade it, so a finished run degrades
                  to a clean "done" rather than "its process is gone → crashed".
-    ``crashed``  the owning process is *definitely* gone and the run never finalized.
-                 Needs proof (a pid file naming a pid on this host that no longer
-                 exists) — ``alive is None`` never reaches this branch.
+    ``crashed``  the owning process is *definitely* gone, the run never finalized, AND
+                 the log has stopped moving. Needs proof (a pid file naming a pid on this
+                 host that no longer exists) — ``alive is None`` never reaches this
+                 branch — plus the corroboration that nothing is still writing, because
+                 ``run.pid`` is never deleted and a stale marker in a reused dir would
+                 otherwise condemn a live writer.
     ``stalled``  silent for longer than the run's own derived expectation, while its
                  process is still alive or unknown. "Alive but not talking."
     ``live``     everything else, including long silences that are still within what
@@ -550,9 +690,9 @@ def classify(facts: dict) -> str:
     """
     if facts.get("finalized"):
         return "done"
-    if facts.get("alive") is False:
-        return "crashed"
     silence, threshold = facts.get("silence"), facts.get("threshold") or STALL_FLOOR_SECONDS
+    if facts.get("alive") is False and (silence or 0.0) >= CRASH_MIN_SILENCE_SECONDS:
+        return "crashed"
     if silence is not None and silence > threshold:
         return "stalled"
     return "live"

--- a/core/tests/test_eventstream.py
+++ b/core/tests/test_eventstream.py
@@ -1,8 +1,9 @@
 """Tests for the shared events.jsonl tail helper + the --follow / tail CLI paths."""
 import io
-import os
-import shutil
 import json
+import os
+import shlex
+import shutil
 import subprocess
 import sys
 import threading
@@ -11,6 +12,28 @@ from pathlib import Path
 
 from cap_evolve import eventstream
 from cap_evolve.cli import _cmd_tail, _events_path
+
+
+def _toy_project(tmp_path: Path) -> tuple[Path, dict]:
+    """Scaffold the zero-API toy_calc project (mock optimizer) + its env. Shared by the
+    real end-to-end `cap-evolve run --follow` tests."""
+    repo = Path(__file__).resolve().parents[2]
+    example = repo / "examples" / "toy_calc"
+    proj = tmp_path / ".capevolve" / "project"
+    (proj / "adapters").mkdir(parents=True)
+    shutil.copy(example / "adapter.py", proj / "adapters" / "adapter.py")
+    shutil.copytree(example / "capability", tmp_path / "seed_capability")
+    shutil.copy(repo / "templates" / "project" / "capevolve.yaml", proj / "capevolve.yaml")
+    env = dict(os.environ)
+    env.update(PYTHONPATH=str(repo / "core"), CAPEVOLVE_CORE=str(repo / "core"),
+               CAPEVOLVE_SKILLS_DIR=str(repo / "skills"), CAPEVOLVE_TOY_DATA=str(example),
+               CAPEVOLVE_MOCK_SCRIPT=str(example / "mock_script.json"))
+    return proj, env
+
+
+def _kinds(it):
+    """Event kinds, minus the terminal sentinel (asserted separately)."""
+    return [e["kind"] for e in it if e["kind"] != eventstream.FOLLOW_END]
 
 
 def _write(p: Path, *recs):
@@ -51,14 +74,18 @@ def test_read_new_events_missing_file(tmp_path):
 def test_follow_events_stops_on_finalize_and_replays(tmp_path):
     p = tmp_path / "events.jsonl"
     _write(p, {"kind": "baseline"}, {"kind": "finalize"}, {"kind": "after"})
-    kinds = [e["kind"] for e in eventstream.follow_events(p, idle_timeout=1.0)]
-    assert kinds == ["baseline", "finalize"]  # stops at finalize, nothing after
+    got = list(eventstream.follow_events(p, idle_timeout=1.0))
+    assert _kinds(got) == ["baseline", "finalize"]  # stops at finalize, nothing after
+    assert got[-1] == {"kind": eventstream.FOLLOW_END, "reason": "stop_kind",
+                       "last_kind": "finalize"}
 
 
 def test_follow_events_idle_timeout_on_empty(tmp_path):
     t0 = time.monotonic()
     got = list(eventstream.follow_events(tmp_path / "events.jsonl", poll=0.05, idle_timeout=0.2))
-    assert got == []
+    assert _kinds(got) == []
+    # #118: an idle exit is distinguishable from a finished run, not a bare return.
+    assert got == [{"kind": eventstream.FOLLOW_END, "reason": "idle", "idle_seconds": 0.2}]
     assert time.monotonic() - t0 < 5.0
 
 
@@ -73,7 +100,7 @@ def test_follow_events_picks_up_appends_live(tmp_path):
         _write(p, {"kind": "finalize"})
 
     threading.Thread(target=writer, daemon=True).start()
-    kinds = [e["kind"] for e in eventstream.follow_events(p, poll=0.05, idle_timeout=5.0)]
+    kinds = _kinds(eventstream.follow_events(p, poll=0.05, idle_timeout=5.0))
     assert kinds == ["baseline", "step", "finalize"]
 
 
@@ -83,9 +110,10 @@ def test_follow_events_should_stop_drains_tail(tmp_path):
     stop = threading.Event()
     _write(p, {"kind": "baseline"}, {"kind": "step"})
     stop.set()  # already stopped: first read yields both, then the drain returns
-    kinds = [e["kind"] for e in eventstream.follow_events(
-        p, poll=0.01, idle_timeout=1.0, should_stop=stop.is_set)]
-    assert kinds == ["baseline", "step"]
+    got = list(eventstream.follow_events(
+        p, poll=0.01, idle_timeout=1.0, should_stop=lambda _last: stop.is_set()))
+    assert _kinds(got) == ["baseline", "step"]
+    assert got[-1]["reason"] == "should_stop"
 
 
 # ---- format_event / render_line --------------------------------------------
@@ -121,9 +149,12 @@ def test_format_event_shows_unknown_kinds():
 
 
 def test_cost_meter_accumulates_across_events():
+    """Runner spend comes from `evaluate`, optimizer spend from `step` — once each."""
     totals = {}
-    eventstream.format_event({"kind": "step", "cost_usd": 0.01, "tokens": 500}, totals)
-    line = eventstream.format_event({"kind": "step", "cost_usd": 0.02, "tokens": 1500}, totals)
+    eventstream.format_event({"kind": "evaluate", "cost_usd": 0.01, "tokens": 500}, totals)
+    line = eventstream.format_event(
+        {"kind": "step", "cost_usd": 0.01, "tokens": 500,          # re-stated, must NOT recount
+         "opt_cost_usd": 0.02, "opt_tokens": 1500}, totals)
     assert abs(totals["usd"] - 0.03) < 1e-9 and totals["tokens"] == 2000
     assert "$0.0300" in line and "2.0k tok" in line
 
@@ -218,18 +249,7 @@ def test_run_follow_end_to_end_pipes_clean_progress(tmp_path):
     stdout is piped (not a TTY), so: progress lines land on stderr with NO ANSI, and
     stdout stays the parseable final JSON that scripts depend on.
     """
-    repo = Path(__file__).resolve().parents[2]
-    example = repo / "examples" / "toy_calc"
-    proj = tmp_path / ".capevolve" / "project"
-    (proj / "adapters").mkdir(parents=True)
-    shutil.copy(example / "adapter.py", proj / "adapters" / "adapter.py")
-    shutil.copytree(example / "capability", tmp_path / "seed_capability")
-    shutil.copy(repo / "templates" / "project" / "capevolve.yaml", proj / "capevolve.yaml")
-
-    env = dict(os.environ)
-    env.update(PYTHONPATH=str(repo / "core"), CAPEVOLVE_CORE=str(repo / "core"),
-               CAPEVOLVE_SKILLS_DIR=str(repo / "skills"), CAPEVOLVE_TOY_DATA=str(example),
-               CAPEVOLVE_MOCK_SCRIPT=str(example / "mock_script.json"))
+    proj, env = _toy_project(tmp_path)
     proc = subprocess.run(
         [sys.executable, "-m", "cap_evolve.cli", "run", "--spec", str(proj / "capevolve.yaml"),
          "--project", str(proj), "--run-ts", "t", "--follow", "--dashboard", "off"],
@@ -255,3 +275,218 @@ def test_dashboard_stream_reexports_the_shared_helper():
         assert stream.read_new_events is eventstream.read_new_events
     finally:
         sys.path.remove(str(root))
+
+
+# ---- B1: a malformed record must never kill the follower --------------------
+
+POISON = [
+    {"kind": "baseline", "t": "not-a-number"},   # ValueError from float()
+    {"kind": "baseline", "t": {"nested": 1}},    # TypeError from float()
+    {"kind": "baseline", "t": 1e300},            # OverflowError from localtime()
+    42, None, [1, 2, 3], "just a string",        # non-dict records
+]
+
+
+def test_format_event_survives_every_malformed_record():
+    """format_event is total: no record shape may raise out of the render loop."""
+    for bad in POISON:
+        line = eventstream.format_event(bad, {})          # must not raise
+        assert line is None or isinstance(line, str)
+    assert "--:--:--" in eventstream.format_event({"kind": "baseline", "t": "nope"})
+    assert eventstream.format_event(42) is None
+
+
+def test_poisoned_record_does_not_kill_the_follower(tmp_path):
+    """The bug #116 exists to fix: one bad event must not blank the rest of the run."""
+    p = tmp_path / "events.jsonl"
+    with p.open("w", encoding="utf-8") as fh:
+        fh.write(json.dumps({"kind": "baseline", "val": 0.1}) + "\n")
+        fh.write(json.dumps({"kind": "baseline", "t": "not-a-number"}) + "\n")
+        fh.write("42\n")                    # non-dict record
+        fh.write("NOT JSON AT ALL\n")       # unparseable
+        fh.write(json.dumps({"kind": "step", "candidate": "cand_0001", "accept": True,
+                             "val": 1.0}) + "\n")
+        fh.write(json.dumps({"kind": "finalize", "test_reward": 1.0}) + "\n")
+    lines = [eventstream.render_line(e, {})
+             for e in eventstream.follow_events(p, idle_timeout=2.0)]
+    text = "\n".join(l for l in lines if l)
+    assert "cand_0001" in text and "FINALIZE" in text   # events AFTER the poison render
+    assert "--:--:--" in text                           # the poisoned one degraded, not fatal
+
+
+def test_follower_thread_reports_instead_of_dying_silently(tmp_path, monkeypatch, capsys):
+    """If the follower does die, the user is TOLD — silence must never look like progress."""
+    from cap_evolve import cli as _cli
+
+    base = tmp_path
+    (base / "run_z").mkdir()
+    _write(base / "run_z" / "events.jsonl", {"kind": "baseline", "val": 0.0})
+    boom = RuntimeError("simulated renderer explosion")
+    monkeypatch.setattr(eventstream, "render_line",
+                        lambda *a, **k: (_ for _ in ()).throw(boom))
+    monkeypatch.setattr(_cli, "_stderr_is_usable", lambda: True)
+    stop, t = _cli._spawn_follower(base, "z", None)
+    t.join(timeout=5.0)
+    assert not t.is_alive()
+    assert "[follow] live progress stopped" in capsys.readouterr().err
+
+
+# ---- B1b/N2: only dict records escape read_new_events -----------------------
+
+def test_read_new_events_filters_non_dict_records(tmp_path):
+    p = tmp_path / "events.jsonl"
+    p.write_text('42\nnull\n[1,2]\n"str"\ntrue\n{"kind":"finalize"}\n', encoding="utf-8")
+    evs, _ = eventstream.read_new_events(p, 0)
+    assert [e["kind"] for e in evs if e["kind"] != "log_corruption"] == ["finalize"]
+    assert all(isinstance(e, dict) for e in evs)
+    assert {"kind": "log_corruption", "dropped": 5} in evs   # damage is reported, not hidden
+
+
+def test_corrupt_line_is_counted_not_silently_dropped(tmp_path):
+    p = tmp_path / "events.jsonl"
+    p.write_text('{"kind":"a"}\nNOT JSON AT ALL\n{"kind":"finalize"}\n', encoding="utf-8")
+    evs, _ = eventstream.read_new_events(p, 0)
+    assert [e["kind"] for e in evs] == ["a", "finalize", "log_corruption"]
+    assert "1 unreadable record" in eventstream.format_event(evs[-1])
+
+
+# ---- N3: a shrunk file re-reads instead of getting stuck --------------------
+
+def test_read_new_events_rereads_after_truncation(tmp_path):
+    p = tmp_path / "events.jsonl"
+    _write(p, {"kind": "a"}, {"kind": "b"})
+    _, off = eventstream.read_new_events(p, 0)
+    p.write_text('{"kind":"x"}\n', encoding="utf-8")       # rewritten shorter
+    evs, off2 = eventstream.read_new_events(p, off)
+    assert [e["kind"] for e in evs] == ["x"] and off2 == p.stat().st_size
+
+
+# ---- B2: terminal escape injection -----------------------------------------
+
+def test_escape_injection_from_event_payloads_is_neutralised():
+    """All three demonstrated attacks: OSC title, screen clear, newline-forged line."""
+    osc = eventstream.format_event({"kind": "optimizer_error", "candidate": "c1",
+                                   "error": "boom\033]0;PWNED\007\033[2J\033[31mfake red"})
+    clear = eventstream.format_event({"kind": "brand_new", "payload": "\033[2J\033[Hcleared"})
+    forge = eventstream.format_event(
+        {"kind": "brand_new",
+         "payload": "a\nFINALIZE  test=1.0000 (baseline 0.0000) best=FAKE"})
+    for line in (osc, clear, forge):
+        assert "\033" not in line and "\x1b" not in line
+        assert "\007" not in line and "\x9b" not in line
+        assert "\n" not in line and "\r" not in line       # cannot forge extra lines
+        assert line.count("\n") == 0 and len(line.splitlines()) == 1
+    assert "PWNED" in osc and "boom" in osc                # inert, but still readable
+    assert "⏎" in forge and "FINALIZE" in forge            # visibly one line, not two
+
+
+def test_sanitize_strips_c0_c1_and_keeps_tab():
+    # ESC/BEL/DEL and 8-bit CSI vanish; the leftover "[31m" is inert printable text.
+    assert eventstream.sanitize("a\x1b[31mb\x07c\x9bd\x7fe") == "a[31mbcde"
+    assert eventstream.sanitize("\x1b]0;t\x07\x1b[2J\x1b[H") == "]0;t[2J[H"
+    assert eventstream.sanitize("a\tb") == "a\tb"
+    assert eventstream.sanitize("a\nb\rc") == "a⏎b⏎c"
+
+
+def test_render_line_is_also_escape_safe_with_color():
+    """color=True adds exactly the styling escapes — never the payload's own."""
+    ev = {"kind": "optimizer_error", "candidate": "c", "error": "x\033]0;PWNED\007"}
+    line = eventstream.render_line(ev, color=True)
+    assert line.startswith("\033[31m") and line.endswith("\033[0m")
+    assert "\033" not in line[5:-4] and "PWNED" in line
+
+
+# ---- B3: the cost meter must equal the run's own recorded total -------------
+
+def test_cost_meter_matches_the_runs_recorded_total(tmp_path):
+    """The meter must equal Spent.total_usd, not double-count the runner."""
+    from cap_evolve.rundir import RunDir
+
+    rd = RunDir.create(tmp_path, ts="cost")
+    # Exactly what the harness does: evaluate logs runner spend (harness.py:307-312),
+    # then step re-states it alongside the optimizer's own (harness.py:1322-1328).
+    rd.update_spent(metric_calls=2, usd=0.50, runner_tokens=1000)
+    rd.log_event("evaluate", split="val", tag="cand_0001", reward=1.0,
+                 cost_usd=0.50, tokens=1000, seconds=1.0)
+    rd.update_spent(optimizer_seconds=1.0, optimizer_usd=0.20, optimizer_tokens=500)
+    rd.log_event("step", candidate="cand_0001", accept=True, val=1.0, parent_val=0.0,
+                 cost_usd=0.50, tokens=1000, opt_cost_usd=0.20, opt_tokens=500)
+
+    totals: dict = {}
+    events, _ = eventstream.read_new_events(rd.events_path, 0)
+    for ev in events:
+        eventstream.format_event(ev, totals)
+    recorded = rd.spent.total_usd
+    assert abs(recorded - 0.70) < 1e-9, recorded
+    assert abs(totals["usd"] - recorded) < 1e-9, (totals, recorded)
+    assert totals["tokens"] == 1500
+
+
+def test_accrue_totals_is_public_for_138():
+    assert eventstream.accrue_totals in vars(eventstream).values()
+    assert "accrue_totals" in eventstream.__all__
+    t: dict = {}
+    eventstream.accrue_totals({"kind": "intake", "usd": 0.05, "tokens": 100}, t)
+    eventstream.accrue_totals({"kind": "gepa_local_gate", "cost_usd": 99.0}, t)  # not a cost event
+    assert t == {"usd": 0.05, "tokens": 100}
+
+
+# ---- B4: closed stderr must not corrupt the stdout JSON contract ------------
+
+def test_stderr_unusable_disables_following(monkeypatch):
+    from cap_evolve import cli as _cli
+
+    monkeypatch.setattr(sys, "stderr", None)
+    assert _cli._stderr_is_usable() is False
+    assert _cli._spawn_follower(Path("/nope"), "x", None) == (None, None)
+
+    class Reused(io.StringIO):
+        def fileno(self):
+            return 7            # fd 2 was closed and handed to another file
+    monkeypatch.setattr(sys, "stderr", Reused())
+    assert _cli._stderr_is_usable() is False
+
+
+def test_run_follow_with_stderr_closed_keeps_stdout_valid_json(tmp_path):
+    """`cap-evolve run --follow 2>&-` must still emit parseable JSON on stdout."""
+    proj, env = _toy_project(tmp_path)
+    out = tmp_path / "cl.out"
+    # Real `2>&-`: the shell closes fd 2 before exec, so CPython starts with a dead
+    # stderr and would hand fd 2 to the next open() — the corruption path.
+    cmd = (f"exec 2>&-; {shlex.quote(sys.executable)} -m cap_evolve.cli run "
+           f"--spec {shlex.quote(str(proj / 'capevolve.yaml'))} "
+           f"--project {shlex.quote(str(proj))} --run-ts cl --follow --dashboard off "
+           f"> {shlex.quote(str(out))}")
+    proc = subprocess.run(["/bin/sh", "-c", cmd], env=env, timeout=600)
+    assert proc.returncode == 0
+    text = out.read_text()
+    assert json.loads(text)["test_reward"] == 1.0          # contract intact
+    assert "baseline  val=" not in text                    # no progress leaked into stdout
+
+
+# ---- N1: tail exit codes ----------------------------------------------------
+
+def test_cmd_tail_rejects_a_path_that_can_never_be_a_run_dir(tmp_path, capsys):
+    assert _cmd_tail([str(tmp_path / "no" / "such" / "run_typo")]) == 2
+    assert "no such run dir" in capsys.readouterr().err
+
+
+def test_cmd_tail_returns_3_on_idle_timeout_with_no_events(tmp_path, capsys):
+    assert _cmd_tail([str(tmp_path / "run_pending"), "--idle-timeout", "0.2"]) == 3
+    assert "timed out" in capsys.readouterr().err
+
+
+def test_cmd_tail_rejects_negative_idle_timeout(tmp_path):
+    import pytest
+    with pytest.raises(SystemExit):
+        _cmd_tail([str(tmp_path), "--idle-timeout", "-5"])
+
+
+# ---- #138: every kind is reachable -----------------------------------------
+
+def test_skip_kinds_can_be_disabled_to_see_bookkeeping_events():
+    ev = {"kind": "minibatch", "tag": "mb1"}
+    assert eventstream.format_event(ev) is None                       # default: hidden
+    assert "minibatch" in eventstream.format_event(ev, skip_kinds=())  # #138: visible
+    assert "minibatch" in eventstream.render_line(ev, skip_kinds=())
+    assert eventstream.BOOKKEEPING_KINDS                              # documented set

--- a/core/tests/test_eventstream.py
+++ b/core/tests/test_eventstream.py
@@ -1,0 +1,257 @@
+"""Tests for the shared events.jsonl tail helper + the --follow / tail CLI paths."""
+import io
+import os
+import shutil
+import json
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+from cap_evolve import eventstream
+from cap_evolve.cli import _cmd_tail, _events_path
+
+
+def _write(p: Path, *recs):
+    with p.open("a", encoding="utf-8") as fh:
+        for r in recs:
+            fh.write(json.dumps(r) + "\n")
+
+
+# ---- read_new_events -------------------------------------------------------
+
+def test_read_new_events_incremental(tmp_path):
+    p = tmp_path / "events.jsonl"
+    _write(p, {"kind": "baseline", "val": 0.25})
+    evs, off = eventstream.read_new_events(p, 0)
+    assert evs == [{"kind": "baseline", "val": 0.25}]
+    assert off == p.stat().st_size
+
+    _write(p, {"kind": "step", "candidate": "cand_0001"})
+    evs2, off2 = eventstream.read_new_events(p, off)
+    assert evs2 == [{"kind": "step", "candidate": "cand_0001"}]
+    assert off2 == p.stat().st_size
+
+
+def test_read_new_events_leaves_partial_line(tmp_path):
+    p = tmp_path / "events.jsonl"
+    p.write_text('{"kind": "baseline"}\n{"kind": "ste', encoding="utf-8")
+    evs, off = eventstream.read_new_events(p, 0)
+    assert evs == [{"kind": "baseline"}]
+    assert off == len('{"kind": "baseline"}\n')
+
+
+def test_read_new_events_missing_file(tmp_path):
+    assert eventstream.read_new_events(tmp_path / "nope.jsonl", 0) == ([], 0)
+
+
+# ---- follow_events ---------------------------------------------------------
+
+def test_follow_events_stops_on_finalize_and_replays(tmp_path):
+    p = tmp_path / "events.jsonl"
+    _write(p, {"kind": "baseline"}, {"kind": "finalize"}, {"kind": "after"})
+    kinds = [e["kind"] for e in eventstream.follow_events(p, idle_timeout=1.0)]
+    assert kinds == ["baseline", "finalize"]  # stops at finalize, nothing after
+
+
+def test_follow_events_idle_timeout_on_empty(tmp_path):
+    t0 = time.monotonic()
+    got = list(eventstream.follow_events(tmp_path / "events.jsonl", poll=0.05, idle_timeout=0.2))
+    assert got == []
+    assert time.monotonic() - t0 < 5.0
+
+
+def test_follow_events_picks_up_appends_live(tmp_path):
+    p = tmp_path / "events.jsonl"
+    _write(p, {"kind": "baseline"})
+
+    def writer():
+        time.sleep(0.15)
+        _write(p, {"kind": "step", "accept": True})
+        time.sleep(0.15)
+        _write(p, {"kind": "finalize"})
+
+    threading.Thread(target=writer, daemon=True).start()
+    kinds = [e["kind"] for e in eventstream.follow_events(p, poll=0.05, idle_timeout=5.0)]
+    assert kinds == ["baseline", "step", "finalize"]
+
+
+def test_follow_events_should_stop_drains_tail(tmp_path):
+    """A stop signal must not lose events written just before it."""
+    p = tmp_path / "events.jsonl"
+    stop = threading.Event()
+    _write(p, {"kind": "baseline"}, {"kind": "step"})
+    stop.set()  # already stopped: first read yields both, then the drain returns
+    kinds = [e["kind"] for e in eventstream.follow_events(
+        p, poll=0.01, idle_timeout=1.0, should_stop=stop.is_set)]
+    assert kinds == ["baseline", "step"]
+
+
+# ---- format_event / render_line --------------------------------------------
+
+def test_format_event_covers_the_key_kinds():
+    assert "splits frozen" in eventstream.format_event(
+        {"kind": "splits", "train": 4, "val": 2, "test": 2})
+    assert "baseline  val=0.2500" in eventstream.format_event({"kind": "baseline", "val": 0.25})
+    acc = eventstream.format_event(
+        {"kind": "step", "candidate": "cand_0001", "accept": True, "val": 1.0,
+         "parent_val": 0.0, "reason": "Δ>0"})
+    assert "ACCEPT" in acc and "cand_0001" in acc and "Δ>0" in acc
+    rej = eventstream.format_event({"kind": "step", "candidate": "c2", "accept": False, "val": 0.5})
+    assert "reject" in rej
+    fin = eventstream.format_event(
+        {"kind": "finalize", "test_reward": 1.0, "test_baseline_reward": 0.0,
+         "test_delta": 1.0, "best_id": "cand_0001"})
+    assert "FINALIZE" in fin and "test=1.0000" in fin
+    assert "BUDGET 80%" in eventstream.format_event(
+        {"kind": "budget_warning", "pct": 80, "metric": "max_usd", "spent": 8, "limit": 10})
+    assert "OPTIMIZER ERROR" in eventstream.format_event(
+        {"kind": "optimizer_error", "candidate": "c1", "error": "boom"})
+
+
+def test_format_event_skips_bookkeeping_kinds():
+    assert eventstream.format_event({"kind": "minibatch", "tag": "mb"}) is None
+    assert eventstream.format_event({"kind": "optimizer_context_warning"}) is None
+
+
+def test_format_event_shows_unknown_kinds():
+    line = eventstream.format_event({"kind": "brand_new_thing", "x": 1})
+    assert "brand_new_thing" in line and "x=1" in line
+
+
+def test_cost_meter_accumulates_across_events():
+    totals = {}
+    eventstream.format_event({"kind": "step", "cost_usd": 0.01, "tokens": 500}, totals)
+    line = eventstream.format_event({"kind": "step", "cost_usd": 0.02, "tokens": 1500}, totals)
+    assert abs(totals["usd"] - 0.03) < 1e-9 and totals["tokens"] == 2000
+    assert "$0.0300" in line and "2.0k tok" in line
+
+
+def test_format_event_never_emits_ansi():
+    """format_event is pure text; only render_line(color=True) adds escapes."""
+    for ev in ({"kind": "step", "accept": True, "candidate": "c"},
+               {"kind": "optimizer_error", "candidate": "c", "error": "x"},
+               {"kind": "finalize", "test_reward": 1.0}):
+        assert "\033" not in eventstream.format_event(ev)
+
+
+def test_render_line_color_on_and_off():
+    ev = {"kind": "step", "accept": True, "candidate": "c", "val": 1.0}
+    assert "\033[32m" in eventstream.render_line(ev, color=True)
+    assert "\033" not in eventstream.render_line(ev, color=False)
+
+
+def test_use_color_false_for_non_tty_and_no_color(monkeypatch):
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    assert eventstream.use_color(io.StringIO()) is False        # not a tty
+    assert eventstream.use_color(object()) is False             # no isatty attr
+
+    class Tty(io.StringIO):
+        def isatty(self):
+            return True
+    assert eventstream.use_color(Tty()) is True
+    monkeypatch.setenv("NO_COLOR", "1")
+    assert eventstream.use_color(Tty()) is False
+
+
+# ---- CLI: tail -------------------------------------------------------------
+
+def test_events_path_prefers_run_ts_and_ignores_pre_existing(tmp_path):
+    (tmp_path / "run_old").mkdir()
+    (tmp_path / "run_new").mkdir()
+    assert _events_path(tmp_path, "old", None) == tmp_path / "run_old" / "events.jsonl"
+    # unpinned: skip the dirs that existed before this run started
+    assert _events_path(tmp_path, None, {"run_old"}) == tmp_path / "run_new" / "events.jsonl"
+    assert _events_path(tmp_path, None, {"run_old", "run_new"}) is None
+
+
+def test_cmd_tail_missing_base(tmp_path, capsys):
+    assert _cmd_tail(["--base", str(tmp_path)]) == 1
+    assert "no run_* dirs" in capsys.readouterr().err
+
+
+def test_cmd_tail_from_start_plain_when_piped(tmp_path, capsys):
+    """capsys stdout is not a TTY → plain lines, no ANSI (the CI/piped case)."""
+    root = tmp_path / "run_x"
+    root.mkdir()
+    _write(root / "events.jsonl",
+           {"kind": "baseline", "val": 0.0},
+           {"kind": "step", "candidate": "cand_0001", "accept": True, "val": 1.0,
+            "parent_val": 0.0},
+           {"kind": "finalize", "test_reward": 1.0, "test_baseline_reward": 0.0,
+            "test_delta": 1.0, "best_id": "cand_0001"})
+    assert _cmd_tail([str(root), "--from-start"]) == 0
+    out = capsys.readouterr().out
+    assert "\033" not in out
+    assert "baseline" in out and "ACCEPT" in out and "FINALIZE" in out
+
+
+def test_cmd_tail_attaches_to_an_ongoing_run(tmp_path, capsys):
+    """Default (no --from-start) skips history and follows new events only."""
+    root = tmp_path / "run_x"
+    root.mkdir()
+    ev = root / "events.jsonl"
+    _write(ev, {"kind": "baseline", "val": 0.0})  # history: must NOT be printed
+
+    def writer():
+        time.sleep(0.2)
+        _write(ev, {"kind": "step", "candidate": "cand_0007", "accept": True, "val": 1.0})
+        _write(ev, {"kind": "finalize", "test_reward": 1.0})
+
+    threading.Thread(target=writer, daemon=True).start()
+    assert _cmd_tail([str(root), "--idle-timeout", "10"]) == 0
+    out = capsys.readouterr().out
+    assert "cand_0007" in out and "FINALIZE" in out
+    assert "val=0.0000 ±" not in out  # the pre-attach baseline line was skipped
+
+
+def test_tail_is_a_registered_subcommand():
+    out = subprocess.run([sys.executable, "-m", "cap_evolve.cli"],
+                         capture_output=True, text=True).stderr
+    assert "tail" in out
+
+
+def test_run_follow_end_to_end_pipes_clean_progress(tmp_path):
+    """Real `cap-evolve run --follow` over toy_calc (zero API, mock optimizer).
+
+    stdout is piped (not a TTY), so: progress lines land on stderr with NO ANSI, and
+    stdout stays the parseable final JSON that scripts depend on.
+    """
+    repo = Path(__file__).resolve().parents[2]
+    example = repo / "examples" / "toy_calc"
+    proj = tmp_path / ".capevolve" / "project"
+    (proj / "adapters").mkdir(parents=True)
+    shutil.copy(example / "adapter.py", proj / "adapters" / "adapter.py")
+    shutil.copytree(example / "capability", tmp_path / "seed_capability")
+    shutil.copy(repo / "templates" / "project" / "capevolve.yaml", proj / "capevolve.yaml")
+
+    env = dict(os.environ)
+    env.update(PYTHONPATH=str(repo / "core"), CAPEVOLVE_CORE=str(repo / "core"),
+               CAPEVOLVE_SKILLS_DIR=str(repo / "skills"), CAPEVOLVE_TOY_DATA=str(example),
+               CAPEVOLVE_MOCK_SCRIPT=str(example / "mock_script.json"))
+    proc = subprocess.run(
+        [sys.executable, "-m", "cap_evolve.cli", "run", "--spec", str(proj / "capevolve.yaml"),
+         "--project", str(proj), "--run-ts", "t", "--follow", "--dashboard", "off"],
+        capture_output=True, text=True, env=env, timeout=600)
+    assert proc.returncode == 0, proc.stderr[-3000:]
+
+    # progress went to stderr, live, and is plain text (safe for CI logs)
+    assert "\033" not in proc.stderr, "ANSI leaked into non-TTY output"
+    assert "splits frozen" in proc.stderr
+    assert "baseline  val=" in proc.stderr
+    assert "ACCEPT" in proc.stderr, proc.stderr          # >=1 per-candidate line
+    assert "FINALIZE" in proc.stderr                     # the finalize line
+    # stdout is still just the final JSON blob
+    assert json.loads(proc.stdout)["test_reward"] == 1.0
+
+
+def test_dashboard_stream_reexports_the_shared_helper():
+    """The SSE route and the CLI must read events.jsonl through the same function."""
+    root = Path(__file__).resolve().parents[2] / "dashboard" / "backend"
+    sys.path.insert(0, str(root))
+    try:
+        from capevolve_dashboard import stream
+        assert stream.read_new_events is eventstream.read_new_events
+    finally:
+        sys.path.remove(str(root))

--- a/core/tests/test_stall_detection.py
+++ b/core/tests/test_stall_detection.py
@@ -1,0 +1,306 @@
+"""#118: tell a stalled/hung run from an idle one from a finished one.
+
+The state machine under test (``eventstream.classify``):
+
+    done      finalize sealed the test → terminal, nothing downgrades it
+    crashed   the owning process is PROVABLY gone and the run never finalized
+    stalled   silent longer than THIS RUN's own derived expectation, process alive/unknown
+    live      everything else, including long silences a slow run has earned
+
+The test that matters most is :func:`test_a_slow_but_healthy_run_is_never_called_hung`:
+a false "hung" is worse than no signal at all, because the user's reaction is to kill a
+run that was working.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from cap_evolve import eventstream  # noqa: E402
+from cap_evolve.cli import _cmd_tail  # noqa: E402
+
+
+def _run_dir(tmp_path, gaps_seconds, *, silent_for=0.0, finalize=False,
+             pid=None, host=None, name="run_t") -> Path:
+    """A run dir whose events are spaced by ``gaps_seconds`` and whose events file was
+    last touched ``silent_for`` seconds ago. mtime is set explicitly so a stall of hours
+    is testable in milliseconds."""
+    root = tmp_path / name
+    root.mkdir(parents=True, exist_ok=True)
+    now = time.time()
+    last = now - silent_for
+    # Walk the timestamps backwards from `last` so the newest event is `silent_for` old.
+    ts, cursor = [], last
+    for g in reversed(list(gaps_seconds)):
+        ts.append(cursor)
+        cursor -= g
+    ts.append(cursor)
+    ts.reverse()
+    lines = [json.dumps({"t": t, "kind": "evaluate", "split": "val"}) for t in ts]
+    if finalize:
+        lines.append(json.dumps({"t": last, "kind": "finalize", "test_reward": 1.0}))
+    (root / "events.jsonl").write_text("\n".join(lines) + "\n", encoding="utf-8")
+    os.utime(root / "events.jsonl", (last, last))
+    if pid is not None:
+        import socket
+        (root / "run.pid").write_text(json.dumps(
+            {"pid": pid, "host": host or socket.gethostname()}), encoding="utf-8")
+    return root
+
+
+def _classify(root) -> str:
+    return eventstream.classify(eventstream.liveness_facts(root))
+
+
+# ---- the four states -------------------------------------------------------
+
+def test_working_run_is_live(tmp_path):
+    root = _run_dir(tmp_path, [30.0, 30.0, 30.0], silent_for=5.0, pid=os.getpid())
+    assert _classify(root) == "live"
+    assert "working" in eventstream.describe_status(eventstream.liveness_facts(root))
+
+
+def test_a_quiet_fast_run_whose_process_lives_is_stalled(tmp_path):
+    """Fast events then long silence, owner alive → stalled, not crashed, not done."""
+    root = _run_dir(tmp_path, [1.0, 1.0, 1.0], silent_for=3600.0, pid=os.getpid())
+    facts = eventstream.liveness_facts(root)
+    assert facts["alive"] is True
+    assert eventstream.classify(facts) == "stalled"
+    detail = eventstream.describe_status(facts)
+    assert "STALLED" in detail and "still alive" in detail
+
+
+def test_a_run_whose_process_is_gone_is_crashed_not_live(tmp_path):
+    """The bug in the issue: 1 candidate then a crash showed 'live' forever."""
+    dead = subprocess.Popen([sys.executable, "-c", "pass"])
+    dead.wait()
+    root = _run_dir(tmp_path, [1.0, 1.0], silent_for=10.0, pid=dead.pid)
+    facts = eventstream.liveness_facts(root)
+    assert facts["alive"] is False
+    assert eventstream.classify(facts) == "crashed"
+    assert "CRASHED" in eventstream.describe_status(facts)
+
+
+def test_a_finalized_run_is_done_even_when_ancient_and_processless(tmp_path):
+    """Degrades sanely for a finished run: done outranks both stall and crash."""
+    dead = subprocess.Popen([sys.executable, "-c", "pass"])
+    dead.wait()
+    root = _run_dir(tmp_path, [1.0, 1.0], silent_for=86_400.0 * 30, finalize=True,
+                    pid=dead.pid)
+    assert _classify(root) == "done"
+    assert "done" in eventstream.describe_status(eventstream.liveness_facts(root))
+
+
+# ---- THE critical negative case -------------------------------------------
+
+def test_a_slow_but_healthy_run_is_never_called_hung(tmp_path):
+    """A τ²-bench-shaped run: 20-minute steps. 25 minutes of silence is NORMAL for it.
+
+    A fixed 5-minute idle timeout (the old heuristic) would call this hung and invite
+    the user to kill a working run. The derived threshold must not.
+    """
+    twenty_min = 20 * 60.0
+    root = _run_dir(tmp_path, [twenty_min] * 3, silent_for=25 * 60.0, pid=os.getpid())
+    facts = eventstream.liveness_facts(root)
+    assert facts["silence"] > eventstream.STALL_FLOOR_SECONDS   # the old rule would fire
+    assert eventstream.classify(facts) == "live"                # the new one does not
+    assert facts["threshold"] == pytest.approx(twenty_min * eventstream.STALL_SLACK)
+    # …and it still fires eventually: the bar rises, it does not vanish.
+    late = _run_dir(tmp_path, [twenty_min] * 3, silent_for=twenty_min * 4,
+                    pid=os.getpid(), name="run_late")
+    assert _classify(late) == "stalled"
+
+
+def test_a_toy_run_still_gets_the_five_minute_floor(tmp_path):
+    """The other direction: millisecond gaps must NOT derive a millisecond threshold."""
+    root = _run_dir(tmp_path, [0.04, 0.04], silent_for=30.0, pid=os.getpid())
+    facts = eventstream.liveness_facts(root)
+    assert facts["threshold"] == eventstream.STALL_FLOOR_SECONDS
+    assert eventstream.classify(facts) == "live"
+
+
+def test_threshold_uses_the_slowest_gap_not_the_mean(tmp_path):
+    """A run alternating 1s evals with 20-minute optimizer calls has a small mean; a
+    mean-based bar would fire during every optimizer call."""
+    gaps = [1.0, 1200.0, 1.0, 1200.0]
+    assert eventstream.stall_threshold(gaps) == pytest.approx(1200.0 * 3)
+    mean = sum(gaps) / len(gaps)
+    assert eventstream.stall_threshold(gaps) > mean * eventstream.STALL_SLACK
+
+
+# ---- liveness signal edge cases -------------------------------------------
+
+def test_no_pid_file_means_unknown_never_crashed(tmp_path):
+    """The per-phase skill-chain workflow has no single owning process; its runs must
+    get the time verdict only, never a fabricated 'crashed'."""
+    root = _run_dir(tmp_path, [1.0, 1.0], silent_for=3600.0)  # no run.pid
+    facts = eventstream.liveness_facts(root)
+    assert facts["alive"] is None
+    assert eventstream.classify(facts) == "stalled"   # quiet, but not declared dead
+    assert "not reporting a pid" in eventstream.describe_status(facts)
+
+
+def test_a_pid_from_another_host_is_unknown_not_dead(tmp_path):
+    """Someone else's process table is not ours to read: a shared-filesystem run must
+    not be reported crashed just because its pid doesn't exist here."""
+    root = _run_dir(tmp_path, [1.0], silent_for=10.0, pid=999_999, host="some-other-box")
+    assert eventstream.liveness_facts(root)["alive"] is None
+    assert _classify(root) == "live"
+
+
+def test_malformed_pid_file_and_malformed_timestamps_do_not_raise(tmp_path):
+    root = tmp_path / "run_bad"
+    root.mkdir()
+    (root / "events.jsonl").write_text(
+        json.dumps({"t": "not-a-number", "kind": "evaluate"}) + "\n"
+        + json.dumps({"t": None, "kind": "step"}) + "\n"
+        + "{ not json\n", encoding="utf-8")
+    (root / "run.pid").write_text("<<not json>>", encoding="utf-8")
+    facts = eventstream.liveness_facts(root)
+    assert facts["alive"] is None and facts["events"] == 0
+    assert eventstream.classify(facts) in ("live", "stalled")
+
+
+def test_missing_events_file_is_live_not_stalled(tmp_path):
+    """A run dir that exists but hasn't spoken yet is starting up, not hung."""
+    root = tmp_path / "run_new"
+    root.mkdir()
+    facts = eventstream.liveness_facts(root)
+    assert facts["silence"] is None
+    assert eventstream.classify(facts) == "live"
+
+
+def test_env_override_wins_over_the_derived_threshold(tmp_path, monkeypatch):
+    """Configurable: a user who knows their workload can pin the number."""
+    monkeypatch.setenv(eventstream.STALL_ENV, "60")
+    root = _run_dir(tmp_path, [1200.0, 1200.0], silent_for=120.0, pid=os.getpid())
+    facts = eventstream.liveness_facts(root)
+    assert facts["threshold"] == 60.0
+    assert eventstream.classify(facts) == "stalled"
+    monkeypatch.setenv(eventstream.STALL_ENV, "garbage")   # bad value → derive
+    assert eventstream.liveness_facts(root)["threshold"] == pytest.approx(3600.0)
+
+
+# ---- terminal surface: cap-evolve tail ------------------------------------
+
+def test_tail_exits_4_and_says_stalled(tmp_path, capsys):
+    """A hung run must not exit 0 with a silence that reads like success."""
+    root = _run_dir(tmp_path, [0.01, 0.01], silent_for=3600.0, pid=os.getpid(),
+                    name="run_hung")
+    monkey = eventstream.STALL_FLOOR_SECONDS
+    assert monkey == 300.0
+    rc = _cmd_tail([str(root), "--from-start"])
+    err = capsys.readouterr().err
+    assert rc == 4, err
+    assert "STALLED" in err and "no events for" in err
+
+
+def test_tail_exits_5_and_says_crashed(tmp_path, capsys):
+    dead = subprocess.Popen([sys.executable, "-c", "pass"])
+    dead.wait()
+    root = _run_dir(tmp_path, [0.01], silent_for=600.0, pid=dead.pid, name="run_dead")
+    rc = _cmd_tail([str(root), "--from-start"])
+    err = capsys.readouterr().err
+    assert rc == 5, err
+    assert "CRASHED" in err
+
+
+def test_tail_exits_0_and_says_done_for_a_finalized_run(tmp_path, capsys):
+    root = _run_dir(tmp_path, [0.01], silent_for=7200.0, finalize=True, name="run_fin")
+    assert _cmd_tail([str(root), "--from-start"]) == 0
+    err = capsys.readouterr().err
+    assert "done" in err and "STALLED" not in err and "CRASHED" not in err
+
+
+def test_tail_no_stall_check_keeps_following(tmp_path, capsys):
+    """Opt-out: a user who wants the old wait-forever behavior gets it."""
+    root = _run_dir(tmp_path, [0.01], silent_for=3600.0, pid=os.getpid(),
+                    name="run_optout")
+
+    def finish():
+        time.sleep(0.4)
+        with (root / "events.jsonl").open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps({"t": time.time(), "kind": "finalize",
+                                 "test_reward": 1.0}) + "\n")
+
+    threading.Thread(target=finish, daemon=True).start()
+    assert _cmd_tail([str(root), "--from-start", "--no-stall-check"]) == 0
+    assert "FINALIZE" in capsys.readouterr().out
+
+
+def test_tail_does_not_stall_out_a_slow_but_healthy_run(tmp_path, capsys):
+    """End to end through the CLI: the negative case must hold at the surface too."""
+    root = _run_dir(tmp_path, [20 * 60.0] * 3, silent_for=25 * 60.0, pid=os.getpid(),
+                    name="run_slow")
+
+    def finish():
+        time.sleep(0.5)
+        with (root / "events.jsonl").open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps({"t": time.time(), "kind": "finalize",
+                                 "test_reward": 1.0}) + "\n")
+
+    threading.Thread(target=finish, daemon=True).start()
+    rc = _cmd_tail([str(root), "--from-start"])
+    err = capsys.readouterr().err
+    assert rc == 0, err
+    assert "STALLED" not in err
+
+
+def test_tail_attaching_mid_run_uses_the_whole_log_not_just_what_it_streamed(tmp_path,
+                                                                            capsys):
+    """`tail` without --from-start prints only new events, but the stall bar must still
+    come from the WHOLE log — otherwise attaching to a 20-min-per-step run sees no gaps,
+    falls back to the 300s floor, and reports a healthy run hung."""
+    root = _run_dir(tmp_path, [20 * 60.0] * 3, silent_for=25 * 60.0, pid=os.getpid(),
+                    name="run_attach")
+
+    def finish():
+        time.sleep(0.5)
+        with (root / "events.jsonl").open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps({"t": time.time(), "kind": "finalize",
+                                 "test_reward": 1.0}) + "\n")
+
+    threading.Thread(target=finish, daemon=True).start()
+    rc = _cmd_tail([str(root)])           # NOT --from-start: history is skipped
+    out, err = capsys.readouterr()
+    assert rc == 0, err
+    assert "STALLED" not in err
+    assert "eval val" not in out          # history really was skipped
+
+
+def test_tail_still_returns_3_when_nothing_ever_arrives(tmp_path, capsys):
+    """--idle-timeout keeps bounding the wait for the FIRST event (unchanged, #116)."""
+    assert _cmd_tail([str(tmp_path / "run_pending"), "--idle-timeout", "0.3"]) == 3
+    assert "timed out" in capsys.readouterr().err
+
+
+# ---- one shared source of truth -------------------------------------------
+
+def test_run_writes_a_pid_marker_so_liveness_is_knowable():
+    """`cap-evolve run` must record its pid; without it crash detection is impossible."""
+    src = Path(eventstream.__file__).with_name("cli.py").read_text(encoding="utf-8")
+    assert '"run.pid"' in src and "os.getpid()" in src and "gethostname()" in src
+
+
+def test_dashboard_classifies_through_the_shared_helper_not_its_own_rule():
+    """The surfaces cannot disagree because there is only one classifier.
+
+    Asserted on the source rather than by import identity: the dashboard package is a
+    sibling tree, and what must hold is that it *routes through* eventstream and owns
+    no threshold of its own — a second copy of the rule is the bug (#118 exists because
+    the SSE route and ``_status`` each had their own).
+    """
+    src = (Path(__file__).resolve().parents[2] / "dashboard" / "backend"
+           / "capevolve_dashboard" / "runs.py").read_text(encoding="utf-8")
+    assert "eventstream.classify" in src and "eventstream.liveness_facts" in src
+    for forked in ("300", "STALL_FLOOR", "timedelta", "mtime >"):
+        assert forked not in src, f"dashboard re-derives the stall rule ({forked})"

--- a/core/tests/test_stall_detection.py
+++ b/core/tests/test_stall_detection.py
@@ -30,10 +30,13 @@ from cap_evolve.cli import _cmd_tail  # noqa: E402
 
 
 def _run_dir(tmp_path, gaps_seconds, *, silent_for=0.0, finalize=False,
-             pid=None, host=None, name="run_t") -> Path:
+             pid=None, host=None, name="run_t", started=None) -> Path:
     """A run dir whose events are spaced by ``gaps_seconds`` and whose events file was
     last touched ``silent_for`` seconds ago. mtime is set explicitly so a stall of hours
-    is testable in milliseconds."""
+    is testable in milliseconds.
+
+    ``started`` writes that value as the marker's start stamp (pid-reuse detection);
+    omitted means a legacy marker with no ``started`` at all."""
     root = tmp_path / name
     root.mkdir(parents=True, exist_ok=True)
     now = time.time()
@@ -52,8 +55,10 @@ def _run_dir(tmp_path, gaps_seconds, *, silent_for=0.0, finalize=False,
     os.utime(root / "events.jsonl", (last, last))
     if pid is not None:
         import socket
-        (root / "run.pid").write_text(json.dumps(
-            {"pid": pid, "host": host or socket.gethostname()}), encoding="utf-8")
+        marker = {"pid": pid, "host": host or socket.gethostname()}
+        if started is not None:
+            marker["started"] = started
+        (root / "run.pid").write_text(json.dumps(marker), encoding="utf-8")
     return root
 
 
@@ -83,7 +88,7 @@ def test_a_run_whose_process_is_gone_is_crashed_not_live(tmp_path):
     """The bug in the issue: 1 candidate then a crash showed 'live' forever."""
     dead = subprocess.Popen([sys.executable, "-c", "pass"])
     dead.wait()
-    root = _run_dir(tmp_path, [1.0, 1.0], silent_for=10.0, pid=dead.pid)
+    root = _run_dir(tmp_path, [1.0, 1.0], silent_for=120.0, pid=dead.pid)
     facts = eventstream.liveness_facts(root)
     assert facts["alive"] is False
     assert eventstream.classify(facts) == "crashed"
@@ -111,7 +116,7 @@ def test_a_slow_but_healthy_run_is_never_called_hung(tmp_path):
     twenty_min = 20 * 60.0
     root = _run_dir(tmp_path, [twenty_min] * 3, silent_for=25 * 60.0, pid=os.getpid())
     facts = eventstream.liveness_facts(root)
-    assert facts["silence"] > eventstream.STALL_FLOOR_SECONDS   # the old rule would fire
+    assert facts["silence"] > 300.0            # the OLD fixed 5-minute rule would fire
     assert eventstream.classify(facts) == "live"                # the new one does not
     assert facts["threshold"] == pytest.approx(twenty_min * eventstream.STALL_SLACK)
     # …and it still fires eventually: the bar rises, it does not vanish.
@@ -120,12 +125,123 @@ def test_a_slow_but_healthy_run_is_never_called_hung(tmp_path):
     assert _classify(late) == "stalled"
 
 
-def test_a_toy_run_still_gets_the_five_minute_floor(tmp_path):
+def test_a_toy_run_still_gets_the_floor(tmp_path):
     """The other direction: millisecond gaps must NOT derive a millisecond threshold."""
     root = _run_dir(tmp_path, [0.04, 0.04], silent_for=30.0, pid=os.getpid())
     facts = eventstream.liveness_facts(root)
     assert facts["threshold"] == eventstream.STALL_FLOOR_SECONDS
     assert eventstream.classify(facts) == "live"
+
+
+# ---- the false positive the #218 review caught -----------------------------
+
+def test_a_healthy_run_in_its_FIRST_slow_step_is_not_stalled(tmp_path):
+    """The review's blocking #1, and the shape that matters most.
+
+    A real run opens with a burst of sub-second events and only then makes its first
+    genuinely slow optimizer call. There is no COMPLETED slow gap to derive a bar from,
+    so the floor is what judges it — and at 300s every run whose first step ran over five
+    minutes was reported `stalled` while its owner was alive in `ps`. Nothing here is
+    pre-seeded with completed slow gaps; that pre-seeding is exactly what hid the bug.
+    """
+    for elapsed in (301.0, 900.0, 1800.0, 3000.0):
+        root = _run_dir(tmp_path, [0.2, 0.1], silent_for=elapsed, pid=os.getpid(),
+                        name=f"run_first_{int(elapsed)}")
+        facts = eventstream.liveness_facts(root)
+        assert facts["slowest_gap"] < 1.0, "no completed slow gap, by construction"
+        assert facts["alive"] is True
+        assert eventstream.classify(facts) == "live", (
+            f"a live run {elapsed}s into its first slow step must not read stalled")
+    # A single event and nothing since (review probe B) is the same shape.
+    solo = _run_dir(tmp_path, [], silent_for=600.0, pid=os.getpid(), name="run_solo")
+    assert _classify(solo) == "live"
+    # It is still not a wait-forever: past the floor, a fast run that really wedged trips.
+    wedged = _run_dir(tmp_path, [0.2, 0.1], silent_for=eventstream.STALL_FLOOR_SECONDS + 60,
+                      pid=os.getpid(), name="run_wedged")
+    assert _classify(wedged) == "stalled"
+
+
+def test_folding_the_open_gap_into_the_bar_would_never_fire(tmp_path):
+    """Why the floor was raised instead of taking the review's suggested fix.
+
+    The suggestion was to fold the CURRENT silence into the ``max`` that derives the bar.
+    But the bar is what that same silence is compared against, so with any factor >= 1 the
+    bar outruns the silence forever and ``stalled`` becomes unreachable; with a factor < 1
+    the bar collapses onto the floor and the fold does nothing. Either way it is not a fix,
+    which is why the conservative prior (a floor no legitimate first step exceeds) is.
+    """
+    for factor in (eventstream.STALL_SLACK, 1.0):
+        silence = 0.0
+        for _ in range(600):  # ten hours, one minute at a time
+            silence += 60.0
+            assert silence <= max(300.0, factor * silence), "would have fired"
+    for factor in (0.5, 0.1):
+        silence = 10_000.0
+        assert max(300.0, factor * silence) != 300.0 or silence > 3000.0
+        # …collapses to the bare floor for any silence under 300/factor.
+        assert max(300.0, factor * 100.0) == 300.0
+
+
+def test_a_live_writer_with_a_stale_dead_marker_is_not_crashed(tmp_path):
+    """The review's blocking #2 / probe T: ``run.pid`` is never deleted, so a reused run
+    dir can hold a dead pid from a previous attempt while the current writer (the
+    per-phase skill chain writes no marker at all) is actively appending. That read
+    `crashed` on a run with silence=0.0s — a demonstrably live run declared dead."""
+    dead = subprocess.Popen([sys.executable, "-c", "pass"])
+    dead.wait()
+    root = _run_dir(tmp_path, [1.0, 1.0], silent_for=0.0, pid=dead.pid, name="run_reused")
+    facts = eventstream.liveness_facts(root)
+    assert facts["alive"] is False and facts["silence"] < 5.0
+    assert eventstream.classify(facts) == "live", "a run writing NOW is not dead"
+    # The corroboration is silence, not trust: once the log really stops, crashed lands.
+    gone = _run_dir(tmp_path, [1.0, 1.0], silent_for=120.0, pid=dead.pid, name="run_gone")
+    assert _classify(gone) == "crashed"
+
+
+def test_a_reused_pid_is_dead_because_started_disagrees(tmp_path):
+    """``started`` was written and never read. A marker naming a pid that now belongs to a
+    DIFFERENT, later-started process must read crashed — the old run really is gone."""
+    live = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+    try:
+        # Marker claims the owner began an hour before this process actually did.
+        root = _run_dir(tmp_path, [1.0], silent_for=600.0, pid=live.pid,
+                        started=time.time() - 3600.0, name="run_recycled")
+        facts = eventstream.liveness_facts(root)
+        if eventstream._proc_start_time(live.pid) is None:
+            pytest.skip("no usable `ps -o lstart=` on this platform")
+        assert facts["alive"] is False, "same pid, a process that started later"
+        assert eventstream.classify(facts) == "crashed"
+        # The genuine owner — marker written just after the process began — stays alive.
+        same = _run_dir(tmp_path, [1.0],
+                        silent_for=eventstream.STALL_FLOOR_SECONDS + 60, pid=live.pid,
+                        started=time.time(), name="run_genuine")
+        assert eventstream.liveness_facts(same)["alive"] is True
+        assert _classify(same) == "stalled"  # alive but quiet, never crashed
+    finally:
+        live.kill()
+        live.wait()
+
+
+def test_a_zombie_owner_is_stalled_not_crashed(tmp_path):
+    """``os.kill(pid, 0)`` succeeds on a zombie, so it reads alive → stalled. Correct: a
+    reaped-but-unwaited child is not proof the run's work is gone."""
+    z = subprocess.Popen([sys.executable, "-c", "pass"])
+    z.poll()  # do NOT wait() — leave it un-reaped so it stays a zombie
+    try:
+        root = _run_dir(tmp_path, [1.0], silent_for=7200.0, pid=z.pid, name="run_zombie")
+        facts = eventstream.liveness_facts(root)
+        assert facts["alive"] is not False   # a zombie is never proof of a dead run
+        assert eventstream.classify(facts) in ("stalled", "live")
+    finally:
+        z.wait()
+
+
+def test_a_marker_without_started_still_works(tmp_path):
+    """Backwards compatibility: a marker written by an older `cap-evolve run` has no
+    ``started`` field, and must fall back to pid-only rather than guessing."""
+    root = _run_dir(tmp_path, [1.0], silent_for=600.0, pid=os.getpid(), name="run_legacy")
+    assert "started" not in json.loads((root / "run.pid").read_text())
+    assert eventstream.liveness_facts(root)["alive"] is True
 
 
 def test_threshold_uses_the_slowest_gap_not_the_mean(tmp_path):
@@ -194,10 +310,9 @@ def test_env_override_wins_over_the_derived_threshold(tmp_path, monkeypatch):
 
 def test_tail_exits_4_and_says_stalled(tmp_path, capsys):
     """A hung run must not exit 0 with a silence that reads like success."""
-    root = _run_dir(tmp_path, [0.01, 0.01], silent_for=3600.0, pid=os.getpid(),
+    root = _run_dir(tmp_path, [0.01, 0.01],
+                    silent_for=eventstream.STALL_FLOOR_SECONDS * 2, pid=os.getpid(),
                     name="run_hung")
-    monkey = eventstream.STALL_FLOOR_SECONDS
-    assert monkey == 300.0
     rc = _cmd_tail([str(root), "--from-start"])
     err = capsys.readouterr().err
     assert rc == 4, err
@@ -212,6 +327,53 @@ def test_tail_exits_5_and_says_crashed(tmp_path, capsys):
     err = capsys.readouterr().err
     assert rc == 5, err
     assert "CRASHED" in err
+
+
+def test_tail_exits_5_on_a_dead_run_WITHOUT_from_start_too(tmp_path, capsys):
+    """The review's blocking #4, second half. Without ``--from-start`` nothing new ever
+    arrives on a dead run, so `last` stayed None, the liveness probe never ran, and the
+    crash verdict — the headline feature — degraded to the OLD ambiguous exit 3. `crashed`
+    is proof-based, so it must not depend on whether this process happened to see a line."""
+    dead = subprocess.Popen([sys.executable, "-c", "pass"])
+    dead.wait()
+    root = _run_dir(tmp_path, [0.01], silent_for=600.0, pid=dead.pid, name="run_dead2")
+    rc = _cmd_tail([str(root), "--idle-timeout", "30"])
+    err = capsys.readouterr().err
+    assert rc == 5, err            # was 3: "timed out … with no events"
+    assert "CRASHED" in err and "timed out" not in err
+
+
+def test_tail_idle_timeout_zero_still_exits_on_a_provably_dead_run(tmp_path, capsys):
+    """`--idle-timeout 0` is documented as "wait forever" — for a run that might still
+    speak. On a run whose owner is provably gone there is nothing left to wait for, and
+    the old code hung indefinitely instead of reporting the crash."""
+    dead = subprocess.Popen([sys.executable, "-c", "pass"])
+    dead.wait()
+    root = _run_dir(tmp_path, [0.01], silent_for=600.0, pid=dead.pid, name="run_dead0")
+    done: list = []
+
+    def watch():
+        done.append(_cmd_tail([str(root), "--idle-timeout", "0"]))
+
+    t = threading.Thread(target=watch, daemon=True)
+    t.start()
+    t.join(timeout=30)
+    assert not t.is_alive(), "tail --idle-timeout 0 hung on a provably dead run"
+    assert done == [5], capsys.readouterr().err
+
+
+def test_tail_idle_timeout_zero_still_waits_forever_when_nothing_is_proven_dead(tmp_path):
+    """The other direction: no marker → `alive is None` → no proof → keep waiting. The
+    stall branch must stay gated on having seen an event, or a run that has not started
+    talking yet would be declared wedged."""
+    root = tmp_path / "run_quiet"
+    root.mkdir()
+    (root / "events.jsonl").write_text("", encoding="utf-8")
+    t = threading.Thread(target=lambda: _cmd_tail([str(root), "--idle-timeout", "0"]),
+                         daemon=True)
+    t.start()
+    t.join(timeout=6)
+    assert t.is_alive(), "must still wait forever when nothing is provably dead"
 
 
 def test_tail_exits_0_and_says_done_for_a_finalized_run(tmp_path, capsys):
@@ -285,10 +447,27 @@ def test_tail_still_returns_3_when_nothing_ever_arrives(tmp_path, capsys):
 
 # ---- one shared source of truth -------------------------------------------
 
-def test_run_writes_a_pid_marker_so_liveness_is_knowable():
-    """`cap-evolve run` must record its pid; without it crash detection is impossible."""
+def test_run_writes_a_pid_marker_so_liveness_is_knowable(tmp_path):
+    """`cap-evolve run` must record its pid; without it crash detection is impossible.
+
+    The source-text half is unavoidable (driving the real `run` needs a skill tree, which
+    ``test_e2e_slice`` owns) but it is no longer the whole test: the review's non-blocking
+    #9 notes the old grep would pass with the marker written to the WRONG DIRECTORY. So the
+    exact expression `cli.py` writes is evaluated here and read back through the real
+    ``_owner_alive``, pinning both the field set and the location liveness looks in.
+    """
+    import socket
     src = Path(eventstream.__file__).with_name("cli.py").read_text(encoding="utf-8")
-    assert '"run.pid"' in src and "os.getpid()" in src and "gethostname()" in src
+    assert '(workdir / run_dir / "run.pid").write_text(' in src, "marker moved out of the run dir"
+    assert "os.getpid()" in src and "gethostname()" in src and '"started": time.time()' in src
+
+    run_dir = tmp_path / "run_marker"
+    run_dir.mkdir()
+    (run_dir / "run.pid").write_text(json.dumps(
+        {"pid": os.getpid(), "host": socket.gethostname(), "started": time.time()}),
+        encoding="utf-8")
+    assert eventstream._owner_alive(run_dir) is True     # found where `run` puts it
+    assert eventstream._owner_alive(tmp_path) is None    # and nowhere else
 
 
 def test_dashboard_classifies_through_the_shared_helper_not_its_own_rule():

--- a/dashboard/backend/capevolve_dashboard/app.py
+++ b/dashboard/backend/capevolve_dashboard/app.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import time
 from pathlib import Path
 
 from fastapi import FastAPI, HTTPException, Query
@@ -100,8 +101,9 @@ def create_app(base_dir: Path, static_dir: Path | None = None) -> FastAPI:
         return compare.compare_runs(base, run_ids)
 
     @app.get("/api/runs/{run_id}/stream")
-    async def run_stream(run_id: str):
-        events_path = _resolve_or_404(run_id) / "events.jsonl"
+    async def run_stream(run_id: str, poll: float = 0.5, status_every: float = 5.0):
+        run_root = _resolve_or_404(run_id)
+        events_path = run_root / "events.jsonl"
 
         async def gen():
             # Initial snapshot of the full reduced run.
@@ -110,7 +112,7 @@ def create_app(base_dir: Path, static_dir: Path | None = None) -> FastAPI:
             except runs.RunNotFound:
                 return
             offset = events_path.stat().st_size
-            idle = 0
+            last_status = 0.0
             while True:
                 new, offset = _stream.read_new_events(events_path, offset)
                 for ev in new:
@@ -118,11 +120,22 @@ def create_app(base_dir: Path, static_dir: Path | None = None) -> FastAPI:
                     if ev.get("kind") == "finalize":
                         yield _stream.sse_format("done", {"run_id": run_id})
                         return
-                idle = idle + 1 if not new else 0
-                if idle > 600:  # ~5 min of silence -> stop holding the connection
-                    yield _stream.sse_format("idle", {"run_id": run_id})
-                    return
-                await asyncio.sleep(0.5)
+                # #118: the connection is no longer dropped after a fixed 5 idle minutes
+                # — a silent close was indistinguishable from a clean finish. Instead the
+                # client is periodically told WHICH kind of quiet this is (working /
+                # stalled / crashed), with the numbers behind the verdict. The frame
+                # doubles as the keepalive, so an idle proxy has traffic to see.
+                now = time.monotonic()
+                if now - last_status >= status_every:
+                    last_status = now
+                    live = runs.liveness(run_root)
+                    yield _stream.sse_format("status", {"run_id": run_id, **live})
+                    if live["status"] == "crashed":
+                        # No process is left to produce another event, so holding the
+                        # socket open would be a lie. Deliberately NOT "done": done means
+                        # the test split was sealed.
+                        return
+                await asyncio.sleep(poll)
 
         return StreamingResponse(gen(), media_type="text/event-stream")
 

--- a/dashboard/backend/capevolve_dashboard/runs.py
+++ b/dashboard/backend/capevolve_dashboard/runs.py
@@ -72,13 +72,17 @@ def _status(summary: dict, live: dict | None = None) -> str:
     finished nor empty is subject to the liveness verdict, which is where ``stalled``
     and ``crashed`` come from — previously such a run read ``live`` forever.
     """
-    if summary.get("test_reward") is not None or summary.get("test_sealed"):
+    verdict = (live or {}).get("status")
+    # `test_sealed`/`test_reward` come from splits.json/final.json; the `finalize` EVENT
+    # is the same fact seen in the log, and it is what the terminal reads. Accept either,
+    # or the two surfaces disagree about a run whose artifacts lag its log.
+    if summary.get("test_reward") is not None or summary.get("test_sealed") \
+            or verdict == "done":
         return "done"
     counts = summary.get("counts") or {}
     if counts.get("total", 0) == 0:
         return "failed"
-    return (live or {}).get("status") if (live or {}).get("status") in (
-        "stalled", "crashed") else "live"
+    return verdict if verdict in ("stalled", "crashed") else "live"
 
 
 def list_runs(base_dir: Path) -> list[dict]:

--- a/dashboard/backend/capevolve_dashboard/runs.py
+++ b/dashboard/backend/capevolve_dashboard/runs.py
@@ -66,11 +66,9 @@ def liveness(path: Path) -> dict:
 def _status(summary: dict, live: dict | None = None) -> str:
     """``done`` / ``failed`` / ``crashed`` / ``stalled`` / ``live``.
 
-    ``done`` and ``failed`` are decided from the reduced summary and stay FIRST: a
-    finished run must degrade to a clean "done" no matter that its process is long
-    gone and its log has been silent for a week (#118). Only a run that is neither
-    finished nor empty is subject to the liveness verdict, which is where ``stalled``
-    and ``crashed`` come from — previously such a run read ``live`` forever.
+    ``done`` is decided from the reduced summary and stays FIRST: a finished run must
+    degrade to a clean "done" no matter that its process is long gone and its log has been
+    silent for a week (#118).
     """
     verdict = (live or {}).get("status")
     # `test_sealed`/`test_reward` come from splits.json/final.json; the `finalize` EVENT
@@ -79,10 +77,18 @@ def _status(summary: dict, live: dict | None = None) -> str:
     if summary.get("test_reward") is not None or summary.get("test_sealed") \
             or verdict == "done":
         return "done"
+    # The liveness verdict comes BEFORE the zero-candidate branch. A run whose seed eval
+    # blew up (adapter raised → no candidates) and whose process then died read `failed`
+    # here while the DeepDive badge read `crashed`, because the badge prefers the fresher
+    # SSE `status` frame: two panels, two words, one run — the exact defect class #118
+    # exists to remove. `crashed`/`stalled` are also the more actionable words, naming a
+    # gone or wedged process where `failed` says only "produced nothing".
+    if verdict in ("stalled", "crashed"):
+        return verdict
     counts = summary.get("counts") or {}
     if counts.get("total", 0) == 0:
         return "failed"
-    return verdict if verdict in ("stalled", "crashed") else "live"
+    return "live"
 
 
 def list_runs(base_dir: Path) -> list[dict]:

--- a/dashboard/backend/capevolve_dashboard/runs.py
+++ b/dashboard/backend/capevolve_dashboard/runs.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from . import _bootstrap  # noqa: F401
-from cap_evolve import RunDir, dashboard
+from cap_evolve import RunDir, dashboard, eventstream
 
 
 class RunNotFound(Exception):
@@ -40,15 +40,45 @@ def _reduce(path: Path) -> dict:
     return dashboard.reduce_run(rd)
 
 
-def _status(summary: dict) -> str:
-    # A run is "done" once finalize sealed the test; "failed" if there were no
-    # accepted/seed nodes and no candidates; otherwise "live".
+def liveness(path: Path) -> dict:
+    """Fresh stall/crash facts for a run dir — deliberately NOT part of ``_reduce``.
+
+    ``reduce_run`` is cached on the run's on-disk stamp (#119), and "how long has this
+    run been silent" is the one fact that changes precisely *while nothing on disk
+    changes*: a cached answer would be permanently 0s. So it is computed here, per
+    request, from the same ``cap_evolve.eventstream`` helpers the terminal uses — one
+    ``stat`` plus one read of ``events.jsonl``, no reduction.
+    """
+    try:
+        facts = eventstream.liveness_facts(path)
+        return {"status": eventstream.classify(facts),
+                "detail": eventstream.describe_status(facts),
+                "silence_seconds": facts["silence"],
+                "stall_threshold_seconds": facts["threshold"],
+                "slowest_gap_seconds": facts["slowest_gap"],
+                "process_alive": facts["alive"]}
+    except Exception:  # noqa: BLE001 — a hub row must never 500 over a liveness probe
+        return {"status": "live", "detail": None, "silence_seconds": None,
+                "stall_threshold_seconds": None, "slowest_gap_seconds": None,
+                "process_alive": None}
+
+
+def _status(summary: dict, live: dict | None = None) -> str:
+    """``done`` / ``failed`` / ``crashed`` / ``stalled`` / ``live``.
+
+    ``done`` and ``failed`` are decided from the reduced summary and stay FIRST: a
+    finished run must degrade to a clean "done" no matter that its process is long
+    gone and its log has been silent for a week (#118). Only a run that is neither
+    finished nor empty is subject to the liveness verdict, which is where ``stalled``
+    and ``crashed`` come from — previously such a run read ``live`` forever.
+    """
     if summary.get("test_reward") is not None or summary.get("test_sealed"):
         return "done"
     counts = summary.get("counts") or {}
     if counts.get("total", 0) == 0:
         return "failed"
-    return "live"
+    return (live or {}).get("status") if (live or {}).get("status") in (
+        "stalled", "crashed") else "live"
 
 
 def list_runs(base_dir: Path) -> list[dict]:
@@ -60,11 +90,13 @@ def list_runs(base_dir: Path) -> list[dict]:
             continue
         s = reduced["summary"]
         counts = s.get("counts") or {}
+        live = liveness(path)
         rows.append({
             "run_id": path.name,
             "path": str(path),
             "algorithm": s.get("algorithm"),
-            "status": _status(s),
+            "status": _status(s, live),
+            "liveness": live,
             "best_val": s.get("best_val"),
             "baseline_val": s.get("baseline_val"),
             "delta_pct": s.get("delta_pct"),
@@ -79,4 +111,9 @@ def list_runs(base_dir: Path) -> list[dict]:
 def load_run(base_dir: Path, run_id: str) -> dict:
     path = resolve_run(base_dir, run_id)
     reduced = _reduce(path)
+    live = liveness(path)
+    # Same key, same computation, same source of truth as the hub row and as
+    # `cap-evolve tail` — so the two surfaces cannot report different verdicts.
+    reduced["summary"]["liveness"] = live
+    reduced["summary"]["status"] = _status(reduced["summary"], live)
     return {"run_id": run_id, "path": str(path), **reduced}

--- a/dashboard/backend/capevolve_dashboard/stream.py
+++ b/dashboard/backend/capevolve_dashboard/stream.py
@@ -1,38 +1,18 @@
-"""Server-Sent-Events helpers: format frames and tail events.jsonl by byte offset."""
+"""Server-Sent-Events helpers: format frames and tail events.jsonl by byte offset.
+
+The tail itself lives in ``cap_evolve.eventstream`` (core, stdlib-only) so the SSE
+route, ``cap-evolve run --follow`` and ``cap-evolve tail`` all read the run's event
+log through the same code — the web view and the terminal can't disagree.
+``read_new_events`` is re-exported here for the existing callers/tests.
+"""
 from __future__ import annotations
 
 import json
-from pathlib import Path
+
+from cap_evolve.eventstream import read_new_events  # noqa: F401 — re-export
+
+__all__ = ["sse_format", "read_new_events"]
 
 
 def sse_format(event: str, data: dict) -> str:
     return f"event: {event}\ndata: {json.dumps(data)}\n\n"
-
-
-def read_new_events(path: Path, offset: int) -> tuple[list[dict], int]:
-    """Return (new events, new byte offset). A partial trailing line (no newline)
-    is left unconsumed so the next read picks it up once complete."""
-    p = Path(path)
-    if not p.exists():
-        return [], offset
-    if offset >= p.stat().st_size:
-        return [], offset
-    # Seek-and-read so each poll costs O(new bytes), not O(file size) — the stream
-    # route calls this twice a second per client over a growing events.jsonl.
-    with p.open("rb") as fh:
-        fh.seek(offset)
-        chunk = fh.read()
-    last_nl = chunk.rfind(b"\n")
-    if last_nl == -1:
-        return [], offset  # only a partial line so far
-    complete = chunk[: last_nl + 1]
-    events = []
-    for line in complete.splitlines():
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            events.append(json.loads(line))
-        except json.JSONDecodeError:
-            continue
-    return events, offset + last_nl + 1

--- a/dashboard/backend/tests/test_stall_status.py
+++ b/dashboard/backend/tests/test_stall_status.py
@@ -76,16 +76,25 @@ def test_a_finalize_event_alone_is_enough_to_report_done(tmp_base, make_run):
     assert runs.load_run(tmp_base, "run_a")["summary"]["status"] == "done"
 
 
-def test_failed_and_done_outrank_the_liveness_verdict(tmp_base, make_run):
-    """Ordering: the summary-derived terminal states are decided BEFORE liveness.
+def test_done_outranks_liveness_but_the_zero_candidate_branch_does_not(tmp_base, make_run):
+    """Ordering: ``done`` is decided BEFORE liveness; zero-candidate ``failed`` AFTER it.
+
+    That second half is the review's blocking #3. A zero-candidate run with a dead process
+    read ``failed`` on the hub while the DeepDive badge read ``crashed`` (the badge prefers
+    the fresher SSE ``status`` frame): two panels, two words, one run. ``crashed``/``stalled``
+    now win — consistent, and more actionable, naming a gone or wedged process where
+    ``failed`` says only "produced nothing".
 
     Checked on ``_status`` directly because the reducer always synthesises a ``seed``
-    node, so ``counts.total == 0`` is unreachable through a real run dir — the
-    ``failed`` branch predates this PR and is left exactly as it was.
+    node, so ``counts.total == 0`` is unreachable through a real run dir.
     """
     from capevolve_dashboard import runs
     dead = {"status": "crashed"}
-    assert runs._status({"counts": {"total": 0}}, dead) == "failed"
+    assert runs._status({"counts": {"total": 0}}, dead) == "crashed"
+    assert runs._status({"counts": {"total": 0}}, {"status": "stalled"}) == "stalled"
+    # With no liveness verdict on offer, a zero-candidate run is still `failed`.
+    assert runs._status({"counts": {"total": 0}}, {"status": "live"}) == "failed"
+    assert runs._status({"counts": {"total": 0}}, None) == "failed"
     assert runs._status({"counts": {"total": 0}}, {"status": "done"}) == "done"
     assert runs._status({"test_sealed": True, "counts": {"total": 3}}, dead) == "done"
     assert runs._status({"test_reward": 0.9, "counts": {"total": 3}}, dead) == "done"
@@ -102,6 +111,26 @@ def test_a_dead_run_with_no_candidates_is_crashed_not_live(tmp_base, make_run):
     rd = make_run("run_a", events=[{"kind": "splits", "train": 1, "val": 1, "test": 1}])
     _age(rd, 99_999.0, pid=_dead_pid())
     assert runs.list_runs(tmp_base)[0]["status"] == "crashed"
+
+
+def test_the_hub_row_and_the_deepdive_badge_agree_on_a_zero_candidate_dead_run(
+        tmp_base, make_run):
+    """The review's blocking #3, end to end on a real run dir.
+
+    ``RunDeepDive.tsx`` picks the SSE ``status`` frame whenever it is not ``live``, and the
+    frame carries ``liveness.status``. So the badge shows the liveness verdict while the hub
+    showed ``failed`` — this asserts the two words are now one word, on the shape that broke
+    it: a run whose seed eval produced no candidates and whose process then died.
+    """
+    from capevolve_dashboard import runs
+    rd = make_run("run_a", events=[{"kind": "splits", "train": 1, "val": 1, "test": 1}])
+    _age(rd, 99_999.0, pid=_dead_pid())
+    hub = runs.list_runs(tmp_base)[0]
+    deep = runs.load_run(tmp_base, "run_a")["summary"]
+    sse_frame = runs.liveness(rd)["status"]                    # what /stream sends
+    badge = sse_frame if sse_frame != "live" else deep["status"]  # RunDeepDive precedence
+    assert hub["status"] == deep["status"] == badge == "crashed", (
+        hub["status"], deep["status"], badge)
 
 
 def test_a_working_run_is_live(tmp_base, make_run):

--- a/dashboard/backend/tests/test_stall_status.py
+++ b/dashboard/backend/tests/test_stall_status.py
@@ -1,0 +1,213 @@
+"""#118: the hub/DeepDive must distinguish stalled/crashed from live and from done.
+
+Every verdict here comes from ``cap_evolve.eventstream`` — the same functions
+``cap-evolve tail`` uses — so a test asserting the API payload is also asserting that
+the terminal would say the same thing about the same run dir.
+"""
+import json
+import os
+import subprocess
+import sys
+import threading
+import time
+
+from conftest import BASE_EVENTS
+
+
+def _age(rd, seconds, *, pid=None, host=None):
+    """Backdate the run's events.jsonl mtime and (optionally) name an owning process."""
+    last = time.time() - seconds
+    os.utime(rd.events_path, (last, last))
+    if pid is not None:
+        import socket
+        (rd.root / "run.pid").write_text(json.dumps(
+            {"pid": pid, "host": host or socket.gethostname()}), encoding="utf-8")
+
+
+def _dead_pid():
+    p = subprocess.Popen([sys.executable, "-c", "pass"])
+    p.wait()
+    return p.pid
+
+
+# ---- _status ---------------------------------------------------------------
+
+def test_a_silent_unfinalized_run_is_stalled_not_live(tmp_base, make_run):
+    from capevolve_dashboard import runs
+    rd = make_run("run_a", events=BASE_EVENTS, baseline={"val": {"reward": 0.25}})
+    _age(rd, 3600.0, pid=os.getpid())          # events seconds apart, silent an hour
+    rows = runs.list_runs(tmp_base)
+    assert rows[0]["status"] == "stalled"
+    assert "STALLED" in rows[0]["liveness"]["detail"]
+    assert rows[0]["liveness"]["silence_seconds"] > 3000
+
+
+def test_a_run_whose_process_died_is_crashed_not_live_forever(tmp_base, make_run):
+    """The issue's second bug: 1 candidate then a crash showed `live` forever."""
+    from capevolve_dashboard import runs
+    rd = make_run("run_a", events=BASE_EVENTS, baseline={"val": {"reward": 0.25}})
+    _age(rd, 600.0, pid=_dead_pid())
+    assert runs.list_runs(tmp_base)[0]["status"] == "crashed"
+
+
+def test_a_finalized_run_still_reports_done(tmp_base, make_run):
+    """Degrades sanely for a finished run: no amount of silence or a departed process
+    downgrades a sealed run."""
+    from capevolve_dashboard import runs
+    rd = make_run("run_a", events=BASE_EVENTS + [{"kind": "finalize", "test_reward": 0.9}],
+                  baseline={"val": {"reward": 0.25}},
+                  final={"test": {"reward": 0.9}})
+    _age(rd, 86_400.0, pid=_dead_pid())
+    row = runs.list_runs(tmp_base)[0]
+    assert row["status"] == "done"
+    assert row["liveness"]["status"] == "done"
+
+
+def test_failed_and_done_outrank_the_liveness_verdict(tmp_base, make_run):
+    """Ordering: the summary-derived terminal states are decided BEFORE liveness.
+
+    Checked on ``_status`` directly because the reducer always synthesises a ``seed``
+    node, so ``counts.total == 0`` is unreachable through a real run dir — the
+    ``failed`` branch predates this PR and is left exactly as it was.
+    """
+    from capevolve_dashboard import runs
+    dead = {"status": "crashed"}
+    assert runs._status({"counts": {"total": 0}}, dead) == "failed"
+    assert runs._status({"test_sealed": True, "counts": {"total": 3}}, dead) == "done"
+    assert runs._status({"test_reward": 0.9, "counts": {"total": 3}}, dead) == "done"
+    # …and only a run that is neither finished nor empty inherits the liveness verdict.
+    assert runs._status({"counts": {"total": 3}}, dead) == "crashed"
+    assert runs._status({"counts": {"total": 3}}, {"status": "stalled"}) == "stalled"
+    assert runs._status({"counts": {"total": 3}}, {"status": "live"}) == "live"
+    assert runs._status({"counts": {"total": 3}}, None) == "live"
+
+
+def test_a_dead_run_with_no_candidates_is_crashed_not_live(tmp_base, make_run):
+    """Previously this read `live` forever (the issue's second bug)."""
+    from capevolve_dashboard import runs
+    rd = make_run("run_a", events=[{"kind": "splits", "train": 1, "val": 1, "test": 1}])
+    _age(rd, 99_999.0, pid=_dead_pid())
+    assert runs.list_runs(tmp_base)[0]["status"] == "crashed"
+
+
+def test_a_working_run_is_live(tmp_base, make_run):
+    from capevolve_dashboard import runs
+    make_run("run_a", events=BASE_EVENTS, baseline={"val": {"reward": 0.25}})
+    assert runs.list_runs(tmp_base)[0]["status"] == "live"
+
+
+def test_a_slow_but_healthy_run_is_not_reported_stalled(tmp_base, make_run):
+    """THE case that must not regress: 20-minute steps, 25 minutes quiet → still live.
+
+    The old fixed 5-minute rule called this hung, and a user's response to "hung" is to
+    kill the run.
+    """
+    from capevolve_dashboard import runs
+    slow = []
+    t = time.time() - 4 * 20 * 60.0
+    for ev in BASE_EVENTS:
+        slow.append({**ev, "t": t})
+        t += 20 * 60.0
+    rd = make_run("run_a", events=slow, baseline={"val": {"reward": 0.25}})
+    _age(rd, 25 * 60.0, pid=os.getpid())
+    row = runs.list_runs(tmp_base)[0]
+    assert row["status"] == "live", row["liveness"]
+    assert row["liveness"]["stall_threshold_seconds"] > 25 * 60.0
+
+
+def test_load_run_carries_the_same_verdict_as_the_hub_row(tmp_base, make_run):
+    """One computation, two payloads: hub and DeepDive cannot disagree."""
+    from capevolve_dashboard import runs
+    rd = make_run("run_a", events=BASE_EVENTS, baseline={"val": {"reward": 0.25}})
+    _age(rd, 3600.0, pid=os.getpid())
+    row = runs.list_runs(tmp_base)[0]
+    detail = runs.load_run(tmp_base, "run_a")["summary"]
+    assert detail["status"] == row["status"] == "stalled"
+    assert detail["liveness"]["detail"] == row["liveness"]["detail"]
+
+
+def test_liveness_never_raises_on_a_broken_run_dir(tmp_base, make_run):
+    from capevolve_dashboard import runs
+    rd = make_run("run_a", events=BASE_EVENTS)
+    rd.events_path.write_bytes(b"\x00\xff not json at all\n")
+    (rd.root / "run.pid").write_text("garbage", encoding="utf-8")
+    assert runs.liveness(rd.root)["status"] in {"live", "stalled"}
+
+
+# ---- SSE: a silent run gets a named verdict, not an ambiguous close --------
+#
+# The route is an unbounded generator, and TestClient buffers such a response instead of
+# yielding frames as they are produced — so these drive the endpoint's body_iterator
+# directly and stop after the frames under test. Same code path, no 5-minute wait.
+
+def _frames(app, run_id, *, want, limit=8, **params):
+    """Collect SSE frames from the live stream route until ``want`` appears in them."""
+    import asyncio
+    endpoint = next(r.endpoint for r in app.routes
+                    if getattr(r, "path", "") == "/api/runs/{run_id}/stream")
+
+    async def drive():
+        resp = await endpoint(run_id, **params)
+        out = []
+        async for chunk in resp.body_iterator:
+            out.append(chunk if isinstance(chunk, str) else chunk.decode())
+            if want in "".join(out) or len(out) >= limit:
+                break
+        return "".join(out)
+
+    return asyncio.run(drive())
+
+
+def test_stream_sends_a_status_frame_naming_the_stall(tmp_base, make_run):
+    from capevolve_dashboard.app import create_app
+
+    rd = make_run("run_a", events=BASE_EVENTS, baseline={"val": {"reward": 0.25}})
+    _age(rd, 3600.0, pid=os.getpid())
+    body = _frames(create_app(tmp_base), "run_a", want="event: status",
+                   poll=0.01, status_every=0)
+    assert "event: status" in body
+    assert '"status": "stalled"' in body
+    assert "STALLED" in body                  # the reason, with the numbers
+    assert "event: idle" not in body          # the ambiguous frame is gone
+    assert "event: done" not in body          # and it is NOT reported as finished
+
+
+def test_stream_closes_on_crashed_but_never_calls_it_done(tmp_base, make_run):
+    from capevolve_dashboard.app import create_app
+
+    rd = make_run("run_a", events=BASE_EVENTS, baseline={"val": {"reward": 0.25}})
+    _age(rd, 600.0, pid=_dead_pid())
+    body = _frames(create_app(tmp_base), "run_a", want="event: status",
+                   poll=0.01, status_every=0)
+    assert '"status": "crashed"' in body
+    assert "event: done" not in body
+
+
+def test_stream_status_frame_says_live_for_a_working_run(tmp_base, make_run):
+    from capevolve_dashboard.app import create_app
+
+    make_run("run_a", events=BASE_EVENTS, baseline={"val": {"reward": 0.25}})
+    body = _frames(create_app(tmp_base), "run_a", want="event: status",
+                   poll=0.01, status_every=0)
+    assert '"status": "live"' in body
+    assert "working" in body
+
+
+def test_stream_still_ends_with_done_when_the_run_finalizes(tmp_base, make_run):
+    """Unchanged happy path: a real finish is still a `done` frame."""
+    from capevolve_dashboard.app import create_app
+
+    rd = make_run("run_a", events=BASE_EVENTS, baseline={"val": {"reward": 0.25}})
+
+    def append_finalize():
+        # After the route has recorded its start offset, so the event is seen as NEW.
+        time.sleep(0.3)
+        with rd.events_path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps({"t": time.time(), "kind": "finalize",
+                                 "test_reward": 0.9}) + "\n")
+
+    threading.Thread(target=append_finalize, daemon=True).start()
+    body = _frames(create_app(tmp_base), "run_a", want="event: done", limit=200,
+                   poll=0.05, status_every=30)
+    assert "event: done" in body
+    assert "crashed" not in body and "stalled" not in body

--- a/dashboard/backend/tests/test_stall_status.py
+++ b/dashboard/backend/tests/test_stall_status.py
@@ -63,6 +63,19 @@ def test_a_finalized_run_still_reports_done(tmp_base, make_run):
     assert row["liveness"]["status"] == "done"
 
 
+def test_a_finalize_event_alone_is_enough_to_report_done(tmp_base, make_run):
+    """A run whose log says `finalize` but whose final.json/splits.json lag must still
+    read `done` — otherwise the hub says `live` while `cap-evolve tail` says `done`."""
+    from capevolve_dashboard import runs
+    rd = make_run("run_a", events=BASE_EVENTS + [{"t": time.time(), "kind": "finalize",
+                                                  "test_reward": 0.9}],
+                  baseline={"val": {"reward": 0.25}})   # no final.json, test not sealed
+    row = runs.list_runs(tmp_base)[0]
+    assert row["liveness"]["status"] == "done"
+    assert row["status"] == "done"
+    assert runs.load_run(tmp_base, "run_a")["summary"]["status"] == "done"
+
+
 def test_failed_and_done_outrank_the_liveness_verdict(tmp_base, make_run):
     """Ordering: the summary-derived terminal states are decided BEFORE liveness.
 
@@ -73,6 +86,7 @@ def test_failed_and_done_outrank_the_liveness_verdict(tmp_base, make_run):
     from capevolve_dashboard import runs
     dead = {"status": "crashed"}
     assert runs._status({"counts": {"total": 0}}, dead) == "failed"
+    assert runs._status({"counts": {"total": 0}}, {"status": "done"}) == "done"
     assert runs._status({"test_sealed": True, "counts": {"total": 3}}, dead) == "done"
     assert runs._status({"test_reward": 0.9, "counts": {"total": 3}}, dead) == "done"
     # …and only a run that is neither finished nor empty inherits the liveness verdict.

--- a/dashboard/frontend/src/components/StatusBadge.tsx
+++ b/dashboard/frontend/src/components/StatusBadge.tsx
@@ -1,4 +1,4 @@
-import { CheckCircle2, CircleDot, XCircle } from 'lucide-react'
+import { AlertTriangle, CheckCircle2, CircleDot, PlugZap, XCircle } from 'lucide-react'
 import type { RunStatus } from '../lib/types'
 import { cn } from '../lib/cn'
 
@@ -6,13 +6,29 @@ const MAP: Record<RunStatus, { label: string; tone: string; Icon: typeof CircleD
   live: { label: 'live', tone: 'text-accent', Icon: CircleDot, live: true },
   done: { label: 'done', tone: 'text-accepted', Icon: CheckCircle2 },
   failed: { label: 'failed', tone: 'text-rejected', Icon: XCircle },
+  // #118: a run that went quiet or died must not read as a clean finish.
+  stalled: { label: 'stalled', tone: 'text-warn', Icon: AlertTriangle },
+  crashed: { label: 'crashed', tone: 'text-rejected', Icon: PlugZap },
 }
 
 /** Status pill. Color is never the sole signal — icon + label always present. */
-export function StatusBadge({ status, className }: { status: RunStatus; className?: string }) {
+export function StatusBadge({
+  status,
+  detail,
+  className,
+}: {
+  status: RunStatus
+  /** Why, with the numbers — the reason a user can act on ("no events for 42m, over
+   * this run's own threshold 12m"). Rendered as the accessible title (#118). */
+  detail?: string | null
+  className?: string
+}) {
   const { label, tone, Icon, live } = MAP[status] ?? MAP.failed
   return (
-    <span className={cn('inline-flex items-center gap-1.5 text-xs font-medium', tone, className)}>
+    <span
+      title={detail ?? undefined}
+      className={cn('inline-flex items-center gap-1.5 text-xs font-medium', tone, className)}
+    >
       <span className="relative inline-flex">
         {live && (
           <span

--- a/dashboard/frontend/src/index.css
+++ b/dashboard/frontend/src/index.css
@@ -18,6 +18,7 @@
   --accent-strong: #d97706;
   --accepted: #22c55e;      /* accepted / improved */
   --rejected: #ef4444;      /* rejected / regressed */
+  --warn: #eab308;          /* stalled / needs attention — distinct from live amber */
   --seed: #64748b;          /* seed / neutral */
 
   color-scheme: dark;

--- a/dashboard/frontend/src/lib/types.ts
+++ b/dashboard/frontend/src/lib/types.ts
@@ -1,6 +1,19 @@
 /** Mirrors the Plan 1 backend payloads (see core/cap_evolve/dashboard.py schemas). */
 
-export type RunStatus = 'live' | 'done' | 'failed'
+export type RunStatus = 'live' | 'done' | 'failed' | 'stalled' | 'crashed'
+
+/** Stall/crash verdict for a run, computed per-request from events.jsonl by the same
+ * `cap_evolve.eventstream` helpers `cap-evolve tail` uses — so the terminal and the web
+ * UI can never report different verdicts. `stall_threshold_seconds` is derived from this
+ * run's own slowest observed gap, not a global constant (#118). */
+export interface Liveness {
+  status: RunStatus
+  detail: string | null
+  silence_seconds: number | null
+  stall_threshold_seconds: number | null
+  slowest_gap_seconds: number | null
+  process_alive: boolean | null
+}
 
 /** One row from GET /api/runs (light hub summary). */
 export interface RunSummary {
@@ -14,6 +27,7 @@ export interface RunSummary {
   iterations: number
   total_usd: number | null
   mtime: number
+  liveness?: Liveness
 }
 
 export type NodeStatus = 'seed' | 'accepted' | 'rejected' | 'failed'
@@ -88,6 +102,8 @@ export interface RunSummaryDetail {
   delta_pct: number | null
   test_reward: number | null
   test_sealed?: boolean
+  status?: RunStatus
+  liveness?: Liveness
   test_pass_k?: number | null
   counts?: { accepted: number; rejected: number; failed: number; seed: number; total: number }
   frontier?: number

--- a/dashboard/frontend/src/lib/useRunStream.ts
+++ b/dashboard/frontend/src/lib/useRunStream.ts
@@ -8,7 +8,7 @@
 import { useEffect, useReducer, useRef } from 'react'
 import { api, STATIC_MODE } from './api'
 
-export type StreamStatus = 'connecting' | 'live' | 'done' | 'idle' | 'error'
+export type StreamStatus = 'connecting' | 'live' | 'done' | 'idle' | 'error' | 'stalled' | 'crashed'
 
 export interface StreamEntry {
   kind: string
@@ -20,6 +20,9 @@ export interface StreamState {
   status: StreamStatus
   log: StreamEntry[]
   count: number
+  /** Why, with the numbers, from the backend's `status` frame — the same sentence
+   * `cap-evolve tail` prints for the same run dir (#118). */
+  detail?: string | null
 }
 
 export type StreamAction =
@@ -28,6 +31,7 @@ export type StreamAction =
   | { type: 'done' }
   | { type: 'idle' }
   | { type: 'error' }
+  | { type: 'status'; data: Record<string, unknown> }
 
 const LOG_CAP = 200
 
@@ -44,7 +48,16 @@ export function streamReducer(state: StreamState, action: StreamAction): StreamS
         seq: state.count,
       }
       const log = [...state.log, entry].slice(-LOG_CAP)
-      return { status: 'live', log, count: state.count + 1 }
+      return { status: 'live', log, count: state.count + 1, detail: null }
+    }
+    case 'status': {
+      // The backend's periodic verdict. `live` here means "quiet but within this run's
+      // own demonstrated pace" — it must not overwrite a terminal 'done'.
+      if (state.status === 'done') return state
+      const s = String(action.data.status ?? 'live')
+      const status: StreamStatus =
+        s === 'stalled' || s === 'crashed' ? s : state.status === 'connecting' ? 'live' : state.status
+      return { ...state, status, detail: (action.data.detail as string | null) ?? null }
     }
     case 'done':
       return { ...state, status: 'done' }
@@ -88,6 +101,15 @@ export function useRunStream(id: string | undefined, onActivity?: () => void): S
     es.addEventListener('idle', () => {
       dispatch({ type: 'idle' })
       es.close()
+    })
+    // #118: the backend now names which kind of quiet a silent run is, instead of
+    // closing the connection with an ambiguous idle frame that read like completion.
+    es.addEventListener('status', (e) => {
+      try {
+        dispatch({ type: 'status', data: JSON.parse((e as MessageEvent).data) })
+      } catch {
+        /* ignore malformed frame */
+      }
     })
     es.onerror = () => dispatch({ type: 'error' })
 

--- a/dashboard/frontend/src/routes/Hub.tsx
+++ b/dashboard/frontend/src/routes/Hub.tsx
@@ -140,7 +140,7 @@ function RunRow({
               </span>
             )}
           </div>
-          <StatusBadge status={run.status} className="mt-1" />
+          <StatusBadge status={run.status} detail={run.liveness?.detail} className="mt-1" />
         </div>
 
         <Metric label="best" value={pct(run.best_val)} accent />

--- a/dashboard/frontend/src/routes/RunDeepDive.tsx
+++ b/dashboard/frontend/src/routes/RunDeepDive.tsx
@@ -79,8 +79,14 @@ export function RunDeepDive() {
   }, [id, queryClient])
 
   const stream = useRunStream(id, onActivity)
+  // #118: 'stalled'/'crashed' come from the backend's periodic status frame; they must
+  // survive to the badge rather than being flattened into 'live' or (worse) 'done'.
   const liveStatus: RunStatus =
-    stream.status === 'live' ? 'live' : stream.status === 'idle' || stream.status === 'done' ? 'done' : 'live'
+    stream.status === 'stalled' || stream.status === 'crashed'
+      ? stream.status
+      : stream.status === 'idle' || stream.status === 'done'
+        ? 'done'
+        : 'live'
 
   return (
     <AppShell live={stream.status === 'live'}>
@@ -91,7 +97,18 @@ export function RunDeepDive() {
 
         <div className="mb-5 flex flex-wrap items-center gap-3">
           <h1 className="text-2xl font-semibold tracking-tight">{id}</h1>
-          {data && <StatusBadge status={data.summary.test_reward != null ? 'done' : liveStatus} />}
+          {data && (
+            <StatusBadge
+              status={
+                data.summary.test_reward != null
+                  ? 'done'
+                  : liveStatus !== 'live'
+                    ? liveStatus // the live SSE verdict is fresher than the cached snapshot
+                    : (data.summary.status ?? 'live')
+              }
+              detail={stream.detail ?? data.summary.liveness?.detail}
+            />
+          )}
           {data?.summary.algorithm && (
             <span className="rounded bg-surface-2 px-2 py-0.5 text-xs text-muted">{data.summary.algorithm}</span>
           )}

--- a/dashboard/frontend/src/test/StatusBadge.test.tsx
+++ b/dashboard/frontend/src/test/StatusBadge.test.tsx
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { StatusBadge } from '../components/StatusBadge'
+
+describe('StatusBadge (#118)', () => {
+  it('renders the two new states with a distinct label, not as a finish', () => {
+    render(<StatusBadge status="stalled" detail="STALLED — no events for 42.0m" />)
+    expect(screen.getByText('stalled')).toBeTruthy()
+    expect(screen.getByTitle('STALLED — no events for 42.0m')).toBeTruthy()
+  })
+
+  it('renders crashed distinctly from failed', () => {
+    const { container } = render(<StatusBadge status="crashed" />)
+    expect(container.textContent).toBe('crashed')
+  })
+
+  it('a finished run still reads done', () => {
+    const { container } = render(<StatusBadge status="done" />)
+    expect(container.textContent).toBe('done')
+  })
+})

--- a/dashboard/frontend/src/test/useRunStream.test.ts
+++ b/dashboard/frontend/src/test/useRunStream.test.ts
@@ -39,3 +39,47 @@ describe('streamReducer', () => {
     expect(s.log[0].kind).toBe('event')
   })
 })
+
+describe('streamReducer: stall/crash status frames (#118)', () => {
+  it('promotes a stalled verdict and keeps its reason', () => {
+    let s = streamReducer(initialStreamState, { type: 'open' })
+    s = streamReducer(s, {
+      type: 'status',
+      data: { status: 'stalled', detail: 'STALLED — no events for 42.0m, over this run’s own threshold 12.0m' },
+    })
+    expect(s.status).toBe('stalled')
+    expect(s.detail).toContain('STALLED')
+  })
+
+  it('promotes a crashed verdict', () => {
+    const s = streamReducer(initialStreamState, {
+      type: 'status',
+      data: { status: 'crashed', detail: 'CRASHED — the process that owned this run is gone' },
+    })
+    expect(s.status).toBe('crashed')
+  })
+
+  it('a live verdict does NOT downgrade a finished run', () => {
+    let s = streamReducer(initialStreamState, { type: 'done' })
+    s = streamReducer(s, { type: 'status', data: { status: 'live', detail: 'working' } })
+    expect(s.status).toBe('done')
+  })
+
+  it('a stalled verdict does NOT downgrade a finished run either', () => {
+    let s = streamReducer(initialStreamState, { type: 'done' })
+    s = streamReducer(s, { type: 'status', data: { status: 'stalled', detail: 'STALLED' } })
+    expect(s.status).toBe('done')
+  })
+
+  it('a slow-but-healthy run stays live and clears a stale reason', () => {
+    let s = streamReducer(initialStreamState, { type: 'open' })
+    s = streamReducer(s, { type: 'status', data: { status: 'stalled', detail: 'STALLED' } })
+    expect(s.status).toBe('stalled')
+    // progress resumes: the next event re-arms 'live' and drops the stale reason
+    s = streamReducer(s, { type: 'event', data: { kind: 'step' } })
+    expect(s.status).toBe('live')
+    expect(s.detail).toBeNull()
+    s = streamReducer(s, { type: 'status', data: { status: 'live', detail: 'working — last event 3s ago' } })
+    expect(s.status).toBe('live')
+  })
+})

--- a/dashboard/frontend/tailwind.config.js
+++ b/dashboard/frontend/tailwind.config.js
@@ -16,6 +16,7 @@ export default {
         accent: { DEFAULT: 'var(--accent)', strong: 'var(--accent-strong)' },
         accepted: 'var(--accepted)',
         rejected: 'var(--rejected)',
+        warn: 'var(--warn)',
         seed: 'var(--seed)',
       },
       fontFamily: {

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -73,9 +73,42 @@ cap-evolve tail                                    # newest run under .capevolve
 cap-evolve tail .capevolve/run_20260130_140211 --from-start
 ```
 
-`tail` waits for the run dir to appear, so you can attach before the run creates it. It
-exits `0` when the run finishes, `2` on a path that can never be a run dir, and `3` when
-`--idle-timeout` elapses with no events — so a script can tell a timeout from a result.
+`tail` waits for the run dir to appear, so you can attach before the run creates it.
+
+### Is it working, stuck, or dead?
+
+`tail` ends by naming which kind of quiet the run is in, and exits on a code a script can
+branch on:
+
+| Exit | Verdict | Meaning |
+|---|---|---|
+| `0` | `done` / `working` | `finalize` sealed the test, or the run is still within its own pace |
+| `4` | `STALLED` | silent longer than this run has ever been, process still alive → probably wedged |
+| `5` | `CRASHED` | the process that owned the run is gone and it never finalized |
+| `3` | — | `--idle-timeout` elapsed before the *first* event ever arrived |
+| `2` | — | a path that can never be a run dir |
+
+```text
+[02:54:58] ACCEPT  cand_0001  val=1.0000 (parent 0.0000)  — paired Δ̄=+1.0000 > 0
+CRASHED — the process that owned this run is gone and it never finalized (last event 1s ago)
+```
+
+**The stall threshold is derived from the run, not fixed.** It is
+`max(5 min, 3 × the slowest gap between events this run has already produced)`, so a
+τ²-bench rollout that legitimately takes 20 minutes per step raises its own bar to an
+hour rather than being reported hung — a false "hung" is worse than no signal, because
+the reaction to it is to kill a working run. Set `CAPEVOLVE_STALL_SECONDS=N` to pin a
+fixed number instead, or pass `--no-stall-check` to follow forever.
+
+Crash detection needs a liveness signal, so `cap-evolve run` writes a small `run.pid`
+(`{pid, host, started}`) into the run dir and leaves it there — once the process exits,
+its absence from the process table *is* the signal. A run recorded on another host, or
+one driven through the per-phase skill chain (which has no single owning process), reads
+as *unknown* and is never reported crashed; it can still be reported stalled. A finalized
+run always reports `done`, however long ago it ran.
+
+The dashboard reads the same classifier through the same `events.jsonl`, so the Hub badge,
+the run header, and `cap-evolve tail` always agree.
 
 The `[$… · … tok]` meter is the run's own recorded spend: runner cost from `evaluate`
 events plus optimizer cost from `step` events, matching `Spent.total_usd` in `state.json`.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -56,8 +56,8 @@ cap-evolve run --spec .capevolve/project/capevolve.yaml --follow
 ```text
 [14:02:11] splits frozen  train=4 val=2 test=2 (test sealed)
 [14:02:12] baseline  val=0.0000 ±0.0000
-[14:02:40] ACCEPT  cand_0001  val=1.0000 (parent 0.0000)  — paired Δ̄=+1.0000 > 0  [$0.1240 · 8.3k tok]
-[14:03:05] reject  cand_0002  val=1.0000 (parent 1.0000)  — paired Δ̄=+0.0000 <= 0  [$0.2480 · 16.1k tok]
+[14:02:40] ACCEPT  cand_0001  val=1.0000 (parent 0.0000)  — paired Δ̄=+1.0000 > 0  [$0.0620 · 4.1k tok]
+[14:03:05] reject  cand_0002  val=1.0000 (parent 1.0000)  — paired Δ̄=+0.0000 <= 0  [$0.1240 · 8.3k tok]
 [14:03:31] FINALIZE  test=1.0000 (baseline 0.0000, Δ+1.0000)  best=cand_0001
 ```
 
@@ -73,7 +73,14 @@ cap-evolve tail                                    # newest run under .capevolve
 cap-evolve tail .capevolve/run_20260130_140211 --from-start
 ```
 
-`tail` waits for the run dir to appear, so you can attach before the run creates it.
+`tail` waits for the run dir to appear, so you can attach before the run creates it. It
+exits `0` when the run finishes, `2` on a path that can never be a run dir, and `3` when
+`--idle-timeout` elapses with no events — so a script can tell a timeout from a result.
+
+The `[$… · … tok]` meter is the run's own recorded spend: runner cost from `evaluate`
+events plus optimizer cost from `step` events, matching `Spent.total_usd` in `state.json`.
+Event text is stripped of control characters before it reaches your terminal, so an
+optimizer's stderr can never move the cursor, clear the screen, or forge a progress line.
 
 ## 5. Where to next
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -43,7 +43,39 @@ This is exactly what `core/tests/test_e2e_slice.py` asserts. The script prints a
 directory; open the `dashboard.html` it writes in any browser to see the run (KPIs,
 per-iteration diffs, the tasks × iterations heatmap).
 
-## 4. Where to next
+## 4. Watch a run live in the terminal
+
+A run is otherwise silent until it finishes. `--follow` prints progress from the run's
+`events.jsonl` — the same typed event stream the web dashboard reads, so the two can
+never disagree:
+
+```bash
+cap-evolve run --spec .capevolve/project/capevolve.yaml --follow
+```
+
+```text
+[14:02:11] splits frozen  train=4 val=2 test=2 (test sealed)
+[14:02:12] baseline  val=0.0000 ±0.0000
+[14:02:40] ACCEPT  cand_0001  val=1.0000 (parent 0.0000)  — paired Δ̄=+1.0000 > 0  [$0.1240 · 8.3k tok]
+[14:03:05] reject  cand_0002  val=1.0000 (parent 1.0000)  — paired Δ̄=+0.0000 <= 0  [$0.2480 · 16.1k tok]
+[14:03:31] FINALIZE  test=1.0000 (baseline 0.0000, Δ+1.0000)  best=cand_0001
+```
+
+Progress goes to **stderr**; stdout stays the machine-readable final JSON, so
+`cap-evolve run --follow > result.json` still works for scripts. Output is plain text
+whenever the stream is not a TTY (piped, CI, `NO_COLOR`) — no ANSI in your logs.
+
+To watch a run started elsewhere (another shell, `nohup`, a CI job), attach to its run
+dir instead:
+
+```bash
+cap-evolve tail                                    # newest run under .capevolve/
+cap-evolve tail .capevolve/run_20260130_140211 --from-start
+```
+
+`tail` waits for the run dir to appear, so you can attach before the run creates it.
+
+## 5. Where to next
 
 | You want to… | Go to |
 |---|---|

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -82,11 +82,17 @@ branch on:
 
 | Exit | Verdict | Meaning |
 |---|---|---|
-| `0` | `done` / `working` | `finalize` sealed the test, or the run is still within its own pace |
+| `0` | `done` **or** `working` | `finalize` sealed the test, **or** the run is still within its own pace and you stopped watching |
+| `2` | — | a path that can never be a run dir |
+| `3` | — | `--idle-timeout` elapsed before the *first* event ever arrived |
 | `4` | `STALLED` | silent longer than this run has ever been, process still alive → probably wedged |
 | `5` | `CRASHED` | the process that owned the run is gone and it never finalized |
-| `3` | — | `--idle-timeout` elapsed before the *first* event ever arrived |
-| `2` | — | a path that can never be a run dir |
+
+**Do not branch on `0` to mean "it finished".** `0` also means "still working, I stopped
+watching" — a deliberate choice, because a healthy slow run must not exit non-zero. To test
+for completion, check for `finalize` in the log or `final.json` in the run dir; `tail`'s
+last stderr line also distinguishes the two (`done — finalize sealed the test split` vs
+`working — last event …`).
 
 ```text
 [02:54:58] ACCEPT  cand_0001  val=1.0000 (parent 0.0000)  — paired Δ̄=+1.0000 > 0
@@ -94,11 +100,19 @@ CRASHED — the process that owned this run is gone and it never finalized (last
 ```
 
 **The stall threshold is derived from the run, not fixed.** It is
-`max(5 min, 3 × the slowest gap between events this run has already produced)`, so a
+`max(60 min, 3 × the slowest gap between events this run has already produced)`, so a
 τ²-bench rollout that legitimately takes 20 minutes per step raises its own bar to an
 hour rather than being reported hung — a false "hung" is worse than no signal, because
 the reaction to it is to kill a working run. Set `CAPEVOLVE_STALL_SECONDS=N` to pin a
 fixed number instead, or pass `--no-stall-check` to follow forever.
+
+The 60-minute floor is the bar for a run that has not yet *completed* a slow step: a run
+opens with a burst of sub-second events and only then makes its first slow optimizer call,
+so there is no demonstrated gap to derive from and the floor is what judges it. A lower
+floor reported `STALLED` on healthy runs whose first step ran long. `crashed` is unaffected
+— it needs proof (a departed pid), not silence — so only the "wedged" guess is delayed, and
+`CAPEVOLVE_STALL_SECONDS` pins it lower for a workload you know is fast. Note the pin does
+**not** suppress `crashed`: a crash verdict is proof-based, not time-based.
 
 Crash detection needs a liveness signal, so `cap-evolve run` writes a small `run.pid`
 (`{pid, host, started}`) into the run dir and leaves it there — once the process exits,

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -29,6 +29,9 @@ pip install ./dashboard/backend            # package: capevolve-dashboard
 cap-evolve dashboard --base .capevolve --port 7878   # or: cap-evolve run --dashboard auto
 ```
 
+No backend needed to watch a run in the terminal: `cap-evolve run --follow` prints live
+progress, and `cap-evolve tail [run_dir]` attaches to a run started elsewhere.
+
 A prebuilt frontend is committed under `dashboard/frontend/dist/`. Every run also writes a
 self-contained static `dashboard.html` you can open with no backend.
 


### PR DESCRIPTION
**Closes #118**

Built directly on **#191 (issue #116)**, which landed the shared event tail specifically for this: `follow_events(..., idle_timeout=None)` left the stall threshold for me to define, and the typed `{"kind": FOLLOW_END, "reason": ...}` sentinel already distinguishes *finished* from *went quiet* from *stopped*. This PR turns that distinction into a named, surfaced state.

## Before → After

**Before.** A hung run masqueraded as finished. The SSE stream closed after a fixed ~5 idle minutes (`app.py:116`) and the UI flipped to "idle" — which reads like *completion*, not a *hang*. And `_status` (`runs.py:43-51`) was coarse enough that a run which produced one candidate and then crashed showed `live` **forever**.

**After.** Every surface reports one of four states, from one classifier:

| | means |
|---|---|
| `live` | last event is within what this run has already shown itself capable of |
| `stalled` | silent longer than that, process still alive/unknown — probably wedged |
| `crashed` | the process that owned the run is *provably* gone and it never finalized |
| `done` | `finalize` sealed the test — terminal, nothing downgrades it |

```text
$ cap-evolve tail /tmp/e118b/.capevolve/run_killed --from-start
[02:54:58] ACCEPT  cand_0001  val=1.0000 (parent 0.0000)  — paired Δ̄=+1.0000 > 0
CRASHED — the process that owned this run is gone and it never finalized (last event 1s ago)
$ echo $?
5
```

## Design decision 1: the threshold, and why it won't false-alarm

**A fixed 5-minute idle timeout is wrong in both directions.** A toy run is silent that long only if it is dead; one τ²-bench rollout with 50 tool calls can legitimately take 20 minutes. And the two errors are not symmetric: a false "hung" is *worse than no signal at all*, because the user's reaction to "hung" is to kill a run that was working — and that run cost money.

So the expectation is derived **from the same run**:

```
threshold = max(300s, 3 × the slowest inter-event gap this run has already produced)
```

Three deliberate choices:

- **`max`, not a mean or a quantile.** A run alternating 1s evals with 20-minute optimizer calls has a mean of a couple of minutes — a mean-based bar would fire during *every* optimizer call. The slowest thing the run has already done is the only defensible estimate of the slowest thing it might do next.
- **The bar only rises.** The run that sets the bar is the run judged by it. A workload that takes 20 minutes a step raises its own bar to an hour instead of tripping a global constant. It never *vanishes*, though — a genuinely wedged slow run still trips at 3× its own worst gap (tested).
- **300s is the floor, not the rule.** The old hard-coded SSE number is demoted: it stops a run whose first two events landed 40 ms apart from being declared hung 120 ms later.

Configurable: `CAPEVOLVE_STALL_SECONDS=N` pins a fixed number for a user who knows their workload better than the heuristic does; `cap-evolve tail --no-stall-check` opts out entirely.

One subtlety worth naming: `tail` without `--from-start` prints only *new* events, but the bar is derived from the **whole log** — otherwise attaching mid-run to a 20-min-per-step run would see no gaps at all, fall back to the 300s floor, and report a healthy run hung. That is `test_tail_attaching_mid_run_uses_the_whole_log_not_just_what_it_streamed`.

## Design decision 2: liveness — is the process gone, or just quiet?

In an append-only log a dead run and a slow run look identical, so the log alone cannot answer it. There was no liveness signal, so this PR adds the cheapest possible one: `cap-evolve run` writes a small **`run.pid`** (`{pid, host, started}`) into the run dir — one write, once — and **never deletes it**. Once the process exits, its pid stops existing, and that *absence* is the signal. Deleting the marker on exit would erase the evidence.

Liveness is deliberately three-valued, and **only a definite "this pid is gone" yields `crashed`**:

- pid missing from *this host's* process table → `False` → `crashed`
- pid exists (incl. `PermissionError`: owned by another user) → `True`
- **`None` (unknown)** — a pid recorded on another host (shared filesystem), an unparseable marker, or **no marker at all** (the per-phase `/cap-evolve:baseline` … skill chain has no single long-lived owner). Never reported crashed; can still be reported stalled.

No heartbeat event was added: it would mean touching the harness and every algorithm's hot loop, and `run.pid` + the events file's own mtime answers the same question for free. (`ponytail:` pid-only liveness could in principle hit a recycled pid — needs ~32k intervening spawns *and* the same host, and the failure direction is the safe one: a dead run looks quiet, not a live run looking dead. Upgrade path is a pid+start-time pair, noted in the code.)

Silence is measured from the events file's **mtime**, not from the last event's `t`: `t` is wall-clock recorded by the writer and can be skewed or malformed (`log_event` serialises with `default=str`), while mtime is the filesystem's own answer to "when did this run last make a noise".

## Design decision 3: what the dashboard shows, and finished runs

- **Hub row** and **`GET /api/runs/{id}`** both carry `status` plus a `liveness` object (`silence_seconds`, `stall_threshold_seconds`, `slowest_gap_seconds`, `process_alive`, and a one-sentence `detail`). Same key, same computation, same function — so the two payloads cannot disagree.
- **`StatusBadge`** gains `stalled` (amber triangle) and `crashed` (red plug); color is never the sole signal (icon + label always), and the `detail` sentence is the accessible `title`, because a user deciding whether to kill a run needs *the bar*, not just the word.
- **The SSE route no longer drops the connection on a fixed idle period.** It periodically emits a typed `status` frame naming which kind of quiet the run is in — which doubles as the keepalive, so an idle proxy has traffic to see — and closes only on a *proven* crash. Never as `done`: `done` means sealed. The old ambiguous `idle` frame is gone.
- **Degrades sanely for a finished run:** `done` outranks both stall and crash, so a run finalized 30 days ago whose process is long gone reads a clean `done`, not `crashed`. Tested explicitly.

`liveness` is computed **per request, outside `reduce_run`** — deliberately. That reducer is cached on the run's on-disk stamp (#119 / PR #194), and "how long has this run been silent" is precisely the one fact that changes *while nothing on disk changes*; a cached answer would be permanently `0s`. This is also how the change composes with #194: it adds no field to the cached reduction and touches neither `_reduce` nor the cache key.

**A bug the real evidence caught:** for a run whose log carried `finalize` but whose `final.json`/`splits.json` lagged, `liveness` said `done` while `_status` still said `live` — the two surfaces disagreeing about the same run dir, which is the exact failure this issue exists to remove. `_status` now accepts either the sealed artifacts or the `finalize` event; they are the same fact seen through the log vs the artifacts (second commit).

## Verification

### Real end-to-end, zero API cost (`examples/toy_calc` + `mock` optimizer)

**(a) A run that completes → `done`.** Real `cap-evolve run --follow`, then `tail` on the finished dir:

```text
[02:54:37] splits frozen  train=4 val=2 test=2 (test sealed)
[02:54:37] baseline  val=0.0000 ±0.0000
[02:54:38] ACCEPT  cand_0001  val=1.0000 (parent 0.0000)  — paired Δ̄=+1.0000 > 0
[02:54:39] reject  cand_0002  val=1.0000 (parent 1.0000)  — paired Δ̄=+0.0000 <= 0
[02:54:40] reject  cand_0003  val=1.0000 (parent 1.0000)  — paired Δ̄=+0.0000 <= 0
[02:54:40] FINALIZE  test=1.0000 (baseline 0.0000, Δ+1.0000)  best=cand_0001
done — finalize sealed the test split
tail exit=0

run.pid written by the run: {"pid": 14610, "host": "Oshers-MacBook-Pro-2.local", "started": 1785369277.9289129}
```

**(b) A run SIGKILLed mid-flight → `crashed`.** The run process (and its tree) is `kill -9`ed after baseline + one accepted candidate; no `finalize` in the log:

```text
--- events so far:        6 ---
--- killed pid 15109; run.pid on disk: {"pid": 15109, "host": "Oshers-MacBook-Pro-2.local", ...} ---
0        (grep -c finalize → no finalize event, as expected)
[02:54:58] splits frozen  train=4 val=2 test=2 (test sealed)
[02:54:58] baseline  val=0.0000 ±0.0000
[02:54:58] ACCEPT  cand_0001  val=1.0000 (parent 0.0000)  — paired Δ̄=+1.0000 > 0
CRASHED — the process that owned this run is gone and it never finalized (last event 1s ago)
tail exit=5
```

**(c) A deliberately SLOW run → stays `working`.** A live run with real 150-second steps, then 380s of genuine silence — **past the old 300s rule** — before finalizing. Sampled every 30s against both rules:

```text
03:04:58 silence= 112.2s  OLD_5MIN_RULE=quiet ok    NEW status=live  threshold=450s
03:05:28 silence= 142.2s  OLD_5MIN_RULE=quiet ok    NEW status=live  threshold=450s
03:05:58 silence= 172.4s  OLD_5MIN_RULE=quiet ok    NEW status=live  threshold=450s
03:06:28 silence= 202.5s  OLD_5MIN_RULE=quiet ok    NEW status=live  threshold=450s
03:06:58 silence= 232.6s  OLD_5MIN_RULE=quiet ok    NEW status=live  threshold=450s
03:07:28 silence= 262.7s  OLD_5MIN_RULE=quiet ok    NEW status=live  threshold=450s
03:07:58 silence= 292.8s  OLD_5MIN_RULE=quiet ok    NEW status=live  threshold=450s
03:08:28 silence= 322.9s  OLD_5MIN_RULE=WOULD FIRE  NEW status=live  threshold=450s
03:08:58 silence= 353.0s  OLD_5MIN_RULE=WOULD FIRE  NEW status=live  threshold=450s
03:09:29 silence=   3.1s  OLD_5MIN_RULE=quiet ok    NEW status=done  threshold=1140s
```

**This is the money row.** The old fixed rule would have called this run hung — twice — and it went on to finish successfully. The live `tail` attached to it, verbatim:

```text
03:00:59 | [02:55:35] splits frozen  train=4 val=2 test=2 (test sealed)
03:00:59 | [02:58:05] eval val/cand_0001  reward=1.0000 ±0.0000  150.0s
03:00:59 | [03:00:35] eval val/cand_0002  reward=1.0000 ±0.0000  150.0s
03:03:06 | [03:03:05] eval val/cand_0003  reward=1.0000 ±0.0000  150.0s
03:09:26 | [03:09:25] FINALIZE  test=1.0000 (baseline 0.0000, Δ+1.0000)  best=cand_0001
03:09:26 | done — finalize sealed the test split
tail finished at 03:09:26
```

Note the threshold tracking the run: `450s` while its worst gap was 150s, `1140s` once it had demonstrated a 380s gap. The bar rose *because the run earned it*.

### The surfaces agree — same three run dirs, both surfaces

```text
=== (a) COMPLETED run: GET /api/runs ===
  run_id=run_done  status='done'
    liveness.status='done'  silence=976.7  threshold=300.0  slowest_gap=0.81  process_alive=False
    detail=done — finalize sealed the test split
  GET /api/runs/run_done -> summary.status='done' (matches hub row: True)

=== (b) KILLED run: GET /api/runs ===
  run_id=run_killed  status='crashed'
    liveness.status='crashed'  silence=958.5  threshold=300.0  slowest_gap=0.76  process_alive=False
    detail=CRASHED — the process that owned this run is gone and it never finalized (last event 16.0m ago)
  GET /api/runs/run_killed -> summary.status='crashed' (matches hub row: True)

=== (c) SLOW-but-healthy run: GET /api/runs ===
  run_id=run_slow  status='done'
    liveness.status='done'  silence=91.4  threshold=1140.1  slowest_gap=380.0  process_alive=False
    detail=done — finalize sealed the test split
  GET /api/runs/run_slow -> summary.status='done' (matches hub row: True)
```

Terminal, on the same three dirs: `done` (exit 0) / `CRASHED` (exit 5) / `done` (exit 0). **Dashboard `done / crashed / done` = terminal `done / crashed / done`.**

### Suites

```
$ PYTHONPATH=core python -m pytest core/tests -q
238 passed in 68.49s (0:01:08)
```

Baseline on this branch's base (main + #191) is 217 → **+21, 0 failed**.

```
$ cd dashboard/backend && PYTHONPATH=../../core:. python -m pytest tests -q
56 passed, 1 warning in 2.08s
```

(42 before → +14.)

```
$ python -m compileall -q core skills && echo CLEAN
CLEAN
```

Frontend (CI never runs vitest — #207 — so run locally):

```
$ npm ci && npm test
 Test Files  14 passed (14)
      Tests  53 passed (53)
$ npx tsc -b --noEmit   # rc=0
$ npm run build         # ✓ built in 610ms
```

`dashboard/frontend/dist/` is **not** committed, per epic #127's policy (#188 rebuilds it once after the frontend PRs land).

### The tests that matter

| Test | Asserts |
|---|---|
| `test_a_slow_but_healthy_run_is_never_called_hung` | **the critical negative case** — 20-min steps, 25 min quiet, `silence > 300s` yet `live`; and it *does* fire at 4× its own gap |
| `test_a_slow_but_healthy_run_is_not_reported_stalled` | same, through the hub API |
| `test_tail_does_not_stall_out_a_slow_but_healthy_run` | same, through the CLI |
| `test_tail_attaching_mid_run_uses_the_whole_log_not_just_what_it_streamed` | attaching without `--from-start` must not fall back to the floor |
| `test_a_toy_run_still_gets_the_five_minute_floor` | the other direction: 40 ms gaps must not derive a 120 ms bar |
| `test_threshold_uses_the_slowest_gap_not_the_mean` | why `max`, not a mean |
| `test_a_finalized_run_is_done_even_when_ancient_and_processless` | a finished run degrades to `done` |
| `test_a_pid_from_another_host_is_unknown_not_dead` / `test_no_pid_file_means_unknown_never_crashed` | `crashed` requires proof |
| `test_stream_sends_a_status_frame_naming_the_stall` | the ambiguous `idle` close is gone; a stall is never a `done` frame |
| `test_a_finalize_event_alone_is_enough_to_report_done` | the two surfaces cannot disagree about a sealed run |
| `test_dashboard_classifies_through_the_shared_helper_not_its_own_rule` | the dashboard owns **no** threshold of its own |

## Expected merge order

1. **#191 (issue #116)** — this branch is built on it; `eventstream.py` must land first. (This branch = `origin/main` + #191 + these two commits, so a merge after #191 is a clean fast-forward-shaped diff.)
2. **This PR (#118)**.
3. **#194 (issue #119)** — orthogonal by construction (`liveness` deliberately stays out of the cached `reduce_run`; no shared line in `runs.py` beyond the `list_runs` signature, and no overlap in `app.py` past the `snapshot` frame). Either order works; after #194 the SSE `snapshot` frame carries only `{run_id}`, which this PR does not depend on.
4. **#122 (replay)** / **#144 (no-TTY ladder)** — also on `eventstream`; no conflict with the new `classify`/`liveness_facts` surface.
5. **#188** — rebuild `dist/` once, after the frontend PRs.

## House rules

Zero new runtime deps in core (`eventstream.py` additions use `json`, `os`, `socket`, `time`, `pathlib` only). New tests in `core/tests/` (+ the dashboard's own `tests/`). `harness.py` untouched: the run already logged everything needed, which is why the diff is small.
