### PR TITLE
revert: gate matrix legs at job level (#230) — broke benchmarks.yml

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -149,20 +149,14 @@ jobs:
     # Trust guard: run PR code from ANY repo (same-repo or a fork) on the self-hosted
     # runner only when the PR author is a known collaborator — never for outside/
     # first-time contributors, who could otherwise run arbitrary code with secrets.
-    # Matrix-leg selection lives here (not in a step): a leg that fails this check
-    # is reported by the GitHub API as "skipped" (a completed, terminal status)
-    # instead of sitting "queued" for a runner turn it'll immediately no-op — this
-    # is also what the site's live-run panel (site/benchmarks.js) reads, so keeping
-    # the decision at job level is what keeps that panel showing only real work.
+    # PR trigger: any label containing 'benchmark-smoke' or 'benchmark-full'
+    # (an all-label or a per-bench one). The per-matrix gate decides the exact tier×bench.
     if: >-
-      (github.event_name == 'workflow_dispatch' &&
-        ((github.event.inputs.tier || 'smoke') == 'all' || (github.event.inputs.tier || 'smoke') == matrix.tier) &&
-        ((github.event.inputs.benchmark || 'all') == 'all' || (github.event.inputs.benchmark || 'all') == matrix.bench)
-      ) ||
+      github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' &&
         contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association) &&
-        (contains(join(github.event.pull_request.labels.*.name, ','), format('benchmark-{0}', matrix.tier)) ||
-         contains(join(github.event.pull_request.labels.*.name, ','), format('benchmark-{0}-{1}', matrix.tier, matrix.bench))))
+        (contains(join(github.event.pull_request.labels.*.name, ','), 'benchmark-smoke') ||
+         contains(join(github.event.pull_request.labels.*.name, ','), 'benchmark-full')))
     strategy:
       fail-fast: false
       matrix:
@@ -194,10 +188,34 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Gate (decide whether this tier/bench runs)
+        id: gate
+        env:
+          # tier-agnostic exact-match label checks (evaluated by Actions, not the shell):
+          #   benchmark-<tier>  = all benches of this tier;  benchmark-<tier>-<bench> = this one
+          HAS_ALL: ${{ contains(github.event.pull_request.labels.*.name, format('benchmark-{0}', matrix.tier)) }}
+          HAS_THIS: ${{ contains(github.event.pull_request.labels.*.name, format('benchmark-{0}-{1}', matrix.tier, matrix.bench)) }}
+          TIER_SEL: ${{ github.event.inputs.tier || 'smoke' }}
+          BENCH_SEL: ${{ github.event.inputs.benchmark || 'all' }}
+        run: |
+          run=false
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            tier_ok=false; bench_ok=false
+            { [ "$TIER_SEL" = "all" ] || [ "$TIER_SEL" = "${{ matrix.tier }}" ]; } && tier_ok=true
+            { [ "$BENCH_SEL" = "all" ] || [ "$BENCH_SEL" = "${{ matrix.bench }}" ]; } && bench_ok=true
+            if [ "$tier_ok" = true ] && [ "$bench_ok" = true ]; then run=true; fi
+          else
+            # pull_request: benchmark-<tier> (all of tier) OR benchmark-<tier>-<bench>
+            if [ "$HAS_ALL" = "true" ] || [ "$HAS_THIS" = "true" ]; then run=true; fi
+          fi
+          echo "run=$run" >> "$GITHUB_OUTPUT"
+
       - name: Setup runner env
+        if: steps.gate.outputs.run == 'true'
         run: bash ci/benchmarks/lib/ci_setup.sh "${{ matrix.bench }}"
 
       - name: Start live snapshot poller
+        if: steps.gate.outputs.run == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -208,10 +226,11 @@ jobs:
           disown
 
       - name: Run suite
+        if: steps.gate.outputs.run == 'true'
         run: bash ci/benchmarks/lib/run_suite.sh "${{ matrix.bench }}" "$GITHUB_WORKSPACE/ci/benchmarks/.work/suite_${{ matrix.tier }}_${{ matrix.bench }}"
 
       - name: Stop live snapshot poller
-        if: always()
+        if: steps.gate.outputs.run == 'true' && always()
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -224,7 +243,7 @@ jobs:
             || echo "::warning::live cleanup push failed (best-effort, no action needed)"
 
       - name: Export CapEvolve UI snapshot
-        if: always()
+        if: steps.gate.outputs.run == 'true' && always()
         run: |
           run_dir="$GITHUB_WORKSPACE/ci/benchmarks/.work/suite_${{ matrix.tier }}_${{ matrix.bench }}_proj/.capevolve/run_suite"
           out="$GITHUB_WORKSPACE/ci/benchmarks/.work/suite_${{ matrix.tier }}_${{ matrix.bench }}"
@@ -237,7 +256,7 @@ jobs:
           fi
 
       - name: Write run metadata
-        if: always()
+        if: steps.gate.outputs.run == 'true' && always()
         run: |
           out="$GITHUB_WORKSPACE/ci/benchmarks/.work/suite_${{ matrix.tier }}_${{ matrix.bench }}"
           mkdir -p "$out"
@@ -268,7 +287,7 @@ jobs:
           cat "$out/runmeta.json"
 
       - name: Upload artifacts (metrics + optimized capabilities)
-        if: always()
+        if: steps.gate.outputs.run == 'true' && always()
         uses: actions/upload-artifact@v4
         with:
           name: benchmarks-${{ matrix.tier }}-${{ matrix.bench }}
@@ -276,7 +295,7 @@ jobs:
           if-no-files-found: warn
 
       - name: Comment results on the PR
-        if: github.event_name == 'pull_request' && always()
+        if: steps.gate.outputs.run == 'true' && github.event_name == 'pull_request' && always()
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
## Summary
- **Emergency revert of #230.** That PR moved the per-tier/bench gate decision into the job's own `if:` condition, referencing `matrix.tier` / `matrix.bench`. GitHub Actions does not permit the `matrix` context inside a job-level `if:` (only in `env`, `strategy`, `name`, `container`, `services`, `with`) — this made `benchmarks.yml` an **invalid workflow file** on `main`.
- Confirmed via the failed validation run's page: `Unrecognized named-value: 'matrix'. Located at position 140 within expression` (line 157, col 9). Every push since the #230 merge has failed workflow-file validation with zero jobs created — `ci/benchmarks` has been entirely non-functional on `main`.
- This PR reverts `.github/workflows/benchmarks.yml` back to the pre-#230 state: the internal "Gate (decide whether this tier/bench runs)" step (using `steps.gate.outputs.run`) is restored, and the job-level `if:` no longer references `matrix`.
- The original goal of #230 (hide gate-skipped legs from the live-run queue on the benchmarks page) will be redone in a follow-up PR using a dynamic/computed matrix (a separate `plan` job outputs the filtered tier×bench list; `bench`'s `strategy.matrix` consumes it via `fromJson`), which avoids ever creating a job for a skipped leg without hitting this context restriction.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/benchmarks.yml'))"` — YAML parses.
- [x] Confirmed the job-level `if:` no longer references `matrix.*` (grep + manual review).
- [ ] After merge: confirm no further `push`-triggered workflow-file-validation failures appear for `benchmarks.yml`, and a manual `workflow_dispatch` or PR-label-triggered run succeeds.