### PR TITLE
Dashboard phase pipeline + evidence header (sparkline + live token burn)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to cap-evolve are documented here. The format follows
 [Semantic Versioning](https://semver.org/) (currently `0.x` — anything may change).
 
 ## [Unreleased]
+### Added
+- **Live terminal progress: `cap-evolve run --follow` and `cap-evolve tail` (#116).** A
+  classic run was silent for its whole duration — a hung multi-hour run looked exactly
+  like a working one. Both new surfaces render human-readable progress (stage, baseline,
+  per-candidate accept/reject + reason, budget warnings, optimizer errors, finalize, plus
+  a running cost/token meter) from the run's `events.jsonl`. The byte-offset tail is now
+  ONE shared helper — `cap_evolve.eventstream` — consumed by the CLI *and* by the
+  dashboard's SSE route, so the terminal and the web view can never disagree. `--follow`
+  writes to stderr, leaving stdout as the machine-readable final JSON; output is plain
+  text on any non-TTY (piped, CI, `NO_COLOR`). Default behavior is unchanged.
+
 ### Fixed
 - **Benchmark CI robustness (skillberry-1 self-hosted runner).** Three fixes so a broken
   runner or gateway is *loud*, not a silent all-0.000 "success": (1) `ci_setup.sh` now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ All notable changes to cap-evolve are documented here. The format follows
   writes to stderr, leaving stdout as the machine-readable final JSON; output is plain
   text on any non-TTY (piped, CI, `NO_COLOR`). Default behavior is unchanged.
 
+  Hardened after review: a malformed event can no longer kill the follower (and if the
+  follower does stop, it says so on stderr instead of going dark); every rendered line is
+  stripped of control characters, so an optimizer's stderr cannot drive the terminal or
+  forge a progress line; the cost meter counts runner spend from `evaluate` and optimizer
+  spend from `step` exactly once, matching the run's own `Spent.total_usd`; `--follow` is
+  disabled rather than falling back to stdout when stderr is closed (`2>&-`); and
+  `follow_events` yields a typed `_follow_end` sentinel naming *why* it stopped
+  (`stop_kind` / `idle` / `should_stop`). `cap-evolve tail` exits `2` on an impossible run
+  dir and `3` on an idle timeout with no events.
+
 ### Fixed
 - **Benchmark CI robustness (skillberry-1 self-hosted runner).** Three fixes so a broken
   runner or gateway is *loud*, not a silent all-0.000 "success": (1) `ci_setup.sh` now

--- a/core/cap_evolve/cli.py
+++ b/core/cap_evolve/cli.py
@@ -14,6 +14,8 @@ Subcommands:
                        [--follow]  print live progress while the run works
     cap-evolve tail    [run_dir] [--base .capevolve]  attach to an ongoing run's
                        events.jsonl and print human-readable progress
+                       (exit 0 = run finished, 2 = not a possible run dir,
+                        3 = --idle-timeout elapsed with no events)
 
 ``run`` is intentionally minimal in Phase 0 and grows as phase skills land; it
 already resolves the manifest and validates the spec so the wiring is testable.
@@ -78,18 +80,46 @@ def _events_path(base: Path, run_ts: str | None, seen: set[str] | None) -> Path 
     return (runs[-1] / "events.jsonl") if runs else None
 
 
-def _spawn_follower(base: Path, run_ts: str | None, seen: set[str] | None):
+def _stderr_is_usable() -> bool:
+    """True only if progress can safely be written to a real, distinct stderr.
+
+    Under ``2>&-`` CPython either sets ``sys.stderr`` to ``None`` or hands fd 2 to the
+    next ``open()``, so writes would land *interleaved in stdout* and break the
+    machine-readable JSON contract ``--follow`` advertises. Following silently off is
+    strictly better than corrupt stdout.
+    """
+    err = sys.stderr
+    if err is None or getattr(err, "closed", False):
+        return False
+    try:
+        efd = err.fileno()
+    except Exception:  # noqa: BLE001 — a captured StringIO has no fd; safe to write to
+        return True
+    # fd 2 closed and reused by the next open() → that fd is not stderr any more.
+    # (`>f 2>&1` keeps fd 2 == 2 pointing at the same file, which is legitimate.)
+    return efd == 2
+
+
+def _spawn_follower(base: Path, run_ts: str | None, seen: set[str] | None,
+                    offset: int = 0):
     """Print live progress from ``events.jsonl`` on a daemon thread.
 
-    Returns ``(stop_event, thread)``; set the event when the run finishes. Reads the
-    same typed event stream the dashboard's SSE route serves (``cap_evolve.eventstream``),
-    so terminal and web can't disagree. Never raises into the run.
+    Returns ``(stop_event, thread)`` — or ``(None, None)`` when stderr is unusable, in
+    which case following is disabled rather than corrupting stdout. Set the event when
+    the run finishes. Reads the same typed event stream the dashboard's SSE route
+    serves (``cap_evolve.eventstream``), so terminal and web can't disagree. Never
+    raises into the run — but never dies *quietly* either: if the follower stops, it
+    says so on stderr, because silence mistaken for progress is the bug #116 fixes.
     """
     import threading
     from . import eventstream
 
+    if not _stderr_is_usable():
+        return None, None
+
     stop = threading.Event()
-    color = eventstream.use_color(sys.stderr)
+    err = sys.stderr  # bind now: don't follow a stream reassigned mid-run
+    color = eventstream.use_color(err)
 
     def worker():
         # Progress goes to STDERR: stdout stays the machine-readable JSON contract that
@@ -104,12 +134,20 @@ def _spawn_follower(base: Path, run_ts: str | None, seen: set[str] | None):
                 return
             totals: dict = {}
             for ev in eventstream.follow_events(
-                    path, poll=0.5, idle_timeout=None, should_stop=stop.is_set):
+                    path, offset=offset, poll=0.5,
+                    should_stop=lambda _last: stop.is_set()):
                 line = eventstream.render_line(ev, totals, color=color)
                 if line:
-                    print(line, file=sys.stderr, flush=True)
-        except Exception:  # noqa: BLE001 — observability must never break the run
-            pass
+                    print(line, file=err, flush=True)
+        except Exception as e:  # noqa: BLE001 — observability must never break the run
+            # ...but it must never go dark in silence either. #144: this is the hook for
+            # the forensic crash log; the user-visible line below is the minimum.
+            try:
+                print(f"[follow] live progress stopped: {e!r} — the run continues; "
+                      f"use `cap-evolve tail` or the dashboard to watch it",
+                      file=err, flush=True)
+            except Exception:  # noqa: BLE001 — stderr died too; nothing left to do
+                pass
 
     t = threading.Thread(target=worker, name="cap-evolve-follow", daemon=True)
     t.start()
@@ -133,6 +171,8 @@ def _cmd_tail(argv):
                    help="give up after N seconds of silence (0 = wait forever)")
     p.add_argument("--no-color", action="store_true")
     args = p.parse_args(argv)
+    if args.idle_timeout < 0:  # a negative timeout used to trip the check immediately
+        p.error("--idle-timeout must be >= 0 (0 = wait forever)")
 
     if args.run_dir:
         root = Path(args.run_dir)
@@ -144,23 +184,36 @@ def _cmd_tail(argv):
         root = runs[-1]
     events = root / "events.jsonl"
     # A named run dir need NOT exist yet: attaching before `cap-evolve run` creates it
-    # is the whole point. follow_events waits for the file; --idle-timeout bounds the
-    # wait, so a typo'd path exits on the timeout instead of hanging forever.
+    # is the whole point. But a path whose PARENT doesn't exist can never become a run
+    # dir, so a typo fails fast with a distinct code instead of pretend-waiting 5 min.
+    if not root.exists() and not root.parent.is_dir():
+        print(f"no such run dir: {root}", file=sys.stderr)
+        return 2
     if not events.exists():
         print(f"waiting for {events} …", file=sys.stderr, flush=True)
 
     color = not args.no_color and eventstream.use_color(sys.stdout)
     offset = 0 if args.from_start or not events.exists() else events.stat().st_size
     totals: dict = {}
+    shown, reason = 0, None
     try:
         for ev in eventstream.follow_events(
                 events, offset=offset, poll=0.5,
                 idle_timeout=(args.idle_timeout or None)):
+            if ev.get("kind") == eventstream.FOLLOW_END:
+                reason = ev.get("reason")
+                continue
             line = eventstream.render_line(ev, totals, color=color)
             if line:
                 print(line, flush=True)
+                shown += 1
     except KeyboardInterrupt:
         return 130
+    if reason == "idle" and not shown:
+        # Distinct from "the run finished": scripts can tell a timeout from a result.
+        print(f"timed out after {args.idle_timeout:g}s with no events from {events}",
+              file=sys.stderr)
+        return 3
     return 0
 
 
@@ -380,7 +433,11 @@ def _cmd_run(argv):
     if args.follow:
         base_abs = proj_abs.parent
         seen = {p.name for p in base_abs.glob("run_*") if p.is_dir()} if not resume_ts else None
-        follow_stop, follow_thread = _spawn_follower(base_abs, resume_ts, seen)
+        # On --resume, skip the prior log (10k old events are not "live progress"):
+        # start at the current end of file, the way `cap-evolve tail` does.
+        prior = base_abs / f"run_{resume_ts}" / "events.jsonl" if resume_ts else None
+        off = prior.stat().st_size if prior and prior.exists() else 0
+        follow_stop, follow_thread = _spawn_follower(base_abs, resume_ts, seen, off)
 
     def done(code: int) -> int:
         """Drain + stop the follower thread, then return ``code``. Used at every exit."""

--- a/core/cap_evolve/cli.py
+++ b/core/cap_evolve/cli.py
@@ -479,6 +479,22 @@ def _cmd_run(argv):
         if overrides:
             _RunDir.open(workdir / run_dir).update_budget(**overrides)
 
+    # Attest the hard gate INTO the run's own log. The check ran above, before the run
+    # dir existed, so this is the first moment it can be recorded. It is the only
+    # evidence the dashboard's "Implement & check" phase accepts: previously that phase
+    # lit off `target_profile`/`seed_dir_created`, neither of which says anything about
+    # the gate, so a run could render "✓ Implement & check" having never proved it
+    # (#234 review, finding 1). Best-effort, like intake below: failing to log the
+    # attestation must not fail a run whose gate genuinely passed — the phase then reads
+    # `unknown`, which is the honest state.
+    try:
+        from .rundir import RunDir as _RunDir
+        _RunDir.open(workdir / run_dir).log_event(
+            "check_gate", ok=bool(chk.ok), project=str(proj_abs),
+            problems=len(getattr(chk, "problems", ()) or ()))
+    except Exception:  # noqa: BLE001 — attestation is best-effort; absence reads `unknown`
+        pass
+
     # Record the intake phase's spend + summary into the run, if the intake phase
     # wrote <project>/intake.json. Best-effort: a missing/malformed file is ignored so
     # it never breaks the run. (run_dir is workdir-relative; resolve under workdir.)

--- a/core/cap_evolve/cli.py
+++ b/core/cap_evolve/cli.py
@@ -11,6 +11,9 @@ Subcommands:
     cap-evolve check   [project_dir]
     cap-evolve run     --spec .capevolve/project/capevolve.yaml   (sequences phase skills)
                        [--resume [--run-ts TS]]  resume an interrupted run in place
+                       [--follow]  print live progress while the run works
+    cap-evolve tail    [run_dir] [--base .capevolve]  attach to an ongoing run's
+                       events.jsonl and print human-readable progress
 
 ``run`` is intentionally minimal in Phase 0 and grows as phase skills land; it
 already resolves the manifest and validates the spec so the wiring is testable.
@@ -60,6 +63,105 @@ def _cmd_check(argv):
     rep = run_check(project)
     print(json.dumps(rep.to_dict(), indent=2))
     return 0 if rep.ok else 1
+
+
+def _events_path(base: Path, run_ts: str | None, seen: set[str] | None) -> Path | None:
+    """Locate the run's ``events.jsonl``, or ``None`` if no run dir exists yet.
+
+    With ``run_ts`` the path is known up front. Otherwise pick the newest ``run_*``
+    that is NOT in ``seen`` (the dirs that existed before this run started), so a
+    follower attaches to *this* run and not a previous one.
+    """
+    if run_ts:
+        return base / f"run_{run_ts}" / "events.jsonl"
+    runs = sorted(p for p in base.glob("run_*") if p.is_dir() and p.name not in (seen or set()))
+    return (runs[-1] / "events.jsonl") if runs else None
+
+
+def _spawn_follower(base: Path, run_ts: str | None, seen: set[str] | None):
+    """Print live progress from ``events.jsonl`` on a daemon thread.
+
+    Returns ``(stop_event, thread)``; set the event when the run finishes. Reads the
+    same typed event stream the dashboard's SSE route serves (``cap_evolve.eventstream``),
+    so terminal and web can't disagree. Never raises into the run.
+    """
+    import threading
+    from . import eventstream
+
+    stop = threading.Event()
+    color = eventstream.use_color(sys.stderr)
+
+    def worker():
+        # Progress goes to STDERR: stdout stays the machine-readable JSON contract that
+        # scripts parse, so `cap-evolve run --follow > out.json` keeps working.
+        try:
+            path = None
+            while path is None and not stop.is_set():
+                path = _events_path(base, run_ts, seen)
+                if path is None:
+                    stop.wait(0.5)
+            if path is None:
+                return
+            totals: dict = {}
+            for ev in eventstream.follow_events(
+                    path, poll=0.5, idle_timeout=None, should_stop=stop.is_set):
+                line = eventstream.render_line(ev, totals, color=color)
+                if line:
+                    print(line, file=sys.stderr, flush=True)
+        except Exception:  # noqa: BLE001 — observability must never break the run
+            pass
+
+    t = threading.Thread(target=worker, name="cap-evolve-follow", daemon=True)
+    t.start()
+    return stop, t
+
+
+def _cmd_tail(argv):
+    """Attach to an existing/ongoing run dir and print its event stream."""
+    import argparse
+    from . import eventstream
+
+    p = argparse.ArgumentParser(
+        prog="cap-evolve tail",
+        description="tail a run's events.jsonl as human-readable progress lines")
+    p.add_argument("run_dir", nargs="?", default=None,
+                   help="run dir (default: newest run_* under --base)")
+    p.add_argument("--base", default=".capevolve", help="dir containing run_* dirs")
+    p.add_argument("--from-start", action="store_true",
+                   help="replay the whole log first (default: only new events)")
+    p.add_argument("--idle-timeout", type=float, default=300.0,
+                   help="give up after N seconds of silence (0 = wait forever)")
+    p.add_argument("--no-color", action="store_true")
+    args = p.parse_args(argv)
+
+    if args.run_dir:
+        root = Path(args.run_dir)
+    else:
+        runs = sorted(q for q in Path(args.base).glob("run_*") if q.is_dir())
+        if not runs:
+            print(f"no run_* dirs under {args.base}", file=sys.stderr)
+            return 1
+        root = runs[-1]
+    events = root / "events.jsonl"
+    # A named run dir need NOT exist yet: attaching before `cap-evolve run` creates it
+    # is the whole point. follow_events waits for the file; --idle-timeout bounds the
+    # wait, so a typo'd path exits on the timeout instead of hanging forever.
+    if not events.exists():
+        print(f"waiting for {events} …", file=sys.stderr, flush=True)
+
+    color = not args.no_color and eventstream.use_color(sys.stdout)
+    offset = 0 if args.from_start or not events.exists() else events.stat().st_size
+    totals: dict = {}
+    try:
+        for ev in eventstream.follow_events(
+                events, offset=offset, poll=0.5,
+                idle_timeout=(args.idle_timeout or None)):
+            line = eventstream.render_line(ev, totals, color=color)
+            if line:
+                print(line, flush=True)
+    except KeyboardInterrupt:
+        return 130
+    return 0
 
 
 # Old hill-climb skill names → (skill, focus). The three byte-identical clones are
@@ -124,6 +226,9 @@ def _cmd_run(argv):
     p.add_argument("--stall", type=int, default=None)
     p.add_argument("--optimizer-max-turns", type=int, default=None,
                    help="per-iteration cap passed to the optimizer agent CLI (e.g. claude --max-turns)")
+    p.add_argument("--follow", action="store_true",
+                   help="print live progress (stage/candidate/accept-reject/cost) to stderr "
+                        "as the run writes events.jsonl; stdout stays the final JSON")
     p.add_argument("--dashboard", choices=("auto", "report-only", "off"), default=None,
                    help="live dashboard: auto (default, launch at run start), report-only, or off")
     p.add_argument("--dashboard-port", type=int, default=None, help="dashboard server port (default 7878)")
@@ -268,6 +373,22 @@ def _cmd_run(argv):
                 f"--resume: no run_* found under {proj_abs.parent}; pass --run-ts to name one")}))
             return 1
 
+    # --follow: start tailing events.jsonl now, BEFORE baseline creates the run dir, so
+    # the very first events (splits/baseline) are seen. `seen` freezes the pre-existing
+    # run dirs so an unpinned --run-ts follower attaches to this run, not the last one.
+    follow_stop = follow_thread = None
+    if args.follow:
+        base_abs = proj_abs.parent
+        seen = {p.name for p in base_abs.glob("run_*") if p.is_dir()} if not resume_ts else None
+        follow_stop, follow_thread = _spawn_follower(base_abs, resume_ts, seen)
+
+    def done(code: int) -> int:
+        """Drain + stop the follower thread, then return ``code``. Used at every exit."""
+        if follow_stop is not None:
+            follow_stop.set()
+            follow_thread.join(timeout=3.0)
+        return code
+
     # 1) baseline (creates the run dir; capture its relative path)
     base_cmd = [py, skill_run("baseline"), "--base", base, "--project", project,
                 "--capability", cap_path, "--seed", str(spec.get("split_seed", 0)),
@@ -289,7 +410,7 @@ def _cmd_run(argv):
     proc = run(base_cmd)
     if proc.returncode != 0:
         print(json.dumps({"step": "baseline", "error": proc.stderr[-1500:]}))
-        return 1
+        return done(1)
     run_dir = json.loads(proc.stdout)["run_dir"]
 
     # Resume: explicit budget flags EXTEND the reopened run (e.g. bump max_iterations to
@@ -329,7 +450,7 @@ def _cmd_run(argv):
                           "stop_condition": str(spec.get("stop_condition", "")),
                           "next": "drive via the orchestrate Agent-mode loop; "
                                   "seal with `cap-evolve finalize`"}))
-        return 0
+        return done(0)
 
     # 2) algorithm (hill-climb variants select their schedule via --focus)
     alg_cmd = [py, skill_run(algorithm_name), "--run-dir", run_dir, "--project", project,
@@ -409,7 +530,7 @@ def _cmd_run(argv):
     proc = run(alg_cmd)
     if proc.returncode != 0:
         print(json.dumps({"step": "algorithm", "error": proc.stderr[-1500:]}))
-        return 1
+        return done(1)
 
     # 3) finalize  4) report
     last = proc.stdout
@@ -432,11 +553,11 @@ def _cmd_run(argv):
         proc = run(cmd)
         if proc.returncode != 0:
             print(json.dumps({"step": step, "error": proc.stderr[-1500:]}))
-            return 1
+            return done(1)
         last = proc.stdout
 
     print(last)
-    return 0
+    return done(0)
 
 
 def _cmd_dashboard(argv):
@@ -619,13 +740,15 @@ COMMANDS = {
     "run": _cmd_run,
     "estimate": _cmd_estimate,
     "dashboard": _cmd_dashboard,
+    "tail": _cmd_tail,
 }
 
 
 def main(argv=None) -> int:
     argv = list(sys.argv[1:] if argv is None else argv)
     if not argv or argv[0] in ("-h", "--help"):
-        print("usage: cap-evolve {version|splits|check|run|estimate|dashboard} [args]", file=sys.stderr)
+        print("usage: cap-evolve {version|splits|check|run|estimate|dashboard|tail} [args]",
+              file=sys.stderr)
         return 0 if argv else 2
     fn = COMMANDS.get(argv[0])
     if fn is None:

--- a/core/cap_evolve/dashboard.py
+++ b/core/cap_evolve/dashboard.py
@@ -50,6 +50,7 @@ import os
 import re
 import shutil
 import subprocess
+import time
 from pathlib import Path
 
 # ---------------------------------------------------------------------------
@@ -242,10 +243,18 @@ def _step_candidate(ev: dict):
 #: two phases apart.
 _PHASE_KINDS: tuple[tuple[str, str, tuple[str, ...]], ...] = (
     ("intake", "Intake", ("intake",)),
-    ("check", "Implement & check", ("seed_dir_created", "target_profile")),
+    # ONLY `check_gate` — the event `cap-evolve run` logs from the hard gate itself
+    # (``cli.py``), carrying that check's own verdict. `target_profile` used to be here
+    # and was wrong: it is logged by the ALGORITHM runner, after baseline, and only when
+    # a target model is configured, so any `--target-model` run rendered a green
+    # "✓ Implement & check" with nothing proving the gate ran (#234 review, finding 1).
+    # `seed_dir_created` was equally wrong — it fires inside `harness.baseline`, and only
+    # when the seed dir is missing. Nothing here is INFERRED: the gate attests itself, or
+    # the phase reads `unknown`.
+    ("check", "Implement & check", ("check_gate",)),
     ("baseline", "Baseline", ("splits", "splits_warning", "baseline", "baseline_reused")),
     ("optimize", "Optimize", (
-        "algorithm", "minibatch", "diagnose", "optimizer_error", "gate_warning",
+        "minibatch", "optimizer_error", "gate_warning",
         "optimizer_context_warning", "budget_warning",
         "step",                                                        # hill-climb
         "gepa_start", "gepa_select", "gepa_local_gate", "gepa_val_gate",  # gepa
@@ -256,6 +265,17 @@ _PHASE_KINDS: tuple[tuple[str, str, tuple[str, ...]], ...] = (
     ("finalize", "Finalize", ("finalize",)),
     ("report", "Report", ()),  # no event of its own: this artifact IS the report
 )
+
+#: Kinds that record a FAILURE inside a phase. A phase whose only evidence is one of
+#: these produced nothing, so it must not render `done` (a clean tick over an empty
+#: phase) nor `skipped` (which claims it was legitimately not run) — those are
+#: different facts (#234 review, finding 4). ``check_gate`` with ``ok=False`` is
+#: handled the same way, below.
+_PHASE_ERROR_KINDS = frozenset(("optimizer_error", "log_corruption"))
+
+#: The hard gate. Silence here can never read `done` or `skipped`: an evidence header
+#: must not state that the gate which guards all spend passed, on no evidence.
+_HARD_GATE_PHASE = "check"
 
 _PHASE_DETAIL = {
     "intake": "Interview + scaffold the project, adapter, and seed capability.",
@@ -280,47 +300,86 @@ def _event_time(ev: dict) -> float | None:
     return t if t > 0 else None
 
 
-def _rate(total, elapsed_seconds: float, *, finalized: bool, digits: int):
+#: A rate is suppressed once the log has been silent for this many seconds. A quiet log
+#: means the spend the numerator measured is not the spend happening now, and the reader
+#: trusts ``$/min`` most in exactly that case (the run is quiet BECAUSE something
+#: expensive is in flight).
+_RATE_STALE_SECONDS = 120.0
+
+
+def _rate(total, elapsed_seconds: float, *, finalized: bool, digits: int,
+          stale_seconds: float | None = None):
     """A per-minute rate, or ``None`` when reporting one would be dishonest.
 
     ``None`` for a FINALIZED run: a burn *rate* answers "what is this costing me right
     now", and a 2.6-second toy run that spent $0.81 is not burning $18.69/min — it is
     not burning anything, it is over. Also ``None`` below a minute of elapsed time,
     where extrapolating a few seconds to a per-minute figure is invention.
+
+    ``stale_seconds`` is how long the log has been silent. Both the numerator and the
+    denominator stop advancing when the log goes quiet, so the surviving ratio describes
+    only the DENSE part of the log: a run 58 minutes into one slow step reported 30x the
+    honest rate off a frozen 120s denominator (#234 review, finding 3). Past
+    :data:`_RATE_STALE_SECONDS` there is no supportable recent-burn claim, so we make
+    none. ``elapsed_seconds`` must be wall-clock elapsed (``now - first_t``), not the
+    event span, so the denominator keeps growing while the log is quiet.
     """
     if finalized or elapsed_seconds < 60.0 or not total:
+        return None
+    if stale_seconds is not None and stale_seconds > _RATE_STALE_SECONDS:
         return None
     return round(total / (elapsed_seconds / 60.0), digits)
 
 
-def derive_pipeline(events: list[dict], *, finalized: bool = False) -> dict:
+def derive_pipeline(events: list[dict], *, finalized: bool = False,
+                    now: float | None = None, liveness: str | None = None) -> dict:
     """Phase pipeline + live burn for the evidence header, from events alone.
 
     Returns ``{"phases": [...], "current", "now", "burn"}`` where each phase is
-    ``{"key", "label", "status": done|active|skipped|pending, "detail", "started_at"}``.
-    A phase is *done* once a LATER phase has started, *active* when it is the latest
-    phase to have started, *pending* when nothing has reached it yet — and *skipped*
-    when the run is already past it but it logged no event of its own. ``skipped`` is
-    not cosmetic: ``cap-evolve run`` on a pre-scaffolded project never emits ``intake``,
-    and calling that phase "pending" on a finalized run states something false.
+    ``{"key", "label", "status", "detail", "started_at"}``. Status is one of:
 
-    ``now`` is the newest renderable event as ``eventstream.format_event`` renders it
-    (the terminal's own words and the terminal's own sanitiser, so no model-controlled
-    string reaches a renderer unescaped) plus the wall-clock ``t`` a caller needs to
-    compute time-in-state client-side.
+    ``done``
+        A later phase has started, and this one logged real (non-error) evidence.
+    ``active``
+        The latest phase to have started — and the run is not known to be dead.
+    ``interrupted``
+        The latest phase to have started, but ``liveness`` says ``crashed``/``stalled``.
+        ``active`` next to a "crashed" badge is a contradiction the reader cannot
+        resolve (#234 review): the phase is where the run STOPPED, not what is running.
+    ``errored``
+        Reached, but its only evidence is failure (``optimizer_error`` and nothing
+        else). Neither ``done`` (a clean tick over a phase that produced nothing) nor
+        ``skipped`` (which claims it was legitimately not run) is true of it.
+    ``skipped``
+        Past it, and it logged nothing — a legitimately-absent stage. ``cap-evolve run``
+        on a pre-scaffolded project never emits ``intake``, and calling that phase
+        "pending" on a finished run states something false.
+    ``unknown``
+        Past it, it logged nothing, and silence is not evidence of absence. Used for
+        the ``check`` hard gate: the gate that guards all spend either attests itself
+        (``check_gate``) or its state is unknown. It never reads ``done`` or ``skipped``.
+    ``pending``
+        Nothing has reached it yet.
+
+    ``now`` (the parameter) is the wall clock, defaulting to ``time.time()``. It is the
+    burn RATE's denominator — ``now - first_t``, not ``last_t - first_t``, because the
+    event span freezes the instant the log goes quiet and the ratio then describes only
+    the dense part of the log (30x overstatement, #234 review finding 3). Pass it
+    explicitly to keep a caller deterministic. Phase detection itself still reads no
+    clock, so ``#194``'s event-log-keyed cache stays correct for everything but the rate.
 
     ``burn`` is spend accumulated with ``eventstream.accrue_totals`` — the one
-    arithmetic that counts runner cost from ``evaluate`` and optimizer cost from
-    ``step``-likes exactly once. Re-deriving it here double-counted the runner and
-    showed ~2x the real spend (#191 review); ``reduce_run`` overrides these totals with
-    ``state.json``'s authoritative ``Spent`` when the run wrote one, and records which
-    source won in ``burn["source"]``.
+    arithmetic that counts each dollar once, across all three algorithms.
+    ``reduce_run`` overrides these totals with ``state.json``'s authoritative ``Spent``
+    when the run wrote one, and records which source won in ``burn["source"]``.
     """
     from .eventstream import accrue_totals, format_event  # local: keeps import cost off report
 
     started: dict[str, float | None] = {}
     order = [k for k, _, _ in _PHASE_KINDS]
     kind_to_phase = {kind: key for key, _, kinds in _PHASE_KINDS for kind in kinds}
+    #: Phases with at least one non-error event — what separates `done` from `errored`.
+    real_evidence: set[str] = set()
 
     totals: dict = {}
     now_line: str | None = None
@@ -334,9 +393,16 @@ def derive_pipeline(events: list[dict], *, finalized: bool = False) -> dict:
         if t is not None:
             first_t = t if first_t is None else min(first_t, t)
             last_t = t if last_t is None else max(last_t, t)
-        phase = kind_to_phase.get(str(ev.get("kind") or ""))
-        if phase is not None and phase not in started:
-            started[phase] = t
+        kind = str(ev.get("kind") or "")
+        phase = kind_to_phase.get(kind)
+        if phase is not None:
+            if phase not in started:
+                started[phase] = t
+            # A gate that attests its own FAILURE is evidence of a failure, not of a
+            # pass, so it doesn't count as real evidence either.
+            failed_gate = kind == "check_gate" and not ev.get("ok", True)
+            if kind not in _PHASE_ERROR_KINDS and not failed_gate:
+                real_evidence.add(phase)
         # skip_kinds=() so the bookkeeping kinds this phase detection needs are
         # rendered too, not dropped as terminal noise.
         line = format_event(ev, totals, skip_kinds=())
@@ -346,25 +412,42 @@ def derive_pipeline(events: list[dict], *, finalized: bool = False) -> dict:
     if finalized:
         started.setdefault("finalize", last_t)
         started.setdefault("report", last_t)
+        real_evidence.update(("finalize", "report"))
 
+    dead = liveness in ("crashed", "stalled")
     latest = next((k for k in reversed(order) if k in started), None)
     reached = order.index(latest) if latest is not None else -1
     phases = []
     for i, key in enumerate(order):
         label = next(lbl for k, lbl, _ in _PHASE_KINDS if k == key)
         if key not in started:
-            # Past it but silent → skipped, not pending: a finalized run whose project
-            # was already scaffolded never logs `intake`, and "pending" would be a lie.
-            status = "skipped" if i < reached else "pending"
+            if i >= reached:
+                status = "pending"
+            elif key == _HARD_GATE_PHASE:
+                # Silence about the hard gate is NOT evidence it was skipped: unlike
+                # `intake`, there is no legitimate path that runs without it. Saying
+                # either "done" or "skipped" here would state a fact we do not have.
+                status = "unknown"
+            else:
+                status = "skipped"
+        elif key not in real_evidence:
+            status = "errored"
         elif key == latest:
-            status = "active"
+            # A phase cannot be "currently active" while liveness says the process is
+            # gone or wedged — it is where the run stopped.
+            status = "interrupted" if dead else "active"
         else:
             status = "done"
         phases.append({"key": key, "label": label, "status": status,
                        "detail": _PHASE_DETAIL[key], "started_at": started.get(key),
                        "index": i + 1})
 
-    elapsed = (last_t - first_t) if (first_t is not None and last_t is not None) else 0.0
+    span = (last_t - first_t) if (first_t is not None and last_t is not None) else 0.0
+    wall = float(time.time() if now is None else now)
+    # Wall-clock elapsed and silence, both anchored on real event timestamps. max(span)
+    # guards a clock that has moved backwards since the log was written.
+    elapsed = max(span, wall - first_t) if first_t is not None else 0.0
+    stale = max(0.0, wall - last_t) if last_t is not None else None
     usd = float(totals.get("usd") or 0.0)
     tokens = int(totals.get("tokens") or 0)
     return {
@@ -375,8 +458,12 @@ def derive_pipeline(events: list[dict], *, finalized: bool = False) -> dict:
         "burn": {
             "usd": round(usd, 6), "tokens": tokens,
             "elapsed_seconds": round(elapsed, 1),
-            "usd_per_min": _rate(usd, elapsed, finalized=finalized, digits=6),
-            "tokens_per_min": _rate(tokens, elapsed, finalized=finalized, digits=1),
+            "event_span_seconds": round(span, 1),
+            "stale_seconds": None if stale is None else round(stale, 1),
+            "usd_per_min": _rate(usd, elapsed, finalized=finalized, digits=6,
+                                 stale_seconds=stale),
+            "tokens_per_min": _rate(tokens, elapsed, finalized=finalized, digits=1,
+                                    stale_seconds=stale),
             "source": "events",
         },
     }
@@ -683,10 +770,13 @@ def reduce_run(run_dir) -> dict:
         })
 
     # --- #138 evidence header: phase pipeline + live burn ----------------
-    # Derived from events.jsonl alone, so #194's reduce cache (keyed on the event
-    # log's mtime/size/inode) invalidates exactly when this changes. Nothing here
-    # reads the wall clock: `now.since` is an event timestamp and time-in-state is
-    # computed by the viewer, so a cache hit can never serve a frozen "3m ago".
+    # PHASES are derived from events.jsonl alone, so #194's reduce cache (keyed on the
+    # event log's mtime/size/inode) invalidates exactly when they change, and `now.since`
+    # is an event timestamp with time-in-state computed by the viewer — a cache hit can
+    # never serve a frozen "3m ago". The burn RATE is the one clock-dependent field
+    # (finding 3 requires a wall-clock denominator); it is recomputed below on every
+    # reduce, and being suppressed by staleness it can only ever go from a number to
+    # `None` as a run goes quiet, never to a larger fabricated rate.
     _finalized = bool(test_reward is not None or sealed)
     pipeline = derive_pipeline(events, finalized=_finalized)
     if sp is not None and (sp.total_usd or sp.runner_tokens or sp.optimizer_tokens):
@@ -698,10 +788,13 @@ def reduce_run(run_dir) -> dict:
                                         + sp.intake_tokens)
         pipeline["burn"]["source"] = "spent"
         el = pipeline["burn"]["elapsed_seconds"] or 0.0
+        _stale = pipeline["burn"]["stale_seconds"]
         pipeline["burn"]["usd_per_min"] = _rate(pipeline["burn"]["usd"], el,
-                                               finalized=_finalized, digits=6)
+                                               finalized=_finalized, digits=6,
+                                               stale_seconds=_stale)
         pipeline["burn"]["tokens_per_min"] = _rate(pipeline["burn"]["tokens"], el,
-                                                  finalized=_finalized, digits=1)
+                                                  finalized=_finalized, digits=1,
+                                                  stale_seconds=_stale)
 
     delta_pct = None
     if baseline_val not in (None, 0) and best_val is not None:
