### PR TITLE
fix(ci): keep the plan job's log line out of $GITHUB_OUTPUT (Benchmarks is dead on main)

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -180,7 +180,7 @@ jobs:
           LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
         run: |
           python3 - <<'PY' >> "$GITHUB_OUTPUT"
-          import json, os
+          import json, os, sys
 
           # Single source of truth for the benchmark dimensions (these used to be the
           # literal `matrix.tier` / `matrix.bench` lists).
@@ -205,9 +205,14 @@ jobs:
                   if run:
                       legs.append({"tier": tier, "bench": bench})
 
+          # stdout of this heredoc IS $GITHUB_OUTPUT, which accepts ONLY `key=value`
+          # lines — so the human-readable summary has to go to stderr. Printing it to
+          # stdout fails the whole step with "Invalid format", which took down every
+          # dispatch and every labelled PR (the legs were selected correctly; only the
+          # reporting was wrong).
           print("matrix=" + json.dumps(legs))
           print("has_legs=" + ("true" if legs else "false"))
-          print(f"selected {len(legs)} leg(s): {legs}", flush=True)
+          print(f"selected {len(legs)} leg(s): {json.dumps(legs)}", file=sys.stderr, flush=True)
           PY
 
   bench:


### PR DESCRIPTION
## The whole Benchmarks suite is currently broken on `main`

`plan legs` (added in #232) fails on **every** `workflow_dispatch` and **every** labelled PR, and because `bench` `needs: plan`, no benchmark leg can run at all. First hit when dispatching `smoke / spreadsheetbench` after #240 merged — [run 30553166191](https://github.com/skillberry-ai/cap-evolve/actions/runs/30553166191) died in 2 seconds:

```
##[error]Invalid format 'selected 1 leg(s): [{'tier': 'smoke', 'bench': 'spreadsheetbench'}]'
##[error]Unable to process file command 'output' successfully.
```

## Cause

The step redirects the whole heredoc's stdout into `$GITHUB_OUTPUT`:

```yaml
python3 - <<'PY' >> "$GITHUB_OUTPUT"
```

…and then prints a human-readable summary to that same stdout:

```python
print("matrix=" + json.dumps(legs))
print("has_legs=" + ("true" if legs else "false"))
print(f"selected {len(legs)} leg(s): {legs}", flush=True)   # <-- lands in $GITHUB_OUTPUT
```

`$GITHUB_OUTPUT` accepts only `key=value` lines, so the third one fails the step. **Leg selection was correct** — the log shows it picked exactly `[{'tier': 'smoke', 'bench': 'spreadsheetbench'}]`. Only the reporting was wrong.

## Fix

Send the summary to **stderr**: still visible in the job log, not parsed as output. Also `json.dumps()` it so the log shows real JSON rather than Python repr with single quotes.

## Verification

Extracted the heredoc verbatim and ran it over all six selection paths, asserting every `$GITHUB_OUTPUT` line matches GitHub's `key=value` rule:

| case | result |
|---|---|
| dispatch `smoke`/`spreadsheetbench` | output OK, 1 leg |
| dispatch `all`/`all` | output OK, 8 legs |
| dispatch `smoke`/`all` | output OK, 4 legs |
| PR label `benchmark-smoke-tau2` | output OK, 1 leg |
| PR label `benchmark-full` | output OK, 4 legs |
| PR, no labels | output OK, `matrix=[]` + `has_legs=false` |

The pre-fix script reproduces the exact error line from the run above, so this is confirmed as the cause and not a guess. `actionlint` clean (the one `github.head_ref` finding is pre-existing and untouched).

## Note

This is the second time a workflow change has broken `main`'s CI in a way YAML parsing alone could not catch (cf. #230). Worth considering an `actionlint` step in `ci.yml` — happy to add it here or separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)