### PR TITLE
fix(spreadsheetbench): unblock sandbox output writes, and fail CI on crashed runs

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -357,6 +357,24 @@ jobs:
               await github.rest.issues.createComment({owner, repo, issue_number, body});
             }
 
+      # Completion gate — LAST, so metrics/UI/artifacts/PR-comment are all published
+      # before the job is allowed to go red. Without this the suite is green whenever
+      # `cap-evolve run` exits non-zero: run_suite.sh only emits an annotation, so a run
+      # that crashed mid-optimization and never produced a sealed test number still
+      # reports "success". Regression is NOT asserted here (see --allow-regression in
+      # assert_run.py) — real model rewards are noisy; this checks the run COMPLETED.
+      - name: Assert the suite run completed
+        if: always()
+        run: |
+          tasks="ci/benchmarks/${{ matrix.bench }}/${{ matrix.tier }}/tasks.json"
+          if [ ! -f "$tasks" ]; then
+            echo "no tasks.json for ${{ matrix.tier }}/${{ matrix.bench }} — nothing to assert"
+            exit 0
+          fi
+          run_dir="$GITHUB_WORKSPACE/ci/benchmarks/.work/suite_${{ matrix.tier }}_${{ matrix.bench }}_proj/.capevolve/run_suite"
+          "${CAPEVOLVE_PY:-python3}" ci/benchmarks/lib/assert_run.py "$run_dir" \
+            --min-iterations 1 --allow-regression
+
   # Collect each run's per-(run x bench) record onto the benchmark-history branch (single
   # writer → no push races) and regenerate benchmarks.json for the Pages history page.
   # Runs on a GitHub-hosted runner (JSON + git only; no VPC access needed).

--- a/ci/benchmarks/README.md
+++ b/ci/benchmarks/README.md
@@ -85,6 +85,16 @@ Runs come in two **tiers** (a first-class dimension in the workflow, same workfl
   via the env var / workflow input if the runner's Docker headroom can't take it — each
   container is ~8GB RAM / 2 CPU).
 
+  **`spreadsheetbench` runner prerequisites** (installed on `skillberry-1`):
+  - **LibreOffice** (`sudo dnf install libreoffice-calc`). Scoring uses it to recalculate
+    formula cells before comparing; without it a formula-only cell reads as empty and
+    never matches, so solved tasks silently score 0. The adapter warns rather than fails,
+    so treat `LibreOffice not found` in the log as a broken runner.
+  - **A data dir the sandbox can write to.** The executor image runs as uid 1000 while the
+    runner is uid 1004, so the adapter widens the mode of the output dirs it creates; see
+    `_make_container_writable` in the adapter. A `PermissionError` on `*_output.xlsx` in
+    the traces means that fix regressed.
+
 The tier surfaces everywhere: PR checks read **`<tier> / <bench>`** (e.g. `smoke / tau2`,
 `full / swebench`), the report header reads **`## <Tier> suite — <bench>`**, and the history page
 has a **Type** column + filter.

--- a/ci/benchmarks/lib/assert_run.py
+++ b/ci/benchmarks/lib/assert_run.py
@@ -1,12 +1,18 @@
 #!/usr/bin/env python3
 """Assert a cap-evolve run dir completed and did not regress on the sealed test.
 
-  assert_run.py <run_dir> [--min-iterations N]
+  assert_run.py <run_dir> [--min-iterations N] [--allow-regression]
 
 - completed: baseline.json + final.json present
 - iteration_ran: state.json spent.iterations >= N (default 1)
 - no_regression: final test reward >= baseline val reward
 Exit 0 on pass, 1 on failure (prints why).
+
+--allow-regression drops the no_regression check and asserts COMPLETION only. Use it
+where the reward is a real, noisy model measurement (the benchmarks suite): there,
+re-scoring the winner on the sealed test can land a hair under baseline through trial
+noise alone, and failing CI for that would be a false alarm. The completion checks are
+the ones that catch a genuinely broken run — a crashed step leaves no final.json.
 """
 from __future__ import annotations
 import json, sys