@@ -723,11 +816,13 @@ def reduce_run(run_dir) -> dict:
         "test_sealed": sealed,
         # #138: the evidence header. `pipeline.phases` is which stage is lit,
         # `pipeline.now` the focal line, `pipeline.burn` the live spend readout.
-        # `metric_direction` is stated rather than assumed: every gate in the repo
-        # accepts on `val > parent_val`, so reward is higher-is-better, and the header
-        # says so instead of leaving an arrow's meaning to the reader.
+        # Reward is higher-is-better, period: every gate in the repo accepts on
+        # `val > parent_val`. That used to be published as a `metric_direction` field
+        # with a `lower_is_better` branch in two components — a constant dressed as a
+        # variable, whose only test asserted a value nothing could emit (#234 nit 6).
+        # The renderers state the constant; when a metric direction becomes a real spec
+        # field, publish it then.
         "pipeline": pipeline,
-        "metric_direction": "higher_is_better",
         "counts": counts,
         "frontier": frontier,
         "tasks": tasks,
@@ -1030,7 +1125,11 @@ header .tag{color:var(--muted);font-size:12px;margin-left:auto}
 .phase .nm{font-weight:600} .phase .st{font-size:11px;text-transform:uppercase;letter-spacing:.05em}
 .phase.done{border-color:#1f3a23} .phase.done .st{color:var(--ok)}
 .phase.active{border-color:var(--accent)} .phase.active .st{color:var(--accent)}
-.phase.pending .st,.phase.skipped .st{color:var(--muted)}
+/* interrupted/errored are FAILURE states, not quiet ones: a phase the run stopped in,
+   and a phase whose only evidence is an error, must not read like a clean tick. */
+.phase.interrupted,.phase.errored{border-color:var(--bad)}
+.phase.interrupted .st,.phase.errored .st{color:var(--bad)}
+.phase.pending .st,.phase.skipped .st,.phase.unknown .st{color:var(--muted)}
 .phase .d{color:var(--muted);font-size:11px;margin-top:4px}
 .dead{background:var(--card2);border:1px solid var(--line);border-left:3px solid var(--bad);border-radius:0 8px 8px 0;padding:6px 12px;margin:6px 0}
 .dead .x{color:var(--bad);font-size:11px;float:right}
@@ -1145,7 +1244,9 @@ function sec(title){const s=$('section');s.append($('h2',{text:title}));main.app
         st:p.status, d:M[p.key]||p.detail}))
     : [
     {nm:'Intake',st:D(total>0||hasBase),d:'Interview + scaffold project, adapter, seed.'},
-    {nm:'Implement & check',st:D(total>0||hasBase),d:'Hard gate before any budget is spent.'},
+    /* A pre-#138 payload has no event log, so nothing attests the hard gate. Getting
+       PAST it is not proof it passed, so this reads `unknown`, never a green tick. */
+    {nm:'Implement & check',st:'unknown',d:'Hard gate before any budget is spent — no event attests it in this payload.'},
     {nm:'Baseline',st:D(hasBase),d:M.baseline},
     {nm:'Optimize'+(S.algorithm?' · '+S.algorithm:''),st:finalized?'done':(hasBase?'active':'pending'),
      d:M.optimize},
@@ -1166,7 +1267,6 @@ function sec(title){const s=$('section');s.append($('h2',{text:title}));main.app
 (function(){
   const P=S.pipeline; if(!P) return;
   const s=sec('Evidence'); const b=P.burn||{};
-  const dir=S.metric_direction==='lower_is_better'?'lower':'higher';
   const pc=v=>v==null?'—':(v*100).toFixed(1)+'%';
 
   if(P.now&&P.now.line){
@@ -1200,7 +1300,7 @@ function sec(title){const s=$('section');s.append($('h2',{text:title}));main.app
     if(s2)k.append($('div',{class:'s',text:s2}));return k;};
   const src=b.source==='spent'
     ?'state.json Spent.total_usd (runner + optimizer + intake) — the same total the budget check uses.'
-    :'events.jsonl via eventstream.accrue_totals — each dollar counted once.';
+    :'events.jsonl via eventstream.accrue_totals — runner from evaluate/minibatch, optimizer from the per-iteration gate events; each dollar counted once.';
   row.append(
     kp2('burn','$'+(b.usd||0).toFixed(4),b.usd_per_min!=null?'$'+b.usd_per_min.toFixed(4)+'/min':'',src),
     kp2('tokens',(b.tokens||0).toLocaleString(),

--- a/core/cap_evolve/dashboard.py
+++ b/core/cap_evolve/dashboard.py
@@ -229,6 +229,159 @@ def _step_candidate(ev: dict):
     return ev.get("candidate") or ev.get("candidate_id")
 
 
+# ---------------------------------------------------------------------------
+# Pipeline phases + live burn (#138) — the evidence header's inputs
+# ---------------------------------------------------------------------------
+
+#: Pipeline order, and for each phase EVERY event kind that proves it has started.
+#: Keyed off event kinds rather than ``kind == "step"``: hill-climb logs ``step``,
+#: GEPA logs ``gepa_val_gate``/``gepa_select``/…, SkillOpt logs ``skillopt_step``, and
+#: four bugs in this epic (#224) came from a consumer assuming one shape. A kind absent
+#: here simply doesn't advance the phase — ``evaluate`` is deliberately absent because
+#: it fires for BOTH the baseline eval and every candidate eval, so it cannot tell the
+#: two phases apart.
+_PHASE_KINDS: tuple[tuple[str, str, tuple[str, ...]], ...] = (
+    ("intake", "Intake", ("intake",)),
+    ("check", "Implement & check", ("seed_dir_created", "target_profile")),
+    ("baseline", "Baseline", ("splits", "splits_warning", "baseline", "baseline_reused")),
+    ("optimize", "Optimize", (
+        "algorithm", "minibatch", "diagnose", "optimizer_error", "gate_warning",
+        "optimizer_context_warning", "budget_warning",
+        "step",                                                        # hill-climb
+        "gepa_start", "gepa_select", "gepa_local_gate", "gepa_val_gate",  # gepa
+        "gepa_merge_local", "gepa_merge_skip", "gepa_resume", "gepa_stop",
+        "skillopt_start", "skillopt_step",                             # skillopt
+        "skillopt_slow_eval", "skillopt_slow_update",
+    )),
+    ("finalize", "Finalize", ("finalize",)),
+    ("report", "Report", ()),  # no event of its own: this artifact IS the report
+)
+
+_PHASE_DETAIL = {
+    "intake": "Interview + scaffold the project, adapter, and seed capability.",
+    "check": "Hard gate: the adapter must pass cap-evolve check before any budget is spent.",
+    "baseline": "Freeze train/val/test splits; score the seed on validation.",
+    "optimize": "Propose → evaluate → gate by significance → snapshot. Repeat.",
+    "finalize": "Score the best candidate once on the sealed test split.",
+    "report": "This dashboard — baseline → best → sealed test, fully explained.",
+}
+
+
+def _event_time(ev: dict) -> float | None:
+    """An event's ``t`` as a float, or ``None`` when absent/malformed.
+
+    ``RunDir.log_event`` serialises with ``default=str``, so a ``t`` that is a string
+    or a dict is reachable in a real log and must not raise here.
+    """
+    try:
+        t = float(ev.get("t"))
+    except (TypeError, ValueError):
+        return None
+    return t if t > 0 else None
+
+
+def _rate(total, elapsed_seconds: float, *, finalized: bool, digits: int):
+    """A per-minute rate, or ``None`` when reporting one would be dishonest.
+
+    ``None`` for a FINALIZED run: a burn *rate* answers "what is this costing me right
+    now", and a 2.6-second toy run that spent $0.81 is not burning $18.69/min — it is
+    not burning anything, it is over. Also ``None`` below a minute of elapsed time,
+    where extrapolating a few seconds to a per-minute figure is invention.
+    """
+    if finalized or elapsed_seconds < 60.0 or not total:
+        return None
+    return round(total / (elapsed_seconds / 60.0), digits)
+
+
+def derive_pipeline(events: list[dict], *, finalized: bool = False) -> dict:
+    """Phase pipeline + live burn for the evidence header, from events alone.
+
+    Returns ``{"phases": [...], "current", "now", "burn"}`` where each phase is
+    ``{"key", "label", "status": done|active|skipped|pending, "detail", "started_at"}``.
+    A phase is *done* once a LATER phase has started, *active* when it is the latest
+    phase to have started, *pending* when nothing has reached it yet — and *skipped*
+    when the run is already past it but it logged no event of its own. ``skipped`` is
+    not cosmetic: ``cap-evolve run`` on a pre-scaffolded project never emits ``intake``,
+    and calling that phase "pending" on a finalized run states something false.
+
+    ``now`` is the newest renderable event as ``eventstream.format_event`` renders it
+    (the terminal's own words and the terminal's own sanitiser, so no model-controlled
+    string reaches a renderer unescaped) plus the wall-clock ``t`` a caller needs to
+    compute time-in-state client-side.
+
+    ``burn`` is spend accumulated with ``eventstream.accrue_totals`` — the one
+    arithmetic that counts runner cost from ``evaluate`` and optimizer cost from
+    ``step``-likes exactly once. Re-deriving it here double-counted the runner and
+    showed ~2x the real spend (#191 review); ``reduce_run`` overrides these totals with
+    ``state.json``'s authoritative ``Spent`` when the run wrote one, and records which
+    source won in ``burn["source"]``.
+    """
+    from .eventstream import accrue_totals, format_event  # local: keeps import cost off report
+
+    started: dict[str, float | None] = {}
+    order = [k for k, _, _ in _PHASE_KINDS]
+    kind_to_phase = {kind: key for key, _, kinds in _PHASE_KINDS for kind in kinds}
+
+    totals: dict = {}
+    now_line: str | None = None
+    now_t: float | None = None
+    first_t: float | None = None
+    last_t: float | None = None
+    for ev in events:
+        if not isinstance(ev, dict):
+            continue
+        t = _event_time(ev)
+        if t is not None:
+            first_t = t if first_t is None else min(first_t, t)
+            last_t = t if last_t is None else max(last_t, t)
+        phase = kind_to_phase.get(str(ev.get("kind") or ""))
+        if phase is not None and phase not in started:
+            started[phase] = t
+        # skip_kinds=() so the bookkeeping kinds this phase detection needs are
+        # rendered too, not dropped as terminal noise.
+        line = format_event(ev, totals, skip_kinds=())
+        if line is not None:
+            now_line, now_t = line, t
+
+    if finalized:
+        started.setdefault("finalize", last_t)
+        started.setdefault("report", last_t)
+
+    latest = next((k for k in reversed(order) if k in started), None)
+    reached = order.index(latest) if latest is not None else -1
+    phases = []
+    for i, key in enumerate(order):
+        label = next(lbl for k, lbl, _ in _PHASE_KINDS if k == key)
+        if key not in started:
+            # Past it but silent → skipped, not pending: a finalized run whose project
+            # was already scaffolded never logs `intake`, and "pending" would be a lie.
+            status = "skipped" if i < reached else "pending"
+        elif key == latest:
+            status = "active"
+        else:
+            status = "done"
+        phases.append({"key": key, "label": label, "status": status,
+                       "detail": _PHASE_DETAIL[key], "started_at": started.get(key),
+                       "index": i + 1})
+
+    elapsed = (last_t - first_t) if (first_t is not None and last_t is not None) else 0.0
+    usd = float(totals.get("usd") or 0.0)
+    tokens = int(totals.get("tokens") or 0)
+    return {
+        "phases": phases,
+        "current": latest,
+        "now": {"line": now_line, "t": now_t,
+                "since": started.get(latest) if latest else None},
+        "burn": {
+            "usd": round(usd, 6), "tokens": tokens,
+            "elapsed_seconds": round(elapsed, 1),
+            "usd_per_min": _rate(usd, elapsed, finalized=finalized, digits=6),
+            "tokens_per_min": _rate(tokens, elapsed, finalized=finalized, digits=1),
+            "source": "events",
+        },
+    }
+
+
 def reduce_run(run_dir) -> dict:
     """Fold the run dir into ``{"graph": ..., "summary": ...}`` (redacted)."""
     root = Path(run_dir.root)
@@ -529,6 +682,27 @@ def reduce_run(run_dir) -> dict:
             "tokens": int(test_obj.get("tokens") or 0),
         })
 
+    # --- #138 evidence header: phase pipeline + live burn ----------------
+    # Derived from events.jsonl alone, so #194's reduce cache (keyed on the event
+    # log's mtime/size/inode) invalidates exactly when this changes. Nothing here
+    # reads the wall clock: `now.since` is an event timestamp and time-in-state is
+    # computed by the viewer, so a cache hit can never serve a frozen "3m ago".
+    _finalized = bool(test_reward is not None or sealed)
+    pipeline = derive_pipeline(events, finalized=_finalized)
+    if sp is not None and (sp.total_usd or sp.runner_tokens or sp.optimizer_tokens):
+        # state.json's Spent is the authoritative role-tagged accumulator — the same
+        # number `cost.total_usd` and the budget check use. Prefer it over the event
+        # replay so the header can never disagree with the KPI strip or the cost bars.
+        pipeline["burn"]["usd"] = round(sp.total_usd, 6)
+        pipeline["burn"]["tokens"] = int(sp.runner_tokens + sp.optimizer_tokens
+                                        + sp.intake_tokens)
+        pipeline["burn"]["source"] = "spent"
+        el = pipeline["burn"]["elapsed_seconds"] or 0.0
+        pipeline["burn"]["usd_per_min"] = _rate(pipeline["burn"]["usd"], el,
+                                               finalized=_finalized, digits=6)
+        pipeline["burn"]["tokens_per_min"] = _rate(pipeline["burn"]["tokens"], el,
+                                                  finalized=_finalized, digits=1)
+
     delta_pct = None
     if baseline_val not in (None, 0) and best_val is not None:
         delta_pct = round((best_val - baseline_val) / abs(baseline_val) * 100.0, 1)
@@ -547,6 +721,13 @@ def reduce_run(run_dir) -> dict:
         "test_stderr": test.get("stderr"),
         "test_pass_k": test.get("pass_k"),
         "test_sealed": sealed,
+        # #138: the evidence header. `pipeline.phases` is which stage is lit,
+        # `pipeline.now` the focal line, `pipeline.burn` the live spend readout.
+        # `metric_direction` is stated rather than assumed: every gate in the repo
+        # accepts on `val > parent_val`, so reward is higher-is-better, and the header
+        # says so instead of leaving an arrow's meaning to the reader.
+        "pipeline": pipeline,
+        "metric_direction": "higher_is_better",
         "counts": counts,
         "frontier": frontier,
         "tasks": tasks,
@@ -645,6 +826,23 @@ def build_diffs(run_dir, graph: dict) -> dict:
 # HTML rendering — self-contained (inline CSS + JS + SVG, no CDN)
 # ---------------------------------------------------------------------------
 
+def json_for_html(payload) -> str:
+    """JSON safe to interpolate into an inline ``<script>``. The ONLY such encoder.
+
+    Fixes #209: ``.replace("</", "<\\/")`` was a one-sequence denylist, and HTML's
+    script-data parsing also honours comment-like sequences — a model-written
+    ``reason`` containing ``<!--<script>`` shifted the parser and blanked the page
+    (sections 5 → 0). Every ``<``/``>``/``&`` is encoded instead of pattern-matching
+    the sequences someone already thought of; inside a JSON string literal
+    ``\\u003c`` parses back to ``<``, so the data the JS reads is bit-identical while
+    being inert to the HTML parser. Also covers ``</script>`` and U+2028/9, which
+    are valid JSON but illegal JS line terminators.
+    """
+    return (json.dumps(payload, default=str)
+            .replace("<", "\\u003c").replace(">", "\\u003e").replace("&", "\\u0026")
+            .replace("\u2028", "\\u2028").replace("\u2029", "\\u2029"))
+
+
 def render_html(reduced: dict, run_dir=None) -> str:
     """Render the self-contained dashboard HTML from a reduced run."""
     diffs = {}
@@ -654,8 +852,7 @@ def render_html(reduced: dict, run_dir=None) -> str:
         except Exception:  # noqa: BLE001 — diff panel is optional
             diffs = {}
     payload = {"graph": reduced["graph"], "summary": reduced["summary"], "diffs": diffs}
-    data = json.dumps(payload, default=str).replace("</", "<\\/")
-    return _HTML_TEMPLATE.replace("/*__RUN_DATA__*/null", data)
+    return _HTML_TEMPLATE.replace("/*__RUN_DATA__*/null", json_for_html(payload))
 
 
 def write_dashboard(run_dir) -> Path:
@@ -833,7 +1030,7 @@ header .tag{color:var(--muted);font-size:12px;margin-left:auto}
 .phase .nm{font-weight:600} .phase .st{font-size:11px;text-transform:uppercase;letter-spacing:.05em}
 .phase.done{border-color:#1f3a23} .phase.done .st{color:var(--ok)}
 .phase.active{border-color:var(--accent)} .phase.active .st{color:var(--accent)}
-.phase.pending .st{color:var(--muted)}
+.phase.pending .st,.phase.skipped .st{color:var(--muted)}
 .phase .d{color:var(--muted);font-size:11px;margin-top:4px}
 .dead{background:var(--card2);border:1px solid var(--line);border-left:3px solid var(--bad);border-radius:0 8px 8px 0;padding:6px 12px;margin:6px 0}
 .dead .x{color:var(--bad);font-size:11px;float:right}
@@ -931,18 +1128,28 @@ function sec(title){const s=$('section');s.append($('h2',{text:title}));main.app
   const s=sec('Narrative'); s.append($('p',{class:'muted',text:parts.join('. ')+'.'}));
 })();
 
-/* ---------- 1c. Phases timeline ---------- */
+/* ---------- 1c. Phases timeline ----------
+   Phase status comes from S.pipeline (derive_pipeline over events.jsonl — it knows the
+   event kinds of all three algorithms). The summary-shaped inference is the fallback
+   for a payload written before #138. */
 (function(){
   const c=S.counts, total=c.total, evaluated=c.accepted+c.rejected;
   const hasBase=S.baseline_val!=null, finalized=(S.test_reward!=null)||S.test_sealed;
   const D=b=>b?'done':'pending';
-  const phases=[
+  const M={baseline:`Freeze splits; seed val ${fmt(S.baseline_val)}.`,
+           optimize:`${evaluated} iters · ${c.accepted} accepted · best ${fmt(S.best_val)}.`,
+           finalize:`Sealed test ${fmt(S.test_reward)}.`};
+  const phases=(S.pipeline&&S.pipeline.phases&&S.pipeline.phases.length)
+    ? S.pipeline.phases.map(p=>({
+        nm:(p.key==='optimize'&&S.algorithm)?p.label+' · '+S.algorithm:p.label,
+        st:p.status, d:M[p.key]||p.detail}))
+    : [
     {nm:'Intake',st:D(total>0||hasBase),d:'Interview + scaffold project, adapter, seed.'},
     {nm:'Implement & check',st:D(total>0||hasBase),d:'Hard gate before any budget is spent.'},
-    {nm:'Baseline',st:D(hasBase),d:`Freeze splits; seed val ${fmt(S.baseline_val)}.`},
+    {nm:'Baseline',st:D(hasBase),d:M.baseline},
     {nm:'Optimize'+(S.algorithm?' · '+S.algorithm:''),st:finalized?'done':(hasBase?'active':'pending'),
-     d:`${evaluated} iters · ${c.accepted} accepted · best ${fmt(S.best_val)}.`},
-    {nm:'Finalize',st:D(finalized),d:`Sealed test ${fmt(S.test_reward)}.`},
+     d:M.optimize},
+    {nm:'Finalize',st:D(finalized),d:M.finalize},
     {nm:'Report',st:D(finalized),d:'This dashboard.'},
   ];
   const s=sec('Pipeline phases'); const g=$('div',{class:'phases'});
@@ -950,6 +1157,67 @@ function sec(title){const s=$('section');s.append($('h2',{text:title}));main.app
     e.append($('div',{class:'nm',text:p.nm}),$('div',{class:'st',text:p.st}),$('div',{class:'d',text:p.d}));
     g.append(e);}
   s.append(g);
+})();
+
+/* ---------- 1e. Evidence header (#138): now · sparkline · burn · evidence line ----
+   Every value is attributed via title=. The burn is S.pipeline.burn — state.json's
+   Spent when the run wrote one, else eventstream.accrue_totals over the log — never
+   re-derived here, because summing every cost-ish key double-counts the runner. */
+(function(){
+  const P=S.pipeline; if(!P) return;
+  const s=sec('Evidence'); const b=P.burn||{};
+  const dir=S.metric_direction==='lower_is_better'?'lower':'higher';
+  const pc=v=>v==null?'—':(v*100).toFixed(1)+'%';
+
+  if(P.now&&P.now.line){
+    const n=$('p',{class:'muted'});
+    n.append($('strong',{text:'now '}),$('code',{text:P.now.line}));
+    if(P.current)n.append($('span',{text:'  ('+P.current+' phase)'}));
+    s.append(n);
+  }
+
+  /* running-best sparkline: inline SVG, no dependency, static (nothing to animate) */
+  const bests=G.nodes.filter(n=>n.iteration!=null&&n.best_so_far!=null)
+    .sort((a,b2)=>a.iteration-b2.iteration).map(n=>n.best_so_far);
+  const words=bests.length<2?'Not enough evaluated candidates for a trend yet.':
+    `Best score over ${bests.length} evaluated candidates: `+
+    `${bests[bests.length-1]>bests[0]?'improved':'unchanged'} from ${pc(bests[0])} `+
+    `to ${pc(bests[bests.length-1])} (${dir} is better).`;
+  const row=$('div',{class:'kpis'});
+  if(bests.length>=2){
+    const W=140,H=34,mn=Math.min(...bests),mx=Math.max(...bests),sp=(mx-mn)||1;
+    const el=svg('svg',{viewBox:`0 0 ${W} ${H}`,width:W,height:H,role:'img'});
+    el.setAttribute('aria-label',words);
+    const pts=bests.map((v,i)=>`${(i*W/(bests.length-1)).toFixed(1)},${(H-3-(v-mn)/sp*(H-6)).toFixed(1)}`);
+    el.append(svg('polyline',{points:pts.join(' '),fill:'none',stroke:'#3fb950','stroke-width':1.6,
+      'stroke-linejoin':'round','stroke-linecap':'round'}));
+    const k=$('div',{class:'kpi'});k.append($('div',{class:'l',text:'best on val'}),el,
+      $('div',{class:'s',text:(bests[bests.length-1]>bests[0]?'↑ ':'→ ')+dir+' is better'}));
+    row.append(k);
+  }
+  const kp2=(l,v,s2,tt)=>{const k=$('div',{class:'kpi',title:tt||''});
+    k.append($('div',{class:'l',text:l}),$('div',{class:'v',text:v}));
+    if(s2)k.append($('div',{class:'s',text:s2}));return k;};
+  const src=b.source==='spent'
+    ?'state.json Spent.total_usd (runner + optimizer + intake) — the same total the budget check uses.'
+    :'events.jsonl via eventstream.accrue_totals — each dollar counted once.';
+  row.append(
+    kp2('burn','$'+(b.usd||0).toFixed(4),b.usd_per_min!=null?'$'+b.usd_per_min.toFixed(4)+'/min':'',src),
+    kp2('tokens',(b.tokens||0).toLocaleString(),
+        b.tokens_per_min!=null?Math.round(b.tokens_per_min).toLocaleString()+'/min':'',src),
+    kp2('baseline (seed on val)',pc(S.baseline_val),'','baseline.json → val.reward'),
+    kp2('best on val',pc(S.best_val),'','highest gated val score in events.jsonl'),
+    /* % change off a zero baseline is undefined — show POINTS there, not a fake %. */
+    kp2('Δ vs baseline',S.delta_pct!=null?(S.delta_pct>0?'+':'')+S.delta_pct+'%':
+        (S.delta_abs!=null?(S.delta_abs>0?'+':'')+(S.delta_abs*100).toFixed(1)+' pts':'—'),'',
+        'best val − baseline val (points when the baseline is 0, where a % change is undefined)'),
+    kp2('sealed test',S.test_reward!=null?pc(S.test_reward):(S.test_sealed?'sealed':'not finalized'),
+        '','final.json → test.reward — scored once, on data the optimizer never saw'),
+    kp2('metric',dir+' is better','',
+        'Every gate accepts on val > parent_val, so reward is higher-is-better.')
+  );
+  s.append(row);
+  s.append($('p',{class:'muted',text:words}));   /* the sparkline's text equivalent */
 })();
 
 /* ---------- 1d. What not to try (deduped dead-ends) ---------- */

--- a/core/cap_evolve/eventstream.py
+++ b/core/cap_evolve/eventstream.py
@@ -76,6 +76,29 @@ BOOKKEEPING_KINDS = ("minibatch", "optimizer_context_warning", "target_profile",
 # The one-iteration-finished events, each carrying the optimizer's own spend.
 _STEP_KINDS = ("step", "gepa_val_gate", "skillopt_step")
 
+#: The ONE place that says which event kind is the authoritative source for which
+#: role's spend, as ``kind -> (usd_key, tokens_key)``. Every kind appears once, so
+#: :func:`accrue_totals` cannot double-count a dollar, and a new emitter is wired up
+#: by adding one row here rather than by editing a chain of ``elif``s.
+#:
+#: Runner spend has TWO sources because there are two rollout loops:
+#: ``harness.evaluate_candidate`` (logs ``evaluate``) and GEPA's ``_eval_minibatch``
+#: (logs ``minibatch``). They never cover the same rollouts — each charges
+#: ``update_spent(usd=...)`` for its own — so both must be counted. Omitting
+#: ``minibatch`` understated GEPA's spend 3.9x (#234 review, finding 2).
+#: Optimizer spend is taken from ``gepa_local_gate`` on the GEPA path rather than
+#: ``gepa_val_gate``: the optimizer is paid on EVERY iteration, but ``gepa_val_gate``
+#: only fires on the ones that pass the cheap local gate, so keying off it would
+#: still miss every locally-rejected iteration's spend.
+_SPEND_SOURCES: dict[str, tuple[str, str]] = {
+    "evaluate": ("cost_usd", "tokens"),            # runner    — harness.py:311
+    "minibatch": ("cost_usd", "tokens"),           # runner    — gepa.py:186
+    "step": ("opt_cost_usd", "opt_tokens"),        # optimizer — harness.py:1328
+    "skillopt_step": ("opt_cost_usd", "opt_tokens"),   # optimizer — skillopt
+    "gepa_local_gate": ("opt_cost_usd", "opt_tokens"),  # optimizer — gepa.py:586
+    "intake": ("usd", "tokens"),                   # intake    — cli.py:495
+}
+
 
 def read_new_events(path: Path, offset: int) -> tuple[list[dict], int]:
     """Return (new events, new byte offset). A partial trailing line (no newline)
@@ -244,39 +267,28 @@ def accrue_totals(ev: dict, totals: dict | None) -> None:
     each dollar exactly once. Public so every live readout (terminal meter, #138's
     dashboard burn line) uses one arithmetic instead of forking it.
 
-    The harness reports the SAME runner spend twice: ``evaluate`` logs
-    ``cost_usd``/``tokens`` (``harness.py:311``) and the following ``step`` re-states
-    it alongside the optimizer's own ``opt_cost_usd``/``opt_tokens``
-    (``harness.py:1326``). So the authoritative sources are:
-
-    * runner spend    → ``evaluate`` only  (``cost_usd`` / ``tokens``)
-    * optimizer spend → ``step``-like only (``opt_cost_usd`` / ``opt_tokens``)
-    * intake spend    → ``intake`` only    (``usd`` / ``tokens``)
-
-    which reproduces ``Spent.total_usd = usd + optimizer_usd + intake_usd``
-    (``rundir.py:137``). Summing every cost-ish key on every event double-counted the
-    runner and displayed ~2x the real spend.
+    :data:`_SPEND_SOURCES` names the ONE authoritative kind per role, which is what
+    keeps each dollar counted once: the harness reports the SAME runner spend twice
+    (``evaluate`` logs ``cost_usd``, and the following ``step`` re-states it alongside
+    the optimizer's own ``opt_cost_usd``), so only ``evaluate``'s copy is read. The
+    result reproduces ``Spent.total_usd = usd + optimizer_usd + intake_usd``
+    (``rundir.py:137``) for every algorithm — including GEPA, whose runner spend flows
+    through ``minibatch`` and whose optimizer spend rides ``gepa_local_gate``.
     """
     if totals is None or not isinstance(ev, dict):
         return
-    kind = str(ev.get("kind") or "")
-    if kind == "evaluate":
-        pairs = (("cost_usd", "tokens"),)
-    elif kind in _STEP_KINDS:
-        pairs = (("opt_cost_usd", "opt_tokens"),)
-    elif kind == "intake":
-        pairs = (("usd", "tokens"),)
-    else:
+    pair = _SPEND_SOURCES.get(str(ev.get("kind") or ""))
+    if pair is None:
         return
-    for usd_key, tok_key in pairs:
-        try:
-            totals["usd"] = totals.get("usd", 0.0) + float(ev.get(usd_key) or 0.0)
-        except (TypeError, ValueError):
-            pass
-        try:
-            totals["tokens"] = totals.get("tokens", 0) + int(ev.get(tok_key) or 0)
-        except (TypeError, ValueError):
-            pass
+    usd_key, tok_key = pair
+    try:
+        totals["usd"] = totals.get("usd", 0.0) + float(ev.get(usd_key) or 0.0)
+    except (TypeError, ValueError):
+        pass
+    try:
+        totals["tokens"] = totals.get("tokens", 0) + int(ev.get(tok_key) or 0)
+    except (TypeError, ValueError):
+        pass
 
 
 

--- a/core/cap_evolve/eventstream.py
+++ b/core/cap_evolve/eventstream.py
@@ -12,15 +12,39 @@ Public API (stdlib only, no deps):
     partial trailing line unconsumed so a half-written record is never parsed.
 
 ``follow_events(path, *, offset=0, poll=0.5, stop_kinds=("finalize",),
-                idle_timeout=300.0, should_stop=None) -> Iterator[dict]``
+                idle_timeout=None, should_stop=None) -> Iterator[dict]``
     Blocking generator that yields event dicts as they are appended. Stops after
     an event whose ``kind`` is in ``stop_kinds``, after ``idle_timeout`` seconds
-    with no new events, or when ``should_stop()`` returns true.
+    with no new events, or when ``should_stop(last_event)`` returns true. The LAST
+    record yielded is always a ``{"kind": "_follow_end", "reason": ...}`` sentinel
+    naming *which* exit fired ("stop_kind" / "idle" / "should_stop"), so a consumer
+    can tell "the run finished" from "the run went quiet" (see ``FOLLOW_END``).
 
-``format_event(ev, totals=None) -> str | None``
+``format_event(ev, totals=None, *, skip_kinds=BOOKKEEPING_KINDS) -> str | None``
     One human-readable line for an event, or ``None`` for events with nothing
     worth showing. ``totals`` is an optional caller-owned dict used to accumulate
-    the live cost/token meter across events.
+    the live cost/token meter across events (see :func:`accrue_totals`). Pass
+    ``skip_kinds=()`` to render *every* kind, including the bookkeeping ones.
+
+``accrue_totals(ev, totals) -> None``
+    Add one event's spend to ``totals``, counting each dollar exactly once (runner
+    cost from ``evaluate``, optimizer cost from ``step``-likes, intake from
+    ``intake``). Public so every live spend readout uses one arithmetic.
+
+``sanitize(text) -> str``
+    Strip control characters / ESC sequences and collapse newlines.
+
+``render_line(ev, totals=None, *, color=False, **kw) -> str | None``
+    :func:`format_event` plus optional ANSI styling. Styling only — text safety lives
+    in :func:`format_event`, so neither entry point can return an unsafe line.
+
+``use_color(stream) -> bool``
+    The single TTY / ``NO_COLOR`` decision. ``stream`` is required.
+
+Terminal safety: :func:`format_event` is the ONLY place event text is made
+terminal-safe (see :func:`sanitize`). Event values are model/subprocess-controlled
+(``optimizer_error.error`` is the optimizer CLI's own stderr), so every renderer
+must go through it rather than formatting raw fields itself.
 """
 
 from __future__ import annotations
@@ -33,16 +57,41 @@ from pathlib import Path
 from typing import Callable, Iterator
 
 __all__ = ["read_new_events", "follow_events", "format_event", "render_line",
-           "colorize", "use_color"]
+           "colorize", "use_color", "sanitize", "accrue_totals",
+           "FOLLOW_END", "BOOKKEEPING_KINDS"]
+
+#: ``kind`` of the sentinel :func:`follow_events` yields last. Its ``reason`` is one
+#: of ``"stop_kind"`` / ``"idle"`` / ``"should_stop"``. #118 keys stall detection off
+#: ``reason == "idle"``; ``format_event`` renders it as ``None`` (nothing to show).
+FOLLOW_END = "_follow_end"
+
+#: Kinds :func:`format_event` skips by default (the dashboard shows them, the
+#: terminal shouldn't). Pass ``skip_kinds=()`` to see every kind — #138 needs the
+#: bookkeeping ones for phase detection.
+BOOKKEEPING_KINDS = ("minibatch", "optimizer_context_warning", "target_profile",
+                     "seed_dir_created", "splits_warning", "gepa_resume",
+                     "gepa_merge_skip", "gepa_merge_local", "skillopt_slow_eval",
+                     "skillopt_slow_update")
+
+# The one-iteration-finished events, each carrying the optimizer's own spend.
+_STEP_KINDS = ("step", "gepa_val_gate", "skillopt_step")
 
 
 def read_new_events(path: Path, offset: int) -> tuple[list[dict], int]:
     """Return (new events, new byte offset). A partial trailing line (no newline)
-    is left unconsumed so the next read picks it up once complete."""
+    is left unconsumed so the next read picks it up once complete.
+
+    Only JSON *objects* are returned: a bare ``42``/``null``/``[1,2]`` record parses
+    fine but every consumer (CLI renderer, dashboard SSE route) treats events as
+    dicts, so non-dicts are dropped at the source rather than at each caller.
+    """
     p = Path(path)
     if not p.exists():
         return [], offset
-    if offset >= p.stat().st_size:
+    size = p.stat().st_size
+    if size < offset:
+        offset = 0  # file shrank (truncate/rewrite/rotation) → re-read from the top
+    if offset >= size:
         return [], offset
     # Seek-and-read so each poll costs O(new bytes), not O(file size) — callers poll
     # a growing events.jsonl twice a second, per client.
@@ -53,15 +102,24 @@ def read_new_events(path: Path, offset: int) -> tuple[list[dict], int]:
     if last_nl == -1:
         return [], offset  # only a partial line so far
     complete = chunk[: last_nl + 1]
-    events = []
+    events, dropped = [], 0
     for line in complete.splitlines():
         line = line.strip()
         if not line:
             continue
         try:
-            events.append(json.loads(line))
+            obj = json.loads(line)
         except json.JSONDecodeError:
+            dropped += 1
             continue
+        if isinstance(obj, dict):
+            events.append(obj)
+        else:
+            dropped += 1  # a bare 42/null/[1,2] is not an event
+    if dropped:
+        # Don't silently lose audit-log records: surface the count as an event so both
+        # the terminal and the dashboard see that the log has damage.
+        events.append({"kind": "log_corruption", "dropped": dropped})
     return events, offset + last_nl + 1
 
 
@@ -71,40 +129,61 @@ def follow_events(
     offset: int = 0,
     poll: float = 0.5,
     stop_kinds: tuple[str, ...] = ("finalize",),
-    idle_timeout: float | None = 300.0,
-    should_stop: Callable[[], bool] | None = None,
+    idle_timeout: float | None = None,
+    should_stop: Callable[[dict | None], bool] | None = None,
 ) -> Iterator[dict]:
     """Yield events from ``path`` as they are appended (blocking generator).
 
     ``offset=0`` replays the whole file first, then follows. Waits for the file to
-    appear, so a follower can attach before the run creates it. ``idle_timeout=None``
-    means wait forever.
+    appear, so a follower can attach before the run creates it.
+
+    The final record yielded is ALWAYS a ``{"kind": FOLLOW_END, "reason": r}``
+    sentinel where ``r`` is:
+
+    ``"stop_kind"``   an event whose ``kind`` is in ``stop_kinds`` arrived (run ended)
+    ``"idle"``        ``idle_timeout`` seconds passed with no new event (possible stall)
+    ``"should_stop"`` the caller's ``should_stop`` returned true
+
+    so a consumer can distinguish "done" from "quiet" (#118). ``should_stop`` is
+    called with the last event seen (``None`` before any), so a stall rule can look
+    at its ``t`` without running a second poller. ``idle_timeout=None`` (the default)
+    means wait forever — each caller owns its own threshold; there is deliberately no
+    module-level default, because a shared one would pre-decide #118's configurable
+    stall threshold for every consumer.
     """
     idle_start = time.monotonic()
+    last: dict | None = None
     while True:
         events, offset = read_new_events(path, offset)
         for ev in events:
+            last = ev
             yield ev
             if ev.get("kind") in stop_kinds:
+                yield {"kind": FOLLOW_END, "reason": "stop_kind", "last_kind": ev.get("kind")}
                 return
         if events:
             idle_start = time.monotonic()
         elif idle_timeout is not None and time.monotonic() - idle_start >= idle_timeout:
+            yield {"kind": FOLLOW_END, "reason": "idle", "idle_seconds": idle_timeout}
             return
-        if should_stop is not None and should_stop():
+        if should_stop is not None and should_stop(last):
             # Drain whatever landed between the last read and the stop signal, so the
             # final events of a finished run are never lost to a race.
             for ev in read_new_events(path, offset)[0]:
                 yield ev
+            yield {"kind": FOLLOW_END, "reason": "should_stop"}
             return
         time.sleep(poll)
 
 
 # ---- human-readable rendering ----------------------------------------------
 
-def use_color(stream=None) -> bool:
-    """True only on a real TTY without ``NO_COLOR``. Piped/CI output stays plain."""
-    stream = stream or sys.stdout
+def use_color(stream) -> bool:
+    """True only on a real TTY without ``NO_COLOR``. Piped/CI output stays plain.
+
+    ``stream`` is required: the decision must be made about the stream the caller
+    actually writes to, never a default that could colorize stderr based on stdout.
+    """
     if os.environ.get("NO_COLOR"):
         return False
     try:
@@ -120,6 +199,26 @@ def colorize(text: str, style: str, *, enabled: bool) -> str:
     if not enabled or style not in _CODES:
         return text
     return f"\033[{_CODES[style]}m{text}\033[0m"
+
+
+# Every C0 control char (except TAB) and every C1 control char, mapped away. Event
+# values are model/subprocess-controlled — `optimizer_error.error` is the optimizer
+# CLI's own stderr — so an ESC/OSC/CSI sequence in a payload would otherwise reach the
+# terminal verbatim (set window title, clear screen, OSC 52 clipboard write), and a
+# raw "\n" would forge an extra progress line ("FINALIZE test=1.0 …") for a run that
+# never finished. Newlines/CRs collapse to a visible "⏎" rather than vanishing, so a
+# multi-line optimizer error is still legible on one line.
+_CTRL = {c: None for c in range(0x20) if c != 0x09}
+_CTRL[0x7F] = None                       # DEL
+_CTRL.update({c: None for c in range(0x80, 0xA0)})  # C1, incl. 0x9B (8-bit CSI)
+_CTRL[0x0A] = _CTRL[0x0D] = "⏎"
+
+
+def sanitize(text: str) -> str:
+    """Strip control characters / ESC sequences so no event value can drive the
+    terminal or forge extra output lines. Applied by :func:`format_event` to the
+    whole finished line, so every field and every future event kind is covered."""
+    return str(text).translate(_CTRL)
 
 
 def _num(v, fmt="{:.4f}") -> str:
@@ -140,30 +239,80 @@ def _meter(totals: dict | None) -> str:
     return f"  [${usd:.4f} · {tokens} tok]"
 
 
-def _accrue(ev: dict, totals: dict | None) -> None:
-    if totals is None:
+def accrue_totals(ev: dict, totals: dict | None) -> None:
+    """Accumulate the run's spend into ``totals`` (``{"usd","tokens"}``), counting
+    each dollar exactly once. Public so every live readout (terminal meter, #138's
+    dashboard burn line) uses one arithmetic instead of forking it.
+
+    The harness reports the SAME runner spend twice: ``evaluate`` logs
+    ``cost_usd``/``tokens`` (``harness.py:311``) and the following ``step`` re-states
+    it alongside the optimizer's own ``opt_cost_usd``/``opt_tokens``
+    (``harness.py:1326``). So the authoritative sources are:
+
+    * runner spend    → ``evaluate`` only  (``cost_usd`` / ``tokens``)
+    * optimizer spend → ``step``-like only (``opt_cost_usd`` / ``opt_tokens``)
+    * intake spend    → ``intake`` only    (``usd`` / ``tokens``)
+
+    which reproduces ``Spent.total_usd = usd + optimizer_usd + intake_usd``
+    (``rundir.py:137``). Summing every cost-ish key on every event double-counted the
+    runner and displayed ~2x the real spend.
+    """
+    if totals is None or not isinstance(ev, dict):
         return
-    for k in ("cost_usd", "opt_cost_usd", "usd"):
+    kind = str(ev.get("kind") or "")
+    if kind == "evaluate":
+        pairs = (("cost_usd", "tokens"),)
+    elif kind in _STEP_KINDS:
+        pairs = (("opt_cost_usd", "opt_tokens"),)
+    elif kind == "intake":
+        pairs = (("usd", "tokens"),)
+    else:
+        return
+    for usd_key, tok_key in pairs:
         try:
-            totals["usd"] = totals.get("usd", 0.0) + float(ev.get(k) or 0.0)
+            totals["usd"] = totals.get("usd", 0.0) + float(ev.get(usd_key) or 0.0)
         except (TypeError, ValueError):
             pass
-    for k in ("tokens", "opt_tokens"):
         try:
-            totals["tokens"] = totals.get("tokens", 0) + int(ev.get(k) or 0)
+            totals["tokens"] = totals.get("tokens", 0) + int(ev.get(tok_key) or 0)
         except (TypeError, ValueError):
             pass
 
 
-def format_event(ev: dict, totals: dict | None = None) -> str | None:
+
+def _timestamp(v) -> str:
+    """``HH:MM:SS`` for an event's ``t``, or ``--:--:--`` for a malformed one.
+
+    ``rundir.log_event`` serialises with ``json.dumps(..., default=str)``, so a ``t``
+    that is a string / dict / out-of-range float is reachable in a real log. It must
+    never raise: one bad record used to kill the follower thread and take the rest of
+    the run's live output with it, which is the exact silence #116 exists to fix.
+    """
+    try:
+        return time.strftime("%H:%M:%S", time.localtime(float(v if v else time.time())))
+    except (TypeError, ValueError, OverflowError, OSError):
+        return "--:--:--"
+
+
+def format_event(ev: dict, totals: dict | None = None, *,
+                 skip_kinds: tuple[str, ...] = BOOKKEEPING_KINDS) -> str | None:
     """Render one event as a single terminal line, or ``None`` to skip it.
 
-    Never emits ANSI: color is layered on by :func:`render_line`, so the piped /
-    no-TTY path is plain text by construction.
+    Total function: any malformed record (non-dict, bad ``t``, hostile string) yields
+    ``None`` or a safe line, never an exception — a renderer that raises silences the
+    whole run. Never emits ANSI, and no event value can: the finished line is run
+    through :func:`sanitize`, so color is only ever added by :func:`render_line`.
+
+    ``skip_kinds`` defaults to :data:`BOOKKEEPING_KINDS`; pass ``()`` to render every
+    kind (what #138 needs for phase detection).
     """
+    if not isinstance(ev, dict):
+        return None
     kind = str(ev.get("kind") or "")
-    _accrue(ev, totals)
-    ts = time.strftime("%H:%M:%S", time.localtime(float(ev.get("t") or time.time())))
+    if kind in skip_kinds or kind == FOLLOW_END:
+        return None  # bookkeeping / noise — the dashboard shows these, the terminal shouldn't
+    accrue_totals(ev, totals)
+    ts = _timestamp(ev.get("t"))
     meter = _meter(totals)
 
     if kind == "splits":
@@ -173,7 +322,7 @@ def format_event(ev: dict, totals: dict | None = None) -> str | None:
         body = f"baseline  val={_num(ev.get('val'))} ±{_num(ev.get('stderr'))}"
     elif kind == "baseline_reused":
         body = f"baseline reused from {ev.get('prior') or ev.get('from') or '?'}"
-    elif kind in ("step", "gepa_val_gate", "skillopt_step"):
+    elif kind in _STEP_KINDS:
         ok = bool(ev.get("accept"))
         verdict = "ACCEPT" if ok else "reject"
         where = ""
@@ -210,29 +359,35 @@ def format_event(ev: dict, totals: dict | None = None) -> str | None:
                 f"Δ{_num(ev.get('test_delta'), '{:+.4f}')})  best={ev.get('best_id')}")
     elif kind == "intake":
         body = f"intake  ${_num(ev.get('usd'), '{:.4f}')}  {ev.get('output_summary') or ''}".rstrip()
-    elif kind in ("minibatch", "optimizer_context_warning", "target_profile",
-                  "seed_dir_created", "splits_warning", "gepa_resume",
-                  "gepa_merge_skip", "gepa_merge_local", "skillopt_slow_eval",
-                  "skillopt_slow_update"):
-        return None  # bookkeeping / noise — the dashboard shows these, the terminal shouldn't
+    elif kind == "log_corruption":
+        body = f"WARNING  {ev.get('dropped')} unreadable record(s) skipped in events.jsonl"
     else:
         # Unknown kind: still show it rather than hide progress from a new event type.
         extra = " ".join(f"{k}={v}" for k, v in ev.items() if k not in ("t", "kind"))
         body = f"{kind} {extra}".strip()
-    return f"[{ts}] {body}{meter}"
+    # Sanitize the FINISHED line, once: every field of every kind (present and future)
+    # is covered, so no event value can emit an escape sequence or forge an extra line.
+    return sanitize(f"[{ts}] {body}{meter}")
 
 
 _STYLE_BY_KIND = {"optimizer_error": "red", "budget_warning": "yellow",
+                  "log_corruption": "yellow",
                   "finalize": "bold", "baseline": "cyan"}
 
 
-def render_line(ev: dict, totals: dict | None = None, *, color: bool = False) -> str | None:
-    """:func:`format_event` plus optional ANSI styling (accept green / reject dim)."""
-    line = format_event(ev, totals)
+def render_line(ev: dict, totals: dict | None = None, *, color: bool = False,
+                **kw) -> str | None:
+    """:func:`format_event` plus optional ANSI styling (accept green / reject dim).
+
+    Styling only — all text safety lives in :func:`format_event`, so a caller can
+    never get an unsanitised line by choosing one of these two over the other.
+    ``**kw`` (e.g. ``skip_kinds``) is passed through to :func:`format_event`.
+    """
+    line = format_event(ev, totals, **kw)
     if line is None or not color:
         return line
     kind = str(ev.get("kind") or "")
     style = _STYLE_BY_KIND.get(kind)
-    if kind in ("step", "gepa_val_gate", "skillopt_step"):
+    if kind in _STEP_KINDS:
         style = "green" if ev.get("accept") else "dim"
     return colorize(line, style, enabled=True) if style else line

--- a/core/cap_evolve/eventstream.py
+++ b/core/cap_evolve/eventstream.py
@@ -1,0 +1,238 @@
+"""One source of truth for reading a run's ``events.jsonl`` stream.
+
+``events.jsonl`` is the run's append-only audit log (see :mod:`cap_evolve.rundir`).
+Every live view of a run — the dashboard's SSE route, ``cap-evolve run --follow``,
+``cap-evolve tail`` — reads it through this module, so the terminal and the web UI
+can never disagree about what happened.
+
+Public API (stdlib only, no deps):
+
+``read_new_events(path, offset) -> (events, new_offset)``
+    One incremental, byte-offset read. Cheap (seeks to ``offset``); leaves a
+    partial trailing line unconsumed so a half-written record is never parsed.
+
+``follow_events(path, *, offset=0, poll=0.5, stop_kinds=("finalize",),
+                idle_timeout=300.0, should_stop=None) -> Iterator[dict]``
+    Blocking generator that yields event dicts as they are appended. Stops after
+    an event whose ``kind`` is in ``stop_kinds``, after ``idle_timeout`` seconds
+    with no new events, or when ``should_stop()`` returns true.
+
+``format_event(ev, totals=None) -> str | None``
+    One human-readable line for an event, or ``None`` for events with nothing
+    worth showing. ``totals`` is an optional caller-owned dict used to accumulate
+    the live cost/token meter across events.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Callable, Iterator
+
+__all__ = ["read_new_events", "follow_events", "format_event", "render_line",
+           "colorize", "use_color"]
+
+
+def read_new_events(path: Path, offset: int) -> tuple[list[dict], int]:
+    """Return (new events, new byte offset). A partial trailing line (no newline)
+    is left unconsumed so the next read picks it up once complete."""
+    p = Path(path)
+    if not p.exists():
+        return [], offset
+    if offset >= p.stat().st_size:
+        return [], offset
+    # Seek-and-read so each poll costs O(new bytes), not O(file size) — callers poll
+    # a growing events.jsonl twice a second, per client.
+    with p.open("rb") as fh:
+        fh.seek(offset)
+        chunk = fh.read()
+    last_nl = chunk.rfind(b"\n")
+    if last_nl == -1:
+        return [], offset  # only a partial line so far
+    complete = chunk[: last_nl + 1]
+    events = []
+    for line in complete.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            events.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return events, offset + last_nl + 1
+
+
+def follow_events(
+    path: Path,
+    *,
+    offset: int = 0,
+    poll: float = 0.5,
+    stop_kinds: tuple[str, ...] = ("finalize",),
+    idle_timeout: float | None = 300.0,
+    should_stop: Callable[[], bool] | None = None,
+) -> Iterator[dict]:
+    """Yield events from ``path`` as they are appended (blocking generator).
+
+    ``offset=0`` replays the whole file first, then follows. Waits for the file to
+    appear, so a follower can attach before the run creates it. ``idle_timeout=None``
+    means wait forever.
+    """
+    idle_start = time.monotonic()
+    while True:
+        events, offset = read_new_events(path, offset)
+        for ev in events:
+            yield ev
+            if ev.get("kind") in stop_kinds:
+                return
+        if events:
+            idle_start = time.monotonic()
+        elif idle_timeout is not None and time.monotonic() - idle_start >= idle_timeout:
+            return
+        if should_stop is not None and should_stop():
+            # Drain whatever landed between the last read and the stop signal, so the
+            # final events of a finished run are never lost to a race.
+            for ev in read_new_events(path, offset)[0]:
+                yield ev
+            return
+        time.sleep(poll)
+
+
+# ---- human-readable rendering ----------------------------------------------
+
+def use_color(stream=None) -> bool:
+    """True only on a real TTY without ``NO_COLOR``. Piped/CI output stays plain."""
+    stream = stream or sys.stdout
+    if os.environ.get("NO_COLOR"):
+        return False
+    try:
+        return bool(stream.isatty())
+    except Exception:  # noqa: BLE001 — a stub stream without isatty is "not a tty"
+        return False
+
+
+_CODES = {"dim": "2", "bold": "1", "green": "32", "red": "31", "yellow": "33", "cyan": "36"}
+
+
+def colorize(text: str, style: str, *, enabled: bool) -> str:
+    if not enabled or style not in _CODES:
+        return text
+    return f"\033[{_CODES[style]}m{text}\033[0m"
+
+
+def _num(v, fmt="{:.4f}") -> str:
+    try:
+        return fmt.format(float(v))
+    except (TypeError, ValueError):
+        return "?"
+
+
+def _meter(totals: dict | None) -> str:
+    """`  [$0.0123 · 4.2k tok]` — the live cost meter, or '' if nothing spent yet."""
+    if not totals:
+        return ""
+    usd, tok = totals.get("usd", 0.0), totals.get("tokens", 0)
+    if not usd and not tok:
+        return ""
+    tokens = f"{tok / 1000:.1f}k" if tok >= 1000 else str(tok)
+    return f"  [${usd:.4f} · {tokens} tok]"
+
+
+def _accrue(ev: dict, totals: dict | None) -> None:
+    if totals is None:
+        return
+    for k in ("cost_usd", "opt_cost_usd", "usd"):
+        try:
+            totals["usd"] = totals.get("usd", 0.0) + float(ev.get(k) or 0.0)
+        except (TypeError, ValueError):
+            pass
+    for k in ("tokens", "opt_tokens"):
+        try:
+            totals["tokens"] = totals.get("tokens", 0) + int(ev.get(k) or 0)
+        except (TypeError, ValueError):
+            pass
+
+
+def format_event(ev: dict, totals: dict | None = None) -> str | None:
+    """Render one event as a single terminal line, or ``None`` to skip it.
+
+    Never emits ANSI: color is layered on by :func:`render_line`, so the piped /
+    no-TTY path is plain text by construction.
+    """
+    kind = str(ev.get("kind") or "")
+    _accrue(ev, totals)
+    ts = time.strftime("%H:%M:%S", time.localtime(float(ev.get("t") or time.time())))
+    meter = _meter(totals)
+
+    if kind == "splits":
+        body = (f"splits frozen  train={ev.get('train')} val={ev.get('val')} "
+                f"test={ev.get('test')} (test sealed)")
+    elif kind == "baseline":
+        body = f"baseline  val={_num(ev.get('val'))} ±{_num(ev.get('stderr'))}"
+    elif kind == "baseline_reused":
+        body = f"baseline reused from {ev.get('prior') or ev.get('from') or '?'}"
+    elif kind in ("step", "gepa_val_gate", "skillopt_step"):
+        ok = bool(ev.get("accept"))
+        verdict = "ACCEPT" if ok else "reject"
+        where = ""
+        if kind == "skillopt_step":
+            where = f" e{ev.get('epoch')}s{ev.get('step_in_epoch')}"
+        body = (f"{verdict}{where}  {ev.get('candidate')}  val={_num(ev.get('val'))}"
+                f" (parent {_num(ev.get('parent_val'))})")
+        if ev.get("reason"):
+            body += f"  — {ev['reason']}"
+    elif kind == "gepa_local_gate":
+        body = (f"minibatch gate {'pass' if ev.get('passed') else 'fail'}  {ev.get('candidate')}"
+                f"  child={_num(ev.get('child_sum'), '{:.3f}')}"
+                f" parent={_num(ev.get('parent_sum'), '{:.3f}')}")
+    elif kind == "gepa_select":
+        body = f"selected parent {ev.get('parent')} ({ev.get('strategy')})"
+    elif kind in ("gepa_start", "skillopt_start"):
+        body = f"{kind.split('_')[0]} started  " + " ".join(
+            f"{k}={v}" for k, v in ev.items() if k not in ("t", "kind"))
+    elif kind == "gepa_stop":
+        body = f"gepa stopped: {ev.get('reason')}"
+    elif kind == "evaluate":
+        body = (f"eval {ev.get('split')}/{ev.get('tag')}  reward={_num(ev.get('reward'))}"
+                f" ±{_num(ev.get('stderr'))}  {_num(ev.get('seconds'), '{:.1f}')}s")
+    elif kind == "gate_warning":
+        body = f"gate warning ({ev.get('mode')}): {str(ev.get('reason')).split(' — ')[0]}"
+    elif kind == "budget_warning":
+        body = (f"BUDGET {ev.get('pct')}% of {ev.get('metric')}  "
+                f"{ev.get('spent')}/{ev.get('limit')}")
+    elif kind == "optimizer_error":
+        body = f"OPTIMIZER ERROR  {ev.get('candidate')}: {str(ev.get('error'))[:200]}"
+    elif kind == "finalize":
+        body = (f"FINALIZE  test={_num(ev.get('test_reward'))} "
+                f"(baseline {_num(ev.get('test_baseline_reward'))}, "
+                f"Δ{_num(ev.get('test_delta'), '{:+.4f}')})  best={ev.get('best_id')}")
+    elif kind == "intake":
+        body = f"intake  ${_num(ev.get('usd'), '{:.4f}')}  {ev.get('output_summary') or ''}".rstrip()
+    elif kind in ("minibatch", "optimizer_context_warning", "target_profile",
+                  "seed_dir_created", "splits_warning", "gepa_resume",
+                  "gepa_merge_skip", "gepa_merge_local", "skillopt_slow_eval",
+                  "skillopt_slow_update"):
+        return None  # bookkeeping / noise — the dashboard shows these, the terminal shouldn't
+    else:
+        # Unknown kind: still show it rather than hide progress from a new event type.
+        extra = " ".join(f"{k}={v}" for k, v in ev.items() if k not in ("t", "kind"))
+        body = f"{kind} {extra}".strip()
+    return f"[{ts}] {body}{meter}"
+
+
+_STYLE_BY_KIND = {"optimizer_error": "red", "budget_warning": "yellow",
+                  "finalize": "bold", "baseline": "cyan"}
+
+
+def render_line(ev: dict, totals: dict | None = None, *, color: bool = False) -> str | None:
+    """:func:`format_event` plus optional ANSI styling (accept green / reject dim)."""
+    line = format_event(ev, totals)
+    if line is None or not color:
+        return line
+    kind = str(ev.get("kind") or "")
+    style = _STYLE_BY_KIND.get(kind)
+    if kind in ("step", "gepa_val_gate", "skillopt_step"):
+        style = "green" if ev.get("accept") else "dim"
+    return colorize(line, style, enabled=True) if style else line

--- a/core/cap_evolve/gepa.py
+++ b/core/cap_evolve/gepa.py
@@ -183,9 +183,16 @@ def _eval_minibatch(
                          runner_tokens=run_tokens, runner_seconds=elapsed)
     result = aggregate_scores("train", scores, ks=(1,))
     result.cost_usd, result.tokens, result.seconds = run_cost, run_tokens, elapsed
+    # cost_usd/tokens mirror `evaluate` (harness.py:311) so the log carries the runner
+    # spend this function just charged to `update_spent`. Without them a burn read from
+    # events alone understated live GEPA spend 3.9x — GEPA's rollouts never pass
+    # through `evaluate_candidate`, which is the only other runner-spend event
+    # (#234 review, finding 2).
     run_dir.log_event("minibatch", tag=tag, ids=list(task_ids),
                       reward=result.reward, fired=n_called,
-                      cached=len(task_ids) - n_called)
+                      cached=len(task_ids) - n_called,
+                      cost_usd=round(run_cost, 6), tokens=run_tokens,
+                      seconds=round(elapsed, 2))
     return result
 
 
@@ -586,7 +593,12 @@ def gepa_loop(
         child_mb = _eval_minibatch(adapter, workdir, mb, run_dir=run_dir,
                                    cache=cache, tag=f"mb_c_{n:04d}", seed=seed)
         local_pass = _sum_reward(child_mb) > _sum_reward(parent_mb)
+        # opt_cost_usd/opt_tokens ride the LOCAL gate, not `gepa_val_gate`: the
+        # optimizer is paid on every iteration, but the val gate only fires on the ones
+        # that pass here, so putting them there would lose every locally-rejected
+        # iteration's spend (#234 review, finding 2).
         run_dir.log_event("gepa_local_gate", candidate=cid, parent=parent["id"],
+                          opt_cost_usd=round(opt_cost_usd, 6), opt_tokens=opt_tokens,
                           child_sum=_sum_reward(child_mb), parent_sum=_sum_reward(parent_mb),
                           passed=local_pass)
 

--- a/core/tests/test_dashboard_pipeline.py
+++ b/core/tests/test_dashboard_pipeline.py
@@ -7,8 +7,13 @@ Two invariants worth a test:
   ``skillopt_step``. Four bugs in this epic (#224) came from a consumer assuming
   ``kind == "step"``; the Optimize stage must light for every one of them.
 * **The burn is not re-derived.** ``eventstream.accrue_totals`` counts each dollar
-  once (runner from ``evaluate``, optimizer from ``step``-likes) and must reproduce
-  ``RunDir.spent.total_usd``. Summing every cost-ish key overstates it.
+  once and must reproduce ``RunDir.spent.total_usd`` FOR EVERY ALGORITHM — the #234
+  review found it understating GEPA 3.9x because GEPA writes neither ``evaluate`` nor
+  ``opt_cost_usd``. Summing every cost-ish key overstates it in the other direction.
+* **A phase never claims more than the log proves.** The hard gate reads ``unknown``
+  unless it attested itself; a dead run's phase reads ``interrupted``, not ``active``;
+  a phase whose only evidence is an error reads ``errored``, not ``skipped``/``done``.
+* **A rate's denominator is wall clock, and goes away when the log is stale.**
 """
 from __future__ import annotations
 
@@ -53,7 +58,7 @@ def test_optimize_phase_lights_for_every_algorithm():
 def test_every_phase_reachable_for_every_algorithm():
     """Walk each algorithm through the full pipeline and see all six phases resolve."""
     for algo, steps in ALGO_STEP_EVENTS.items():
-        events = ([_ev("intake", usd=0.0), _ev("seed_dir_created", path="/x"),
+        events = ([_ev("intake", usd=0.0), _ev("check_gate", ok=True, problems=0),
                    _ev("splits", train=2, val=2, test=2), _ev("baseline", val=0.1)]
                   + steps + [_ev("finalize", test_reward=0.9, best_id="b")])
         p = dashboard.derive_pipeline(events, finalized=True)
@@ -69,7 +74,10 @@ def test_unreached_phase_is_pending_but_a_silent_past_phase_is_skipped():
         [_ev("baseline", val=0.1), _ev("step", candidate="c", val=0.2, accept=True),
          _ev("finalize", test_reward=0.5)], finalized=True)
     got = {x["key"]: x["status"] for x in p["phases"]}
-    assert got["intake"] == "skipped" and got["check"] == "skipped"
+    # intake: legitimately silent (pre-scaffolded) → skipped. check: silence about the
+    # HARD GATE is not evidence it was skipped → unknown, never a green tick.
+    assert got["intake"] == "skipped"
+    assert got["check"] == "unknown"
     assert "pending" not in got.values()
 
     early = dashboard.derive_pipeline([_ev("intake", usd=0.0)])
@@ -119,27 +127,29 @@ def test_burn_rate_is_only_reported_when_it_means_something():
     """A burn *rate* answers "what is this costing me right now". There is no honest
     answer for a finished run (a 2.6s toy run that spent $0.81 is not burning
     $18.69/min) or under a minute of elapsed time — report the total, and `None`."""
+    # `now` is passed explicitly so the assertions are about the arithmetic, not the
+    # test's own wall clock.
     one = dashboard.derive_pipeline(
-        [_ev("evaluate", t=100.0, split="val", cost_usd=0.5, tokens=10)])["burn"]
+        [_ev("evaluate", t=100.0, split="val", cost_usd=0.5, tokens=10)], now=100.0)["burn"]
     assert one["usd"] == 0.5 and one["elapsed_seconds"] == 0.0
     assert one["usd_per_min"] is None and one["tokens_per_min"] is None
 
     live = [_ev("evaluate", t=60.0, split="val", cost_usd=0.5, tokens=600),
             _ev("evaluate", t=180.0, split="val", cost_usd=0.5, tokens=600)]
-    burn = dashboard.derive_pipeline(live)["burn"]
+    burn = dashboard.derive_pipeline(live, now=180.0)["burn"]
     assert burn["elapsed_seconds"] == 120.0
     assert abs(burn["usd_per_min"] - 0.5) < 1e-9
     assert abs(burn["tokens_per_min"] - 600.0) < 1e-9
 
     # same events, but the run is over → total stands, rate goes away
-    done = dashboard.derive_pipeline(live, finalized=True)["burn"]
+    done = dashboard.derive_pipeline(live, finalized=True, now=180.0)["burn"]
     assert done["usd"] == burn["usd"]
     assert done["usd_per_min"] is None and done["tokens_per_min"] is None
 
     # under a minute: extrapolating 3 seconds to a per-minute figure is invention
     short = dashboard.derive_pipeline(
         [_ev("evaluate", t=1.0, split="val", cost_usd=0.5, tokens=10),
-         _ev("evaluate", t=4.0, split="val", cost_usd=0.5, tokens=10)])["burn"]
+         _ev("evaluate", t=4.0, split="val", cost_usd=0.5, tokens=10)], now=4.0)["burn"]
     assert short["elapsed_seconds"] == 3.0 and short["usd_per_min"] is None
 
 
@@ -184,3 +194,209 @@ def test_json_for_html_neutralises_script_data(tmp_path):
     out = dashboard.json_for_html(hostile)
     assert "<" not in out and ">" not in out and "&" not in out
     assert json.loads(out) == hostile  # the data the JS reads is unchanged
+
+
+# --- the three blocking findings from the #234 review ------------------------
+
+def test_events_burn_equals_spent_for_every_algorithm(tmp_path):
+    """The regression the #234 review found: the events-only burn understated GEPA by
+    3.9x ($0.28 vs $1.09) because `accrue_totals` read `evaluate`/`opt_cost_usd`, and
+    the GEPA path writes NEITHER — its runner spend goes through `minibatch` and its
+    optimizer spend rides the per-iteration gate.
+
+    This asserts the events-only burn against each algorithm's own `Spent`, charged
+    through the same `update_spent` calls the real code makes. It is the test whose
+    absence let a hill-climb-only proof generalise to a false claim about GEPA.
+    """
+    from cap_evolve.rundir import RunDir
+
+    # (algorithm, events, the update_spent charges the real code makes for them)
+    cases = {
+        # hill-climb / skillopt: runner spend on `evaluate`, optimizer on the step.
+        "hill-climb": ([
+            _ev("evaluate", split="val", tag="seed", cost_usd=0.30, tokens=4000),
+            _ev("evaluate", split="val", tag="c1", cost_usd=0.51, tokens=7700),
+            _ev("step", candidate="c1", val=0.5, accept=True,
+                cost_usd=0.51, tokens=7700, opt_cost_usd=0.28, opt_tokens=6000),
+        ], dict(usd=0.81, runner_tokens=11700, optimizer_usd=0.28, optimizer_tokens=6000)),
+        "skillopt": ([
+            _ev("evaluate", split="val", tag="seed", cost_usd=0.30, tokens=4000),
+            _ev("evaluate", split="val", tag="s1", cost_usd=0.51, tokens=7700),
+            _ev("skillopt_step", candidate="s1", val=0.5, accept=True, epoch=1,
+                step_in_epoch=1, opt_cost_usd=0.28, opt_tokens=6000),
+        ], dict(usd=0.81, runner_tokens=11700, optimizer_usd=0.28, optimizer_tokens=6000)),
+        # GEPA: minibatch rollouts (gepa.py:182) + a full-val eval, optimizer paid per
+        # iteration whether or not the local gate passes (gepa.py:589).
+        "gepa": ([
+            _ev("evaluate", split="val", tag="seed", cost_usd=0.30, tokens=4000),
+            _ev("gepa_start"), _ev("gepa_select", parent="seed", strategy="pareto"),
+            _ev("minibatch", tag="mb_p_0001", cost_usd=0.09, tokens=1200),
+            _ev("gepa_local_gate", candidate="g1", passed=True,
+                opt_cost_usd=0.28, opt_tokens=6000),
+            _ev("minibatch", tag="mb_c_0001", cost_usd=0.09, tokens=1300),
+            _ev("evaluate", split="val", tag="g1", cost_usd=0.33, tokens=5200),
+            _ev("gepa_val_gate", candidate="g1", val=0.5, accept=True),
+        ], dict(usd=0.81, runner_tokens=11700, optimizer_usd=0.28, optimizer_tokens=6000)),
+    }
+
+    for algo, (events, charges) in cases.items():
+        rd = RunDir.create(tmp_path / algo, ts="t")
+        rd.update_spent(**charges)
+        truth = rd.spent
+        burn = dashboard.derive_pipeline(events)["burn"]
+        assert burn["source"] == "events", algo
+        assert abs(burn["usd"] - truth.total_usd) < 1e-9, (algo, burn["usd"], truth.total_usd)
+        assert burn["tokens"] == truth.runner_tokens + truth.optimizer_tokens, algo
+
+
+def test_gepa_emits_the_cost_fields_the_burn_reads():
+    """Fixing the burn in the dashboard alone would have left #191's `--follow` meter and
+    every future consumer reading the same blind events, so the fix is at the SOURCE.
+    Pin the emitter contract: `minibatch` carries runner cost, `gepa_local_gate` carries
+    optimizer cost, and `accrue_totals` classifies both."""
+    import inspect
+    from cap_evolve import gepa
+    from cap_evolve.eventstream import _SPEND_SOURCES
+
+    mb = inspect.getsource(gepa._eval_minibatch)
+    assert 'log_event("minibatch"' in mb and "cost_usd=" in mb and "tokens=run_tokens" in mb
+    loop = inspect.getsource(gepa.gepa_loop)
+    assert 'log_event("gepa_local_gate"' in loop and "opt_cost_usd=" in loop
+
+    assert _SPEND_SOURCES["minibatch"] == ("cost_usd", "tokens")
+    assert _SPEND_SOURCES["gepa_local_gate"] == ("opt_cost_usd", "opt_tokens")
+    # …and no kind is a source for two roles, which is what keeps each dollar once.
+    assert len(_SPEND_SOURCES) == len(set(_SPEND_SOURCES))
+
+
+def test_optimizer_spend_is_counted_on_locally_rejected_gepa_iterations():
+    """The optimizer is paid every iteration; `gepa_val_gate` only fires on the ones that
+    pass the cheap local gate. Keying optimizer spend off the val gate would silently
+    lose the spend of every locally-rejected iteration."""
+    events = [_ev("gepa_start"),
+              _ev("minibatch", tag="mb_p", cost_usd=0.05, tokens=500),
+              # local gate FAILS → no gepa_val_gate is ever logged for this iteration
+              _ev("gepa_local_gate", candidate="g1", passed=False,
+                  opt_cost_usd=0.40, opt_tokens=9000),
+              _ev("minibatch", tag="mb_c", cost_usd=0.05, tokens=500)]
+    burn = dashboard.derive_pipeline(events)["burn"]
+    assert abs(burn["usd"] - 0.50) < 1e-9, burn   # 0.05 + 0.05 runner + 0.40 optimizer
+    assert burn["tokens"] == 500 + 500 + 9000
+
+
+def test_check_phase_never_claims_done_without_the_gate_attesting_itself():
+    """`target_profile` is logged by the ALGORITHM runner, after baseline, whenever a
+    target model is configured — so keying the hard gate off it rendered a green
+    "✓ Implement & check" on any `--target-model` run with nothing proving the gate ran
+    (#234 finding 1). Only `check_gate`, logged by the gate itself, counts."""
+    real_order = [_ev("splits", t=1, train=2, val=2, test=2), _ev("baseline", t=2, val=0.1),
+                  _ev("target_profile", t=3, model="gpt-oss-120b", tier="mid"),
+                  _ev("step", t=4, candidate="c1", val=0.5, accept=True),
+                  _ev("finalize", t=5, test_reward=0.9)]
+    got = {x["key"]: x["status"]
+           for x in dashboard.derive_pipeline(real_order, finalized=True)["phases"]}
+    assert got["check"] == "unknown", got
+    assert got["check"] not in ("done", "skipped")
+
+    # …and it DOES read done once the gate attests itself.
+    attested = [_ev("check_gate", t=1, ok=True, problems=0)] + real_order
+    got = {x["key"]: x["status"]
+           for x in dashboard.derive_pipeline(attested, finalized=True)["phases"]}
+    assert got["check"] == "done", got
+
+    # A gate that attested its own FAILURE is not evidence of a pass.
+    failed = [_ev("check_gate", t=1, ok=False, problems=3)] + real_order
+    got = {x["key"]: x["status"]
+           for x in dashboard.derive_pipeline(failed, finalized=True)["phases"]}
+    assert got["check"] == "errored", got
+
+
+def test_the_live_rate_uses_wall_clock_and_is_suppressed_when_the_log_is_stale():
+    """The 30x case (#234 finding 3): two events 120s apart, but the last one is 58
+    minutes old because a slow eval is in flight. `last_t - first_t` freezes at 120s, so
+    the surviving ratio describes only the dense part of the log."""
+    # t>0: `_event_time` rejects t<=0 as clock skew, so anchor on a real epoch value.
+    t0 = 1_700_000_000.0
+    events = [_ev("evaluate", t=t0, split="val", cost_usd=1.0, tokens=1200),
+              _ev("evaluate", t=t0 + 120.0, split="val", cost_usd=1.0, tokens=1200)]
+    now = t0 + 120.0 + 58 * 60.0
+
+    burn = dashboard.derive_pipeline(events, now=now)["burn"]
+    assert burn["event_span_seconds"] == 120.0          # the OLD denominator
+    assert burn["elapsed_seconds"] == now - t0          # wall clock, and still growing
+    assert burn["stale_seconds"] == 58 * 60.0
+    # Stale log → no recent-burn claim at all, rather than 30x the honest figure.
+    assert burn["usd_per_min"] is None and burn["tokens_per_min"] is None
+
+    # A live run whose log is CURRENT still gets a rate — off wall clock, not the span.
+    fresh = dashboard.derive_pipeline(events, now=t0 + 180.0)["burn"]
+    assert fresh["elapsed_seconds"] == 180.0
+    assert abs(fresh["usd_per_min"] - 2.0 / 3.0) < 1e-6   # $2 over 3 minutes (6dp)
+    # …and the event span would have claimed $1.00/min, i.e. 1.5x more.
+    assert fresh["usd_per_min"] < 2.0 / (120.0 / 60.0)
+
+
+def test_a_dead_run_shows_interrupted_not_active():
+    """Merged with #218, the header rendered "● Optimize" (lit) next to a `crashed`
+    StatusBadge and the reader could not tell which was true. `active` claims a phase is
+    RUNNING; for a dead run it is only where the run stopped."""
+    events = [_ev("splits", train=2, val=2, test=2), _ev("baseline", val=0.1),
+              _ev("step", candidate="c1", val=0.5, accept=True)]
+    assert _phase(dashboard.derive_pipeline(events), "optimize") == "active"
+    for status in ("crashed", "stalled"):
+        p = dashboard.derive_pipeline(events, liveness=status)
+        assert _phase(p, "optimize") == "interrupted", status
+        assert "active" not in {x["status"] for x in p["phases"]}, status
+        assert p["current"] == "optimize", status  # still says WHERE, just not "running"
+    # #221's plateau is orthogonal — "live and plateaued" is coherent, so `live` and any
+    # unknown liveness value leave `active` alone.
+    for status in ("live", None, "plateaued"):
+        assert _phase(dashboard.derive_pipeline(events, liveness=status), "optimize") == "active"
+
+
+def test_an_errored_phase_is_not_reported_as_skipped_or_done():
+    """`skipped` says "legitimately not run" and `done` says "completed"; a phase whose
+    only evidence is failure is neither (#234 finding 4)."""
+    events = [_ev("splits", train=2, val=2, test=2), _ev("baseline", val=0.1),
+              _ev("optimizer_error", candidate="c1", error="boom"),
+              _ev("finalize", test_reward=0.1)]
+    got = {x["key"]: x["status"]
+           for x in dashboard.derive_pipeline(events, finalized=True)["phases"]}
+    assert got["optimize"] == "errored", got
+    assert got["optimize"] not in ("done", "skipped")
+    # One successful sibling is enough to make it a real phase again.
+    ok = events[:2] + [_ev("optimizer_error", candidate="c1", error="boom"),
+                       _ev("step", candidate="c2", val=0.4, accept=True),
+                       _ev("finalize", test_reward=0.4)]
+    got = {x["key"]: x["status"]
+           for x in dashboard.derive_pipeline(ok, finalized=True)["phases"]}
+    assert got["optimize"] == "done", got
+
+
+def test_rate_survives_a_backwards_clock():
+    """A wall clock behind the log's own timestamps must not produce a negative
+    denominator (and so a negative rate)."""
+    events = [_ev("evaluate", t=1000.0, split="val", cost_usd=1.0, tokens=100),
+              _ev("evaluate", t=1120.0, split="val", cost_usd=1.0, tokens=100)]
+    burn = dashboard.derive_pipeline(events, now=0.0)["burn"]
+    assert burn["elapsed_seconds"] >= 0.0
+    assert burn["stale_seconds"] == 0.0
+    assert burn["usd_per_min"] is None or burn["usd_per_min"] > 0
+
+
+def test_every_log_event_kind_in_core_is_classified_by_at_most_one_phase():
+    """#224's failure mode is a per-consumer kind table drifting from the emitters. Pin
+    both directions: no kind is claimed by two phases, and every kind `_PHASE_KINDS`
+    names is either really emitted in the tree or the sentinel `report` has none."""
+    seen: dict[str, str] = {}
+    for key, _label, kinds in dashboard._PHASE_KINDS:
+        for k in kinds:
+            assert k not in seen, f"{k} claimed by both {seen.get(k)} and {key}"
+            seen[k] = key
+
+    import pathlib
+    root = pathlib.Path(dashboard.__file__).resolve().parent
+    src = "\n".join(p.read_text(encoding="utf-8") for p in root.glob("*.py"))
+    # `check_gate` is logged from cli.py; the rest from harness/gepa/skillopt/rundir/gate.
+    for kind, phase in seen.items():
+        assert f'"{kind}"' in src, f"{kind} ({phase}) is not emitted anywhere in core/"

--- a/core/tests/test_dashboard_pipeline.py
+++ b/core/tests/test_dashboard_pipeline.py
@@ -1,0 +1,186 @@
+"""#138 — phase pipeline + evidence-header burn (`dashboard.derive_pipeline`).
+
+Two invariants worth a test:
+
+* **Phase detection covers all three deterministic algorithms.** hill-climb logs
+  ``step``, GEPA logs ``gepa_val_gate``/``gepa_select``/…, SkillOpt logs
+  ``skillopt_step``. Four bugs in this epic (#224) came from a consumer assuming
+  ``kind == "step"``; the Optimize stage must light for every one of them.
+* **The burn is not re-derived.** ``eventstream.accrue_totals`` counts each dollar
+  once (runner from ``evaluate``, optimizer from ``step``-likes) and must reproduce
+  ``RunDir.spent.total_usd``. Summing every cost-ish key overstates it.
+"""
+from __future__ import annotations
+
+import json
+
+from cap_evolve import dashboard
+
+
+def _ev(kind, t=1000.0, **kw):
+    return dict(kind=kind, t=t, **kw)
+
+
+def _phase(pipeline, key):
+    return next(p["status"] for p in pipeline["phases"] if p["key"] == key)
+
+
+# --- phase detection, per algorithm -----------------------------------------
+
+ALGO_STEP_EVENTS = {
+    "hill-climb": [_ev("step", candidate="c1", val=0.5, accept=True)],
+    "gepa": [_ev("gepa_start"), _ev("gepa_select", parent="seed", strategy="pareto"),
+             _ev("minibatch", tag="g1"), _ev("gepa_local_gate", candidate="g1", passed=True),
+             _ev("gepa_val_gate", candidate="g1", val=0.5, accept=True)],
+    "skillopt": [_ev("skillopt_start"),
+                 _ev("skillopt_step", candidate="s1", val=0.5, accept=True, epoch=1,
+                     step_in_epoch=1),
+                 _ev("skillopt_slow_update", epoch=1)],
+}
+
+
+def test_optimize_phase_lights_for_every_algorithm():
+    """No consumer may assume ``kind == "step"`` (#224)."""
+    for algo, steps in ALGO_STEP_EVENTS.items():
+        events = [_ev("splits", train=2, val=2, test=2), _ev("baseline", val=0.1)] + steps
+        p = dashboard.derive_pipeline(events)
+        assert _phase(p, "baseline") == "done", algo
+        assert _phase(p, "optimize") == "active", algo
+        assert p["current"] == "optimize", algo
+        assert _phase(p, "finalize") == "pending", algo
+
+
+def test_every_phase_reachable_for_every_algorithm():
+    """Walk each algorithm through the full pipeline and see all six phases resolve."""
+    for algo, steps in ALGO_STEP_EVENTS.items():
+        events = ([_ev("intake", usd=0.0), _ev("seed_dir_created", path="/x"),
+                   _ev("splits", train=2, val=2, test=2), _ev("baseline", val=0.1)]
+                  + steps + [_ev("finalize", test_reward=0.9, best_id="b")])
+        p = dashboard.derive_pipeline(events, finalized=True)
+        got = {x["key"]: x["status"] for x in p["phases"]}
+        assert got == {"intake": "done", "check": "done", "baseline": "done",
+                       "optimize": "done", "finalize": "done", "report": "active"}, (algo, got)
+
+
+def test_unreached_phase_is_pending_but_a_silent_past_phase_is_skipped():
+    """`cap-evolve run` on a scaffolded project logs no `intake` — calling that phase
+    "pending" on a finalized run would state something false."""
+    p = dashboard.derive_pipeline(
+        [_ev("baseline", val=0.1), _ev("step", candidate="c", val=0.2, accept=True),
+         _ev("finalize", test_reward=0.5)], finalized=True)
+    got = {x["key"]: x["status"] for x in p["phases"]}
+    assert got["intake"] == "skipped" and got["check"] == "skipped"
+    assert "pending" not in got.values()
+
+    early = dashboard.derive_pipeline([_ev("intake", usd=0.0)])
+    got = {x["key"]: x["status"] for x in early["phases"]}
+    assert got["intake"] == "active" and got["finalize"] == "pending"
+
+
+def test_empty_log_has_no_current_phase():
+    p = dashboard.derive_pipeline([])
+    assert p["current"] is None
+    assert all(x["status"] == "pending" for x in p["phases"])
+    assert p["now"]["line"] is None
+
+
+def test_malformed_events_do_not_raise():
+    """A non-dict record, a string `t`, a dict `t` — all reachable in a real log
+    (`log_event` serialises with default=str) and none may kill the header."""
+    p = dashboard.derive_pipeline(
+        ["not a dict", 42, None, _ev("baseline", t="nope", val=0.1),
+         _ev("step", t={"a": 1}, candidate="c", val=0.2, accept=True)])
+    assert _phase(p, "optimize") == "active"
+    assert p["burn"]["usd"] == 0.0
+
+
+# --- the burn ---------------------------------------------------------------
+
+def test_burn_uses_accrue_totals_and_does_not_double_count_the_runner():
+    """The harness reports the SAME runner spend twice: on ``evaluate`` and restated on
+    the following ``step``. Counting both showed ~2x the real spend (#191 review)."""
+    events = [
+        _ev("evaluate", split="val", tag="seed", cost_usd=0.07, tokens=1500),
+        _ev("evaluate", split="val", tag="c1", cost_usd=0.07, tokens=1500),
+        # the step restates the runner spend AND adds the optimizer's own
+        _ev("step", candidate="c1", val=0.5, accept=True, cost_usd=0.07, tokens=1500,
+            opt_cost_usd=0.13, opt_tokens=900),
+    ]
+    burn = dashboard.derive_pipeline(events)["burn"]
+    # runner 2 x 0.07 (from `evaluate` only) + optimizer 0.13 = Spent.total_usd
+    assert abs(burn["usd"] - 0.27) < 1e-9, burn
+    assert burn["tokens"] == 1500 * 2 + 900
+    naive = sum(float(e.get("cost_usd") or 0) + float(e.get("opt_cost_usd") or 0)
+                for e in events)
+    assert naive > burn["usd"]  # what re-deriving the arithmetic would have shown
+
+
+def test_burn_rate_is_only_reported_when_it_means_something():
+    """A burn *rate* answers "what is this costing me right now". There is no honest
+    answer for a finished run (a 2.6s toy run that spent $0.81 is not burning
+    $18.69/min) or under a minute of elapsed time — report the total, and `None`."""
+    one = dashboard.derive_pipeline(
+        [_ev("evaluate", t=100.0, split="val", cost_usd=0.5, tokens=10)])["burn"]
+    assert one["usd"] == 0.5 and one["elapsed_seconds"] == 0.0
+    assert one["usd_per_min"] is None and one["tokens_per_min"] is None
+
+    live = [_ev("evaluate", t=60.0, split="val", cost_usd=0.5, tokens=600),
+            _ev("evaluate", t=180.0, split="val", cost_usd=0.5, tokens=600)]
+    burn = dashboard.derive_pipeline(live)["burn"]
+    assert burn["elapsed_seconds"] == 120.0
+    assert abs(burn["usd_per_min"] - 0.5) < 1e-9
+    assert abs(burn["tokens_per_min"] - 600.0) < 1e-9
+
+    # same events, but the run is over → total stands, rate goes away
+    done = dashboard.derive_pipeline(live, finalized=True)["burn"]
+    assert done["usd"] == burn["usd"]
+    assert done["usd_per_min"] is None and done["tokens_per_min"] is None
+
+    # under a minute: extrapolating 3 seconds to a per-minute figure is invention
+    short = dashboard.derive_pipeline(
+        [_ev("evaluate", t=1.0, split="val", cost_usd=0.5, tokens=10),
+         _ev("evaluate", t=4.0, split="val", cost_usd=0.5, tokens=10)])["burn"]
+    assert short["elapsed_seconds"] == 3.0 and short["usd_per_min"] is None
+
+
+def test_reduce_run_burn_equals_the_run_dirs_own_spent(tmp_path):
+    """The header's dollars must be the run's own dollars — not a second opinion."""
+    from cap_evolve.rundir import RunDir
+
+    rd = RunDir.create(tmp_path, ts="t")
+    rd.log_event("splits", train=1, val=1, test=1)
+    rd.log_event("baseline", val=0.1)
+    rd.log_event("evaluate", split="val", tag="seed", cost_usd=0.07, tokens=1500)
+    rd.log_event("evaluate", split="val", tag="c1", cost_usd=0.07, tokens=1500)
+    rd.log_event("step", candidate="c1", val=0.5, accept=True, cost_usd=0.07, tokens=1500,
+                 opt_cost_usd=0.13, opt_tokens=900)
+    rd.update_spent(usd=0.14, runner_tokens=3000, optimizer_usd=0.13, optimizer_tokens=900)
+
+    reduced = dashboard.reduce_run(rd)
+    burn = reduced["summary"]["pipeline"]["burn"]
+    truth = rd.spent
+    assert burn["source"] == "spent"
+    assert abs(burn["usd"] - truth.total_usd) < 1e-9
+    assert burn["tokens"] == truth.runner_tokens + truth.optimizer_tokens + truth.intake_tokens
+    # …and the same total the KPI strip and the cost bars show.
+    assert abs(burn["usd"] - reduced["summary"]["cost"]["total_usd"]) < 1e-4
+    assert burn["tokens"] == reduced["summary"]["tokens"]
+
+
+def test_now_line_is_sanitised_by_format_event():
+    """Event text is model-controlled. The `now` line goes through
+    `eventstream.format_event`, so an ESC sequence or a forged newline cannot reach a
+    terminal or an HTML renderer."""
+    p = dashboard.derive_pipeline(
+        [_ev("optimizer_error", candidate="c", error="boom\033[2Jwiped\nFINALIZE test=1.0")])
+    line = p["now"]["line"]
+    assert "\033" not in line and "\n" not in line
+    assert "⏎" in line  # the forged newline is visible, not obeyed
+
+
+def test_json_for_html_neutralises_script_data(tmp_path):
+    """#209: a model-written reason containing `<!--<script>` blanked the page."""
+    hostile = {"reason": "<!--<script>alert(1)</script>", "amp": "a&b"}
+    out = dashboard.json_for_html(hostile)
+    assert "<" not in out and ">" not in out and "&" not in out
+    assert json.loads(out) == hostile  # the data the JS reads is unchanged

--- a/core/tests/test_eventstream.py
+++ b/core/tests/test_eventstream.py
@@ -1,8 +1,9 @@
 """Tests for the shared events.jsonl tail helper + the --follow / tail CLI paths."""
 import io
-import os
-import shutil
 import json
+import os
+import shlex
+import shutil
 import subprocess
 import sys
 import threading
@@ -11,6 +12,28 @@ from pathlib import Path
 
 from cap_evolve import eventstream
 from cap_evolve.cli import _cmd_tail, _events_path
+
+
+def _toy_project(tmp_path: Path) -> tuple[Path, dict]:
+    """Scaffold the zero-API toy_calc project (mock optimizer) + its env. Shared by the
+    real end-to-end `cap-evolve run --follow` tests."""
+    repo = Path(__file__).resolve().parents[2]
+    example = repo / "examples" / "toy_calc"
+    proj = tmp_path / ".capevolve" / "project"
+    (proj / "adapters").mkdir(parents=True)
+    shutil.copy(example / "adapter.py", proj / "adapters" / "adapter.py")
+    shutil.copytree(example / "capability", tmp_path / "seed_capability")
+    shutil.copy(repo / "templates" / "project" / "capevolve.yaml", proj / "capevolve.yaml")
+    env = dict(os.environ)
+    env.update(PYTHONPATH=str(repo / "core"), CAPEVOLVE_CORE=str(repo / "core"),
+               CAPEVOLVE_SKILLS_DIR=str(repo / "skills"), CAPEVOLVE_TOY_DATA=str(example),
+               CAPEVOLVE_MOCK_SCRIPT=str(example / "mock_script.json"))
+    return proj, env
+
+
+def _kinds(it):
+    """Event kinds, minus the terminal sentinel (asserted separately)."""
+    return [e["kind"] for e in it if e["kind"] != eventstream.FOLLOW_END]
 
 
 def _write(p: Path, *recs):
@@ -51,14 +74,18 @@ def test_read_new_events_missing_file(tmp_path):
 def test_follow_events_stops_on_finalize_and_replays(tmp_path):
     p = tmp_path / "events.jsonl"
     _write(p, {"kind": "baseline"}, {"kind": "finalize"}, {"kind": "after"})
-    kinds = [e["kind"] for e in eventstream.follow_events(p, idle_timeout=1.0)]
-    assert kinds == ["baseline", "finalize"]  # stops at finalize, nothing after
+    got = list(eventstream.follow_events(p, idle_timeout=1.0))
+    assert _kinds(got) == ["baseline", "finalize"]  # stops at finalize, nothing after
+    assert got[-1] == {"kind": eventstream.FOLLOW_END, "reason": "stop_kind",
+                       "last_kind": "finalize"}
 
 
 def test_follow_events_idle_timeout_on_empty(tmp_path):
     t0 = time.monotonic()
     got = list(eventstream.follow_events(tmp_path / "events.jsonl", poll=0.05, idle_timeout=0.2))
-    assert got == []
+    assert _kinds(got) == []
+    # #118: an idle exit is distinguishable from a finished run, not a bare return.
+    assert got == [{"kind": eventstream.FOLLOW_END, "reason": "idle", "idle_seconds": 0.2}]
     assert time.monotonic() - t0 < 5.0
 
 
@@ -73,7 +100,7 @@ def test_follow_events_picks_up_appends_live(tmp_path):
         _write(p, {"kind": "finalize"})
 
     threading.Thread(target=writer, daemon=True).start()
-    kinds = [e["kind"] for e in eventstream.follow_events(p, poll=0.05, idle_timeout=5.0)]
+    kinds = _kinds(eventstream.follow_events(p, poll=0.05, idle_timeout=5.0))
     assert kinds == ["baseline", "step", "finalize"]
 
 
@@ -83,9 +110,10 @@ def test_follow_events_should_stop_drains_tail(tmp_path):
     stop = threading.Event()
     _write(p, {"kind": "baseline"}, {"kind": "step"})
     stop.set()  # already stopped: first read yields both, then the drain returns
-    kinds = [e["kind"] for e in eventstream.follow_events(
-        p, poll=0.01, idle_timeout=1.0, should_stop=stop.is_set)]
-    assert kinds == ["baseline", "step"]
+    got = list(eventstream.follow_events(
+        p, poll=0.01, idle_timeout=1.0, should_stop=lambda _last: stop.is_set()))
+    assert _kinds(got) == ["baseline", "step"]
+    assert got[-1]["reason"] == "should_stop"
 
 
 # ---- format_event / render_line --------------------------------------------
@@ -121,9 +149,12 @@ def test_format_event_shows_unknown_kinds():
 
 
 def test_cost_meter_accumulates_across_events():
+    """Runner spend comes from `evaluate`, optimizer spend from `step` — once each."""
     totals = {}
-    eventstream.format_event({"kind": "step", "cost_usd": 0.01, "tokens": 500}, totals)
-    line = eventstream.format_event({"kind": "step", "cost_usd": 0.02, "tokens": 1500}, totals)
+    eventstream.format_event({"kind": "evaluate", "cost_usd": 0.01, "tokens": 500}, totals)
+    line = eventstream.format_event(
+        {"kind": "step", "cost_usd": 0.01, "tokens": 500,          # re-stated, must NOT recount
+         "opt_cost_usd": 0.02, "opt_tokens": 1500}, totals)
     assert abs(totals["usd"] - 0.03) < 1e-9 and totals["tokens"] == 2000
     assert "$0.0300" in line and "2.0k tok" in line
 
@@ -218,18 +249,7 @@ def test_run_follow_end_to_end_pipes_clean_progress(tmp_path):
     stdout is piped (not a TTY), so: progress lines land on stderr with NO ANSI, and
     stdout stays the parseable final JSON that scripts depend on.
     """
-    repo = Path(__file__).resolve().parents[2]
-    example = repo / "examples" / "toy_calc"
-    proj = tmp_path / ".capevolve" / "project"
-    (proj / "adapters").mkdir(parents=True)
-    shutil.copy(example / "adapter.py", proj / "adapters" / "adapter.py")
-    shutil.copytree(example / "capability", tmp_path / "seed_capability")
-    shutil.copy(repo / "templates" / "project" / "capevolve.yaml", proj / "capevolve.yaml")
-
-    env = dict(os.environ)
-    env.update(PYTHONPATH=str(repo / "core"), CAPEVOLVE_CORE=str(repo / "core"),
-               CAPEVOLVE_SKILLS_DIR=str(repo / "skills"), CAPEVOLVE_TOY_DATA=str(example),
-               CAPEVOLVE_MOCK_SCRIPT=str(example / "mock_script.json"))
+    proj, env = _toy_project(tmp_path)
     proc = subprocess.run(
         [sys.executable, "-m", "cap_evolve.cli", "run", "--spec", str(proj / "capevolve.yaml"),
          "--project", str(proj), "--run-ts", "t", "--follow", "--dashboard", "off"],
@@ -255,3 +275,218 @@ def test_dashboard_stream_reexports_the_shared_helper():
         assert stream.read_new_events is eventstream.read_new_events
     finally:
         sys.path.remove(str(root))
+
+
+# ---- B1: a malformed record must never kill the follower --------------------
+
+POISON = [
+    {"kind": "baseline", "t": "not-a-number"},   # ValueError from float()
+    {"kind": "baseline", "t": {"nested": 1}},    # TypeError from float()
+    {"kind": "baseline", "t": 1e300},            # OverflowError from localtime()
+    42, None, [1, 2, 3], "just a string",        # non-dict records
+]
+
+
+def test_format_event_survives_every_malformed_record():
+    """format_event is total: no record shape may raise out of the render loop."""
+    for bad in POISON:
+        line = eventstream.format_event(bad, {})          # must not raise
+        assert line is None or isinstance(line, str)
+    assert "--:--:--" in eventstream.format_event({"kind": "baseline", "t": "nope"})
+    assert eventstream.format_event(42) is None
+
+
+def test_poisoned_record_does_not_kill_the_follower(tmp_path):
+    """The bug #116 exists to fix: one bad event must not blank the rest of the run."""
+    p = tmp_path / "events.jsonl"
+    with p.open("w", encoding="utf-8") as fh:
+        fh.write(json.dumps({"kind": "baseline", "val": 0.1}) + "\n")
+        fh.write(json.dumps({"kind": "baseline", "t": "not-a-number"}) + "\n")
+        fh.write("42\n")                    # non-dict record
+        fh.write("NOT JSON AT ALL\n")       # unparseable
+        fh.write(json.dumps({"kind": "step", "candidate": "cand_0001", "accept": True,
+                             "val": 1.0}) + "\n")
+        fh.write(json.dumps({"kind": "finalize", "test_reward": 1.0}) + "\n")
+    lines = [eventstream.render_line(e, {})
+             for e in eventstream.follow_events(p, idle_timeout=2.0)]
+    text = "\n".join(l for l in lines if l)
+    assert "cand_0001" in text and "FINALIZE" in text   # events AFTER the poison render
+    assert "--:--:--" in text                           # the poisoned one degraded, not fatal
+
+
+def test_follower_thread_reports_instead_of_dying_silently(tmp_path, monkeypatch, capsys):
+    """If the follower does die, the user is TOLD — silence must never look like progress."""
+    from cap_evolve import cli as _cli
+
+    base = tmp_path
+    (base / "run_z").mkdir()
+    _write(base / "run_z" / "events.jsonl", {"kind": "baseline", "val": 0.0})
+    boom = RuntimeError("simulated renderer explosion")
+    monkeypatch.setattr(eventstream, "render_line",
+                        lambda *a, **k: (_ for _ in ()).throw(boom))
+    monkeypatch.setattr(_cli, "_stderr_is_usable", lambda: True)
+    stop, t = _cli._spawn_follower(base, "z", None)
+    t.join(timeout=5.0)
+    assert not t.is_alive()
+    assert "[follow] live progress stopped" in capsys.readouterr().err
+
+
+# ---- B1b/N2: only dict records escape read_new_events -----------------------
+
+def test_read_new_events_filters_non_dict_records(tmp_path):
+    p = tmp_path / "events.jsonl"
+    p.write_text('42\nnull\n[1,2]\n"str"\ntrue\n{"kind":"finalize"}\n', encoding="utf-8")
+    evs, _ = eventstream.read_new_events(p, 0)
+    assert [e["kind"] for e in evs if e["kind"] != "log_corruption"] == ["finalize"]
+    assert all(isinstance(e, dict) for e in evs)
+    assert {"kind": "log_corruption", "dropped": 5} in evs   # damage is reported, not hidden
+
+
+def test_corrupt_line_is_counted_not_silently_dropped(tmp_path):
+    p = tmp_path / "events.jsonl"
+    p.write_text('{"kind":"a"}\nNOT JSON AT ALL\n{"kind":"finalize"}\n', encoding="utf-8")
+    evs, _ = eventstream.read_new_events(p, 0)
+    assert [e["kind"] for e in evs] == ["a", "finalize", "log_corruption"]
+    assert "1 unreadable record" in eventstream.format_event(evs[-1])
+
+
+# ---- N3: a shrunk file re-reads instead of getting stuck --------------------
+
+def test_read_new_events_rereads_after_truncation(tmp_path):
+    p = tmp_path / "events.jsonl"
+    _write(p, {"kind": "a"}, {"kind": "b"})
+    _, off = eventstream.read_new_events(p, 0)
+    p.write_text('{"kind":"x"}\n', encoding="utf-8")       # rewritten shorter
+    evs, off2 = eventstream.read_new_events(p, off)
+    assert [e["kind"] for e in evs] == ["x"] and off2 == p.stat().st_size
+
+
+# ---- B2: terminal escape injection -----------------------------------------
+
+def test_escape_injection_from_event_payloads_is_neutralised():
+    """All three demonstrated attacks: OSC title, screen clear, newline-forged line."""
+    osc = eventstream.format_event({"kind": "optimizer_error", "candidate": "c1",
+                                   "error": "boom\033]0;PWNED\007\033[2J\033[31mfake red"})
+    clear = eventstream.format_event({"kind": "brand_new", "payload": "\033[2J\033[Hcleared"})
+    forge = eventstream.format_event(
+        {"kind": "brand_new",
+         "payload": "a\nFINALIZE  test=1.0000 (baseline 0.0000) best=FAKE"})
+    for line in (osc, clear, forge):
+        assert "\033" not in line and "\x1b" not in line
+        assert "\007" not in line and "\x9b" not in line
+        assert "\n" not in line and "\r" not in line       # cannot forge extra lines
+        assert line.count("\n") == 0 and len(line.splitlines()) == 1
+    assert "PWNED" in osc and "boom" in osc                # inert, but still readable
+    assert "⏎" in forge and "FINALIZE" in forge            # visibly one line, not two
+
+
+def test_sanitize_strips_c0_c1_and_keeps_tab():
+    # ESC/BEL/DEL and 8-bit CSI vanish; the leftover "[31m" is inert printable text.
+    assert eventstream.sanitize("a\x1b[31mb\x07c\x9bd\x7fe") == "a[31mbcde"
+    assert eventstream.sanitize("\x1b]0;t\x07\x1b[2J\x1b[H") == "]0;t[2J[H"
+    assert eventstream.sanitize("a\tb") == "a\tb"
+    assert eventstream.sanitize("a\nb\rc") == "a⏎b⏎c"
+
+
+def test_render_line_is_also_escape_safe_with_color():
+    """color=True adds exactly the styling escapes — never the payload's own."""
+    ev = {"kind": "optimizer_error", "candidate": "c", "error": "x\033]0;PWNED\007"}
+    line = eventstream.render_line(ev, color=True)
+    assert line.startswith("\033[31m") and line.endswith("\033[0m")
+    assert "\033" not in line[5:-4] and "PWNED" in line
+
+
+# ---- B3: the cost meter must equal the run's own recorded total -------------
+
+def test_cost_meter_matches_the_runs_recorded_total(tmp_path):
+    """The meter must equal Spent.total_usd, not double-count the runner."""
+    from cap_evolve.rundir import RunDir
+
+    rd = RunDir.create(tmp_path, ts="cost")
+    # Exactly what the harness does: evaluate logs runner spend (harness.py:307-312),
+    # then step re-states it alongside the optimizer's own (harness.py:1322-1328).
+    rd.update_spent(metric_calls=2, usd=0.50, runner_tokens=1000)
+    rd.log_event("evaluate", split="val", tag="cand_0001", reward=1.0,
+                 cost_usd=0.50, tokens=1000, seconds=1.0)
+    rd.update_spent(optimizer_seconds=1.0, optimizer_usd=0.20, optimizer_tokens=500)
+    rd.log_event("step", candidate="cand_0001", accept=True, val=1.0, parent_val=0.0,
+                 cost_usd=0.50, tokens=1000, opt_cost_usd=0.20, opt_tokens=500)
+
+    totals: dict = {}
+    events, _ = eventstream.read_new_events(rd.events_path, 0)
+    for ev in events:
+        eventstream.format_event(ev, totals)
+    recorded = rd.spent.total_usd
+    assert abs(recorded - 0.70) < 1e-9, recorded
+    assert abs(totals["usd"] - recorded) < 1e-9, (totals, recorded)
+    assert totals["tokens"] == 1500
+
+
+def test_accrue_totals_is_public_for_138():
+    assert eventstream.accrue_totals in vars(eventstream).values()
+    assert "accrue_totals" in eventstream.__all__
+    t: dict = {}
+    eventstream.accrue_totals({"kind": "intake", "usd": 0.05, "tokens": 100}, t)
+    eventstream.accrue_totals({"kind": "gepa_local_gate", "cost_usd": 99.0}, t)  # not a cost event
+    assert t == {"usd": 0.05, "tokens": 100}
+
+
+# ---- B4: closed stderr must not corrupt the stdout JSON contract ------------
+
+def test_stderr_unusable_disables_following(monkeypatch):
+    from cap_evolve import cli as _cli
+
+    monkeypatch.setattr(sys, "stderr", None)
+    assert _cli._stderr_is_usable() is False
+    assert _cli._spawn_follower(Path("/nope"), "x", None) == (None, None)
+
+    class Reused(io.StringIO):
+        def fileno(self):
+            return 7            # fd 2 was closed and handed to another file
+    monkeypatch.setattr(sys, "stderr", Reused())
+    assert _cli._stderr_is_usable() is False
+
+
+def test_run_follow_with_stderr_closed_keeps_stdout_valid_json(tmp_path):
+    """`cap-evolve run --follow 2>&-` must still emit parseable JSON on stdout."""
+    proj, env = _toy_project(tmp_path)
+    out = tmp_path / "cl.out"
+    # Real `2>&-`: the shell closes fd 2 before exec, so CPython starts with a dead
+    # stderr and would hand fd 2 to the next open() — the corruption path.
+    cmd = (f"exec 2>&-; {shlex.quote(sys.executable)} -m cap_evolve.cli run "
+           f"--spec {shlex.quote(str(proj / 'capevolve.yaml'))} "
+           f"--project {shlex.quote(str(proj))} --run-ts cl --follow --dashboard off "
+           f"> {shlex.quote(str(out))}")
+    proc = subprocess.run(["/bin/sh", "-c", cmd], env=env, timeout=600)
+    assert proc.returncode == 0
+    text = out.read_text()
+    assert json.loads(text)["test_reward"] == 1.0          # contract intact
+    assert "baseline  val=" not in text                    # no progress leaked into stdout
+
+
+# ---- N1: tail exit codes ----------------------------------------------------
+
+def test_cmd_tail_rejects_a_path_that_can_never_be_a_run_dir(tmp_path, capsys):
+    assert _cmd_tail([str(tmp_path / "no" / "such" / "run_typo")]) == 2
+    assert "no such run dir" in capsys.readouterr().err
+
+
+def test_cmd_tail_returns_3_on_idle_timeout_with_no_events(tmp_path, capsys):
+    assert _cmd_tail([str(tmp_path / "run_pending"), "--idle-timeout", "0.2"]) == 3
+    assert "timed out" in capsys.readouterr().err
+
+
+def test_cmd_tail_rejects_negative_idle_timeout(tmp_path):
+    import pytest
+    with pytest.raises(SystemExit):
+        _cmd_tail([str(tmp_path), "--idle-timeout", "-5"])
+
+
+# ---- #138: every kind is reachable -----------------------------------------
+
+def test_skip_kinds_can_be_disabled_to_see_bookkeeping_events():
+    ev = {"kind": "minibatch", "tag": "mb1"}
+    assert eventstream.format_event(ev) is None                       # default: hidden
+    assert "minibatch" in eventstream.format_event(ev, skip_kinds=())  # #138: visible
+    assert "minibatch" in eventstream.render_line(ev, skip_kinds=())
+    assert eventstream.BOOKKEEPING_KINDS                              # documented set

--- a/core/tests/test_eventstream.py
+++ b/core/tests/test_eventstream.py
@@ -1,0 +1,257 @@
+"""Tests for the shared events.jsonl tail helper + the --follow / tail CLI paths."""
+import io
+import os
+import shutil
+import json
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+from cap_evolve import eventstream
+from cap_evolve.cli import _cmd_tail, _events_path
+
+
+def _write(p: Path, *recs):
+    with p.open("a", encoding="utf-8") as fh:
+        for r in recs:
+            fh.write(json.dumps(r) + "\n")
+
+
+# ---- read_new_events -------------------------------------------------------
+
+def test_read_new_events_incremental(tmp_path):
+    p = tmp_path / "events.jsonl"
+    _write(p, {"kind": "baseline", "val": 0.25})
+    evs, off = eventstream.read_new_events(p, 0)
+    assert evs == [{"kind": "baseline", "val": 0.25}]
+    assert off == p.stat().st_size
+
+    _write(p, {"kind": "step", "candidate": "cand_0001"})
+    evs2, off2 = eventstream.read_new_events(p, off)
+    assert evs2 == [{"kind": "step", "candidate": "cand_0001"}]
+    assert off2 == p.stat().st_size
+
+
+def test_read_new_events_leaves_partial_line(tmp_path):
+    p = tmp_path / "events.jsonl"
+    p.write_text('{"kind": "baseline"}\n{"kind": "ste', encoding="utf-8")
+    evs, off = eventstream.read_new_events(p, 0)
+    assert evs == [{"kind": "baseline"}]
+    assert off == len('{"kind": "baseline"}\n')
+
+
+def test_read_new_events_missing_file(tmp_path):
+    assert eventstream.read_new_events(tmp_path / "nope.jsonl", 0) == ([], 0)
+
+
+# ---- follow_events ---------------------------------------------------------
+
+def test_follow_events_stops_on_finalize_and_replays(tmp_path):
+    p = tmp_path / "events.jsonl"
+    _write(p, {"kind": "baseline"}, {"kind": "finalize"}, {"kind": "after"})
+    kinds = [e["kind"] for e in eventstream.follow_events(p, idle_timeout=1.0)]
+    assert kinds == ["baseline", "finalize"]  # stops at finalize, nothing after
+
+
+def test_follow_events_idle_timeout_on_empty(tmp_path):
+    t0 = time.monotonic()
+    got = list(eventstream.follow_events(tmp_path / "events.jsonl", poll=0.05, idle_timeout=0.2))
+    assert got == []
+    assert time.monotonic() - t0 < 5.0
+
+
+def test_follow_events_picks_up_appends_live(tmp_path):
+    p = tmp_path / "events.jsonl"
+    _write(p, {"kind": "baseline"})
+
+    def writer():
+        time.sleep(0.15)
+        _write(p, {"kind": "step", "accept": True})
+        time.sleep(0.15)
+        _write(p, {"kind": "finalize"})
+
+    threading.Thread(target=writer, daemon=True).start()
+    kinds = [e["kind"] for e in eventstream.follow_events(p, poll=0.05, idle_timeout=5.0)]
+    assert kinds == ["baseline", "step", "finalize"]
+
+
+def test_follow_events_should_stop_drains_tail(tmp_path):
+    """A stop signal must not lose events written just before it."""
+    p = tmp_path / "events.jsonl"
+    stop = threading.Event()
+    _write(p, {"kind": "baseline"}, {"kind": "step"})
+    stop.set()  # already stopped: first read yields both, then the drain returns
+    kinds = [e["kind"] for e in eventstream.follow_events(
+        p, poll=0.01, idle_timeout=1.0, should_stop=stop.is_set)]
+    assert kinds == ["baseline", "step"]
+
+
+# ---- format_event / render_line --------------------------------------------
+
+def test_format_event_covers_the_key_kinds():
+    assert "splits frozen" in eventstream.format_event(
+        {"kind": "splits", "train": 4, "val": 2, "test": 2})
+    assert "baseline  val=0.2500" in eventstream.format_event({"kind": "baseline", "val": 0.25})
+    acc = eventstream.format_event(
+        {"kind": "step", "candidate": "cand_0001", "accept": True, "val": 1.0,
+         "parent_val": 0.0, "reason": "Δ>0"})
+    assert "ACCEPT" in acc and "cand_0001" in acc and "Δ>0" in acc
+    rej = eventstream.format_event({"kind": "step", "candidate": "c2", "accept": False, "val": 0.5})
+    assert "reject" in rej
+    fin = eventstream.format_event(
+        {"kind": "finalize", "test_reward": 1.0, "test_baseline_reward": 0.0,
+         "test_delta": 1.0, "best_id": "cand_0001"})
+    assert "FINALIZE" in fin and "test=1.0000" in fin
+    assert "BUDGET 80%" in eventstream.format_event(
+        {"kind": "budget_warning", "pct": 80, "metric": "max_usd", "spent": 8, "limit": 10})
+    assert "OPTIMIZER ERROR" in eventstream.format_event(
+        {"kind": "optimizer_error", "candidate": "c1", "error": "boom"})
+
+
+def test_format_event_skips_bookkeeping_kinds():
+    assert eventstream.format_event({"kind": "minibatch", "tag": "mb"}) is None
+    assert eventstream.format_event({"kind": "optimizer_context_warning"}) is None
+
+
+def test_format_event_shows_unknown_kinds():
+    line = eventstream.format_event({"kind": "brand_new_thing", "x": 1})
+    assert "brand_new_thing" in line and "x=1" in line
+
+
+def test_cost_meter_accumulates_across_events():
+    totals = {}
+    eventstream.format_event({"kind": "step", "cost_usd": 0.01, "tokens": 500}, totals)
+    line = eventstream.format_event({"kind": "step", "cost_usd": 0.02, "tokens": 1500}, totals)
+    assert abs(totals["usd"] - 0.03) < 1e-9 and totals["tokens"] == 2000
+    assert "$0.0300" in line and "2.0k tok" in line
+
+
+def test_format_event_never_emits_ansi():
+    """format_event is pure text; only render_line(color=True) adds escapes."""
+    for ev in ({"kind": "step", "accept": True, "candidate": "c"},
+               {"kind": "optimizer_error", "candidate": "c", "error": "x"},
+               {"kind": "finalize", "test_reward": 1.0}):
+        assert "\033" not in eventstream.format_event(ev)
+
+
+def test_render_line_color_on_and_off():
+    ev = {"kind": "step", "accept": True, "candidate": "c", "val": 1.0}
+    assert "\033[32m" in eventstream.render_line(ev, color=True)
+    assert "\033" not in eventstream.render_line(ev, color=False)
+
+
+def test_use_color_false_for_non_tty_and_no_color(monkeypatch):
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    assert eventstream.use_color(io.StringIO()) is False        # not a tty
+    assert eventstream.use_color(object()) is False             # no isatty attr
+
+    class Tty(io.StringIO):
+        def isatty(self):
+            return True
+    assert eventstream.use_color(Tty()) is True
+    monkeypatch.setenv("NO_COLOR", "1")
+    assert eventstream.use_color(Tty()) is False
+
+
+# ---- CLI: tail -------------------------------------------------------------
+
+def test_events_path_prefers_run_ts_and_ignores_pre_existing(tmp_path):
+    (tmp_path / "run_old").mkdir()
+    (tmp_path / "run_new").mkdir()
+    assert _events_path(tmp_path, "old", None) == tmp_path / "run_old" / "events.jsonl"
+    # unpinned: skip the dirs that existed before this run started
+    assert _events_path(tmp_path, None, {"run_old"}) == tmp_path / "run_new" / "events.jsonl"
+    assert _events_path(tmp_path, None, {"run_old", "run_new"}) is None
+
+
+def test_cmd_tail_missing_base(tmp_path, capsys):
+    assert _cmd_tail(["--base", str(tmp_path)]) == 1
+    assert "no run_* dirs" in capsys.readouterr().err
+
+
+def test_cmd_tail_from_start_plain_when_piped(tmp_path, capsys):
+    """capsys stdout is not a TTY → plain lines, no ANSI (the CI/piped case)."""
+    root = tmp_path / "run_x"
+    root.mkdir()
+    _write(root / "events.jsonl",
+           {"kind": "baseline", "val": 0.0},
+           {"kind": "step", "candidate": "cand_0001", "accept": True, "val": 1.0,
+            "parent_val": 0.0},
+           {"kind": "finalize", "test_reward": 1.0, "test_baseline_reward": 0.0,
+            "test_delta": 1.0, "best_id": "cand_0001"})
+    assert _cmd_tail([str(root), "--from-start"]) == 0
+    out = capsys.readouterr().out
+    assert "\033" not in out
+    assert "baseline" in out and "ACCEPT" in out and "FINALIZE" in out
+
+
+def test_cmd_tail_attaches_to_an_ongoing_run(tmp_path, capsys):
+    """Default (no --from-start) skips history and follows new events only."""
+    root = tmp_path / "run_x"
+    root.mkdir()
+    ev = root / "events.jsonl"
+    _write(ev, {"kind": "baseline", "val": 0.0})  # history: must NOT be printed
+
+    def writer():
+        time.sleep(0.2)
+        _write(ev, {"kind": "step", "candidate": "cand_0007", "accept": True, "val": 1.0})
+        _write(ev, {"kind": "finalize", "test_reward": 1.0})
+
+    threading.Thread(target=writer, daemon=True).start()
+    assert _cmd_tail([str(root), "--idle-timeout", "10"]) == 0
+    out = capsys.readouterr().out
+    assert "cand_0007" in out and "FINALIZE" in out
+    assert "val=0.0000 ±" not in out  # the pre-attach baseline line was skipped
+
+
+def test_tail_is_a_registered_subcommand():
+    out = subprocess.run([sys.executable, "-m", "cap_evolve.cli"],
+                         capture_output=True, text=True).stderr
+    assert "tail" in out
+
+
+def test_run_follow_end_to_end_pipes_clean_progress(tmp_path):
+    """Real `cap-evolve run --follow` over toy_calc (zero API, mock optimizer).
+
+    stdout is piped (not a TTY), so: progress lines land on stderr with NO ANSI, and
+    stdout stays the parseable final JSON that scripts depend on.
+    """
+    repo = Path(__file__).resolve().parents[2]
+    example = repo / "examples" / "toy_calc"
+    proj = tmp_path / ".capevolve" / "project"
+    (proj / "adapters").mkdir(parents=True)
+    shutil.copy(example / "adapter.py", proj / "adapters" / "adapter.py")
+    shutil.copytree(example / "capability", tmp_path / "seed_capability")
+    shutil.copy(repo / "templates" / "project" / "capevolve.yaml", proj / "capevolve.yaml")
+
+    env = dict(os.environ)
+    env.update(PYTHONPATH=str(repo / "core"), CAPEVOLVE_CORE=str(repo / "core"),
+               CAPEVOLVE_SKILLS_DIR=str(repo / "skills"), CAPEVOLVE_TOY_DATA=str(example),
+               CAPEVOLVE_MOCK_SCRIPT=str(example / "mock_script.json"))
+    proc = subprocess.run(
+        [sys.executable, "-m", "cap_evolve.cli", "run", "--spec", str(proj / "capevolve.yaml"),
+         "--project", str(proj), "--run-ts", "t", "--follow", "--dashboard", "off"],
+        capture_output=True, text=True, env=env, timeout=600)
+    assert proc.returncode == 0, proc.stderr[-3000:]
+
+    # progress went to stderr, live, and is plain text (safe for CI logs)
+    assert "\033" not in proc.stderr, "ANSI leaked into non-TTY output"
+    assert "splits frozen" in proc.stderr
+    assert "baseline  val=" in proc.stderr
+    assert "ACCEPT" in proc.stderr, proc.stderr          # >=1 per-candidate line
+    assert "FINALIZE" in proc.stderr                     # the finalize line
+    # stdout is still just the final JSON blob
+    assert json.loads(proc.stdout)["test_reward"] == 1.0
+
+
+def test_dashboard_stream_reexports_the_shared_helper():
+    """The SSE route and the CLI must read events.jsonl through the same function."""
+    root = Path(__file__).resolve().parents[2] / "dashboard" / "backend"
+    sys.path.insert(0, str(root))
+    try:
+        from capevolve_dashboard import stream
+        assert stream.read_new_events is eventstream.read_new_events
+    finally:
+        sys.path.remove(str(root))

--- a/dashboard/backend/capevolve_dashboard/stream.py
+++ b/dashboard/backend/capevolve_dashboard/stream.py
@@ -1,38 +1,18 @@
-"""Server-Sent-Events helpers: format frames and tail events.jsonl by byte offset."""
+"""Server-Sent-Events helpers: format frames and tail events.jsonl by byte offset.
+
+The tail itself lives in ``cap_evolve.eventstream`` (core, stdlib-only) so the SSE
+route, ``cap-evolve run --follow`` and ``cap-evolve tail`` all read the run's event
+log through the same code — the web view and the terminal can't disagree.
+``read_new_events`` is re-exported here for the existing callers/tests.
+"""
 from __future__ import annotations
 
 import json
-from pathlib import Path
+
+from cap_evolve.eventstream import read_new_events  # noqa: F401 — re-export
+
+__all__ = ["sse_format", "read_new_events"]
 
 
 def sse_format(event: str, data: dict) -> str:
     return f"event: {event}\ndata: {json.dumps(data)}\n\n"
-
-
-def read_new_events(path: Path, offset: int) -> tuple[list[dict], int]:
-    """Return (new events, new byte offset). A partial trailing line (no newline)
-    is left unconsumed so the next read picks it up once complete."""
-    p = Path(path)
-    if not p.exists():
-        return [], offset
-    if offset >= p.stat().st_size:
-        return [], offset
-    # Seek-and-read so each poll costs O(new bytes), not O(file size) — the stream
-    # route calls this twice a second per client over a growing events.jsonl.
-    with p.open("rb") as fh:
-        fh.seek(offset)
-        chunk = fh.read()
-    last_nl = chunk.rfind(b"\n")
-    if last_nl == -1:
-        return [], offset  # only a partial line so far
-    complete = chunk[: last_nl + 1]
-    events = []
-    for line in complete.splitlines():
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            events.append(json.loads(line))
-        except json.JSONDecodeError:
-            continue
-    return events, offset + last_nl + 1

--- a/dashboard/frontend/src/components/EvidenceHeader.tsx
+++ b/dashboard/frontend/src/components/EvidenceHeader.tsx
@@ -1,0 +1,214 @@
+/** The evidence header (#138): phase pipeline · now · sparkline · burn · evidence line.
+ *
+ * Every number here is attributed — each cell's `title` names the file or event the
+ * value came from, because this epic has already shipped a cost meter that overstated
+ * spend 2x and cost bars that didn't sum to their own total. Nothing is re-derived
+ * client-side: the burn comes from `summary.pipeline.burn` (state.json's `Spent`, or
+ * `eventstream.accrue_totals` over the log before a Spent exists), the scores from
+ * `baseline.json` / the gated val evals / `final.json`.
+ *
+ * Complementary to the StatusBadge (#118), not a second opinion: the badge answers "is
+ * this process alive", this header answers "what stage, what now, is it improving, what
+ * has it cost". The header never claims a run is live or done.
+ */
+import { useEffect, useState } from 'react'
+import type { RunDetail } from '../lib/types'
+import { cumulativeBest } from '../lib/bestCurve'
+import { compactNum, duration, pct, signedPct, usd } from '../lib/format'
+import { Card } from './ui/Card'
+import { Sparkline } from './Sparkline'
+import { cn } from '../lib/cn'
+
+/** Seconds since an epoch timestamp, ticking once a second. `null` t → null. */
+function useSecondsSince(t: number | null | undefined): number | null {
+  const [now, setNow] = useState(() => Date.now() / 1000)
+  useEffect(() => {
+    if (t == null) return
+    // 1s text tick, not an animation: prefers-reduced-motion is about motion, and a
+    // clock that stops updating would be a wrong number rather than a calmer one.
+    const id = setInterval(() => setNow(Date.now() / 1000), 1000)
+    return () => clearInterval(id)
+  }, [t])
+  if (t == null) return null
+  return Math.max(0, now - t)
+}
+
+export function EvidenceHeader({ detail }: { detail: RunDetail }) {
+  const s = detail.summary
+  const p = s.pipeline
+  const inState = useSecondsSince(p?.now?.since ?? null)
+  const sinceEvent = useSecondsSince(p?.now?.t ?? null)
+
+  // The running-best series — the same `cumulativeBest` the overview chart draws, so
+  // the sparkline and the chart can never disagree about the curve.
+  const best = cumulativeBest(detail.graph.nodes).map((c) => c.best)
+  const burn = p?.burn
+  const direction = s.metric_direction ?? 'higher_is_better'
+
+  return (
+    <Card className="p-4" data-testid="evidence-header">
+      {p?.phases?.length ? <PhasePipeline phases={p.phases} algorithm={s.algorithm} /> : null}
+
+      {p?.now?.line ? (
+        <p className="mt-3 flex flex-wrap items-baseline gap-x-2 text-sm" data-testid="now-line">
+          <span className="text-[10px] uppercase tracking-wide text-muted">now</span>
+          <span className="font-mono text-xs text-foreground">{p.now.line}</span>
+          {sinceEvent != null && (
+            <span className="tnum text-xs text-muted" title="Wall clock since this event's own timestamp">
+              {duration(sinceEvent)} ago
+            </span>
+          )}
+          {inState != null && p.current && (
+            <span
+              className="tnum text-xs text-muted"
+              title={`Wall clock since the first event of the ${p.current} phase`}
+            >
+              · {duration(inState)} in {p.current}
+            </span>
+          )}
+        </p>
+      ) : null}
+
+      <div className="mt-4 flex flex-wrap items-start gap-x-8 gap-y-3">
+        <div>
+          <div className="text-[10px] uppercase tracking-wide text-muted">best on val</div>
+          <div className="mt-1 flex items-center text-accent" data-testid="sparkline-cell">
+            <Sparkline values={best} direction={direction} />
+          </div>
+        </div>
+
+        <Cell
+          label="burn"
+          value={usd(burn?.usd ?? null)}
+          // No rate for a finished run or under a minute of elapsed time: a burn rate
+          // answers "what is this costing right now", and there is no honest answer
+          // once the run is over (see dashboard._rate).
+          hint={burn?.usd_per_min != null ? `${usd(burn.usd_per_min)}/min` : undefined}
+          title={
+            burn?.source === 'spent'
+              ? 'state.json Spent.total_usd (runner + optimizer + intake) — the same total the budget check and the KPI strip use.'
+              : 'Accumulated from events.jsonl by eventstream.accrue_totals: runner cost from `evaluate`, optimizer cost from `step`-likes, intake from `intake` — each counted once.'
+          }
+        />
+        <Cell
+          label="tokens"
+          value={compactNum(burn?.tokens ?? null)}
+          hint={burn?.tokens_per_min != null ? `${compactNum(burn.tokens_per_min)}/min` : undefined}
+          title={
+            burn?.source === 'spent'
+              ? 'state.json Spent: runner_tokens + optimizer_tokens + intake_tokens.'
+              : 'Accumulated from events.jsonl by eventstream.accrue_totals.'
+          }
+        />
+      </div>
+
+      {/* ---- the evidence line: the honest-eval story, always visible ---- */}
+      <dl
+        className="mt-4 flex flex-wrap gap-x-6 gap-y-2 border-t border-border pt-3"
+        data-testid="evidence-line"
+      >
+        <Fact label="baseline (seed on val)" value={pct(s.baseline_val)} title="baseline.json → val.reward" />
+        <Fact label="best on val" value={pct(s.best_val)} title="the highest gated val score in events.jsonl" />
+        {/* A % change off a zero baseline is undefined — reduce_run leaves delta_pct
+            null there and only delta_abs is honest, so label it as POINTS, not %. */}
+        {s.delta_pct != null ? (
+          <Fact
+            label="Δ vs baseline"
+            value={signedPct(s.delta_pct)}
+            title="computed: (best val − baseline val) / |baseline val|"
+          />
+        ) : (
+          <Fact
+            label="Δ vs baseline"
+            value={s.delta_abs != null ? `${s.delta_abs > 0 ? '+' : ''}${(s.delta_abs * 100).toFixed(1)} pts` : '—'}
+            title="computed: best val − baseline val, in points. A % change off a zero baseline is undefined, so the absolute delta is shown instead."
+          />
+        )}
+        <Fact
+          label="sealed test"
+          value={s.test_reward != null ? pct(s.test_reward) : s.test_sealed ? 'sealed' : 'not finalized'}
+          title="final.json → test.reward — scored once, on data the optimizer never saw"
+        />
+        <Fact
+          label="metric"
+          value={direction === 'lower_is_better' ? 'lower is better' : 'higher is better'}
+          title="Every gate in cap-evolve accepts on val > parent_val, so reward is higher-is-better."
+        />
+      </dl>
+    </Card>
+  )
+}
+
+function Cell({
+  label,
+  value,
+  hint,
+  title,
+}: {
+  label: string
+  value: string
+  hint?: string
+  title?: string
+}) {
+  return (
+    <div title={title}>
+      <div className="text-[10px] uppercase tracking-wide text-muted">{label}</div>
+      <div className="tnum mt-0.5 text-lg font-semibold text-foreground">{value}</div>
+      {hint && <div className="tnum text-[10px] text-muted">{hint}</div>}
+    </div>
+  )
+}
+
+function Fact({ label, value, title }: { label: string; value: string; title: string }) {
+  return (
+    <div title={title}>
+      <dt className="text-[10px] uppercase tracking-wide text-muted">{label}</dt>
+      <dd className="tnum text-sm font-medium text-foreground">{value}</dd>
+    </div>
+  )
+}
+
+/** The stages, with the active one lit. State is icon + label + text, never colour
+ * alone (the StatusBadge pairing); `aria-current="step"` marks the active stage. */
+function PhasePipeline({
+  phases,
+  algorithm,
+}: {
+  phases: NonNullable<RunDetail['summary']['pipeline']>['phases']
+  algorithm?: string | null
+}) {
+  return (
+    <ol className="flex flex-wrap items-center gap-1.5" data-testid="phase-pipeline">
+      {phases.map((ph, i) => {
+        const label = ph.key === 'optimize' && algorithm ? `${ph.label} · ${algorithm}` : ph.label
+        const glyph =
+          ph.status === 'done' ? '✓' : ph.status === 'active' ? '●' : ph.status === 'skipped' ? '–' : '○'
+        return (
+          <li key={ph.key} className="flex items-center gap-1.5">
+            <span
+              aria-current={ph.status === 'active' ? 'step' : undefined}
+              title={ph.detail}
+              className={cn(
+                'inline-flex items-center gap-1 rounded-md border px-2 py-0.5 text-xs',
+                ph.status === 'done'
+                  ? 'border-accepted/40 text-accepted'
+                  : ph.status === 'active'
+                    ? 'border-accent/60 bg-accent/10 font-semibold text-accent'
+                    : 'border-border text-muted',
+              )}
+            >
+              <span aria-hidden>{glyph}</span>
+              {label}
+              <span className="sr-only"> ({ph.status})</span>
+            </span>
+            {i < phases.length - 1 && (
+              <span className="text-muted" aria-hidden>
+                →
+              </span>
+            )}
+          </li>
+        )
+      })}
+    </ol>
+  )
+}

--- a/dashboard/frontend/src/components/EvidenceHeader.tsx
+++ b/dashboard/frontend/src/components/EvidenceHeader.tsx
@@ -15,6 +15,7 @@ import { useEffect, useState } from 'react'
 import type { RunDetail } from '../lib/types'
 import { cumulativeBest } from '../lib/bestCurve'
 import { compactNum, duration, pct, signedPct, usd } from '../lib/format'
+import { PHASE_PRESENTATION } from '../lib/phases'
 import { Card } from './ui/Card'
 import { Sparkline } from './Sparkline'
 import { cn } from '../lib/cn'
@@ -33,9 +34,36 @@ function useSecondsSince(t: number | null | undefined): number | null {
   return Math.max(0, now - t)
 }
 
-export function EvidenceHeader({ detail }: { detail: RunDetail }) {
+/**
+ * `liveness` is the caller's verdict on whether the PROCESS is alive — `#218`'s
+ * `liveness.status` once that lands, and today the badge's own status. It exists only to
+ * stop the header contradicting the badge rendered beside it: `derive_pipeline` calls a
+ * phase `active` because it is the latest to have STARTED, which for a crashed run is a
+ * phase that stopped running, so "● Optimize" appeared next to a `crashed` badge with no
+ * way for the reader to tell which was true (#234 review). The rule: a phase may read as
+ * *currently active* only while liveness does not say the run is dead or wedged;
+ * otherwise it reads `interrupted` — where the run stopped. Plateau/stall DEPTH (`#221`)
+ * is deliberately not an input: "live and plateaued" is a coherent pair, "live and
+ * crashed" is not.
+ */
+export function EvidenceHeader({
+  detail,
+  liveness,
+}: {
+  detail: RunDetail
+  liveness?: 'live' | 'done' | 'crashed' | 'stalled' | null
+}) {
   const s = detail.summary
-  const p = s.pipeline
+  const dead = liveness === 'crashed' || liveness === 'stalled'
+  const p =
+    dead && s.pipeline
+      ? {
+          ...s.pipeline,
+          phases: s.pipeline.phases.map((ph) =>
+            ph.status === 'active' ? { ...ph, status: 'interrupted' as const } : ph,
+          ),
+        }
+      : s.pipeline
   const inState = useSecondsSince(p?.now?.since ?? null)
   const sinceEvent = useSecondsSince(p?.now?.t ?? null)
 
@@ -43,7 +71,6 @@ export function EvidenceHeader({ detail }: { detail: RunDetail }) {
   // the sparkline and the chart can never disagree about the curve.
   const best = cumulativeBest(detail.graph.nodes).map((c) => c.best)
   const burn = p?.burn
-  const direction = s.metric_direction ?? 'higher_is_better'
 
   return (
     <Card className="p-4" data-testid="evidence-header">
@@ -73,21 +100,23 @@ export function EvidenceHeader({ detail }: { detail: RunDetail }) {
         <div>
           <div className="text-[10px] uppercase tracking-wide text-muted">best on val</div>
           <div className="mt-1 flex items-center text-accent" data-testid="sparkline-cell">
-            <Sparkline values={best} direction={direction} />
+            <Sparkline values={best} />
           </div>
         </div>
 
         <Cell
           label="burn"
           value={usd(burn?.usd ?? null)}
-          // No rate for a finished run or under a minute of elapsed time: a burn rate
-          // answers "what is this costing right now", and there is no honest answer
-          // once the run is over (see dashboard._rate).
+          // No rate for a finished run, under a minute of elapsed time, or a log that
+          // has gone quiet: a burn rate answers "what is this costing right now", and
+          // there is no honest answer once the run is over — nor while nothing is being
+          // logged, when the ratio would describe only the dense part of the log
+          // (see dashboard._rate).
           hint={burn?.usd_per_min != null ? `${usd(burn.usd_per_min)}/min` : undefined}
           title={
             burn?.source === 'spent'
               ? 'state.json Spent.total_usd (runner + optimizer + intake) — the same total the budget check and the KPI strip use.'
-              : 'Accumulated from events.jsonl by eventstream.accrue_totals: runner cost from `evaluate`, optimizer cost from `step`-likes, intake from `intake` — each counted once.'
+              : 'Accumulated from events.jsonl by eventstream.accrue_totals: runner cost from `evaluate`/`minibatch`, optimizer cost from the per-iteration gate events, intake from `intake` — each counted exactly once, for every algorithm.'
           }
         />
         <Cell
@@ -129,9 +158,11 @@ export function EvidenceHeader({ detail }: { detail: RunDetail }) {
           value={s.test_reward != null ? pct(s.test_reward) : s.test_sealed ? 'sealed' : 'not finalized'}
           title="final.json → test.reward — scored once, on data the optimizer never saw"
         />
+        {/* A constant, and stated as one: `metric_direction` was a hardcoded field whose
+            `lower_is_better` branch nothing could reach (#234 nit 6). */}
         <Fact
           label="metric"
-          value={direction === 'lower_is_better' ? 'lower is better' : 'higher is better'}
+          value="higher is better"
           title="Every gate in cap-evolve accepts on val > parent_val, so reward is higher-is-better."
         />
       </dl>
@@ -181,25 +212,28 @@ function PhasePipeline({
     <ol className="flex flex-wrap items-center gap-1.5" data-testid="phase-pipeline">
       {phases.map((ph, i) => {
         const label = ph.key === 'optimize' && algorithm ? `${ph.label} · ${algorithm}` : ph.label
-        const glyph =
-          ph.status === 'done' ? '✓' : ph.status === 'active' ? '●' : ph.status === 'skipped' ? '–' : '○'
+        const { glyph, word, tone } = PHASE_PRESENTATION[ph.status] ?? PHASE_PRESENTATION.pending
         return (
           <li key={ph.key} className="flex items-center gap-1.5">
             <span
+              // aria-current="step" says "this is where you ARE". Only `active` is:
+              // `interrupted` is where the run STOPPED, a different claim.
               aria-current={ph.status === 'active' ? 'step' : undefined}
-              title={ph.detail}
+              title={`${ph.detail} — ${word}`}
               className={cn(
                 'inline-flex items-center gap-1 rounded-md border px-2 py-0.5 text-xs',
-                ph.status === 'done'
+                tone === 'good'
                   ? 'border-accepted/40 text-accepted'
-                  : ph.status === 'active'
+                  : tone === 'live'
                     ? 'border-accent/60 bg-accent/10 font-semibold text-accent'
-                    : 'border-border text-muted',
+                    : tone === 'bad'
+                      ? 'border-rejected/50 text-rejected'
+                      : 'border-border text-muted',
               )}
             >
               <span aria-hidden>{glyph}</span>
               {label}
-              <span className="sr-only"> ({ph.status})</span>
+              <span className="sr-only"> ({word})</span>
             </span>
             {i < phases.length - 1 && (
               <span className="text-muted" aria-hidden>

--- a/dashboard/frontend/src/components/PhasesTimeline.tsx
+++ b/dashboard/frontend/src/components/PhasesTimeline.tsx
@@ -1,5 +1,5 @@
 import { motion } from 'framer-motion'
-import { Check, Loader2 } from 'lucide-react'
+import { Check, Loader2, Minus } from 'lucide-react'
 import type { RunDetail } from '../lib/types'
 import { derivePhases, type PhaseStep } from '../lib/phases'
 import { fadeUpItem, staggerContainer } from '../lib/motion'
@@ -67,6 +67,13 @@ function Marker({ status, index }: { status: PhaseStep['status']; index: number 
     return (
       <span className={cn(base, 'bg-primary/20 text-primary')} aria-label="active">
         <Loader2 size={14} className="animate-spin" />
+      </span>
+    )
+  if (status === 'skipped')
+    // Past this stage but it logged nothing — say "skipped", never "pending".
+    return (
+      <span className={cn(base, 'bg-surface-2 text-muted')} aria-label="skipped">
+        <Minus size={14} />
       </span>
     )
   return <span className={cn(base, 'bg-surface-2 text-muted')}>{index}</span>

--- a/dashboard/frontend/src/components/PhasesTimeline.tsx
+++ b/dashboard/frontend/src/components/PhasesTimeline.tsx
@@ -1,7 +1,7 @@
 import { motion } from 'framer-motion'
-import { Check, Loader2, Minus } from 'lucide-react'
+import { AlertTriangle, Check, HelpCircle, Loader2, Minus, PauseCircle } from 'lucide-react'
 import type { RunDetail } from '../lib/types'
-import { derivePhases, type PhaseStep } from '../lib/phases'
+import { derivePhases, PHASE_PRESENTATION, type PhaseStep } from '../lib/phases'
 import { fadeUpItem, staggerContainer } from '../lib/motion'
 import { Card } from './ui/Card'
 import { cn } from '../lib/cn'
@@ -24,13 +24,18 @@ export function PhasesTimeline({ detail }: { detail: RunDetail }) {
   )
 }
 
+const CARD_TONE: Record<PhaseStep['status'], string> = {
+  done: 'border-accepted/40',
+  active: 'border-primary/60',
+  interrupted: 'border-rejected/50',
+  errored: 'border-rejected/50',
+  skipped: 'border-border',
+  unknown: 'border-border',
+  pending: 'border-border',
+}
+
 function PhaseCard({ step, index }: { step: PhaseStep; index: number }) {
-  const tone =
-    step.status === 'done'
-      ? 'border-accepted/40'
-      : step.status === 'active'
-        ? 'border-primary/60'
-        : 'border-border'
+  const tone = CARD_TONE[step.status] ?? 'border-border'
   return (
     <Card className={cn('relative h-full p-4', tone)}>
       {step.status === 'active' && (
@@ -55,26 +60,26 @@ function PhaseCard({ step, index }: { step: PhaseStep; index: number }) {
   )
 }
 
+/** Icon per status. Icon + label always, never color alone. */
+const MARKER: Partial<
+  Record<PhaseStep['status'], { Icon: typeof Check; className: string; spin?: boolean }>
+> = {
+  done: { Icon: Check, className: 'bg-accepted/20 text-accepted' },
+  active: { Icon: Loader2, className: 'bg-primary/20 text-primary', spin: true },
+  // Not a spinner: nothing is spinning — the run stopped here.
+  interrupted: { Icon: PauseCircle, className: 'bg-rejected/20 text-rejected' },
+  errored: { Icon: AlertTriangle, className: 'bg-rejected/20 text-rejected' },
+  skipped: { Icon: Minus, className: 'bg-surface-2 text-muted' },
+  unknown: { Icon: HelpCircle, className: 'bg-surface-2 text-muted' },
+}
+
 function Marker({ status, index }: { status: PhaseStep['status']; index: number }) {
   const base = 'flex h-6 w-6 items-center justify-center rounded-full text-xs font-semibold'
-  if (status === 'done')
-    return (
-      <span className={cn(base, 'bg-accepted/20 text-accepted')} aria-label="done">
-        <Check size={14} />
-      </span>
-    )
-  if (status === 'active')
-    return (
-      <span className={cn(base, 'bg-primary/20 text-primary')} aria-label="active">
-        <Loader2 size={14} className="animate-spin" />
-      </span>
-    )
-  if (status === 'skipped')
-    // Past this stage but it logged nothing — say "skipped", never "pending".
-    return (
-      <span className={cn(base, 'bg-surface-2 text-muted')} aria-label="skipped">
-        <Minus size={14} />
-      </span>
-    )
-  return <span className={cn(base, 'bg-surface-2 text-muted')}>{index}</span>
+  const m = MARKER[status]
+  if (!m) return <span className={cn(base, 'bg-surface-2 text-muted')}>{index}</span>
+  return (
+    <span className={cn(base, m.className)} aria-label={PHASE_PRESENTATION[status].word}>
+      <m.Icon size={14} className={m.spin ? 'animate-spin' : undefined} />
+    </span>
+  )
 }

--- a/dashboard/frontend/src/components/Sparkline.tsx
+++ b/dashboard/frontend/src/components/Sparkline.tsx
@@ -9,8 +9,6 @@
 export interface SparklineProps {
   /** Running-best values, oldest first. Fewer than 2 points renders nothing. */
   values: number[]
-  /** Stated, never assumed — the label says which way is better. */
-  direction?: 'higher_is_better' | 'lower_is_better'
   width?: number
   height?: number
   className?: string
@@ -19,26 +17,23 @@ export interface SparklineProps {
 const pct = (v: number) => `${(v * 100).toFixed(1)}%`
 
 /** The text equivalent of the shape. Exported so a test asserts the same sentence
- * the screen reader hears. */
-export function sparklineLabel(values: number[], direction = 'higher_is_better'): string {
+ * the screen reader hears.
+ *
+ * Reward in cap-evolve is higher-is-better, full stop: every gate in the repo accepts
+ * on `val > parent_val` (`gate.decide`) and nothing emits a direction. There used to be
+ * a `lower_is_better` branch here, wired to a hardcoded `metric_direction`; it was
+ * unreachable flexibility whose only test asserted a value the backend cannot produce
+ * (#234 review, nit 6). State the constant instead of branching on a fiction. */
+export function sparklineLabel(values: number[]): string {
   if (values.length === 0) return 'No score history yet.'
   const first = values[0]
   const last = values[values.length - 1]
-  const better = direction === 'lower_is_better' ? last < first : last > first
-  const worse = direction === 'lower_is_better' ? last > first : last < first
-  const trend = better ? 'improved' : worse ? 'regressed' : 'unchanged'
-  const arrow = direction === 'lower_is_better' ? 'lower is better' : 'higher is better'
-  return `Best score over ${values.length} evaluated candidate${values.length === 1 ? '' : 's'}: ${trend} from ${pct(first)} to ${pct(last)} (${arrow}).`
+  const trend = last > first ? 'improved' : last < first ? 'regressed' : 'unchanged'
+  return `Best score over ${values.length} evaluated candidate${values.length === 1 ? '' : 's'}: ${trend} from ${pct(first)} to ${pct(last)} (higher is better).`
 }
 
-export function Sparkline({
-  values,
-  direction = 'higher_is_better',
-  width = 96,
-  height = 26,
-  className,
-}: SparklineProps) {
-  const label = sparklineLabel(values, direction)
+export function Sparkline({ values, width = 96, height = 26, className }: SparklineProps) {
+  const label = sparklineLabel(values)
   if (values.length < 2) {
     // One point is not a trend: say so in words rather than drawing a flat line that
     // would read as "no progress".
@@ -53,15 +48,11 @@ export function Sparkline({
   const max = Math.max(...values)
   const span = max - min || 1
   const dx = width / (values.length - 1)
-  // y is inverted (SVG grows downward) and, for lower-is-better, inverted again so
-  // "up and to the right" always means "better" whatever the metric direction is.
-  const norm = (v: number) =>
-    direction === 'lower_is_better' ? (max - v) / span : (v - min) / span
+  // y is inverted (SVG grows downward), so "up and to the right" means better.
+  const norm = (v: number) => (v - min) / span
   const pts = values.map((v, i) => `${(i * dx).toFixed(2)},${(height - 2 - norm(v) * (height - 4)).toFixed(2)}`)
 
-  const improved = direction === 'lower_is_better'
-    ? values[values.length - 1] < values[0]
-    : values[values.length - 1] > values[0]
+  const improved = values[values.length - 1] > values[0]
 
   return (
     <span className={className}>
@@ -91,8 +82,7 @@ export function Sparkline({
       </svg>
       {/* Direction is never colour-only: the arrow glyph and the words carry it too. */}
       <span className="tnum ml-1.5 align-middle text-xs text-muted">
-        <span aria-hidden>{improved ? '↑' : '→'}</span>{' '}
-        {direction === 'lower_is_better' ? 'lower' : 'higher'} is better
+        <span aria-hidden>{improved ? '↑' : '→'}</span> higher is better
       </span>
     </span>
   )

--- a/dashboard/frontend/src/components/Sparkline.tsx
+++ b/dashboard/frontend/src/components/Sparkline.tsx
@@ -1,0 +1,99 @@
+/** Inline-SVG sparkline of the running-best curve. No chart dependency (#138).
+ *
+ * A sparkline conveys information, so it is not decoration: the <svg> carries
+ * role="img" and an aria-label that states the shape in words, and the same sentence
+ * is rendered as visible text next to it. Nothing here animates — the shape is static,
+ * so there is nothing for prefers-reduced-motion to suppress.
+ */
+
+export interface SparklineProps {
+  /** Running-best values, oldest first. Fewer than 2 points renders nothing. */
+  values: number[]
+  /** Stated, never assumed — the label says which way is better. */
+  direction?: 'higher_is_better' | 'lower_is_better'
+  width?: number
+  height?: number
+  className?: string
+}
+
+const pct = (v: number) => `${(v * 100).toFixed(1)}%`
+
+/** The text equivalent of the shape. Exported so a test asserts the same sentence
+ * the screen reader hears. */
+export function sparklineLabel(values: number[], direction = 'higher_is_better'): string {
+  if (values.length === 0) return 'No score history yet.'
+  const first = values[0]
+  const last = values[values.length - 1]
+  const better = direction === 'lower_is_better' ? last < first : last > first
+  const worse = direction === 'lower_is_better' ? last > first : last < first
+  const trend = better ? 'improved' : worse ? 'regressed' : 'unchanged'
+  const arrow = direction === 'lower_is_better' ? 'lower is better' : 'higher is better'
+  return `Best score over ${values.length} evaluated candidate${values.length === 1 ? '' : 's'}: ${trend} from ${pct(first)} to ${pct(last)} (${arrow}).`
+}
+
+export function Sparkline({
+  values,
+  direction = 'higher_is_better',
+  width = 96,
+  height = 26,
+  className,
+}: SparklineProps) {
+  const label = sparklineLabel(values, direction)
+  if (values.length < 2) {
+    // One point is not a trend: say so in words rather than drawing a flat line that
+    // would read as "no progress".
+    return (
+      <span className={className} data-testid="sparkline-empty">
+        <span className="text-xs text-muted">{label}</span>
+      </span>
+    )
+  }
+
+  const min = Math.min(...values)
+  const max = Math.max(...values)
+  const span = max - min || 1
+  const dx = width / (values.length - 1)
+  // y is inverted (SVG grows downward) and, for lower-is-better, inverted again so
+  // "up and to the right" always means "better" whatever the metric direction is.
+  const norm = (v: number) =>
+    direction === 'lower_is_better' ? (max - v) / span : (v - min) / span
+  const pts = values.map((v, i) => `${(i * dx).toFixed(2)},${(height - 2 - norm(v) * (height - 4)).toFixed(2)}`)
+
+  const improved = direction === 'lower_is_better'
+    ? values[values.length - 1] < values[0]
+    : values[values.length - 1] > values[0]
+
+  return (
+    <span className={className}>
+      <svg
+        role="img"
+        aria-label={label}
+        width={width}
+        height={height}
+        viewBox={`0 0 ${width} ${height}`}
+        className="overflow-visible align-middle"
+        data-testid="sparkline"
+      >
+        <polyline
+          points={pts.join(' ')}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={1.5}
+          strokeLinejoin="round"
+          strokeLinecap="round"
+        />
+        <circle
+          cx={(values.length - 1) * dx}
+          cy={height - 2 - norm(values[values.length - 1]) * (height - 4)}
+          r={2.5}
+          fill="currentColor"
+        />
+      </svg>
+      {/* Direction is never colour-only: the arrow glyph and the words carry it too. */}
+      <span className="tnum ml-1.5 align-middle text-xs text-muted">
+        <span aria-hidden>{improved ? '↑' : '→'}</span>{' '}
+        {direction === 'lower_is_better' ? 'lower' : 'higher'} is better
+      </span>
+    </span>
+  )
+}

--- a/dashboard/frontend/src/lib/phases.ts
+++ b/dashboard/frontend/src/lib/phases.ts
@@ -1,7 +1,7 @@
 /** Derive the pipeline phase timeline from a reduced run (no extra backend data). */
 import type { RunDetail } from './types'
 
-export type PhaseStatus = 'done' | 'active' | 'pending'
+export type PhaseStatus = 'done' | 'active' | 'skipped' | 'pending'
 
 export interface PhaseStep {
   key: string
@@ -14,13 +14,45 @@ export interface PhaseStep {
 const pctStr = (v: number | null | undefined) =>
   v == null || Number.isNaN(v) ? '—' : `${(v * 100).toFixed(1)}%`
 
+/** Per-phase metrics, keyed by the backend's phase key (and the legacy key below). */
+function metricsFor(key: string, s: RunDetail['summary']): PhaseStep['metrics'] {
+  const c = s.counts
+  if (key === 'baseline') return [{ label: 'seed val', value: pctStr(s.baseline_val) }]
+  if (key === 'optimize' || key === 'algorithm')
+    return [
+      { label: 'iterations', value: String((c?.accepted ?? 0) + (c?.rejected ?? 0)) },
+      { label: 'accepted', value: String(c?.accepted ?? 0) },
+      { label: 'best val', value: pctStr(s.best_val) },
+    ]
+  if (key === 'finalize') return [{ label: 'sealed test', value: pctStr(s.test_reward) }]
+  return []
+}
+
 /**
  * The cap-evolve sequence is intake → implement-and-check → baseline →
- * algorithm → finalize → report. We infer each phase's status from the reduced
- * summary/graph: a run that produced candidates has cleared intake/check/baseline;
- * a sealed test means finalize ran; the dashboard existing means report ran.
+ * algorithm → finalize → report.
+ *
+ * The backend detects phases from the event log itself (`summary.pipeline`, #138) —
+ * enumerating every kind each of the three deterministic algorithms emits, so GEPA's
+ * `gepa_val_gate` and SkillOpt's `skillopt_step` light the Optimize stage exactly like
+ * hill-climb's `step`. When it's present we use it verbatim and only attach the display
+ * metrics. The summary-shaped inference below stays as the fallback for a reduced
+ * payload written before #138 (a cached dashboard.html, a checked-in fixture).
  */
 export function derivePhases(detail: RunDetail): PhaseStep[] {
+  const fromBackend = detail.summary.pipeline?.phases
+  if (fromBackend?.length) {
+    return fromBackend.map((p) => ({
+      key: p.key,
+      label:
+        p.key === 'optimize' && detail.summary.algorithm
+          ? `${p.label} · ${detail.summary.algorithm}`
+          : p.label,
+      status: p.status,
+      detail: p.detail,
+      metrics: metricsFor(p.key, detail.summary),
+    }))
+  }
   const s = detail.summary
   const counts = s.counts
   const total = counts?.total ?? detail.graph.nodes.length

--- a/dashboard/frontend/src/lib/phases.ts
+++ b/dashboard/frontend/src/lib/phases.ts
@@ -1,7 +1,9 @@
 /** Derive the pipeline phase timeline from a reduced run (no extra backend data). */
-import type { RunDetail } from './types'
+import type { PipelinePhaseStatus, RunDetail } from './types'
 
-export type PhaseStatus = 'done' | 'active' | 'skipped' | 'pending'
+/** Alias of the backend's status union, so a new status can't be added on one side
+ * only — `PhasesTimeline` and `PhasePipeline` then fail to compile until handled. */
+export type PhaseStatus = PipelinePhaseStatus
 
 export interface PhaseStep {
   key: string
@@ -9,6 +11,26 @@ export interface PhaseStep {
   status: PhaseStatus
   detail: string
   metrics: { label: string; value: string }[]
+}
+
+/** How each status reads. One table, consumed by every phase renderer, so the compact
+ * pipeline and the timeline cards can never label the same status differently.
+ * `word` is what a screen reader gets; `glyph` is decorative (always `aria-hidden`).
+ * Exhaustive over `PhaseStatus` by type, so adding a status fails to compile here. */
+export const PHASE_PRESENTATION: Record<
+  PhaseStatus,
+  { glyph: string; word: string; tone: 'good' | 'live' | 'bad' | 'muted' }
+> = {
+  done: { glyph: '✓', word: 'done', tone: 'good' },
+  active: { glyph: '●', word: 'active', tone: 'live' },
+  // Where the run STOPPED, not what is running: liveness says the process is gone or
+  // wedged, so this must not read as active (#234).
+  interrupted: { glyph: '⏸', word: 'interrupted — the run is no longer progressing', tone: 'bad' },
+  errored: { glyph: '✕', word: 'errored — reached, but it produced nothing', tone: 'bad' },
+  skipped: { glyph: '–', word: 'skipped', tone: 'muted' },
+  // Not a tick and not a skip: the evidence simply is not there.
+  unknown: { glyph: '?', word: 'unknown — no event attests this phase', tone: 'muted' },
+  pending: { glyph: '○', word: 'pending', tone: 'muted' },
 }
 
 const pctStr = (v: number | null | undefined) =>
@@ -73,8 +95,11 @@ export function derivePhases(detail: RunDetail): PhaseStep[] {
     },
     {
       key: 'check',
+      // A pre-#138 payload carries no event log, so nothing here can attest the hard
+      // gate — `total > 0 || hasBaseline` only proves the run got PAST it, which is not
+      // the same as proving it passed (#234 finding 1). `unknown`, not a green tick.
       label: 'Implement & check',
-      status: done(total > 0 || hasBaseline),
+      status: 'unknown',
       detail: 'Hard gate: the adapter must pass cap-evolve check before any budget is spent.',
       metrics: [],
     },

--- a/dashboard/frontend/src/lib/types.ts
+++ b/dashboard/frontend/src/lib/types.ts
@@ -81,12 +81,30 @@ export interface RunGraph {
 }
 
 /** One stage of the cap-evolve pipeline, as detected from events.jsonl by
- * `dashboard.derive_pipeline` (#138). `status` is monotone: done once a later phase
- * started, active for the latest started phase, pending otherwise. */
+ * `dashboard.derive_pipeline` (#138):
+ * - `done` — a later phase started, and this one logged real (non-error) evidence
+ * - `active` — the latest started phase, on a run not known to be dead
+ * - `interrupted` — the latest started phase, but liveness says crashed/stalled. A
+ *   phase must never read as *currently active* next to a "crashed" badge (#234)
+ * - `errored` — reached, but its only evidence is failure. Not `done` (a clean tick
+ *   over a phase that produced nothing) and not `skipped` (a different fact)
+ * - `skipped` — past it, legitimately silent (a pre-scaffolded project logs no intake)
+ * - `unknown` — past it, silent, and silence is not evidence of absence: the `check`
+ *   hard gate either attests itself via `check_gate` or reads unknown, never `done`
+ * - `pending` — nothing has reached it yet */
+export type PipelinePhaseStatus =
+  | 'done'
+  | 'active'
+  | 'interrupted'
+  | 'errored'
+  | 'skipped'
+  | 'unknown'
+  | 'pending'
+
 export interface PipelinePhase {
   key: string
   label: string
-  status: 'done' | 'active' | 'skipped' | 'pending'
+  status: PipelinePhaseStatus
   detail: string
   started_at: number | null
   index: number
@@ -99,7 +117,13 @@ export interface PipelinePhase {
 export interface Burn {
   usd: number
   tokens: number
+  /** Wall-clock seconds since the FIRST event — the rate's denominator. Not the event
+   * span, which freezes when the log goes quiet and inflates the rate (#234). */
   elapsed_seconds: number
+  /** `last_t - first_t`. Kept for display; never a rate denominator. */
+  event_span_seconds?: number
+  /** Seconds of silence since the last event. Past ~2min the rates are `null`. */
+  stale_seconds?: number | null
   usd_per_min: number | null
   tokens_per_min: number | null
   source: 'spent' | 'events'
@@ -117,7 +141,6 @@ export interface RunSummaryDetail {
   run_id?: string
   algorithm?: string | null
   pipeline?: Pipeline
-  metric_direction?: 'higher_is_better' | 'lower_is_better'
   baseline_val: number | null
   best_val: number | null
   delta_pct: number | null

--- a/dashboard/frontend/src/lib/types.ts
+++ b/dashboard/frontend/src/lib/types.ts
@@ -80,12 +80,48 @@ export interface RunGraph {
   best_id: string | null
 }
 
+/** One stage of the cap-evolve pipeline, as detected from events.jsonl by
+ * `dashboard.derive_pipeline` (#138). `status` is monotone: done once a later phase
+ * started, active for the latest started phase, pending otherwise. */
+export interface PipelinePhase {
+  key: string
+  label: string
+  status: 'done' | 'active' | 'skipped' | 'pending'
+  detail: string
+  started_at: number | null
+  index: number
+}
+
+/** Live spend. `source: 'spent'` means these are state.json's authoritative Spent
+ * totals (the same numbers the KPI strip and the budget check use); `'events'` means
+ * they were accumulated from the event log by `eventstream.accrue_totals` because the
+ * run has not written a Spent yet. Either way each dollar is counted exactly once. */
+export interface Burn {
+  usd: number
+  tokens: number
+  elapsed_seconds: number
+  usd_per_min: number | null
+  tokens_per_min: number | null
+  source: 'spent' | 'events'
+}
+
+export interface Pipeline {
+  phases: PipelinePhase[]
+  current: string | null
+  /** The newest renderable event, already sanitised by `eventstream.format_event`. */
+  now: { line: string | null; t: number | null; since: number | null }
+  burn: Burn
+}
+
 export interface RunSummaryDetail {
   run_id?: string
   algorithm?: string | null
+  pipeline?: Pipeline
+  metric_direction?: 'higher_is_better' | 'lower_is_better'
   baseline_val: number | null
   best_val: number | null
   delta_pct: number | null
+  delta_abs?: number | null
   test_reward: number | null
   test_sealed?: boolean
   test_pass_k?: number | null

--- a/dashboard/frontend/src/routes/RunDeepDive.tsx
+++ b/dashboard/frontend/src/routes/RunDeepDive.tsx
@@ -10,6 +10,7 @@ import { Skeleton } from '../components/ui/Skeleton'
 import { Tabs, type TabDef } from '../components/ui/Tabs'
 import { StatusBadge } from '../components/StatusBadge'
 import { KpiStrip } from '../components/KpiStrip'
+import { EvidenceHeader } from '../components/EvidenceHeader'
 import { BestCurveChart } from '../components/BestCurveChart'
 import { LineageTree } from '../components/LineageTree'
 import { PhasesTimeline } from '../components/PhasesTimeline'
@@ -128,6 +129,9 @@ export function RunDeepDive() {
 
         {data && (
           <div className="space-y-5">
+            {/* #138: stage · now · sparkline · burn · evidence, above the KPI grid so the
+                four during-a-run questions are answered without opening a tab. */}
+            <EvidenceHeader detail={data} />
             <KpiStrip summary={data.summary} />
             <Tabs tabs={tabs}>
               {(active) =>

--- a/dashboard/frontend/src/routes/RunDeepDive.tsx
+++ b/dashboard/frontend/src/routes/RunDeepDive.tsx
@@ -130,8 +130,16 @@ export function RunDeepDive() {
         {data && (
           <div className="space-y-5">
             {/* #138: stage · now · sparkline · burn · evidence, above the KPI grid so the
-                four during-a-run questions are answered without opening a tab. */}
-            <EvidenceHeader detail={data} />
+                four during-a-run questions are answered without opening a tab.
+                `liveness` is the SAME value the StatusBadge above renders, so the two can
+                never disagree about whether the run is progressing — the header shows the
+                latest phase as `interrupted` rather than `active` for a dead run. When
+                #218 lands, pass its richer `liveness.status` (crashed/stalled) here; the
+                header already accepts both. */}
+            <EvidenceHeader
+              detail={data}
+              liveness={data.summary.test_reward != null ? 'done' : liveStatus}
+            />
             <KpiStrip summary={data.summary} />
             <Tabs tabs={tabs}>
               {(active) =>

--- a/dashboard/frontend/src/test/EvidenceHeader.test.tsx
+++ b/dashboard/frontend/src/test/EvidenceHeader.test.tsx
@@ -28,7 +28,6 @@ const detail = (over: Partial<RunDetail['summary']> = {}, nodes: GraphNode[] = [
     delta_pct: 300,
     test_reward: null,
     algorithm: 'gepa',
-    metric_direction: 'higher_is_better',
     pipeline: {
       phases: [phase('baseline', 'done'), phase('optimize', 'active'), phase('finalize', 'pending')],
       current: 'optimize',
@@ -122,6 +121,50 @@ describe('EvidenceHeader', () => {
     expect(screen.getByTestId('evidence-line').textContent).toContain('20.0%')
   })
 
+  // --- the #234 review's merged-header contradiction --------------------------
+
+  it('never shows a phase as active when liveness says the run is dead', () => {
+    // Merged with #218 the header rendered "● Optimize" (lit, aria-current) beside a
+    // `crashed` StatusBadge, and the reader could not tell which was true.
+    for (const status of ['crashed', 'stalled'] as const) {
+      const { container, unmount } = render(<EvidenceHeader detail={detail()} liveness={status} />)
+      const pipeline = container.querySelector('[data-testid="phase-pipeline"]')!
+      expect(pipeline.textContent).toContain('(interrupted')
+      expect(pipeline.textContent).not.toContain('(active)')
+      // nothing claims to be the step the user is currently on
+      expect(pipeline.querySelectorAll('[aria-current="step"]')).toHaveLength(0)
+      unmount()
+    }
+  })
+
+  it('leaves the active phase alone while the run is live', () => {
+    // #221's plateau dimension is orthogonal: "live and plateaued" is a coherent pair.
+    render(<EvidenceHeader detail={detail()} liveness="live" />)
+    const pipeline = screen.getByTestId('phase-pipeline')
+    expect(pipeline.textContent).toContain('(active)')
+    expect(pipeline.querySelectorAll('[aria-current="step"]')).toHaveLength(1)
+  })
+
+  it('renders unknown and errored phases as neither done nor skipped', () => {
+    const base = detail()
+    render(
+      <EvidenceHeader
+        detail={detail({
+          pipeline: {
+            ...base.summary.pipeline!,
+            phases: [phase('check', 'unknown'), phase('optimize', 'errored')],
+          },
+        })}
+      />,
+    )
+    const pipeline = screen.getByTestId('phase-pipeline')
+    // the words, not the colour, carry it
+    expect(pipeline.textContent).toContain('no event attests this phase')
+    expect(pipeline.textContent).toContain('errored')
+    expect(pipeline.textContent).not.toContain('(done)')
+    expect(pipeline.textContent).not.toContain('(skipped)')
+  })
+
   it('draws the sparkline from the running-best curve', () => {
     render(<EvidenceHeader detail={detail({}, [node('c1', 1, 0.4), node('c2', 2, 0.8)])} />)
     const svg = screen.getByTestId('sparkline')
@@ -152,11 +195,16 @@ describe('Sparkline', () => {
     expect(container.innerHTML).not.toContain('animate-')
   })
 
-  it('inverts y for lower-is-better so up-and-right always means better', () => {
-    const { container } = render(<Sparkline values={[0.9, 0.1]} direction="lower_is_better" />)
+  // The old `lower_is_better` test asserted a value the backend cannot emit — the
+  // hardcoded `metric_direction` had no producer (#234 nit 6). Reward is
+  // higher-is-better, so assert THAT: a falling series reads as a regression.
+  it('states higher-is-better and reads a falling series as a regression', () => {
+    const { container } = render(<Sparkline values={[0.9, 0.1]} />)
     const [p0, p1] = container.querySelector('polyline')!.getAttribute('points')!.split(' ')
-    expect(Number(p1.split(',')[1])).toBeLessThan(Number(p0.split(',')[1])) // y shrinks = up
-    expect(sparklineLabel([0.9, 0.1], 'lower_is_better')).toContain('improved')
+    expect(Number(p1.split(',')[1])).toBeGreaterThan(Number(p0.split(',')[1])) // y grows = down
+    expect(sparklineLabel([0.9, 0.1])).toContain('regressed')
+    expect(sparklineLabel([0.1, 0.9])).toContain('improved')
+    expect(container.textContent).toContain('higher is better')
   })
 })
 
@@ -192,5 +240,19 @@ describe('derivePhases with the backend pipeline', () => {
       'finalize',
       'report',
     ])
+    // …and even in the fallback the hard gate is never a green tick: a pre-#138 payload
+    // has no event log, so nothing there can attest it (#234 finding 1).
+    expect(steps.find((s) => s.key === 'check')!.status).toBe('unknown')
+  })
+
+  it('carries errored/interrupted/unknown through without softening them', () => {
+    const base = detail()
+    const d = detail({
+      pipeline: {
+        ...base.summary.pipeline!,
+        phases: [phase('check', 'unknown'), phase('optimize', 'errored'), phase('finalize', 'interrupted')],
+      },
+    })
+    expect(derivePhases(d).map((s) => s.status)).toEqual(['unknown', 'errored', 'interrupted'])
   })
 })

--- a/dashboard/frontend/src/test/EvidenceHeader.test.tsx
+++ b/dashboard/frontend/src/test/EvidenceHeader.test.tsx
@@ -1,0 +1,196 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { EvidenceHeader } from '../components/EvidenceHeader'
+import { Sparkline, sparklineLabel } from '../components/Sparkline'
+import { derivePhases } from '../lib/phases'
+import type { GraphNode, PipelinePhase, RunDetail } from '../lib/types'
+
+const phase = (key: string, status: PipelinePhase['status']): PipelinePhase => ({
+  key,
+  label: key,
+  status,
+  detail: `${key} detail`,
+  started_at: 1000,
+  index: 1,
+})
+
+function node(id: string, iteration: number, val: number): GraphNode {
+  return { id, parent: 'seed', children: [], status: 'accepted', val, iteration }
+}
+
+const detail = (over: Partial<RunDetail['summary']> = {}, nodes: GraphNode[] = []): RunDetail => ({
+  run_id: 'run_x',
+  path: '/run_x',
+  graph: { nodes, root: 'seed', best_id: null },
+  summary: {
+    baseline_val: 0.2,
+    best_val: 0.8,
+    delta_pct: 300,
+    test_reward: null,
+    algorithm: 'gepa',
+    metric_direction: 'higher_is_better',
+    pipeline: {
+      phases: [phase('baseline', 'done'), phase('optimize', 'active'), phase('finalize', 'pending')],
+      current: 'optimize',
+      now: { line: '[12:00:00] ACCEPT  c1  val=0.8000 (parent 0.2000)', t: 1000, since: 900 },
+      burn: {
+        usd: 0.81,
+        tokens: 11700,
+        elapsed_seconds: 120,
+        usd_per_min: 0.405,
+        tokens_per_min: 5850,
+        source: 'spent',
+      },
+    },
+    ...over,
+  },
+})
+
+describe('EvidenceHeader', () => {
+  it('renders the pipeline with the active phase lit and marked for a11y', () => {
+    render(<EvidenceHeader detail={detail()} />)
+    const pipeline = screen.getByTestId('phase-pipeline')
+    // status is text, not colour: the sr-only suffix names it for every stage
+    expect(pipeline.textContent).toContain('(done)')
+    expect(pipeline.textContent).toContain('(active)')
+    expect(pipeline.textContent).toContain('(pending)')
+    // exactly one stage carries aria-current="step"
+    expect(pipeline.querySelectorAll('[aria-current="step"]')).toHaveLength(1)
+    // the algorithm name is appended to Optimize
+    expect(pipeline.textContent).toContain('gepa')
+  })
+
+  it('renders the now line verbatim from the backend (already sanitised)', () => {
+    render(<EvidenceHeader detail={detail()} />)
+    expect(screen.getByTestId('now-line').textContent).toContain('ACCEPT  c1  val=0.8000')
+  })
+
+  it('shows the burn readout and its rate, attributed to state.json Spent', () => {
+    render(<EvidenceHeader detail={detail()} />)
+    expect(screen.getByText('$0.810')).toBeTruthy()
+    expect(screen.getByText('11.7K')).toBeTruthy()
+    expect(screen.getByText('$0.405/min')).toBeTruthy()
+    const cell = screen.getByText('burn').parentElement!
+    expect(cell.getAttribute('title')).toContain('state.json Spent.total_usd')
+  })
+
+  it('attributes every evidence-line number to its source file', () => {
+    render(<EvidenceHeader detail={detail()} />)
+    const line = screen.getByTestId('evidence-line')
+    expect(line.textContent).toContain('baseline (seed on val)')
+    expect(line.textContent).toContain('20.0%')
+    expect(line.textContent).toContain('80.0%')
+    expect(line.textContent).toContain('+300.0%')
+    expect(line.textContent).toContain('not finalized')
+    expect(line.textContent).toContain('higher is better')
+    expect(screen.getByText('baseline (seed on val)').parentElement!.getAttribute('title'))
+      .toContain('baseline.json')
+    expect(screen.getByText('sealed test').parentElement!.getAttribute('title'))
+      .toContain('final.json')
+  })
+
+  it('shows POINTS, not a fake %, when the baseline is zero', () => {
+    // reduce_run leaves delta_pct null off a zero baseline (a % change is undefined
+    // there); rendering signedPct(delta_abs*100) as "%" would have claimed +100.0%.
+    render(<EvidenceHeader detail={detail({ baseline_val: 0, best_val: 1, delta_pct: null, delta_abs: 1 })} />)
+    const line = screen.getByTestId('evidence-line')
+    expect(line.textContent).toContain('+100.0 pts')
+    expect(line.textContent).not.toContain('+100.0%')
+  })
+
+  it('omits the burn rate when the backend reports none (finished / sub-minute run)', () => {
+    const base = detail()
+    render(
+      <EvidenceHeader
+        detail={detail({
+          pipeline: { ...base.summary.pipeline!, burn: { ...base.summary.pipeline!.burn, usd_per_min: null, tokens_per_min: null } },
+        })}
+      />,
+    )
+    expect(screen.getByText('$0.810')).toBeTruthy()
+    expect(screen.queryByText(/\/min/)).toBeNull()
+  })
+
+  it('shows the sealed test once finalize ran', () => {
+    render(<EvidenceHeader detail={detail({ test_reward: 0.75, test_sealed: true })} />)
+    expect(screen.getByTestId('evidence-line').textContent).toContain('75.0%')
+  })
+
+  it('degrades to the evidence line when the payload predates #138', () => {
+    render(<EvidenceHeader detail={detail({ pipeline: undefined })} />)
+    expect(screen.queryByTestId('phase-pipeline')).toBeNull()
+    expect(screen.getByTestId('evidence-line').textContent).toContain('20.0%')
+  })
+
+  it('draws the sparkline from the running-best curve', () => {
+    render(<EvidenceHeader detail={detail({}, [node('c1', 1, 0.4), node('c2', 2, 0.8)])} />)
+    const svg = screen.getByTestId('sparkline')
+    expect(svg.querySelector('polyline')!.getAttribute('points')!.split(' ')).toHaveLength(2)
+    expect(svg.getAttribute('aria-label')).toContain('improved from 40.0% to 80.0%')
+  })
+})
+
+describe('Sparkline', () => {
+  it('gives the shape a text equivalent, not colour alone', () => {
+    render(<Sparkline values={[0.1, 0.5, 0.9]} />)
+    const svg = screen.getByTestId('sparkline')
+    expect(svg.getAttribute('role')).toBe('img')
+    expect(svg.getAttribute('aria-label')).toBe(sparklineLabel([0.1, 0.5, 0.9]))
+    // and the direction is also words on screen, not just an arrow glyph
+    expect(screen.getByText(/higher is better/)).toBeTruthy()
+  })
+
+  it('says so in words rather than drawing a misleading flat line', () => {
+    render(<Sparkline values={[0.5]} />)
+    expect(screen.queryByTestId('sparkline')).toBeNull()
+    expect(screen.getByTestId('sparkline-empty').textContent).toContain('Best score over 1')
+  })
+
+  it('renders nothing animated (nothing for prefers-reduced-motion to suppress)', () => {
+    const { container } = render(<Sparkline values={[0.1, 0.9]} />)
+    expect(container.querySelectorAll('animate, animateTransform')).toHaveLength(0)
+    expect(container.innerHTML).not.toContain('animate-')
+  })
+
+  it('inverts y for lower-is-better so up-and-right always means better', () => {
+    const { container } = render(<Sparkline values={[0.9, 0.1]} direction="lower_is_better" />)
+    const [p0, p1] = container.querySelector('polyline')!.getAttribute('points')!.split(' ')
+    expect(Number(p1.split(',')[1])).toBeLessThan(Number(p0.split(',')[1])) // y shrinks = up
+    expect(sparklineLabel([0.9, 0.1], 'lower_is_better')).toContain('improved')
+  })
+})
+
+describe('derivePhases with the backend pipeline', () => {
+  it('uses the backend statuses verbatim and attaches display metrics', () => {
+    const steps = derivePhases(detail())
+    expect(steps.map((s) => [s.key, s.status])).toEqual([
+      ['baseline', 'done'],
+      ['optimize', 'active'],
+      ['finalize', 'pending'],
+    ])
+    expect(steps[0].metrics).toEqual([{ label: 'seed val', value: '20.0%' }])
+    expect(steps[1].label).toContain('gepa')
+  })
+
+  it('carries a skipped phase through rather than calling it pending', () => {
+    const d = detail({
+      pipeline: {
+        ...detail().summary.pipeline!,
+        phases: [phase('intake', 'skipped'), phase('finalize', 'done')],
+      },
+    })
+    expect(derivePhases(d)[0].status).toBe('skipped')
+  })
+
+  it('falls back to summary-shaped inference without a pipeline', () => {
+    const steps = derivePhases(detail({ pipeline: undefined }))
+    expect(steps.map((s) => s.key)).toEqual([
+      'intake',
+      'check',
+      'baseline',
+      'algorithm',
+      'finalize',
+      'report',
+    ])
+  })
+})

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -56,8 +56,8 @@ cap-evolve run --spec .capevolve/project/capevolve.yaml --follow
 ```text
 [14:02:11] splits frozen  train=4 val=2 test=2 (test sealed)
 [14:02:12] baseline  val=0.0000 ±0.0000
-[14:02:40] ACCEPT  cand_0001  val=1.0000 (parent 0.0000)  — paired Δ̄=+1.0000 > 0  [$0.1240 · 8.3k tok]
-[14:03:05] reject  cand_0002  val=1.0000 (parent 1.0000)  — paired Δ̄=+0.0000 <= 0  [$0.2480 · 16.1k tok]
+[14:02:40] ACCEPT  cand_0001  val=1.0000 (parent 0.0000)  — paired Δ̄=+1.0000 > 0  [$0.0620 · 4.1k tok]
+[14:03:05] reject  cand_0002  val=1.0000 (parent 1.0000)  — paired Δ̄=+0.0000 <= 0  [$0.1240 · 8.3k tok]
 [14:03:31] FINALIZE  test=1.0000 (baseline 0.0000, Δ+1.0000)  best=cand_0001
 ```
 
@@ -73,7 +73,14 @@ cap-evolve tail                                    # newest run under .capevolve
 cap-evolve tail .capevolve/run_20260130_140211 --from-start
 ```
 
-`tail` waits for the run dir to appear, so you can attach before the run creates it.
+`tail` waits for the run dir to appear, so you can attach before the run creates it. It
+exits `0` when the run finishes, `2` on a path that can never be a run dir, and `3` when
+`--idle-timeout` elapses with no events — so a script can tell a timeout from a result.
+
+The `[$… · … tok]` meter is the run's own recorded spend: runner cost from `evaluate`
+events plus optimizer cost from `step` events, matching `Spent.total_usd` in `state.json`.
+Event text is stripped of control characters before it reaches your terminal, so an
+optimizer's stderr can never move the cursor, clear the screen, or forge a progress line.
 
 ## 5. Where to next
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -43,7 +43,39 @@ This is exactly what `core/tests/test_e2e_slice.py` asserts. The script prints a
 directory; open the `dashboard.html` it writes in any browser to see the run (KPIs,
 per-iteration diffs, the tasks × iterations heatmap).
 
-## 4. Where to next
+## 4. Watch a run live in the terminal
+
+A run is otherwise silent until it finishes. `--follow` prints progress from the run's
+`events.jsonl` — the same typed event stream the web dashboard reads, so the two can
+never disagree:
+
+```bash
+cap-evolve run --spec .capevolve/project/capevolve.yaml --follow
+```
+
+```text
+[14:02:11] splits frozen  train=4 val=2 test=2 (test sealed)
+[14:02:12] baseline  val=0.0000 ±0.0000
+[14:02:40] ACCEPT  cand_0001  val=1.0000 (parent 0.0000)  — paired Δ̄=+1.0000 > 0  [$0.1240 · 8.3k tok]
+[14:03:05] reject  cand_0002  val=1.0000 (parent 1.0000)  — paired Δ̄=+0.0000 <= 0  [$0.2480 · 16.1k tok]
+[14:03:31] FINALIZE  test=1.0000 (baseline 0.0000, Δ+1.0000)  best=cand_0001
+```
+
+Progress goes to **stderr**; stdout stays the machine-readable final JSON, so
+`cap-evolve run --follow > result.json` still works for scripts. Output is plain text
+whenever the stream is not a TTY (piped, CI, `NO_COLOR`) — no ANSI in your logs.
+
+To watch a run started elsewhere (another shell, `nohup`, a CI job), attach to its run
+dir instead:
+
+```bash
+cap-evolve tail                                    # newest run under .capevolve/
+cap-evolve tail .capevolve/run_20260130_140211 --from-start
+```
+
+`tail` waits for the run dir to appear, so you can attach before the run creates it.
+
+## 5. Where to next
 
 | You want to… | Go to |
 |---|---|

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -29,6 +29,9 @@ pip install ./dashboard/backend            # package: capevolve-dashboard
 cap-evolve dashboard --base .capevolve --port 7878   # or: cap-evolve run --dashboard auto
 ```
 
+No backend needed to watch a run in the terminal: `cap-evolve run --follow` prints live
+progress, and `cap-evolve tail [run_dir]` attaches to a run started elsewhere.
+
 A prebuilt frontend is committed under `dashboard/frontend/dist/`. Every run also writes a
 self-contained static `dashboard.html` you can open with no backend.
 


### PR DESCRIPTION
Closes #138.

The dashboard answered "what happened" but not the four questions a user has *during* a run: **what stage are we in, what's happening now, is it improving, and what's the honest evidence so far.** Those facts existed but were spread across tabs.

## What the header shows, and where each number comes from

`dashboard.derive_pipeline(events)` folds `events.jsonl` into `summary.pipeline` = `{phases, current, now, burn}`. The SPA renders it as one compact header above the KPI grid (`EvidenceHeader.tsx`); the self-contained `dashboard.html` gets the same **Evidence** section.

| Header cell | Source — attributed in the cell's own `title=` |
|---|---|
| phase pipeline (active stage lit) | `events.jsonl` event kinds, via `derive_pipeline` |
| `now …` + time-in-state | `eventstream.format_event(ev, skip_kinds=())` — the terminal's own words and the terminal's own sanitiser. Time-in-state is computed viewer-side from an event `t`, so a cached reduction can never serve a frozen "3m ago" |
| best-on-val sparkline | `cumulativeBest(graph.nodes)` — the same helper the Overview chart draws, so they cannot disagree |
| **burn** $ / tokens (+ rate) | `state.json` `Spent` when the run wrote one (`burn.source == "spent"`), else `eventstream.accrue_totals` over the log (`"events"`) |
| baseline (seed on val) | `baseline.json` → `val.reward` |
| best on val | highest gated val score in `events.jsonl` |
| Δ vs baseline | computed; **points** when the baseline is 0 |
| sealed test | `final.json` → `test.reward` |
| metric direction | stated, not left to an arrow's implication |

**The burn is not re-derived.** It uses #191's `accrue_totals`, because the harness reports the same runner spend **twice** (`evaluate` at `harness.py:311`, restated on the following `step` at `:1326`) and summing every cost-ish key showed ~2x the real spend. Measured on a priced run: **$0.8100 / 11,700 tok == `Spent.total_usd` 0.8100 == `summary.cost.total_usd` 0.8100** — exactly, both via `Spent` and via `accrue_totals` over the log alone. The naive sum gives $1.0200.

## Phase-detection mechanism

`_PHASE_KINDS` enumerates, per phase, **every event kind that proves it started** — not `kind == "step"`, which this epic has hit **four** bugs from (#224). hill-climb's `step`, GEPA's `gepa_val_gate` / `gepa_select` / `gepa_local_gate` / `minibatch`, and SkillOpt's `skillopt_step` / `skillopt_slow_update` all light **Optimize**. `evaluate` is deliberately *absent*: it fires for both the baseline eval and every candidate eval, so it cannot tell those phases apart.

Status is monotone (done once a later phase started, active for the latest, pending otherwise) with a fourth state: a phase the run is already **past** but which logged nothing reads **`skipped`**, not `pending`. `cap-evolve run` on a pre-scaffolded project never emits `intake`, and calling that "pending" on a finalized run states something false.

## Two honesty fixes the first screenshot exposed

- **No burn *rate* for a finished run, or under a minute elapsed.** A 2.6-second toy run that spent $0.81 is not burning `$18.69/min`; it is not burning anything, it is over. Total stands; rate goes to `null` (`dashboard._rate`).
- **`Δ vs baseline` off a ZERO baseline is shown in POINTS.** `reduce_run` already leaves `delta_pct` null there (a % change off zero is undefined); rendering `delta_abs * 100` with a `%` suffix would have claimed `+100.0%`. It now reads `+100.0 pts`.

## Accessibility

- The sparkline is `role="img"` with an `aria-label` that states the shape **in words** (`sparklineLabel`, exported so a test asserts the exact sentence a screen reader hears), and the same sentence renders as **visible text** beside it.
- One data point says so in words rather than drawing a flat line that would read as "no progress".
- Nothing animates — the shape is static, so there is nothing for `prefers-reduced-motion` to suppress (asserted by test).
- Phase state is **glyph + label + an `sr-only` status word**, never colour alone (`StatusBadge.tsx`'s in-repo pairing), with `aria-current="step"` on the active stage.
- For lower-is-better metrics the y axis inverts, so "up and to the right" always means better.

Complementary to #118, not a second opinion: the badge answers *is this process alive*, the header answers *what stage / what now / is it improving / what has it cost*. The header never claims a run is live or done.

## Also fixed here: #209 at the root

`render_html` escaped the inline-`<script>` payload with a one-sequence denylist (`.replace("</", "<\\/")`). HTML's script-data parsing also honours comment-like sequences, so a model-written `reason` containing `<!--<script>` shifted the parser and blanked the page. Replaced with `json_for_html`, matching #220's fix. Zero new deps: inline SVG for the sparkline, stdlib only in core. `dist/` deliberately **not** rebuilt (#188).

## Expected merge order

Branched on **#191** (`feat/issue-116-follow-tail`), rebased onto `main` — `accrue_totals` / `format_event` / `sanitize` come from there, so **#191 must land first**. After that, any order; the conflicts are mechanical and adjacent:

1. **#191** — hard dependency (`core/cap_evolve/eventstream.py`).
2. **#194** (reduce cache) — `pipeline` is derived from `events.jsonl` alone, so the existing `(mtime_ns, size, st_ino)` stamp already invalidates it exactly. Nothing wall-clock-dependent went inside the cached payload: `now.since` is an *event* timestamp and time-in-state is computed viewer-side.
3. **#204** (event ticker) — adds `summary.algorithm`, which the Optimize label consumes (`Optimize · gepa`); both edit `RunDeepDive.tsx` in different places, and #204's `algorithm` event kind is already in `_PHASE_KINDS`.
4. **#218** (stall detection) — shares the DeepDive header; complementary by design (see above). Both touch `types.ts`/`RunDeepDive.tsx`; also brings a full `eventstream.py` that supersedes #191's, which this branch only reads from.
5. **#221** (plateau) / **#205** (model tiering) — independent; #205's `Aux` cost bar stays consistent because both it and this header trace back to `Spent`.
6. **#220** (#122 replay) — also adds `json_for_html`; whichever lands second drops its copy.
7. **#188** rebuilds `dist/` once after all frontend PRs land.

## Verification

Real end-to-end, **zero API cost** — `examples/toy_calc` + the `mock` optimizer, one full run per algorithm (3 iterations each, sealed test):

```
===== hill-climb
  event kinds: baseline evaluate finalize gate_warning splits step
  phases: intake=skipped check=skipped baseline=done optimize=done finalize=done report=active
  current: report | now: [13:30:53] FINALIZE  test=1.0000 (baseline 0.0000, Δ+1.0000)  best=cand_0001
===== gepa
  event kinds: baseline evaluate finalize gate_warning gepa_local_gate gepa_select gepa_start gepa_val_gate minibatch splits
  phases: intake=skipped check=skipped baseline=done optimize=done finalize=done report=active
  current: report | now: [13:30:56] FINALIZE  test=1.0000 (baseline 0.0000, Δ+1.0000)  best=gepa_0001
===== skillopt
  event kinds: baseline evaluate finalize gate_warning skillopt_slow_eval skillopt_slow_update skillopt_start skillopt_step splits step
  phases: intake=skipped check=skipped baseline=done optimize=done finalize=done report=active
  current: report | now: [13:30:59] FINALIZE  test=1.0000 (baseline 0.0000, Δ+1.0000)  best=so_e01s01
```

Burn numbers asserted against the run's own records (the mock optimizer is free, so the real hill-climb log was re-priced the way a paid backend writes it — `evaluate` carries runner spend, `step` restates it plus `opt_cost_usd`):

```
priced log: 6 evaluate x $0.07 runner, 3 step x $0.13 optimizer (+ runner spend restated)
  rundir Spent.total_usd  = 0.8100   tokens = 11700
  header burn.usd         = 0.8100   tokens = 11700  (source=spent)
  summary.cost.total_usd  = 0.8100   tokens = 11700
  EXACT MATCH: header burn == RunDir Spent == summary.cost.total_usd
  events-only via accrue_totals: $0.8100  11700 tok
  accrue_totals over the log alone reproduces Spent.total_usd exactly
  naive 'sum every cost key' = $1.0200  (1.26x the truth — the #191 double-count)
  mid-run (truncated after step 1):  intake=skipped check=skipped baseline=done optimize=active finalize=pending report=pending
    current: optimize | now: [13:30:51] ACCEPT  cand_0001  val=1.0000 (parent 0.0000)  — paired Δ̄=
  mid-run pipeline lights Optimize and leaves Finalize pending
```

Suites:

```
core:     227 passed in 69.78s          (217 on the #191 base + 10 new)
backend:   42 passed
frontend:  61 passed (14 files)          (45 before + 16 new)
tsc -b --noEmit: clean
compileall core dashboard/backend: clean
```

Screenshots (rendered in a real browser against a real served run dir — see the Evidence comment for the full commands and output): the finished-run header, the mid-run header with Optimize lit and a live `$0.069/min` rate, and the self-contained `dashboard.html`.
