### PR TITLE
fix(site): show spreadsheetbench jobs in the live-run panel

### DIFF
--- a/site/benchmarks.html
+++ b/site/benchmarks.html
@@ -67,7 +67,7 @@
   </div>
 
   <div id="running-now" class="callout callout-accent" hidden>
-    <p class="callout-title">Running now</p>
+    <p class="callout-title">Running now / queued</p>
     <ul id="running-list" class="running-list"></ul>
   </div>
 
@@ -149,7 +149,7 @@
   </div>
 </footer>
 
-<script src="benchmarks.js?v=20260730a"></script>
+<script src="benchmarks.js?v=20260730b"></script>
 <script src="js/site.js?v=20260724" defer></script>
 </body>
 </html>

--- a/site/benchmarks.html
+++ b/site/benchmarks.html
@@ -149,7 +149,7 @@
   </div>
 </footer>
 
-<script src="benchmarks.js?v=20260729c"></script>
+<script src="benchmarks.js?v=20260730a"></script>
 <script src="js/site.js?v=20260724" defer></script>
 </body>
 </html>

--- a/site/benchmarks.js
+++ b/site/benchmarks.js
@@ -41,10 +41,13 @@ async function loadRunning() {
       if (!jobsResp.ok) continue;
       const { jobs } = await jobsResp.json();
       for (const job of jobs || []) {
-        if (job.status !== "in_progress") continue;
+        if (job.status !== "in_progress" && job.status !== "queued") continue;
         const m = JOB_RE.exec(job.name);
         if (!m) continue;
-        items.push({ runId: run.id, tier: m[1], bench: m[2], jobUrl: job.html_url, startedAt: job.started_at });
+        items.push({
+          runId: run.id, tier: m[1], bench: m[2], jobUrl: job.html_url,
+          startedAt: job.started_at, live: job.status === "in_progress",
+        });
       }
     }
     renderRunning(items);
@@ -61,7 +64,12 @@ function renderRunning(items) {
     return;
   }
   panel.hidden = false;
-  list.innerHTML = items.map((it) => {
+  const sorted = [...items].sort((a, b) => (a.live === b.live ? 0 : a.live ? -1 : 1));
+  list.innerHTML = sorted.map((it) => {
+    if (!it.live) {
+      return `<li><span class="badge badge-amber">queued</span>
+        <a href="${esc(it.jobUrl)}" target="_blank" rel="noopener">${esc(it.tier)} / ${esc(it.bench)}</a></li>`;
+    }
     const dataBase = encodeURIComponent(`${RAW}/live/${it.runId}__${it.tier}-${it.bench}/data`);
     return `<li><span class="badge badge-accent">live</span>
       <a href="${esc(it.jobUrl)}" target="_blank" rel="noopener">${esc(it.tier)} / ${esc(it.bench)}</a>

--- a/site/benchmarks.js
+++ b/site/benchmarks.js
@@ -1,6 +1,6 @@
 const RAW = "https://raw.githubusercontent.com/skillberry-ai/cap-evolve/benchmark-history";
 const GH_API = "https://api.github.com/repos/skillberry-ai/cap-evolve";
-const JOB_RE = /^(smoke|full) \/ (tau2|swebench|skillsbench)$/;
+const JOB_RE = /^(smoke|full) \/ (tau2|swebench|skillsbench|spreadsheetbench)$/;
 let RECORDS = [], sortKey = "date", sortDir = -1;
 
 const $ = (s) => document.querySelector(s);


### PR DESCRIPTION
## Summary
- `JOB_RE` in `site/benchmarks.js` only matched `tau2|swebench|skillsbench`, so an in-progress `smoke / spreadsheetbench` or `full / spreadsheetbench` job (job name comes from `benchmarks.yml`'s `name: ${{ matrix.tier }} / ${{ matrix.bench }}`) silently failed the match and never rendered in the "Running now" live panel.
- The regex predates spreadsheetbench's addition to the CI matrix (#174) — no one updated `benchmarks.js` when that landed.
- Bumped the `benchmarks.js` cache-busting query string per the repo's convention.

## Test plan
- [ ] Trigger a `spreadsheetbench` smoke run via Actions → Benchmarks and confirm it now appears under "Running now" on the Pages benchmarks.html while in progress.