@@ -20,10 +26,12 @@ def main(argv: list[str]) -> int:
     min_it = 1
     if "--min-iterations" in argv:
         min_it = int(argv[argv.index("--min-iterations") + 1])
+    allow_regression = "--allow-regression" in argv
 
     for f in ("baseline.json", "final.json", "state.json"):
         if not (rd / f).exists():
-            print(f"FAIL: missing {f}"); return 1
+            print(f"FAIL: missing {f} — the run did not complete (a step crashed or was killed)")
+            return 1
 
     base = json.loads((rd / "baseline.json").read_text())["val"]["reward"]
     fin = json.loads((rd / "final.json").read_text())["test"]["reward"]
@@ -31,9 +39,12 @@ def main(argv: list[str]) -> int:
 
     if it < min_it:
         print(f"FAIL: only {it} optimizer iteration(s), need >= {min_it}"); return 1
-    if fin + 1e-9 < base:
+    if fin + 1e-9 < base and not allow_regression:
         print(f"FAIL: regression — test {fin} < baseline {base}"); return 1
-    print(f"OK: baseline={base} test={fin} iterations={it}")
+    note = ""
+    if fin + 1e-9 < base:
+        note = f" (test < baseline by {base - fin:.4f}; regression check waived)"
+    print(f"OK: baseline={base} test={fin} iterations={it}{note}")
     return 0
 
 

--- a/ci/benchmarks/lib/run_suite.sh
+++ b/ci/benchmarks/lib/run_suite.sh
@@ -185,9 +185,13 @@ cd "$WORK"
 "$PY" -m cap_evolve.cli check .capevolve/project >&2
 
 # ONE optimization: baseline (all tasks) + ITER optimize iterations + finalize (all tasks).
+# A non-zero exit is deliberately NOT fatal here: metrics/report/UI below still turn the
+# partial run dir into reviewable artifacts. The job is failed afterwards by the workflow's
+# "Assert the suite run completed" gate (ci/benchmarks/lib/assert_run.py), so a crashed run
+# cannot be mistaken for a clean one.
 "$PY" -m cap_evolve.cli run --spec .capevolve/project/capevolve.yaml \
       --project .capevolve/project --run-ts suite --max-iterations "$ITER" </dev/null || \
-  echo "::warning::suite run exited non-zero for $BENCH"
+  echo "::error::suite run exited non-zero for $BENCH — see the algorithm step's returncode/stderr above"
 RUN_DIR="$WORK/.capevolve/run_suite"
 
 # ---- metrics + report (per-task base→opt from the ONE run) -----------------

--- a/core/cap_evolve/cli.py
+++ b/core/cap_evolve/cli.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import json
 import os
+import signal
 import sys
 from pathlib import Path
 
@@ -92,6 +93,32 @@ def _resolve_skills(skills_dir: Path) -> dict:
         raise FileNotFoundError(
             "no manifest — run install.sh or skills/_registry/build_manifest.py first")
     return json.loads(manifest.read_text()).get("skills", {})
+
+
+def _step_failure(step: str, proc) -> dict:
+    """Build the failure record for a step that exited non-zero.
+
+    Steps run under ``capture_output``, so this record is the ONLY evidence of what
+    happened. A stderr tail alone is not enough: when a step is killed by a signal
+    (the OOM killer, most often) it leaves no Python traceback at all, so the tail is
+    whatever harmless warnings happened to be last and the record reads as if nothing
+    went wrong. The returncode — and, for a signal, its name — is what distinguishes
+    "raised" from "was killed".
+    """
+    rec: dict = {"step": step, "returncode": proc.returncode}
+    if proc.returncode < 0:
+        try:
+            rec["signal"] = signal.Signals(-proc.returncode).name
+        except ValueError:
+            rec["signal"] = f"signal {-proc.returncode}"
+        rec["hint"] = (
+            f"{step} was killed by a signal, not a Python exception — there is no "
+            "traceback to find. SIGKILL is usually the OOM killer; check dmesg/journalctl -k."
+        )
+    rec["error"] = proc.stderr[-8000:] if proc.stderr else ""
+    if proc.stdout:
+        rec["stdout_tail"] = proc.stdout[-2000:]
+    return rec
 
 
 def _cmd_run(argv):
