### PR TITLE
docs: opus-4.6 optimization run (val 0.281 → 0.357, +27%) + summarize_run.py tool

### DIFF
--- a/docs/RESULTS.md
+++ b/docs/RESULTS.md
@@ -174,6 +174,71 @@ structured methodology in SKILL.md.
 `[skill-package, system-prompt, tools]` with `hill-climb` outperformed the tools-only run
 (+41.2%) when paired with hill-climb's conservative gating.
 
+## SkillsBench — full 87-task optimization (fit metric, Opus 4.6)
+
+A 3-iteration hill-climb over the same four shared office-document skills as the
+baseline section above, starting from the `run_baseline_opus` frozen baseline
+(reused via `--reuse-baseline`). Same fit-metric split (train == val == test =
+all 87), `num_trials: 1`, paired gate `k_se: 0.2`.
+
+Artifacts under `.capevolve/run_opus_optimize3/` (gitignored, per-run): `SUMMARY.md`,
+`summary.json`, `baseline.json`, `final.json`, `events.jsonl`, `PATCH_NOTE.md`,
+`rollouts/val/*.json` (348: 87 seed + 87 × 3 candidates), `rollouts/test/*.json`
+(174: 87 optimized + 87 baseline-seed).
+
+| | baseline (seed) | best (`cand_0001`) | Δ |
+|---|---|---|---|
+| val_reward (mean) | 0.281 ± 0.048 | **0.357 ± 0.050** | **+0.076 (+27.2% relative)** |
+| pass_at_1 (fully-passing tasks / 87) | 23 (26.4%) | **28 (32.2%)** | **+5 tasks (+22% relative)** |
+| test_reward (fit metric = val by construction) | 0.281 * | **0.357** | +0.076 |
+
+\* The finalize step's baseline-test re-evaluation broke overnight (VPN drop; every
+task returned 0 across a 5-hour eval); `test_baseline_reward` here is manually
+spliced from the properly-scored seed val in `run_baseline_opus`. Under the fit-
+metric split (train == val == test = same 87 tasks) the seed's test reward is
+identical to its val reward by construction, so the splice is exact.
+Documented in a `PATCH_NOTE.md` file inside the (gitignored) run dir on the
+recording host; the raw broken artifacts remain untouched for audit.
+
+### Iterations
+
+| iter | candidate | parent | val | Δ vs parent | accepted? |
+|---|---|---|---|---|---|
+| 1 | `cand_0001` | `seed` | **0.357** | **+0.077** | ✓ (paired gate: Δ > 0.2·SE) |
+| 2 | `cand_0002` | `cand_0001` | 0.325 | −0.033 | ✗ regressed |
+| 3 | `cand_0003` | `cand_0001` | 0.170 | −0.187 | ✗ large regression |
+
+The optimizer converged to `cand_0001`; two follow-up attempts both regressed
+and were correctly rejected. Optimizer spend: ~$32 total (well below the $400 cap).
+
+### What the optimizer changed (net delta on task passes)
+
+**8 tasks newly passing under `cand_0001`** (5 non-office + 3 office):
+`bike-rebalance`, `energy-ac-optimal-power-flow`, `energy-market-pricing`,
+**`exceltable-in-ppt`** (xlsx+pptx), `grid-dispatch-operator`,
+`paper-anonymizer`, `paratransit-routing`, **`weighted-gdp-calc`** (xlsx).
+
+**3 tasks regressed from baseline**: `citation-check`,
+`crystallographic-wyckoff-position-analysis`, **`pptx-reference-formatting`** (pptx).
+
+Net: **+5 tasks** (23 → 28) on `pass_at_1`. Two of the newly-passing tasks and
+one of the regressed tasks are shared-office-skill tasks — the optimizer's edits
+to `xlsx`/`pptx` had real cross-task effect.
+
+### Caveats
+
+- **Fit metric, not held-out.** `test == val` by construction; the `test_delta`
+  above just re-affirms the val_delta at higher confidence. Not a generalization
+  claim.
+- **Single trial.** `num_trials: 1` — one draw per task per iteration. The paired
+  gate still ran cleanly on the accepted iteration (Δ = +0.077 > 0.007 = 0.2·SE).
+- **Not directly comparable to EvoSkills' 71.1%.** Different paradigm (shared
+  4-skill package vs per-task skills), different setup (BenchFlow strips each
+  task's own bundled skills and mounts ours). This is the same
+  shared-skill approach as the baselines above.
+
+---
+
 ## SkillsBench — skill-package optimization (held-out, committed)
 
 Artifact: [`examples/skillsbench/run_full/`](../examples/skillsbench/run_full/)

--- a/docs/runs/local-20260730-skillsbench-opus46-optimize.md
+++ b/docs/runs/local-20260730-skillsbench-opus46-optimize.md
@@ -1,0 +1,103 @@
+<!-- Local benchmark run detail page. Linked from https://skillberry-ai.github.io/cap-evolve/benchmarks.html -->
+
+> **Local optimization run** (recorded on the benchmark-history branch).
+> Ran outside the CI workflow (source: `bcarmeli`); optimizer proposed 3 candidates over the shared office-document skills (docx/pptx/xlsx/pdf), 1 accepted by paired gate.
+> Benchmark: SkillsBench (all 87 tasks, fit metric — train==val==test); agent + optimizer: `claude-opus-4-6`.
+
+> **Splice note:** the finalize steps baseline-test re-evaluation was broken by an overnight VPN drop; `test_baseline_reward` here is spliced from a properly-scored prior baseline run (fit-metric: test == val by construction). See PATCH_NOTE.md in the run dir for details.
+
+
+# Run summary — `run_opus_optimize3`
+
+- **Benchmark:** `skillsbench`
+- **Agent under test:** `claude-opus-4-6`
+- **Optimizer:** `claude-opus-4-6`
+- **Tasks / trials:** 87 tasks · 1 trials
+- **Iterations (actual / cap):** 3 / 3  ·  1 accepted
+- **Split discipline:** fit-metric (train==val==test, no holdout)
+- **Best candidate:** `cand_0001`
+
+## Headline
+
+| | baseline (seed) | best (`cand_0001`) |
+|---|---|---|
+| val_reward (mean) | 0.2809 ± 0.0475 | **0.3574 ± 0.0502** (35.7%) |
+| pass_at_1 (fully passing) | — | **28/87** (—) |
+| test_reward | 0.2809 | **0.3574** |
+| test_delta (best − baseline) |  | **0.0765** |
+| val wall-clock |  | 188m 52s |
+| test wall-clock |  | 301m 5s |
+| total wall-clock |  | 1272m 2s |
+
+## Iterations
+
+| iter | candidate | parent | val | Δ vs parent | accepted? |
+|---|---|---|---|---|---|
+| 1 | `cand_0001` | `seed` | 0.3574 | +0.0765 | ✓ |
+| 2 | `cand_0002` | `cand_0001` | 0.3247 | -0.0327 | ✗ |
+| 3 | `cand_0003` | `cand_0001` | 0.1703 | -0.1871 | ✗ |
+
+## Passing tasks
+
+- ✓ `3d-scan-calc`
+- ✓ `adaptive-cruise-control`
+- ✓ `bike-rebalance`
+- ✓ `court-form-filling`
+- ✓ `econ-detrending-correlation`
+- ✓ `energy-ac-optimal-power-flow`
+- ✓ `energy-market-pricing`
+- ✓ `exam-block-sequencing`
+- ✓ `exceltable-in-ppt`
+- ✓ `fix-erlang-ssh-cve`
+- ✓ `glm-lake-mendota`
+- ✓ `gravitational-wave-detection`
+- ✓ `grid-dispatch-operator`
+- ✓ `hvac-control`
+- ✓ `lean4-proof`
+- ✓ `mars-clouds-clustering`
+- ✓ `offer-letter-generator`
+- ✓ `paper-anonymizer`
+- ✓ `parallel-tfidf-search`
+- ✓ `paratransit-routing`
+- ✓ `pddl-tpp-planning`
+- ✓ `pdf-excel-diff`
+- ✓ `powerlifting-coef-calc`
+- ✓ `protein-expression-analysis`
+- ✓ `spring-boot-jakarta-migration`
+- ✓ `threejs-to-obj`
+- ✓ `tictoc-unnecessary-abort-detection`
+- ✓ `weighted-gdp-calc`
+
+## Partial credit
+
+| task | reward |
+|---|---|
+| `dialogue-parser` | 0.833 |
+| `lab-unit-harmonization` | 0.646 |
+| `debug-trl-grpo` | 0.600 |
+| `drone-planning-control` | 0.567 |
+| `crystallographic-wyckoff-position-analysis` | 0.450 |
+
+## Errored tasks (infra, not skill defect)
+
+- ⚠ `earthquake-phase-association`
+- ⚠ `fix-build-google-auto`
+- ⚠ `fix-druid-loophole-cve`
+- ⚠ `multilingual-video-dubbing`
+- ⚠ `python-scala-translation`
+- ⚠ `quantum-numerical-simulation`
+- ⚠ `seismic-phase-picking`
+- ⚠ `shock-analysis-demand`
+
+## Artifacts
+
+Local run — artifacts live on the recording host under `.capevolve/run_opus_optimize3/`
+(gitignored, per-run):
+
+- `baseline.json` — full per-task rewards
+- `final.json` — headline numbers
+- `events.jsonl` — event timeline (including manual splice records)
+- `PATCH_NOTE.md` — human-readable splice documentation
+- `rollouts/val/*.json` — 348 per-rollout JSONs across the 4 candidates (agent transcript + CTRF)
+- `rollouts/test/*.json` — 174 per-rollout JSONs for the finalize step
+- `dashboard.html` — static snapshot of the run's dashboard

--- a/scripts/tools/summarize_run.py
+++ b/scripts/tools/summarize_run.py
@@ -1,0 +1,407 @@
+#!/usr/bin/env python3
+"""summarize_run.py — condense one cap-evolve run dir into a portable summary.
+
+Usage:
+    summarize_run.py <run_dir> [--bench BENCH] [--agent MODEL] [--optimizer MODEL]
+
+Reads a cap-evolve run directory (contains baseline.json / final.json / events.jsonl
+/ rollouts/) and writes two portable summaries next to those files:
+
+  SUMMARY.md    — one-page human-readable, matches docs/RESULTS.md section style
+  summary.json  — machine-readable, matches site/benchmarks.fixture.json schema=1
+
+Idempotent; safe to rerun on the same dir. Defaults extract MODEL/AGENT from the
+associated capevolve.yaml + adapter, but CLI flags override.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import glob
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def _load(path: Path, default=None):
+    if not path.is_file():
+        return default
+    try:
+        return json.loads(path.read_text())
+    except Exception:
+        return default
+
+
+def _iter_events(events_jsonl: Path):
+    if not events_jsonl.is_file():
+        return
+    for line in events_jsonl.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            yield json.loads(line)
+        except Exception:
+            continue
+
+
+def summarize(run_dir: Path, bench: str, agent_model: str, optimizer_model: str) -> dict:
+    """Extract the canonical fields from one run dir."""
+    baseline = _load(run_dir / "baseline.json", {}) or {}
+    final = _load(run_dir / "final.json", {}) or {}
+    state = _load(run_dir / "state.json", {}) or {}
+    events = list(_iter_events(run_dir / "events.jsonl"))
+
+    # final.json wraps results per-split (e.g. {"test": {reward, per_task, ...}}).
+    # The finalize EVENT (in events.jsonl) has flat top-level test_reward/test_delta.
+    # Prefer `finalize_patched` if present (manual splice supersedes the original).
+    final_test_block = (final or {}).get("test") or {}
+    final_headline = {}
+    for e in events:
+        if e.get("kind") == "finalize":
+            final_headline = e
+    for e in events:
+        if e.get("kind") == "finalize_patched":
+            final_headline = e  # overrides finalize when present
+
+    # Build a per-iteration timeline from evaluate + step events. For optimization
+    # runs, the HEADLINE metrics should reflect the BEST candidate — not the seed.
+    per_iter_val = {}       # candidate_id -> {reward, stderr}
+    steps: list[dict] = []
+    for e in events:
+        if e.get("kind") == "evaluate" and e.get("split") == "val":
+            per_iter_val[e.get("tag") or "seed"] = {
+                "reward": e.get("reward"),
+                "stderr": e.get("stderr"),
+                "seconds": e.get("seconds"),
+            }
+        elif e.get("kind") == "step":
+            steps.append({
+                "candidate": e.get("candidate"),
+                "parent": e.get("parent"),
+                "parent_val": e.get("parent_val"),
+                "val": e.get("val"),
+                "accepted": e.get("accept"),
+                "reason": e.get("reason"),
+                "optimizer_seconds": e.get("optimizer_seconds"),
+                "runner_seconds": e.get("runner_seconds"),
+                "optimizer_usd": e.get("opt_cost_usd"),
+                "optimizer_tokens": e.get("opt_tokens"),
+            })
+
+    best_id = final_headline.get("best_id") or state.get("best_id") or "seed"
+
+    # For OPTIMIZATION runs, prefer the best candidate's per-task rollouts if we have them;
+    # otherwise (baseline-only runs) fall back to baseline.json's per_task.
+    import glob
+    per_task = baseline.get("val", {}).get("per_task") or []
+    if best_id != "seed":
+        # Re-derive per-task list from rollouts/val/*__<best_id>__t0.json
+        rollout_files = sorted(glob.glob(str(run_dir / "rollouts" / "val" / f"*__{best_id}__t*.json")))
+        if rollout_files:
+            per_task = []
+            for f in rollout_files:
+                try:
+                    d = json.loads(Path(f).read_text())
+                except Exception:
+                    continue
+                score = d.get("score") or {}
+                rollout = d.get("rollout") or {}
+                per_task.append({
+                    "task_id": d.get("input"),
+                    "reward": score.get("reward"),
+                    "feedback": score.get("feedback"),
+                    "raw": {"errored_trials": 1 if rollout.get("error") else 0, "n_trials": 1},
+                })
+
+    val_block = per_iter_val.get(best_id) or baseline.get("val") or {}
+
+    # Aggregate per-task stats
+    passed, partial, errored, failed = [], [], [], []
+    for t in per_task:
+        tid = t.get("task_id")
+        r = t.get("reward")
+        errs = t.get("raw", {}).get("errored_trials", 0)
+        if errs and errs > 0:
+            errored.append(tid)
+        elif r is None:
+            errored.append(tid)  # treat missing as error
+        elif r >= 1.0:
+            passed.append(tid)
+        elif r > 0:
+            partial.append({"task_id": tid, "reward": r})
+        else:
+            failed.append(tid)
+
+    # Timing from events
+    ts_first = ts_last = None
+    val_seconds = test_seconds = None
+    for e in events:
+        t = e.get("t")
+        if t:
+            ts_first = ts_first or t
+            ts_last = t
+        if e.get("kind") == "evaluate":
+            if e.get("split") == "val":
+                val_seconds = e.get("seconds")
+            elif e.get("split") == "test":
+                test_seconds = e.get("seconds")
+
+    wall_sec = int(ts_last - ts_first) if (ts_first and ts_last) else None
+
+    # Config knobs (read from capevolve.yaml if reachable)
+    project_yaml = run_dir.parent / "project" / "capevolve.yaml"
+    num_trials = max_iterations = split_kind = None
+    if project_yaml.is_file():
+        for line in project_yaml.read_text().splitlines():
+            s = line.strip()
+            if s.startswith("num_trials:"):
+                num_trials = int(s.split(":", 1)[1].split("#", 1)[0].strip())
+            elif s.startswith("max_iterations:"):
+                max_iterations = int(s.split(":", 1)[1].split("#", 1)[0].strip())
+
+    # Split kind (fit vs held-out) inferred from split_ids.json
+    split_ids_file = run_dir.parent / "project" / "split_ids.json"
+    if split_ids_file.is_file():
+        d = _load(split_ids_file, {}) or {}
+        train, val, test = d.get("train", []), d.get("val", []), d.get("test", [])
+        if set(train) == set(val) == set(test):
+            split_kind = "fit-metric (train==val==test, no holdout)"
+        elif set(val) & set(test):
+            split_kind = f"partial holdout (val {len(val)}, test {len(test)})"
+        else:
+            split_kind = f"held-out (train={len(train)}, val={len(val)}, test={len(test)})"
+
+    # Baseline (seed) val — always the reused/measured seed val
+    baseline_val = per_iter_val.get("seed") or (baseline.get("val") or {})
+    return {
+        "run_id": run_dir.name,
+        "run_dir": str(run_dir),
+        "bench": bench,
+        "agent_model": agent_model,
+        "optimizer_model": optimizer_model,
+        "config": {
+            "n_tasks": len(per_task),
+            "num_trials": num_trials,
+            "max_iterations": max_iterations,
+            "split_kind": split_kind,
+        },
+        "val": {
+            "reward": val_block.get("reward"),
+            "stderr": val_block.get("stderr"),
+            "pass_at_k": val_block.get("pass_at_k"),
+            "n_tasks": len(per_task),
+        },
+        "baseline_val": {
+            "reward": baseline_val.get("reward"),
+            "stderr": baseline_val.get("stderr"),
+        },
+        "steps": steps,
+        "final": {
+            "best_id": final_headline.get("best_id") or state.get("best_id") or "seed",
+            "test_reward": final_headline.get("test_reward") or final_test_block.get("reward"),
+            "test_baseline_reward": final_headline.get("test_baseline_reward"),
+            "test_delta": final_headline.get("test_delta", 0.0),
+            # actual iterations from state.json (config value is the *cap*, not the count)
+            "iterations": state.get("iters") or state.get("iterations") or 0,
+        },
+        "counts": {
+            "passed": len(passed),
+            "partial": len(partial),
+            "errored": len(errored),
+            "failed": len(failed),
+        },
+        "passed": sorted(passed),
+        "partial": sorted(partial, key=lambda x: -x["reward"]),
+        "errored": sorted(errored),
+        "timing": {
+            "val_seconds": val_seconds,
+            "test_seconds": test_seconds,
+            "wall_seconds": wall_sec,
+        },
+    }
+
+
+def to_markdown(summary: dict) -> str:
+    """Render SUMMARY.md — matches the docs/RESULTS.md section style."""
+    s = summary
+    c = s["config"]
+    v = s["val"]
+    f = s["final"]
+    cnt = s["counts"]
+
+    def fmt_sec(x):
+        return f"{int(x//60)}m {int(x%60)}s" if x else "—"
+
+    def fmt_reward(x):
+        return f"{x:.4f}" if isinstance(x, (int, float)) else "—"
+
+    reward_pct = f"{v['reward']*100:.1f}%" if v["reward"] is not None else "—"
+    pass_k1 = (v.get("pass_at_k") or {}).get("1")
+    pass_k1_pct = f"{pass_k1*100:.1f}%" if pass_k1 is not None else "—"
+
+    baseline_val = s.get("baseline_val") or {}
+    steps = s.get("steps") or []
+    n_iter = len(steps)
+    n_accepted = sum(1 for st in steps if st.get("accepted"))
+    best_id = f["best_id"]
+
+    lines = [
+        f"# Run summary — `{s['run_id']}`",
+        "",
+        f"- **Benchmark:** `{s['bench']}`",
+        f"- **Agent under test:** `{s['agent_model']}`",
+        f"- **Optimizer:** `{s['optimizer_model']}`",
+        f"- **Tasks / trials:** {c['n_tasks']} tasks · {c['num_trials'] or '?'} trials",
+        f"- **Iterations (actual / cap):** {n_iter} / {c['max_iterations'] or 0}  ·  {n_accepted} accepted",
+        f"- **Split discipline:** {c['split_kind'] or '?'}",
+        f"- **Best candidate:** `{best_id}`",
+        "",
+        "## Headline",
+        "",
+        f"| | baseline (seed) | best (`{best_id}`) |",
+        "|---|---|---|",
+        f"| val_reward (mean) | {fmt_reward(baseline_val.get('reward'))} ± {fmt_reward(baseline_val.get('stderr'))} | **{fmt_reward(v['reward'])} ± {fmt_reward(v.get('stderr'))}** ({reward_pct}) |",
+        f"| pass_at_1 (fully passing) | — | **{cnt['passed']}/{c['n_tasks']}** ({pass_k1_pct}) |",
+        f"| test_reward | {fmt_reward(f.get('test_baseline_reward'))} | **{fmt_reward(f.get('test_reward'))}** |",
+        f"| test_delta (best − baseline) |  | **{fmt_reward(f.get('test_delta'))}** |",
+        f"| val wall-clock |  | {fmt_sec(s['timing']['val_seconds'])} |",
+        f"| test wall-clock |  | {fmt_sec(s['timing']['test_seconds'])} |",
+        f"| total wall-clock |  | {fmt_sec(s['timing']['wall_seconds'])} |",
+        "",
+    ]
+
+    if steps:
+        lines += [
+            "## Iterations",
+            "",
+            "| iter | candidate | parent | val | Δ vs parent | accepted? |",
+            "|---|---|---|---|---|---|",
+        ]
+        for i, st in enumerate(steps, 1):
+            pv = st.get("parent_val")
+            vv = st.get("val")
+            delta = f"{(vv - pv):+.4f}" if pv is not None and vv is not None else "—"
+            accept_glyph = "✓" if st.get("accepted") else "✗"
+            lines.append(
+                f"| {i} | `{st.get('candidate')}` | `{st.get('parent')}` | "
+                f"{fmt_reward(vv)} | {delta} | {accept_glyph} |"
+            )
+        lines.append("")
+
+    if s["passed"]:
+        lines += ["## Passing tasks", "", *[f"- ✓ `{t}`" for t in s["passed"]], ""]
+    if s["partial"]:
+        lines += ["## Partial credit", "", "| task | reward |", "|---|---|"]
+        for p in s["partial"]:
+            lines.append(f"| `{p['task_id']}` | {p['reward']:.3f} |")
+        lines.append("")
+    if s["errored"]:
+        lines += ["## Errored tasks (infra, not skill defect)", ""]
+        lines += [f"- ⚠ `{t}`" for t in s["errored"]]
+        lines.append("")
+
+    # Emit RELATIVE artifact hints, not absolute paths — this file may end up
+    # on a public detail page (e.g. via a `summary_url` field on a
+    # benchmark-history record) and a hard-coded /Users/... path would leak
+    # local layout and fail relative-link checks in CI (lychee, etc.).
+    run_name = Path(s["run_dir"]).name
+    lines += [
+        "## Artifacts",
+        "",
+        f"Local run — artifacts live on the recording host under `.capevolve/{run_name}/`",
+        "(gitignored, per-run). See the run dir for:",
+        "",
+        "- `baseline.json` — full per-task rewards",
+        "- `final.json` — headline numbers",
+        "- `events.jsonl` — event timeline (including any manual splice records)",
+        "- `PATCH_NOTE.md` — human-readable splice documentation (when applicable)",
+        f"- `rollouts/val/*.json` — per-rollout JSONs (agent transcript + CTRF)",
+        "- `rollouts/test/*.json` — finalize per-rollout JSONs",
+        "- `dashboard.html` — static snapshot of the run's dashboard",
+        "",
+    ]
+
+    return "\n".join(lines)
+
+
+def to_fixture_json(summary: dict) -> dict:
+    """Render summary.json in benchmarks.fixture.json schema=1."""
+    s = summary
+    v = s["val"]; f = s["final"]; c = s["config"]
+    return {
+        "schema": 1,
+        "run_id": s["run_id"],
+        "run_url": None,
+        "bench": s["bench"],
+        "tier": "local",
+        "event": "local",
+        "source": "local (manual)",
+        "pr": None,
+        "branch": None,
+        "sha": None,
+        "date": dt.datetime.utcnow().isoformat() + "Z",
+        "iterations": len(s.get("steps") or []),  # actual iterations completed (accept+reject)
+        "max_iterations": c["max_iterations"],    # config cap
+        "num_trials": c["num_trials"],
+        "n_tasks": c["n_tasks"],
+        "split_kind": c["split_kind"],
+        "agent_model": s["agent_model"],
+        "optimizer_model": s["optimizer_model"],
+        "conclusion": "success" if v["reward"] is not None else "failure",
+        "suite": {
+            "reward_base": (s.get("baseline_val") or {}).get("reward"),
+            "reward_opt": v["reward"],  # best candidate val (was: test_reward)
+            "n": c["n_tasks"],
+            "optimizer_usd": None,
+            "eval_usd": None,
+        },
+        "counts": s["counts"],
+        "timing_seconds": s["timing"],
+        "passed_tasks": s["passed"],
+        "partial_tasks": s["partial"],
+        "errored_tasks": s["errored"],
+        "steps": s.get("steps") or [],
+        "baseline_val": s.get("baseline_val"),
+    }
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(prog="summarize_run.py")
+    p.add_argument("run_dir")
+    p.add_argument("--bench", default="skillsbench")
+    p.add_argument("--agent", default=None, help="agent-under-test model id")
+    p.add_argument("--optimizer", default=None, help="optimizer model id")
+    args = p.parse_args()
+
+    run_dir = Path(args.run_dir).resolve()
+    if not run_dir.is_dir():
+        print(f"error: {run_dir} is not a directory", file=sys.stderr)
+        return 2
+
+    # Defaults from adapter + capevolve.yaml if not overridden
+    agent = args.agent or os.environ.get("SKILLSBENCH_MODEL", "?")
+    optimizer = args.optimizer
+    if optimizer is None:
+        y = run_dir.parent / "project" / "capevolve.yaml"
+        if y.is_file():
+            for line in y.read_text().splitlines():
+                if line.strip().startswith("optimizer_model:"):
+                    optimizer = line.split(":", 1)[1].split("#", 1)[0].strip()
+                    break
+        optimizer = optimizer or "?"
+
+    summary = summarize(run_dir, bench=args.bench, agent_model=agent, optimizer_model=optimizer)
+
+    md_path = run_dir / "SUMMARY.md"
+    js_path = run_dir / "summary.json"
+    md_path.write_text(to_markdown(summary))
+    js_path.write_text(json.dumps(to_fixture_json(summary), indent=2))
+    print(f"wrote {md_path}")
+    print(f"wrote {js_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

First end-to-end optimization result on the full **SkillsBench 87-task** setup (fit-metric split). Companion to PRs #179 (baseline detail pages + `summary_url` support) and #180 (baseline records) — same infra, first optimization payload.

**Result** (paired-gate significant, single-trial):

| | baseline (seed) | best (`cand_0001`) | Δ |
|---|---|---|---|
| val_reward | 0.281 ± 0.048 | **0.357 ± 0.050** | **+0.076 (+27% relative)** |
| pass_at_1 | 23/87 | **28/87** | **+5 tasks (+22% relative)** |

3 iterations · 1 accepted · optimizer $ ~$32 (well under the $400 cap).

**Task-level delta:** +8 newly passing (incl. 2 office-skill tasks: `exceltable-in-ppt`, `weighted-gdp-calc`) and −3 regressed (incl. 1 office-skill: `pptx-reference-formatting`). The optimizer's `xlsx`/`pptx` edits had real cross-task effect.

## Files in this PR

- **`docs/runs/local-20260730-skillsbench-opus46-optimize.md`** — the run's detail page. Same SUMMARY.md format as the baseline detail pages from #179 (headline table, iterations table, per-task pass/partial/errored lists), so the benchmarks table row (from the companion `benchmark-history` PR) can link to it via the `summary_url` field.
- **`docs/RESULTS.md`** — new "SkillsBench — full 87-task optimization (fit metric, Opus 4.6)" section following the format of the baseline section from #179. Sits above the existing "SkillsBench — skill-package optimization (held-out, committed)" section.
- **`scripts/tools/summarize_run.py`** — the tool that produces `SUMMARY.md` + `summary.json`. Improved over the version landed in #179 to also handle **optimization runs** (baseline-vs-best columns in headline, per-iteration table, steps array in JSON, per-task lists read from the best candidate's rollouts rather than baseline.json). Backward compatible: baseline-only runs render identically to before.

## The splice caveat

The finalize step's baseline-test re-evaluation was broken by an overnight VPN drop (5-hour eval, 74 tasks produced empty output because the LLM gateway was unreachable, 13 hit direct infra errors). Under our fit-metric split (train == val == test = all 87 tasks) the seed's test reward is by construction identical to its val reward, so I spliced the properly-scored value (0.281) from the reused baseline (`run_baseline_opus`) into the events.jsonl via superseding `evaluate_patched` + `finalize_patched` events. Raw broken artifacts remain untouched for audit. See `PATCH_NOTE.md` in the run dir; the detail page above notes it briefly.

## Test plan

- [ ] Verify https://skillberry-ai.github.io/cap-evolve/docs/RESULTS.md renders the new section correctly after merge (or view the raw md — should be readable).
- [ ] Once the companion `benchmark-history` PR lands, the new row on https://skillberry-ai.github.io/cap-evolve/benchmarks.html should show `bcarmeli` as a clickable link opening the detail page.
- [ ] `scripts/tools/summarize_run.py` idempotent-rerun on `run_baseline_opus/` (a baseline-only run) still produces the same 26.4% pass_at_1 that PR #180 landed with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
