### PR TITLE
fix(site): raise runs-list per_page from 5 to 100 in the live-run panel

### DIFF
--- a/site/benchmarks.html
+++ b/site/benchmarks.html
@@ -149,7 +149,7 @@
   </div>
 </footer>
 
-<script src="benchmarks.js?v=20260730c"></script>
+<script src="benchmarks.js?v=20260730d"></script>
 <script src="js/site.js?v=20260724" defer></script>
 </body>
 </html>

--- a/site/benchmarks.js
+++ b/site/benchmarks.js
@@ -29,7 +29,11 @@ async function loadRunning() {
     // ones: GitHub reports runs/jobs that haven't finished as "queued", "pending", or
     // "in_progress" depending on matrix position and concurrency-group state, and a
     // 6-way matrix (tier × bench) run can sit in any mix of those before its legs start.
-    const runsResp = await fetch(`${GH_API}/actions/workflows/benchmarks.yml/runs?per_page=5`);
+    // per_page=100 (the API max): PR-triggered benchmark runs churn fast (labeled event,
+    // several per PR) and can push a long-running manual dispatch — the thing this panel
+    // most needs to surface — past a small page before it finishes. Cheap to raise: only
+    // non-completed runs in the page trigger a follow-up jobs fetch below.
+    const runsResp = await fetch(`${GH_API}/actions/workflows/benchmarks.yml/runs?per_page=100`);
     if (!runsResp.ok) throw new Error(String(runsResp.status));
     const { workflow_runs: runs } = await runsResp.json();
     const active = (runs || []).filter((r) => r.status !== "completed");


### PR DESCRIPTION
## Summary

Third fix in the live-run-panel saga (follow-up to #227, #228). After #228 merged, the panel still showed nothing. Root cause this time: `loadRunning()` fetches the workflow's recent runs with `per_page=5`, and PR-triggered benchmark CI churn (each of the recent fix PRs auto-triggered several `pull_request`-type benchmark runs) pushed the actual active `workflow_dispatch` runs past position 5 in the most-recent-runs list — so they were filtered out before their jobs were ever fetched. Same end symptom as before, different cause.

Verified directly against the live GitHub API before fixing:
- Two runs are currently non-completed: `30520700500` (pending) and `30518857693` (queued)
- In the unfiltered runs-list, they sit at rank 9 and rank 15 — both past `per_page=5`, both within `per_page=100`
- Confirmed their jobs include `queued`/`pending`/`in_progress` legs matching `JOB_RE` (e.g. `smoke / skillsbench` `in_progress` on run `30518857693`)

Fix: bump `per_page` to 100 (the API max). This is cheap — only non-completed runs in the page trigger a follow-up per-run jobs fetch, so the extra page size doesn't multiply request volume.

## Test plan

- [x] `node --check site/benchmarks.js` passes
- [x] Fetched `per_page=100` against the live API and confirmed both currently-active runs (and their non-completed jobs) are now within the window
- [ ] After merge + Pages deploy, confirm the "Running now / queued" panel on https://skillberry-ai.github.io/cap-evolve/benchmarks.html actually renders these two runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)