### PR TITLE
fix(site): stop filtering the live-run query to status=in_progress

### DIFF
--- a/site/benchmarks.js
+++ b/site/benchmarks.js
@@ -25,11 +25,18 @@ const fmtElapsed = (ms) => {
 async function loadRunning() {
   const panel = $("#running-now");
   try {
-    const runsResp = await fetch(`${GH_API}/actions/workflows/benchmarks.yml/runs?status=in_progress&per_page=20`);
+    // No status filter: benchmarks.yml's bench job is a 6-way matrix (tier × bench) that
+    // all queue on the single self-hosted runner, so GitHub reports the *run's* top-level
+    // status as "queued" for as long as any leg hasn't started yet — even while other legs
+    // are actively in_progress. Filtering the run list to status=in_progress would miss
+    // that almost entirely; fetch recent runs instead and let the per-job check below be
+    // the real gate on what's actually running.
+    const runsResp = await fetch(`${GH_API}/actions/workflows/benchmarks.yml/runs?per_page=5`);
     if (!runsResp.ok) throw new Error(String(runsResp.status));
     const { workflow_runs: runs } = await runsResp.json();
+    const active = (runs || []).filter((r) => r.status === "in_progress" || r.status === "queued");
     const items = [];
-    for (const run of runs || []) {
+    for (const run of active) {
       const jobsResp = await fetch(`${GH_API}/actions/runs/${run.id}/jobs`);
       if (!jobsResp.ok) continue;
       const { jobs } = await jobsResp.json();


### PR DESCRIPTION
## Summary
- The "Running now" panel on benchmarks.html was querying GitHub's Actions API with `?status=in_progress` on the *run* level to find live jobs.
- `benchmarks.yml`'s `bench` job is a 6-way matrix (`tier: [smoke, full] × bench: [tau2, swebench, skillsbench]`), all pinned to one self-hosted runner — so only one leg executes at a time and GitHub reports the run's overall `status` as `"queued"` for as long as *any* leg hasn't started, even while other legs are genuinely `in_progress`.
- Verified live against run `30518857693`: top-level `status: "queued"` while job `smoke / skillsbench` was actually `in_progress` — so the old query excluded it and the panel silently stayed empty for nearly the whole run.
- Fix: drop the run-level status filter, fetch the last 5 runs, and treat both `"in_progress"` and `"queued"` runs as candidates. The existing per-job `job.status !== "in_progress"` check already gates on what's truly running, so this adds no extra API calls in the normal case (one active run at a time) and doesn't change rate-limit behavior from #178.

## Test plan
- [x] Simulated the new query logic against the live GitHub API — confirms it now surfaces the actually-running `smoke / skillsbench` job that the old query missed.
- [ ] After merge, confirm the "Running now" panel on https://skillberry-ai.github.io/cap-evolve/benchmarks.html shows the live job during the next benchmark run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)