@@ -408,7 +435,7 @@ def _cmd_run(argv):
         alg_cmd += _shlex.split(str(spec["algorithm_args"]))
     proc = run(alg_cmd)
     if proc.returncode != 0:
-        print(json.dumps({"step": "algorithm", "error": proc.stderr[-1500:]}))
+        print(json.dumps(_step_failure("algorithm", proc)))
         return 1
 
     # 3) finalize  4) report
@@ -431,7 +458,7 @@ def _cmd_run(argv):
         cmd += extra
         proc = run(cmd)
         if proc.returncode != 0:
-            print(json.dumps({"step": step, "error": proc.stderr[-1500:]}))
+            print(json.dumps(_step_failure(step, proc)))
             return 1
         last = proc.stdout
 

--- a/templates/adapters/spreadsheetbench/adapter.py
+++ b/templates/adapters/spreadsheetbench/adapter.py
@@ -62,6 +62,13 @@ NOTE ON SCORING:
   Jupyter Kernel Gateway container per task, all bind-mounting the same dataset dir at
   /mnt/data). Ensure Docker is running and has enough headroom for
   SPREADSHEETBENCH_CONCURRENCY containers (8GB RAM / 2 CPU each) at once.
+
+  The executor image runs as uid 1000, so unless SPREADSHEETBENCH_DATA_DIR happens to be
+  owned by uid 1000 the container can read the inputs but not create the output file.
+  The adapter widens the mode of the outputs dirs it creates to compensate (see
+  _make_container_writable); if a write is still denied, the rollout is reported as an
+  infrastructure error rather than as a zero-reward miss, so the optimizer is not sent
+  chasing a mount problem it cannot fix from the prompt.
 """
 
 from __future__ import annotations
@@ -329,6 +336,89 @@ def _sanitize_conv_id(s: str) -> str:
     return out if out and out[0].isalnum() else f"t{out}"
 
 
+def _make_container_writable(p: Path, *, sticky: bool = False) -> None:
+    """Widen a bind-mounted dir so the sandbox container can create files in it.
+
+    The executor image (docker.io/xingyaoww/codeact-executor) runs as a FIXED uid
+    (1000), which is generally NOT the uid running this adapter. A dir we create here
+    is owned by our uid at mode 0755, so the container gets r-x: it can READ the input
+    workbooks but cannot create the output file, and every rollout dies with
+    `PermissionError: [Errno 13] ... <n>_<id>_output.xlsx` and scores 0. Widening the
+    mode is the least invasive fix — running the container as our uid instead breaks
+    the image's own jupyter HOME.
+
+    `sticky` (0o1777, as on /tmp) is for the shared outputs root, where many
+    concurrent rollouts write side by side: it lets each create its own subdir while
+    preventing one from deleting another's. Best-effort — if we do not own a
+    pre-existing dir the chmod fails, and the write itself then surfaces the real
+    error instead of this being silently papered over.
+    """
+    try:
+        os.chmod(p, 0o1777 if sticky else 0o777)
+    except OSError:
+        pass
+
+
+_FENCE_RE = re.compile(r"```[a-zA-Z0-9_+-]*[ \t]*\r?\n(.*?)```", re.DOTALL)
+
+_NO_CODE_REMINDER = (
+    "No python code block was found in your reply, so NOTHING was executed and the "
+    "round was wasted. Reply with exactly ONE ```python fenced code block containing "
+    "runnable code, with no prose or XML outside the block."
+)
+
+
+def _extract_python(vendor, response: str) -> str | None:
+    """Extract the fenced python block, or None when the reply contains no code fence.
+
+    The vendored `extract_code` falls back to the RAW response when there is no
+    ```python fence, so a reply that is prose — or a literal `<function_calls>` block,
+    which some models emit — gets sent to the Jupyter kernel verbatim and burns a
+    round on `SyntaxError: invalid syntax`. Returning None lets the caller re-state the
+    contract instead of spending the round.
+    """
+    if "```python" in response:
+        # Delegate so fenced replies stay byte-identical to upstream's behaviour.
+        return vendor["extract_code"](response)
+    m = _FENCE_RE.search(response)
+    return m.group(1).rstrip("\n") if m else None
+
+
+def _cleanup_output_dir(rollout) -> None:
+    """Drop a rollout's per-rollout output dir once nothing more will read it.
+
+    Without this a full run (912 tasks × trials × iterations) accumulates thousands of
+    per-rollout dirs inside SPREADSHEETBENCH_DATA_DIR. Safe on every path: the dir is
+    owned by us (we created it), so rmtree succeeds even though the files inside were
+    written by the container's uid.
+    """
+    run_tag = (getattr(rollout, "metadata", None) or {}).get("run_tag")
+    if not run_tag:
+        return
+    try:
+        shutil.rmtree(_data_dir() / "outputs" / run_tag, ignore_errors=True)
+    except RuntimeError:
+        pass  # _data_dir() unset — nothing was created, nothing to clean
+
+
+def _output_write_blocked(exec_results: list[str], container_out_dir: str) -> str | None:
+    """Return the offending line if the sandbox was denied writes to the output dir.
+
+    A PermissionError/OSError on output_path is an INFRASTRUCTURE fault (the bind mount
+    is not writable by the container's uid — see _make_container_writable), not a defect
+    in the prompt under optimization. Reporting it as a plain zero-reward miss sends the
+    optimizer chasing an unfixable wall; surfacing it as a rollout error routes it
+    through score()'s "do not optimize against it" path instead.
+    """
+    for res in reversed(exec_results):
+        if "PermissionError" not in res and "OSError" not in res:
+            continue
+        for line in res.splitlines():
+            if ("PermissionError" in line or "OSError" in line) and container_out_dir in line:
+                return line.strip()
+    return None
+
+
 # ---------------------------------------------------------------------------
 # Prompting
 # ---------------------------------------------------------------------------
