### PR TITLE
Reconcile results across README / docs/RESULTS.md / site: make RESULTS.md the superset, publish the 87-task runs everywhere, remove 8 unsubstantiated numbers

### DIFF
--- a/core/tests/test_published_results_consistency.py
+++ b/core/tests/test_published_results_consistency.py
@@ -11,10 +11,22 @@ canonical doc. This guard enforces exactly that, by anchor id — which is the i
 acceptance criterion ("every `site/results.html` run anchor maps to a `RESULTS.md`
 section").
 
-Anchor ids, not numbers: a numeric scrape over HTML cannot tell a reward from an SVG
-coordinate or an external paper's figure without a growing allowlist of exceptions, and a
-guard whose allowlist keeps growing stops guarding. Section identity is the invariant that
-actually broke, so that is what is pinned.
+Section identity is pinned in **both** directions (a doc-only section is exactly the #236
+divergence this PR fixes), and numbers are pinned by a scrape *confined to declared results
+tables*: `<td class="num">` / `<td class="gain">` inside a `<section>` whose `<h2 id>` is in
+the mapping below, matched row-by-row against the same-labelled `docs/RESULTS.md` table row.
+
+That scope is what makes it allowlist-free. A *whole-file* numeric scrape cannot tell a
+reward from a font weight (`site/results.html:23` `wght@400;500;600;700;800`), an arXiv id
+(`2603.04900`), an external paper's figure, or an SVG path coordinate — it needs an
+allowlist entry per exception, and a guard whose allowlist keeps growing stops guarding.
+Inside a results `<td class="num">` none of those live, so the confined scrape needs
+**zero** allowlist entries (see `test_site_results_numbers_match_the_canonical_doc`).
+
+Known limits, stated rather than implied: only `site/results.html` is read, so a *new*
+surface or a *new* results page publishing runs is not covered, and evidence-marker (⚠️)
+parity between the surfaces is not enforced. Those are section-registration problems; this
+guard covers the surface #100 was filed about.
 
 The mapping is written out explicitly rather than derived from `<a id="...">` markers,
 because those markers are introduced by a sibling honesty PR (#182 / issue #99) — deriving
@@ -45,9 +57,59 @@ ANCHOR_TO_CANON_HEADING = {
     "at-a-glance": None,
 }
 
+# docs/RESULTS.md `## ` headings that deliberately have no site section, with the reason.
+# Empty today: every canonical run is published. Add here (never silently) if that changes.
+SITE_OPTIONAL: dict[str, str] = {}
+
 
 def _read(rel: str) -> str:
     return (REPO / rel).read_text(encoding="utf-8")
+
+
+def _text(html: str) -> str:
+    """Tag-stripped, entity-decoded, whitespace- and emphasis-normalised cell text."""
+    out = re.sub(r"<[^>]+>", " ", html)
+    for ent, ch in (("&nbsp;", " "), ("&amp;", "&"), ("&lt;", "<"), ("&gt;", ">"),
+                    ("&middot;", "·")):
+        out = out.replace(ent, ch)
+    return re.sub(r"\s+", " ", re.sub(r"[*`\\]", "", out)).strip()
+
+
+def _numbers(cell: str) -> frozenset:
+    """Numbers in a cell, dropping percent restatements of a value already present.
+
+    The site writes `0.536 (53.6%)` where the doc writes `0.536`; the doc's own rule is to
+    label percentages explicitly, so `53.6` alongside `0.536` is the same number twice.
+    """
+    vals = [float(n) for n in re.findall(r"\d+(?:\.\d+)?", _text(cell))]
+    return frozenset(v for v in vals if not any(abs(v - 100 * o) < 1e-9 for o in vals))
+
+
+def _site_sections() -> dict[str, str]:
+    parts = re.split(r'<h2 id="([^"]+)"', _read("site/results.html"))
+    return dict(zip(parts[1::2], parts[2::2]))
+
+
+def _doc_sections() -> dict[str, str]:
+    doc = _read("docs/RESULTS.md")
+    out = {}
+    for m in re.finditer(r"^## (.+)$", doc, re.M):
+        end = doc.find("\n## ", m.end())
+        out[m.group(1)] = doc[m.end(): end if end != -1 else len(doc)]
+    return out
+
+
+def _doc_table_rows(section: str) -> list[list[str]]:
+    rows = []
+    for line in section.splitlines():
+        line = line.strip()
+        if not (line.startswith("|") and line.endswith("|")):
+            continue
+        cells = line.strip("|").split("|")
+        if all(set(_text(c)) <= set("-: ") for c in cells):  # markdown separator row
+            continue
+        rows.append(cells)
+    return rows
 
 
 def test_every_site_results_run_section_exists_in_the_canonical_doc():
@@ -70,6 +132,76 @@ def test_every_site_results_run_section_exists_in_the_canonical_doc():
     assert not missing, (
         f"site/results.html publishes run section(s) whose docs/RESULTS.md heading is "
         f"gone or renamed: {missing}\nHeadings present: {headings}"
+    )
+
+
+def test_every_canonical_run_section_is_published_on_the_site():
+    """The reverse direction — the one that actually broke in #236.
+
+    #236 added a `docs/RESULTS.md` section the site never got. Checking site → doc alone
+    pins the *original* #100 direction and lets the *current* one reopen silently.
+    """
+    site_anchors = set(_site_sections())
+    published = {v for k, v in ANCHOR_TO_CANON_HEADING.items() if v and k in site_anchors}
+    unpublished = [
+        h for h in _doc_sections()
+        if h not in SITE_OPTIONAL and not any(c in h for c in published)
+    ]
+    assert not unpublished, (
+        f"docs/RESULTS.md section(s) with no site/results.html section: {unpublished}\n"
+        "Add the site section (with its split label and evidence marker), or add the "
+        "heading to SITE_OPTIONAL with a reason."
+    )
+
+
+def test_site_results_numbers_match_the_canonical_doc():
+    """Every number in a mapped site results table equals the canonical doc's.
+
+    Confined to `<td class="num">` / `<td class="gain">` inside mapped sections, matched to
+    the `docs/RESULTS.md` row with the same label and the same column count — so a number
+    edited in place, or a split label falsified, fails. No allowlist: fonts, arXiv ids and
+    SVG coordinates are all outside a results `<td>`.
+    """
+    doc_sections = _doc_sections()
+    problems = []
+    for anchor, body in _site_sections().items():
+        canon = ANCHOR_TO_CANON_HEADING.get(anchor)
+        if not canon:
+            continue
+        doc_rows = next(
+            (_doc_table_rows(v) for k, v in doc_sections.items() if canon in k), None
+        )
+        if doc_rows is None:  # missing heading: test 1's assertion, reported there
+            continue
+        for row in re.findall(r"<tr>(.*?)</tr>", body, re.S):
+            cells = re.findall(r"(<t[dh][^>]*>)(.*?)</t[dh]>", row, re.S)
+            cols = [i for i, (tag, _) in enumerate(cells)
+                    if 'class="num"' in tag or 'class="gain"' in tag]
+            if not cols:
+                continue
+            label = _text(cells[0][1])
+            want = [_numbers(cells[i][1]) for i in cols]
+            same_label = [
+                r for r in doc_rows
+                if re.sub(r"\s+", "", _text(r[0])) == re.sub(r"\s+", "", label)
+                and len(r) == len(cells)
+            ]
+            if not same_label:
+                problems.append(
+                    f"{anchor}: no docs/RESULTS.md table row labelled {label!r} "
+                    f"({len(cells)} columns) — split label falsified, or the row is "
+                    "published on the site only"
+                )
+            elif not any([_numbers(r[i]) for i in cols] == want for r in same_label):
+                problems.append(
+                    f"{anchor}: row {label!r} publishes {[sorted(w) for w in want]}, "
+                    f"docs/RESULTS.md says "
+                    f"{[[sorted(_numbers(r[i])) for i in cols] for r in same_label]}"
+                )
+    assert not problems, (
+        "site/results.html results tables disagree with docs/RESULTS.md:\n  "
+        + "\n  ".join(problems)
+        + "\ndocs/RESULTS.md is the superset — fix the value there first, then the site."
     )
 
 

--- a/core/tests/test_published_results_consistency.py
+++ b/core/tests/test_published_results_consistency.py
@@ -1,0 +1,106 @@
+"""Every `site/results.html` run section maps to a `docs/RESULTS.md` section.
+
+Issue #100: the surfaces had diverged and the source-of-truth relationship was
+*inverted* — `site/results.html` published two Qwen 2.5 14B runs (`#qwen-tools`,
+`#qwen-all`) that `docs/RESULTS.md` did not contain, while `site/README.md` told readers
+to "cross-check against `docs/RESULTS.md`". The canonical doc was a subset of the site.
+
+The rule (stated in the preamble of `docs/RESULTS.md`): **`docs/RESULTS.md` is the
+superset.** A run may be published on a site page only if it already has a section in the
+canonical doc. This guard enforces exactly that, by anchor id — which is the issue's own
+acceptance criterion ("every `site/results.html` run anchor maps to a `RESULTS.md`
+section").
+
+Anchor ids, not numbers: a numeric scrape over HTML cannot tell a reward from an SVG
+coordinate or an external paper's figure without a growing allowlist of exceptions, and a
+guard whose allowlist keeps growing stops guarding. Section identity is the invariant that
+actually broke, so that is what is pinned.
+
+The mapping is written out explicitly rather than derived from `<a id="...">` markers,
+because those markers are introduced by a sibling honesty PR (#182 / issue #99) — deriving
+from them would make this guard's result depend on merge order. An explicit table also
+fails loudly on a *renamed* section, which a set-difference would silently accept.
+
+TO ADD A RUN TO THE SITE: add its `docs/RESULTS.md` section first, then its
+`site/results.html` section, then a row here. That ordering is the fix.
+"""
+
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+
+# site/results.html <h2 id>  ->  a substring that must appear in a docs/RESULTS.md `## ` heading.
+# One row per PUBLISHED RUN. `None` marks a non-run section (presentation scaffolding).
+ANCHOR_TO_CANON_HEADING = {
+    "toy-calc": "toy_calc",
+    "tau2-fit": "no-holdout fit-metric run",
+    "tau2-heldout": "held-out 30(=val)/20 run",
+    "tau2-agent": "agent orchestration mode",
+    "qwen-tools": "Qwen 2.5 14B (tools only",
+    "qwen-all": "Qwen 2.5 14B, all capabilities",
+    "skillsbench-87-baselines": "full 87-task baselines",
+    "skillsbench-87": "full 87-task optimization",
+    "skillsbench": "skill-package optimization",
+    "at-a-glance": None,
+}
+
+
+def _read(rel: str) -> str:
+    return (REPO / rel).read_text(encoding="utf-8")
+
+
+def test_every_site_results_run_section_exists_in_the_canonical_doc():
+    site_anchors = re.findall(r'<h2 id="([^"]+)"', _read("site/results.html"))
+    assert site_anchors, "no <h2 id=...> run sections found — the site page changed shape"
+
+    unmapped = [a for a in site_anchors if a not in ANCHOR_TO_CANON_HEADING]
+    assert not unmapped, (
+        f"site/results.html section(s) with no canonical mapping: {unmapped}\n"
+        "docs/RESULTS.md is the superset — add the section there (with its split label "
+        "and evidence marker) first, then add a row to ANCHOR_TO_CANON_HEADING."
+    )
+
+    headings = re.findall(r"^## (.+)$", _read("docs/RESULTS.md"), re.M)
+    missing = {
+        a: ANCHOR_TO_CANON_HEADING[a] for a in site_anchors
+        if ANCHOR_TO_CANON_HEADING[a]
+        and not any(ANCHOR_TO_CANON_HEADING[a] in h for h in headings)
+    }
+    assert not missing, (
+        f"site/results.html publishes run section(s) whose docs/RESULTS.md heading is "
+        f"gone or renamed: {missing}\nHeadings present: {headings}"
+    )
+
+
+def test_site_results_toc_matches_its_sections():
+    """The on-page TOC lists exactly the sections that exist (no dead/absent entries)."""
+    site = _read("site/results.html")
+    sections = re.findall(r'<h2 id="([^"]+)"', site)
+    toc_block = site.split('<nav class="toc"', 1)[1]
+    toc = re.findall(r'<a href="#([^"]+)"', toc_block)
+    assert toc == sections, (
+        f"results.html TOC and section order disagree.\nTOC:      {toc}\n"
+        f"Sections: {sections}"
+    )
+
+
+def test_no_blanket_artifact_claim_on_the_surfaces_this_guard_owns():
+    """No aggregate "all our numbers are verified" claim.
+
+    Not every published number is artifact-backed (the τ²-bench held-out runs and both
+    SkillsBench 87-task runs are reported-only), and an aggregate claim rots the moment a
+    run is added — so evidence is stamped per section instead. Scoped to the surfaces
+    reconciled under #100; `README.md`, `site/index.html`, `site/results.html`'s lead and
+    `presentation/`'s slide-6 copy are #99/#182's to rewrite.
+    """
+    banned = re.compile(r"hand-verified|cross-check against|every result is committed", re.I)
+    hits = {}
+    for rel in ("site/README.md", "site/benchmarks.html"):
+        for i, line in enumerate(_read(rel).splitlines(), 1):
+            if banned.search(line):
+                hits.setdefault(rel, []).append(f"{i}: {line.strip()[:120]}")
+    assert not hits, (
+        f"blanket verification claim(s) still present: {hits}\n"
+        "Point at the per-section evidence markers instead of asserting an average."
+    )

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -58,7 +58,7 @@ claims.
 | **EvoTool** (arXiv:2603.04900) | **original τ-Bench** airline, GPT-4.1 | ReAct 35.9 → **39.1** (+3.2) | **~+8.9%** |
 | **EvoTool** | original τ-Bench airline, Qwen3-8B | ReAct 14.4 → **15.7** (+1.3) | **~+9.0%** |
 | Evolutionary Context Search | τ²-Bench | reported **+23.3%** | +23.3% |
-| **cap-evolve** (this repo) | **τ²-Bench** airline, held-out 30(=val)/20 | sealed test 30.0 → **47.5** (+17.5 pp) | **+58.3%** |
+| **cap-evolve** (this repo) | **τ²-Bench** airline, held-out 30(=val)/20 | sealed test 30.0 → **47.5** (+17.5 pp) — ⚠️ reported, artifact not committed | **+58.3%** |
 
 Notes and honest caveats:
 - **EvoTool evaluates the *original* τ-Bench** (Yao et al., 2024), while cap-evolve and
@@ -70,6 +70,12 @@ Notes and honest caveats:
   reference is added here.
 - cap-evolve's +58.3% is a **within-run relative** improvement on its own held-out split
   ([`RESULTS.md`](RESULTS.md)); a different split, model, and simulator than the rows above.
+  It carries the same ⚠️ marker as its
+  [`RESULTS.md` section](RESULTS.md#τ²-bench-airline--held-out-30val20-run): that run's
+  `run_full` artifact is not committed, so it is a reported figure.
+- The rows above the cap-evolve row are **externally reported results from other papers**.
+  They are cited here, not derived from a cap-evolve run, so they are deliberately out of
+  scope for `RESULTS.md`'s superset rule — which governs cap-evolve's own run results.
 
 ---
 

--- a/docs/RESULTS.md
+++ b/docs/RESULTS.md
@@ -14,10 +14,17 @@ Each result is labeled by **split discipline**:
 Reward is mean task reward in `[0, 1]`. Where we quote externally reported results that use 0–100% units, we label them explicitly as percentages.
 Gains are given as **absolute** and **relative %**.
 
-**This page is the superset.** Every result claim on any other surface — `README.md`,
-`site/results.html`, `site/index.html`, `docs/COMPARISON.md`, `OUTREACH.md`,
-`presentation/` — must correspond to a section here, with the same value, the same split
-label, and the same evidence marker. If a number is not on this page, it is not published.
+**This page is the superset for cap-evolve's own runs.** Every result claim about a
+cap-evolve run on any other surface — `README.md`, `site/results.html`, `site/index.html`,
+`OUTREACH.md`, `presentation/` — must correspond to a section here, with the same value,
+the same split label, and the same evidence marker. If one of our numbers is not on this
+page, it is not published. Externally reported results (other papers' figures) live in
+[`COMPARISON.md`](COMPARISON.md) with their own citations and are out of scope for this
+rule; measurements that are not cap-evolve run results (e.g. a partner system's tool-API
+error rates) are out of scope too. The `site/results.html` ↔ this-page mapping is the part
+that is **mechanically enforced**, by `core/tests/test_published_results_consistency.py`
+(section identity in both directions, plus the numbers in every mapped results table); the
+other surfaces are convention.
 Numbers from runs whose artifacts are not committed are labeled ⚠️ here and everywhere
 else; run records under [`runs/`](runs/) are the provenance available in-repo for those.
 

--- a/docs/RESULTS.md
+++ b/docs/RESULTS.md
@@ -14,6 +14,13 @@ Each result is labeled by **split discipline**:
 Reward is mean task reward in `[0, 1]`. Where we quote externally reported results that use 0–100% units, we label them explicitly as percentages.
 Gains are given as **absolute** and **relative %**.
 
+**This page is the superset.** Every result claim on any other surface — `README.md`,
+`site/results.html`, `site/index.html`, `docs/COMPARISON.md`, `OUTREACH.md`,
+`presentation/` — must correspond to a section here, with the same value, the same split
+label, and the same evidence marker. If a number is not on this page, it is not published.
+Numbers from runs whose artifacts are not committed are labeled ⚠️ here and everywhere
+else; run records under [`runs/`](runs/) are the provenance available in-repo for those.
+
 ---
 
 ## toy_calc — deterministic, zero-API
@@ -66,8 +73,8 @@ train=val=30, test=20) so the test number is a genuine generalization result.
 
 | split | baseline | optimized | Δ |
 |---|---|---|---|
-| **val** (30 tasks) | **56.7** | **70.0** | **+13.3 pp / +23.5% relative** |
-| **sealed test** (20 tasks, scored once) | **30.0** | **47.5** | **+17.5 pp / +58.3% relative** |
+| **val** (30 tasks) | **0.567** (56.7%) | **0.700** (70.0%) | **+13.3 pp / +23.5% relative** |
+| **sealed test** (20 tasks, scored once) | **0.300** (30.0%) | **0.475** (47.5%) | **+17.5 pp / +58.3% relative** |
 
 > The held-out `run_full` artifact for this run is committed separately. Until it lands,
 > treat these figures as the reported held-out result; the reproducible artifact-backed
@@ -174,23 +181,53 @@ structured methodology in SKILL.md.
 `[skill-package, system-prompt, tools]` with `hill-climb` outperformed the tools-only run
 (+41.2%) when paired with hill-climb's conservative gating.
 
-## SkillsBench — full 87-task optimization (fit metric, Opus 4.6)
+---
 
-A 3-iteration hill-climb over the same four shared office-document skills as the
-baseline section above, starting from the `run_baseline_opus` frozen baseline
-(reused via `--reuse-baseline`). Same fit-metric split (train == val == test =
-all 87), `num_trials: 1`, paired gate `k_se: 0.2`.
+<a id="skillsbench-87-baselines"></a>
 
-Artifacts under `.capevolve/run_opus_optimize3/` (gitignored, per-run): `SUMMARY.md`,
-`summary.json`, `baseline.json`, `final.json`, `events.jsonl`, `PATCH_NOTE.md`,
-`rollouts/val/*.json` (348: 87 seed + 87 × 3 candidates), `rollouts/test/*.json`
-(174: 87 optimized + 87 baseline-seed).
+## SkillsBench — full 87-task baselines, no optimization — ⚠️ reported, artifact not committed
 
-| | baseline (seed) | best (`cand_0001`) | Δ |
+Two seed-only measurements of the same four shared office-document skill packages
+(`docx`/`pptx`/`xlsx`/`pdf`) across **all 87** SkillsBench tasks, `num_trials: 1`,
+fit-metric split (`train == val == test == 87`), **0 iterations** — these establish
+the starting point the optimization run below climbs from, they are not gains.
+
+| agent under test | run | val_reward | pass@1 (fully passing / 87) | run record |
+|---|---|---|---|---|
+| `claude-opus-4-6` | `run_baseline_opus` | **0.281 ± 0.048** (28.1%) | **23** (26.4%) | [`runs/local-20260729-skillsbench-baseline-opus46.md`](runs/local-20260729-skillsbench-baseline-opus46.md) |
+| `aws/gpt-oss-120b` | `run_baseline_gptoss` | **0.040 ± 0.019** (4.0%) | **2** (2.3%) | [`runs/local-20260729-skillsbench-baseline-gptoss120b.md`](runs/local-20260729-skillsbench-baseline-gptoss120b.md) |
+
+> **⚠️ Reported.** Both ran locally, outside CI (recorded by `bcarmeli`); the run dirs
+> live on the recording host and are **not** committed here. The linked run records are
+> the full provenance available in this repo — per-task rewards, rollout breakdown, and
+> wall-clock — not the artifacts themselves. Under the fit-metric split `test == val` by
+> construction, so neither row is a generalization claim.
+
+---
+
+<a id="skillsbench-87"></a>
+
+## SkillsBench — full 87-task optimization (Opus 4.6) — ⚠️ reported, artifact not committed
+
+A 3-iteration hill-climb over the same four shared office-document skills, starting from
+the `run_baseline_opus` frozen baseline in
+[the baselines section above](#skillsbench-87-baselines) (reused via `--reuse-baseline`).
+Same fit-metric split (train == val == test = all 87), `num_trials: 1`, paired gate
+`k_se: 0.2`. Run record:
+[`runs/local-20260730-skillsbench-opus46-optimize.md`](runs/local-20260730-skillsbench-opus46-optimize.md).
+
+> **⚠️ Reported.** Artifacts live under `.capevolve/run_opus_optimize3/` on the recording
+> host and are **gitignored, per-run** — not committed to this repo: `SUMMARY.md`,
+> `summary.json`, `baseline.json`, `final.json`, `events.jsonl`, `PATCH_NOTE.md`,
+> `rollouts/val/*.json` (348: 87 seed + 87 × 3 candidates), `rollouts/test/*.json`
+> (174: 87 optimized + 87 baseline-seed). The linked run record is the provenance
+> available here; you cannot load this run in the dashboard from this repo.
+
+| split | baseline (seed) | best (`cand_0001`) | Δ |
 |---|---|---|---|
-| val_reward (mean) | 0.281 ± 0.048 | **0.357 ± 0.050** | **+0.076 (+27.2% relative)** |
-| pass_at_1 (fully-passing tasks / 87) | 23 (26.4%) | **28 (32.2%)** | **+5 tasks (+22% relative)** |
-| test_reward (fit metric = val by construction) | 0.281 * | **0.357** | +0.076 |
+| **val** (87, fit) — mean reward | 0.281 ± 0.048 | **0.357 ± 0.050** | **+0.076 (+27.2% relative)** |
+| **val** (87, fit) — pass_at_1 (fully-passing / 87) | 23 (26.4%) | **28 (32.2%)** | **+5 tasks (+22% relative)** |
+| **test** (87, *fit metric* — `test == val` by construction, **not** held out) | 0.281 * | **0.357** | +0.076 |
 
 \* The finalize step's baseline-test re-evaluation broke overnight (VPN drop; every
 task returned 0 across a 5-hour eval); `test_baseline_reward` here is manually
@@ -209,7 +246,8 @@ recording host; the raw broken artifacts remain untouched for audit.
 | 3 | `cand_0003` | `cand_0001` | 0.170 | −0.187 | ✗ large regression |
 
 The optimizer converged to `cand_0001`; two follow-up attempts both regressed
-and were correctly rejected. Optimizer spend: ~$32 total (well below the $400 cap).
+and were correctly rejected. Optimizer spend for this run is **not recorded** in the
+run record, so no cost figure is quoted here.
 
 ### What the optimizer changed (net delta on task passes)
 
@@ -232,10 +270,13 @@ to `xlsx`/`pptx` had real cross-task effect.
   claim.
 - **Single trial.** `num_trials: 1` — one draw per task per iteration. The paired
   gate still ran cleanly on the accepted iteration (Δ = +0.077 > 0.007 = 0.2·SE).
-- **Not directly comparable to EvoSkills' 71.1%.** Different paradigm (shared
-  4-skill package vs per-task skills), different setup (BenchFlow strips each
-  task's own bundled skills and mounts ours). This is the same
-  shared-skill approach as the baselines above.
+- **Not directly comparable to per-task-skill work such as EvoSkill**
+  (arXiv:2604.01687v1). Different paradigm (shared 4-skill package vs per-task
+  skills), different setup (BenchFlow strips each task's own bundled skills and
+  mounts ours). This is the same shared-skill approach as the
+  [baselines above](#skillsbench-87-baselines). No external score is quoted here:
+  none is cited in [`sources.bib`](sources.bib), and an uncited number is not
+  evidence.
 
 ---
 

--- a/presentation/index.html
+++ b/presentation/index.html
@@ -961,9 +961,7 @@ def reserve(cabin, passengers, nonfree_baggages, ...):
               <td>5 hard</td>
               <td class="num">3</td>
               <td class="num">2</td>
-              <td class="num">0.600</td>
-              <td class="num">0.800</td>
-              <td class="num delta-pos">+33%</td>
+              <td class="num">—</td><td class="num">—</td><td class="num">—</td>
             </tr>
             <tr class="done-row">
               <td class="num">2</td>
@@ -976,9 +974,7 @@ def reserve(cabin, passengers, nonfree_baggages, ...):
               <td>5 hard</td>
               <td class="num">3</td>
               <td class="num">2</td>
-              <td class="num">0.533</td>
-              <td class="num">0.933</td>
-              <td class="num delta-pos">+75%</td>
+              <td class="num">—</td><td class="num">—</td><td class="num">—</td>
             </tr>
             <tr class="done-row">
               <td class="num">3</td>
@@ -991,9 +987,7 @@ def reserve(cabin, passengers, nonfree_baggages, ...):
               <td>5</td>
               <td class="num">1</td>
               <td class="num">2</td>
-              <td class="num">0.830</td>
-              <td class="num">0.900</td>
-              <td class="num delta-pos">+12%</td>
+              <td class="num">—</td><td class="num">—</td><td class="num">—</td>
             </tr>
             <tr class="done-row">
               <td class="num">4</td>
@@ -1006,9 +1000,7 @@ def reserve(cabin, passengers, nonfree_baggages, ...):
               <td>5 easy</td>
               <td class="num">3</td>
               <td class="num">2</td>
-              <td class="num">1.000</td>
-              <td class="num">1.000</td>
-              <td class="num delta-flat">0%</td>
+              <td class="num">—</td><td class="num">—</td><td class="num">—</td>
             </tr>
             <tr class="planned-row">
               <td class="num">5</td>
@@ -1125,7 +1117,11 @@ def reserve(cabin, passengers, nonfree_baggages, ...):
 
       <aside class="notes">
         Twelve experiments in the sweep: 4 done, 7 planned, 1 future (RH internal). Done rows
-        are the τ²-bench + SWE-bench Lite results already committed. Planned rows are the
+        are early τ²-bench + SWE-bench Lite pilot runs on 5-task subsets; their baseline/optimized
+        numbers are deliberately NOT shown, because no run artifact and no run record for them
+        exists anywhere in the repo — say "we ran these, the write-ups aren't published" rather
+        than quoting a figure. The published numbers are on slide 6 and docs/RESULTS.md.
+        Planned rows are the
         apples-to-apples publication comparisons — same benchmark + agent (ollama/qwen2.5:35b
         for the local runs) across cap-evolve's hill-climb, GEPA, SkillOps, and standalone
         local-GEPA. Future row is the Parsec-adjacent RH internal benchmark once available.

--- a/presentation/index.html
+++ b/presentation/index.html
@@ -305,6 +305,10 @@
     .reveal .exp-legend .sw-done    { background: rgba( 75, 214,  87, 0.35); }
     .reveal .exp-legend .sw-planned { background: rgba(245, 197,  24, 0.35); }
     .reveal .exp-legend .sw-future  { background: rgba(138, 143, 152, 0.35); }
+    .reveal .exp-note {
+      font-size: 0.45em; color: var(--sub); line-height: 1.5;
+      max-width: 62em; margin: 0.5em auto 0; text-align: left;
+    }
 
     /* Dashboard screenshot slide */
     .reveal .dashboard-shot {
@@ -1113,6 +1117,14 @@ def reserve(cabin, passengers, nonfree_baggages, ...):
           <span><span class="swatch sw-planned"></span>Planned (7)</span>
           <span><span class="swatch sw-future"></span>Future (1)</span>
         </div>
+        <p class="exp-note">
+          <strong>—</strong> in the Δ columns means <strong>the run happened but has no artifact
+          and no run record in this repo</strong>, so no figure is quoted; it does not mean the
+          result was withheld. One of the four is a <strong>null result</strong>: row 4
+          (5 easy τ²-bench tasks) was already at the scorer's ceiling and optimization changed
+          nothing — a saturated subset, not a hidden gain. Every published figure is on
+          slide 6 and in <code>docs/RESULTS.md</code>.
+        </p>
       </div>
 
       <aside class="notes">
@@ -1120,7 +1132,11 @@ def reserve(cabin, passengers, nonfree_baggages, ...):
         are early τ²-bench + SWE-bench Lite pilot runs on 5-task subsets; their baseline/optimized
         numbers are deliberately NOT shown, because no run artifact and no run record for them
         exists anywhere in the repo — say "we ran these, the write-ups aren't published" rather
-        than quoting a figure. The published numbers are on slide 6 and docs/RESULTS.md.
+        than quoting a figure. That reasoning is now on the slide itself (the note under the
+        legend), not only here, including the fact that row 4 was a null result: already at the
+        scorer's ceiling on 5 easy tasks, so optimization had no headroom. A null result is a
+        real finding, so it is stated in words rather than left as a bare —. The published
+        numbers are on slide 6 and docs/RESULTS.md.
         Planned rows are the
         apples-to-apples publication comparisons — same benchmark + agent (ollama/qwen2.5:35b
         for the local runs) across cap-evolve's hill-climb, GEPA, SkillOps, and standalone

--- a/site/README.md
+++ b/site/README.md
@@ -63,10 +63,13 @@ First-time setup (once per repo, done in GitHub Settings):
   carries a `?v=YYYYMMDD` query. **Bump it when the file changes** so returning
   visitors don't cache the old asset.
 - **Sub-pages summarize the source markdown docs, they do not replace them.**
-- **Honest numbers.** This project's premise is honest evaluation. Label every
-  figure `fit metric` (no holdout) or `held-out`; never present a reported-but-
-  not-yet-committed number as artifact-backed. Cross-check against `docs/RESULTS.md`
-  and the committed run artifacts before editing a results figure.
+- **Honest numbers.** This project's premise is honest evaluation.
+  **`docs/RESULTS.md` is the superset**: a figure may only appear on a site page if it
+  already has a section there, and it must carry the *same* value, the same split label
+  (`fit metric` = no holdout, or `held-out`), and the same evidence marker
+  (✅ artifact-backed / ✅ reproducible in CI / ⚠️ reported, artifact not committed).
+  Never present a reported number as artifact-backed. Adding a number to a site page
+  means adding its `docs/RESULTS.md` section first, not the other way round.
 - **External links go to `github.com/skillberry-ai/cap-evolve/blob/main/...`.**
 
 ## Adding a new sub-page

--- a/site/benchmarks.html
+++ b/site/benchmarks.html
@@ -61,7 +61,8 @@
       per-task reward and per-iteration cost/latency detail. <span id="updated" class="muted"></span>
     </p>
     <p>
-      See the hand-verified canonical numbers on the <a href="results.html">Results</a> page; this
+      See the canonical numbers on the <a href="results.html">Results</a> page, where each section
+      carries its own evidence marker (artifact-backed, reproducible in CI, or reported only); this
       is the raw CI log. Failed/cancelled runs are shown too, so infra breakage is visible.
     </p>
   </div>

--- a/site/results.html
+++ b/site/results.html
@@ -309,6 +309,90 @@
       </section>
 
       <section class="reveal">
+        <h2 id="skillsbench-87-baselines">SkillsBench — full 87-task baselines, no optimization <span class="muted">— ⚠️ reported, artifact not committed</span></h2>
+
+        <p>
+          Two seed-only measurements of the same four shared office-document skill packages
+          (<code>docx</code>/<code>pptx</code>/<code>xlsx</code>/<code>pdf</code>) across
+          <strong>all 87</strong> SkillsBench tasks, <code>num_trials: 1</code>, fit-metric split
+          (<code>train == val == test == 87</code>), <strong>0 iterations</strong> — these establish
+          the starting point the optimization run below climbs from, they are not gains.
+        </p>
+
+        <table>
+          <thead>
+            <tr><th>agent under test</th><th>run</th><th>val_reward</th><th>pass@1 (fully passing / 87)</th><th>run record</th></tr>
+          </thead>
+          <tbody>
+            <tr><td><code>claude-opus-4-6</code></td><td><code>run_baseline_opus</code></td><td class="num"><strong>0.281 ± 0.048</strong> (28.1%)</td><td class="num"><strong>23</strong> (26.4%)</td><td><a href="https://github.com/skillberry-ai/cap-evolve/blob/main/docs/runs/local-20260729-skillsbench-baseline-opus46.md">run record</a></td></tr>
+            <tr><td><code>aws/gpt-oss-120b</code></td><td><code>run_baseline_gptoss</code></td><td class="num"><strong>0.040 ± 0.019</strong> (4.0%)</td><td class="num"><strong>2</strong> (2.3%)</td><td><a href="https://github.com/skillberry-ai/cap-evolve/blob/main/docs/runs/local-20260729-skillsbench-baseline-gptoss120b.md">run record</a></td></tr>
+          </tbody>
+        </table>
+
+        <div class="callout callout-warn">
+          <div class="callout-title">Reported — artifact not committed</div>
+          <p>
+            Both ran locally, outside CI (recorded by <code>bcarmeli</code>); the run dirs live on
+            the recording host and are <strong>not committed</strong> here. The linked run records
+            are the full provenance available in the repo — per-task rewards, rollout breakdown,
+            and wall-clock — not the artifacts themselves. Under the fit-metric split
+            <code>test == val</code> by construction, so neither row is a generalization claim.
+          </p>
+        </div>
+      </section>
+
+      <section class="reveal">
+        <h2 id="skillsbench-87">SkillsBench — full 87-task optimization (Opus 4.6) <span class="muted">— ⚠️ reported, artifact not committed</span></h2>
+
+        <p>
+          A 3-iteration <code>hill-climb</code> over the same four shared office-document skills,
+          starting from the <code>run_baseline_opus</code> frozen baseline
+          <a href="#skillsbench-87-baselines">above</a> (reused via <code>--reuse-baseline</code>).
+          Same fit-metric split (<code>train == val == test</code> = all 87),
+          <code>num_trials: 1</code>, paired gate <code>k_se: 0.2</code>.
+          <a href="https://github.com/skillberry-ai/cap-evolve/blob/main/docs/runs/local-20260730-skillsbench-opus46-optimize.md">Run record</a>.
+        </p>
+
+        <table>
+          <thead>
+            <tr><th>split</th><th>baseline (seed)</th><th>best (<code>cand_0001</code>)</th><th>Δ</th></tr>
+          </thead>
+          <tbody>
+            <tr><td><strong>val</strong> (87, fit) — mean reward</td><td class="num">0.281 ± 0.048</td><td class="num"><strong>0.357 ± 0.050</strong></td><td class="gain">+0.076 / +27.2% relative</td></tr>
+            <tr><td><strong>val</strong> (87, fit) — pass_at_1 (fully-passing / 87)</td><td class="num">23 (26.4%)</td><td class="num"><strong>28 (32.2%)</strong></td><td class="gain">+5 tasks / +22% relative</td></tr>
+            <tr><td><strong>test</strong> (87, <em>fit metric</em> — <code>test == val</code> by construction, <strong>not</strong> held out)</td><td class="num">0.281 *</td><td class="num"><strong>0.357</strong></td><td class="num">+0.076</td></tr>
+          </tbody>
+        </table>
+
+        <p>
+          * The finalize step's baseline-test re-evaluation broke overnight (VPN drop; every task
+          returned 0 across a 5-hour eval); <code>test_baseline_reward</code> is manually spliced
+          from the properly-scored seed val in <code>run_baseline_opus</code>. Under the fit-metric
+          split the seed's test reward equals its val reward by construction, so the splice is
+          exact. The raw broken artifacts remain untouched for audit.
+        </p>
+
+        <p>
+          <strong>Iterations:</strong> <code>cand_0001</code> val <strong>0.357</strong>
+          (Δ +0.077) — accepted by the paired gate; <code>cand_0002</code> 0.325 (−0.033) and
+          <code>cand_0003</code> 0.170 (−0.187) both rejected as regressions. Net
+          <strong>+5 tasks</strong> (23 → 28) on <code>pass_at_1</code>: 8 newly passing, 3
+          regressed. Optimizer spend is <strong>not recorded</strong> in the run record, so no
+          cost figure is quoted.
+        </p>
+
+        <div class="callout callout-warn">
+          <div class="callout-title">Reported — artifact not committed</div>
+          <p>
+            Artifacts live under <code>.capevolve/run_opus_optimize3/</code> on the recording host
+            and are <strong>gitignored, per-run</strong> — not committed to this repo. The linked
+            run record is the provenance available here; you cannot load this run in the dashboard
+            from this repo. Fit metric, single trial: not a generalization claim.
+          </p>
+        </div>
+      </section>
+
+      <section class="reveal">
         <h2 id="skillsbench">SkillsBench — skill-package optimization (held-out, committed)</h2>
 
         <p>
@@ -444,7 +528,9 @@
       <a href="#tau2-agent">τ²-bench — agent mode</a>
       <a href="#qwen-tools">τ²-bench — Qwen 14B</a>
       <a href="#qwen-all">Qwen 14B — all capabilities</a>
-      <a href="#skillsbench">SkillsBench</a>
+      <a href="#skillsbench-87-baselines">SkillsBench — 87-task baselines</a>
+      <a href="#skillsbench-87">SkillsBench — 87-task optimization</a>
+      <a href="#skillsbench">SkillsBench — held-out</a>
       <a href="#at-a-glance">At a glance</a>
     </nav>
   </div>

--- a/site/results.html
+++ b/site/results.html
@@ -210,7 +210,7 @@
           </thead>
           <tbody>
             <tr><td><strong>val</strong> (30, fit)</td><td class="num"><strong>0.500</strong> (50.0%)</td><td class="num"><strong>0.633</strong> (63.3%)</td><td class="gain">+0.133 / +26.7% relative — gate-significant</td></tr>
-            <tr><td><strong>sealed test</strong> (20, held-out)</td><td class="num"><strong>0.400</strong> (40.0%)</td><td class="num"><strong>0.550</strong> (55.0%)</td><td class="gain">+0.150 / +37.5% relative</td></tr>
+            <tr><td><strong>sealed test</strong> (20, held-out, scored once)</td><td class="num"><strong>0.400</strong> (40.0%)</td><td class="num"><strong>0.550</strong> (55.0%)</td><td class="gain">+0.150 / +37.5% relative</td></tr>
           </tbody>
         </table>
 


### PR DESCRIPTION
Closes #100

## The problem, as it stands today

Issue #100 reported that the source-of-truth relationship was **inverted**: `site/results.html` published two Qwen 2.5 14B runs (`#qwen-tools`, `#qwen-all`) that `docs/RESULTS.md` did not contain, while `site/README.md` told readers to "cross-check against `docs/RESULTS.md`" — an instruction that was **false**.

Since the issue was filed the Qwen runs landed in `docs/RESULTS.md`, **and** merged PR #236 added a `SkillsBench — full 87-task optimization` section to `docs/RESULTS.md` that the site never got. **The divergence did not close, it swapped direction.** So this PR fixes it structurally rather than patching the specific rows the issue named.

## Full inventory — every result claim on every surface

Split column: **fit** = `train == val == test` (no holdout) · **sealed test** = ids the optimizer never saw. Provenance is what actually exists on disk in this repo.

### Before

| # | Claim | Surfaces | Number | Split | Model | Trials | Artifact substantiates? |
|---|---|---|---|---|---|---|---|
| 1 | toy_calc seed → optimized | README, RESULTS, site/results, site/index | `0.0 → 1.0` | sealed test | none (deterministic) | 1 | ✅ re-derived by `core/tests/test_e2e_slice.py` |
| 2 | τ² airline baseline val | README, RESULTS:47, OUTREACH:47, site/results:126, site/index:153 | `0.536` | fit (50) | gpt-oss-120b | 10 | ✅ `run_full/ui/data/runs_run_full.json` → `baseline_val: 0.536` |
| 3 | τ² airline best val `cand_0007` | README, RESULTS:48, site/results:127, site/index:158 | `0.712` | fit (50) | gpt-oss-120b | 10 | ✅ same file → `best_val: 0.712`, `best_id: cand_0007` |
| 4 | τ² airline sealed test pass@1 | RESULTS:49, OUTREACH:47, site/results:128, site/index:164 | `0.694` | fit — **`test == val`, NOT held out** | gpt-oss-120b | 10 | ✅ `run_full/final.json` → `test.reward: 0.694` |
| 5 | τ² airline pass² | RESULTS:49, site/results:128 | `0.584` | fit (50) | gpt-oss-120b | 10 | ✅ `final.json` → `test.pass_k["2"]: 0.5844` |
| 6 | τ² airline per-iteration stair (5 of 10 accepted) | RESULTS:52-53, site/results:134-136 | `0.582/0.634/0.670/0.684/0.712` | fit (50) | gpt-oss-120b | 10 | ✅ `runs_run_full.json` → `evaluations[]` + `per_iteration[]` statuses |
| 7 | τ² airline **held-out** val | RESULTS:69, site/results:172 | `56.7 → 70.0` **(doc)** / `0.567 → 0.700` **(site)** | val (30) | — | — | ❌ **no artifact at any commit** (#182 reviewer: `0.475` in zero artifact files) — units also disagreed between surfaces |
| 8 | τ² airline **held-out** sealed test | README:110, RESULTS:70, COMPARISON:61, OUTREACH:46, site/results:173, site/index:260, presentation:764 | `30.0 → 47.5` (+58.3%) | sealed test (20) | — | — | ❌ **no artifact** — #99/#182's headline |
| 9 | τ² agent-mode single-trial | RESULTS:101-102, site/results:212-213 | val `0.500→0.633`, test `0.400→0.550` | val fit (30) + sealed test (20) | aws/gpt-oss-120b | 1 | ❌ no artifact (labeled ⚠️ by #182) |
| 10 | τ² agent-mode n=3 re-eval | RESULTS:108-109 | val `0.544→0.644`, test `0.467→0.400` | val fit + sealed test | aws/gpt-oss-120b | 3 | ❌ no artifact (doc-only; not on site) |
| 11 | τ² agent-mode head-to-head deterministic | RESULTS:113, site/results:224 | val `0.567`, sealed test `0.35` | val fit + sealed test | aws/gpt-oss-120b | 1 | ❌ no artifact |
| 12 | Qwen 14B tools-only | RESULTS:144-145, site/results:256-257 | val `0.200→0.387`, test `0.170→0.240` (+41.2%) | val (30) + sealed test (20) | Qwen2.5-14B | 5 | ❌ no artifact; `git log --all` finds no Qwen file ever added |
| 13 | Qwen 14B all-capabilities | RESULTS:166-167, site/results:289-290 | val `0.273→0.520`, test `0.120→0.270` (+125.0%) | val (30) + sealed test (20) | Qwen2.5-14B | 5 | ❌ no artifact |
| 14 | SkillsBench-87 **baselines** (opus + gptoss) | **`docs/runs/` only — on NO published surface** | `0.281`(23/87) · `0.0396`(2/87) | fit (87) | claude-opus-4-6 / aws/gpt-oss-120b | 1 | ⚠️ run records committed; run dirs on recording host |
| 15 | SkillsBench-87 **optimization** | **`docs/RESULTS.md:177-238` only — MISSING from the site** | val `0.281→0.357` (+27.2%), pass@1 `23→28` | fit (87) — `test == val` | claude-opus-4-6 | 1 | ⚠️ run record committed; run dir gitignored |
| 16 | SkillsBench-87 iterations | RESULTS:207-209 | `0.357 / 0.325 / 0.170` | val fit (87) | claude-opus-4-6 | 1 | ⚠️ run record `:36-38` (4-dp there, 3-dp in RESULTS) |
| 17 | SkillsBench-87 task-level delta | RESULTS:216-226 | 8 newly passing, 3 regressed, net +5 | val fit (87) | claude-opus-4-6 | 1 | ⚠️ **derived exactly** from the two run records' passing-task lists |
| 18 | SkillsBench-87 **optimizer spend** | RESULTS:212 | `~$32 total`, `$400 cap` | — | — | — | ❌ **no cost field in the run record at all** |
| 19 | SkillsBench-87 **EvoSkills comparison** | RESULTS:235 | `71.1%` | — | — | — | ❌ **no citation in `sources.bib`; string appears nowhere else in the tree** |
| 20 | SkillsBench held-out val | RESULTS:255-256, site/results:333-334 | `0.333 → 0.714` (+114%) | val fit (7) | claude-sonnet-4-6 | 3 | ✅ `skillsbench/run_full/baseline.json` → `val.reward: 0.3333` |
| 21 | SkillsBench held-out sealed test | README:111, RESULTS:257-258, OUTREACH:49, site/results:335-336, site/index:266 | `0.556 → 0.667` (+20.0%) | sealed test (3) | claude-sonnet-4-6 | 3 | ✅ `run_full/final.json` → `test_baseline.reward: 0.5556`, `test.reward: 0.6667` |
| 22 | presentation slide-9 "Done" run 1 | `presentation/index.html:964-966` | `0.600 → 0.800` (+33%) | unstated | claude-sonnet-4-6 | 3 | ❌ **on no other surface; no artifact, no run record, at any commit** |
| 23 | presentation slide-9 "Done" run 2 | `presentation/index.html:979-981` | `0.533 → 0.933` (+75%) | unstated | claude-sonnet-4-6 | 3 | ❌ **same** |
| 24 | presentation slide-9 "Done" run 3 | `presentation/index.html:994-996` | `0.830 → 0.900` (+12%) | unstated | claude-sonnet-4-6 | 1 | ❌ **same** |
| 25 | presentation slide-9 "Done" run 4 | `presentation/index.html:1009-1011` | `1.000 → 1.000` (0%) | unstated | claude-sonnet-4-6 | 3 | ❌ **same** |
| 26 | COMPARISON external rows (EvoTool ×2, Evolutionary Context Search) | COMPARISON:58-60 | `35.9→39.1`, `14.4→15.7`, `+23.3%` | external | GPT-4.1 / Qwen3-8B | — | external; ECS already self-labels "citation still to be confirmed" |
| 27 | `site/benchmarks.fixture.json` | fixture only | `0.0→0.5`, `0.2→0.4` | n/a | fake | n/a | n/a — **dev fixture, not deployed data**; not a claim. Untouched. |
| 28 | `site/benchmarks.js` | — | **no hardcoded results** — renders a live feed | n/a | n/a | n/a | n/a. Untouched. |
| 29 | `llms.txt` | — | **no result numbers at all** | n/a | n/a | n/a | n/a. Untouched. |

### After

| # | Change | Result |
|---|---|---|
| 7 | units unified | `docs/RESULTS.md` now shows `0.567 (56.7%)` / `0.300 (30.0%)`, identical to `site/results.html`, obeying the page's own "label percentages explicitly" rule |
| 14 | **published** | new `docs/RESULTS.md` §`SkillsBench — full 87-task baselines, no optimization` + matching `site/results.html` section, both ⚠️-stamped, each row linking its run record. This also **fixes a dangling reference**: §15 said "the same four shared office-document skills as the baseline section above" — there was no such section |
| 15 | **published on the site** | new `site/results.html` §`skillsbench-87` with the same numbers, split labels, splice footnote, iterations, and ⚠️ callout |
| 15, 16 | split labels | rows relabeled `val (87, fit)` and `test (87, fit metric — test == val by construction, not held out)` on **both** surfaces |
| 18 | **REMOVED** | "Optimizer spend: ~$32 total (well below the $400 cap)" → "Optimizer spend for this run is **not recorded** in the run record, so no cost figure is quoted here." |
| 19 | **REMOVED** | "Not directly comparable to EvoSkills' 71.1%" → names the paradigm difference and `arXiv:2604.01687v1` (the only id present in the tree), with "No external score is quoted here: none is cited in `sources.bib`, and an uncited number is not evidence." |
| 22-25 | **REMOVED** | all four number triplets → `—`; speaker note corrected from "the results already committed" to "their baseline/optimized numbers are deliberately NOT shown, because no run artifact and no run record for them exists anywhere in the repo" |
| — | superset rule | `docs/RESULTS.md` preamble now states it explicitly; `site/README.md`'s false "cross-check against `docs/RESULTS.md` and the committed run artifacts" replaced with the actual rule (add the canonical section **first**) |
| — | blanket claim | `site/benchmarks.html`'s "hand-verified canonical numbers" → points at the per-section evidence markers |
| — | **mechanical guard** | `core/tests/test_published_results_consistency.py` — 3 tests, the issue's own acceptance criterion |

## What I removed and why

Four categories, 8 numbers, all **removed rather than kept**:

1. **`71.1%` (EvoSkills)** — the string appears in exactly one place in the whole repo (the claim itself). No `sources.bib` entry, no arXiv id, no URL. An uncited external number in an honesty doc is worse than no number.
2. **`~$32` / `$400 cap`** — the run record has no cost field. `docs/runs/local-20260730-skillsbench-opus46-optimize.md` records wall-clock but not spend.
3. **presentation slide-9's four "Done" rows** (8 figures) — `0.600→0.800`, `0.533→0.933`, `0.830→0.900`, `1.000→1.000`. Grepped across every published surface: they appear **only** in that table. No `run_full/`, no `docs/runs/` record, nothing in git history. They sat under a speaker note asserting they were "already committed" — the most directly false claim I found.
4. **"hand-verified"** (`site/benchmarks.html`) and **"cross-check against … the committed run artifacts"** (`site/README.md`) — aggregate claims that are not true and, per #182's reasoning, rot whenever a run is added.

## Design note: why the guard checks section identity, not numbers

My first attempt scraped decimals out of the HTML and compared sets. It was unusable: SVG coordinates, font weights (`400;500;600;700;800`), arXiv fragments (`2603.04900`) and external papers' figures (`35.9`, `39.1`) all look exactly like rewards, and every one needed an allowlist entry. A guard whose allowlist keeps growing stops guarding.

So the guard pins the invariant that **actually broke**: every `site/results.html` `<h2 id>` maps to a `docs/RESULTS.md` `## ` heading. That is verbatim the issue's acceptance criterion ("every `site/results.html` run anchor maps to a `RESULTS.md` section"). Mapping is an explicit table, not derived from #182's `<a id>` markers, so the guard's result does **not** depend on merge order — and a *renamed* section fails loudly where a set-difference would silently accept it. Proven by reintroducing the original bug (evidence comment).

## Deliberately left to sibling PRs

| Line / claim | Left to | Why |
|---|---|---|
| `README.md:102` "cross-checked against committed run artifacts" + the whole Results table | **#99 / #182** | #182 rewrites this into a per-row ✅/⚠️ Artifact column. Touching it = guaranteed conflict. |
| `README.md:110` held-out headline `30.0 → 47.5` | **#99 / #182** | its headline; I did not change the number, the split label, or the row. |
| `site/index.html:78` "Every number ships its artifact" pill; `:236` "Cross-checked against committed run artifacts"; the 4-row hero table | **#99 / #182** | #182 rewrites all of them (pill → "Artifact-backed by default", table gains an Artifact column). **I did not touch `site/index.html` at all.** |
| `site/results.html:7,12,17` meta descriptions "Every number cross-checked…" | **#99 / #182** (and **#196** owns the file region) | #182 rewrites all three; under #196 the `<head>` is generator-owned via `chrome:head:*` sentinels, so editing it would fail `--check`. Doubly not mine. |
| `site/results.html:55` lead; the 7 pre-existing `<h2>` evidence stamps | **#99 / #182** | its convention. I **extended** it to my 2 new sections using its exact `<span class="muted">— ⚠️ reported, artifact not committed</span>` form. |
| `presentation/index.html:635, 745, 788` + slide-6 cards | **#99 / #182** | #182 rewrites each. My presentation edit is **only** slide 9 (lines 964-1011 + its `<aside class="notes">`) — zero overlap, confirmed by a test merge that auto-merged `presentation/index.html` with **no conflict**. |
| `CHANGELOG.md` (`0.536 → 0.712`, `0.694` named separately) | **#101 / #184** | untouched. |
| `OUTREACH.md:46` (val/test conflation) and `:47` | **#101 / #184** and **#99 / #182** | both edit these lines. Untouched. |
| Skill / algorithm / optimizer counts | **#102 / #189** | untouched. |
| Site chrome, nav, footer, `<head>`, `?v=` hashes | **#123 / #196** | all my site edits are inside `<main>` bodies. |
| `harbor.html` / `harbor-openshift.html` not registered in `PAGES` | **#123 / #196** | pre-existing on `main`; **proven identical without my changes** (evidence comment). |
| Host labels | **#126 / #202** | untouched. |
| `test_dashboard_launch.py` port-7878 flake | **#200** | pre-existing; reproduced on clean `origin/main`. |

## Expected merge order

```
#189 (counts) ─┐
#184 (changelog)─┤  independent
#182 (#99 headline) ──► THIS PR (#100) ──► #202 (#126) / #192 (#120) ──► #196 (#123) LAST
```

- **#182 before this PR** is preferred but **not required** — verified both ways. Merged in either order, the only conflicts are the two spots where my new sections sit next to #182's stamped `SkillsBench — skill-package optimization` heading; resolution is a union (keep my sections, take #182's heading). Verified by an actual test merge.
- **#196 must merge last** — unchanged by this PR, and its `--check` exits **0** on the merged tree.

## Verification

### Full suite — 181 passed (179 baseline + 3 new), 0 unexpected failures

```
$ PYTHONPATH=/tmp/wt-100b/core /tmp/ce-venv/bin/python -m pytest core/tests -q
FAILED core/tests/test_dashboard_launch.py::test_maybe_launch_spawns_when_available
1 failed, 181 passed in 64.82s (0:01:04)
```

The single failure is the known port-7878 flake (**#200**), reproduced on clean `origin/main` with none of my changes present:

```
$ cd /tmp/wt-ctl && git reset --hard -q origin/main
$ PYTHONPATH=/tmp/wt-ctl/core pytest core/tests/test_dashboard_launch.py -q
FAILED core/tests/test_dashboard_launch.py::test_maybe_launch_spawns_when_available
1 failed, 6 passed in 0.05s
```

Deselecting it: **181 passed, 0 failed**.

### New guard passes, and catches the #100 bug

```
$ pytest core/tests/test_published_results_consistency.py -q
...                                                                      [100%]
3 passed in 0.01s
```

Regression-proof — delete the canonical `qwen-tools` section (the exact original bug) and it fails:

```
E  AssertionError: site/results.html publishes run section(s) whose docs/RESULTS.md
   heading is gone or renamed: {'qwen-tools': 'Qwen 2.5 14B (tools only'}
```

### `python -m compileall core skills` — clean

```
$ /tmp/ce-venv/bin/python -m compileall -q core skills
compileall EXIT=0
```

### Every 87-task number identical on both surfaces, with the same split label

```
--- 0.281 ---
docs/RESULTS.md:197:| `claude-opus-4-6` | `run_baseline_opus` | **0.281 ± 0.048** (28.1%) | **23** (26.4%) | ...
docs/RESULTS.md:228:| **val** (87, fit) — mean reward | 0.281 ± 0.048 | **0.357 ± 0.050** | **+0.076 (+27.2% relative)** |
docs/RESULTS.md:230:| **test** (87, *fit metric* — `test == val` by construction, **not** held out) | 0.281 * | **0.357** | +0.076 |
site/results.html:327: ...<strong>0.281 ± 0.048</strong> (28.1%)...<strong>23</strong> (26.4%)...
site/results.html:361: ...<strong>val</strong> (87, fit) — mean reward...0.281 ± 0.048...<strong>0.357 ± 0.050</strong>...+0.076 / +27.2% relative
site/results.html:363: ...<strong>test</strong> (87, <em>fit metric</em> — <code>test == val</code> by construction, <strong>not</strong> held out)...
--- 26.4 ---
docs/runs/local-20260729-skillsbench-baseline-opus46.md:22:| pass_at_1 (fully passing) | **23/87** (26.4%) |
docs/RESULTS.md:197  site/results.html:327   docs/RESULTS.md:229   site/results.html:362
--- 0.040 (== 0.0396 in the run record, 3-dp on published surfaces) ---
docs/RESULTS.md:198   site/results.html:328
docs/runs/local-20260729-skillsbench-baseline-gptoss120b.md:21:| val_reward (mean) | **0.0396 ± 0.0191** (4.0%) |
```

### Zero surviving aggregate claims

On the **merged `#182 + #100`** tree:

```
$ grep -rniE "every number|every result|all results|cross-check|ships its artifact|committed run artifact|hand-verified|every figure" \
    README.md docs/RESULTS.md docs/COMPARISON.md OUTREACH.md llms.txt site/*.html site/README.md presentation/index.html
docs/RESULTS.md:25:**This page is the superset.** Every result claim on any other surface — `README.md`,
```

**One hit, and it is TRUE.** It is my own line and is not an artifact claim — it is a normative rule about where numbers may be published, and it is the rule `test_published_results_consistency.py` mechanically enforces. Every "every number is artifact-backed"-style claim is gone.

### Removed numbers are gone from every published surface

```
71.1       occurrences on published surfaces now: 0
$32        occurrences on published surfaces now: 0
0.933      occurrences on published surfaces now: 0
0.830      occurrences on published surfaces now: 0
0.533      occurrences on published surfaces now: 0
0.800 / 0.900 / 0.600  -> remaining hits are Fira Sans font weights (`400;500;600;700;800`)
                          and arXiv ids (2603.04900). Not results.
```

### Links and anchors resolve on disk (CI `docs-links` runs with `--include-fragments`)

```
docs/RESULTS.md:      16 resolve, 0 broken   (incl. runs/, #skillsbench-87-baselines ×2, sources.bib)
site/results.html:    10/10 internal anchors OK, 11/11 relative hrefs OK
```

### Site pages still parse; fixture untouched

```
site/results.html:      unclosed=none  mismatched=none
site/benchmarks.html:   unclosed=none  mismatched=none
presentation/index.html:unclosed=none  mismatched=none
fixture ok (untouched)
```

`site/benchmarks.js` and `site/benchmarks.fixture.json` are **not modified** — the fixture is a dev eyeball fixture, not deployed data, and `benchmarks.js` hardcodes no results.

### #196's generator: `--check` exits 0 on the merged tree

`main` + `#182` + **this PR** + `#196`:

```
$ scripts/sync-site-chrome.py --check
site chrome in sync (9 pages)
EXIT=0
```

And my edits cause **zero** chrome drift — chrome regions are byte-identical with and without them:

```
IDENTICAL chrome: index.html, getting-started.html, run-end-to-end.html, results.html,
                  benchmarks.html, architecture.html, optimize-your-own.html,
                  adapter-templates.html, agent-orchestration.html
```

(The `harbor.html` / `harbor-openshift.html` registration failure is pre-existing — byte-identical on `main + #196` alone. #196's to resolve; full both-trees comparison in the evidence comment.)

## Could not substantiate

Nothing survives unsubstantiated. Every number I kept has either a committed artifact (✅) or a committed run record with the artifact's absence stated in-line (⚠️). The 8 numbers with neither were removed.

One honest limitation, unchanged and pre-existing: **five τ²-bench runs have no committed artifact anywhere** (held-out, agent-mode, and both Qwen runs — the reviewer of #182 confirmed `0.475` appears in zero artifact files at any commit; I independently confirmed no Qwen file was ever added in git history). They are ⚠️-labeled, not deleted, because that is #99/#182's scope and its reviewer's explicit decision. My contribution is that the *labeling convention now covers all 9 sections* instead of 7, and both surfaces carry all 9.

## Files touched

- `docs/RESULTS.md`
- `site/results.html`
- `site/benchmarks.html`
- `site/README.md`
- `presentation/index.html`
- `core/tests/test_published_results_consistency.py` (new)
