### PR TITLE
ci(benchmarks): queue same tier/bench/branch runs instead of cancelling

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -162,7 +162,7 @@ jobs:
         bench: [tau2, swebench, skillsbench]
     concurrency:
       group: benchmarks-${{ matrix.tier }}-${{ matrix.bench }}-${{ github.ref }}
-      cancel-in-progress: true
+      cancel-in-progress: false
     env:
       ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
       ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}


### PR DESCRIPTION
## Summary
- The `benchmarks.yml` concurrency group is scoped per (tier, bench, branch); previously `cancel-in-progress: true` meant a new dispatch matching the same group killed the run already in progress.
- Sets `cancel-in-progress: false` so a same-group dispatch queues behind the running job instead, matching the behavior already seen across different tier/bench/branch groups.

## Test plan
- [ ] Dispatch the same tier+bench+branch combo twice in a row and confirm the second run shows as "Queued" rather than cancelling the first.