@@ -422,8 +512,15 @@ class Adapter(CapabilityAdapter):
             local_dir = data_dir / "spreadsheet" / sid
             container_dir = f"/mnt/data/spreadsheet/{sid}"
             container_out_dir = f"/mnt/data/outputs/{run_tag}"
-            host_out_dir = data_dir / "outputs" / run_tag
+            outputs_root = data_dir / "outputs"
+            host_out_dir = outputs_root / run_tag
+            # Both levels must be writable by the container's uid, not just the leaf:
+            # the generated code typically re-mkdir's the leaf, which needs write on the
+            # parent too.
+            outputs_root.mkdir(parents=True, exist_ok=True)
+            _make_container_writable(outputs_root, sticky=True)
             host_out_dir.mkdir(parents=True, exist_ok=True)
+            _make_container_writable(host_out_dir)
 
             input_file = _resolve_case_file(local_dir, 1, sid, "input")
             preview = _spreadsheet_preview(input_file, PREVIEW_ROWS)
@@ -441,7 +538,10 @@ class Adapter(CapabilityAdapter):
                 sandbox = _get_sandbox()
                 client = sandbox.client_for(conv_id)
             except Exception as e:  # noqa: BLE001
-                return Rollout(task_id=task.id, error=f"sandbox startup failed: {e}")
+                return Rollout(
+                    task_id=task.id, error=f"sandbox startup failed: {e}",
+                    metadata={"run_tag": run_tag},
+                )
 
             system_prompt = _read_system_prompt(ctx)
             messages = [
@@ -451,7 +551,8 @@ class Adapter(CapabilityAdapter):
 
             cost = 0.0
             tokens = 0
-            last_code = ""
+            last_code = ""  # last code actually EXECUTED (what cases 2/3 replay)
+            exec_results: list[str] = []
             case1_path = host_out_dir / f"1_{sid}_output.xlsx"
 
             import litellm
@@ -465,7 +566,10 @@ class Adapter(CapabilityAdapter):
                         **model_config.llm_kwargs(),
                     )
                 except Exception as e:  # noqa: BLE001
