### PR TITLE
fix(site): recognize "pending" run/job status in the live-run panel

### DIFF
--- a/site/benchmarks.html
+++ b/site/benchmarks.html
@@ -149,7 +149,7 @@
   </div>
 </footer>
 
-<script src="benchmarks.js?v=20260730b"></script>
+<script src="benchmarks.js?v=20260730c"></script>
 <script src="js/site.js?v=20260724" defer></script>
 </body>
 </html>

--- a/site/benchmarks.js
+++ b/site/benchmarks.js
@@ -25,23 +25,21 @@ const fmtElapsed = (ms) => {
 async function loadRunning() {
   const panel = $("#running-now");
   try {
-    // No status filter: benchmarks.yml's bench job is a 6-way matrix (tier × bench) that
-    // all queue on the single self-hosted runner, so GitHub reports the *run's* top-level
-    // status as "queued" for as long as any leg hasn't started yet — even while other legs
-    // are actively in_progress. Filtering the run list to status=in_progress would miss
-    // that almost entirely; fetch recent runs instead and let the per-job check below be
-    // the real gate on what's actually running.
+    // Filter on the terminal state ("completed") rather than enumerating non-terminal
+    // ones: GitHub reports runs/jobs that haven't finished as "queued", "pending", or
+    // "in_progress" depending on matrix position and concurrency-group state, and a
+    // 6-way matrix (tier × bench) run can sit in any mix of those before its legs start.
     const runsResp = await fetch(`${GH_API}/actions/workflows/benchmarks.yml/runs?per_page=5`);
     if (!runsResp.ok) throw new Error(String(runsResp.status));
     const { workflow_runs: runs } = await runsResp.json();
-    const active = (runs || []).filter((r) => r.status === "in_progress" || r.status === "queued");
+    const active = (runs || []).filter((r) => r.status !== "completed");
     const items = [];
     for (const run of active) {
       const jobsResp = await fetch(`${GH_API}/actions/runs/${run.id}/jobs`);
       if (!jobsResp.ok) continue;
       const { jobs } = await jobsResp.json();
       for (const job of jobs || []) {
-        if (job.status !== "in_progress" && job.status !== "queued") continue;
+        if (job.status === "completed") continue;
         const m = JOB_RE.exec(job.name);
         if (!m) continue;
         items.push({


### PR DESCRIPTION
## Summary
- Follow-up to #227. That PR's queued-jobs feature filtered runs/jobs on an allowlist of `in_progress`/`queued` — but a live run (id 30520700500, workflow_dispatch on main) currently sits at top-level status `pending`, with its own matrix legs split between `queued` and `pending`. That run was dropped by the run-level filter before its jobs were even fetched, so the panel showed nothing at all (no live, no queued).
- Switched both the run-level and job-level filters to check the terminal state (`status !== "completed"`) instead of enumerating non-terminal ones, so any status GitHub reports before completion (`queued`, `pending`, `in_progress`, or anything else) is treated as active.

## Test plan
- [ ] Confirm https://skillberry-ai.github.io/cap-evolve/benchmarks.html now shows the currently pending/queued run's legs under "Running now / queued" once this deploys.