### PR TITLE
Worktree-isolated parallel candidate evaluation with a serialized commit point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,17 +24,29 @@ All notable changes to cap-evolve are documented here. The format follows
 - **Bounded parallel candidate evaluation, isolated per candidate (#131).** `--parallel N`
   (or `max_parallel_candidates: N` in the spec) evaluates up to N *sibling* candidates per
   hill-climb round, each in its own hermetic workspace forked from the same champion.
-  **Default is 1 (serial) — a run without the flag is byte-identical to before**, and a
-  serial vs `--parallel 4` run on the same spec + seed produces identical `final.json`,
-  identical per-candidate val scores, and the identical sealed test number. Measured
-  ~2.4x wall-clock at N=4 with agent-latency rollouts (~0.5s each); no win when rollouts
-  are instant, so parallelism stays opt-in.
+  **Default is 1 (serial) — a run without the flag is byte-identical to before.**
+
+  **`N > 1` changes the SEARCH, and is not score-equivalent to serial.** A round forks N
+  siblings from one champion, so `--parallel N` explores *breadth* (N variations of the
+  same parent) where serial explores *depth* (each step forked from the previous accept).
+  The accept sequence, `best_id`, spend and the sealed test number all legitimately differ
+  from serial's, and where each accept unlocks the next, parallel can end up **worse** on
+  the same iteration budget: on a deterministic monotone probe serial reaches val `1.0`
+  where `--parallel 6` reaches `0.1667`, because all six siblings are forked from the same
+  pre-round champion and five are redundant. `N = 1` is the only mode with the serial
+  guarantee. Measured ~2.2x wall-clock at N=4 with agent-latency rollouts (~0.5s each) and
+  ~1.5x at N=4 with instant rollouts (this is workload-dependent — an earlier measurement
+  of the same probe saw 0.95x, i.e. a slight slowdown, when the per-candidate `copytree`
+  was larger); it also keeps N copies of the capability tree under `work/`. Parallelism
+  therefore stays opt-in, and the flag's `--help` says all of this.
 
   The honesty core stays **single-threaded**: `run_step` is split into
   `propose_candidate` (workspace → optimize → val eval, parallelizable) and
   `commit_candidate` (gate → snapshot → `best_id` → memory → store, serialized). A round's
   proposals are committed one at a time in candidate order, each re-gated against the
-  champion as of that moment, so the accept sequence is exactly a serial run's.
+  champion as of that moment, so a sibling forked from a champion its peer superseded is
+  rejected rather than banked — every recorded score cleared the same gate a serial run
+  would have applied.
   Concurrency-unsafe adapters (an `apply`/`live` override that may be a *global* inject)
   are automatically downgraded to serial and the downgrade is logged as
   `parallel_downgraded`; an adapter that is genuinely hermetic opts in with
@@ -47,14 +59,23 @@ All notable changes to cap-evolve are documented here. The format follows
   truncating write mutated already-archived hardlinked evidence); `_atomic_write` temp
   names are unique per thread; the eval cache serializes its whole-file flush so a
   concurrent `put` can't be lost; and a parallel round is clamped to the run's remaining
-  budget headroom (new `RunDir.budget_headroom`) so N=4 spends exactly the budget N=1
-  does instead of overshooting `max_iterations`/`stall`/`max_metric_calls`.
+  budget headroom (new `RunDir.budget_headroom`) so N>1 respects **every** cap —
+  `max_iterations`, `stall`, `max_metric_calls`, and the two money caps `max_usd` /
+  `max_optimizer_usd`, projected from the run's own observed spend per iteration. At any N
+  a cap is overshot by at most the one candidate already in flight, which is exactly the
+  serial (N=1) behaviour; the `max_metric_calls` ceil overshoot is pre-existing at N=1 and
+  unchanged.
 
   Isolation is a plain hermetic directory, not a `git worktree`: a worktree of the run
   repo checks out the *run dir's* shape rather than the capability-at-root shape adapters
   and optimizers expect, the capability project need not be a git repo, and worktrees cost