-                    return Rollout(task_id=task.id, error=f"LLM call failed: {e}", cost_usd=cost, tokens=tokens)
+                    return Rollout(
+                        task_id=task.id, error=f"LLM call failed: {e}", cost_usd=cost,
+                        tokens=tokens, metadata={"run_tag": run_tag},
+                    )
 
                 cost += float(getattr(response, "_hidden_params", {}).get("response_cost", 0) or 0)
                 usage = getattr(response, "usage", None)
@@ -473,7 +577,14 @@ class Adapter(CapabilityAdapter):
 
                 assistant_text = response.choices[0].message.content or ""
                 messages.append({"role": "assistant", "content": assistant_text})
-                last_code = vendor["extract_code"](assistant_text)
+
+                code = _extract_python(vendor, assistant_text)
+                if code is None or not code.strip():
+                    # Nothing runnable in the reply — re-state the contract rather than
+                    # feeding prose to the kernel for a guaranteed SyntaxError.
+                    messages.append({"role": "user", "content": _NO_CODE_REMINDER})
+                    continue
+                last_code = code
 
                 try:
                     exec_result = vendor["exec_code"](client, last_code)
@@ -483,14 +594,33 @@ class Adapter(CapabilityAdapter):
                     # exec_code's own traceback handling) — infrastructure, not fixable by
                     # the prompt.
                     return Rollout(
-                        task_id=task.id, error=f"sandbox exec failed: {e}", cost_usd=cost, tokens=tokens
+                        task_id=task.id, error=f"sandbox exec failed: {e}", cost_usd=cost,
+                        tokens=tokens, metadata={"run_tag": run_tag},
                     )
 
+                exec_results.append(exec_result)
                 messages.append({"role": "user", "content": exec_result})
                 if case1_path.exists():
                     break
 
-            if case1_path.exists():
+            if not case1_path.exists():
+                blocked = _output_write_blocked(exec_results, container_out_dir)
+                if blocked:
+                    return Rollout(
+                        task_id=task.id,
+                        output=last_code,
+                        trace=messages,
+                        cost_usd=cost,
+                        tokens=tokens,
+                        error=(
+                            f"sandbox denied writes to the bind-mounted output dir "
+                            f"{container_out_dir} ({blocked}) — the host dir is not "
+                            f"writable by the container's uid; see _make_container_writable"
+                        ),
+                        metadata={"run_tag": run_tag, "id": sid, "model": model_config.MODEL, "seed": seed},
+                    )
+            else:
+                # Case 1 solved — replay the SAME code onto cases 2 and 3 (no new LLM calls).
                 for idx in (2, 3):
                     case_input = _resolve_case_file(local_dir, idx, sid, "input")
                     solution = last_code.replace(input_file.name, case_input.name)
@@ -515,6 +645,10 @@ class Adapter(CapabilityAdapter):
 
     def score(self, task: Task, rollout: Rollout) -> Score:
         if rollout.error:
