### PR TITLE
feat(algorithm): plateau/convergence detection with escalation + per-lineage exhaustion

### DIFF
--- a/core/cap_evolve/__init__.py
+++ b/core/cap_evolve/__init__.py
@@ -17,6 +17,7 @@ from .cache import EvalCache, hash_candidate_dir
 from .gate import GateDecision, TrainGateError, decide
 from .lr_schedule import build_schedule
 from .memory import History, RejectedMemory
+from .plateau import PlateauConfig, PlateauState
 from .rundir import Budget, RunDir, Spent
 from .selection import PICKERS, STRATEGIES, pick, validate_strategy
 from .splits import Splits, TestSealError, make_splits
@@ -41,6 +42,8 @@ __all__ = [
     "decide",
     "History",
     "RejectedMemory",
+    "PlateauConfig",
+    "PlateauState",
     "Budget",
     "RunDir",
     "Spent",

--- a/core/cap_evolve/cli.py
+++ b/core/cap_evolve/cli.py
@@ -399,6 +399,16 @@ def _cmd_run(argv):
         alg_cmd += ["--max-metric-calls", str(spec["max_metric_calls"])]
     if spec.get("store_commit_cmd"):
         alg_cmd += ["--store-commit-cmd", str(spec["store_commit_cmd"])]
+    # Plateau/convergence thresholds — one loop, every deterministic algorithm, so a
+    # new knob can't be silently dropped for gepa/skillopt the way #109's flags were.
+    if algorithm_name in ("hill-climb", "gepa", "skillopt"):
+        for key, flag in (("plateau_window", "--plateau-window"),
+                          ("plateau_escalate_every", "--plateau-escalate-every"),
+                          ("plateau_lineage_window", "--plateau-lineage-window")):
+            if spec.get(key):
+                alg_cmd += [flag, str(int(spec[key]))]
+        if spec.get("plateau_stop") is False:
+            alg_cmd += ["--no-plateau-stop"]
     # Algorithm-specific knobs without hardcoding per-algorithm: a spec may set
     # `algorithm_args` (string) to pass extra flags straight through to the
     # algorithm run.py — e.g. "--epochs 6 --lr-schedule cosine" for skillopt,

--- a/core/cap_evolve/dashboard.py
+++ b/core/cap_evolve/dashboard.py
@@ -567,6 +567,13 @@ def reduce_run(run_dir) -> dict:
         "budget": (run_dir.budget.to_dict() if sp is not None else None),
         "spent": (sp.to_dict() if sp is not None else None),
         "budget_warnings": [e for e in events if e.get("kind") == "budget_warning"],
+        # Plateau/convergence state (cap_evolve.plateau): the LAST `plateau` event is the
+        # current escalation level (ok|warn|diversify|stop). Distinct from #118's run
+        # LIVENESS (live/stalled/crashed/done, derived from events.jsonl mtime):
+        # "stalled" = nothing happening; "plateaued" = plenty happening, none of it helps.
+        "plateau": ([e for e in events if e.get("kind") == "plateau"] or [None])[-1],
+        "exhausted_lineages": sorted({str(e.get("parent")) for e in events
+                                      if e.get("kind") == "lineage_exhausted" and e.get("parent")}),
         "gate_warnings": gate_warnings,
         "diagnoses": diagnoses,
         "git_log": _git_log(root),
@@ -788,6 +795,18 @@ def render_ansi(reduced: dict, *, color: bool = True, top_n: int = 8) -> str:
                     (f"{dlt:>+9.3f}" if dlt is not None else f"{'—':>9}") +
                     f"{n.get('iteration', 0):>6}")
             lines.append(line)
+        lines.append("")
+
+    pl = s.get("plateau") or {}
+    if pl.get("level") in ("warn", "diversify", "stop"):
+        col = {"warn": _C.YELLOW, "diversify": _C.YELLOW, "stop": _C.RED}[pl["level"]]
+        lines.append(c(col, f"◼ PLATEAU: {pl['level']} — {pl.get('run_length', 0)} "
+                            f"consecutive iterations bought no new best val"))
+        lines.append(c(_C.GREY, "  " + str(pl.get("reason") or "")[: width - 4]))
+    if s.get("exhausted_lineages"):
+        lines.append(c(_C.YELLOW, "◼ exhausted lineage(s): "
+                                  + ", ".join(s["exhausted_lineages"][:6])))
+    if pl or s.get("exhausted_lineages"):
         lines.append("")
 
     if s["gate_warnings"]:
@@ -1241,9 +1260,16 @@ function sec(title){const s=$('section');s.append($('h2',{text:title}));main.app
 
 /* ---------- 7. Annotations / diagnoses stream ---------- */
 (function(){
-  const W=S.gate_warnings||[], D=S.diagnoses||[];
-  if(!W.length&&!D.length)return;
+  const W=S.gate_warnings||[], D=S.diagnoses||[], P=S.plateau||null, X=S.exhausted_lineages||[];
+  const plOn = P && P.level && P.level!=='ok';
+  if(!W.length&&!D.length&&!plOn&&!X.length)return;
   const s=sec('Annotations & diagnoses');
+  if(plOn){const a=$('div',{class:'ann diag'});
+    a.append($('div',{class:'who',text:'plateau · '+P.level}),
+             $('div',{text:(P.reason||'')}));s.append(a);}
+  if(X.length){const a=$('div',{class:'ann diag'});
+    a.append($('div',{class:'who',text:'lineage exhausted'}),
+             $('div',{text:X.join(', ')}));s.append(a);}
   W.forEach(w=>{const a=$('div',{class:'ann'});a.append($('div',{class:'who',text:'gate · '+(w.mode||'')}),
     $('div',{text:w.reason||''}));s.append(a);});
   D.forEach(d=>{const a=$('div',{class:'ann diag'});a.append($('div',{class:'who',text:(d.kind||'diagnose')+(d.candidate?' · '+d.candidate:'')}),

--- a/core/cap_evolve/gepa.py
+++ b/core/cap_evolve/gepa.py
@@ -589,8 +589,13 @@ def gepa_loop(
         refl_summary = _write_reflection(workdir, parent_mb)
         focus_label = _write_focus(workdir, comps, focus)
         instructions = _instructions(refl_summary, focus_label, mb)
-        instructions = _augment_instructions(instructions, workdir, run_dir, rejected, history)
-        instructions += plateau.prompt_block(pstate, rejected=rejected)
+        # The plateau block goes THROUGH _augment_instructions (extra=) so it lands inside
+        # #222's MAX_INSTRUCTIONS_CHARS cap, and in its PRESERVED TAIL. Appending it after
+        # this call escaped the cap entirely (measured 64941 > 60000); appending it before
+        # would put the one *behavioural* block in the middle, which is the part truncation
+        # elides — silently dropping it while keeping the two context-only blocks.
+        instructions = _augment_instructions(instructions, workdir, run_dir, rejected, history,
+                                             extra=plateau.prompt_block(pstate))
 
         opt_error = None
         opt_cost_usd, opt_tokens = 0.0, 0

--- a/core/cap_evolve/gepa.py
+++ b/core/cap_evolve/gepa.py
@@ -51,6 +51,7 @@ from pathlib import Path
 from typing import Callable
 
 from . import gate as gate_mod
+from . import plateau
 from . import selection
 from .cache import EvalCache, hash_candidate_dir
 from .harness import (
@@ -460,6 +461,7 @@ def gepa_loop(
     seed: int = 0,
     store=None,
     resume: bool = False,
+    plateau_cfg: "plateau.PlateauConfig | None" = None,
 ) -> dict:
     """Run GEPA's sample-efficient reflective Pareto loop.
 
@@ -521,9 +523,21 @@ def gepa_loop(
                             merges_done=merges_done, comp_cursor=comp_cursor,
                             n_steps=step_offset + len(steps))
 
+    # Plateau/convergence detection — a third stop condition next to budget and stall.
+    # GEPA is multi-lineage, so exhaustion is used to STEER (drop the dead parents from
+    # the sampling pool) while the run continues on the lineages that still move.
+    pcfg = plateau_cfg or plateau.PlateauConfig()
+    pstate = plateau.PlateauState()
+
     while True:
         ok, why = _budget_left()
         if not ok:
+            break
+
+        pstate = plateau.check(run_dir, pcfg, last=pstate, algorithm="gepa")
+        if pstate.should_stop:
+            run_dir.log_event("gepa_stop", reason=f"plateaued ({pstate.reason})")
+            why = why or f"plateaued ({pstate.reason})"
             break
 
         # Global step index across resumes: names candidates/tags/commits so a resumed
@@ -531,11 +545,20 @@ def gepa_loop(
         n = step_offset + len(steps)
 
         # 2. select a parent from the per-instance frontier (frequency-weighted).
+        # Per-lineage exhaustion: a parent whose last K children were ALL dead is
+        # removed from the sampling pool for this iteration, so the frontier's own
+        # weighting operates over the lineages that can still move. Never emptied —
+        # if every lineage is exhausted the full pool is used and the GLOBAL level
+        # (not this filter) is what decides to stop.
+        dead_parents = set(pstate.exhausted_lineages)
+        sample_pool = [c for c in pool if c["id"] not in dead_parents] or pool
         sel_seed = rng.randrange(2 ** 31)
-        ranked, _ = selection.pick(pool, selection_strategy, seed=sel_seed)
+        ranked, _ = selection.pick(sample_pool, selection_strategy, seed=sel_seed)
         parent = ranked[0]
         run_dir.log_event("gepa_select", parent=parent["id"], strategy=selection_strategy,
-                          sel_seed=sel_seed, pool=len(pool))
+                          sel_seed=sel_seed, pool=len(pool),
+                          sampled_from=len(sample_pool),
+                          skipped_exhausted=sorted(dead_parents & {c["id"] for c in pool}))
         parent_dir = Path(parent["dir"])
 
         # 3. sample a minibatch of TRAIN ids.
@@ -567,6 +590,7 @@ def gepa_loop(
         focus_label = _write_focus(workdir, comps, focus)
         instructions = _instructions(refl_summary, focus_label, mb)
         instructions = _augment_instructions(instructions, workdir, run_dir, rejected, history)
+        instructions += plateau.prompt_block(pstate, rejected=rejected)
 
         opt_error = None
         opt_cost_usd, opt_tokens = 0.0, 0
@@ -659,6 +683,7 @@ def gepa_loop(
     _save()
     best = max(pool, key=lambda c: c["val"])
     run_dir.set_best(best["id"])
+    pstate = plateau.check(run_dir, pcfg, last=pstate, algorithm="gepa")
     _, why2 = run_dir.budget_exhausted()
     return {
         "algorithm": "gepa",
@@ -671,6 +696,7 @@ def gepa_loop(
         "merges": merges_done,
         "metric_calls": run_dir.spent.metric_calls,
         "stop_reason": why or why2 or "max_iterations",
+        "plateau": pstate.to_dict(),
         "steps": steps,
     }
 

--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import Callable
 
 from . import gate as gate_mod
+from . import plateau
 from .loop import SplitResult, aggregate_scores
 from .rundir import RunDir, _atomic_write
 from .splits import Splits, make_splits
@@ -1856,6 +1857,7 @@ def hill_climb_loop(
     project_dir: Path | None = None,
     target_model: str = "",
     target_profile_file: str | None = None,
+    plateau_cfg: "plateau.PlateauConfig | None" = None,
 ) -> dict:
     """The loop behind the ``hill-climb`` skill's three ``--focus`` schedules
     (all / cyclic / hardest-first).
@@ -1883,10 +1885,20 @@ def hill_climb_loop(
         score_by = {pt["task_id"]: pt["reward"] for pt in train_res.per_task}
         order.sort(key=lambda t: score_by.get(t, 0.0))  # hardest (lowest) first
 
+    # Plateau/convergence detection (see cap_evolve.plateau): a THIRD stop condition,
+    # orthogonal to budget and to the `stall` reject-counter. It escalates
+    # warn -> diversify (prompt intervention) -> stop.
+    pcfg = plateau_cfg or plateau.PlateauConfig()
+    pstate = plateau.PlateauState()
+
     steps = []
     for i in range(max_iterations):
         exhausted, why = run_dir.budget_exhausted()
         if exhausted:
+            break
+        pstate = plateau.check(run_dir, pcfg, last=pstate, algorithm=algorithm)
+        if pstate.should_stop:
+            why = f"plateaued ({pstate.reason})"
             break
         if focus == "all":
             focus_ids, label = None, "whole train set"
@@ -1901,6 +1913,7 @@ def hill_climb_loop(
                                             instructions_file=instructions_file,
                                             bench_repo=bench_repo, optimizer_name=optimizer_name,
                                             seed_empty=seed_empty, target_reader=_target_reader)
+        instructions += plateau.prompt_block(pstate, rejected=rejected)
         step = run_step(
             adapter, run_dir=run_dir, parent_dir=run_dir.candidate_dir(run_dir.best_id),
             optimizer=optimizer, instructions=instructions, current_val=current_val,
@@ -1913,14 +1926,17 @@ def hill_climb_loop(
         if step["accepted"]:
             current_val = SplitResult.from_dict(step["candidate_val"])
 
-    _, why = run_dir.budget_exhausted()
+    pstate = plateau.check(run_dir, pcfg, last=pstate, algorithm=algorithm)
+    stop_why = why if why and why.startswith("plateaued") else None
+    _, budget_why = run_dir.budget_exhausted()
     return {
         "algorithm": algorithm,
         "best_id": run_dir.best_id,
         "best_val": current_val.reward,
         "iterations": len(steps),
         "accepts": sum(1 for s in steps if s["accepted"]),
-        "stop_reason": why or "max_iterations",
+        "stop_reason": stop_why or budget_why or "max_iterations",
+        "plateau": pstate.to_dict(),
         "steps": steps,
     }
 

--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -900,8 +900,17 @@ def _build_runmap(workdir: Path, run_dir: RunDir) -> None:
 
 
 def _augment_instructions(instructions: str, workdir: Path, run_dir: RunDir,
-                          rejected, history) -> str:
+                          rejected, history, extra: str = "") -> str:
     """Give the optimizer its four cross-iteration files + a prompt pointer to each.
+
+    ``extra`` is an algorithm-level block that must land LAST and must be inside whatever
+    cap this function ends with (#129/PR222 makes it ``return cap_instructions(...)``).
+    Appending such a block at the call site instead does two bad things: for GEPA it
+    escapes the cap entirely, and for every algorithm it puts a *behavioural* instruction
+    in the middle of the string, which is the part ``cap_instructions`` elides — so
+    truncation would silently drop the one block that changes search behaviour while
+    keeping the two that are only context. Passing it here puts it in the preserved tail.
+    Used by ``cap_evolve.plateau.prompt_block``.
 
     Clean ownership (see the file-header comment near ``_JOURNAL_SEED``):
       - LEDGER.md  — framework-written facts (outcomes + per-task broke/fixed);
@@ -931,7 +940,24 @@ def _augment_instructions(instructions: str, workdir: Path, run_dir: RunDir,
         "capability diff, copied in for you. Read the ones targeting your cluster BEFORE "
         "proposing, so you build on prior work instead of repeating it.\n"
     )
-    return f"{instructions}\n\n{pointer}\n"
+    out = f"{instructions}\n\n{pointer}\n"
+    if extra:
+        out = f"{out}\n{extra}"
+    return _cap_instructions(out)
+
+
+def _cap_instructions(text: str) -> str:
+    """Apply #129/PR222's one-iteration prompt ceiling when it exists in this tree.
+
+    ponytail: no second cap invented here. #222 owns ``MAX_INSTRUCTIONS_CHARS`` and the
+    head+tail truncation in ``optimizer_context``; this is a one-line adapter so the
+    plateau block is inside that cap the moment #222 lands, and a no-op before it.
+    """
+    try:
+        from .optimizer_context import cap_instructions
+    except Exception:  # noqa: BLE001 — pre-#222 tree has no cap to apply
+        return text
+    return cap_instructions(text)
 
 
 def _copy_step_trajectories(adapter, run_dir: RunDir, workdir: Path, split: str) -> None:
@@ -1217,6 +1243,7 @@ def run_step(
     current_val: SplitResult,
     n_trials: int = 1,
     gate_kwargs: dict | None = None,
+    extra_instructions: str = "",
     candidate_id: str | None = None,
     parent_id: str | None = None,
     no_regression: bool = False,
@@ -1254,7 +1281,10 @@ def run_step(
                               capabilities=capabilities, optimizer_name=optimizer_name,
                               capability_sources=capability_sources, project_dir=project_dir)
 
-    instructions = _augment_instructions(instructions, workdir, run_dir, rejected, history)
+    # ``extra_instructions`` (the plateau block) goes THROUGH _augment_instructions so it
+    # lands in the capped, preserved tail rather than being appended past the cap.
+    instructions = _augment_instructions(instructions, workdir, run_dir, rejected, history,
+                                         extra=extra_instructions)
 
     optimizer_error = None
     opt_cost_usd, opt_tokens = 0.0, 0
@@ -1892,6 +1922,8 @@ def hill_climb_loop(
     pstate = plateau.PlateauState()
 
     steps = []
+    why = ""   # read after the loop, so it must be bound when the body never runs
+               # (max_iterations=0, or a resume whose budget is already spent).
     for i in range(max_iterations):
         exhausted, why = run_dir.budget_exhausted()
         if exhausted:
@@ -1913,10 +1945,10 @@ def hill_climb_loop(
                                             instructions_file=instructions_file,
                                             bench_repo=bench_repo, optimizer_name=optimizer_name,
                                             seed_empty=seed_empty, target_reader=_target_reader)
-        instructions += plateau.prompt_block(pstate, rejected=rejected)
         step = run_step(
             adapter, run_dir=run_dir, parent_dir=run_dir.candidate_dir(run_dir.best_id),
             optimizer=optimizer, instructions=instructions, current_val=current_val,
+            extra_instructions=plateau.prompt_block(pstate),
             n_trials=n_trials, gate_kwargs=gate_kwargs, no_regression=no_regression,
             rejected=rejected, history=history, store=store, capabilities=capabilities,
             optimizer_name=optimizer_name, capability_sources=capability_sources,

--- a/core/cap_evolve/plateau.py
+++ b/core/cap_evolve/plateau.py
@@ -40,10 +40,26 @@ without ever topping the incumbent best, and a naive accept-reset lets such a ru
 grind forever at flat best-val.
 
 **The ratchet:** an accept in the streak, even a non-best one, caps escalation at
-``diversify``. Only a streak with *zero* accepts can reach ``stop``. So a GEPA run
-still widening its Pareto frontier gets nudged to diversify but is never killed,
-while a run that has stopped accepting entirely does get stopped. Stopping early is
-the expensive error, so the conservative side is the default.
+``warn``. Only a streak with *zero* accepts can reach ``diversify`` or ``stop``. A run
+that is still clearing the honest val gate every iteration is doing the thing it was
+built to do — widening a per-instance Pareto frontier is *GEPA's mechanism*
+(arXiv:2507.19457), not a failure — so it gets a warning and no behavioural
+intervention: telling such an optimizer "the direction is dead, change approach" would
+be factually wrong. A run that has stopped accepting entirely does get stopped.
+Stopping early is the expensive error, so the conservative side is the default.
+
+**The honest cost of the Δ≤0 rule.** A run that produces N consecutive *regressions* and
+would have broken through on N+1 is stopped at N. No ratchet saves it (zero accepts, and
+a regression is not a near-miss). This is inherent to any rule keyed on the sign of Δ,
+it is the real price of having a ``stop`` at all, and it is why the window defaults to 6
+and ``plateau_stop: false`` exists. A genuine Pareto trade on a tiny val split (fixes one
+task, breaks another, net Δ=0) reads as dead for the same reason.
+
+**Resume carries the streak.** ``assess`` reads the whole event log, so ``--resume`` on a
+plateaued run re-derives ``stop`` before spending an iteration. That is deliberate — a
+dead region is still dead after a restart, and re-spending budget to rediscover it is the
+error this module exists to prevent. ``plateau_stop: false`` / ``--no-plateau-stop`` is
+the escape hatch.
 
 Escalation ladder (``run_length`` vs the configured window W and step E)::
 
@@ -52,15 +68,23 @@ Escalation ladder (``run_length`` vs the configured window W and step E)::
                                                + exhausted lineages de-prioritized
     run_length >= W + 2*E      -> "stop"       loop breaks (if plateau_stop)
 
-Defaults W=6, E=2 → warn at 6, diversify at 8, stop at 10 dead iterations.
+Defaults W=6, E=2 → warn at 6, diversify at 8, stop at 10 dead iterations. Any accept in
+the streak caps this at ``warn`` (the ratchet, above).
 
-Per-lineage exhaustion is a *different* question and is reported separately: a
-single parent can be exhausted (its last K children all dead) while the global
-search is fine, because another lineage is accepting. GEPA maintains many
-lineages, so it uses this to steer its Pareto sampling away from the dead region
-without stopping the run; hill-climb/skillopt are single-lineage (parent is always
-the current best), so for them exhaustion coincides with the global signal and
+Per-lineage exhaustion is a *different* question, is reported separately, and uses a
+*narrower* deadness test (:func:`_lineage_dead`): an ACCEPT is never dead ground for a
+lineage, whatever it means for global best-val velocity. A single parent can be exhausted
+(its last K children all rejected with Δ≤0) while the global search is fine, because
+another lineage is accepting. GEPA uses this to steer its Pareto sampling away from the
+dead region without stopping the run; hill-climb/skillopt are single-lineage (parent is
+always the current best), so for them exhaustion coincides with the global signal and
 only reaches the prompt.
+
+Note the asymmetry is deliberate: the global level *does* count an accept that did not
+top the best as dead-for-the-streak, because the zero-accept ratchet means such a streak
+can never be killed. Per lineage there is no ratchet — an exhausted lineage is silently
+dropped from GEPA's sampling pool — so the same clause there would steer the search off
+its most productive lineage with nothing to catch it.
 
 Not to be confused with #118's run *liveness* states (``live``/``stalled``/
 ``crashed``/``done``), which are derived from events.jsonl mtime: *stalled* means
@@ -81,7 +105,18 @@ from . import rundir as _rundir
 # added by #109/PR199). ponytail: one definition, preferred at runtime; delete this
 # literal once #199 lands. Never hand-filter on kind == "step" — GEPA emits
 # gepa_val_gate and would silently vanish.
-_FALLBACK_KINDS = ("step", "skillopt_step", "gepa_val_gate")
+#
+# ``skillopt_step`` is deliberately ABSENT. SkillOpt delegates to ``harness.run_step``,
+# which already logs ``step`` for the SAME candidate — and carries ``parent``/``parent_val``,
+# which ``skillopt_step`` does not. Listing both counted every SkillOpt iteration TWICE,
+# firing the ladder at half the configured window (stop at iteration 5 of a window=6
+# ladder) and recording a genuine near-miss once alive and once dead. PR #219 owns the
+# root fix (dropping the kind from ``rundir.ITERATION_EVENT_KINDS``); this pre-#199
+# fallback only has to agree with it. ``skillopt_step`` stays in events.jsonl as an audit
+# record — it is just not an *iteration* event. Do NOT dedupe by candidate id instead:
+# SkillOpt re-mints ``so_eNNsMM`` after ``--resume``, so id-keyed dedup drops real
+# resumed iterations (verified on #219).
+_FALLBACK_KINDS = ("step", "gepa_val_gate")
 
 # GEPA's cheap local minibatch gate. A child killed here never reaches the val gate,
 # so it emits no iteration event — but it IS a spent iteration that produced no
@@ -101,8 +136,17 @@ class PlateauConfig:
 
     @classmethod
     def from_spec(cls, spec: dict | None) -> "PlateauConfig":
+        """``plateau_stop: false`` is the off switch; a 0/negative window is NOT.
+
+        ``plateau_window: 0`` used to silently revert to the default (``or d.window``),
+        which reads like "off" and behaves like "on at 6". It now means the same thing as
+        ``plateau_stop: false`` — the honest reading of "disable this" — rather than
+        quietly ignoring the user.
+        """
         s = spec or {}
         d = cls()
+        if s.get("plateau_window") is not None and int(s["plateau_window"] or 0) <= 0:
+            return cls(stop=False, window=10 ** 9)   # unreachable ladder == disabled
         return cls(
             window=max(2, int(s.get("plateau_window") or d.window)),
             escalate_every=max(1, int(s.get("plateau_escalate_every") or d.escalate_every)),
@@ -205,8 +249,15 @@ def series(run_dir) -> list[dict]:
     for _t, ev, local in rows:
         cid = ev.get("candidate") or ev.get("candidate_id")
         if local:
+            # Carry the real signed delta the event already holds instead of hardcoding
+            # 0.0, so a tie is distinguishable from a regression in the series (review #7).
+            # This cannot change deadness: gepa.py's pass condition is a strict
+            # ``child_sum > parent_sum``, so every row reaching here already has Δ <= 0.
+            # It is diagnostic information, not a new escape hatch.
+            cs, ps = ev.get("child_sum"), ev.get("parent_sum")
+            d = (float(cs) - float(ps)) if (cs is not None and ps is not None) else 0.0
             out.append({"candidate": cid, "parent": ev.get("parent"),
-                        "accepted": False, "delta": 0.0, "local": True})
+                        "accepted": False, "delta": d, "local": True})
             continue
         accepted = bool(ev.get("accept"))
         val = ev.get("val")
@@ -236,11 +287,30 @@ def _dead(row: dict) -> bool:
     return row["delta"] <= 0.0           # rejected: a near-miss (Δ>0) is alive
 
 
+def _lineage_dead(row: dict) -> bool:
+    """Dead ground *for one parent* — a strictly narrower test than :func:`_dead`.
+
+    An ACCEPT is never dead ground for a lineage, even when it did not top the global
+    best. Widening the per-instance Pareto frontier *is* GEPA's mechanism
+    (arXiv:2507.19457): a specialist child that clears the honest val gate is the most
+    productive thing a lineage can produce. Reusing :func:`_dead` here marked a lineage
+    whose children were ALL accepted as exhausted and dropped it from GEPA's sampling
+    pool — steering the search away from its best region, with no ratchet on this path
+    and no stop event to show for it.
+
+    ``_dead``'s accepted-but-not-best clause stays at the GLOBAL level, where the
+    zero-accept ratchet means such a streak can only ever reach ``diversify``. There is
+    no ratchet per lineage, so the clause does not belong here.
+    """
+    return (not row["accepted"]) and row["delta"] <= 0.0
+
+
 def exhausted_lineages(rows: list[dict], cfg: PlateauConfig) -> list[str]:
     """Parents whose last ``lineage_window`` children were all dead.
 
     Independent of the global level: GEPA can have one exhausted lineage while
-    another is accepting every iteration.
+    another is accepting every iteration. Uses :func:`_lineage_dead`, NOT :func:`_dead` —
+    see that docstring for why an accept is never dead ground for a lineage.
     """
     by_parent: dict[str, list[dict]] = {}
     for r in rows:
@@ -250,7 +320,7 @@ def exhausted_lineages(rows: list[dict], cfg: PlateauConfig) -> list[str]:
     out = []
     for parent, children in by_parent.items():
         tail = children[-cfg.lineage_window:]
-        if len(tail) >= cfg.lineage_window and all(_dead(c) for c in tail):
+        if len(tail) >= cfg.lineage_window and all(_lineage_dead(c) for c in tail):
             out.append(parent)
     return sorted(out)
 
@@ -278,10 +348,16 @@ def assess(run_dir, cfg: PlateauConfig | None = None) -> PlateauState:
     near = sum(1 for r in tail if (not r["accepted"]) and r["delta"] > 0.0)
     accepts = sum(1 for r in rows if r["accepted"])
 
-    # The ratchet: any accept inside the streak caps escalation at `diversify`. Only a
-    # streak with zero accepts may reach `stop` — a GEPA run still widening its Pareto
-    # frontier is nudged, never killed.
-    if run_length >= cfg.stop_at and cfg.stop and accepts_in_streak == 0:
+    # The ratchet: any accept inside the streak caps escalation at `warn`. A run that is
+    # still clearing the honest val gate every iteration is doing the thing it was built
+    # to do — GEPA widening its per-instance Pareto frontier is exactly this shape — so it
+    # gets a warning and nothing more: no behavioural prompt intervention, never a stop.
+    # Only a streak with ZERO accepts may reach `diversify` or `stop`. That also keeps the
+    # diversify prompt block honest: it can only ever fire on a streak that really did
+    # fail, so it never tells the optimizer a lineage failed when it was accepting.
+    if accepts_in_streak:
+        level = "warn" if run_length >= cfg.warn_at else "ok"
+    elif run_length >= cfg.stop_at and cfg.stop:
         level = "stop"
     elif run_length >= cfg.diversify_at:
         level = "diversify"
@@ -295,12 +371,14 @@ def assess(run_dir, cfg: PlateauConfig | None = None) -> PlateauState:
                   f"(< window {cfg.window}); {near} near-miss(es) in the last "
                   f"{len(tail)}, {accepts} accept(s) total")
     else:
-        ratchet = ("" if accepts_in_streak == 0 else
-                   f"; {accepts_in_streak} non-best accept(s) in the streak cap "
-                   "escalation at diversify (frontier still widening)")
+        # Only claim "no near-miss" when the streak really contained neither a near-miss
+        # nor an accept; otherwise the string contradicts its own ratchet clause.
+        detail = ("; no near-miss in that streak" if accepts_in_streak == 0 else
+                  f"; but {accepts_in_streak} accept(s) in the streak cap escalation at "
+                  "warn (the gate is still passing — frontier still widening)")
         reason = (f"plateau: {run_length} consecutive iterations bought no new best val "
                   f"(warn {cfg.warn_at} / diversify {cfg.diversify_at} / "
-                  f"stop {cfg.stop_at}); no near-miss in that streak{ratchet}")
+                  f"stop {cfg.stop_at}){detail}")
 
     return PlateauState(
         level=level, run_length=run_length, iterations=len(rows), best_val=best_val,
@@ -331,7 +409,7 @@ def check(run_dir, cfg: PlateauConfig | None = None, *, last: PlateauState | Non
     return st
 
 
-def prompt_block(st: PlateauState, *, rejected=None, max_ids: int = 6) -> str:
+def prompt_block(st: PlateauState, *, max_ids: int = 6, max_id_chars: int = 60) -> str:
     """The escalation-level-1 intervention: a paradigm-shift block for the prompt.
 
     Empty string unless the level reached ``diversify``. This is *additive* to the
@@ -339,15 +417,21 @@ def prompt_block(st: PlateauState, *, rejected=None, max_ids: int = 6) -> str:
     "do not repeat these specific edits"; this says "the whole direction is dead,
     change strategy". Composed, they read as: avoid these, and do not just perturb
     them either.
+
+    Deliberately does NOT list rejected candidate ids: #129/PR222 already injects the
+    rejected approaches with their normalized signatures and reasons, which is strictly
+    more informative than bare ids. One channel, one owner. (The old ``rejected=``
+    parameter also called ``RejectedMemory.entries()``, which #199 removes — behind a
+    bare ``except`` that swallowed the AttributeError, so the line silently vanished in
+    the composed tree. Deleting it fixes the overlap and the silent loss at once.)
+
+    Bounded: ``max_ids`` lineages, each truncated to ``max_id_chars``, so the block has a
+    hard ceiling regardless of how many lineages a long GEPA run exhausts. The caller
+    must still route the result through ``optimizer_context.cap_instructions`` (or
+    ``render_instructions(extra=...)``) so the ASSEMBLED prompt is capped too.
     """
     if not st.should_diversify:
         return ""
-    ids = []
-    try:
-        entries = rejected.entries()[-max_ids:] if rejected is not None else []
-        ids = [str(e.get("candidate_id")) for e in entries if e.get("candidate_id")]
-    except Exception:  # noqa: BLE001 — memory shape is best-effort context
-        ids = []
     lines = [
         "",
         "## PLATEAU — CHANGE APPROACH (escalation: diversify)",
@@ -361,11 +445,12 @@ def prompt_block(st: PlateauState, *, rejected=None, max_ids: int = 6) -> str:
         "have not touched, remove something instead of adding), and state in one line "
         "which prior approach you are abandoning and why the new one differs in kind.",
     ]
-    if ids:
-        lines.append(f"Recently rejected candidates (do not re-derive these): {', '.join(ids)}.")
     if st.exhausted_lineages:
-        lines.append("Exhausted lineage(s) — every recent child of these failed, treat them "
-                     f"as dead ground: {', '.join(st.exhausted_lineages)}.")
+        shown = [str(p)[:max_id_chars] for p in st.exhausted_lineages[:max_ids]]
+        more = len(st.exhausted_lineages) - len(shown)
+        tail = f" (+{more} more)" if more > 0 else ""
+        lines.append("Exhausted lineage(s) — every recent child of these was rejected with "
+                     f"no improvement, treat them as dead ground: {', '.join(shown)}{tail}.")
     return "\n".join(lines) + "\n"
 
 

--- a/core/cap_evolve/plateau.py
+++ b/core/cap_evolve/plateau.py
@@ -1,0 +1,405 @@
+"""Plateau / convergence detection with escalating interventions.
+
+The engine already stops on *budget* (iterations, metric calls, USD) and on the
+``stall`` counter (N consecutive non-accepts). Neither answers the question this
+module answers: **is the search still making progress, or is it grinding a dead
+region?** ``stall`` counts rejections, and a rejection is not the same thing as a
+lack of progress.
+
+The criterion — why counting rejections is the wrong thing
+---------------------------------------------------------
+Optimization is legitimately spiky: several rejected iterations followed by a
+breakthrough is the normal shape of a run, so "N rejects in a row → stop" kills
+productive searches. The fix is to look at *what the gate actually rejected*.
+
+``gate.decide`` accepts iff ``Δ̄ > k_eff·SE(Δ)``. That splits rejections into two
+qualitatively different classes:
+
+* **near-miss** — ``Δ > 0`` but below the significance bar. The edit *did* move the
+  score; the run has not proven it yet. This is progress-in-flight, and #113's
+  Student-t small-sample correction makes it *strictly more common* (at n=5 the bar
+  is 1.14× wider than the old z bar, at n=2 it is 1.84× wider), so on small val
+  splits a healthy run now produces many near-misses. A heuristic that counted
+  those as "no progress" would over-trigger exactly where #113 tightened the bar.
+* **dead** — ``Δ ≤ 0``. The edit did not move the score at all, in the direction it
+  was supposed to.
+
+So ``run_length`` = the count of **trailing iterations that produced no new global
+best and were not a near-miss**. Concretely, an iteration is *dead* when it neither
+raised best-val nor moved the score in the right direction:
+
+* accepted **and** a new global best → alive, streak resets (real progress).
+* rejected with **Δ > 0** (near-miss) → alive, streak resets.
+* rejected with **Δ ≤ 0** → dead.
+* accepted but **not** a new best → dead *for the streak* (best-val velocity is 0,
+  which is what the user is paying for) — but see the ratchet below.
+
+That last case is why velocity is not a separate condition: it is folded in. It also
+matters in practice — GEPA can accept a frontier specialist that beats its own parent
+without ever topping the incumbent best, and a naive accept-reset lets such a run
+grind forever at flat best-val.
+
+**The ratchet:** an accept in the streak, even a non-best one, caps escalation at
+``diversify``. Only a streak with *zero* accepts can reach ``stop``. So a GEPA run
+still widening its Pareto frontier gets nudged to diversify but is never killed,
+while a run that has stopped accepting entirely does get stopped. Stopping early is
+the expensive error, so the conservative side is the default.
+
+Escalation ladder (``run_length`` vs the configured window W and step E)::
+
+    run_length >= W            -> "warn"       plateau_warning event only
+    run_length >= W + E        -> "diversify"  + a paradigm-shift prompt block,
+                                               + exhausted lineages de-prioritized
+    run_length >= W + 2*E      -> "stop"       loop breaks (if plateau_stop)
+
+Defaults W=6, E=2 → warn at 6, diversify at 8, stop at 10 dead iterations.
+
+Per-lineage exhaustion is a *different* question and is reported separately: a
+single parent can be exhausted (its last K children all dead) while the global
+search is fine, because another lineage is accepting. GEPA maintains many
+lineages, so it uses this to steer its Pareto sampling away from the dead region
+without stopping the run; hill-climb/skillopt are single-lineage (parent is always
+the current best), so for them exhaustion coincides with the global signal and
+only reaches the prompt.
+
+Not to be confused with #118's run *liveness* states (``live``/``stalled``/
+``crashed``/``done``), which are derived from events.jsonl mtime: *stalled* means
+nothing is happening at all. *Plateaued* means plenty is happening and none of it
+helps. Different question, different vocabulary, different event kind.
+
+Pure stdlib.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+
+from . import rundir as _rundir
+
+# Fallback for the shared iteration-event kind list (rundir.ITERATION_EVENT_KINDS,
+# added by #109/PR199). ponytail: one definition, preferred at runtime; delete this
+# literal once #199 lands. Never hand-filter on kind == "step" — GEPA emits
+# gepa_val_gate and would silently vanish.
+_FALLBACK_KINDS = ("step", "skillopt_step", "gepa_val_gate")
+
+# GEPA's cheap local minibatch gate. A child killed here never reaches the val gate,
+# so it emits no iteration event — but it IS a spent iteration that produced no
+# movement (sum(child) <= sum(parent) is the pass condition), and a GEPA run can grind
+# for many iterations without ever logging gepa_val_gate. Counted as dead.
+_LOCAL_GATE_KIND = "gepa_local_gate"
+
+
+@dataclass
+class PlateauConfig:
+    """Thresholds. All config-driven from ``capevolve.yaml`` / algorithm CLI flags."""
+
+    window: int = 6              # dead iterations before the first warning
+    escalate_every: int = 2      # further dead iterations per escalation step
+    lineage_window: int = 4      # dead children of one parent before it is exhausted
+    stop: bool = True            # allow the ladder to reach "stop"; False = warn/diversify only
+
+    @classmethod
+    def from_spec(cls, spec: dict | None) -> "PlateauConfig":
+        s = spec or {}
+        d = cls()
+        return cls(
+            window=max(2, int(s.get("plateau_window") or d.window)),
+            escalate_every=max(1, int(s.get("plateau_escalate_every") or d.escalate_every)),
+            lineage_window=max(2, int(s.get("plateau_lineage_window") or d.lineage_window)),
+            stop=(d.stop if s.get("plateau_stop") is None else bool(s.get("plateau_stop"))),
+        )
+
+    @property
+    def warn_at(self) -> int:
+        return self.window
+
+    @property
+    def diversify_at(self) -> int:
+        return self.window + self.escalate_every
+
+    @property
+    def stop_at(self) -> int:
+        return self.window + 2 * self.escalate_every
+
+
+LEVELS = ("ok", "warn", "diversify", "stop")
+
+
+@dataclass
+class PlateauState:
+    level: str = "ok"
+    run_length: int = 0           # trailing iterations rejected with Δ <= 0
+    iterations: int = 0           # iterations observed in total
+    best_val: float = 0.0
+    velocity: float = 0.0         # best-val gain over the trailing streak (0 while plateaued)
+    near_misses: int = 0          # rejected-but-Δ>0 seen in the last `window` iterations
+    accepts: int = 0
+    accepts_in_streak: int = 0   # accepts inside the dead streak -> caps escalation at diversify
+    exhausted_lineages: list[str] = field(default_factory=list)
+    reason: str = ""
+
+    @property
+    def should_stop(self) -> bool:
+        return self.level == "stop"
+
+    @property
+    def should_diversify(self) -> bool:
+        return self.level in ("diversify", "stop")
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+def _iteration_events(run_dir) -> list[dict]:
+    """Gated iterations (accept/reject with a val number), via the shared reader."""
+    fn = getattr(run_dir, "iteration_events", None)
+    if callable(fn):
+        return fn()
+    kinds = getattr(_rundir, "ITERATION_EVENT_KINDS", _FALLBACK_KINDS)
+    cand = getattr(_rundir, "iteration_candidate", lambda e: e.get("candidate") or e.get("candidate_id"))
+    out = []
+    for rec in _raw_events(run_dir):
+        if rec.get("kind") in kinds and cand(rec):
+            out.append(rec)
+    return out
+
+
+def _raw_events(run_dir) -> list[dict]:
+    out: list[dict] = []
+    try:
+        path = run_dir.events_path
+        if not path.exists():
+            return out
+        for line in path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line:
+                out.append(json.loads(line))
+    except Exception:  # noqa: BLE001 — a torn/absent log must not break the loop
+        return out
+    return out
+
+
+def series(run_dir) -> list[dict]:
+    """Every spent iteration in order, as ``{candidate, parent, accepted, delta}``.
+
+    Merges the gated iterations (``step`` / ``skillopt_step`` / ``gepa_val_gate``)
+    with GEPA's locally-killed children (``gepa_local_gate`` with ``passed=False``),
+    which are spent iterations that never reach the val gate. ``delta`` is
+    ``val - parent_val``; when the event carries no ``parent_val`` (skillopt_step,
+    single lineage) it is taken against the running best, which is that algorithm's
+    actual parent.
+    """
+    gated = {id(e): e for e in _iteration_events(run_dir)}
+    rows = []
+    for rec in _raw_events(run_dir):
+        if rec.get("kind") == _LOCAL_GATE_KIND and not rec.get("passed"):
+            rows.append((rec.get("t") or 0.0, rec, True))
+    for e in _iteration_events(run_dir):
+        rows.append((e.get("t") or 0.0, e, False))
+    rows.sort(key=lambda r: r[0])
+    del gated
+
+    out: list[dict] = []
+    best = None
+    for _t, ev, local in rows:
+        cid = ev.get("candidate") or ev.get("candidate_id")
+        if local:
+            out.append({"candidate": cid, "parent": ev.get("parent"),
+                        "accepted": False, "delta": 0.0, "local": True})
+            continue
+        accepted = bool(ev.get("accept"))
+        val = ev.get("val")
+        val = float(val) if val is not None else None
+        pv = ev.get("parent_val")
+        base = float(pv) if pv is not None else best
+        delta = (val - base) if (val is not None and base is not None) else 0.0
+        new_best = bool(accepted and val is not None and (best is None or val > best))
+        out.append({"candidate": cid, "parent": ev.get("parent"),
+                    "accepted": accepted, "delta": delta, "local": False,
+                    "val": val, "new_best": new_best})
+        if val is not None and (best is None or val > best):
+            best = val
+    return out
+
+
+def _dead(row: dict) -> bool:
+    """A spent iteration that bought no progress.
+
+    Alive = raised the global best, OR was a near-miss (rejected with Δ > 0 — the
+    anti-false-positive class, which #113's t-correction enlarged). Everything else
+    is dead, including an accept that did not top the incumbent best (best-val
+    velocity 0). ``new_best`` is annotated by :func:`series`.
+    """
+    if row["accepted"]:
+        return not row.get("new_best")   # accepted but not a new best -> velocity 0
+    return row["delta"] <= 0.0           # rejected: a near-miss (Δ>0) is alive
+
+
+def exhausted_lineages(rows: list[dict], cfg: PlateauConfig) -> list[str]:
+    """Parents whose last ``lineage_window`` children were all dead.
+
+    Independent of the global level: GEPA can have one exhausted lineage while
+    another is accepting every iteration.
+    """
+    by_parent: dict[str, list[dict]] = {}
+    for r in rows:
+        p = r.get("parent")
+        if p:
+            by_parent.setdefault(str(p), []).append(r)
+    out = []
+    for parent, children in by_parent.items():
+        tail = children[-cfg.lineage_window:]
+        if len(tail) >= cfg.lineage_window and all(_dead(c) for c in tail):
+            out.append(parent)
+    return sorted(out)
+
+
+def assess(run_dir, cfg: PlateauConfig | None = None) -> PlateauState:
+    """Read the run's event stream and decide the current escalation level."""
+    cfg = cfg or PlateauConfig()
+    rows = series(run_dir)
+    if not rows:
+        return PlateauState(reason="no iterations yet")
+
+    run_length = 0
+    accepts_in_streak = 0
+    for r in reversed(rows):
+        if _dead(r):
+            run_length += 1
+            if r["accepted"]:
+                accepts_in_streak += 1
+        else:
+            break
+
+    vals = [r["val"] for r in rows if r.get("val") is not None]
+    best_val = max(vals) if vals else 0.0
+    tail = rows[-cfg.window:]
+    near = sum(1 for r in tail if (not r["accepted"]) and r["delta"] > 0.0)
+    accepts = sum(1 for r in rows if r["accepted"])
+
+    # The ratchet: any accept inside the streak caps escalation at `diversify`. Only a
+    # streak with zero accepts may reach `stop` — a GEPA run still widening its Pareto
+    # frontier is nudged, never killed.
+    if run_length >= cfg.stop_at and cfg.stop and accepts_in_streak == 0:
+        level = "stop"
+    elif run_length >= cfg.diversify_at:
+        level = "diversify"
+    elif run_length >= cfg.warn_at:
+        level = "warn"
+    else:
+        level = "ok"
+
+    if level == "ok":
+        reason = (f"progressing: {run_length} dead iteration(s) in a row "
+                  f"(< window {cfg.window}); {near} near-miss(es) in the last "
+                  f"{len(tail)}, {accepts} accept(s) total")
+    else:
+        ratchet = ("" if accepts_in_streak == 0 else
+                   f"; {accepts_in_streak} non-best accept(s) in the streak cap "
+                   "escalation at diversify (frontier still widening)")
+        reason = (f"plateau: {run_length} consecutive iterations bought no new best val "
+                  f"(warn {cfg.warn_at} / diversify {cfg.diversify_at} / "
+                  f"stop {cfg.stop_at}); no near-miss in that streak{ratchet}")
+
+    return PlateauState(
+        level=level, run_length=run_length, iterations=len(rows), best_val=best_val,
+        velocity=0.0 if run_length else best_val, near_misses=near, accepts=accepts,
+        accepts_in_streak=accepts_in_streak,
+        exhausted_lineages=exhausted_lineages(rows, cfg), reason=reason,
+    )
+
+
+def check(run_dir, cfg: PlateauConfig | None = None, *, last: PlateauState | None = None,
+          algorithm: str = "") -> PlateauState:
+    """``assess`` + emit events on change, so the terminal/dashboard can show it.
+
+    ``plateau`` fires whenever the escalation level changes (including back to
+    ``ok`` — a plateau that broke is news too). ``lineage_exhausted`` fires once per
+    newly-exhausted parent.
+    """
+    st = assess(run_dir, cfg)
+    prev_level = last.level if last else "ok"
+    prev_ex = set(last.exhausted_lineages) if last else set()
+    if st.level != prev_level:
+        run_dir.log_event("plateau", algorithm=algorithm, **st.to_dict())
+    for parent in st.exhausted_lineages:
+        if parent not in prev_ex:
+            run_dir.log_event("lineage_exhausted", algorithm=algorithm, parent=parent,
+                              window=(cfg or PlateauConfig()).lineage_window,
+                              plateau_level=st.level)
+    return st
+
+
+def prompt_block(st: PlateauState, *, rejected=None, max_ids: int = 6) -> str:
+    """The escalation-level-1 intervention: a paradigm-shift block for the prompt.
+
+    Empty string unless the level reached ``diversify``. This is *additive* to the
+    algorithm's own prompt and to #129's rejected-approach constraints — those say
+    "do not repeat these specific edits"; this says "the whole direction is dead,
+    change strategy". Composed, they read as: avoid these, and do not just perturb
+    them either.
+    """
+    if not st.should_diversify:
+        return ""
+    ids = []
+    try:
+        entries = rejected.entries()[-max_ids:] if rejected is not None else []
+        ids = [str(e.get("candidate_id")) for e in entries if e.get("candidate_id")]
+    except Exception:  # noqa: BLE001 — memory shape is best-effort context
+        ids = []
+    lines = [
+        "",
+        "## PLATEAU — CHANGE APPROACH (escalation: diversify)",
+        f"The last {st.run_length} iterations bought no new best val: no near-misses, "
+        "no movement in the direction that counts. Best val has not improved "
+        f"({st.best_val:.3f}). Incrementally refining the current approach is not "
+        "working and repeating it will spend the rest of the budget for nothing.",
+        "REQUIRED this iteration: make a MATERIALLY DIFFERENT change, not a variation "
+        "of the previous attempts. Pick a different mechanism (e.g. move a rule from "
+        "prose into code, restructure rather than reword, attack a task cluster you "
+        "have not touched, remove something instead of adding), and state in one line "
+        "which prior approach you are abandoning and why the new one differs in kind.",
+    ]
+    if ids:
+        lines.append(f"Recently rejected candidates (do not re-derive these): {', '.join(ids)}.")
+    if st.exhausted_lineages:
+        lines.append("Exhausted lineage(s) — every recent child of these failed, treat them "
+                     f"as dead ground: {', '.join(st.exhausted_lineages)}.")
+    return "\n".join(lines) + "\n"
+
+
+def _demo() -> None:
+    """Self-check: a spiky-but-progressing run must NOT trigger; a dead one must."""
+    import tempfile
+    from pathlib import Path
+
+    from .rundir import RunDir
+
+    cfg = PlateauConfig(window=4, escalate_every=2)
+
+    def build(steps):
+        d = Path(tempfile.mkdtemp())
+        rd = RunDir.create(d)
+        prev = 0.0
+        for accept, val in steps:
+            rd.log_event("step", candidate=f"c{val}", accept=accept, val=val, parent_val=prev)
+            if accept:
+                prev = val
+        return rd
+
+    # Spiky but progressing: near-misses (Δ>0, sub-significant) then a breakthrough.
+    spiky = build([(False, 0.05), (False, 0.08), (False, 0.06), (False, 0.09),
+                   (False, 0.07), (False, 0.10), (True, 0.40)])
+    assert assess(spiky, cfg).level == "ok", assess(spiky, cfg)
+
+    # Dead: every child scores at or below its parent.
+    dead = build([(False, 0.0)] * 8)
+    st = assess(dead, cfg)
+    assert st.level == "stop", st
+    assert st.run_length == 8, st
+    print("plateau self-check OK")
+
+
+if __name__ == "__main__":
+    _demo()

--- a/core/cap_evolve/skillopt.py
+++ b/core/cap_evolve/skillopt.py
@@ -303,13 +303,13 @@ def skillopt_loop(
             label += f"(mini-batch of {len(minibatch_ids)} train tasks, L={L})"
             instructions = harness._focus_instructions(current_val, minibatch_ids, label)
             instructions += "\n" + _buffer_block(L, step_buffer, rejected_this_epoch)
-            instructions += plateau.prompt_block(pstate, rejected=rejected)
 
             cid = f"so_e{epoch:02d}s{s + 1:02d}"
             parent_dir = run_dir.candidate_dir(run_dir.best_id)  # single lineage: always best
             step = harness.run_step(
                 adapter, run_dir=run_dir, parent_dir=parent_dir,
                 optimizer=optimizer, instructions=instructions, current_val=current_val,
+                extra_instructions=plateau.prompt_block(pstate),
                 n_trials=n_trials, gate_kwargs=gate_kwargs, candidate_id=cid,
                 no_regression=no_regression, rejected=rejected, history=history, store=store,
             )

--- a/core/cap_evolve/skillopt.py
+++ b/core/cap_evolve/skillopt.py
@@ -49,6 +49,7 @@ import random
 from pathlib import Path
 
 from . import harness
+from . import plateau
 from .lr_schedule import build_schedule
 from .loop import SplitResult
 from .rundir import RunDir
@@ -213,6 +214,7 @@ def skillopt_loop(
     slow_update_sample: int = 20,
     algorithm: str = "skillopt",
     store=None,
+    plateau_cfg: "plateau.PlateauConfig | None" = None,
 ) -> dict:
     """Run the SkillOpt epochs × mini-batches climb.
 
@@ -253,11 +255,19 @@ def skillopt_loop(
     epoch_stats: list[dict] = []
     global_step = 0
     stop_reason = None
+    # Plateau detection (cap_evolve.plateau): third stop condition. SkillOpt is
+    # single-lineage (parent is always best), so lineage exhaustion coincides with the
+    # global signal and only reaches the prompt — there is no alternative parent to
+    # steer toward, which is exactly the distinction from GEPA.
+    pcfg = plateau_cfg or plateau.PlateauConfig()
+    pstate = plateau.PlateauState()
 
     for epoch in range(1, epochs + 1):
         exhausted, why = run_dir.budget_exhausted()
         if exhausted:
             stop_reason = why
+            break
+        if pstate.should_stop:
             break
 
         # Per-epoch: shuffle ids (seeded by epoch for reproducibility), reset the
@@ -277,6 +287,10 @@ def skillopt_loop(
             if exhausted:
                 stop_reason = why
                 break
+            pstate = plateau.check(run_dir, pcfg, last=pstate, algorithm=algorithm)
+            if pstate.should_stop:
+                stop_reason = f"plateaued ({pstate.reason})"
+                break
 
             # mini-batch(es): the accumulation window of the shuffled order.
             start = s * group
@@ -289,6 +303,7 @@ def skillopt_loop(
             label += f"(mini-batch of {len(minibatch_ids)} train tasks, L={L})"
             instructions = harness._focus_instructions(current_val, minibatch_ids, label)
             instructions += "\n" + _buffer_block(L, step_buffer, rejected_this_epoch)
+            instructions += plateau.prompt_block(pstate, rejected=rejected)
 
             cid = f"so_e{epoch:02d}s{s + 1:02d}"
             parent_dir = run_dir.candidate_dir(run_dir.best_id)  # single lineage: always best
@@ -363,6 +378,7 @@ def skillopt_loop(
             "slow_update": (slow_rec["action"] if slow_rec else "skipped"),
         })
 
+    pstate = plateau.check(run_dir, pcfg, last=pstate, algorithm=algorithm)
     if stop_reason is None:
         _, why = run_dir.budget_exhausted()
         stop_reason = why or "epochs_exhausted"
@@ -380,6 +396,7 @@ def skillopt_loop(
         "slow_updates": [{"epoch": r["epoch"], "action": r["action"],
                           "accepted": r["step"]["accepted"]} for r in slow_updates],
         "stop_reason": stop_reason,
+        "plateau": pstate.to_dict(),
         "steps": steps,
     }
 

--- a/core/tests/test_plateau.py
+++ b/core/tests/test_plateau.py
@@ -106,10 +106,12 @@ def test_plateau_stop_false_caps_at_diversify(tmp_path):
     assert st.should_diversify
 
 
-def test_non_best_accepts_are_dead_but_ratchet_caps_at_diversify(tmp_path):
+def test_non_best_accepts_are_dead_but_ratchet_caps_at_warn(tmp_path):
     """GEPA can accept a frontier specialist that beats its own parent but never tops
-    the incumbent best. Best-val velocity is 0, so those iterations ARE dead — but a
-    streak containing accepts is capped at ``diversify`` and never killed."""
+    the incumbent best. Best-val velocity is 0, so those iterations ARE dead for the
+    streak — but a streak containing accepts is capped at ``warn``: no stop, and no
+    behavioural prompt block either, because telling an optimizer that is clearing the
+    honest val gate every iteration "the direction is dead" would be false."""
     cfg = plateau.PlateauConfig(window=2, escalate_every=1)
     rd = _rd(tmp_path)
     _step(rd, "best", accept=True, val=1.0, parent_val=0.0, parent="seed")
@@ -118,8 +120,13 @@ def test_non_best_accepts_are_dead_but_ratchet_caps_at_diversify(tmp_path):
     st = plateau.assess(rd, cfg)
     assert st.run_length == 10, st
     assert st.accepts_in_streak == 10, st
-    assert st.level == "diversify", "a still-accepting run must not be stopped"
-    assert not st.should_stop and st.should_diversify
+    assert st.level == "warn", "a still-accepting run must not be stopped or redirected"
+    assert not st.should_stop and not st.should_diversify
+    # The reason must not contradict its own ratchet clause (review #6).
+    assert "no near-miss" not in st.reason, st.reason
+    assert "frontier still widening" in st.reason, st.reason
+    # No prompt block on this path: the block asserts the direction failed.
+    assert plateau.prompt_block(st) == ""
 
 
 def test_zero_accept_streak_does_reach_stop(tmp_path):
@@ -172,16 +179,48 @@ def test_gepa_local_gate_rejections_count(tmp_path):
     assert st.iterations == 5 and st.level == "stop", st
 
 
-def test_skillopt_step_events_are_seen(tmp_path):
+def test_real_skillopt_iteration_is_counted_ONCE(tmp_path):
+    """REGRESSION (review blocking #1) — the false positive that killed productive runs.
+
+    A real SkillOpt iteration logs the event PAIR: ``harness.run_step`` logs ``step``
+    (with parent + parent_val), then ``skillopt.py`` logs ``skillopt_step`` for the SAME
+    candidate as an audit record. Counting both meant one iteration counted twice, so a
+    ``window=6`` ladder reached ``stop`` at iteration 5 — with a *productive* run — and a
+    genuine near-miss was recorded once alive and once dead (the duplicate carries no
+    parent_val, so its delta was taken against the running best).
+
+    The old ``test_skillopt_step_events_are_seen`` logged ``skillopt_step`` ALONE, a shape
+    that never occurs in production, which is why 28 tests missed this.
+    """
+    cfg = plateau.PlateauConfig(window=6, escalate_every=2)   # shipped defaults
+    rd = _rd(tmp_path)
+    for i in range(1, 6):
+        cid = f"so_e01s{i:02d}"
+        # the production pair, in production order:
+        rd.log_event("step", candidate=cid, accept=False, val=0.5,
+                     parent_val=0.5, parent="seed")
+        rd.log_event("skillopt_step", candidate=cid, accept=False, val=0.5, epoch=1)
+    st = plateau.assess(rd, cfg)
+    assert st.iterations == 5, f"5 real iterations must be 5 rows, got {st.iterations}"
+    assert st.run_length == 5, st
+    assert st.level == "ok", "a window=6 ladder must NOT fire at iteration 5"
+
+
+def test_skillopt_near_miss_is_not_also_recorded_dead(tmp_path):
+    """The nastier half of blocking #1: the duplicate row had no ``parent_val``, so a
+    near-miss (Δ>0, sub-significant) was recorded alive by ``step`` and dead by
+    ``skillopt_step`` — and the dead copy was the trailing row ``assess`` reads."""
     cfg = plateau.PlateauConfig(window=2, escalate_every=1)
     rd = _rd(tmp_path)
-    for i in range(5):
-        rd.log_event("skillopt_step", candidate=f"so_{i}", accept=False, val=0.2)
+    _step(rd, "so_e01s01", accept=True, val=0.9, parent_val=0.0, parent="seed")
+    for i in range(2, 8):   # a run of genuine near-misses against a best of 0.9
+        cid = f"so_e01s{i:02d}"
+        rd.log_event("step", candidate=cid, accept=False, val=0.95,
+                     parent_val=0.90, parent="so_e01s01")
+        rd.log_event("skillopt_step", candidate=cid, accept=False, val=0.95, epoch=1)
     st = plateau.assess(rd, cfg)
-    assert st.iterations == 5, st
-    # skillopt_step carries no parent_val; delta is taken against the running best,
-    # which for a single-lineage climber IS the parent.
-    assert st.level == "stop", st
+    assert st.run_length == 0, f"near-misses must keep the streak at 0, got {st.run_length}"
+    assert st.level == "ok", st
 
 
 # ---- per-lineage exhaustion vs GLOBAL plateau -----------------------------
@@ -272,14 +311,33 @@ def test_prompt_block_only_from_diversify(tmp_path):
     assert "5 iterations" in blk
 
 
-def test_prompt_block_lists_rejected_ids(tmp_path):
-    from cap_evolve.memory import RejectedMemory
-    mem = RejectedMemory(tmp_path / "rejected.jsonl")
-    mem.add("cand_a", "summary a", "gate reject", 0.1)
-    mem.add("cand_b", "summary b", "gate reject", 0.1)
-    blk = plateau.prompt_block(plateau.PlateauState(level="diversify", run_length=5),
-                               rejected=mem)
-    assert "cand_a" in blk and "cand_b" in blk
+def test_prompt_block_does_not_duplicate_222s_rejected_channel(tmp_path):
+    """The block deliberately lists NO rejected candidate ids (review blocking #3b / #11).
+
+    #129/PR222 already injects rejected approaches with normalized signatures and reasons;
+    bare ids were strictly less informative and sat right next to that block. The old
+    implementation also called ``RejectedMemory.entries()``, which #199 REMOVES, behind a
+    bare ``except`` — so on the composed tree the line silently vanished with no error.
+    Deleting the line fixes the overlap and the silent loss in one edit; ``prompt_block``
+    no longer takes a ``rejected`` argument at all, so a caller passing one fails loudly.
+    """
+    st = plateau.PlateauState(level="diversify", run_length=5)
+    blk = plateau.prompt_block(st)
+    assert "MATERIALLY DIFFERENT" in blk
+    assert "rejected candidates" not in blk
+    with pytest.raises(TypeError):
+        plateau.prompt_block(st, rejected=object())      # type: ignore[call-arg]
+
+
+def test_prompt_block_is_bounded(tmp_path):
+    """Blocking #3a, second half: the block itself had no ceiling — ``exhausted_lineages``
+    was joined with no limit, so 200 lineages x 400-char ids grew it without bound."""
+    st = plateau.PlateauState(level="diversify", run_length=9,
+                              exhausted_lineages=[f"lineage_{i}_" + "x" * 400
+                                                  for i in range(200)])
+    blk = plateau.prompt_block(st)
+    assert len(blk) < 2000, f"block must be bounded, got {len(blk)}"
+    assert "+194 more" in blk, blk[-300:]
 
 
 # ---- config ---------------------------------------------------------------
@@ -292,8 +350,11 @@ def test_config_from_spec_and_ladder():
     assert cfg.lineage_window == 5 and cfg.stop is False
     d = plateau.PlateauConfig.from_spec({})
     assert (d.window, d.escalate_every, d.lineage_window, d.stop) == (6, 2, 4, True)
-    # an absent key must not be read as 0 (which would escalate immediately)
-    assert plateau.PlateauConfig.from_spec({"plateau_window": 0}).window == 6
+    # An absent key must not be read as 0 (which would escalate immediately)...
+    assert plateau.PlateauConfig.from_spec({}).window == 6
+    # ...but an EXPLICIT `plateau_window: 0` now means "off" (review #10), not "default 6".
+    off = plateau.PlateauConfig.from_spec({"plateau_window": 0})
+    assert off.stop is False and off.warn_at > 10 ** 6, off
 
 
 def test_empty_and_unreadable_run_is_ok(tmp_path):
@@ -401,8 +462,11 @@ def test_hill_climb_loop_injects_diversify_block(tmp_path, monkeypatch):
     n = {"i": 0}
 
     def fake_run_step(adapter, *, run_dir, parent_dir, optimizer, instructions,
-                      current_val, **kw):
-        seen.append(instructions)
+                      current_val, extra_instructions="", **kw):
+        # The block now travels as `extra_instructions` so run_step can route it THROUGH
+        # _augment_instructions (inside #222's cap, in its preserved tail) rather than
+        # having it appended past the cap at the call site. Assert on what really ships.
+        seen.append(instructions + extra_instructions)
         n["i"] += 1
         run_dir.log_event("step", candidate=f"c{n['i']}", accept=False, val=0.5,
                           parent="seed", parent_val=0.5)
@@ -436,6 +500,144 @@ def test_gepa_skips_exhausted_lineage_in_selection():
     # every lineage dead -> fall back to the whole pool, the GLOBAL level decides
     sample_pool = [c for c in pool if c["id"] not in {"seed", "a", "b"}] or pool
     assert len(sample_pool) == 3
+
+
+def test_all_accepted_lineage_is_NOT_exhausted(tmp_path):
+    """REGRESSION (review blocking #4) — GEPA steering away from its BEST lineage.
+
+    ``exhausted_lineages`` reused ``_dead()``, which counts accepted-but-not-global-best
+    as dead. So a lineage whose children were ALL accepted was marked exhausted and
+    dropped from GEPA's sampling pool — and unlike the global level there is no ratchet on
+    this path, no stop event, nothing in the summary. Widening the per-instance Pareto
+    frontier IS GEPA's mechanism, so an accept is never dead ground for a lineage.
+    """
+    cfg = plateau.PlateauConfig(lineage_window=4)
+    rd = _rd(tmp_path)
+    _step(rd, "champion", accept=True, val=1.0, parent_val=0.0, parent="other")
+    for i in range(5):   # 5 children of `p_hot`, ALL ACCEPTED, all Δ>0, none topping 1.0
+        _step(rd, f"hot{i}", accept=True, val=0.70 + i * 0.01, parent_val=0.60,
+              parent="p_hot")
+    st = plateau.assess(rd, cfg)
+    assert st.exhausted_lineages == [], \
+        f"an all-accepting lineage must stay in the pool, got {st.exhausted_lineages}"
+    # ...while a genuinely dead lineage in the same run IS still reported.
+    for i in range(4):
+        _step(rd, f"cold{i}", accept=False, val=0.5, parent_val=0.5, parent="p_cold")
+    assert plateau.assess(rd, cfg).exhausted_lineages == ["p_cold"]
+
+
+def test_lineage_with_one_accept_in_the_tail_is_not_exhausted(tmp_path):
+    """The narrower predicate at its boundary: a single accept inside the window keeps a
+    lineage alive, whatever it did for the global best."""
+    cfg = plateau.PlateauConfig(lineage_window=3)
+    rd = _rd(tmp_path)
+    _step(rd, "best", accept=True, val=1.0, parent_val=0.0, parent="seed")
+    _step(rd, "a", accept=False, val=0.4, parent_val=0.5, parent="p1")
+    _step(rd, "b", accept=True, val=0.6, parent_val=0.4, parent="p1")   # non-best accept
+    _step(rd, "c", accept=False, val=0.4, parent_val=0.5, parent="p1")
+    assert plateau.assess(rd, cfg).exhausted_lineages == []
+
+
+def test_local_gate_tie_and_regression_are_distinguishable(tmp_path):
+    """Review #7: ``series`` hardcoded ``delta: 0.0`` for every local-gate row, throwing
+    away the ``child_sum``/``parent_sum`` the event already carries. Both are still dead
+    (gepa's pass condition is a strict ``>``), but the series must not lie about which."""
+    rd = _rd(tmp_path)
+    rd.log_event("gepa_local_gate", candidate="tie", parent="seed",
+                 child_sum=2.0, parent_sum=2.0, passed=False)
+    rd.log_event("gepa_local_gate", candidate="reg", parent="seed",
+                 child_sum=1.0, parent_sum=2.0, passed=False)
+    rows = plateau.series(rd)
+    assert rows[0]["delta"] == 0.0, rows[0]
+    assert rows[1]["delta"] == -1.0, rows[1]
+    assert all(plateau._dead(r) for r in rows), "both are still dead"
+
+
+# ---- the crash and the prompt-assembly seam -------------------------------
+
+def test_zero_iteration_loop_does_not_crash(tmp_path):
+    """REGRESSION (review blocking #2) — ``NameError: cannot access local variable 'why'``.
+
+    ``why`` was only bound inside the ``for i in range(max_iterations)`` body, but read
+    after it. ``max_iterations=0`` — reachable from a spec and from a resume whose budget
+    is already spent — crashed instead of returning a clean zero-iteration result.
+    """
+    from cap_evolve import harness
+    from cap_evolve.loop import SplitResult
+    from cap_evolve.splits import Splits
+
+    rd = RunDir.create(tmp_path, budget=Budget(max_iterations=0))
+    rd.write_splits(Splits(train=["t1"], val=["v1"], test=["s1"]))
+    rd.candidate_dir("seed").mkdir(parents=True, exist_ok=True)
+    rd.set_best("seed")
+    base = SplitResult(split="val", reward=0.5, stderr=0.0,
+                       per_task=[{"task_id": "v1", "reward": 0.5}])
+
+    res = harness.hill_climb_loop(object(), run_dir=rd, optimizer=lambda w, i: None,
+                                  current_val=base, max_iterations=0)
+    assert res["iterations"] == 0 and res["steps"] == []
+    assert res["stop_reason"], "a zero-iteration run must still report why"
+
+
+def test_plateau_block_reaches_the_prompt_inside_the_cap(tmp_path):
+    """REGRESSION (review blocking #3a + the #199 merge trap).
+
+    Two things must hold at once and only one of them is about size:
+
+    1. The block must be INSIDE whatever cap the tree has. It used to be appended after
+       ``_augment_instructions``, escaping #222's ``MAX_INSTRUCTIONS_CHARS`` (measured
+       64941 > 60000), and landing where truncation elides — so the one *behavioural*
+       block would be dropped while the two context-only blocks survived.
+    2. The block must actually ARRIVE. #199 replaces ``_focus_instructions`` with
+       ``render_instructions`` and reassigns ``instructions``; resolving that conflict the
+       obvious "keep both sides" way compiles clean with the plateau feature SILENTLY
+       DEAD. This assertion is what makes a bad merge resolution fail loudly.
+    """
+    from cap_evolve import harness
+    from cap_evolve.memory import History, RejectedMemory
+
+    rd = _rd(tmp_path)
+    workdir = tmp_path / "wd"
+    workdir.mkdir()
+    block = plateau.prompt_block(plateau.PlateauState(level="diversify", run_length=9,
+                                                      exhausted_lineages=["p1"]))
+    assert block, "diversify must produce a block"
+    # Signature-agnostic: #129/PR222 drops `rejected, history` from this function (it reads
+    # them off the run dir instead). Only `extra` is #221's contract, so bind by NAME and
+    # fill whatever positional memory params this tree still has.
+    import inspect
+    params = list(inspect.signature(harness._augment_instructions).parameters)
+    extras = {"rejected": RejectedMemory(tmp_path / "r.jsonl"),
+              "history": History(tmp_path / "h.jsonl")}
+    kw = {k: v for k, v in extras.items() if k in params}
+    out = harness._augment_instructions("BASE INSTRUCTIONS", workdir, rd, extra=block, **kw)
+    assert "MATERIALLY DIFFERENT" in out, "the plateau block never reached the prompt"
+    assert out.rstrip().endswith(block.rstrip()), \
+        "the behavioural block must be LAST, in the tail truncation preserves"
+    try:
+        from cap_evolve.optimizer_context import MAX_INSTRUCTIONS_CHARS
+    except Exception:                                  # pre-#222 tree: no cap to check
+        return
+    assert len(out) <= MAX_INSTRUCTIONS_CHARS, len(out)
+
+
+def test_resume_carries_the_streak(tmp_path):
+    """Review #9, documenting the intended behaviour rather than changing it: the streak
+    is derived from the whole event log, so a resumed run re-derives ``stop`` before
+    spending an iteration. A dead region is still dead after a restart; re-spending
+    budget to rediscover it is the error this module exists to prevent. The escape hatch
+    is ``plateau_stop: false`` / ``--no-plateau-stop``."""
+    cfg = plateau.PlateauConfig(window=2, escalate_every=1)
+    rd = _rd(tmp_path)
+    for i in range(6):
+        _step(rd, f"d{i}", accept=False, val=0.5, parent_val=0.5, parent="seed")
+    assert plateau.assess(rd, cfg).level == "stop"
+
+    reopened = RunDir(rd.root)                    # a fresh handle == what --resume does
+    st = plateau.assess(reopened, cfg)
+    assert st.level == "stop" and st.run_length == 6, st
+    off = plateau.PlateauConfig(window=2, escalate_every=1, stop=False)
+    assert plateau.assess(reopened, off).level == "diversify"
 
 
 # ---- surfacing ------------------------------------------------------------

--- a/core/tests/test_plateau.py
+++ b/core/tests/test_plateau.py
@@ -1,0 +1,472 @@
+"""Plateau/convergence detection (#130).
+
+The load-bearing test is ``test_spiky_but_progressing_never_escalates``: the whole
+design risk is a heuristic that kills a productive-but-slow run.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from cap_evolve import plateau
+from cap_evolve.rundir import Budget, RunDir
+
+
+def _rd(tmp_path) -> RunDir:
+    return RunDir.create(tmp_path, budget=Budget(max_iterations=50))
+
+
+def _step(rd, cid, *, accept, val, parent_val, kind="step", parent=None):
+    rd.log_event(kind, candidate=cid, accept=accept, val=val,
+                 parent_val=parent_val, parent=parent)
+
+
+# ---- the criterion --------------------------------------------------------
+
+def test_dead_run_escalates_warn_then_diversify_then_stop(tmp_path):
+    """Every child scores at or below its parent -> the full ladder."""
+    cfg = plateau.PlateauConfig(window=3, escalate_every=2)
+    rd = _rd(tmp_path)
+    seen = []
+    for i in range(1, 8):
+        _step(rd, f"c{i}", accept=False, val=0.5, parent_val=0.5, parent="seed")
+        seen.append(plateau.assess(rd, cfg).level)
+    # run_length 1,2 -> ok; 3,4 -> warn; 5,6 -> diversify; 7 -> stop
+    assert seen == ["ok", "ok", "warn", "warn", "diversify", "diversify", "stop"], seen
+
+
+def test_spiky_but_progressing_never_escalates(tmp_path):
+    """THE anti-false-positive test.
+
+    A healthy run on a small val split under #113's Student-t bar produces long
+    stretches of *near-misses*: rejected because Δ did not clear k_eff·SE, but Δ>0.
+    That is progress-in-flight, not a plateau, and must never escalate — even for
+    far more consecutive rejections than the plateau window.
+    """
+    cfg = plateau.PlateauConfig(window=3, escalate_every=2)
+    rd = _rd(tmp_path)
+    # 12 consecutive REJECTIONS, all with Δ>0 (sub-significant improvements).
+    for i, v in enumerate([0.51, 0.53, 0.52, 0.55, 0.54, 0.57,
+                           0.56, 0.58, 0.59, 0.57, 0.60, 0.62], 1):
+        _step(rd, f"c{i}", accept=False, val=v, parent_val=0.50, parent="seed")
+    st = plateau.assess(rd, cfg)
+    assert st.level == "ok", st
+    assert st.run_length == 0, st
+    assert st.near_misses > 0, st
+    # And the naive heuristic WOULD have fired: 12 rejects in a row >> window 3.
+    assert st.iterations == 12
+
+
+def test_one_near_miss_resets_the_streak(tmp_path):
+    """A single Δ>0 rejection mid-streak resets, so a run can't be killed by noise."""
+    cfg = plateau.PlateauConfig(window=3, escalate_every=2)
+    rd = _rd(tmp_path)
+    for i in range(4):  # dead
+        _step(rd, f"d{i}", accept=False, val=0.5, parent_val=0.5, parent="seed")
+    assert plateau.assess(rd, cfg).level == "warn"
+    _step(rd, "near", accept=False, val=0.55, parent_val=0.50, parent="seed")  # Δ>0
+    st = plateau.assess(rd, cfg)
+    assert st.level == "ok" and st.run_length == 0, st
+
+
+def test_accept_resets_the_streak(tmp_path):
+    cfg = plateau.PlateauConfig(window=3, escalate_every=2)
+    rd = _rd(tmp_path)
+    for i in range(6):
+        _step(rd, f"d{i}", accept=False, val=0.5, parent_val=0.5, parent="seed")
+    assert plateau.assess(rd, cfg).level == "diversify"
+    _step(rd, "win", accept=True, val=0.9, parent_val=0.5, parent="seed")
+    st = plateau.assess(rd, cfg)
+    assert st.level == "ok" and st.run_length == 0 and st.accepts == 1, st
+
+
+def test_regression_counts_as_dead(tmp_path):
+    """Δ<0 (an edit that made things worse) is dead, not a near-miss."""
+    cfg = plateau.PlateauConfig(window=2, escalate_every=1)
+    rd = _rd(tmp_path)
+    for i, v in enumerate([0.4, 0.3, 0.2, 0.1], 1):
+        _step(rd, f"r{i}", accept=False, val=v, parent_val=0.5, parent="seed")
+    st = plateau.assess(rd, cfg)
+    assert st.run_length == 4 and st.level == "stop", st
+
+
+def test_plateau_stop_false_caps_at_diversify(tmp_path):
+    cfg = plateau.PlateauConfig(window=2, escalate_every=1, stop=False)
+    rd = _rd(tmp_path)
+    for i in range(10):
+        _step(rd, f"d{i}", accept=False, val=0.0, parent_val=0.0, parent="seed")
+    st = plateau.assess(rd, cfg)
+    assert st.level == "diversify" and not st.should_stop, st
+    assert st.should_diversify
+
+
+def test_non_best_accepts_are_dead_but_ratchet_caps_at_diversify(tmp_path):
+    """GEPA can accept a frontier specialist that beats its own parent but never tops
+    the incumbent best. Best-val velocity is 0, so those iterations ARE dead — but a
+    streak containing accepts is capped at ``diversify`` and never killed."""
+    cfg = plateau.PlateauConfig(window=2, escalate_every=1)
+    rd = _rd(tmp_path)
+    _step(rd, "best", accept=True, val=1.0, parent_val=0.0, parent="seed")
+    for i in range(10):  # accepted specialists, each below the incumbent best of 1.0
+        _step(rd, f"spec{i}", accept=True, val=0.7, parent_val=0.5, parent=f"p{i}")
+    st = plateau.assess(rd, cfg)
+    assert st.run_length == 10, st
+    assert st.accepts_in_streak == 10, st
+    assert st.level == "diversify", "a still-accepting run must not be stopped"
+    assert not st.should_stop and st.should_diversify
+
+
+def test_zero_accept_streak_does_reach_stop(tmp_path):
+    cfg = plateau.PlateauConfig(window=2, escalate_every=1)
+    rd = _rd(tmp_path)
+    _step(rd, "best", accept=True, val=1.0, parent_val=0.0, parent="seed")
+    for i in range(6):
+        _step(rd, f"d{i}", accept=False, val=1.0, parent_val=1.0, parent="best")
+    st = plateau.assess(rd, cfg)
+    assert st.accepts_in_streak == 0 and st.level == "stop", st
+
+
+def test_new_best_accept_resets_the_streak(tmp_path):
+    cfg = plateau.PlateauConfig(window=2, escalate_every=1)
+    rd = _rd(tmp_path)
+    for i in range(6):
+        _step(rd, f"d{i}", accept=False, val=0.5, parent_val=0.5, parent="seed")
+    assert plateau.assess(rd, cfg).level == "stop"
+    _step(rd, "up", accept=True, val=0.9, parent_val=0.5, parent="seed")
+    st = plateau.assess(rd, cfg)
+    assert st.run_length == 0 and st.level == "ok", st
+
+
+# ---- GEPA: the event kind that used to be invisible -----------------------
+
+def test_gepa_val_gate_events_are_seen(tmp_path):
+    """#199's bug class: filtering kind == 'step' makes GEPA's history empty.
+
+    Plateau detection must see ``gepa_val_gate``, or it can never fire for GEPA.
+    """
+    cfg = plateau.PlateauConfig(window=3, escalate_every=2)
+    rd = _rd(tmp_path)
+    for i in range(1, 8):
+        _step(rd, f"gepa_{i:04d}", accept=False, val=0.5, parent_val=0.5,
+              kind="gepa_val_gate", parent="seed")
+    st = plateau.assess(rd, cfg)
+    assert st.iterations == 7, st
+    assert st.level == "stop", st
+
+
+def test_gepa_local_gate_rejections_count(tmp_path):
+    """A GEPA child killed by the cheap minibatch gate never reaches the val gate,
+    but it IS a spent iteration with no movement."""
+    cfg = plateau.PlateauConfig(window=2, escalate_every=1)
+    rd = _rd(tmp_path)
+    for i in range(5):
+        rd.log_event("gepa_local_gate", candidate=f"g{i}", parent="seed",
+                     child_sum=1.0, parent_sum=1.0, passed=False)
+    st = plateau.assess(rd, cfg)
+    assert st.iterations == 5 and st.level == "stop", st
+
+
+def test_skillopt_step_events_are_seen(tmp_path):
+    cfg = plateau.PlateauConfig(window=2, escalate_every=1)
+    rd = _rd(tmp_path)
+    for i in range(5):
+        rd.log_event("skillopt_step", candidate=f"so_{i}", accept=False, val=0.2)
+    st = plateau.assess(rd, cfg)
+    assert st.iterations == 5, st
+    # skillopt_step carries no parent_val; delta is taken against the running best,
+    # which for a single-lineage climber IS the parent.
+    assert st.level == "stop", st
+
+
+# ---- per-lineage exhaustion vs GLOBAL plateau -----------------------------
+
+def test_lineage_exhausted_while_global_search_progresses(tmp_path):
+    """The distinction: one dead lineage, healthy run.
+
+    ``dead_parent`` gets 4 dead children while ``live_parent`` keeps accepting. The
+    global level stays ``ok`` (the trailing iteration is an accept) and only the one
+    parent is reported exhausted.
+    """
+    cfg = plateau.PlateauConfig(window=3, escalate_every=2, lineage_window=4)
+    rd = _rd(tmp_path)
+    for i in range(4):
+        # interleave so the streak is broken by the accepts on the other lineage
+        _step(rd, f"dead{i}", accept=False, val=0.5, parent_val=0.5, parent="dead_parent")
+        _step(rd, f"live{i}", accept=True, val=0.6 + i * 0.05, parent_val=0.5,
+              parent="live_parent")
+    st = plateau.assess(rd, cfg)
+    assert st.level == "ok", st
+    assert st.exhausted_lineages == ["dead_parent"], st.exhausted_lineages
+    assert st.accepts == 4, st
+
+
+def test_lineage_not_exhausted_below_window(tmp_path):
+    cfg = plateau.PlateauConfig(lineage_window=4)
+    rd = _rd(tmp_path)
+    for i in range(3):
+        _step(rd, f"d{i}", accept=False, val=0.5, parent_val=0.5, parent="p1")
+    assert plateau.assess(rd, cfg).exhausted_lineages == []
+
+
+def test_lineage_recovers_on_a_near_miss(tmp_path):
+    cfg = plateau.PlateauConfig(lineage_window=3)
+    rd = _rd(tmp_path)
+    for i in range(3):
+        _step(rd, f"d{i}", accept=False, val=0.5, parent_val=0.5, parent="p1")
+    assert plateau.assess(rd, cfg).exhausted_lineages == ["p1"]
+    _step(rd, "near", accept=False, val=0.55, parent_val=0.50, parent="p1")
+    assert plateau.assess(rd, cfg).exhausted_lineages == []
+
+
+# ---- events (surfacing) ---------------------------------------------------
+
+def test_check_emits_plateau_and_lineage_events_once_per_change(tmp_path):
+    cfg = plateau.PlateauConfig(window=2, escalate_every=1, lineage_window=3)
+    rd = _rd(tmp_path)
+    last = plateau.PlateauState()
+    for i in range(6):
+        _step(rd, f"d{i}", accept=False, val=0.0, parent_val=0.0, parent="seed")
+        last = plateau.check(rd, cfg, last=last, algorithm="hill-climb:all")
+    raw = [json.loads(l) for l in rd.events_path.read_text().splitlines()]
+    levels = [e["level"] for e in raw if e["kind"] == "plateau"]
+    assert levels == ["warn", "diversify", "stop"], levels  # one event per CHANGE
+    ex = [e for e in raw if e["kind"] == "lineage_exhausted"]
+    assert len(ex) == 1 and ex[0]["parent"] == "seed", ex
+
+
+def test_plateau_event_fires_on_recovery(tmp_path):
+    """A plateau that BROKE is news too — the dashboard must not stay red."""
+    cfg = plateau.PlateauConfig(window=2, escalate_every=1)
+    rd = _rd(tmp_path)
+    last = plateau.PlateauState()
+    for i in range(3):
+        _step(rd, f"d{i}", accept=False, val=0.0, parent_val=0.0, parent="seed")
+        last = plateau.check(rd, cfg, last=last)
+    assert last.level in ("warn", "diversify", "stop")
+    _step(rd, "win", accept=True, val=0.9, parent_val=0.0, parent="seed")
+    last = plateau.check(rd, cfg, last=last)
+    assert last.level == "ok"
+    levels = [json.loads(l)["level"] for l in rd.events_path.read_text().splitlines()
+              if json.loads(l)["kind"] == "plateau"]
+    assert levels[-1] == "ok", levels
+
+
+# ---- the intervention -----------------------------------------------------
+
+def test_prompt_block_only_from_diversify(tmp_path):
+    ok = plateau.PlateauState(level="ok")
+    warn = plateau.PlateauState(level="warn", run_length=3)
+    div = plateau.PlateauState(level="diversify", run_length=5, best_val=0.5,
+                               exhausted_lineages=["p1"])
+    assert plateau.prompt_block(ok) == ""
+    assert plateau.prompt_block(warn) == "", "warn is observation only, no prompt change"
+    blk = plateau.prompt_block(div)
+    assert "MATERIALLY DIFFERENT" in blk
+    assert "p1" in blk, "exhausted lineage named as dead ground"
+    assert "5 iterations" in blk
+
+
+def test_prompt_block_lists_rejected_ids(tmp_path):
+    from cap_evolve.memory import RejectedMemory
+    mem = RejectedMemory(tmp_path / "rejected.jsonl")
+    mem.add("cand_a", "summary a", "gate reject", 0.1)
+    mem.add("cand_b", "summary b", "gate reject", 0.1)
+    blk = plateau.prompt_block(plateau.PlateauState(level="diversify", run_length=5),
+                               rejected=mem)
+    assert "cand_a" in blk and "cand_b" in blk
+
+
+# ---- config ---------------------------------------------------------------
+
+def test_config_from_spec_and_ladder():
+    cfg = plateau.PlateauConfig.from_spec(
+        {"plateau_window": 8, "plateau_escalate_every": 3,
+         "plateau_lineage_window": 5, "plateau_stop": False})
+    assert (cfg.warn_at, cfg.diversify_at, cfg.stop_at) == (8, 11, 14)
+    assert cfg.lineage_window == 5 and cfg.stop is False
+    d = plateau.PlateauConfig.from_spec({})
+    assert (d.window, d.escalate_every, d.lineage_window, d.stop) == (6, 2, 4, True)
+    # an absent key must not be read as 0 (which would escalate immediately)
+    assert plateau.PlateauConfig.from_spec({"plateau_window": 0}).window == 6
+
+
+def test_empty_and_unreadable_run_is_ok(tmp_path):
+    rd = _rd(tmp_path)
+    assert plateau.assess(rd).level == "ok"
+    rd.events_path.write_text("{not json\n")
+    assert plateau.assess(rd).level == "ok"
+
+
+# ---- interaction with the existing stop conditions ------------------------
+
+def test_plateau_does_not_preempt_budget_stop(tmp_path):
+    """Budget still wins: a plateaued run whose budget is already gone stops on
+    budget, and the plateau ladder does not change the reject/stall counters."""
+    rd = RunDir.create(tmp_path, budget=Budget(max_iterations=2, stall=99))
+    for i in range(6):
+        _step(rd, f"d{i}", accept=False, val=0.0, parent_val=0.0, parent="seed")
+        rd.update_spent(iterations=1, accepted=False)
+    exhausted, why = rd.budget_exhausted()
+    assert exhausted and "max_iterations" in why
+    assert plateau.assess(rd, plateau.PlateauConfig(window=2, escalate_every=1)).level == "stop"
+    # the plateau module is READ-ONLY over spend: stall is untouched by assess/check
+    before = rd.spent.stall
+    plateau.check(rd, plateau.PlateauConfig(window=2, escalate_every=1))
+    assert rd.spent.stall == before
+
+
+def test_stall_and_plateau_are_different_signals(tmp_path):
+    """``stall`` counts rejections; plateau counts rejections WITH no movement.
+
+    The spiky-but-progressing run trips ``stall`` (correctly — it is configurable and
+    off by default at 0) but must not trip plateau. This is why plateau is a separate
+    condition rather than a re-tuned ``stall``.
+    """
+    rd = RunDir.create(tmp_path, budget=Budget(max_iterations=50, stall=4))
+    for i, v in enumerate([0.51, 0.53, 0.55, 0.57, 0.59, 0.61], 1):
+        _step(rd, f"c{i}", accept=False, val=v, parent_val=0.50, parent="seed")
+        rd.update_spent(iterations=1, accepted=False)
+    exhausted, why = rd.budget_exhausted()
+    assert exhausted and "stalled" in why, why
+    assert plateau.assess(rd, plateau.PlateauConfig(window=3)).level == "ok"
+
+
+# ---- loop integration -----------------------------------------------------
+
+def test_hill_climb_loop_stops_on_plateau(tmp_path, monkeypatch):
+    """End-to-end through the real loop with a no-op optimizer: the run must break
+    out on plateau well before max_iterations and say so in ``stop_reason``."""
+    from cap_evolve import harness
+    from cap_evolve.loop import SplitResult
+    from cap_evolve.splits import Splits
+
+    rd = RunDir.create(tmp_path, budget=Budget(max_iterations=30))
+    rd.write_splits(Splits(train=["t1"], val=["v1", "v2"], test=["s1"]))
+    (rd.candidate_dir("seed")).mkdir(parents=True, exist_ok=True)
+    (rd.candidate_dir("seed") / "prompt.txt").write_text("seed")
+    rd.set_best("seed")
+
+    base = SplitResult(split="val", reward=0.5, stderr=0.0,
+                       per_task=[{"task_id": "v1", "reward": 0.5},
+                                 {"task_id": "v2", "reward": 0.5}])
+
+    calls = {"n": 0}
+
+    def fake_run_step(adapter, *, run_dir, parent_dir, optimizer, instructions,
+                      current_val, **kw):
+        calls["n"] += 1
+        cid = f"c{calls['n']:03d}"
+        # A dead child: identical val to the parent, rejected.
+        cand = SplitResult(split="val", reward=0.5, stderr=0.0,
+                           per_task=[{"task_id": "v1", "reward": 0.5},
+                                     {"task_id": "v2", "reward": 0.5}])
+        run_dir.log_event("step", candidate=cid, accept=False, val=0.5,
+                          parent=run_dir.best_id, parent_val=current_val.reward)
+        run_dir.update_spent(iterations=1, accepted=False)
+        return {"candidate_id": cid, "accepted": False,
+                "candidate_val": cand.to_dict(), "workdir": str(parent_dir),
+                "instructions": instructions}
+
+    monkeypatch.setattr(harness, "run_step", fake_run_step)
+    res = harness.hill_climb_loop(
+        object(), run_dir=rd, optimizer=lambda w, i: None, current_val=base,
+        max_iterations=30, plateau_cfg=plateau.PlateauConfig(window=3, escalate_every=2),
+    )
+    assert "plateaued" in res["stop_reason"], res["stop_reason"]
+    assert res["iterations"] < 30, res["iterations"]
+    assert res["plateau"]["level"] == "stop"
+
+
+def test_hill_climb_loop_injects_diversify_block(tmp_path, monkeypatch):
+    """At escalation level 1 the prompt gains the paradigm-shift block; before that
+    it must be untouched."""
+    from cap_evolve import harness
+    from cap_evolve.loop import SplitResult
+    from cap_evolve.splits import Splits
+
+    rd = RunDir.create(tmp_path, budget=Budget(max_iterations=30))
+    rd.write_splits(Splits(train=["t1"], val=["v1", "v2"], test=["s1"]))
+    (rd.candidate_dir("seed")).mkdir(parents=True, exist_ok=True)
+    (rd.candidate_dir("seed") / "prompt.txt").write_text("seed")
+    rd.set_best("seed")
+    base = SplitResult(split="val", reward=0.5, stderr=0.0, per_task=[{"task_id": "v1", "reward": 0.5}])
+
+    seen: list[str] = []
+    n = {"i": 0}
+
+    def fake_run_step(adapter, *, run_dir, parent_dir, optimizer, instructions,
+                      current_val, **kw):
+        seen.append(instructions)
+        n["i"] += 1
+        run_dir.log_event("step", candidate=f"c{n['i']}", accept=False, val=0.5,
+                          parent="seed", parent_val=0.5)
+        run_dir.update_spent(iterations=1, accepted=False)
+        return {"candidate_id": f"c{n['i']}", "accepted": False,
+                "candidate_val": base.to_dict(), "workdir": str(parent_dir)}
+
+    monkeypatch.setattr(harness, "run_step", fake_run_step)
+    harness.hill_climb_loop(
+        object(), run_dir=rd, optimizer=lambda w, i: None, current_val=base,
+        max_iterations=30, plateau_cfg=plateau.PlateauConfig(window=2, escalate_every=2),
+    )
+    # window=2, escalate=2 -> warn at 2, diversify at 4, stop at 6.
+    assert not any("MATERIALLY DIFFERENT" in s for s in seen[:4]), \
+        "diversify block leaked before the diversify threshold"
+    assert any("MATERIALLY DIFFERENT" in s for s in seen[4:]), \
+        "diversify block never injected"
+
+
+def test_gepa_skips_exhausted_lineage_in_selection():
+    """The steering behaviour, at the selection call: exhausted parents are dropped
+    from the sampling pool, and the pool is never emptied."""
+    from cap_evolve import selection
+
+    pool = [{"id": "seed", "val": 0.5}, {"id": "a", "val": 0.6}, {"id": "b", "val": 0.7}]
+    dead = {"a", "b"}
+    sample_pool = [c for c in pool if c["id"] not in dead] or pool
+    assert [c["id"] for c in sample_pool] == ["seed"]
+    ranked, _ = selection.pick(sample_pool, "best", seed=0)
+    assert ranked[0]["id"] == "seed"
+    # every lineage dead -> fall back to the whole pool, the GLOBAL level decides
+    sample_pool = [c for c in pool if c["id"] not in {"seed", "a", "b"}] or pool
+    assert len(sample_pool) == 3
+
+
+# ---- surfacing ------------------------------------------------------------
+
+def test_dashboard_surfaces_plateau_state(tmp_path):
+    from cap_evolve import dashboard
+
+    rd = _rd(tmp_path)
+    rd.log_event("splits", train=1, val=2, test=1)
+    cfg = plateau.PlateauConfig(window=2, escalate_every=1, lineage_window=3)
+    last = plateau.PlateauState()
+    for i in range(5):
+        _step(rd, f"d{i}", accept=False, val=0.0, parent_val=0.0, parent="seed")
+        last = plateau.check(rd, cfg, last=last, algorithm="gepa")
+    data = dashboard.reduce_run(rd)
+    s = data["summary"]
+    assert s["plateau"] and s["plateau"]["level"] == "stop", s["plateau"]
+    assert s["exhausted_lineages"] == ["seed"], s["exhausted_lineages"]
+    txt = dashboard.render_ansi(data)
+    assert "PLATEAU" in txt and "exhausted lineage" in txt, txt
+
+
+def test_plateau_state_is_not_liveness(tmp_path):
+    """#118 classifies run LIVENESS (live/stalled/crashed/done) from events.jsonl
+    mtime. Our vocabulary is disjoint by construction, so the two can never render
+    contradictory words for the same condition."""
+    assert set(plateau.LEVELS).isdisjoint({"live", "stalled", "crashed", "done", "idle",
+                                           "failed", "incomplete"})
+    # A plateaued run is by definition NOT stalled: it is appending events.
+    rd = _rd(tmp_path)
+    for i in range(8):
+        _step(rd, f"d{i}", accept=False, val=0.0, parent_val=0.0, parent="seed")
+    st = plateau.assess(rd, plateau.PlateauConfig(window=2, escalate_every=1))
+    assert st.level == "stop" and st.iterations == 8, st

--- a/dashboard/backend/capevolve_dashboard/runs.py
+++ b/dashboard/backend/capevolve_dashboard/runs.py
@@ -69,6 +69,11 @@ def list_runs(base_dir: Path) -> list[dict]:
             "baseline_val": s.get("baseline_val"),
             "delta_pct": s.get("delta_pct"),
             "iterations": counts.get("accepted", 0) + counts.get("rejected", 0),
+            # PROGRESS, not liveness: "status" above says whether the process is running,
+            # this says whether anything it does helps. A plateaued run is BOTH `live` and
+            # `stop` — different questions, separate fields, never one string.
+            # See core/cap_evolve/plateau.py.
+            "plateau_level": (s.get("plateau") or {}).get("level") or "ok",
             "total_usd": (s.get("cost") or {}).get("total_usd"),
             "mtime": path.stat().st_mtime,
         })

--- a/dashboard/backend/tests/test_runs.py
+++ b/dashboard/backend/tests/test_runs.py
@@ -27,6 +27,37 @@ def test_list_runs_projects_light_summary(tmp_base, make_run):
     assert row["status"] in {"live", "done", "failed"}
 
 
+def test_plateau_is_surfaced_and_is_not_liveness(tmp_base, make_run):
+    """Plateau state must reach the REACT dashboard, not only the static HTML.
+
+    A stop decision the user cannot see is half a feature. It is a field separate from
+    ``status`` on purpose: ``status`` is liveness (is the process running), plateau is
+    progress (is anything it does helping) — a plateaued run is BOTH ``live`` and ``stop``.
+    """
+    from capevolve_dashboard import runs
+    events = BASE_EVENTS + [
+        {"kind": "plateau", "level": "stop", "run_length": 7, "accepts_in_streak": 0,
+         "algorithm": "gepa", "reason": "plateau: 7 consecutive iterations bought no best val"},
+        {"kind": "lineage_exhausted", "parent": "cand_0001", "window": 4,
+         "plateau_level": "stop"},
+    ]
+    make_run("run_a", events=events, baseline={"val": {"reward": 0.25}, "best_id": "seed"})
+
+    row = runs.list_runs(tmp_base)[0]
+    assert row["plateau_level"] == "stop"
+    assert row["status"] == "live", "liveness and plateau answer different questions"
+
+    s = runs.load_run(tmp_base, "run_a")["summary"]
+    assert s["plateau"]["level"] == "stop" and s["plateau"]["run_length"] == 7
+    assert s["exhausted_lineages"] == ["cand_0001"]
+
+
+def test_plateau_level_defaults_to_ok(tmp_base, make_run):
+    from capevolve_dashboard import runs
+    make_run("run_a", events=BASE_EVENTS)
+    assert runs.list_runs(tmp_base)[0]["plateau_level"] == "ok"
+
+
 def test_load_run_returns_graph_and_summary(tmp_base, make_run):
     from capevolve_dashboard import runs
     make_run("run_a", events=BASE_EVENTS,

--- a/dashboard/frontend/src/components/KpiStrip.tsx
+++ b/dashboard/frontend/src/components/KpiStrip.tsx
@@ -50,6 +50,20 @@ export function KpiStrip({ summary }: { summary: RunSummaryDetail }) {
       <Kpi label="frontier">{summary.frontier ?? 0}</Kpi>
       <Kpi label="wall clock">{duration(summary.wall_clock_seconds)}</Kpi>
       <Kpi label="$ / +1%">{dollarPerPct != null ? usd(dollarPerPct) : '—'}</Kpi>
+      {/* PROGRESS, not liveness — the run status badge answers "is it running", this
+          answers "is anything it does helping". A `live` run can read `stop` here. */}
+      <Kpi
+        label="plateau"
+        tone={summary.plateau?.level === 'ok' || !summary.plateau ? undefined : 'rejected'}
+        hint={summary.plateau?.reason}
+      >
+        {summary.plateau ? `${summary.plateau.level} · ${summary.plateau.run_length} dead` : 'ok'}
+      </Kpi>
+      {!!summary.exhausted_lineages?.length && (
+        <Kpi label="exhausted lineages" tone="rejected" hint={summary.exhausted_lineages.join(', ')}>
+          {summary.exhausted_lineages.length}
+        </Kpi>
+      )}
     </motion.div>
   )
 }

--- a/dashboard/frontend/src/lib/types.ts
+++ b/dashboard/frontend/src/lib/types.ts
@@ -2,6 +2,12 @@
 
 export type RunStatus = 'live' | 'done' | 'failed'
 
+/** Plateau escalation level (core/cap_evolve/plateau.py `LEVELS`). Orthogonal to
+ * `RunStatus`: that one is LIVENESS (is the process running), this one is PROGRESS (is
+ * anything it does help). A plateaued run is `live` and `stop` at the same time — they
+ * answer different questions, so they are separate fields and never one string. */
+export type PlateauLevel = 'ok' | 'warn' | 'diversify' | 'stop'
+
 /** One row from GET /api/runs (light hub summary). */
 export interface RunSummary {
   run_id: string
@@ -12,6 +18,8 @@ export interface RunSummary {
   baseline_val: number | null
   delta_pct: number | null
   iterations: number
+  /** Progress, not liveness — see `PlateauLevel`. Defaults to 'ok'. */
+  plateau_level?: PlateauLevel
   total_usd: number | null
   mtime: number
 }
@@ -124,6 +132,16 @@ export interface RunSummaryDetail {
   budget_warnings?: { metric: string; pct: number; spent: number; limit: number }[]
   gate_warnings?: unknown[]
   diagnoses?: unknown[]
+  /** Plateau/convergence state — see `PlateauLevel`. Null until the first plateau event. */
+  plateau?: {
+    level: PlateauLevel
+    run_length: number
+    accepts_in_streak: number
+    near_misses?: number
+    best_val?: number
+    reason?: string
+  } | null
+  exhausted_lineages?: string[]
   git_log?: { hash: string; subject: string }[]
 }
 

--- a/skills/algorithms/gepa/scripts/run.py
+++ b/skills/algorithms/gepa/scripts/run.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 import _bootstrap  # noqa: F401
 
-from cap_evolve import RunDir, gepa, harness
+from cap_evolve import RunDir, gepa, harness, plateau
 from cap_evolve.check import load_adapter
 from cap_evolve.loop import SplitResult
 from cap_evolve.store import make_store
@@ -54,6 +54,14 @@ def main(argv=None) -> int:
     p.add_argument("--resume", action="store_true",
                    help="reconstruct the pool/frontier from the run dir and continue the "
                         "search instead of restarting from the seed")
+    p.add_argument("--plateau-window", type=int, default=None,
+                   help="dead iterations (rejected with delta<=0) before the plateau warning")
+    p.add_argument("--plateau-escalate-every", type=int, default=None,
+                   help="further dead iterations per escalation step (warn -> diversify -> stop)")
+    p.add_argument("--plateau-lineage-window", type=int, default=None,
+                   help="dead children of ONE parent before that lineage is exhausted")
+    p.add_argument("--no-plateau-stop", action="store_true",
+                   help="warn + diversify only; never stop the run on plateau")
     args = p.parse_args(argv)
 
     run_dir = RunDir.open(Path(args.run_dir))
@@ -63,6 +71,12 @@ def main(argv=None) -> int:
     seed_val = SplitResult.from_dict(
         json.loads((run_dir.root / "baseline.json").read_text())["val"])
 
+    plateau_cfg = plateau.PlateauConfig.from_spec({
+        "plateau_window": args.plateau_window,
+        "plateau_escalate_every": args.plateau_escalate_every,
+        "plateau_lineage_window": args.plateau_lineage_window,
+        "plateau_stop": (False if args.no_plateau_stop else None),
+    })
     result = gepa.gepa_loop(
         adapter, run_dir=run_dir, optimizer=optimizer, seed_val=seed_val,
         max_metric_calls=args.max_metric_calls, max_iterations=args.max_iterations,
@@ -74,6 +88,7 @@ def main(argv=None) -> int:
                      else {"mode": args.gate_mode, "k_se": args.k_se}),
         no_regression=args.no_regression, seed=args.seed, store=store,
         resume=args.resume,
+        plateau_cfg=plateau_cfg,
     )
     print(json.dumps(result, indent=2))
     return 0

--- a/skills/algorithms/hill-climb/scripts/run.py
+++ b/skills/algorithms/hill-climb/scripts/run.py
@@ -23,7 +23,7 @@ from pathlib import Path
 
 import _bootstrap  # noqa: F401
 
-from cap_evolve import RunDir, harness
+from cap_evolve import RunDir, harness, plateau
 from cap_evolve.store import make_store
 from cap_evolve.check import load_adapter
 from cap_evolve.loop import SplitResult
@@ -75,6 +75,14 @@ def main(argv=None) -> int:
                    help="consuming/runtime model id or tier keyword (frontier|strong|mid|weak)")
     p.add_argument("--target-profile-file", default=None,
                    help="optional project-local brief overriding the tier's built-in brief")
+    p.add_argument("--plateau-window", type=int, default=None,
+                   help="dead iterations (rejected with delta<=0) before the plateau warning")
+    p.add_argument("--plateau-escalate-every", type=int, default=None,
+                   help="further dead iterations per escalation step (warn -> diversify -> stop)")
+    p.add_argument("--plateau-lineage-window", type=int, default=None,
+                   help="dead children of ONE parent before that lineage is exhausted")
+    p.add_argument("--no-plateau-stop", action="store_true",
+                   help="warn + diversify only; never stop the run on plateau")
     args = p.parse_args(argv)
 
     focus = _LEGACY_FOCUS.get(args.focus, args.focus)
@@ -99,6 +107,12 @@ def main(argv=None) -> int:
         current_val = SplitResult.from_dict(
             json.loads((run_dir.root / "baseline.json").read_text())["val"])
 
+    plateau_cfg = plateau.PlateauConfig.from_spec({
+        "plateau_window": args.plateau_window,
+        "plateau_escalate_every": args.plateau_escalate_every,
+        "plateau_lineage_window": args.plateau_lineage_window,
+        "plateau_stop": (False if args.no_plateau_stop else None),
+    })
     result = harness.hill_climb_loop(
         adapter, run_dir=run_dir, optimizer=optimizer, current_val=current_val,
         focus=focus, max_iterations=args.max_iterations, n_trials=args.n_trials,
@@ -112,6 +126,7 @@ def main(argv=None) -> int:
         project_dir=Path(args.project),
         target_model=args.target_model,
         target_profile_file=args.target_profile_file,
+        plateau_cfg=plateau_cfg,
     )
     print(json.dumps(result, indent=2))
     return 0

--- a/skills/algorithms/skillopt/scripts/run.py
+++ b/skills/algorithms/skillopt/scripts/run.py
@@ -21,7 +21,7 @@ from pathlib import Path
 
 import _bootstrap  # noqa: F401
 
-from cap_evolve import RunDir, harness, skillopt
+from cap_evolve import RunDir, harness, plateau, skillopt
 from cap_evolve.check import load_adapter
 from cap_evolve.loop import SplitResult
 from cap_evolve.store import make_store
@@ -69,6 +69,14 @@ def main(argv=None) -> int:
     p.add_argument("--store-commit-cmd", default=None)
     p.add_argument("--resume", action="store_true",
                    help="continue from the run's current best instead of baseline")
+    p.add_argument("--plateau-window", type=int, default=None,
+                   help="dead iterations (rejected with delta<=0) before the plateau warning")
+    p.add_argument("--plateau-escalate-every", type=int, default=None,
+                   help="further dead iterations per escalation step (warn -> diversify -> stop)")
+    p.add_argument("--plateau-lineage-window", type=int, default=None,
+                   help="dead children of ONE parent before that lineage is exhausted")
+    p.add_argument("--no-plateau-stop", action="store_true",
+                   help="warn + diversify only; never stop the run on plateau")
     args = p.parse_args(argv)
 
     run_dir = RunDir.open(Path(args.run_dir))
@@ -81,6 +89,12 @@ def main(argv=None) -> int:
         current_val = SplitResult.from_dict(
             json.loads((run_dir.root / "baseline.json").read_text())["val"])
 
+    plateau_cfg = plateau.PlateauConfig.from_spec({
+        "plateau_window": args.plateau_window,
+        "plateau_escalate_every": args.plateau_escalate_every,
+        "plateau_lineage_window": args.plateau_lineage_window,
+        "plateau_stop": (False if args.no_plateau_stop else None),
+    })
     result = skillopt.skillopt_loop(
         adapter, run_dir=run_dir, optimizer=optimizer, current_val=current_val,
         epochs=args.epochs, batch_size=args.batch_size, accumulation=args.accumulation,
@@ -90,6 +104,7 @@ def main(argv=None) -> int:
                      else {"mode": args.gate_mode, "k_se": args.k_se}),
         no_regression=args.no_regression, slow_update=args.slow_update,
         slow_update_sample=args.slow_update_sample, algorithm=ALGO, store=store,
+        plateau_cfg=plateau_cfg,
     )
     print(json.dumps(result, indent=2))
     return 0

--- a/templates/project/capevolve.yaml
+++ b/templates/project/capevolve.yaml
@@ -89,6 +89,16 @@ max_metric_calls: 0         # 0 = unlimited; else stop after N runner evals
 max_usd: 0.0                # 0 = unlimited; total $ cap (runner + optimizer + intake)
 max_optimizer_usd: 0.0      # 0 = off; separate cap on optimizer spend alone
 
+# --- plateau / convergence detection ----------------------------------------
+# Counts only DEAD iterations: rejected with Δ<=0 on val. A near-miss (rejected but
+# Δ>0 — common on small val splits under the Student-t gate) or an accept RESETS the
+# counter, so a spiky-but-progressing run never escalates.
+# Ladder: warn at plateau_window, diversify at +escalate_every, stop at +2*escalate_every.
+plateau_window: 6           # dead iterations before the plateau warning
+plateau_escalate_every: 2   # further dead iterations per escalation step
+plateau_lineage_window: 4   # dead children of ONE parent before that lineage is exhausted
+plateau_stop: true          # false = warn + diversify only, never stop the run
+
 # --- iteration store (how each iteration is versioned for an inspectable process)
 store: git                               # git (default) | copy | command
 # store_commit_cmd: "npx skills publish {dir} -m {msg}"   # for store: command (e.g. a skills store)

--- a/templates/project/capevolve.yaml
+++ b/templates/project/capevolve.yaml
@@ -84,7 +84,15 @@ gate_k_se: 1.0
 # Run `cap-evolve estimate --spec capevolve.yaml` first to preview call counts + a
 # $ range before spending. All caps below are hard stops; 0 = unlimited/off.
 max_iterations: 10          # optimizer iterations (dominant cost knob)
-stall: 2                    # stop after N consecutive rejects
+# `stall` counts CONSECUTIVE REJECTS, which is not the same thing as a lack of progress:
+# a few rejects then a breakthrough is the normal shape of a run, and #113's Student-t
+# gate makes sub-significant near-misses (Δ>0, rejected) strictly MORE common on small
+# val splits. The old default of 2 killed such runs at iteration 3 — and it always fired
+# before `plateau_window` below, which made the whole plateau ladder unreachable for all
+# three algorithms in a default project. Plateau detection replaces it and counts DEAD
+# iterations (Δ<=0) instead of rejections. Set a positive value to get the blunt
+# reject-counter back; the two conditions coexist, whichever trips first wins.
+stall: 0                    # 0 = off (plateau detection below is the progress-based stop)
 max_metric_calls: 0         # 0 = unlimited; else stop after N runner evals
 max_usd: 0.0                # 0 = unlimited; total $ cap (runner + optimizer + intake)
 max_optimizer_usd: 0.0      # 0 = off; separate cap on optimizer spend alone


### PR DESCRIPTION
Closes #130

The engine stopped on **budget** (iterations / metric-calls / USD) and on **`stall`** (N consecutive non-accepts). Neither answers the question that actually decides whether to keep spending: *is the search still making progress, or grinding a dead region?* `stall` counts **rejections**, and a rejection is not the same thing as a lack of progress.

New `core/cap_evolve/plateau.py` adds a third, orthogonal stop condition with the escalation ladder the issue asks for — **warn → diversify → stop** — plus **per-lineage exhaustion**, wired into all three deterministic algorithms.

## The detection criterion, and why it won't kill a productive run

`gate.decide` accepts iff `Δ̄ > k_eff·SE(Δ)`. That splits rejections into two qualitatively different classes, and the whole design rests on the distinction:

| class | meaning | counted as |
|---|---|---|
| **near-miss** — rejected, `Δ > 0` | the edit *did* move the score; the run just hasn't proven it | **alive** (resets the streak) |
| **dead** — rejected, `Δ ≤ 0` | the edit did not move the score in the direction it was supposed to | **dead** |
| accepted **and** a new global best | real progress | **alive** (resets) |
| accepted but **not** a new best | best-val velocity 0 — what the user pays for didn't move | **dead**, but see the ratchet |

So `run_length` = trailing iterations that bought **no new best val and were not a near-miss**. A single near-miss, or one new best, resets it to zero.

**This is what makes it safe on a spiky run.** Optimization is legitimately spiky, and a naive "N rejects in a row → stop" would kill exactly the productive-but-slow case. The near-miss escape targets that case directly — and it matters *more* after **#113 (PR #195)**, whose Student-t small-sample correction makes the acceptance bar **strictly stricter** at small n (1.14× wider at n=5, 1.84× at n=2). More rejections are now expected on small val splits, and every one of them that moved the score in the right direction is a near-miss that resets the counter. A heuristic tuned on the old z bar would over-trigger precisely where #113 tightened it; this one is indifferent to where the bar sits, because it reads the *sign* of Δ, not the accept/reject verdict.

Proven end-to-end below: **12 consecutive rejections, Δ = +0.5 every time, zero plateau events**. A reject-counting heuristic would have stopped that run at iteration 3.

**The ratchet.** Any accept inside the streak caps escalation at `diversify`; only a **zero-accept** streak may reach `stop`. A GEPA run still widening its Pareto frontier — accepting specialists that beat their own parent without topping the incumbent best — gets nudged, never killed. Stopping early is the expensive error, so the conservative side is the default.

Velocity is not a separate condition: it is folded into the "accepted but not a new best" row. Over any dead streak best-val velocity is 0 by construction.

## What "diversify" actually changes

Two concrete behaviours, both at escalation level 1:

1. **A paradigm-shift block appended to the next proposal prompt** (`plateau.prompt_block`), naming the run length, the flat best-val, the exhausted lineages as dead ground, and requiring the optimizer to *state which prior approach it is abandoning and why the new one differs in kind*:

```
## PLATEAU — CHANGE APPROACH (escalation: diversify)
The last 5 iterations bought no new best val: no near-misses, no movement in the
direction that counts. Best val has not improved (1.000). Incrementally refining the
current approach is not working and repeating it will spend the rest of the budget for
nothing.
REQUIRED this iteration: make a MATERIALLY DIFFERENT change, not a variation of the
previous attempts. Pick a different mechanism (e.g. move a rule from prose into code,
restructure rather than reword, attack a task cluster you have not touched, remove
something instead of adding), and state in one line which prior approach you are
abandoning and why the new one differs in kind.
Exhausted lineage(s) — every recent child of these failed, treat them as dead ground:
gepa_0001, gepa_0005.
```

2. **GEPA's parent sampling drops exhausted lineages** for that iteration: `sample_pool = [c for c in pool if c["id"] not in dead] or pool`. This *composes with* the frontier rather than fighting it — `selection.pick` still runs its own `pareto_per_instance` frequency weighting, just over the lineages that can still move. The `or pool` fallback means the pool is never emptied: if every lineage is exhausted the full pool is used and the **global** level, not this filter, decides whether to stop. hill-climb/SkillOpt are single-lineage (parent is always the current best), so for them there is no alternative parent to steer toward and exhaustion reaches only the prompt — which is exactly the GEPA/single-lineage distinction.

**Interaction with #129** (rejected-approach constraints): #129 says *"don't repeat these specific edits"*; diversify says *"the whole direction is dead, change strategy"*. They compose as "avoid these, and don't merely perturb them either". `prompt_block` also lists the recent `RejectedMemory` ids, so if #129 lands first the two blocks are consistent rather than contradictory. I did not build #128's insight persistence or #129's constraints.

## Per-lineage exhaustion vs global plateau

Different questions, computed independently and reported separately.

* **Global plateau** — the trailing streak over *all* iterations. One number, one ladder, one stop decision.
* **Lineage exhaustion** — per parent: its last `plateau_lineage_window` children were all dead. A single lineage can be exhausted while the search overall is progressing, because a *different* lineage is accepting. Conflating them would either stop a healthy multi-lineage run or leave a dead branch getting extended forever.

`test_lineage_exhausted_while_global_search_progresses` pins the asymmetry: `dead_parent` accrues 4 dead children while `live_parent` accepts throughout — global level stays `ok`, `exhausted_lineages == ["dead_parent"]`. The real GEPA run below shows the same thing with 5 lineages.

## How these states differ from #118's

Disjoint vocabularies, asserted by a test (`test_plateau_state_is_not_liveness`):

| | question | source | states |
|---|---|---|---|
| **#118** | is the run *alive*? | `events.jsonl` mtime / process liveness | `live` · `stalled` · `crashed` · `done` |
| **#130** | is the run *progressing*? | the gated-iteration event series | `ok` · `warn` · `diversify` · `stop` |

**Stalled** = nothing is happening. **Plateaued** = plenty is happening and none of it helps. A plateaued run is by definition *not* stalled — it is appending events every iteration, which is how plateau is detected at all. The two are orthogonal and can be shown together (a run can be `live` + `diversify`), and no word appears in both sets, so the UI can never render contradictory labels for one condition.

## Knobs + defaults (`capevolve.yaml`)

```yaml
plateau_window: 6           # dead iterations before the warning
plateau_escalate_every: 2   # further dead iterations per escalation step
plateau_lineage_window: 4   # dead children of ONE parent before that lineage is exhausted
plateau_stop: true          # false = warn + diversify only, never stop the run
```

Default ladder: **warn at 6, diversify at 8, stop at 10** dead iterations. `plateau_stop: false` is the escape hatch for a user who wants the intervention without the hard stop. Every key is threaded to **all three** algorithms through one loop in `cli.py` over `("hill-climb", "gepa", "skillopt")` — not a per-flag `if algorithm == ...`, so a future knob cannot be silently dropped for gepa/skillopt the way #109's seven flags were.

## Reading the history correctly (the #199 bug class)

Detection reads **`RunDir.iteration_events()`** (added by #199 / issue #109), never a hand-rolled `kind == "step"` filter — GEPA emits `gepa_val_gate`, so a hand filter would make this feature **permanently inert for GEPA**. #216 is a fourth instance of that bug; this is not a fifth. There is a documented literal fallback for the pre-#199 tree only, preferring the shared reader at runtime.

Additionally, GEPA children killed by the **cheap local minibatch gate** (`gepa_local_gate`, `passed=false`) are counted: they never reach the val gate and emit no iteration event, but they *are* spent iterations that produced no movement, and a GEPA run can grind for many of them without logging a single `gepa_val_gate`.

## Surfacing

`plateau` fires on every level **change** (including back to `ok` — a plateau that broke is news too, so the dashboard doesn't stay red); `lineage_exhausted` fires once per newly-exhausted parent.

* **dashboard**: `summary.plateau` + `summary.exhausted_lineages`, rendered in the SPA's annotations stream.
* **terminal** (`render_ansi`): `◼ PLATEAU: stop — 7 consecutive iterations bought no new best val` / `◼ exhausted lineage(s): …`, colored yellow at warn/diversify and red at stop.
* **`--follow` (#191)**: both kinds flow through `eventstream.format_event`'s unknown-kind branch with no change to that branch, so the two PRs don't touch the same lines.

## Expected merge order

Independent of everything, but **after #199** is cleanest (it owns `RunDir.iteration_events`, which this reads). Verified both directions:

* **#130 alone**: 207 passed, 0 failed.
* **#130 + #199**: 227 passed, 0 failed. Conflicts are additive adjacency only (import lists, one signature param, one prompt-assembly line) — both sides keep their lines.
* **#130 + #199 + #195**: **291 passed, 0 failed.** One conflict, in harness.py's import block.

## House rules

Zero new runtime deps (`json`, `dataclasses` only). Honesty untouched: no change to splits, the gate, the seal, or the val-only acceptance path — plateau detection is **read-only** over the event log and over `spent` (a test asserts `assess`/`check` never touch the stall counter).

## Verification

Baseline on `origin/main` is **179 passed** (`test_dashboard_launch.py::test_maybe_launch_spawns_when_available` is environmentally flaky on port 7878 — #200, unrelated; it passes here).

```
$ PYTHONPATH=/tmp/wt-130/core python -m pytest core/tests -q
207 passed in 61.91s (0:01:01)

$ python -m compileall -q core skills
COMPILEALL CLEAN
```

179 → **207** = the 28 new tests in `core/tests/test_plateau.py`.

**Fail-before / pass-after**, proven in two stages by reverting the source and keeping the test:

```
# stage 1: plateau.py removed, __init__ reverted
E   ImportError: cannot import name 'plateau' from 'cap_evolve'
!!!! Interrupted: 1 error during collection !!!!

# stage 2: plateau.py present, the LOOPS unwired (harness/gepa/skillopt/dashboard at origin/main)
FAILED core/tests/test_plateau.py::test_hill_climb_loop_stops_on_plateau
FAILED core/tests/test_plateau.py::test_hill_climb_loop_injects_diversify_block
FAILED core/tests/test_plateau.py::test_dashboard_surfaces_plateau_state
3 failed, 25 passed
```

### THE anti-false-positive run — real `cap-evolve run`, zero API cost

12 consecutive **rejections**, each with **Δ = +0.5** (sub-significant under the paired t gate), on a graded scratch adapter:

```
   step cand_0001 accept= False val= 0.5 parent_val= 0.0
   step cand_0002 accept= False val= 0.5 parent_val= 0.0
   ... (10 more, identical)
   step cand_0012 accept= False val= 0.5 parent_val= 0.0
### plateau events:
  TOTAL plateau/lineage events: 0
```

Zero escalation. A "N rejects in a row" heuristic would have stopped at iteration 3.

### Side-by-side: plateauing vs progressing (same code, same flags)

**Progressing** — graded reward, +1/6 per iteration, `max_iterations=10`, thresholds warn 3 / diversify 5 / stop 7:

```
   step cand_0001 accept= True val= 0.167   step cand_0004 accept= True val= 0.667
   step cand_0002 accept= True val= 0.333   step cand_0005 accept= True val= 0.833
   step cand_0003 accept= True val= 0.500   step cand_0006 accept= True val= 1.000
   step cand_0007..0010 accept= False val= 1.0   <- ceiling reached, nothing left to gain
   TOTAL plateau/lineage events: 2  (warn only, at the ceiling — never diversify, never stop)
   iterations: 10 of 10  — the run is untouched
```

**Plateauing** — `hill-climb`, idempotent mock edit so every child equals its parent:

```
plateau  level=warn       run_length=3   exhausted=[cand_0001]
lineage_exhausted parent=cand_0001
plateau  level=diversify  run_length=5
plateau  level=stop       run_length=7
iterations: 8 of 12   <- stopped 4 iterations early
◼ PLATEAU: stop — 7 consecutive iterations bought no new best val
◼ exhausted lineage(s): cand_0001
```

### All three deterministic algorithms, `examples/toy_calc` + `mock` optimizer

**hill-climb** — full ladder, stops at 8/12 (above).

**skillopt** — full ladder, stops at 7 iterations:
```
plateau  level=warn       run_length=3  accepts_in_streak=0
plateau  level=diversify  run_length=6  exhausted=[so_e01s01]
lineage_exhausted parent=so_e01s01
plateau  level=stop       run_length=9
◼ PLATEAU: stop — 9 consecutive iterations bought no new best val
```

**gepa** — proven twice, because GEPA is the interesting case:

*Multi-lineage, still progressing → correctly does NOT stop* (20 iterations, `--max-merges 0`). Five lineages exhausted and skipped one after another, while the global search keeps accepting, so the ratchet holds it at `diversify`:
```
plateau  level=warn       run_length=3  accepts_in_streak=0  exhausted=[gepa_0001]
plateau  level=diversify  run_length=5  accepts_in_streak=1
lineage_exhausted parent=gepa_0005
lineage_exhausted parent=gepa_0009
lineage_exhausted parent=seed
lineage_exhausted parent=gepa_0013
◼ PLATEAU: diversify — 5 consecutive iterations bought no new best val
◼ exhausted lineage(s): gepa_0001, gepa_0005, gepa_0009, gepa_0013, seed
iterations: 20 of 20  — never killed while the frontier is widening
```

*Genuinely dead region → does stop* (optimizer makes no edits at all, so every child fails the local minibatch gate; zero accepts):
```
plateau  level=warn       run_length=3  accepts_in_streak=0
lineage_exhausted parent=seed
plateau  level=diversify  run_length=5  accepts_in_streak=0
plateau  level=stop       run_length=7  accepts_in_streak=0
gepa_stop  reason=plateaued (7 consecutive iterations bought no new best val
           (warn 3 / diversify 5 / stop 7); no near-miss in that streak)
iterations: 7 of 20   <- 13 iterations of budget saved
```

Full commands and untruncated output in the **🔬 Evidence** comment.