-  200-500ms each and leak into `.git/worktrees` on a crash. The workspace manager cleans
-  up on normal exit, on exception, and on SIGINT/SIGTERM.
+  200-500ms each and leak into `.git/worktrees` on a crash. Every workspace in a real run
+  is created through `parallel.make_workspace`, which registers it for interrupt cleanup,
+  so a Ctrl-C or `SIGTERM` mid-round removes the uncommitted copies instead of orphaning
+  them; committed workspaces are released at the commit point and deliberately kept for
+  inspection. **`SIGKILL` (and a hard power loss) cannot be handled and does leave
+  orphans** — harmless, because the next run `rmtree`s a stale workspace path before
+  reusing it.
 - **SWE-bench oracle mode + calibrated smoke selection.** The SWE-bench adapter gains
   `SWEBENCH_ORACLE=1`, which attaches the "Oracle" retrieval context (the file[s] the
   gold patch touches, from `princeton-nlp/SWE-bench_Lite_oracle`'s `text` field) to the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,40 @@ All notable changes to cap-evolve are documented here. The format follows
   longer looks like a capability regression.
 
 ### Added
+- **Bounded parallel candidate evaluation, isolated per candidate (#131).** `--parallel N`
+  (or `max_parallel_candidates: N` in the spec) evaluates up to N *sibling* candidates per
+  hill-climb round, each in its own hermetic workspace forked from the same champion.
+  **Default is 1 (serial) — a run without the flag is byte-identical to before**, and a
+  serial vs `--parallel 4` run on the same spec + seed produces identical `final.json`,
+  identical per-candidate val scores, and the identical sealed test number. Measured
+  ~2.4x wall-clock at N=4 with agent-latency rollouts (~0.5s each); no win when rollouts
+  are instant, so parallelism stays opt-in.
+
+  The honesty core stays **single-threaded**: `run_step` is split into
+  `propose_candidate` (workspace → optimize → val eval, parallelizable) and
+  `commit_candidate` (gate → snapshot → `best_id` → memory → store, serialized). A round's
+  proposals are committed one at a time in candidate order, each re-gated against the
+  champion as of that moment, so the accept sequence is exactly a serial run's.
+  Concurrency-unsafe adapters (an `apply`/`live` override that may be a *global* inject)
+  are automatically downgraded to serial and the downgrade is logged as
+  `parallel_downgraded`; an adapter that is genuinely hermetic opts in with
+  `parallel_safe = True`.
+
+  Shared-state hardening required by concurrency, all of which also makes serial runs
+  safer: `events.jsonl` appends are now a single `O_APPEND` `os.write` of the whole line
+  (no interleaved or partial lines for the live tail / stall detector / mtime cache);
+  rollout files under `rollouts/` are written atomically instead of truncate-in-place (a
+  truncating write mutated already-archived hardlinked evidence); `_atomic_write` temp
+  names are unique per thread; the eval cache serializes its whole-file flush so a
+  concurrent `put` can't be lost; and a parallel round is clamped to the run's remaining
+  budget headroom (new `RunDir.budget_headroom`) so N=4 spends exactly the budget N=1
+  does instead of overshooting `max_iterations`/`stall`/`max_metric_calls`.
+
+  Isolation is a plain hermetic directory, not a `git worktree`: a worktree of the run
+  repo checks out the *run dir's* shape rather than the capability-at-root shape adapters
+  and optimizers expect, the capability project need not be a git repo, and worktrees cost
+  200-500ms each and leak into `.git/worktrees` on a crash. The workspace manager cleans
+  up on normal exit, on exception, and on SIGINT/SIGTERM.
 - **SWE-bench oracle mode + calibrated smoke selection.** The SWE-bench adapter gains
   `SWEBENCH_ORACLE=1`, which attaches the "Oracle" retrieval context (the file[s] the
   gold patch touches, from `princeton-nlp/SWE-bench_Lite_oracle`'s `text` field) to the

--- a/core/cap_evolve/__init__.py
+++ b/core/cap_evolve/__init__.py
@@ -17,6 +17,7 @@ from .cache import EvalCache, hash_candidate_dir
 from .gate import GateDecision, TrainGateError, decide
 from .lr_schedule import build_schedule
 from .memory import History, RejectedMemory
+from .parallel import adapter_is_parallel_safe, resolve_workers, workspace
 from .rundir import Budget, RunDir, Spent
 from .selection import PICKERS, STRATEGIES, pick, validate_strategy
 from .splits import Splits, TestSealError, make_splits
@@ -41,6 +42,9 @@ __all__ = [
     "decide",
     "History",
     "RejectedMemory",
+    "adapter_is_parallel_safe",
+    "resolve_workers",
+    "workspace",
     "Budget",
     "RunDir",
     "Spent",

--- a/core/cap_evolve/__init__.py
+++ b/core/cap_evolve/__init__.py
@@ -17,7 +17,8 @@ from .cache import EvalCache, hash_candidate_dir
 from .gate import GateDecision, TrainGateError, decide
 from .lr_schedule import build_schedule
 from .memory import History, RejectedMemory
-from .parallel import adapter_is_parallel_safe, resolve_workers, workspace
+from .parallel import (adapter_is_parallel_safe, make_workspace, release_workspace,
+                       resolve_workers, workspace)
 from .rundir import Budget, RunDir, Spent
 from .selection import PICKERS, STRATEGIES, pick, validate_strategy
 from .splits import Splits, TestSealError, make_splits
@@ -45,6 +46,8 @@ __all__ = [
     "adapter_is_parallel_safe",
     "resolve_workers",
     "workspace",
+    "make_workspace",
+    "release_workspace",
     "Budget",
     "RunDir",
     "Spent",

--- a/core/cap_evolve/adapter.py
+++ b/core/cap_evolve/adapter.py
@@ -27,6 +27,20 @@ uses them when present:
     run_trials(tasks, ctx, *, n_trials, base_seed)            # batched multi-trial fast path
     score_batch(tasks, rollouts)              -> {id: Score}  # batched scoring fast path
 
+**Concurrency declaration** (optional class attribute):
+
+    parallel_safe = True    # this adapter may be driven from several threads at once
+
+Only relevant under ``cap-evolve run --parallel N`` (parallel *candidate* evaluation).
+The default is a conservative NO for any adapter that overrides ``apply`` or ``live``,
+because those hooks are allowed to be a *global* inject — the single shared slot two
+concurrent candidates would clobber. Set ``parallel_safe = True`` when the adapter is
+genuinely hermetic (it reads/writes only ``ctx`` / the candidate dir and mutates no
+process- or host-global state), or ``False`` to opt out explicitly. An adapter that
+overrides neither hook is safe automatically. A non-safe adapter is downgraded to
+sequential and the downgrade is logged (``parallel_downgraded``), so a missing
+declaration costs throughput, never correctness.
+
 Why ``materialize`` + ``live`` instead of a single ``apply``:
 ``apply(candidate_dir)`` used to be a *global* side effect (e.g. monkeypatching a
 benchmark's policy), which (a) prevented two candidates being evaluated

--- a/core/cap_evolve/adapter.py
+++ b/core/cap_evolve/adapter.py
@@ -41,6 +41,20 @@ overrides neither hook is safe automatically. A non-safe adapter is downgraded t
 sequential and the downgrade is logged (``parallel_downgraded``), so a missing
 declaration costs throughput, never correctness.
 
+"Mutates no process-global state" **includes the global RNGs.** ``random.seed()`` /
+``random.random()`` and ``numpy.random.seed()`` / ``numpy.random.random()`` share one
+hidden generator across all threads, so an adapter that seeds it once per batch and then
+draws per task yields DIFFERENT per-task rollouts under ``--parallel`` — and the
+divergence can be invisible in the aggregate mean, which makes it worse than a crash.
+Seed a local instance instead: ``rng = random.Random(seed)`` /
+``numpy.random.default_rng(seed)``. That is also what makes a serial run reproducible,
+and it is what every RNG in ``cap_evolve`` itself does.
+
+This is the one hazard the automatic check cannot see: an adapter overriding neither
+``apply`` nor ``live`` is auto-approved regardless of what other global state it touches.
+So ``parallel_safe`` — declared or inferred — is YOUR assertion of reentrancy, not
+something cap-evolve verified.
+
 Why ``materialize`` + ``live`` instead of a single ``apply``:
 ``apply(candidate_dir)`` used to be a *global* side effect (e.g. monkeypatching a
 benchmark's policy), which (a) prevented two candidates being evaluated

--- a/core/cap_evolve/cache.py
+++ b/core/cap_evolve/cache.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import threading
 from pathlib import Path
 
 # Files that are NOT part of the capability (optimizer scratch, memory, vcs); they
@@ -72,6 +73,14 @@ class EvalCache:
 
     def __init__(self, path: Path):
         self.path = Path(path)
+        # Serializes put/_flush: with parallel candidate evaluation two workers can
+        # put concurrently, and the flush is a read-modify-write of the WHOLE file.
+        # Without this, one flush's dict snapshot overwrites the other's entry (a
+        # lost cache write — harmless for correctness, wasteful for cost) and two
+        # threads could race the same temp path. Entries are keyed on the candidate
+        # CONTENT hash, so two workers on different candidates can never collide on
+        # a key; only the file write needs serializing.
+        self._lock = threading.Lock()
         self._data: dict = {}
         if self.path.exists():
             try:
@@ -87,17 +96,22 @@ class EvalCache:
         return self._data.get(self._key(candidate_hash, task_id))
 
     def put(self, candidate_hash: str, task_id: str, reward: float, feedback: str = "") -> None:
-        self._data[self._key(candidate_hash, task_id)] = {
-            "reward": float(reward), "feedback": str(feedback or "")}
-        self._flush()
+        with self._lock:
+            self._data[self._key(candidate_hash, task_id)] = {
+                "reward": float(reward), "feedback": str(feedback or "")}
+            self._flush_locked()
 
     def _flush(self) -> None:
-        # Atomic-ish write (tmp + replace) so a crash mid-write can't corrupt the cache.
-        import os
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = self.path.with_name(f".{self.path.name}.tmp.{os.getpid()}")
-        tmp.write_text(json.dumps(self._data), encoding="utf-8")
-        os.replace(tmp, self.path)
+        with self._lock:
+            self._flush_locked()
+
+    def _flush_locked(self) -> None:
+        # Atomic write (tmp + replace) so neither a crash nor a concurrent put can
+        # leave a torn cache. Route through rundir._atomic_write, whose temp name is
+        # unique per (process, thread) — a shared temp path would let two writers
+        # splice bytes into one file before the replace.
+        from .rundir import _atomic_write
+        _atomic_write(self.path, json.dumps(self._data))
 
     def __len__(self) -> int:
         return len(self._data)

--- a/core/cap_evolve/cli.py
+++ b/core/cap_evolve/cli.py
@@ -127,6 +127,10 @@ def _cmd_run(argv):
     p.add_argument("--dashboard", choices=("auto", "report-only", "off"), default=None,
                    help="live dashboard: auto (default, launch at run start), report-only, or off")
     p.add_argument("--dashboard-port", type=int, default=None, help="dashboard server port (default 7878)")
+    p.add_argument("--parallel", type=int, default=None,
+                   help="evaluate up to N sibling candidates per round, each in its own "
+                        "hermetic workspace (default 1 = serial). Downgraded to 1 for an "
+                        "adapter that isn't concurrency-safe.")
     args = p.parse_args(argv)
 
     skills_dir = Path(args.skills_dir) if args.skills_dir else _find_skills_dir()
@@ -145,6 +149,10 @@ def _cmd_run(argv):
             spec[key] = v
     if args.reuse_baseline is not None:
         spec["reuse_baseline"] = args.reuse_baseline
+    if args.parallel is not None:
+        spec["max_parallel_candidates"] = args.parallel
+    from .parallel import resolve_workers as _resolve_workers
+    parallel_n = _resolve_workers(spec.get("max_parallel_candidates"))
 
     if args.dry_run:
         print(json.dumps(_estimate_core(spec, Path(args.project)), indent=2))
@@ -233,6 +241,7 @@ def _cmd_run(argv):
         print(json.dumps({"skills_dir": str(skills_dir), "workdir": str(workdir), "spec": spec,
                           "optimizer": optimizer_name, "optimizer_cmd": opt_cmd,
                           "algorithm": algorithm_name, "focus": algorithm_focus,
+                          "max_parallel_candidates": parallel_n,
                           "target_model": spec.get("target_model", ""),
                           "orchestration_mode": orchestration_mode,
                           "gate_mode": spec.get("gate_mode", "auto (paired)"),
@@ -359,6 +368,10 @@ def _cmd_run(argv):
     # workdir. Only hill-climb accepts the flag; other algorithms ignore it.
     if algorithm_name == "hill-climb":
         alg_cmd += ["--optimizer-name", str(optimizer_name)]
+    # Bounded parallel candidate evaluation. Default 1 = serial (unchanged behaviour);
+    # only passed when >1 so a default run's command line is byte-identical to before.
+    if algorithm_name == "hill-climb" and parallel_n > 1:
+        alg_cmd += ["--parallel", str(parallel_n)]
     # Optimizer-instructions template (intake-authored, per benchmark) + benchmark repo
     # as read-only optimizer context. Both are resolved project-relative if not absolute.
     # The instructions file defaults to the scaffolded project/optimizer/INSTRUCTIONS.md.

--- a/core/cap_evolve/cli.py
+++ b/core/cap_evolve/cli.py
@@ -129,8 +129,15 @@ def _cmd_run(argv):
     p.add_argument("--dashboard-port", type=int, default=None, help="dashboard server port (default 7878)")
     p.add_argument("--parallel", type=int, default=None,
                    help="evaluate up to N sibling candidates per round, each in its own "
-                        "hermetic workspace (default 1 = serial). Downgraded to 1 for an "
-                        "adapter that isn't concurrency-safe.")
+                        "hermetic workspace (default 1 = serial). CHANGES THE SEARCH: N>1 "
+                        "forks N siblings from one champion (breadth) instead of one step "
+                        "per accept (depth), so the accept sequence, best_id and the final "
+                        "test number differ from serial and may be WORSE on the same "
+                        "iteration budget; only N=1 reproduces a serial run. Wins wall "
+                        "clock only when rollouts are slow (~2.2x at N=4 with ~0.5s "
+                        "rollouts); with instant rollouts it is a wash. Costs N concurrent "
+                        "copies of the capability tree under work/, kept after the round. "
+                        "Downgraded to 1 for an adapter that isn't concurrency-safe.")
     args = p.parse_args(argv)
 
     skills_dir = Path(args.skills_dir) if args.skills_dir else _find_skills_dir()

--- a/core/cap_evolve/gepa.py
+++ b/core/cap_evolve/gepa.py
@@ -62,7 +62,7 @@ from .harness import (
     split_result_from_rollouts,
 )
 from .loop import SplitResult, aggregate_scores
-from .rundir import RunDir
+from .rundir import RunDir, _atomic_write
 from .types import Rollout, Score
 
 OptimizerFn = Callable[[Path, str], None]
@@ -169,10 +169,13 @@ def _eval_minibatch(
                      "output": _short(getattr(rollout, "output", None)),
                      "trace": _short(getattr(rollout, "trace", None))},
             ))
-            (out_dir / f"{task.id}__{tag}__t0.json").write_text(
+            # Same atomic, never-truncate rule as evaluate_candidate: a truncating
+            # write would mutate an already-archived hardlinked copy, and under
+            # parallel evaluation could be read half-written.
+            _atomic_write(
+                out_dir / f"{task.id}__{tag}__t0.json",
                 json.dumps({"input": task.input, "rollout": rollout.to_dict(),
                             "score": sc.to_dict()}, default=str),
-                encoding="utf-8",
             )
             if cache is not None:
                 cache.put(chash, task.id, sc.reward, sc.feedback or "")

--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -249,10 +249,15 @@ def evaluate_candidate(
             per_task_trials[tid].append(sc.reward)
             per_task_feedback[tid] = sc.feedback or per_task_feedback[tid]
             per_task_metrics[tid].append(sc.metrics)
-            (out_dir / f"{tid}__{tag}__t{k}.json").write_text(
+            # Atomic (tmp + os.replace), never truncate-in-place: a rollout file may
+            # share its inode with an already-archived copy (hardlinked evidence), and
+            # a truncating write would mutate that archive. os.replace swaps a NEW
+            # inode in, leaving any archived link untouched — and under parallel
+            # evaluation a reader never sees a half-written rollout.
+            _atomic_write(
+                out_dir / f"{tid}__{tag}__t{k}.json",
                 json.dumps({"input": task.input, "rollout": rollout.to_dict(),
                             "score": sc.to_dict()}, default=str),
-                encoding="utf-8",
             )
 
     # ``live()`` makes the candidate the one the target uses for this evaluation and
@@ -1235,8 +1240,55 @@ def run_step(
 
     ``no_regression`` adds a SWE-bench-style dual gate: even if the mean improves,
     reject the candidate if it breaks any val task the parent already passed.
+
+    This is ``propose_candidate`` followed immediately by ``commit_candidate`` — the
+    two halves parallel evaluation drives separately (see ``parallel_steps``). The
+    serial path is unchanged: same calls, same order, same artifacts.
     """
-    gate_kwargs = dict(gate_kwargs or {})
+    proposal = propose_candidate(
+        adapter, run_dir=run_dir, parent_dir=parent_dir, optimizer=optimizer,
+        instructions=instructions, n_trials=n_trials, candidate_id=candidate_id,
+        parent_id=parent_id, rejected=rejected, history=history,
+        capabilities=capabilities, eval_split=eval_split, optimizer_name=optimizer_name,
+        capability_sources=capability_sources, project_dir=project_dir,
+    )
+    return commit_candidate(
+        proposal, run_dir=run_dir, current_val=current_val, gate_kwargs=gate_kwargs,
+        no_regression=no_regression, rejected=rejected, history=history, store=store,
+    )
+
+
+def propose_candidate(
+    adapter,
+    *,
+    run_dir: RunDir,
+    parent_dir: Path,
+    optimizer: OptimizerFn,
+    instructions: str,
+    n_trials: int = 1,
+    candidate_id: str | None = None,
+    parent_id: str | None = None,
+    rejected=None,
+    history=None,
+    capabilities=None,
+    eval_split: str = "val",
+    optimizer_name: str | None = None,
+    capability_sources=None,
+    project_dir: Path | None = None,
+) -> dict:
+    """The PARALLELIZABLE half of a step: workspace → optimize → evaluate on val.
+
+    Produces a candidate in its own hermetic workspace and its val ``SplitResult``,
+    and NOTHING else: it does not gate, does not snapshot, does not move ``best_id``,
+    does not touch the run-level JOURNAL, and never reads the test split. Every
+    run-dir mutation it does make is either an atomic whole-line ``log_event`` or a
+    locked read-modify-write (``update_spent``), so N of these can run concurrently
+    without losing spend or corrupting the audit log.
+
+    The returned dict is the input to ``commit_candidate``, which applies results one
+    at a time — the serialized commit point that keeps the honesty core
+    single-threaded.
+    """
     cid = candidate_id or f"cand_{run_dir.spent.iterations + 1:04d}"
     # Lineage edge for the dashboard/report: the parent is the candidate this step
     # was forked from (the current best by default in a global hill-climb). Captured
@@ -1282,6 +1334,51 @@ def run_step(
 
     cand_val = evaluate_candidate(adapter, workdir, run_dir=run_dir, split="val",
                                   n_trials=n_trials, tag=cid)
+
+    return {
+        "candidate_id": cid,
+        "parent_id": parent_id,
+        "workdir": workdir,
+        "candidate_val": cand_val,
+        "optimizer_seconds": optimizer_seconds,
+        "optimizer_usd": opt_cost_usd,
+        "optimizer_tokens": opt_tokens,
+        "optimizer_error": optimizer_error,
+    }
+
+
+def commit_candidate(
+    proposal: dict,
+    *,
+    run_dir: RunDir,
+    current_val: SplitResult,
+    gate_kwargs: dict | None = None,
+    no_regression: bool = False,
+    rejected=None,
+    history=None,
+    store=None,
+) -> dict:
+    """The SERIALIZED half of a step: gate → snapshot → best/memory/store → step event.
+
+    Call this for ONE proposal at a time, in a deterministic order. Everything that
+    makes the run's numbers honest lives here — the significance gate, the
+    no-regression check, ``set_best``, the iteration counter, the ledger/journal, the
+    version-store commit — so it is single-threaded by construction and a parallel
+    run's accept sequence is exactly a serial run's.
+
+    ``current_val`` is the parent this proposal is gated against; a parallel caller
+    re-gates each proposal against the *current* champion as it commits, so accepting
+    one candidate correctly raises the bar for its siblings.
+    """
+    gate_kwargs = dict(gate_kwargs or {})
+    cid = proposal["candidate_id"]
+    parent_id = proposal.get("parent_id")
+    workdir = Path(proposal["workdir"])
+    cand_val = proposal["candidate_val"]
+    optimizer_seconds = float(proposal.get("optimizer_seconds") or 0.0)
+    opt_cost_usd = float(proposal.get("optimizer_usd") or 0.0)
+    opt_tokens = int(proposal.get("optimizer_tokens") or 0)
+    optimizer_error = proposal.get("optimizer_error")
 
     # Paired gate is the default when per-task data is available: candidate and
     # current were scored on the SAME val tasks, so the correct (and far more
@@ -1370,6 +1467,91 @@ def run_step(
         "optimizer_error": optimizer_error,
         "workdir": str(workdir),
     }
+
+
+def parallel_steps(
+    adapter,
+    plans: list[dict],
+    *,
+    run_dir: RunDir,
+    optimizer: OptimizerFn,
+    current_val: SplitResult,
+    workers: int = 1,
+    n_trials: int = 1,
+    gate_kwargs: dict | None = None,
+    no_regression: bool = False,
+    rejected=None,
+    history=None,
+    store=None,
+    capabilities=None,
+    eval_split: str = "val",
+    optimizer_name: str | None = None,
+    capability_sources=None,
+    project_dir: Path | None = None,
+) -> list[dict]:
+    """Propose ``len(plans)`` candidates with up to ``workers`` in flight, then commit
+    them one at a time in ``plans`` order.
+
+    Each plan is ``{"candidate_id", "parent_dir", "instructions"[, "parent_id"]}``.
+    ``workers=1`` (the default) runs proposal-then-commit inline per plan, so the call
+    sequence is identical to looping ``run_step`` — which is why a default run's
+    artifacts are byte-identical to before this feature existed.
+
+    Commit order is ``plans`` order regardless of which worker finished first, so the
+    accept sequence — and therefore ``best_id``, the iteration counter, and every
+    artifact derived from them — is deterministic. Each commit re-gates against the
+    champion as of that moment: if plan 1 is accepted, plan 2 must beat the NEW
+    champion, exactly as it would have in a serial run.
+
+    A worker that raises turns into a rejected step (``proposal_error``) rather than
+    sinking the whole round — same policy ``propose_candidate`` already applies to an
+    optimizer failure.
+    """
+    from . import parallel as _par
+
+    workers = _par.resolve_workers_for(adapter, workers, run_dir=run_dir)
+    if workers > 1:
+        run_dir.log_event("parallel_round", workers=workers,
+                          candidates=[p["candidate_id"] for p in plans])
+
+    def _propose(plan: dict) -> dict:
+        try:
+            return propose_candidate(
+                adapter, run_dir=run_dir, parent_dir=Path(plan["parent_dir"]),
+                optimizer=optimizer, instructions=plan["instructions"],
+                n_trials=n_trials, candidate_id=plan["candidate_id"],
+                parent_id=plan.get("parent_id"), rejected=rejected, history=history,
+                capabilities=capabilities, eval_split=eval_split,
+                optimizer_name=optimizer_name, capability_sources=capability_sources,
+                project_dir=project_dir,
+            )
+        except Exception as e:  # noqa: BLE001 — one bad candidate must not sink the round
+            run_dir.log_event("proposal_error", candidate=plan["candidate_id"],
+                              error=str(e)[:500])
+            # The commit path snapshots the workspace unconditionally, so make sure one
+            # exists even when the failure happened before/during its creation (e.g. an
+            # unreadable parent dir). An empty candidate scores 0 and is rejected — a
+            # wasted iteration recorded honestly, not a crashed run.
+            wd = run_dir.root / "work" / plan["candidate_id"]
+            wd.mkdir(parents=True, exist_ok=True)
+            return {"candidate_id": plan["candidate_id"], "parent_id": plan.get("parent_id"),
+                    "workdir": wd,
+                    "candidate_val": SplitResult(split=eval_split, reward=0.0, stderr=0.0),
+                    "optimizer_seconds": 0.0, "optimizer_usd": 0.0, "optimizer_tokens": 0,
+                    "optimizer_error": f"proposal failed: {e}"}
+
+    proposals = _par.map_ordered(_propose, plans, workers=workers)
+
+    steps: list[dict] = []
+    for proposal in proposals:  # SERIALIZED COMMIT POINT — one at a time, in plan order
+        step = commit_candidate(
+            proposal, run_dir=run_dir, current_val=current_val, gate_kwargs=gate_kwargs,
+            no_regression=no_regression, rejected=rejected, history=history, store=store,
+        )
+        steps.append(step)
+        if step["accepted"]:
+            current_val = SplitResult.from_dict(step["candidate_val"])
+    return steps
 
 
 # ---- memory + version store wiring ----------------------------------------
@@ -1856,6 +2038,7 @@ def hill_climb_loop(
     project_dir: Path | None = None,
     target_model: str = "",
     target_profile_file: str | None = None,
+    parallel: int = 1,
 ) -> dict:
     """The loop behind the ``hill-climb`` skill's three ``--focus`` schedules
     (all / cyclic / hardest-first).
@@ -1864,6 +2047,12 @@ def hill_climb_loop(
     reflection emphasizes — and (for hardest-first) the order. Parent is always
     the current best (global hill-climb). The ``gepa`` algorithm uses its own
     per-instance frontier and parent selection (see ``cap_evolve.gepa``).
+
+    ``parallel`` (default 1 = serial, unchanged) evaluates up to N sibling candidates
+    per round, each in its own hermetic workspace, forked from the SAME champion and
+    given the next N focus slots. They are committed one at a time in candidate order
+    behind the usual val gate, so results are deterministic and the honesty core stays
+    single-threaded. Downgraded to 1 for an adapter that is not concurrency-safe.
     """
     gate_kwargs = dict(gate_kwargs or {})
     rejected, history, store = _init_memory_store(run_dir, store)
@@ -1883,11 +2072,10 @@ def hill_climb_loop(
         score_by = {pt["task_id"]: pt["reward"] for pt in train_res.per_task}
         order.sort(key=lambda t: score_by.get(t, 0.0))  # hardest (lowest) first
 
-    steps = []
-    for i in range(max_iterations):
-        exhausted, why = run_dir.budget_exhausted()
-        if exhausted:
-            break
+    from . import parallel as _par
+    workers = _par.resolve_workers_for(adapter, parallel, run_dir=run_dir)
+
+    def _instructions_for(i: int) -> str:
         if focus == "all":
             focus_ids, label = None, "whole train set"
         elif focus in ("cyclic", "hardest-first"):
@@ -1896,22 +2084,51 @@ def hill_climb_loop(
         else:
             focus_ids, label = None, focus
         seed_empty = _capability_is_empty(capabilities, run_dir.candidate_dir(run_dir.best_id))
-        instructions = _focus_instructions(current_val, focus_ids, label,
-                                            capabilities=capabilities, algorithm=algorithm,
-                                            instructions_file=instructions_file,
-                                            bench_repo=bench_repo, optimizer_name=optimizer_name,
-                                            seed_empty=seed_empty, target_reader=_target_reader)
-        step = run_step(
-            adapter, run_dir=run_dir, parent_dir=run_dir.candidate_dir(run_dir.best_id),
-            optimizer=optimizer, instructions=instructions, current_val=current_val,
-            n_trials=n_trials, gate_kwargs=gate_kwargs, no_regression=no_regression,
-            rejected=rejected, history=history, store=store, capabilities=capabilities,
-            optimizer_name=optimizer_name, capability_sources=capability_sources,
-            project_dir=project_dir,
+        return _focus_instructions(current_val, focus_ids, label,
+                                   capabilities=capabilities, algorithm=algorithm,
+                                   instructions_file=instructions_file,
+                                   bench_repo=bench_repo, optimizer_name=optimizer_name,
+                                   seed_empty=seed_empty, target_reader=_target_reader)
+
+    steps = []
+    i = 0
+    while i < max_iterations:
+        exhausted, why = run_dir.budget_exhausted()
+        if exhausted:
+            break
+        # A round is `workers` siblings forked from the SAME champion (1 = today's
+        # single step). Candidate ids are derived from the iteration index, not from
+        # the live `spent.iterations` counter, so concurrent proposals can't collide
+        # on a name and the numbering is identical to the serial run's.
+        # Clamp the round to the remaining budget headroom, not just the loop counter:
+        # a serial loop re-checks budget_exhausted() between candidates, so a round that
+        # launched `workers` candidates regardless would overshoot max_iterations /
+        # max_metric_calls / stall and make a parallel run LONGER than a serial one with
+        # the same budget. With this clamp, N=1 and N=4 spend the same budget and produce
+        # the same steps.
+        batch = min(workers, max_iterations - i,
+                    run_dir.budget_headroom(
+                        metric_calls_per_candidate=len(run_dir.read_splits().val) * n_trials))
+        if batch < 1:
+            break
+        base_iter = run_dir.spent.iterations
+        parent_dir = run_dir.candidate_dir(run_dir.best_id)
+        parent_id = run_dir.best_id
+        plans = [{"candidate_id": f"cand_{base_iter + j + 1:04d}",
+                  "parent_dir": parent_dir, "parent_id": parent_id,
+                  "instructions": _instructions_for(i + j)} for j in range(batch)]
+        round_steps = parallel_steps(
+            adapter, plans, run_dir=run_dir, optimizer=optimizer, current_val=current_val,
+            workers=workers, n_trials=n_trials, gate_kwargs=gate_kwargs,
+            no_regression=no_regression, rejected=rejected, history=history, store=store,
+            capabilities=capabilities, optimizer_name=optimizer_name,
+            capability_sources=capability_sources, project_dir=project_dir,
         )
-        steps.append(step)
-        if step["accepted"]:
-            current_val = SplitResult.from_dict(step["candidate_val"])
+        steps.extend(round_steps)
+        for step in round_steps:
+            if step["accepted"]:
+                current_val = SplitResult.from_dict(step["candidate_val"])
+        i += batch
 
     _, why = run_dir.budget_exhausted()
     return {

--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import Callable
 
 from . import gate as gate_mod
+from . import parallel as _par
 from .loop import SplitResult, aggregate_scores
 from .rundir import RunDir, _atomic_write
 from .splits import Splits, TestSealError, make_splits
@@ -1294,11 +1295,12 @@ def propose_candidate(
     # was forked from (the current best by default in a global hill-climb). Captured
     # before any accept flips ``best_id`` so the edge points at the true parent.
     parent_id = parent_id or run_dir.best_id
-    workdir = run_dir.root / "work" / cid
-    if workdir.exists():
-        shutil.rmtree(workdir)
-    workdir.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copytree(parent_dir, workdir)
+    # THE workspace creation point for every run, serial or parallel. Going through
+    # parallel.make_workspace instead of an inline copytree is what REGISTERS the
+    # workspace for interrupt cleanup — otherwise a real Ctrl-C mid-round leaves up to
+    # N half-built capability copies under work/. Released at the commit point, once the
+    # workspace has been snapshotted into candidates/.
+    workdir = _par.make_workspace(run_dir.root / "work", cid, parent_dir)
 
     # Give the optimizer the full trajectories + capability guidance, in its own dir.
     _inject_optimizer_context(adapter, run_dir, workdir, split=eval_split,
@@ -1369,12 +1371,17 @@ def commit_candidate(
     Call this for ONE proposal at a time, in a deterministic order. Everything that
     makes the run's numbers honest lives here — the significance gate, the
     no-regression check, ``set_best``, the iteration counter, the ledger/journal, the
-    version-store commit — so it is single-threaded by construction and a parallel
-    run's accept sequence is exactly a serial run's.
+    version-store commit — so it is single-threaded by construction: every score a
+    parallel run banks cleared the same gate, against the same champion, that a serial
+    run would have gated it against.
 
     ``current_val`` is the parent this proposal is gated against; a parallel caller
     re-gates each proposal against the *current* champion as it commits, so accepting
-    one candidate correctly raises the bar for its siblings.
+    one candidate correctly raises the bar for its siblings — a sibling forked from a
+    now-superseded champion is rejected rather than banked. That keeps every recorded
+    score honest, but it does NOT make a parallel round equivalent to N serial steps:
+    the siblings were already *built* from the start-of-round champion. See
+    ``parallel_steps``.
     """
     gate_kwargs = dict(gate_kwargs or {})
     cid = proposal["candidate_id"]
@@ -1420,6 +1427,10 @@ def commit_candidate(
     # capability-only and the diff shows just the real edit. Only an accepted candidate
     # becomes the new best (parent for the next step).
     run_dir.snapshot(cid, workdir, ignore=_SNAPSHOT_IGNORE)
+    # The candidate is durable in candidates/ now, so what is left under work/ is
+    # inspectable scratch rather than uncommitted work — drop it from the interrupt
+    # registry (the dir itself is deliberately kept, as it always has been).
+    _par.release_workspace(workdir)
     if accepted:
         run_dir.set_best(cid)
     run_dir.update_spent(iterations=1, accepted=accepted)
@@ -1523,7 +1534,16 @@ def parallel_steps(
     accept sequence — and therefore ``best_id``, the iteration counter, and every
     artifact derived from them — is deterministic. Each commit re-gates against the
     champion as of that moment: if plan 1 is accepted, plan 2 must beat the NEW
-    champion, exactly as it would have in a serial run.
+    champion.
+
+    **Determinism is not equivalence.** Siblings in one round are *built* from the parent
+    their plan names, which for a hill-climb round is the champion as of the START of the
+    round. Re-gating means a sibling forked from a now-stale champion is correctly
+    *rejected*, not that it would have been proposed at all in a serial run. With
+    ``len(plans) > 1`` this is a breadth-first search over N siblings of one champion, and
+    its accept sequence, ``best_id`` and sealed test number legitimately differ from
+    serial's. See ``resolve_workers``' note; ``workers=1``/one plan per round is the only
+    configuration with the serial guarantee.
 
     A worker that raises turns into a rejected step (``proposal_error``) rather than
     sinking the whole round — same policy ``propose_candidate`` already applies to an
@@ -1559,7 +1579,10 @@ def parallel_steps(
             # The commit path snapshots the workspace unconditionally, so make sure one
             # exists even when the failure happened before/during its creation (e.g. an
             # unreadable parent dir). An empty candidate scores 0 and is rejected — a
-            # wasted iteration recorded honestly, not a crashed run.
+            # wasted iteration recorded honestly, not a crashed run. Note an empty dir
+            # under candidates/ is indistinguishable from a real candidate whose
+            # capability was emptied; the ``proposal_error`` event above is what
+            # disambiguates them, so don't drop it.
             wd = run_dir.root / "work" / plan["candidate_id"]
             wd.mkdir(parents=True, exist_ok=True)
             return {"candidate_id": plan["candidate_id"], "parent_id": plan.get("parent_id"),

--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -26,7 +26,7 @@ from typing import Callable
 from . import gate as gate_mod
 from .loop import SplitResult, aggregate_scores
 from .rundir import RunDir, _atomic_write
-from .splits import Splits, make_splits
+from .splits import Splits, TestSealError, make_splits
 from .types import Rollout, Score, Task
 
 # An optimizer mutates ``workdir`` in place. It MAY return a dict reporting its own
@@ -1315,6 +1315,12 @@ def propose_candidate(
         if isinstance(opt_report, dict):
             opt_cost_usd = float(opt_report.get("cost_usd") or 0.0)
             opt_tokens = int(opt_report.get("tokens") or 0)
+    except _honesty_errors():
+        # A tamper detection or seal violation surfacing from the optimizer call is NOT
+        # "a wasted iteration": no score computed against this tree can be trusted, so it
+        # aborts the run instead of being recorded as a rejected candidate. Serial and
+        # parallel paths agree on this — the guard is not weakened by either.
+        raise
     except Exception as e:  # noqa: BLE001
         # A failed proposal (e.g. a transient optimizer/API error) must not abort a
         # long run — leave the workdir as the parent copy so the candidate == parent
@@ -1469,6 +1475,22 @@ def commit_candidate(
     }
 
 
+def _honesty_errors() -> tuple[type[BaseException], ...]:
+    """Exceptions that must ABORT a run rather than be recorded as a bad candidate.
+
+    ``TestSealError`` (something tried to score sealed test twice) and, when the
+    protected-paths guard is present, ``TamperError`` (the scorer / eval harness / task
+    data was modified, so no score computed against this tree can be trusted). Resolved
+    dynamically because ``protect`` may not exist in every build.
+    """
+    errs: tuple[type[BaseException], ...] = (TestSealError,)
+    try:
+        from .protect import TamperError
+    except ImportError:
+        return errs
+    return (*errs, TamperError)
+
+
 def parallel_steps(
     adapter,
     plans: list[dict],
@@ -1505,7 +1527,10 @@ def parallel_steps(
 
     A worker that raises turns into a rejected step (``proposal_error``) rather than
     sinking the whole round — same policy ``propose_candidate`` already applies to an
-    optimizer failure.
+    optimizer failure. HONESTY failures are the exception: a ``TamperError`` (the grader
+    was edited, so no score from this tree is trustworthy) or a ``TestSealError`` aborts
+    the whole round, exactly as it aborts a serial ``run_step``. Downgrading either to
+    "a rejected candidate" would let parallelism silently weaken a honesty guard.
     """
     from . import parallel as _par
 
@@ -1513,6 +1538,7 @@ def parallel_steps(
     if workers > 1:
         run_dir.log_event("parallel_round", workers=workers,
                           candidates=[p["candidate_id"] for p in plans])
+    fatal = _honesty_errors()
 
     def _propose(plan: dict) -> dict:
         try:
@@ -1525,6 +1551,8 @@ def parallel_steps(
                 optimizer_name=optimizer_name, capability_sources=capability_sources,
                 project_dir=project_dir,
             )
+        except fatal:
+            raise  # tamper / seal violation: abort the round, never record a score
         except Exception as e:  # noqa: BLE001 — one bad candidate must not sink the round
             run_dir.log_event("proposal_error", candidate=plan["candidate_id"],
                               error=str(e)[:500])

--- a/core/cap_evolve/parallel.py
+++ b/core/cap_evolve/parallel.py
@@ -1,0 +1,210 @@
+"""Bounded parallel candidate evaluation with a serialized commit point.
+
+The isolation unit is a **hermetic per-candidate workspace** under
+``<run>/work/<candidate_id>/``: a private copy of the parent capability that the
+optimizer mutates and the adapter evaluates, so ``materialize → run_target →
+score`` for candidate A can never see or clobber candidate B's files. That
+workspace already existed (``harness.run_step``); what this module adds is the two
+things parallelism actually needs:
+
+  1. ``workspace()`` — deterministic teardown of those workspaces on normal exit,
+     on exception, AND on SIGINT/SIGTERM, so a crashed or interrupted run leaves no
+     orphans behind.
+  2. ``map_ordered()`` — bounded concurrency that returns results in INPUT order,
+     with ``workers == 1`` running fully inline (no threads created at all), so the
+     default serial path is byte-for-byte the code path it always was.
+
+Why a directory workspace and not a ``git worktree``: a worktree of the run repo
+checks out the *run dir's* shape (``candidates/``, ``state.json``, …), not the
+capability-at-root shape every optimizer and adapter expects, and the capability's
+own project is not required to be a git repo at all. The isolation property a
+worktree would buy (a private tree + a clean diff vs the parent) is already
+provided by the copy plus the existing per-iteration ``VersionStore`` commit, at
+lower cost (no ``.git`` inside the candidate, nothing to leak into
+``.git/worktrees``, no 200-500ms per candidate). See the PR for the full rationale.
+
+**The honesty core stays single-threaded.** Nothing here gates, accepts, snapshots,
+or touches the seal. Workers only produce a candidate + its val ``SplitResult``; the
+caller applies every result serially, in a deterministic order — that serialized
+commit point is what keeps the gate, ``best_id``, spend accounting and the test seal
+free of races. Pure stdlib (``concurrent.futures`` + ``signal``).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import shutil
+import signal
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Callable, Iterable, Sequence, TypeVar
+
+T = TypeVar("T")
+R = TypeVar("R")
+
+# Workspaces currently checked out, so an interrupt can clean up what a `finally`
+# never gets to run for. Guarded by a lock because workers register concurrently.
+_LIVE: set[Path] = set()
+_LIVE_LOCK = threading.Lock()
+_HANDLERS_INSTALLED = False
+
+
+def resolve_workers(n) -> int:
+    """Clamp a user-supplied ``--parallel`` value to a sane worker count.
+
+    ``None``/0/negative/garbage all collapse to 1 (serial), which is the default
+    everywhere: parallelism must be opt-in so no existing run changes behaviour.
+    Capped at 16 — beyond that the run dir's serialized commit point, not the
+    workers, is the bottleneck.
+    """
+    try:
+        v = int(n)
+    except (TypeError, ValueError):
+        return 1
+    return max(1, min(16, v))
+
+
+def _cleanup_all() -> None:
+    with _LIVE_LOCK:
+        live = sorted(_LIVE)
+        _LIVE.clear()
+    for p in live:
+        shutil.rmtree(p, ignore_errors=True)
+
+
+def _install_handlers() -> None:
+    """Chain SIGINT/SIGTERM cleanup in front of whatever handler is installed.
+
+    A Ctrl-C during a parallel round unwinds the main thread but NOT the worker
+    threads' ``finally`` blocks reliably, so workspaces could survive as orphans.
+    We remove every live workspace first, then re-raise into the previous handler so
+    the process still dies the way it would have. Best-effort: installing a handler
+    is only legal on the main thread, and a run driven from a worker thread simply
+    keeps the ``finally``-based cleanup.
+    """
+    global _HANDLERS_INSTALLED
+    if _HANDLERS_INSTALLED:
+        return
+    if threading.current_thread() is not threading.main_thread():
+        return
+    import atexit
+
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        try:
+            prev = signal.getsignal(sig)
+        except (ValueError, OSError):  # pragma: no cover - platform without the signal
+            continue
+
+        def _handler(signum, frame, _prev=prev):
+            _cleanup_all()
+            if callable(_prev):
+                _prev(signum, frame)
+            elif _prev == signal.SIG_DFL:
+                signal.signal(signum, signal.SIG_DFL)
+                signal.raise_signal(signum)
+
+        with contextlib.suppress(ValueError, OSError):
+            signal.signal(sig, _handler)
+    atexit.register(_cleanup_all)
+    _HANDLERS_INSTALLED = True
+
+
+@contextlib.contextmanager
+def workspace(root: Path, candidate_id: str, parent_dir: Path, *, keep: bool = True):
+    """Hermetic per-candidate workspace at ``root/<candidate_id>``, cleaned up always.
+
+    Yields a fresh copy of ``parent_dir``. A pre-existing dir at that path (a resumed
+    or retried iteration) is removed first, so a candidate never inherits a previous
+    attempt's scratch. With ``keep=True`` (the default, matching today's behaviour)
+    the directory survives for post-hoc inspection and only the interrupt registry
+    entry is dropped; ``keep=False`` removes it on exit, on exception, and on
+    SIGINT/SIGTERM.
+    """
+    root = Path(root)
+    wd = root / candidate_id
+    _install_handlers()
+    if wd.exists():
+        shutil.rmtree(wd)
+    root.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(parent_dir, wd)
+    with _LIVE_LOCK:
+        _LIVE.add(wd)
+    try:
+        yield wd
+    finally:
+        with _LIVE_LOCK:
+            _LIVE.discard(wd)
+        if not keep:
+            shutil.rmtree(wd, ignore_errors=True)
+
+
+def live_workspaces() -> list[Path]:
+    """Workspaces currently checked out (for tests / leak assertions)."""
+    with _LIVE_LOCK:
+        return sorted(_LIVE)
+
+
+def map_ordered(fn: Callable[[T], R], items: Iterable[T], *, workers: int = 1) -> list[R]:
+    """Apply ``fn`` over ``items`` with at most ``workers`` in flight, INPUT order out.
+
+    ``workers <= 1`` runs inline — no executor, no threads — so the serial default is
+    the same call sequence it always was. Exceptions propagate (the caller decides
+    whether a failed candidate is fatal); order is preserved regardless of completion
+    order, which is what makes the caller's serialized commit loop deterministic.
+    """
+    items = list(items)
+    workers = resolve_workers(workers)
+    if workers == 1 or len(items) <= 1:
+        return [fn(x) for x in items]
+    with ThreadPoolExecutor(max_workers=workers) as ex:
+        return list(ex.map(fn, items))
+
+
+def adapter_is_parallel_safe(adapter) -> tuple[bool, str]:
+    """Whether ``adapter`` may be driven from several threads at once.
+
+    DEFAULT DENY, because the adapter contract still supports ``apply()`` as a
+    *global* inject ("make this candidate the one the runner uses") — exactly the
+    single shared slot that makes two concurrent candidates clobber each other. So:
+
+      * an explicit ``parallel_safe = True`` (or ``False``) on the adapter is
+        authoritative — an adapter that knows it is hermetic says so;
+      * otherwise it is safe only if it overrides NEITHER ``apply`` nor ``live``,
+        i.e. it uses the base class's pure default which just yields the candidate
+        dir and mutates nothing outside it.
+
+    Returns ``(safe, reason)``; the reason is logged so a silent downgrade to serial
+    never looks like a speedup that failed to materialize.
+    """
+    declared = getattr(adapter, "parallel_safe", None)
+    if isinstance(declared, bool):
+        return declared, ("adapter declares parallel_safe=True" if declared
+                          else "adapter declares parallel_safe=False")
+    from .adapter import CapabilityAdapter
+    overrides = [name for name in ("apply", "live")
+                 if getattr(type(adapter), name, None)
+                 is not getattr(CapabilityAdapter, name, None)]
+    if overrides:
+        return False, (f"adapter overrides {'/'.join(overrides)}() — that hook may be a "
+                       "GLOBAL inject (one shared slot), so concurrent candidates could "
+                       "clobber each other; set `parallel_safe = True` on the adapter if "
+                       "it is hermetic")
+    return True, "adapter uses the pure default live()/apply() (no global state)"
+
+
+def resolve_workers_for(adapter, n, *, run_dir=None) -> int:
+    """``resolve_workers(n)``, downgraded to 1 when the adapter isn't concurrency-safe.
+
+    Logs ``parallel_downgraded`` in the run dir on a downgrade so the fallback is in
+    the audit trail rather than an unexplained absence of speedup.
+    """
+    workers = resolve_workers(n)
+    if workers == 1:
+        return 1
+    safe, reason = adapter_is_parallel_safe(adapter)
+    if safe:
+        return workers
+    if run_dir is not None:
+        run_dir.log_event("parallel_downgraded", requested=workers, workers=1, reason=reason)
+    return 1

--- a/core/cap_evolve/parallel.py
+++ b/core/cap_evolve/parallel.py
@@ -28,6 +28,19 @@ or touches the seal. Workers only produce a candidate + its val ``SplitResult``;
 caller applies every result serially, in a deterministic order — that serialized
 commit point is what keeps the gate, ``best_id``, spend accounting and the test seal
 free of races. Pure stdlib (``concurrent.futures`` + ``signal``).
+
+**``N > 1`` CHANGES THE SEARCH — it is not a faster serial run.** In a hill-climb the
+parent *is* the current best, so a round of N siblings forked from one champion explores
+BREADTH (N variations of the same parent) where serial explores DEPTH (each step forked
+from the previous accept). Every banked score is still honestly gated — a sibling built
+from a champion that a peer superseded mid-round is rejected, not banked — but the accept
+sequence, ``best_id``, spend, and the sealed test number all legitimately differ from
+serial's, and on a monotone objective serial can reach a strictly better score on the same
+iteration budget (serial 1.0 vs ``--parallel 6`` 0.1667 on the deterministic probe in
+``test_parallel_candidates.py``, where each accept unlocks the next). ``N = 1`` (the
+default) is the ONLY mode that reproduces a serial trajectory. Choose ``N > 1`` when
+rollouts are slow and you want more variations per unit of wall clock, not when you want
+the same answer sooner.
 """
 
 from __future__ import annotations
@@ -110,16 +123,18 @@ def _install_handlers() -> None:
     _HANDLERS_INSTALLED = True
 
 
-@contextlib.contextmanager
-def workspace(root: Path, candidate_id: str, parent_dir: Path, *, keep: bool = True):
-    """Hermetic per-candidate workspace at ``root/<candidate_id>``, cleaned up always.
+def make_workspace(root: Path, candidate_id: str, parent_dir: Path) -> Path:
+    """Fresh hermetic copy of ``parent_dir`` at ``root/<candidate_id>``, interrupt-tracked.
 
-    Yields a fresh copy of ``parent_dir``. A pre-existing dir at that path (a resumed
-    or retried iteration) is removed first, so a candidate never inherits a previous
-    attempt's scratch. With ``keep=True`` (the default, matching today's behaviour)
-    the directory survives for post-hoc inspection and only the interrupt registry
-    entry is dropped; ``keep=False`` removes it on exit, on exception, and on
-    SIGINT/SIGTERM.
+    A pre-existing dir at that path (a resumed or retried iteration, or an orphan a
+    SIGKILL left behind) is removed first, so a candidate never inherits a previous
+    attempt's scratch. The new workspace is registered as live, so a SIGINT/SIGTERM
+    arriving before ``release_workspace`` removes it instead of orphaning it.
+
+    This is the ONE place a candidate workspace is created: ``harness.propose_candidate``
+    calls it, so the interrupt registry covers a REAL run and not just this module's own
+    tests. Not a context manager because a workspace must outlive the proposal that built
+    it — it is snapshotted later, at the serialized commit point.
     """
     root = Path(root)
     wd = root / candidate_id
@@ -130,13 +145,38 @@ def workspace(root: Path, candidate_id: str, parent_dir: Path, *, keep: bool = T
     shutil.copytree(parent_dir, wd)
     with _LIVE_LOCK:
         _LIVE.add(wd)
+    return wd
+
+
+def release_workspace(wd: Path, *, remove: bool = False) -> None:
+    """Stop tracking ``wd`` as interrupt-cleanable — its result has been committed.
+
+    Called from ``harness.commit_candidate`` once the workspace is snapshotted into
+    ``candidates/``: after that the copy under ``work/`` is inspectable scratch, not
+    uncommitted work an interrupt should reclaim. ``remove=True`` deletes it as well.
+    """
+    wd = Path(wd)
+    with _LIVE_LOCK:
+        _LIVE.discard(wd)
+    if remove:
+        shutil.rmtree(wd, ignore_errors=True)
+
+
+@contextlib.contextmanager
+def workspace(root: Path, candidate_id: str, parent_dir: Path, *, keep: bool = True):
+    """``make_workspace`` + a guaranteed ``release_workspace``, for scoped callers.
+
+    Yields the workspace; the registry entry is dropped on normal exit, on exception,
+    and on SIGINT/SIGTERM, and with ``keep=False`` the directory is removed too. The
+    harness uses the unscoped pair instead because a candidate's workspace spans
+    propose → commit, which is two different call frames (and, under ``--parallel``,
+    two different threads).
+    """
+    wd = make_workspace(root, candidate_id, parent_dir)
     try:
         yield wd
     finally:
-        with _LIVE_LOCK:
-            _LIVE.discard(wd)
-        if not keep:
-            shutil.rmtree(wd, ignore_errors=True)
+        release_workspace(wd, remove=not keep)
 
 
 def live_workspaces() -> list[Path]:
@@ -149,7 +189,9 @@ def map_ordered(fn: Callable[[T], R], items: Iterable[T], *, workers: int = 1) -
     """Apply ``fn`` over ``items`` with at most ``workers`` in flight, INPUT order out.
 
     ``workers <= 1`` runs inline — no executor, no threads — so the serial default is
-    the same call sequence it always was. Exceptions propagate (the caller decides
+    the same call sequence it always was. So does a **single item** at any ``workers``:
+    ``map_ordered(fn, [x], workers=8)`` creates no threads, because there is nothing to
+    overlap. Exceptions propagate (the caller decides
     whether a failed candidate is fatal); order is preserved regardless of completion
     order, which is what makes the caller's serialized commit loop deterministic.
     """

--- a/core/cap_evolve/rundir.py
+++ b/core/cap_evolve/rundir.py
@@ -20,6 +20,7 @@ import contextlib
 import json
 import os
 import shutil
+import threading
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -37,7 +38,10 @@ def _atomic_write(path: Path, text: str) -> None:
     partial one. ``fsync`` before the replace so the bytes are durable first.
     """
     path = Path(path)
-    tmp = path.with_name(f".{path.name}.tmp.{os.getpid()}")
+    # Unique per (process, thread): two threads writing the SAME path concurrently
+    # would otherwise share one temp file and splice each other's bytes. With distinct
+    # temps, os.replace makes last-writer-wins — never a torn file.
+    tmp = path.with_name(f".{path.name}.tmp.{os.getpid()}.{threading.get_ident():x}")
     try:
         with tmp.open("w", encoding="utf-8") as f:
             f.write(text)
@@ -299,6 +303,34 @@ class RunDir:
             return True, f"stalled ({s.stall} rejects in a row >= {b.stall})"
         return False, ""
 
+    def budget_headroom(self, *, metric_calls_per_candidate: int = 0) -> int:
+        """How many MORE candidates may be started before a count cap would trip.
+
+        A parallel round launches N candidates at once, so it has to look ahead: the
+        serial loop re-checks ``budget_exhausted`` between every candidate, and a round
+        that ignored the remaining headroom would overshoot ``max_iterations`` or keep
+        proposing past the ``stall`` cutoff — a parallel run that spends MORE budget
+        than a serial one with the same caps.
+
+        ``metric_calls_per_candidate`` (e.g. ``len(val) * n_trials``) converts the
+        ``max_metric_calls`` cap from rollouts into candidates; pass 0 when the caller
+        can't know it, and that cap stays checked between rounds. Cost caps are never
+        included — spend-per-candidate isn't knowable in advance, so like the serial
+        loop (which also can't stop mid-candidate) they are enforced between rounds.
+        """
+        b, s = self.budget, self.spent
+        limits = []
+        if b.max_iterations:
+            limits.append(b.max_iterations - s.iterations)
+        if b.stall:
+            limits.append(b.stall - s.stall)
+        if b.max_metric_calls and metric_calls_per_candidate > 0:
+            remaining = b.max_metric_calls - s.metric_calls
+            # Ceil: a partially-affordable candidate is still started (the serial loop
+            # starts it too — it only checks the cap BEFORE a candidate, never mid-eval).
+            limits.append(-(-remaining // metric_calls_per_candidate))
+        return max(0, min(limits)) if limits else 2 ** 31
+
     def record_spend_warnings(self) -> list[dict]:
         """Emit a ``budget_warning`` event once per crossed soft threshold.
 
@@ -392,6 +424,23 @@ class RunDir:
 
     # ---- audit log ----------------------------------------------------------
     def log_event(self, kind: str, **fields) -> None:
+        """Append one JSON line to ``events.jsonl`` — atomically, whole-line.
+
+        Live readers (the dashboard tail, the stall detector, the mtime+size cache)
+        parse this file line-by-line while it is being written, and with parallel
+        candidate evaluation several threads/processes append at once. A buffered
+        text write can split one record across multiple ``write()`` syscalls
+        (Python's default buffer is 8 KiB, and a ``reason``/``error`` field easily
+        exceeds that), which under concurrency interleaves two records into a
+        corrupt line. ``O_APPEND`` + ONE ``os.write`` of the whole encoded line is
+        atomic for a regular file on POSIX, so every reader sees complete records
+        in some total order — never a partial or spliced one.
+        """
         rec = {"t": time.time(), "kind": kind, **fields}
-        with self.events_path.open("a", encoding="utf-8") as f:
-            f.write(json.dumps(rec, default=str) + "\n")
+        line = (json.dumps(rec, default=str) + "\n").encode("utf-8")
+        self.events_path.parent.mkdir(parents=True, exist_ok=True)
+        fd = os.open(str(self.events_path), os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
+        try:
+            os.write(fd, line)  # single syscall: no interleaving, no partial line
+        finally:
+            os.close(fd)

--- a/core/cap_evolve/rundir.py
+++ b/core/cap_evolve/rundir.py
@@ -314,9 +314,30 @@ class RunDir:
 
         ``metric_calls_per_candidate`` (e.g. ``len(val) * n_trials``) converts the
         ``max_metric_calls`` cap from rollouts into candidates; pass 0 when the caller
-        can't know it, and that cap stays checked between rounds. Cost caps are never
-        included — spend-per-candidate isn't knowable in advance, so like the serial
-        loop (which also can't stop mid-candidate) they are enforced between rounds.
+        can't know it, and that cap stays checked between rounds.
+
+        The MONEY caps (``max_usd``, ``max_optimizer_usd``) are included too, projected
+        from the run's own observed average spend per iteration. Without them a round of
+        N commits N candidates before the next ``budget_exhausted()`` check and a user's
+        hard spend ceiling is overshot by up to N× (measured 2× ``max_optimizer_usd`` and
+        1.35× ``max_usd`` at N=8). Projection is floor division so it never buys a
+        candidate the remaining budget can't cover.
+
+        Every limit is floored at **1**, not 0: the serial loop also cannot stop
+        mid-candidate — it checks the cap BEFORE a candidate and then runs it to
+        completion — so "one candidate of overshoot" is the pre-existing N=1 behaviour
+        and clamping below it would make ``--parallel 1`` behave differently from a
+        pre-#131 serial run. The guarantee this buys is therefore: **at any N, a run
+        overshoots a cap by at most the single candidate that was already in flight,
+        exactly as N=1 does** — the N× overshoot is gone.
+
+        Before the first iteration completes there is nothing to project from (the
+        baseline eval has paid for rollouts but no optimizer call has happened yet, so
+        it under-estimates a candidate by exactly the unknown part). Rather than guess,
+        a money-capped run's FIRST round is limited to one candidate — after which the
+        real average is known and full-width rounds resume. One serial round is a
+        negligible cost for never blowing a spend ceiling on the very first round, which
+        is where an N× overshoot would otherwise be worst.
         """
         b, s = self.budget, self.spent
         limits = []
@@ -329,6 +350,21 @@ class RunDir:
             # Ceil: a partially-affordable candidate is still started (the serial loop
             # starts it too — it only checks the cap BEFORE a candidate, never mid-eval).
             limits.append(-(-remaining // metric_calls_per_candidate))
+        # max_usd is checked against total_usd (run + optimizer + intake), but only
+        # run+optimizer grow per iteration — project with that rate, against the same
+        # total budget_exhausted() compares.
+        for cap, rate_num, remaining in (
+            (b.max_usd, s.usd + s.optimizer_usd, (b.max_usd or 0.0) - s.total_usd),
+            (b.max_optimizer_usd, s.optimizer_usd, (b.max_optimizer_usd or 0.0) - s.optimizer_usd),
+        ):
+            if not cap:
+                continue
+            if not s.iterations:
+                limits.append(1)  # nothing to project from yet — one candidate, then re-check
+                continue
+            per = rate_num / s.iterations
+            if per > 0:
+                limits.append(max(1, int(remaining // per)))
         return max(0, min(limits)) if limits else 2 ** 31
 
     def record_spend_warnings(self) -> list[dict]:
@@ -439,6 +475,9 @@ class RunDir:
         rec = {"t": time.time(), "kind": kind, **fields}
         line = (json.dumps(rec, default=str) + "\n").encode("utf-8")
         self.events_path.parent.mkdir(parents=True, exist_ok=True)
+        # DELIBERATE: open+close per event. Caching the fd would break the MULTI-PROCESS
+        # guarantee (a dashboard, a resumed run and this run all append to one file, and
+        # a cached fd's offset/buffer is per-process). Do not "optimize" this away.
         fd = os.open(str(self.events_path), os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
         try:
             os.write(fd, line)  # single syscall: no interleaving, no partial line

--- a/core/tests/test_parallel_candidates.py
+++ b/core/tests/test_parallel_candidates.py
@@ -626,7 +626,64 @@ def test_budget_headroom(tmp_path):
     assert mc.budget_headroom(metric_calls_per_candidate=3) == 0
 
 
-# ---- 10. a failed proposal doesn't sink the round -------------------------
+# ---- 10. honesty failures must ABORT, not become a rejected candidate -----
+
+def test_seal_violation_aborts_the_round(tmp_path):
+    """A TestSealError from a worker propagates; nothing is scored or banked.
+
+    Regression for a defect found during this issue's own verification: both the
+    optimizer-call ``except Exception`` and the round's ``except Exception`` swallowed
+    honesty errors and recorded them as "a rejected candidate", so a tamper detection
+    or a seal violation was downgraded to a wasted iteration instead of aborting.
+    """
+    rd, _ = _fresh_run(tmp_path, "fatal")
+    adapter = CalcAdapter()
+    base = harness.evaluate_candidate(adapter, rd.candidate_dir("seed"), run_dir=rd,
+                                      split="val", tag="seed")
+
+    def evil_optimizer(workdir: Path, instructions: str) -> dict:
+        raise TestSealError("simulated seal violation from inside a worker")
+
+    plans = [{"candidate_id": f"cand_{i:04d}", "parent_dir": rd.candidate_dir("seed"),
+              "instructions": ""} for i in (1, 2)]
+    with pytest.raises(TestSealError):
+        harness.parallel_steps(adapter, plans, run_dir=rd, optimizer=evil_optimizer,
+                               current_val=base, workers=2, store=None)
+    recs = [json.loads(ln) for ln in rd.events_path.read_text(encoding="utf-8").splitlines()]
+    assert not [r for r in recs if r["kind"] == "step"], "a score was banked despite the abort"
+    assert rd.best_id == "seed"
+    assert rd.read_splits().test_used is False
+
+
+def test_seal_violation_also_aborts_a_serial_step(tmp_path):
+    """Same guarantee on the serial path — the fix is in shared code, not the fork."""
+    rd, _ = _fresh_run(tmp_path, "fatal2")
+    adapter = CalcAdapter()
+    base = harness.evaluate_candidate(adapter, rd.candidate_dir("seed"), run_dir=rd,
+                                      split="val", tag="seed")
+
+    def evil_optimizer(workdir: Path, instructions: str) -> dict:
+        raise TestSealError("simulated seal violation")
+
+    with pytest.raises(TestSealError):
+        harness.run_step(adapter, run_dir=rd, parent_dir=rd.candidate_dir("seed"),
+                         optimizer=evil_optimizer, instructions="", current_val=base,
+                         candidate_id="cand_0001", store=None)
+    assert rd.best_id == "seed"
+
+
+def test_honesty_errors_includes_tamper_when_available():
+    """``TamperError`` (#142) joins the fatal set as soon as ``protect`` exists."""
+    fatal = harness._honesty_errors()
+    assert TestSealError in fatal
+    try:
+        from cap_evolve.protect import TamperError
+    except ImportError:
+        pytest.skip("protected-paths guard (#142) not merged yet")
+    assert TamperError in fatal
+
+
+# ---- 11. a failed proposal doesn't sink the round -------------------------
 
 def test_failed_proposal_becomes_a_rejected_step(tmp_path):
     rd, _ = _fresh_run(tmp_path, "fail")

--- a/core/tests/test_parallel_candidates.py
+++ b/core/tests/test_parallel_candidates.py
@@ -2,8 +2,12 @@
 
 The hazard list this file is written against — every item is one test:
 
-  * serial (parallel=1) and parallel (parallel=4) produce IDENTICAL results for the
-    same seed: same candidate ids, same per-candidate val, same accepts, same best;
+  * ``parallel=N>1`` changes the SEARCH (breadth from one champion, not depth per
+    accept) — proved with a non-idempotent optimizer against a monotone objective, and
+    the old idempotent probe is pinned as a fixture artifact so the false "identical
+    results" claim cannot come back;
+  * every score a parallel run BANKS is still honestly gated — a sibling forked from a
+    champion its peer superseded is rejected, never recorded as progress;
   * two concurrent candidates are hermetically isolated (neither sees the other's
     files) and get independent, correct scores;
   * ``events.jsonl`` never contains an interleaved or partial line under concurrent
@@ -99,7 +103,147 @@ def _optimizer(marker: str = "\n[CALC] compute exactly\n"):
     return _run
 
 
-# ---- 1. serial vs parallel equivalence -------------------------------------
+# ---- 1. what parallel DOES and DOES NOT preserve ---------------------------
+
+class MonotoneAdapter(CapabilityAdapter):
+    """Reward = fraction of val tasks whose index is below the ``[X]`` count.
+
+    Strictly monotone in the number of ``[X]`` markers, so every real improvement is
+    gate-visible and each accept unlocks exactly one more task. Paired with
+    ``_nonidempotent_optimizer`` this makes DEPTH (serial) and BREADTH (parallel)
+    measurably different searches rather than two schedules of the same one.
+    """
+
+    parallel_safe = True
+
+    def tasks(self, split: str) -> list[Task]:
+        return list(TASKS)
+
+    def run_target(self, task: Task, ctx, *, seed: int = 0) -> Rollout:
+        n = (Path(ctx) / "prompt.txt").read_text(encoding="utf-8").count("[X]")
+        return Rollout(task_id=task.id, output=str(n), cost_usd=0.01, tokens=1)
+
+    def score(self, task: Task, rollout: Rollout) -> Score:
+        idx = int(task.id[1:])
+        ok = idx < int(rollout.output or 0)
+        return Score(task_id=task.id, reward=1.0 if ok else 0.0,
+                     feedback="", trial_rewards=[1.0 if ok else 0.0])
+
+
+def _nonidempotent_optimizer():
+    """Append ONE ``[X]`` to whatever parent it is handed — output depends on the parent.
+
+    This is the fixture the equivalence claim needed and did not have. ``_optimizer``
+    above is idempotent (it appends its marker only if absent), so every candidate
+    converges to identical content no matter which parent it forked and a stale-parent
+    fork is structurally undetectable. Here candidate content is a direct function of
+    the parent, so a round of siblings forked from ONE champion produces N
+    byte-identical candidates and the divergence is visible.
+    """
+    def _run(workdir: Path, instructions: str) -> dict:
+        p = Path(workdir) / "prompt.txt"
+        p.write_text(p.read_text(encoding="utf-8") + "[X]", encoding="utf-8")
+        return {"cost_usd": 0.02, "tokens": 3}
+    return _run
+
+
+def _monotone_run(tmp_path: Path, name: str, workers: int, *, iters: int = 6):
+    rd = RunDir.create(tmp_path / name, ts="t", budget=Budget(max_iterations=iters))
+    ids = [t.id for t in TASKS]
+    rd.write_splits(Splits(train=ids[6:7], val=ids[0:6], test=ids[7:], seed=0))
+    seed_dir = tmp_path / name / "seed_capability"
+    seed_dir.mkdir(parents=True)
+    (seed_dir / "prompt.txt").write_text("", encoding="utf-8")
+    rd.snapshot("seed", seed_dir)
+    rd.set_best("seed")
+    adapter = MonotoneAdapter()
+    baseline = harness.evaluate_candidate(adapter, rd.candidate_dir("seed"), run_dir=rd,
+                                          split="val", tag="seed")
+    res = harness.hill_climb_loop(
+        adapter, run_dir=rd, optimizer=_nonidempotent_optimizer(), current_val=baseline,
+        max_iterations=iters, store=None, parallel=workers, gate_kwargs={"k_se": 0.0})
+    trace = [(s["candidate_id"], s["accepted"], round(s["candidate_val"]["reward"], 4))
+             for s in res["steps"]]
+    nx = {s["candidate_id"]: (rd.candidate_dir(s["candidate_id"]) / "prompt.txt")
+          .read_text(encoding="utf-8").count("[X]") for s in res["steps"]}
+    return res, rd, trace, nx
+
+
+def test_parallel_changes_the_search_and_is_not_score_equivalent(tmp_path):
+    """THE honest statement of what ``--parallel N>1`` does. Deterministic, no RNG.
+
+    Serial forks each step from the previous ACCEPT (depth), so ``[X]`` accumulates
+    1,2,3,… and every iteration accepts. A parallel round forks all N siblings from the
+    START-OF-ROUND champion (breadth), so they are byte-identical at ``[X]``=k+1 and only
+    the first can beat the champion — the rest are correctly REJECTED (which is the
+    honesty property that does hold) but the budget is spent.
+
+    Asserting the accept sequence and ``best_id`` progression, not just ``final.json``:
+    a run comparison that looks only at the final score can pass by luck.
+    """
+    ser, rd_s, ser_trace, ser_nx = _monotone_run(tmp_path, "mono_ser", 1)
+    par, rd_p, par_trace, par_nx = _monotone_run(tmp_path, "mono_par", 6)
+
+    # Serial: depth. Every step accepts, [X] climbs 1..6, val climbs to 1.0.
+    assert [a for _, a, _ in ser_trace] == [True] * 6, ser_trace
+    assert [ser_nx[c] for c, _, _ in ser_trace] == [1, 2, 3, 4, 5, 6], ser_nx
+    assert ser["best_val"] == 1.0
+    assert ser["best_id"] == "cand_0006"
+
+    # Parallel at N=6: breadth. ONE round, all six siblings forked from `seed`, so all
+    # six are byte-identical and only the first clears the gate.
+    assert [ser_nx[c] for c, _, _ in ser_trace] != [par_nx[c] for c, _, _ in par_trace]
+    assert set(par_nx.values()) == {1}, par_nx
+    assert [a for _, a, _ in par_trace] == [True] + [False] * 5, par_trace
+    assert par["best_id"] == "cand_0001"
+
+    # The headline: same iteration budget, parallel lands on a strictly WORSE score.
+    assert par["best_val"] < ser["best_val"]
+    # …and the accept sequence and best_id progression differ, which is exactly the
+    # claim the deleted `test_serial_and_parallel_are_identical` used to assert.
+    assert ser_trace != par_trace
+    assert ser["best_id"] != par["best_id"]
+
+
+def test_every_banked_score_is_still_honestly_gated(tmp_path):
+    """What parallelism DOES preserve: a sibling forked from a superseded champion loses.
+
+    The stale-parent fork is a search-quality problem, never an honesty problem — the
+    serialized commit point re-gates each sibling against the champion as of ITS commit,
+    so a redundant sibling is recorded as a reject and never banked as progress. Every
+    accepted step must strictly beat the best val seen before it.
+    """
+    _, _, trace, nx = _monotone_run(tmp_path, "mono_gate", 4, iters=8)
+    best = 0.0
+    for cid, accepted, val in trace:
+        if accepted:
+            assert val > best, f"{cid} accepted without beating {best}: {trace}"
+            best = val
+        else:
+            assert val <= best, f"{cid} rejected despite beating {best}: {trace}"
+    # And best_val only ever came from an accepted step.
+    assert best == max([v for _, a, v in trace if a] or [0.0])
+
+
+def test_the_idempotent_probe_cannot_detect_a_stale_parent_fork(tmp_path):
+    """Guard the test METHODOLOGY, so the false equivalence claim can't come back.
+
+    With the idempotent ``_optimizer`` every candidate converges to the same content
+    regardless of parent, so serial and parallel agree — and that agreement is an
+    artifact of the fixture, not a property of the code. Assert both facts in one place:
+    idempotent → looks identical; non-idempotent → provably differs.
+    """
+    ser, rd_s = _run_loop(tmp_path, "idem_ser", 1)
+    par, rd_p = _run_loop(tmp_path, "idem_par", 4)
+    assert _fingerprint(ser, rd_s) == _fingerprint(par, rd_p)  # a fixture artifact...
+    for s in ser["steps"]:
+        assert ((rd_s.candidate_dir(s["candidate_id"]) / "prompt.txt").read_bytes()
+                == (rd_p.candidate_dir(s["candidate_id"]) / "prompt.txt").read_bytes())
+    # ...and NOT a general guarantee — see the non-idempotent test above.
+    _, _, t1, _ = _monotone_run(tmp_path, "idem_mono1", 1)
+    _, _, t4, _ = _monotone_run(tmp_path, "idem_mono4", 4)
+    assert t1 != t4
+
 
 def _run_loop(tmp_path: Path, name: str, workers: int) -> dict:
     rd, seed_dir = _fresh_run(tmp_path, name)
@@ -127,15 +271,12 @@ def _fingerprint(result: dict, rd: RunDir) -> dict:
     }
 
 
-def test_serial_and_parallel_are_identical(tmp_path):
-    ser, rd_s = _run_loop(tmp_path, "serial", 1)
-    par, rd_p = _run_loop(tmp_path, "par", 4)
-    assert _fingerprint(ser, rd_s) == _fingerprint(par, rd_p)
-    # And the candidate snapshots themselves are byte-identical.
-    for s in ser["steps"]:
-        a = (rd_s.candidate_dir(s["candidate_id"]) / "prompt.txt").read_bytes()
-        b = (rd_p.candidate_dir(s["candidate_id"]) / "prompt.txt").read_bytes()
-        assert a == b
+# NOTE: `test_serial_and_parallel_are_identical` used to live here and asserted something
+# FALSE — it only passed because `_optimizer` is idempotent. Replaced by
+# `test_parallel_changes_the_search_and_is_not_score_equivalent` (the real behaviour),
+# `test_every_banked_score_is_still_honestly_gated` (what parallelism does preserve), and
+# `test_the_idempotent_probe_cannot_detect_a_stale_parent_fork` (which pins the old probe
+# as a fixture artifact so the claim cannot be reintroduced).
 
 
 def test_parallel_default_is_one_and_serial(tmp_path):
@@ -502,6 +643,86 @@ def test_workspace_cleans_up_on_sigint(tmp_path):
     assert not wd.exists(), "SIGINT left an orphan workspace"
 
 
+def test_real_run_sigint_cleans_up_the_workspace(tmp_path):
+    """The PRODUCTION path, not the helper: a real SIGINT to a real ``propose_candidate``.
+
+    Regression for a defect this PR's own SIGINT test could not see: it called
+    ``parallel.workspace()`` directly, but ``propose_candidate`` did its own raw
+    ``copytree`` and never registered anything, so ``_install_handlers`` never ran in a
+    real run and a Ctrl-C mid-round orphaned every live workspace. The child below builds
+    a run dir and calls ``harness.propose_candidate`` with an optimizer that blocks, so
+    the interrupt lands while the workspace is genuinely uncommitted.
+    """
+    script = tmp_path / "realsig.py"
+    marker = tmp_path / "wd_path"
+    script.write_text(
+        "import sys, time\n"
+        "from pathlib import Path\n"
+        "from cap_evolve import Budget, RunDir\n"
+        "from cap_evolve import harness\n"
+        "from cap_evolve.splits import Splits\n"
+        "sys.path.insert(0, str(Path(sys.argv[3])))\n"
+        "from test_parallel_candidates import CalcAdapter, TASKS\n"
+        "base = Path(sys.argv[1]) / 'run'\n"
+        "rd = RunDir.create(base, ts='t', budget=Budget(max_iterations=2))\n"
+        "ids = [t.id for t in TASKS]\n"
+        "rd.write_splits(Splits(train=ids[:4], val=ids[4:7], test=ids[7:], seed=0))\n"
+        "seed = base / 'seed_capability'; seed.mkdir(parents=True)\n"
+        "(seed / 'prompt.txt').write_text('x')\n"
+        "rd.snapshot('seed', seed); rd.set_best('seed')\n"
+        "def blocking_optimizer(workdir, instructions):\n"
+        "    Path(sys.argv[2]).write_text(str(workdir))\n"   # workspace now EXISTS + is live
+        "    time.sleep(60)\n"
+        "    return {}\n"
+        "try:\n"
+        "    harness.propose_candidate(CalcAdapter(), run_dir=rd,\n"
+        "        parent_dir=rd.candidate_dir('seed'), optimizer=blocking_optimizer,\n"
+        "        instructions='go', candidate_id='cand_0001')\n"
+        "except BaseException:\n"
+        "    pass\n",
+        encoding="utf-8")
+    core_dir = Path(harness.__file__).resolve().parents[1]
+    tests_dir = Path(__file__).resolve().parent
+    env = dict(os.environ, PYTHONPATH=str(core_dir))
+    proc = subprocess.Popen(
+        [sys.executable, str(script), str(tmp_path), str(marker), str(tests_dir)], env=env)
+    try:
+        for _ in range(400):
+            if marker.exists() and marker.read_text(encoding="utf-8").strip():
+                break
+            time.sleep(0.05)
+        raw = marker.read_text(encoding="utf-8").strip() if marker.exists() else ""
+        assert raw, "child never reached the optimizer with a live workspace"
+        wd = Path(raw)
+        assert wd.exists(), "workspace should exist while the optimizer is running"
+        assert (wd / "prompt.txt").exists(), "workspace should be a copy of the parent"
+        proc.send_signal(signal.SIGINT)
+        proc.wait(timeout=30)
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=10)
+    assert not wd.exists(), f"SIGINT left an orphan workspace at {wd} (real run path)"
+
+
+def test_committed_workspace_is_released_from_the_interrupt_registry(tmp_path):
+    """Once snapshotted into ``candidates/``, a workspace is scratch — not interrupt work.
+
+    Complements the SIGINT test: the registry must be empty after a normal round, or a
+    later interrupt would delete inspectable scratch belonging to committed candidates
+    (and ``_LIVE`` would grow without bound across a long run).
+    """
+    rd, _ = _fresh_run(tmp_path, "release")
+    adapter = CalcAdapter()
+    baseline = harness.evaluate_candidate(adapter, rd.candidate_dir("seed"), run_dir=rd,
+                                          split="val", tag="seed")
+    harness.hill_climb_loop(adapter, run_dir=rd, optimizer=_optimizer(),
+                            current_val=baseline, max_iterations=2, store=None, parallel=2)
+    assert parallel.live_workspaces() == []
+    # The directories themselves are deliberately kept for post-hoc inspection.
+    assert (rd.root / "work" / "cand_0001").exists()
+
+
 def test_no_git_worktree_orphans(tmp_path):
     """We never create git worktrees, so `git worktree list` can't accumulate orphans.
 
@@ -624,6 +845,89 @@ def test_budget_headroom(tmp_path):
     assert mc.budget_headroom(metric_calls_per_candidate=3) == 1   # ceil(1/3)
     mc.update_spent(metric_calls=1)
     assert mc.budget_headroom(metric_calls_per_candidate=3) == 0
+
+
+def test_budget_headroom_includes_the_money_caps(tmp_path):
+    """The two cost caps must constrain a round, or N>1 overshoots a HARD spend ceiling.
+
+    Regression: ``budget_headroom`` omitted ``max_usd`` and ``max_optimizer_usd``
+    entirely, so a round of N committed N candidates before the next
+    ``budget_exhausted()`` check — measured 2x ``max_optimizer_usd`` at N=8.
+    """
+    rd = RunDir.create(tmp_path / "usd", ts="t", budget=Budget(max_iterations=99, max_usd=1.0))
+    # No observed average yet → the first money-capped round is limited to ONE candidate,
+    # after which the real per-iteration rate is known. Guessing here is what let N=8
+    # blow the cap on round 1.
+    assert rd.budget_headroom() == 1
+    rd.update_spent(iterations=1, usd=0.10)    # $0.10/iteration, $0.90 left → 8 more
+    assert rd.budget_headroom() == 8   # 0.9//0.1 floors to 8 in binary float: conservative
+    rd.update_spent(iterations=1, usd=0.40)    # $0.25/iteration avg, $0.50 left → 2 more
+    assert rd.budget_headroom() == 2
+    rd.update_spent(iterations=1, usd=0.45)    # $0.95 spent, $0.05 left at $0.316/iter
+    assert rd.budget_headroom() == 1           # floored at 1: same as serial's in-flight candidate
+
+    # optimizer_usd is projected off optimizer spend alone, not total.
+    od = RunDir.create(tmp_path / "ousd", ts="t",
+                       budget=Budget(max_iterations=99, max_optimizer_usd=2.0))
+    od.update_spent(iterations=1, optimizer_usd=0.50, usd=5.0)  # runner spend must not count
+    assert od.budget_headroom() == 3           # (2.0-0.5)//0.5
+    # A cap that isn't set never constrains.
+    free = RunDir.create(tmp_path / "free", ts="t", budget=Budget(max_iterations=99))
+    free.update_spent(iterations=1, usd=100.0, optimizer_usd=100.0)
+    assert free.budget_headroom() == 98   # only max_iterations constrains (99 - 1 spent)
+
+
+def _spendy_run(tmp_path: Path, name: str, workers: int, **caps):
+    """Hill-climb with a $0.10/rollout adapter and a $0.50/candidate optimizer."""
+    rd = RunDir.create(tmp_path / name, ts="t", budget=Budget(**caps))
+    ids = [t.id for t in TASKS]
+    rd.write_splits(Splits(train=ids[:4], val=ids[4:7], test=ids[7:], seed=0))
+    seed_dir = tmp_path / name / "seed_capability"
+    seed_dir.mkdir(parents=True)
+    (seed_dir / "prompt.txt").write_text("", encoding="utf-8")
+    rd.snapshot("seed", seed_dir)
+    rd.set_best("seed")
+    adapter = CalcAdapter(cost=0.10, tokens=1)
+
+    def opt(workdir, instructions):
+        return {"cost_usd": 0.50, "tokens": 1}
+
+    baseline = harness.evaluate_candidate(adapter, rd.candidate_dir("seed"), run_dir=rd,
+                                          split="val", tag="seed")
+    res = harness.hill_climb_loop(adapter, run_dir=rd, optimizer=opt, current_val=baseline,
+                                  max_iterations=caps.get("max_iterations") or 99,
+                                  store=None, parallel=workers)
+    return res, rd
+
+
+@pytest.mark.parametrize("workers", [1, 4, 8])
+def test_all_four_caps_hold_at_every_worker_count(tmp_path, workers):
+    """max_iterations, stall, max_usd and max_optimizer_usd must all hold at N=8.
+
+    "Hold" = overshot by at most the ONE candidate already in flight, which is exactly
+    what the serial loop does (it checks the cap before a candidate, then runs it to
+    completion). The N x overshoot is the defect; one candidate is pre-existing N=1
+    behaviour.
+    """
+    per_iter_usd = 0.30 + 0.50   # 3 val tasks x $0.10 + $0.50 optimizer
+    res, rd = _spendy_run(tmp_path, f"usd{workers}", workers,
+                          max_iterations=20, max_usd=2.0)
+    assert rd.spent.iterations <= 20
+    assert rd.spent.total_usd <= 2.0 + per_iter_usd, (
+        f"max_usd overshot at N={workers}: {rd.spent.total_usd}")
+
+    res, rd = _spendy_run(tmp_path, f"opt{workers}", workers,
+                          max_iterations=20, max_optimizer_usd=2.0)
+    assert rd.spent.optimizer_usd <= 2.0 + 0.50, (
+        f"max_optimizer_usd overshot at N={workers}: {rd.spent.optimizer_usd}")
+
+    # max_iterations exactly, and stall (this optimizer never improves, so every step
+    # after the first rejects).
+    res, rd = _spendy_run(tmp_path, f"it{workers}", workers, max_iterations=6)
+    assert rd.spent.iterations == 6, f"iterations at N={workers}: {rd.spent.iterations}"
+    res, rd = _spendy_run(tmp_path, f"st{workers}", workers, max_iterations=20, stall=3)
+    assert rd.spent.stall <= 3, f"stall overshot at N={workers}: {rd.spent.stall}"
+    assert rd.spent.iterations <= 20
 
 
 # ---- 10. honesty failures must ABORT, not become a rejected candidate -----

--- a/core/tests/test_parallel_candidates.py
+++ b/core/tests/test_parallel_candidates.py
@@ -1,0 +1,647 @@
+"""Worktree-isolated parallel candidate evaluation (#131).
+
+The hazard list this file is written against — every item is one test:
+
+  * serial (parallel=1) and parallel (parallel=4) produce IDENTICAL results for the
+    same seed: same candidate ids, same per-candidate val, same accepts, same best;
+  * two concurrent candidates are hermetically isolated (neither sees the other's
+    files) and get independent, correct scores;
+  * ``events.jsonl`` never contains an interleaved or partial line under concurrent
+    append load — every line parses strictly;
+  * cost/token accounting is exact: ``Spent`` == sum of per-candidate spend;
+  * the eval cache doesn't collide across candidates and doesn't lose writes;
+  * the sealed test split is never touched by a worker, and one worker consuming the
+    seal doesn't let another;
+  * workspaces are cleaned up on normal exit, on exception, and on SIGINT;
+  * a concurrency-unsafe adapter is downgraded to sequential, audibly.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+from cap_evolve import Budget, CapabilityAdapter, EvalCache, RunDir, Rollout, Score, Task, parallel
+from cap_evolve import harness
+from cap_evolve.splits import Splits, TestSealError
+
+TASKS = [Task(id=f"t{i}", input=f"{i}+{i}", target=str(i + i)) for i in range(8)]
+
+
+class CalcAdapter(CapabilityAdapter):
+    """Deterministic toy adapter: the candidate's prompt.txt decides correctness.
+
+    Hermetic by construction — ``run_target`` reads ONLY ``ctx`` (the candidate dir),
+    so it uses the base class's pure ``live()``/``apply()`` and is parallel-safe.
+    """
+
+    def __init__(self, cost: float = 0.01, tokens: int = 7, sleep: float = 0.0):
+        self.cost, self.tokens, self.sleep = cost, tokens, sleep
+
+    def tasks(self, split: str) -> list[Task]:
+        return list(TASKS)
+
+    def run_target(self, task: Task, ctx, *, seed: int = 0) -> Rollout:
+        if self.sleep:
+            time.sleep(self.sleep)
+        prompt = (Path(ctx) / "prompt.txt").read_text(encoding="utf-8")
+        a, b = str(task.input).split("+")
+        out = str(int(a) + int(b)) if "[CALC]" in prompt else "dunno"
+        return Rollout(task_id=task.id, output=out, cost_usd=self.cost, tokens=self.tokens)
+
+    def score(self, task: Task, rollout: Rollout) -> Score:
+        ok = (rollout.output or "").strip() == str(task.target)
+        return Score(task_id=task.id, reward=1.0 if ok else 0.0,
+                     feedback="correct" if ok else "wrong", trial_rewards=[1.0 if ok else 0.0])
+
+
+class GlobalInjectAdapter(CalcAdapter):
+    """Not concurrency-safe: overrides ``apply`` as a global inject."""
+
+    LIVE = None
+
+    def apply(self, candidate_dir: Path, edits: dict | None = None) -> None:
+        GlobalInjectAdapter.LIVE = Path(candidate_dir)
+
+
+def _fresh_run(tmp_path: Path, name: str = "r", *, max_iterations: int = 4) -> tuple[RunDir, Path]:
+    base = tmp_path / name
+    rd = RunDir.create(base, ts="t", budget=Budget(max_iterations=max_iterations))
+    ids = [t.id for t in TASKS]
+    rd.write_splits(Splits(train=ids[:4], val=ids[4:7], test=ids[7:], seed=0))
+    seed_dir = base / "seed_capability"
+    seed_dir.mkdir(parents=True)
+    (seed_dir / "prompt.txt").write_text("answer the question\n", encoding="utf-8")
+    rd.snapshot("seed", seed_dir)
+    rd.set_best("seed")
+    return rd, seed_dir
+
+
+def _optimizer(marker: str = "\n[CALC] compute exactly\n"):
+    """A mock optimizer: appends the winning marker, idempotently."""
+    def _run(workdir: Path, instructions: str) -> dict:
+        p = Path(workdir) / "prompt.txt"
+        cur = p.read_text(encoding="utf-8")
+        if marker not in cur:
+            p.write_text(cur + marker, encoding="utf-8")
+        return {"cost_usd": 0.02, "tokens": 3}
+    return _run
+
+
+# ---- 1. serial vs parallel equivalence -------------------------------------
+
+def _run_loop(tmp_path: Path, name: str, workers: int) -> dict:
+    rd, seed_dir = _fresh_run(tmp_path, name)
+    adapter = CalcAdapter()
+    baseline = harness.evaluate_candidate(adapter, rd.candidate_dir("seed"), run_dir=rd,
+                                         split="val", tag="seed")
+    return harness.hill_climb_loop(
+        adapter, run_dir=rd, optimizer=_optimizer(), current_val=baseline,
+        max_iterations=4, store=None, parallel=workers), rd
+
+
+def _fingerprint(result: dict, rd: RunDir) -> dict:
+    return {
+        "best_id": result["best_id"],
+        "best_val": round(result["best_val"], 9),
+        "accepts": result["accepts"],
+        "iterations": result["iterations"],
+        "steps": [{"id": s["candidate_id"], "accepted": s["accepted"],
+                   "val": round(s["candidate_val"]["reward"], 9),
+                   "parent_val": round(s["parent_val"]["reward"], 9)} for s in result["steps"]],
+        "spent_metric_calls": rd.spent.metric_calls,
+        "spent_usd": round(rd.spent.usd, 9),
+        "spent_iterations": rd.spent.iterations,
+        "test_used": rd.read_splits().test_used,
+    }
+
+
+def test_serial_and_parallel_are_identical(tmp_path):
+    ser, rd_s = _run_loop(tmp_path, "serial", 1)
+    par, rd_p = _run_loop(tmp_path, "par", 4)
+    assert _fingerprint(ser, rd_s) == _fingerprint(par, rd_p)
+    # And the candidate snapshots themselves are byte-identical.
+    for s in ser["steps"]:
+        a = (rd_s.candidate_dir(s["candidate_id"]) / "prompt.txt").read_bytes()
+        b = (rd_p.candidate_dir(s["candidate_id"]) / "prompt.txt").read_bytes()
+        assert a == b
+
+
+def test_parallel_default_is_one_and_serial(tmp_path):
+    """The default must be serial: no threads, no behaviour change."""
+    assert parallel.resolve_workers(None) == 1
+    assert parallel.resolve_workers(0) == 1
+    assert parallel.resolve_workers(-5) == 1
+    assert parallel.resolve_workers("nonsense") == 1
+    assert parallel.resolve_workers(4) == 4
+    assert parallel.resolve_workers(9999) == 16
+
+    seen: list[str] = []
+
+    def fn(x):
+        seen.append(threading.current_thread().name)
+        return x * 2
+
+    assert parallel.map_ordered(fn, [1, 2, 3], workers=1) == [2, 4, 6]
+    assert set(seen) == {threading.current_thread().name}  # inline, no worker threads
+
+
+def test_map_ordered_preserves_input_order(tmp_path):
+    """Completion order must not leak into result order (determinism of the commit loop)."""
+    def fn(x):
+        time.sleep(0.05 if x == 0 else 0.0)  # first job finishes LAST
+        return x
+    assert parallel.map_ordered(fn, list(range(6)), workers=4) == list(range(6))
+
+
+# ---- 2. hermetic isolation -------------------------------------------------
+
+def test_concurrent_candidates_are_isolated_and_scored_independently(tmp_path):
+    """Two candidates evaluated at once: neither sees the other's files; scores differ."""
+    rd, _ = _fresh_run(tmp_path, "iso")
+    adapter = CalcAdapter(sleep=0.01)
+    # Candidate A gets the winning marker; candidate B gets a useless edit.
+    plans = [{"candidate_id": "cand_0001", "parent_dir": rd.candidate_dir("seed"),
+              "instructions": "A"},
+             {"candidate_id": "cand_0002", "parent_dir": rd.candidate_dir("seed"),
+              "instructions": "B"}]
+
+    def optimizer(workdir: Path, instructions: str) -> dict:
+        # `instructions` arrives augmented by the harness; the plan's own marker is the
+        # first character (the raw text this test passed in).
+        which = "A" if instructions.startswith("A") else "B"
+        p = Path(workdir) / "prompt.txt"
+        p.write_text(p.read_text(encoding="utf-8") +
+                     ("\n[CALC] go\n" if which == "A" else "\nplease try harder\n"),
+                     encoding="utf-8")
+        # Leave a private file; the sibling must never see it.
+        (Path(workdir) / f"private_{which}.txt").write_text(which, encoding="utf-8")
+        siblings = sorted(q.name for q in Path(workdir).glob("private_*"))
+        assert siblings == [f"private_{which}.txt"], f"leak: {siblings}"
+        return {"cost_usd": 0.0, "tokens": 0}
+
+    base = harness.evaluate_candidate(adapter, rd.candidate_dir("seed"), run_dir=rd,
+                                      split="val", tag="seed")
+    steps = harness.parallel_steps(adapter, plans, run_dir=rd, optimizer=optimizer,
+                                   current_val=base, workers=2, store=None)
+    by_id = {s["candidate_id"]: s for s in steps}
+    assert by_id["cand_0001"]["candidate_val"]["reward"] == 1.0   # [CALC] → all correct
+    assert by_id["cand_0002"]["candidate_val"]["reward"] == 0.0   # no marker → all wrong
+    assert by_id["cand_0001"]["accepted"] is True
+    assert by_id["cand_0002"]["accepted"] is False
+    # The workspaces really are separate directories with separate contents.
+    wa = Path(by_id["cand_0001"]["workdir"])
+    wb = Path(by_id["cand_0002"]["workdir"])
+    assert wa != wb
+    assert (wa / "private_A.txt").exists() and not (wa / "private_B.txt").exists()
+    assert (wb / "private_B.txt").exists() and not (wb / "private_A.txt").exists()
+
+
+def test_commit_point_is_serialized(tmp_path):
+    """Only one commit runs at a time, so the honesty core stays single-threaded."""
+    rd, _ = _fresh_run(tmp_path, "serialcommit", max_iterations=8)
+    adapter = CalcAdapter()
+    concurrent = {"max": 0, "now": 0}
+    lock = threading.Lock()
+    real = harness.commit_candidate
+
+    def spy(proposal, **kw):
+        with lock:
+            concurrent["now"] += 1
+            concurrent["max"] = max(concurrent["max"], concurrent["now"])
+        try:
+            time.sleep(0.01)
+            return real(proposal, **kw)
+        finally:
+            with lock:
+                concurrent["now"] -= 1
+
+    base = harness.evaluate_candidate(adapter, rd.candidate_dir("seed"), run_dir=rd,
+                                      split="val", tag="seed")
+    plans = [{"candidate_id": f"cand_{i:04d}", "parent_dir": rd.candidate_dir("seed"),
+              "instructions": ""} for i in range(1, 5)]
+    orig = harness.commit_candidate
+    harness.commit_candidate = spy
+    try:
+        harness.parallel_steps(adapter, plans, run_dir=rd, optimizer=_optimizer(),
+                               current_val=base, workers=4, store=None)
+    finally:
+        harness.commit_candidate = orig
+    assert concurrent["max"] == 1, f"commits overlapped ({concurrent['max']} at once)"
+
+
+# ---- 3. events.jsonl integrity under concurrent append ---------------------
+
+def test_events_jsonl_has_no_partial_or_interleaved_lines(tmp_path):
+    """N threads append fat records at once; EVERY line must parse strictly."""
+    rd = RunDir.create(tmp_path / "ev", ts="t")
+    n_threads, per_thread = 8, 60
+    # Payloads far larger than Python's 8 KiB text buffer, so a buffered write would
+    # have to split them across syscalls (the interleaving bug this guards).
+    def writer(w: int) -> None:
+        for i in range(per_thread):
+            rd.log_event("load", worker=w, i=i, blob="x" * (4000 + 900 * (i % 9)))
+
+    with ThreadPoolExecutor(max_workers=n_threads) as ex:
+        list(ex.map(writer, range(n_threads)))
+
+    raw = rd.events_path.read_text(encoding="utf-8")
+    assert raw.endswith("\n")
+    lines = raw.splitlines()
+    assert len(lines) == n_threads * per_thread
+    seen = set()
+    for ln in lines:
+        rec = json.loads(ln)  # strict: a spliced line raises here
+        assert rec["kind"] == "load"
+        assert set(rec["blob"]) == {"x"}
+        seen.add((rec["worker"], rec["i"]))
+    assert len(seen) == n_threads * per_thread  # nothing lost, nothing duplicated
+
+
+def test_events_jsonl_survives_a_dribbling_reader(tmp_path):
+    """A reader that consumes 7 bytes at a time still reassembles whole lines."""
+    rd = RunDir.create(tmp_path / "ev2", ts="t")
+    for i in range(30):
+        rd.log_event("dribble", i=i, blob="y" * 9000)
+    data = rd.events_path.read_bytes()
+    buf, out = b"", []
+    for off in range(0, len(data), 7):
+        buf += data[off:off + 7]
+        while b"\n" in buf:
+            line, buf = buf.split(b"\n", 1)
+            out.append(json.loads(line))
+    assert buf == b""
+    assert [r["i"] for r in out] == list(range(30))
+
+
+def test_parallel_run_events_all_parse(tmp_path):
+    """The real loop at parallel=4: every emitted event line parses."""
+    _, rd = _run_loop(tmp_path, "evrun", 4)
+    lines = rd.events_path.read_text(encoding="utf-8").splitlines()
+    recs = [json.loads(ln) for ln in lines]
+    assert recs, "no events written"
+    assert any(r["kind"] == "parallel_round" for r in recs)
+    assert sum(1 for r in recs if r["kind"] == "step") == 4
+
+
+# ---- 4. cost / token accounting is exact -----------------------------------
+
+def test_cost_and_tokens_are_exact_under_parallelism(tmp_path):
+    """Spent == sum of per-candidate spend, with concurrent read-modify-write."""
+    rd, _ = _fresh_run(tmp_path, "cost", max_iterations=8)
+    adapter = CalcAdapter(cost=0.005, tokens=11)
+    base = harness.evaluate_candidate(adapter, rd.candidate_dir("seed"), run_dir=rd,
+                                      split="val", tag="seed")
+    before = rd.spent
+    plans = [{"candidate_id": f"cand_{i:04d}", "parent_dir": rd.candidate_dir("seed"),
+              "instructions": ""} for i in range(1, 7)]
+    steps = harness.parallel_steps(adapter, plans, run_dir=rd, optimizer=_optimizer(),
+                                   current_val=base, workers=6, store=None)
+    after = rd.spent
+    runner_usd = sum(s["candidate_val"]["cost_usd"] for s in steps)
+    runner_tok = sum(s["candidate_val"]["tokens"] for s in steps)
+    opt_usd = sum(s["optimizer_usd"] for s in steps)
+    opt_tok = sum(s["optimizer_tokens"] for s in steps)
+    assert after.usd - before.usd == pytest.approx(runner_usd, abs=1e-12)
+    assert after.runner_tokens - before.runner_tokens == runner_tok
+    assert after.optimizer_usd - before.optimizer_usd == pytest.approx(opt_usd, abs=1e-12)
+    assert after.optimizer_tokens - before.optimizer_tokens == opt_tok
+    assert after.iterations - before.iterations == len(plans)
+    # Nothing lost: every rollout counted (6 candidates x 3 val tasks x 1 trial).
+    assert after.metric_calls - before.metric_calls == len(plans) * 3
+
+
+def test_update_spent_loses_nothing_under_heavy_concurrency(tmp_path):
+    """The locked RMW must not drop a single increment."""
+    rd = RunDir.create(tmp_path / "spend", ts="t")
+    n, per = 8, 40
+
+    def bump(_w):
+        for _ in range(per):
+            rd.update_spent(metric_calls=1, usd=0.01, runner_tokens=3)
+
+    with ThreadPoolExecutor(max_workers=n) as ex:
+        list(ex.map(bump, range(n)))
+    sp = rd.spent
+    assert sp.metric_calls == n * per
+    assert sp.runner_tokens == n * per * 3
+    assert sp.usd == pytest.approx(n * per * 0.01, abs=1e-9)
+
+
+# ---- 5. eval cache under concurrency --------------------------------------
+
+def test_eval_cache_no_collision_and_no_lost_writes(tmp_path):
+    """Distinct candidate hashes never collide; concurrent puts all persist."""
+    cache = EvalCache(tmp_path / "cache.json")
+    hashes = [f"h{i:02d}" for i in range(8)]
+
+    def put(h):
+        for t in range(20):
+            cache.put(h, f"t{t}", reward=float(t) / 20.0, feedback=f"{h}:{t}")
+
+    with ThreadPoolExecutor(max_workers=8) as ex:
+        list(ex.map(put, hashes))
+    for h in hashes:
+        for t in range(20):
+            got = cache.get(h, f"t{t}")
+            assert got is not None and got["feedback"] == f"{h}:{t}"
+    # And the persisted file is valid JSON holding every entry (no torn write).
+    on_disk = json.loads((tmp_path / "cache.json").read_text(encoding="utf-8"))
+    assert len(on_disk) == len(hashes) * 20
+    assert len(EvalCache(tmp_path / "cache.json")) == len(hashes) * 20
+
+
+def test_atomic_write_is_thread_safe(tmp_path):
+    """Concurrent _atomic_write to ONE path yields one of the inputs, never a splice."""
+    from cap_evolve.rundir import _atomic_write
+    target = tmp_path / "x.json"
+    payloads = [json.dumps({"who": i, "pad": "z" * 20000}) for i in range(8)]
+
+    def w(p):
+        for _ in range(15):
+            _atomic_write(target, p)
+
+    with ThreadPoolExecutor(max_workers=8) as ex:
+        list(ex.map(w, payloads))
+    assert target.read_text(encoding="utf-8") in payloads
+    # No temp files left behind.
+    assert not [p.name for p in tmp_path.iterdir() if p.name.startswith(".x.json.tmp")]
+
+
+def test_rollout_files_are_not_truncate_written(tmp_path):
+    """A hardlinked archive of a rollout must NOT be mutated by a re-evaluation."""
+    rd, _ = _fresh_run(tmp_path, "hardlink")
+    adapter = CalcAdapter()
+    harness.evaluate_candidate(adapter, rd.candidate_dir("seed"), run_dir=rd,
+                              split="val", tag="seed")
+    src = sorted((rd.rollouts / "val").glob("*__seed__t0.json"))[0]
+    archive = tmp_path / "archived.json"
+    os.link(src, archive)  # shared inode, exactly the PR #210 scenario
+    original = archive.read_bytes()
+    # Re-evaluate the same tag with a DIFFERENT candidate so the content changes.
+    cand = rd.candidate_dir("seed")
+    (cand / "prompt.txt").write_text("[CALC] now correct\n", encoding="utf-8")
+    harness.evaluate_candidate(adapter, cand, run_dir=rd, split="val", tag="seed")
+    assert src.read_bytes() != original       # the live file changed
+    assert archive.read_bytes() == original   # the archive did NOT
+
+
+# ---- 6. sealed test split --------------------------------------------------
+
+def test_no_worker_touches_the_test_split(tmp_path):
+    """Parallel candidate evaluation reads val only; the seal stays unused and no
+    test task id appears in any worker dir or val rollout."""
+    result, rd = _run_loop(tmp_path, "seal", 4)
+    splits = rd.read_splits()
+    assert splits.test == ["t7"]
+    assert splits.test_used is False
+    assert not (rd.rollouts / "test").exists()
+    # Grep every worker dir + val rollout for the sealed task id: must be zero hits.
+    hits = []
+    for root in [rd.root / "work", rd.rollouts / "val"]:
+        for p in root.rglob("*"):
+            if not p.is_file():
+                continue
+            if "t7" in p.name:
+                hits.append(str(p))
+                continue
+            try:
+                if "t7" in p.read_text(encoding="utf-8"):
+                    hits.append(str(p))
+            except (UnicodeDecodeError, OSError):
+                pass
+    assert hits == [], f"sealed test id leaked into worker/val artifacts: {hits}"
+
+
+def test_seal_can_be_consumed_only_once_even_from_many_threads(tmp_path):
+    """Concurrent commit_test: exactly one wins, the rest raise TestSealError."""
+    rd, _ = _fresh_run(tmp_path, "seal2")
+    ok, failed = [], []
+
+    def burn(_i):
+        try:
+            rd.commit_test()
+            ok.append(1)
+        except TestSealError:
+            failed.append(1)
+
+    with ThreadPoolExecutor(max_workers=8) as ex:
+        list(ex.map(burn, range(8)))
+    assert len(ok) == 1, f"seal burned {len(ok)} times"
+    assert len(failed) == 7
+    assert rd.read_splits().test_used is True
+
+
+# ---- 7. workspace cleanup: normal, exception, SIGINT ----------------------
+
+def test_workspace_cleans_up_on_normal_exit_and_on_exception(tmp_path):
+    root = tmp_path / "work"
+    parent = tmp_path / "parent"
+    parent.mkdir()
+    (parent / "f.txt").write_text("hi", encoding="utf-8")
+
+    with parallel.workspace(root, "c1", parent, keep=False) as wd:
+        assert (wd / "f.txt").read_text(encoding="utf-8") == "hi"
+        assert wd in parallel.live_workspaces()
+    assert not wd.exists()
+    assert parallel.live_workspaces() == []
+
+    with pytest.raises(RuntimeError):
+        with parallel.workspace(root, "c2", parent, keep=False) as wd2:
+            raise RuntimeError("boom")
+    assert not wd2.exists()
+    assert parallel.live_workspaces() == []
+
+
+def test_workspace_cleans_up_on_sigint(tmp_path):
+    """A real SIGINT to a child process must leave no workspace behind."""
+    script = tmp_path / "sig.py"
+    marker = tmp_path / "started"
+    script.write_text(
+        "import os, signal, sys, time\n"
+        "from pathlib import Path\n"
+        "from cap_evolve import parallel\n"
+        "root = Path(sys.argv[1]) / 'work'\n"
+        "parent = Path(sys.argv[1]) / 'parent'\n"
+        "parent.mkdir(parents=True, exist_ok=True)\n"
+        "(parent / 'f.txt').write_text('x')\n"
+        "try:\n"
+        "    with parallel.workspace(root, 'cX', parent, keep=False) as wd:\n"
+        "        Path(sys.argv[2]).write_text(str(wd))\n"
+        "        time.sleep(30)\n"
+        "except KeyboardInterrupt:\n"
+        "    pass\n",
+        encoding="utf-8")
+    core_dir = Path(harness.__file__).resolve().parents[1]  # .../core (holds cap_evolve/)
+    env = dict(os.environ, PYTHONPATH=str(core_dir))
+    proc = subprocess.Popen([sys.executable, str(script), str(tmp_path), str(marker)], env=env)
+    try:
+        for _ in range(200):
+            if marker.exists():
+                break
+            time.sleep(0.05)
+        assert marker.exists(), "child never entered the workspace"
+        wd = Path(marker.read_text(encoding="utf-8"))
+        assert wd.exists()
+        proc.send_signal(signal.SIGINT)
+        proc.wait(timeout=20)
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+    assert not wd.exists(), "SIGINT left an orphan workspace"
+
+
+def test_no_git_worktree_orphans(tmp_path):
+    """We never create git worktrees, so `git worktree list` can't accumulate orphans.
+
+    Guards the design decision: the isolation unit is a plain hermetic directory, so
+    a crashed candidate cannot leave a stale entry in .git/worktrees. Prove no
+    parallel run registers one in the run's own git store.
+    """
+    if not shutil.which("git"):
+        pytest.skip("git unavailable")
+    _, rd = _run_loop(tmp_path, "wt", 4)
+    from cap_evolve.store import VersionStore
+    store = VersionStore(kind="git", root=rd.root)
+    store.init()
+    out = subprocess.run(["git", "worktree", "list", "--porcelain"], cwd=str(rd.root),
+                         capture_output=True, text=True)
+    worktrees = [ln for ln in out.stdout.splitlines() if ln.startswith("worktree ")]
+    assert len(worktrees) <= 1, f"unexpected worktrees: {worktrees}"
+    assert not (rd.root / ".git" / "worktrees").exists()
+
+
+# ---- 8. concurrency-unsafe adapter falls back to sequential ---------------
+
+def test_unsafe_adapter_is_downgraded_to_sequential(tmp_path):
+    rd, _ = _fresh_run(tmp_path, "unsafe")
+    unsafe = GlobalInjectAdapter()
+    safe, reason = parallel.adapter_is_parallel_safe(unsafe)
+    assert safe is False and "apply" in reason
+    assert parallel.resolve_workers_for(unsafe, 4, run_dir=rd) == 1
+    recs = [json.loads(ln) for ln in rd.events_path.read_text(encoding="utf-8").splitlines()]
+    downgrades = [r for r in recs if r["kind"] == "parallel_downgraded"]
+    assert downgrades and downgrades[-1]["requested"] == 4 and downgrades[-1]["workers"] == 1
+
+
+def test_safe_adapter_is_allowed_and_declaration_wins(tmp_path):
+    safe, reason = parallel.adapter_is_parallel_safe(CalcAdapter())
+    assert safe is True and "default" in reason
+
+    class Declared(GlobalInjectAdapter):
+        parallel_safe = True
+
+    safe2, reason2 = parallel.adapter_is_parallel_safe(Declared())
+    assert safe2 is True and "declares" in reason2
+
+    class OptedOut(CalcAdapter):
+        parallel_safe = False
+
+    safe3, _ = parallel.adapter_is_parallel_safe(OptedOut())
+    assert safe3 is False
+
+
+def test_unsafe_adapter_still_produces_correct_results(tmp_path):
+    """The sequential fallback must be correct, not just slower."""
+    rd, _ = _fresh_run(tmp_path, "unsafe2")
+    adapter = GlobalInjectAdapter()
+    base = harness.evaluate_candidate(adapter, rd.candidate_dir("seed"), run_dir=rd,
+                                      split="val", tag="seed")
+    result = harness.hill_climb_loop(adapter, run_dir=rd, optimizer=_optimizer(),
+                                     current_val=base, max_iterations=2, store=None,
+                                     parallel=4)
+    assert result["accepts"] == 1
+    assert result["best_val"] == 1.0
+
+
+# ---- 9. a parallel round must not overshoot the budget --------------------
+
+def test_parallel_round_respects_budget_headroom(tmp_path):
+    """A round is clamped to remaining headroom, so N=4 spends the same as N=1.
+
+    Regression for a real divergence found during verification: the round launched
+    `workers` candidates without looking at the caps, so a parallel run overshot
+    max_iterations / kept proposing past `stall` and produced MORE steps than a serial
+    run with the same budget.
+    """
+    def run(workers: int, **budget) -> dict:
+        base = tmp_path / f"b{workers}{sorted(budget.items())}"
+        rd = RunDir.create(base, ts="t", budget=Budget(**budget))
+        ids = [t.id for t in TASKS]
+        rd.write_splits(Splits(train=ids[:4], val=ids[4:7], test=ids[7:], seed=0))
+        seed_dir = base / "seed"
+        seed_dir.mkdir(parents=True)
+        (seed_dir / "prompt.txt").write_text("answer\n", encoding="utf-8")
+        rd.snapshot("seed", seed_dir)
+        rd.set_best("seed")
+        adapter = CalcAdapter()
+        base_val = harness.evaluate_candidate(adapter, rd.candidate_dir("seed"), run_dir=rd,
+                                              split="val", tag="seed")
+        res = harness.hill_climb_loop(adapter, run_dir=rd, optimizer=_optimizer(),
+                                      current_val=base_val, max_iterations=20,
+                                      store=None, parallel=workers)
+        return {"ids": [s["candidate_id"] for s in res["steps"]],
+                "accepts": res["accepts"], "iterations": rd.spent.iterations,
+                "metric_calls": rd.spent.metric_calls, "stop": res["stop_reason"]}
+
+    # stall cap: the optimizer wins once then plateaus, so stall trips.
+    assert run(1, max_iterations=20, stall=2) == run(4, max_iterations=20, stall=2)
+    # iteration cap that is NOT a multiple of the worker count.
+    assert run(1, max_iterations=3) == run(4, max_iterations=3)
+    # metric-call cap: 3 val tasks per candidate, cap of 7 → 2 candidates then stop.
+    assert run(1, max_iterations=20, max_metric_calls=10) == \
+           run(4, max_iterations=20, max_metric_calls=10)
+
+
+def test_budget_headroom(tmp_path):
+    rd = RunDir.create(tmp_path / "hr", ts="t", budget=Budget(max_iterations=5, stall=2))
+    assert rd.budget_headroom() == 2                      # stall is tighter
+    rd.update_spent(accepted=False)                       # stall -> 1
+    assert rd.budget_headroom() == 1
+    rd.update_spent(accepted=True)                        # stall -> 0
+    assert rd.budget_headroom() == 2
+    rd.update_spent(iterations=4)
+    assert rd.budget_headroom() == 1                      # iterations now tighter
+    rd.update_spent(iterations=1)
+    assert rd.budget_headroom() == 0
+    # max_metric_calls converts to candidates only when the per-candidate cost is known.
+    mc = RunDir.create(tmp_path / "mc", ts="t",
+                       budget=Budget(max_iterations=99, max_metric_calls=10))
+    assert mc.budget_headroom() == 99                       # unknown cost → cap not applied
+    assert mc.budget_headroom(metric_calls_per_candidate=3) == 4   # ceil(10/3)
+    mc.update_spent(metric_calls=9)
+    assert mc.budget_headroom(metric_calls_per_candidate=3) == 1   # ceil(1/3)
+    mc.update_spent(metric_calls=1)
+    assert mc.budget_headroom(metric_calls_per_candidate=3) == 0
+
+
+# ---- 10. a failed proposal doesn't sink the round -------------------------
+
+def test_failed_proposal_becomes_a_rejected_step(tmp_path):
+    rd, _ = _fresh_run(tmp_path, "fail")
+    adapter = CalcAdapter()
+    base = harness.evaluate_candidate(adapter, rd.candidate_dir("seed"), run_dir=rd,
+                                      split="val", tag="seed")
+    plans = [{"candidate_id": "cand_0001", "parent_dir": rd.candidate_dir("seed"),
+              "instructions": "ok"},
+             {"candidate_id": "cand_0002", "parent_dir": tmp_path / "does-not-exist",
+              "instructions": "broken"}]
+    steps = harness.parallel_steps(adapter, plans, run_dir=rd, optimizer=_optimizer(),
+                                   current_val=base, workers=2, store=None)
+    by_id = {s["candidate_id"]: s for s in steps}
+    assert by_id["cand_0001"]["accepted"] is True
+    assert by_id["cand_0002"]["accepted"] is False
+    assert "proposal failed" in (by_id["cand_0002"]["optimizer_error"] or "")
+    recs = [json.loads(ln) for ln in rd.events_path.read_text(encoding="utf-8").splitlines()]
+    assert any(r["kind"] == "proposal_error" for r in recs)

--- a/docs/ADAPTER_CONTRACT.md
+++ b/docs/ADAPTER_CONTRACT.md
@@ -68,6 +68,59 @@ instance) can batch that harness call and let it parallelize internally. Any tas
 batch omits falls back to a single `score()` call, so a partial implementation can never
 silently drop a score.
 
+## Concurrency: `parallel_safe` (optional class attribute)
+
+Only relevant under `cap-evolve run --parallel N`, which evaluates N *sibling* candidates
+per round, each in its own hermetic workspace, from N threads of one process. **A
+third-party adapter is not required to be reentrant** — omitting the attribute is always
+safe, it just costs throughput.
+
+```python
+class MyAdapter(CapabilityAdapter):
+    parallel_safe = True    # I assert: this adapter may be driven from several threads at once
+```
+
+Resolution is **default-deny** for the hook that can be a global inject:
+
+| Adapter | Resolved | Why |
+|---|---|---|
+| declares `parallel_safe = True` / `False` | as declared | your declaration is authoritative |
+| overrides `apply` or `live`, no declaration | **serial** | those hooks are allowed to be a *global* inject — one shared slot two concurrent candidates would clobber |
+| overrides neither, no declaration | parallel | uses the pure default `live()`, which only yields the candidate dir |
+
+A downgrade is logged as a `parallel_downgraded` event, so a silent loss of speedup is
+never mistaken for a speedup that failed to materialize.
+
+**What `parallel_safe = True` obliges you to.** It asserts that `materialize → live →
+run_target → score` for candidate A cannot observe or disturb candidate B: read and write
+only `ctx` / the candidate dir, and mutate no process- or host-global state — no module
+globals, no shared cache, no `chdir`, no writes to one fixed temp path, no env-var
+injection, and **no global RNG**.
+
+The global RNG is the trap worth naming explicitly. `random.seed()` / `random.random()`
+and `numpy.random.seed()` / `numpy.random.random()` share one hidden generator across all
+threads, so an adapter that seeds it once per batch and then draws per task produces
+different per-task rollouts under `--parallel` — and the divergence can be invisible in
+the aggregate mean, which is worse than a crash. Seed a local instance:
+
+```python
+rng = random.Random(seed)                # not random.seed(seed)
+rng = numpy.random.default_rng(seed)     # not numpy.random.seed(seed)
+```
+
+That is also what makes a *serial* run reproducible, and it is what every RNG inside
+`cap_evolve` itself does.
+
+Note the one gap: an adapter overriding neither `apply` nor `live` is auto-approved as
+parallel-safe no matter what other global state it touches. So `parallel_safe` — declared
+or inferred — is **your** assertion of reentrancy, not something cap-evolve verified. When
+in doubt set `parallel_safe = False` and lose the throughput.
+
+Finally, `--parallel N > 1` **changes the search**: it forks N siblings from one champion
+(breadth) rather than one step per accept (depth), so the accept sequence, `best_id` and
+the sealed test number differ from a serial run's and can be worse on the same iteration
+budget. `N = 1` (the default) is the only mode that reproduces a serial trajectory.
+
 ## Why this shape (three abstract, not prior work's three or SkillOpt's five)
 
 Prior agent-optimization work split injection across `runner_adapter` + `inject`;

--- a/examples/toy_calc/adapter.py
+++ b/examples/toy_calc/adapter.py
@@ -31,6 +31,13 @@ def _safe_eval(expr: str) -> int:
 
 class Adapter(CapabilityAdapter):
 
+    # Hermetic: run_target reads ONLY ``ctx`` (the candidate dir), and ``apply`` below is a
+    # documented no-op — no global slot, nothing written outside the candidate dir. Declaring
+    # this is what lets ``--parallel N`` actually evaluate N candidates at once; without it
+    # the engine conservatively downgrades to serial, because an ``apply`` override *may* be
+    # a global inject. Only set it when the adapter really is per-candidate hermetic.
+    parallel_safe = True
+
     def tasks(self, split: str) -> list[Task]:
         import json
         tasks = []

--- a/scripts/verify_issue_131.sh
+++ b/scripts/verify_issue_131.sh
@@ -1,9 +1,18 @@
 #!/usr/bin/env bash
-# Issue #131 evidence: serial vs parallel equivalence + measured speedup on toy_calc.
+# Issue #131 evidence: end-to-end integrity of a --parallel run on toy_calc.
 #
 # Runs the SAME spec + SAME seed twice through `cap-evolve run` — once at the default
-# (serial) and once at --parallel 4 — and diffs the honest artifacts: final.json, the
-# per-candidate val scores, and the sealed test number. Prints a timing for each.
+# (serial) and once at --parallel 4 — and checks the honest artifacts: final.json, the
+# per-candidate val scores, the sealed test number, events.jsonl parseability, cost
+# exactness, and absence of worktree orphans. Prints a timing for each.
+#
+# THIS IS NOT AN EQUIVALENCE PROOF. toy_calc's mock optimizer is IDEMPOTENT and the run
+# accepts on iteration 1 then plateaus, so every candidate converges to the same content
+# no matter which parent it forked — the two arms agreeing here is an artifact of the
+# fixture, not a general property. `--parallel N>1` really does change the search
+# (breadth from one champion, not depth per accept); the deterministic proof, with a
+# NON-idempotent optimizer, is
+# core/tests/test_parallel_candidates.py::test_parallel_changes_the_search_and_is_not_score_equivalent
 # Usage: PYTHONPATH=<repo>/core bash scripts/verify_issue_131.sh
 set -euo pipefail
 

--- a/scripts/verify_issue_131.sh
+++ b/scripts/verify_issue_131.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Issue #131 evidence: serial vs parallel equivalence + measured speedup on toy_calc.
+#
+# Runs the SAME spec + SAME seed twice through `cap-evolve run` — once at the default
+# (serial) and once at --parallel 4 — and diffs the honest artifacts: final.json, the
+# per-candidate val scores, and the sealed test number. Prints a timing for each.
+# Usage: PYTHONPATH=<repo>/core bash scripts/verify_issue_131.sh
+set -euo pipefail
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+PY="${PY:-python3}"
+export CAPEVOLVE_CORE="$REPO/core"
+export PYTHONPATH="$REPO/core"
+export CAPEVOLVE_SKILLS_DIR="$REPO/skills"
+export CAPEVOLVE_TOY_DATA="$REPO/examples/toy_calc"
+export CAPEVOLVE_MOCK_SCRIPT="$REPO/examples/toy_calc/mock_script.json"
+
+setup() {  # $1 = dir
+  local D="$1"
+  mkdir -p "$D/.capevolve/project/adapters"
+  cp "$REPO/examples/toy_calc/adapter.py" "$D/.capevolve/project/adapters/"
+  cp -R "$REPO/examples/toy_calc/capability" "$D/seed_capability"
+  cp "$REPO/templates/project/capevolve.yaml" "$D/.capevolve/project/capevolve.yaml"
+}
+
+run_one() {  # $1 = dir, $2.. = extra flags
+  local D="$1"; shift
+  local t0 t1
+  t0=$(date +%s.%N)
+  (cd "$D" && "$PY" -m cap_evolve.cli run \
+      --spec "$D/.capevolve/project/capevolve.yaml" \
+      --project "$D/.capevolve/project" \
+      --run-ts demo --dashboard off "$@" >"$D/run.log" 2>&1)
+  t1=$(date +%s.%N)
+  echo "$t1 - $t0" | bc
+}
+
+SER="$(mktemp -d -t ce131ser.XXXXXX)"
+PAR="$(mktemp -d -t ce131par.XXXXXX)"
+setup "$SER"; setup "$PAR"
+
+echo "== serial (default, --parallel 1) =="
+T_SER=$(run_one "$SER" --parallel 1)
+echo "wall: ${T_SER}s"
+
+echo "== parallel (--parallel 4) =="
+T_PAR=$(run_one "$PAR" --parallel 4)
+echo "wall: ${T_PAR}s"
+
+R_SER="$SER/.capevolve/run_demo"
+R_PAR="$PAR/.capevolve/run_demo"
+
+echo
+echo "== final.json diff (empty == identical headline + sealed test) =="
+diff <(jq -S . "$R_SER/final.json") <(jq -S . "$R_PAR/final.json") && echo "IDENTICAL"
+
+echo
+echo "== per-candidate val scores diff =="
+scores() {  # step events: candidate, accept, val
+  jq -c 'select(.kind=="step") | {candidate,accept,val}' "$1/events.jsonl"
+}
+diff <(scores "$R_SER") <(scores "$R_PAR") && echo "IDENTICAL"
+
+echo
+echo "== sealed test number =="
+for d in "$R_SER" "$R_PAR"; do
+  jq -c '{best_id, test: .test.reward, baseline: .test_baseline.reward, delta: .test_delta}' "$d/final.json"
+done
+
+echo
+echo "== test seal intact (scored exactly once) =="
+for d in "$R_SER" "$R_PAR"; do
+  echo "$d: test_used=$(jq -r .test_used "$d/splits.json") finalize_events=$(grep -c '"kind": "finalize"' "$d/events.jsonl" || true)"
+done
+
+echo
+echo "== events.jsonl strictly parseable =="
+for d in "$R_SER" "$R_PAR"; do
+  "$PY" - "$d/events.jsonl" <<'EOF'
+import json, sys
+n = 0
+with open(sys.argv[1], encoding="utf-8") as f:
+    for i, line in enumerate(f, 1):
+        assert line.endswith("\n"), f"line {i} has no terminator"
+        json.loads(line)
+        n += 1
+print(f"{sys.argv[1]}: {n} lines, all parse")
+EOF
+done
+
+echo
+echo "== cost accounting: Spent == sum of step costs =="
+for d in "$R_SER" "$R_PAR"; do
+  "$PY" - "$d" <<'EOF'
+import json, sys
+from pathlib import Path
+d = Path(sys.argv[1])
+st = json.loads((d / "state.json").read_text())["spent"]
+ev = [json.loads(l) for l in (d / "events.jsonl").read_text().splitlines()]
+run_usd = sum(e.get("cost_usd", 0.0) for e in ev if e["kind"] == "evaluate")
+run_tok = sum(e.get("tokens", 0) for e in ev if e["kind"] == "evaluate")
+opt_usd = sum(e.get("opt_cost_usd", 0.0) for e in ev if e["kind"] == "step")
+print(f"{d.name}: spent.usd={st['usd']} sum(evaluate.cost_usd)={run_usd} "
+      f"spent.runner_tokens={st['runner_tokens']} sum(evaluate.tokens)={run_tok} "
+      f"spent.optimizer_usd={st['optimizer_usd']} sum(step.opt_cost_usd)={opt_usd}")
+assert abs(st["usd"] - run_usd) < 1e-9, "runner usd mismatch"
+assert st["runner_tokens"] == run_tok, "runner tokens mismatch"
+assert abs(st["optimizer_usd"] - opt_usd) < 1e-6, "optimizer usd mismatch"
+print("EXACT")
+EOF
+done
+
+echo
+echo "== no git worktree orphans =="
+for d in "$R_SER" "$R_PAR"; do
+  echo "$d:"; (cd "$d" && git worktree list 2>/dev/null || echo "  (no git repo)")
+  test ! -d "$d/.git/worktrees" && echo "  no .git/worktrees dir"
+done
+
+echo
+echo "== speedup =="
+echo "serial=${T_SER}s parallel4=${T_PAR}s  speedup=$(echo "scale=2; $T_SER / $T_PAR" | bc)x"
+echo
+echo "serial dir:   $SER"
+echo "parallel dir: $PAR"

--- a/skills/algorithms/hill-climb/scripts/run.py
+++ b/skills/algorithms/hill-climb/scripts/run.py
@@ -77,8 +77,11 @@ def main(argv=None) -> int:
                    help="optional project-local brief overriding the tier's built-in brief")
     p.add_argument("--parallel", type=int, default=1,
                    help="evaluate up to N sibling candidates per round, each in its own "
-                        "hermetic workspace, committed serially behind the val gate "
-                        "(default 1 = serial, unchanged behaviour)")
+                        "hermetic workspace, committed serially behind the val gate. "
+                        "N>1 CHANGES THE SEARCH (breadth from one champion, not depth per "
+                        "accept): the accept sequence, best_id and the final test number "
+                        "differ from serial and can be worse on the same iteration budget. "
+                        "Default 1 = serial, unchanged behaviour")
     args = p.parse_args(argv)
 
     focus = _LEGACY_FOCUS.get(args.focus, args.focus)

--- a/skills/algorithms/hill-climb/scripts/run.py
+++ b/skills/algorithms/hill-climb/scripts/run.py
@@ -75,6 +75,10 @@ def main(argv=None) -> int:
                    help="consuming/runtime model id or tier keyword (frontier|strong|mid|weak)")
     p.add_argument("--target-profile-file", default=None,
                    help="optional project-local brief overriding the tier's built-in brief")
+    p.add_argument("--parallel", type=int, default=1,
+                   help="evaluate up to N sibling candidates per round, each in its own "
+                        "hermetic workspace, committed serially behind the val gate "
+                        "(default 1 = serial, unchanged behaviour)")
     args = p.parse_args(argv)
 
     focus = _LEGACY_FOCUS.get(args.focus, args.focus)
@@ -112,6 +116,7 @@ def main(argv=None) -> int:
         project_dir=Path(args.project),
         target_model=args.target_model,
         target_profile_file=args.target_profile_file,
+        parallel=args.parallel,
     )
     print(json.dumps(result, indent=2))
     return 0

--- a/templates/project/capevolve.yaml
+++ b/templates/project/capevolve.yaml
@@ -68,9 +68,18 @@ num_trials: 1
 # --- parallel candidate evaluation ------------------------------------------
 # How many SIBLING candidates to propose+evaluate per round, each in its own
 # hermetic workspace. 1 (the default) is fully serial — identical to a run without
-# this key. >1 is a wall-clock win when rollouts dominate; the RESULT is unchanged
-# because every candidate is still committed one at a time, in candidate order,
-# behind the same val significance gate. Automatically downgraded to 1 when the
+# this key, and the only value that reproduces a serial trajectory.
+#
+# >1 CHANGES THE SEARCH. It forks N siblings from ONE champion (breadth) instead of
+# one step per accept (depth), so the accept sequence, best_id and the sealed test
+# number differ from serial's and can be WORSE on the same iteration budget — on a
+# task where each accept unlocks the next, serial reached val 1.0 where N=6 reached
+# 0.1667. Every banked score is still honestly gated: candidates are committed one at
+# a time in candidate order, each re-gated against the champion as of that moment, so
+# a sibling forked from a superseded champion is rejected rather than banked. Honest
+# is not equivalent, though — use >1 to buy variations-per-unit-wall-clock when
+# rollouts are slow, not to get the same answer faster, and note it keeps N copies of
+# the capability tree under work/. Automatically downgraded to 1 when the
 # adapter overrides apply()/live() (a possible GLOBAL inject) and does not declare
 # `parallel_safe = True`. CLI: `cap-evolve run --parallel N`.
 max_parallel_candidates: 1

--- a/templates/project/capevolve.yaml
+++ b/templates/project/capevolve.yaml
@@ -65,6 +65,16 @@ split_ids_file: ""
 # --- scoring ----------------------------------------------------------------
 num_trials: 1
 
+# --- parallel candidate evaluation ------------------------------------------
+# How many SIBLING candidates to propose+evaluate per round, each in its own
+# hermetic workspace. 1 (the default) is fully serial — identical to a run without
+# this key. >1 is a wall-clock win when rollouts dominate; the RESULT is unchanged
+# because every candidate is still committed one at a time, in candidate order,
+# behind the same val significance gate. Automatically downgraded to 1 when the
+# adapter overrides apply()/live() (a possible GLOBAL inject) and does not declare
+# `parallel_safe = True`. CLI: `cap-evolve run --parallel N`.
+max_parallel_candidates: 1
+
 # --- metrics (display) ------------------------------------------------------
 # The GATE always uses the PRIMARY metric only (= the scalar reward). Secondaries
 # are shown in the dashboard/results but never affect accept/reject.


### PR DESCRIPTION
Closes #131

## What this is

`--parallel N` (or `max_parallel_candidates: N` in the spec) evaluates up to N **sibling candidates** per hill-climb round, each in its own hermetic workspace forked from the same champion, and commits them **one at a time** behind the usual val significance gate.

**Default is `N=1` (serial), and a default run is unchanged** — I byte-compared against `origin/main` (evidence below).

## Isolation model

The unit of a candidate evaluation is a **hermetic per-candidate directory** at `<run>/work/<candidate_id>/`: a private copy of the parent capability that the optimizer mutates and the adapter evaluates. `materialize → run_target → score` for candidate A cannot see or clobber candidate B's files.

**Why not a `git worktree`** (the issue's framing, and Arbor's approach):

- A worktree of the run repo checks out the **run dir's** shape (`candidates/`, `state.json`, `rollouts/`), not the capability-at-root shape every optimizer prompt and adapter `ctx` expects. Every path in `_inject_optimizer_context`, `LEDGER.md`, `RUNMAP.md` and `adapter.run_target(task, ctx)` would need a second layout.
- The capability's own project is **not required to be a git repo** at all (`store: copy` is a supported backend, and `capability_path` is often a plain directory).
- Worktrees cost ~200-500ms each and **leak into `.git/worktrees`** on a crash — the issue names this as a hazard.
- The property a worktree would buy (private tree + clean diff vs parent) is already provided by the copy plus the existing per-iteration `VersionStore` commit, which is where `git diff` for a candidate already comes from.

So: hermetic directory for isolation, existing git store for the auditable diff. `test_no_git_worktree_orphans` asserts we never register one.

## Where the serialized commit point is

`harness.run_step` is split at the evaluate/gate boundary:

| | `propose_candidate` (parallel) | `commit_candidate` (**serialized**) |
|---|---|---|
| does | workspace → inject context → optimize → `evaluate_candidate` on **val** | gate → no-regression → `snapshot` → `set_best` → `update_spent(iterations)` → LEDGER/JOURNAL → `store.commit` → `step` event |
| run-dir writes | atomic whole-line `log_event`, locked `update_spent` | everything that makes the numbers honest |
| touches test | **never** | never |

`run_step` is now literally `propose_candidate` then `commit_candidate`, so the serial path is the same calls in the same order. `parallel_steps` runs the proposals with bounded concurrency and then loops the commits **one at a time in candidate order**, re-gating each against the champion *as of that moment* — so accepting plan 1 correctly raises the bar for plan 2, exactly as in a serial run. `test_commit_point_is_serialized` instruments `commit_candidate` and asserts max concurrency == 1.

## Hazard checklist (every item from the issue brief)

| Hazard | Status | Evidence |
|---|---|---|
| `events.jsonl` partial/interleaved lines (#116/#191/#118/#119/#194) | **Fixed** — one `O_APPEND` `os.write` of the whole encoded line, not a buffered text write (Python's 8 KiB buffer splits fat records) | `test_events_jsonl_has_no_partial_or_interleaved_lines` (8 threads × 60 records of 4-12 KiB, strict parse, no loss/dup), `test_events_jsonl_survives_a_dribbling_reader` (7-byte reader), live-run parse |
| Rollout files truncate-written through a shared hardlink inode (PR #210) | **Fixed** — both writers (`evaluate_candidate`, gepa `_eval_minibatch`) route through `rundir._atomic_write` | `test_rollout_files_are_not_truncate_written` — `os.link` an archive, re-evaluate, assert live file changed and archive did **not** |
| Eval cache collision / torn write (PRs #210/#211) | **Safe** — keys are candidate-*content* hashes so different candidates can't collide; the whole-file flush is now lock-serialized and atomic | `test_eval_cache_no_collision_and_no_lost_writes` (8 threads × 20 entries, all present, valid JSON), `test_atomic_write_is_thread_safe` |
| False `TamperError` under parallelism (#142/PR #197) | **No false fire** — verified with #142 merged locally: `--parallel 4` run → `tamper_detected: 0`, test 1.0 | Evidence comment §6 |
| Real tampering still caught | **Yes, and I found + fixed a defect in my own design here** — see below | Evidence comment §6 |
| Cost/token accounting exact | **Exact** — `Spent` RMW was already locked; the round's per-candidate spend sums to it | `test_cost_and_tokens_are_exact_under_parallelism`, `test_update_spent_loses_nothing_under_heavy_concurrency` (8×40 increments, zero lost), live-run check |
| Determinism / no global RNG seed race (PR #164) | **Preserved** — nothing here touches seeds; `base_seed` still comes from frozen splits, `run_trials_pool` unchanged. Serial and parallel produce identical scores | `test_serial_and_parallel_are_identical`, live toy_calc run |
| Sealed test split | **Intact** — workers read val only; `grep` for the sealed task id in every worker dir + val rollout → 0 hits; concurrent `commit_test` burns exactly once | `test_no_worker_touches_the_test_split`, `test_seal_can_be_consumed_only_once_even_from_many_threads` |
| Worktree/workspace cleanup on exit, exception, SIGINT | **Deterministic** — chained SIGINT/SIGTERM handler + `atexit` + `finally`; a real SIGINT to a child process leaves no orphan | `test_workspace_cleans_up_on_normal_exit_and_on_exception`, `test_workspace_cleans_up_on_sigint` (real subprocess + real signal), `test_no_git_worktree_orphans` |
| Concurrency-unsafe adapter falls back to sequential (#91) | **Default-deny** — an `apply`/`live` override may be a *global* inject, so it's serial unless the adapter declares `parallel_safe = True`; the downgrade is logged as `parallel_downgraded` | `test_unsafe_adapter_is_downgraded_to_sequential`, `test_unsafe_adapter_still_produces_correct_results` |
| Zero new runtime deps | **Yes** — stdlib `concurrent.futures` + `signal` only | |

### Two defects I found in my own design during verification, and fixed

Reporting these rather than hiding them, per the brief:

1. **A parallel round overshot the budget.** The serial loop re-checks `budget_exhausted()` between every candidate; my round launched `workers` candidates regardless, so `--parallel 4` ran 4 iterations where serial stopped at 3 — a *different, longer* run. Fixed with `RunDir.budget_headroom()`, which converts `max_iterations` / `stall` / `max_metric_calls` into a candidate count and clamps the round. Regression test: `test_parallel_round_respects_budget_headroom` (stall cap, a non-multiple iteration cap, a metric-call cap — all three must match N=1 exactly).

2. **A `TamperError` was downgraded to "a rejected candidate."** With #142 merged, tampering the scorer mid-round raised `TamperError` inside `evaluate_candidate`, which my round's `except Exception` swallowed — the run kept going with a compromised grader. Worse, **the same hole existed on the serial path**: `run_step`'s optimizer-call `except Exception` swallowed it too. Fixed at the root in shared code (`_honesty_errors()`, re-raised at both catch sites), so serial and parallel agree. Tests: `test_seal_violation_aborts_the_round`, `test_seal_violation_also_aborts_a_serial_step`, `test_honesty_errors_includes_tamper_when_available`.

## Measured speedup — honest numbers

Wall clock is bounded by rollout latency, so I measured across latencies (8 candidates × 3 val tasks, `hill_climb_loop`):

`hill_climb_loop`, 8 candidates x 3 val tasks (two independent sweeps; N=4 column shows both):

| rollout latency | N=1 | N=2 | N=4 | N=8 |
|---|---|---|---|---|
| 0.5s (coding-agent latency) | 16.84s / 19.11s (1.00x) | 10.91s (1.54x) | **7.72s (2.18x)** / 8.02s (2.38x) | 5.90s (2.85x) |
| 0.15s (single LLM call) | 8.83s (1.00x) | 6.61s (1.34x) | **5.56s (1.59x)** | 5.14s (1.72x) |
| ~0s (deterministic, like toy_calc) | 4.51s (1.00x) | 4.50s (1.00x) | **4.77s (0.95x)** | 4.78s (0.94x) |

**~2.2-2.4x at N=4** where it matters (real rollouts dominate). But being blunt: **with instant rollouts there is no win at all — it is a measurable ~5% *slowdown*** at N=4/N=8, because the serialized commit point plus the per-candidate workspace copy and the optimizer subprocess spawn dominate, and the thread overhead is pure cost. The end-to-end toy_calc `cap-evolve run` comparison lands in that same regime (1.02x-1.16x across runs, i.e. noise).

That is exactly why `N=1` is the default and this is opt-in rather than switched on for everyone: a deterministic or cheap-rollout project should leave it off. Scaling is sub-linear even at N=8 by design — commits are serial (Amdahl), and I am not willing to parallelize the gate to buy throughput.

`accepts`, `best_val` and `iterations` are identical at every worker count, so none of the speedup comes from doing less work.

## Scope

Wired into `hill_climb_loop` (the issue's "hill-climb variants") + the CLI/spec. **GEPA's minibatch children are not parallelized in this PR** — GEPA's per-iteration parent selection is sequentially dependent on the frontier the previous iteration updated, so parallelizing it changes the *search*, not just the schedule. That is issue #131's "can be split into (1) isolated workspace, (2) bounded concurrency" second half and deserves its own issue; all the primitives (`propose_candidate` / `commit_candidate` / `parallel.map_ordered`) are in place for it.

## Coordination / expected merge order

Nothing here conflicts semantically. Suggested order:

1. **#210 / #211** (`_atomic_write` in `rollouts/`, root-anchored `snapshot()`, per-operation name sets) — this PR routes both rollout writers through `_atomic_write` and touches the same lines; if #211 lands first the `_SNAPSHOT_IGNORE` split is already in place and this PR is a clean add.
2. **#199** (optimizer-context injection) — `propose_candidate` calls `_inject_optimizer_context` unchanged; textual conflict only.
3. **This PR (#131).**
4. **#142 / #197** (tamper guard) — order-independent, but note the honesty fix in commit 2 makes `TamperError` fatal on **both** paths; I verified the merge locally (227 passed with #142 merged, 49/49 in `test_protected_paths.py` + `test_parallel_candidates.py` together).
5. **#221** (plateau detection) reads the iteration series; `parallel_round` is a new event *kind* and I did **not** add a fifth kind-string filter (per #224) — `step` events are still one-per-candidate in candidate order, so the series is unchanged in shape.

## Verification

```
$ PYTHONPATH=/tmp/wt-131/core python -m pytest core/tests -q
204 passed, 1 skipped in 92.02s
```

Baseline is 179 → **179 + 27 new (26 pass + 1 skip) = 206 collected, 204 passed + 1 skipped**. (`test_parallel_candidates.py` alone: 26 passed, 1 skipped.) The 1 skip is `test_honesty_errors_includes_tamper_when_available`, which skips until #142 merges (and passes once it does — verified locally).

`test_dashboard_launch.py::test_maybe_launch_spawns_when_available` is the known environmentally-flaky #200 (a stray dashboard holding port 7878); it fails **identically on `origin/main`** in this environment:

```
$ cd /tmp/wt-131-main && python -m pytest core/tests/test_dashboard_launch.py -q
FAILED core/tests/test_dashboard_launch.py::test_maybe_launch_spawns_when_available
1 failed, 6 passed in 0.04s
```

`compileall`:
```
$ python -m compileall -q core/cap_evolve core/tests skills/algorithms/hill-climb
COMPILEALL_CLEAN
```

### Serial vs `--parallel 4` on `examples/toy_calc` with the `mock` optimizer

Same spec, same seed. `scripts/verify_issue_131.sh` (checked in) runs both and diffs:

```
== final.json diff (empty == identical headline + sealed test) ==
49c49
<     "seconds": 0.001146078109741211
---
>     "seconds": 0.0011320114135742188
99c99
<     "seconds": 0.0009980201721191406
---
>     "seconds": 0.0006232261657714844

== per-candidate val scores diff ==
IDENTICAL

== sealed test number ==
{"best_id":"cand_0001","test":1.0,"baseline":0.0,"delta":1.0}
{"best_id":"cand_0001","test":1.0,"baseline":0.0,"delta":1.0}

== test seal intact (scored exactly once) ==
serial:   test_used=true finalize_events=1
parallel: test_used=true finalize_events=1

== events.jsonl strictly parseable ==
serial:   15 lines, all parse
parallel: 17 lines, all parse

== cost accounting ==
EXACT   (both)

== no git worktree orphans ==
  no .git/worktrees dir   (both)
```

The **only** difference is the wall-clock `seconds` field. Every score, the best id, the accept sequence and the sealed test number are identical.

### A default run is unchanged vs `origin/main`

Same toy_calc run through `cap-evolve run` with **no `--parallel` flag**, on `origin/main` vs this branch:

```
splits.json:    IDENTICAL
report.md:      IDENTICAL
history.jsonl:  IDENTICAL
rejected.jsonl: IDENTICAL
candidates/:    IDENTICAL (recursive diff -r)
events.jsonl:   IDENTICAL (kinds + payloads, timestamps/wall-times stripped)
baseline.json:  differs ONLY in "seconds"
final.json:     differs ONLY in "seconds"
```

Full commands and untruncated output in the `## 🔬 Evidence` comment below.