+            # Errored rollouts leave their output dir behind too — clean it up on this
+            # path as well, or a long run accumulates one stale dir per failed rollout
+            # inside SPREADSHEETBENCH_DATA_DIR.
+            _cleanup_output_dir(rollout)
             return Score(
                 task_id=task.id,
                 reward=0.0,
@@ -526,6 +660,7 @@ class Adapter(CapabilityAdapter):
 
         entry = _entries_by_id().get(task.id)
         if entry is None:
+            _cleanup_output_dir(rollout)
             return Score(task_id=task.id, reward=0.0, feedback="Unknown task id.")
 
         meta = rollout.metadata or {}
@@ -574,11 +709,8 @@ class Adapter(CapabilityAdapter):
         hard = 1.0 if all(test_results) else 0.0
         feedback = _build_feedback(entry, test_results, missing, mismatched, bool(libre))
 
-        # Clean up the per-rollout output dir now that scoring has consumed all outputs.
-        # Without this, a full run (912 tasks × iterations) would accumulate thousands of
-        # per-task output dirs inside SPREADSHEETBENCH_DATA_DIR.
-        out_dir = data_dir / "outputs" / run_tag
-        shutil.rmtree(out_dir, ignore_errors=True)
+        # Scoring has consumed every output; drop the per-rollout dir.
+        _cleanup_output_dir(rollout)
 
         return Score(
             task_id=task.id,
@@ -649,3 +781,61 @@ if __name__ == "__main__":
 
         assert _resolve_case_file(_d, 4, "1000", "input") == _d / "4_1000_input.xlsx"  # missing → canonical fallback
     print("spreadsheetbench case-file resolver self-check: OK")
+
+    # Code extraction: a fenced block runs; prose / tool-call XML must NOT be executed.
+    _vendor_stub = {"extract_code": lambda r: r[r.find("```python") + 9:].split("```")[0].strip("\n")}
+    assert _extract_python(_vendor_stub, "sure!\n```python\nwb.save(p)\n```\ndone") == "wb.save(p)"
+    assert _extract_python(_vendor_stub, "```\nwb.save(p)\n```") == "wb.save(p)"
+    assert _extract_python(_vendor_stub, "```py\nwb.save(p)\n```") == "wb.save(p)"
+    assert _extract_python(_vendor_stub, "I'll start by examining the spreadsheet.") is None
+    assert _extract_python(_vendor_stub, "<function_calls>\n<invoke>x</invoke>") is None
+    assert _extract_python(_vendor_stub, "") is None
+    print("spreadsheetbench code-extraction self-check: OK")
+
+    # Denied output-dir writes are infra, and must be told apart from other errors.
+    _out = "/mnt/data/outputs/160-6_0_dead"
+    _perm = (
+        "PermissionError                        Traceback (most recent call last)\n"
+        "Cell In[1], line 76\n"
+        "---> 76 wb.save(output_path)\n"
+        f"PermissionError: [Errno 13] Permission denied: '{_out}/1_160-6_output.xlsx'"
+    )
+    assert _output_write_blocked([_perm], _out) is not None
+    assert _output_write_blocked(["ok", _perm], _out) is not None
+    assert _output_write_blocked([_perm], "/mnt/data/outputs/other_tag") is None  # different rollout's dir
+    assert _output_write_blocked(["NameError: name 'wb' is not defined"], _out) is None
+    assert _output_write_blocked([], _out) is None
+    print("spreadsheetbench output-write-blocked self-check: OK")
+
+    with _tempfile.TemporaryDirectory() as _td:
+        _p = Path(_td) / "outputs"
+        _p.mkdir()
+        _make_container_writable(_p, sticky=True)
+        assert (_p.stat().st_mode & 0o1777) == 0o1777
+        _leaf = _p / "tag"
+        _leaf.mkdir()
+        _make_container_writable(_leaf)
+        assert (_leaf.stat().st_mode & 0o777) == 0o777
+        _make_container_writable(Path(_td) / "does-not-exist")  # best-effort, must not raise
+    print("spreadsheetbench container-writable self-check: OK")
+
+    class _FakeRollout:
+        def __init__(self, metadata):
+            self.metadata = metadata
+
+    with _tempfile.TemporaryDirectory() as _td:
+        _saved = DATA_DIR
+        try:
+            DATA_DIR = _td  # module global — this is what _data_dir() reads
+            (Path(_td) / "dataset.json").write_text("[]", encoding="utf-8")
+            _tag_dir = Path(_td) / "outputs" / "160-6_0_dead"
+            _tag_dir.mkdir(parents=True)
+            (_tag_dir / "1_160-6_output.xlsx").write_bytes(b"")
+            _cleanup_output_dir(_FakeRollout({"run_tag": "160-6_0_dead"}))
+            assert not _tag_dir.exists(), "output dir should be removed after scoring"
+            _cleanup_output_dir(_FakeRollout({}))            # no run_tag → no-op
+            _cleanup_output_dir(_FakeRollout(None))          # no metadata at all → no-op
+            _cleanup_output_dir(_FakeRollout({"run_tag": "never-created"}))  # already gone
+        finally:
+            DATA_DIR = _saved
+    print("spreadsheetbench output-cleanup self-check: OK")

--- a/templates/adapters/spreadsheetbench/adapter.py
+++ b/templates/adapters/spreadsheetbench/adapter.py
@@ -17,9 +17,14 @@ SETUP:
 
   3. Install Docker (required — each task runs in its own sandboxed container) and,
      for accurate scoring of formula-bearing outputs, LibreOffice:
-       sudo apt install libreoffice-calc   # Linux
+       sudo apt install libreoffice-calc   # Debian/Ubuntu
+       sudo dnf install libreoffice-calc   # RHEL/Fedora
        brew install --cask libreoffice     # macOS
-     Scoring degrades gracefully (skips recalculation) if LibreOffice is absent.
+     Scoring degrades gracefully (skips recalculation) if LibreOffice is absent — but
+     silently: a formula-only cell then reads as empty and never matches, so a task the
+     agent actually solved scores 0. Treat the "LibreOffice not found" warning as a
+     setup error, not a nicety. Upstream's docstring asks for 7.5+; RHEL 9's 7.1.8.1
+     recalculates correctly through `--convert-to xlsx` and is verified in use.
 
   4. Install adapter deps: pip install pandas openpyxl docker tornado requests
 


### PR DESCRIPTION
## Why

[Run 30520700500](https://github.com/skillberry-ai/cap-evolve/actions/runs/30520700500) (`smoke / spreadsheetbench`) reported **success** while producing no valid result: 53 minutes and **~$14.5** for baseline `0.000`, one rejected candidate at `0.000`, and no sealed test number. Four independent faults were stacked on top of each other.

## 1. The sandbox could not write its output file — the actual killer

**37 of the 41** non-infra rollouts died on:

```
PermissionError: [Errno 13] Permission denied: '/mnt/data/outputs/160-6_0_d817132f/1_160-6_output.xlsx'
```

The executor image runs as **uid 1000**; the runner is **uid 1004** and the bind-mounted output dir was created at mode `0755` owned by 1004. The container fell through to `other` (`r-x`) — it could *read* the input workbooks but not *create* the output. The scorer then reported `produced NO output file` for all three test cases, and every task scored 0.

Confirmed on the runner:
```
uid=1004(skillberry) gid=100(users) …
drwxr-xr-x. 4 1004 100 … /home/skillberry/.cache/capevolve-ci/spreadsheetbench-data/sample_data_200
```

`_make_container_writable()` now widens the mode of the output dirs the adapter creates — sticky `1777` on the shared root so concurrent rollouts cannot delete each other's work, `777` on each per-rollout dir. Reproduced against the real `xingyaoww/codeact-executor` image with a uid mismatch and confirmed fixed:

```
BEFORE: PermissionError: [Errno 13] Permission denied: '/mnt/data/outputs/tag_a/1_x_output.xlsx'
AFTER:  WROTE ok -> ['1_x_output.xlsx']   +  mkdir on parent ok
```

Also verified the host side still works — `score()` reads the container-owned file back and `rmtree`s it — and that the sticky bit blocks cross-rollout deletion.

## 2. A denied write is infra, not a zero-reward miss

Reporting it as a plain 0 sent the optimizer chasing a mount bug it cannot fix from a prompt. It spent **two iterations and ~$4.5** on save-retry prose, and concluded in its own journal: *"the mount is read-only and these 8 tasks are genuine infra, un-fixable by prompt."* It was right.

`_output_write_blocked()` now routes these through `score()`'s existing *"infrastructure error, do not optimize against it"* path. Validated against that run's **real traces**: it flags exactly the 37 rollouts that hit the wall and none of the others.

## 3. `extract_code` executed prose as Python

The vendored helper falls back to the **raw response** when there is no ` ```python ` fence, so replies containing prose or a literal `<function_calls>` block went to the Jupyter kernel verbatim:

```
Cell In[1], line 1
    <function_calls>
    ^
SyntaxError: invalid syntax
```

This alone consumed all 5 rounds of 4 rollouts. Unfenced replies are no longer executed; the contract is re-stated instead. Fenced replies still go through the vendored path unchanged — verified byte-identical against the real `code_exec.extract_code`.

## 4. CI was green on a failed run, and the failure was undiagnosable

The recorded error for the crash was **five harmless openpyxl warnings**:

```json
{"step": "algorithm", "error": "…UserWarning: Data Validation extension is not supported…"}
```

`cap-evolve run` printed only `stderr[-1500:]` and dropped the returncode. The step had been killed with no Python traceback, so the tail was whatever happened to be last. `_step_failure()` now records the returncode and, for a signal death, its name plus an OOM hint — so the next occurrence says what happened.

`benchmarks.yml` also never ran the completion gate that `integration-tests.yml` uses. It now runs as the **last** step, so artifacts/UI/PR-comment still publish before the job goes red. It asserts **completion only** (new `--allow-regression`): real model rewards are noisy and a hair of trial noise on the sealed test is not a CI failure, but a missing `final.json` is. Verified against that run's exact run-dir shape:

```
crashed run (state.json + baseline.json, no final.json) → FAIL exit=1
complete run                                           → OK   exit=0
noise regression, benchmarks gate                      → OK   (waived)
noise regression, integration gate (unchanged)         → FAIL exit=1
```

Also fixes a pre-existing leak: errored rollouts skipped the output-dir cleanup, which change 2 would have turned into thousands of stale dirs inside `SPREADSHEETBENCH_DATA_DIR` on a full 912-task run.

## Runner-side (not code)

**LibreOffice installed on `skillberry-1`** (`dnf install libreoffice-calc`, 7.1.8.1 from RHEL 9 AppStream). Upstream asks for 7.5+, so recalculation was verified end-to-end rather than assumed:

```
before recalc: A3=None B1=None   (formula-only, unscoreable)
after recalc:  A3=5    B1=50     → RECALC WORKS
```

`find_libreoffice()` resolves `/usr/bin/soffice` under the exact PATH the runner service uses. Both prerequisites are now documented in `ci/benchmarks/README.md` with the symptom to grep for when either regresses.

## Verification

- adapter offline self-checks — 7 groups, 4 new (code extraction, write-blocked classification, dir modes, cleanup)
- `core/tests` — **179 passed**
- `ci/benchmarks/lib` — **11 passed**
- `actionlint` — clean; the one `github.head_ref` finding is pre-existing (diffed against the unmodified file)
- `bash -n` on `run_suite.sh` — clean

## Still open

The iteration-2 crash cause is not yet proven. Change 4 makes the next run report it directly; OOM is the leading suspect (concurrent containers at 8GB `mem_limit` each, plus in-process workbook scoring). Worth a `smoke / spreadsheetbench` re-run to confirm the whole chain now yields a real, non-zero score.

🤖 Generated with [Claude Code](https://claude.com/claude-code)