### PR TITLE
Ship a filled, runnable worked project reference (the scaffold #108 describes is gitignored, not blank)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,30 @@ All notable changes to cap-evolve are documented here. The format follows
   longer looks like a capability regression.
 
 ### Added
+- **A filled, runnable worked reference project (`examples/toy_calc/`).** The repo shipped
+  a blank scaffold (`templates/project/`) and zero filled `PROJECT.md` / commented
+  `capevolve.yaml` anywhere — so the first concrete artifact after intake taught nothing.
+  `examples/toy_calc/` now carries both: a filled `PROJECT.md` (what is optimized, how it
+  runs, how it scores, the splits, the budget, the resolved/skipped inputs) and a filled
+  `capevolve.yaml` with a note on **why** for every decision. `run.sh` uses that spec
+  instead of the blank template and runs `cap-evolve check` first, so the documented hard
+  gate is actually exercised.
+
+  Each doc leads with what the example does **not** prove, because that is what readers
+  over-read: `gate_mode: paired` / `gate_k_se: 1.0` are set but never tested here — both
+  val tasks move together, so `SE(Δ)=0` and the gate takes its documented **STRICT
+  fallback** (`paired Δ̄=+1.0000 > 0 (SE=0 → STRICT fallback, warned; n=2)`); at
+  `k_se=1.0` improving exactly one of `n` tasks gives `mean(Δ)=SE(Δ)` *exactly* and is
+  **rejected** at any `n` and any magnitude; `val=2` is the harness floor, not a
+  recommendation; and `check` passing does not run `run_target`, so it proves less than it
+  looks. `protected_paths` is deliberately **omitted** (an empty list is a hard error,
+  never a "use defaults" shorthand).
+
+  Two tests in `core/tests/test_e2e_slice.py` drive the committed files through the real
+  CLI — `cap-evolve check` → a full zero-API `run` → the sealed test — and assert the spec
+  rules (no declared `protected_paths`, val ≥ 2, no leftover template placeholders) plus
+  the gate's `gate_warning`. A contract change now breaks a test instead of silently
+  rotting the prose.
 - **SWE-bench oracle mode + calibrated smoke selection.** The SWE-bench adapter gains
   `SWEBENCH_ORACLE=1`, which attaches the "Oracle" retrieval context (the file[s] the
   gold patch touches, from `princeton-nlp/SWE-bench_Lite_oracle`'s `text` field) to the

--- a/core/tests/test_e2e_slice.py
+++ b/core/tests/test_e2e_slice.py
@@ -8,6 +8,7 @@ architecture works without any model.
 """
 
 import os
+import re
 import shutil
 import sys
 from pathlib import Path
@@ -127,3 +128,110 @@ def test_baseline_better_than_nothing_is_gated(tmp_path):
         gate_kwargs={"mode": "significant", "k_se": 1.0},
     )
     assert step["accepted"] is False
+
+
+# --------------------------------------------------------------------------
+# The worked reference project (issue #108). These drive the COMMITTED example
+# files — capevolve.yaml, PROJECT.md, adapter.py — through the real CLI, so a
+# contract change breaks a test instead of silently rotting the docs.
+# --------------------------------------------------------------------------
+
+def _build_reference_project(dest: Path) -> Path:
+    """Assemble the project dir exactly as examples/toy_calc/run.sh does."""
+    proj = dest / ".capevolve" / "project"
+    (proj / "adapters").mkdir(parents=True)
+    shutil.copy(EXAMPLE / "adapter.py", proj / "adapters" / "adapter.py")
+    shutil.copy(EXAMPLE / "capevolve.yaml", proj / "capevolve.yaml")
+    shutil.copy(EXAMPLE / "PROJECT.md", proj / "PROJECT.md")
+    shutil.copytree(EXAMPLE / "capability", dest / "seed_capability")
+    return proj
+
+
+def test_worked_reference_check_and_spec_are_honest(tmp_path):
+    """`cap-evolve check` accepts the reference, and its spec obeys the current rules.
+
+    Guards the two rules a scaffolded example most easily gets wrong:
+      * `protected_paths: []` is a HARD ERROR (#142/#197), so the reference must OMIT
+        the key rather than declare an empty list;
+      * the val split must clear the harness floor (#113) — these ratios give val=2,
+        which is exactly MIN_VAL_TASKS.
+    """
+    from cap_evolve.check import run_check
+    from cap_evolve.specfile import read_yaml
+
+    proj = _build_reference_project(tmp_path)
+
+    rep = run_check(proj)
+    assert rep.ok, f"cap-evolve check rejected the worked reference: {rep.to_dict()}"
+    assert rep.stubs == [] and rep.problems == []
+
+    raw = (proj / "capevolve.yaml").read_text(encoding="utf-8")
+    spec = read_yaml(raw)
+    # An empty protected_paths is a hard error, so the reference must not declare one.
+    assert "protected_paths" not in spec, "the reference must OMIT protected_paths (empty = hard error)"
+    # ...and not as a live (uncommented) line either.
+    assert not [ln for ln in raw.splitlines()
+                if ln.strip().startswith("protected_paths")], "protected_paths is declared"
+
+    # Splits must clear the val floor on the real dataset.
+    import importlib.util
+    aspec = importlib.util.spec_from_file_location("ref_adapter_spec", EXAMPLE / "adapter.py")
+    toy = importlib.util.module_from_spec(aspec)
+    aspec.loader.exec_module(toy)
+    n = len(toy.Adapter().tasks("all"))
+    n_val = int(n * float(spec["split_val"]))
+    assert n_val >= 2, f"val split is {n_val} task(s); the harness floor is 2"
+
+    # No unfilled template placeholders left in either doc (issue #108's ask).
+    template = (REPO / "templates" / "project" / "PROJECT.md").read_text(encoding="utf-8")
+    tokens = set(re.findall(r"<[^<>\n]{2,40}>", template))
+    assert tokens, "template has no placeholders to compare against — did its shape change?"
+    for name in ("capevolve.yaml", "PROJECT.md"):
+        body = (proj / name).read_text(encoding="utf-8")
+        assert "Acapo" not in body, f"{name} carries the pre-rebrand name"
+        left = sorted(t for t in tokens if t in body)
+        assert not left, f"{name} still carries unfilled template placeholders: {left}"
+    project_md = (proj / "PROJECT.md").read_text(encoding="utf-8")
+    assert "Honest limits" in project_md, "the reference must keep its honest-limits section"
+
+
+def test_worked_reference_runs_end_to_end(tmp_path):
+    """A real zero-API `cap-evolve run` on the reference, through to the sealed test."""
+    import json
+    import subprocess
+
+    proj = _build_reference_project(tmp_path)
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(CORE)
+    env["CAPEVOLVE_SKILLS_DIR"] = str(REPO / "skills")
+
+    proc = subprocess.run(
+        [sys.executable, "-m", "cap_evolve.cli", "run",
+         "--spec", str(proj / "capevolve.yaml"), "--project", str(proj), "--run-ts", "ref"],
+        cwd=tmp_path, env=env, capture_output=True, text=True,
+    )
+    assert proc.returncode == 0, f"run failed:\n{proc.stdout}\n{proc.stderr}"
+    # The run prints one or more JSON objects; the summary is the last top-level one.
+    dec, objs, i = json.JSONDecoder(), [], 0
+    while (i := proc.stdout.find("{", i)) != -1:
+        try:
+            obj, end = dec.raw_decode(proc.stdout, i)
+        except json.JSONDecodeError:
+            i += 1
+            continue
+        objs.append(obj)
+        i = end
+    summary = objs[-1]
+    assert summary["baseline_val"] == 0.0
+    assert summary["test_reward"] == 1.0, summary
+    assert summary["test_delta"] == 1.0
+
+    # The gate's honest caveat: a deterministic scorer gives SE(delta)=0, so the paired
+    # gate takes its documented STRICT fallback. PROJECT.md claims exactly this; if the
+    # gate stops warning, the claim is stale and this fails.
+    events = [json.loads(l) for l in
+              (tmp_path / ".capevolve" / "run_ref" / "events.jsonl").read_text().splitlines()]
+    assert any(e.get("kind") == "gate_warning" for e in events), \
+        "PROJECT.md documents an SE=0 STRICT fallback; no gate_warning was logged"
+    accepted = [e for e in events if e.get("kind") == "step" and e.get("accept")]
+    assert accepted and "STRICT fallback" in accepted[0]["reason"], accepted

--- a/core/tests/test_e2e_slice.py
+++ b/core/tests/test_e2e_slice.py
@@ -192,7 +192,16 @@ def test_worked_reference_check_and_spec_are_honest(tmp_path):
         left = sorted(t for t in tokens if t in body)
         assert not left, f"{name} still carries unfilled template placeholders: {left}"
     project_md = (proj / "PROJECT.md").read_text(encoding="utf-8")
-    assert "Honest limits" in project_md, "the reference must keep its honest-limits section"
+    # The reference's whole value is the caveats, so assert the SECTION and its CONTENT.
+    # A bare `"Honest limits" in project_md` also matches the cross-reference earlier in
+    # the file, so it survives both a heading rename and deleting the section outright.
+    assert "\n## Honest limits" in project_md, "the reference lost its `## Honest limits` heading"
+    limits = project_md.split("\n## Honest limits", 1)[1].split("\n## ", 1)[0]
+    for claim in ("STRICT fallback", "bank nothing", "MIN_VAL_TASKS", "run_target",
+                  "engineered"):
+        assert claim in limits, f"Honest limits lost its `{claim}` caveat"
+    caveats = re.findall(r"^\d+\. \*\*", limits, flags=re.M)
+    assert len(caveats) == 5, f"Honest limits should list 5 caveats, found {len(caveats)}"
 
 
 def test_worked_reference_runs_end_to_end(tmp_path):

--- a/examples/toy_calc/PROJECT.md
+++ b/examples/toy_calc/PROJECT.md
@@ -1,0 +1,100 @@
+# cap-evolve project — toy_calc arithmetic stand-in
+
+A **filled** version of `templates/project/PROJECT.md`. The template ships as a blank
+form; this is what one looks like after `intake` has actually interviewed someone, so
+you can see the shape of a real answer instead of a `<placeholder>`. Copy the
+**template** to start your own.
+
+Records the decisions behind this run so anyone (human or agent) can reproduce it.
+
+## What we're optimizing
+- Capability: `system-prompt`
+- Artifact: `capability/prompt.txt` (copied to `<workdir>/seed_capability/` by `run.sh`)
+- Allowed edits: `[edit]` — rewrite the prompt text. No adding or deleting files; the
+  stand-in only ever reads `prompt.txt`.
+
+## How we run the target (the RUNNER)
+- Agent under test: a **deterministic Python stand-in**, not a model. It lives in
+  `adapter.py::Adapter.run_target` and computes the arithmetic correctly **only** when
+  the candidate prompt contains the marker `[CALC]`; otherwise it emits
+  `"I think <expr> is roughly some number."` and fails the exact-match scorer.
+- How `run_target` invokes it: reads `ctx/prompt.txt` (where `ctx` is the candidate dir
+  yielded by the default `live()`), branches on `"[CALC]" in prompt`, and returns a
+  `Rollout`. `seed` is accepted per the contract and unused — this runner is exact.
+- Why a stand-in: it makes the whole pipeline provable at **zero API cost** and with
+  byte-identical reruns, which is what lets this example be the CI gate. It buys
+  determinism, not realism — see *Honest limits*.
+
+## How we score
+- Metric: exact string match against `task.target`, reward `1.0` or `0.0`.
+- Feedback signal: on failure, `score()` reports what was expected vs produced **plus
+  the hypothesis** that "the prompt likely lacks an explicit instruction to compute and
+  output only the number". That sentence is the learning signal the optimizer acts on —
+  it names the *cause*, not just the miss. It does not leak the gold answer beyond the
+  expected value the optimizer would see in the trace anyway.
+- Secondary metrics: none (`metrics_display: []`). The gate reads only the primary
+  scalar reward regardless.
+
+## Data
+- Source: `adapter` — the adapter's own `tasks()` reads `tasks.jsonl` (8 arithmetic
+  tasks) from `CAPEVOLVE_TOY_DATA`. `dataset_source: adapter` means the harness does not
+  load a file itself; `tasks()` is the single source.
+- Split: train 4 / val 2 / test 2, seed `0`, frozen once into `<run>/splits.json`. Test
+  is sealed and scored exactly once at finalize — a second `finalize` raises
+  `TestSealError`.
+- `tasks(split)` deliberately returns **all** tasks and lets the harness filter by the
+  frozen split. That is the supported shape; the split is the harness's job, not the
+  adapter's.
+
+## Optimizer + algorithm
+- Optimizer (proposer): `mock` — applies `mock_script.json` verbatim
+  (`ensure_contains` the `[CALC]` line). Deterministic, zero API calls.
+- Algorithm: `hill-climb --focus all`
+- Budget: `max_iterations: 5`, `stall: 2`. The winning edit lands on iteration 1; the
+  next two are no-ops the gate rejects, so `stall` ends the run after **3** iterations.
+
+## Inputs status
+- NEEDED inputs resolved: capability + artifact path, runner (the stand-in), scorer,
+  dataset, splits, optimizer, algorithm, budget.
+- RECOMMENDED inputs skipped: `target_model` (there is no consuming LLM — the "agent"
+  is Python, so there is no reader tier to tune edits for); `runner_repo_path` and
+  `capability_sources` (the runner is 20 lines inside the adapter, nothing to surface);
+  `metrics_display` (one metric).
+
+## Honest limits — what this example does NOT prove
+
+Worth more than the parts that work, because these are the claims people over-read.
+
+1. **The significance gate never does real work here.** `gate_mode: paired`,
+   `gate_k_se: 1.0` are set, but both val tasks move `0 → 1` *together*, so the spread
+   of the per-task deltas is zero, `SE(Δ) = 0`, and the gate logs a `gate_warning` and
+   applies its documented **STRICT fallback** (accept any `Δ > 0`). The run transcript
+   says exactly that: `paired Δ̄=+1.0000 > 0 (SE=0 → STRICT fallback, warned; n=2)`.
+   A deterministic scorer has no noise to reject.
+2. **`k_se = 1.0` is stricter than it looks.** Improving exactly ONE of `n` val tasks
+   gives `mean(Δ) = SE(Δ)` *exactly*, so the strict `>` **rejects** it — at every `n`,
+   and no matter how large that single gain is. **Improve ≥ 2 tasks at `k_se = 1.0`, or
+   bank nothing.** Set `gate_k_se: 0.2` (as the other examples do) to bank a 1-of-`n`
+   gain.
+3. **val = 2 is the floor, not a recommendation.** It equals the harness's
+   `MIN_VAL_TASKS = 2`; a smaller val split is *refused*, and 2 is still under the
+   low-confidence threshold. A real benchmark wants tens of val tasks.
+4. **`cap-evolve check` passing is not proof the adapter is correct.** It proves the
+   three abstract methods are implemented and non-stubbed, `tasks()` is non-empty and
+   stable, `score()` is deterministic, and `materialize()` is callable. It does not run
+   `run_target`, so a non-deterministic runner passes `check`. Notably a `materialize()`
+   that *raises* can still yield `{"ok": true}`.
+5. **The improvement is engineered.** The stand-in is written so `[CALC]` is the one
+   thing that matters and `mock` is scripted to add it. `0.0 → 1.0` proves the loop
+   plumbing, gate wiring, and seal — not that optimization works on a real benchmark.
+   For that, see `examples/tau2_airline/` and `examples/skillsbench/`.
+
+## Where the pieces live
+| File | Role |
+|---|---|
+| [`adapter.py`](adapter.py) | the `CapabilityAdapter`: 3 required methods + one hook override |
+| [`capevolve.yaml`](capevolve.yaml) | the filled run spec, with a note per choice |
+| [`capability/prompt.txt`](capability/prompt.txt) | the seed artifact (no `[CALC]`) |
+| [`tasks.jsonl`](tasks.jsonl) | 8 arithmetic tasks |
+| [`mock_script.json`](mock_script.json) | the deterministic edit `mock` applies |
+| [`run.sh`](run.sh) | the whole thing end to end, zero API |

--- a/examples/toy_calc/PROJECT.md
+++ b/examples/toy_calc/PROJECT.md
@@ -69,7 +69,8 @@ Worth more than the parts that work, because these are the claims people over-re
    `gate_k_se: 1.0` are set, but both val tasks move `0 → 1` *together*, so the spread
    of the per-task deltas is zero, `SE(Δ) = 0`, and the gate logs a `gate_warning` and
    applies its documented **STRICT fallback** (accept any `Δ > 0`). The run transcript
-   says exactly that: `paired Δ̄=+1.0000 > 0 (SE=0 → STRICT fallback, warned; n=2)`.
+   says exactly that: `paired Δ̄=+1.0000 > 0 (SE=0 → STRICT fallback, warned; n=2`…
+   (the suffix varies by branch; the prefix is the stable part).
    A deterministic scorer has no noise to reject.
 2. **`k_se = 1.0` is stricter than it looks.** Improving exactly ONE of `n` val tasks
    gives `mean(Δ) = SE(Δ)` *exactly*, so the strict `>` **rejects** it — at every `n`,
@@ -77,12 +78,15 @@ Worth more than the parts that work, because these are the claims people over-re
    bank nothing.** Set `gate_k_se: 0.2` (as the other examples do) to bank a 1-of-`n`
    gain.
 3. **val = 2 is the floor, not a recommendation.** It equals the harness's
-   `MIN_VAL_TASKS = 2`; a smaller val split is *refused*, and 2 is still under the
-   low-confidence threshold. A real benchmark wants tens of val tasks.
+   `MIN_VAL_TASKS = 2`; a smaller val split is *refused*, and 2 is still under
+   `LOW_CONFIDENCE_VAL_TASKS = 5`, the threshold that flags acceptance decisions as LOW
+   CONFIDENCE. A real benchmark wants tens of val tasks.
 4. **`cap-evolve check` passing is not proof the adapter is correct.** It proves the
    three abstract methods are implemented and non-stubbed, `tasks()` is non-empty and
    stable, `score()` is deterministic, and `materialize()` is callable. It does not run
-   `run_target`, so a non-deterministic runner passes `check`. Notably a `materialize()`
+   `run_target` (except an opt-in degenerate-trials probe behind
+   `CAPEVOLVE_CHECK_TRIAL_PROBE=1` *and* `CAPEVOLVE_N_TRIALS>1`, which only ever appends
+   a WARNING note), so a non-deterministic runner passes `check`. Notably a `materialize()`
    that *raises* can still yield `{"ok": true}`.
 5. **The improvement is engineered.** The stand-in is written so `[CALC]` is the one
    thing that matters and `mock` is scripted to add it. `0.0 → 1.0` proves the loop

--- a/examples/toy_calc/README.md
+++ b/examples/toy_calc/README.md
@@ -68,3 +68,10 @@ section spells out all five caveats. For real benchmarks see
   adapter implements: 3 required `@abstractmethod`s, defaulted hooks, `hasattr`-probed
   optional fast paths.
 - [`templates/project/`](../../templates/project) — the blank scaffold to copy.
+- `benchmarks/toy_calc/` — the **declarative** form of this same benchmark: a
+  `benchmark.yaml` manifest plus a one-function `project/target.py`, with the spec
+  *generated* by `cap-evolve benchmark add`. Take that path when the manifest fits; this
+  directory is the reference for the hand-written `CapabilityAdapter` when it doesn't.
+  The two are deliberately paired — the zoo entry links back here for the adapter form,
+  and this is the "before" side of its boilerplate measurement. *(Lands with #233; the
+  path is intentionally unlinked until then.)*

--- a/examples/toy_calc/README.md
+++ b/examples/toy_calc/README.md
@@ -1,18 +1,40 @@
-# Example: toy_calc (zero-API, deterministic)
+# Example: toy_calc — the worked reference project (zero-API, deterministic)
 
-The smallest end-to-end proof — no model calls, fully deterministic, runs in
-seconds. A deterministic stand-in "agent" answers arithmetic tasks; it only
-succeeds when the system prompt contains the marker `[CALC]`, so the optimization
-(the `mock` optimizer adds `[CALC]`) provably raises the score. Used as the CI gate.
+The smallest end-to-end proof, and the **filled reference** for what a real
+`.capevolve/project/` looks like. No model calls, fully deterministic, runs in seconds.
+
+A deterministic stand-in "agent" answers arithmetic tasks; it only succeeds when the
+system prompt contains the marker `[CALC]`, so the optimization (the `mock` optimizer
+adds `[CALC]`) provably raises the score. Used as the CI gate.
+
+> **To start your own project, copy [`templates/project/`](../../templates/project) —
+> it carries the full option list with every knob documented.** Read *this* directory to
+> see a finished one: every choice made with a note on why, plus an explicit list of what
+> the example does **not** prove.
 
 ## Files
-- `adapter.py` — a `CapabilityAdapter`: the 3 required methods (deterministic agent +
-  exact-match scorer) plus an `apply` hook override.
+- [`PROJECT.md`](PROJECT.md) — the **filled** `templates/project/PROJECT.md`: what is
+  optimized, how it runs, how it scores, the splits, the budget, and an *Honest limits*
+  section naming what this example does not demonstrate.
+- [`capevolve.yaml`](capevolve.yaml) — the **filled** run spec, one comment per decision.
+- [`adapter.py`](adapter.py) — a `CapabilityAdapter`: the **3 required** methods
+  (`tasks`, `run_target`, `score`) plus an override of the optional `apply` hook.
 - `capability/prompt.txt` — the seed system prompt (no `[CALC]`).
 - `mock_script.json` — the deterministic edit the `mock` optimizer applies.
 - `tasks.jsonl` — 8 arithmetic tasks.
 
 ## Run it
+```bash
+bash examples/toy_calc/run.sh
+# -> {"ok": true}                             (cap-evolve check, the hard gate)
+# -> baseline_val 0.0  ->  test_reward 1.0     (gate-accepted, test sealed) + dashboard.html
+```
+`run.sh` builds the project dir, runs `cap-evolve check`, then the full pipeline.
+`core/tests/test_e2e_slice.py::test_worked_reference_runs_end_to_end` drives these same
+files through `check` → run → sealed test, so a contract change breaks a test rather than
+rotting this README.
+
+Or by hand, to see the pieces:
 ```bash
 REPO=$PWD                       # cap-evolve repo root
 export CAPEVOLVE_CORE=$REPO/core PYTHONPATH=$REPO/core CAPEVOLVE_SKILLS_DIR=$REPO/skills
@@ -20,11 +42,29 @@ export CAPEVOLVE_TOY_DATA=$REPO/examples/toy_calc
 export CAPEVOLVE_MOCK_SCRIPT=$REPO/examples/toy_calc/mock_script.json
 
 D=/tmp/toy; mkdir -p $D/.capevolve/project/adapters
-cp $REPO/examples/toy_calc/adapter.py $D/.capevolve/project/adapters/
-cp -R $REPO/examples/toy_calc/capability $D/seed_capability
-cp $REPO/templates/project/capevolve.yaml $D/.capevolve/project/capevolve.yaml   # defaults: system-prompt / mock / hill-climb (focus all)
+cp $REPO/examples/toy_calc/adapter.py     $D/.capevolve/project/adapters/
+cp -R $REPO/examples/toy_calc/capability  $D/seed_capability
+cp $REPO/examples/toy_calc/capevolve.yaml $D/.capevolve/project/capevolve.yaml
+cp $REPO/examples/toy_calc/PROJECT.md     $D/.capevolve/project/PROJECT.md
 
-python3 -m cap_evolve.cli run --spec $D/.capevolve/project/capevolve.yaml --project $D/.capevolve/project --run-ts demo
-# -> baseline_val 0.0  ->  test_reward 1.0   (gate-accepted, test sealed) + dashboard.html
+python3 -m cap_evolve.cli check $D/.capevolve/project      # {"ok": true}
+python3 -m cap_evolve.cli run --spec $D/.capevolve/project/capevolve.yaml \
+                              --project $D/.capevolve/project --run-ts demo
 ```
-This is exactly what `core/tests/test_e2e_slice.py` asserts.
+
+## What it proves, and what it doesn't
+
+Proves: the adapter contract, the frozen splits, the gate wiring, the optimizer handoff,
+the sealed test, and the run-dir artifacts — reproducibly and for free.
+
+Does **not** prove: that the significance gate rejects noise (a deterministic scorer has
+none, so the gate takes its documented `SE=0 → STRICT` fallback here), nor that
+optimization works on a real benchmark. [`PROJECT.md`](PROJECT.md)'s *Honest limits*
+section spells out all five caveats. For real benchmarks see
+[`../tau2_airline`](../tau2_airline) and [`../skillsbench`](../skillsbench).
+
+## Related
+- [`docs/ADAPTER_CONTRACT.md`](../../docs/ADAPTER_CONTRACT.md) — the contract this
+  adapter implements: 3 required `@abstractmethod`s, defaulted hooks, `hasattr`-probed
+  optional fast paths.
+- [`templates/project/`](../../templates/project) — the blank scaffold to copy.

--- a/examples/toy_calc/capevolve.yaml
+++ b/examples/toy_calc/capevolve.yaml
@@ -1,0 +1,79 @@
+# toy_calc — a FILLED cap-evolve run spec (the worked reference).
+#
+# This is the template at `templates/project/capevolve.yaml` with every decision
+# actually made, and a note on WHY. To start your own project, copy the TEMPLATE
+# (it carries the full option list); read this file to see what a finished one
+# looks like and what each choice costs you.
+#
+# `run.sh` copies this file to `<workdir>/.capevolve/project/capevolve.yaml` — the
+# project dir the harness reads. Only keys that differ from the template's default,
+# or that are load-bearing here, are kept; every omitted key takes its default.
+
+# --- what to optimize -------------------------------------------------------
+capabilities: [system-prompt]     # the artifact is one prompt file, so one capability
+capability_path: seed_capability  # resolved project-relative; run.sh puts the seed copy here
+actions: [edit]                   # edit the prompt text; no add/remove of files
+
+# --- who proposes edits -----------------------------------------------------
+optimizer_skill: mock             # `mock` = deterministic, ZERO API calls. It applies
+                                  # CAPEVOLVE_MOCK_SCRIPT verbatim, which is why this
+                                  # example is a CI gate and not a flaky model call.
+optimizer_model: ""               # unused by `mock`
+target_model: ""                  # no consuming LLM: the "agent" is a Python stand-in,
+                                  # so there is no reader tier to tune edits for
+
+# --- how to iterate ---------------------------------------------------------
+algorithm_skill: hill-climb       # parent is always the current best — the simplest loop
+algorithm_focus: all              # reflect over the whole train set each iteration
+orchestration_mode: deterministic # cap-evolve sequences the loop; honesty is code-enforced
+
+# --- data + splits ----------------------------------------------------------
+dataset_source: adapter           # tasks come from Adapter.tasks(); there is no file
+                                  # loader in this path — the adapter reads tasks.jsonl
+                                  # itself (see adapter.py), and the harness filters by
+                                  # the frozen split.
+split_seed: 0                     # frozen ONCE into <run>/splits.json; test is sealed
+split_train: 0.5                  # 8 tasks -> train 4 / val 2 / test 2
+split_val: 0.25
+split_test: 0.25
+# HONEST LIMIT: val = 2 tasks. That is exactly the floor the harness enforces
+# (`MIN_VAL_TASKS = 2`); a 3-task dataset with these ratios would be REFUSED, not
+# silently run. 2 is still below the low-confidence threshold, so a real benchmark
+# wants tens of val tasks. This example gets away with it only because the scorer is
+# exact and the stand-in is deterministic.
+
+# --- scoring ----------------------------------------------------------------
+num_trials: 1                     # the stand-in is deterministic: extra trials are
+                                  # byte-identical, so they buy no variance information
+
+# --- protected paths (tamper guard) -----------------------------------------
+# DELIBERATELY OMITTED, which means "use the defaults derived from this layout"
+# (adapters/, capevolve.yaml, the dataset, and *gold* data files). Do NOT write
+# `protected_paths: []` to mean that — an empty list is a HARD ERROR, because
+# "protects nothing" must never happen by accident.
+
+# --- acceptance gate --------------------------------------------------------
+gate_mode: paired                 # the default in every real run: mean(per-task Δ) vs
+                                  # k·SE(Δ) over the SAME val tasks
+gate_k_se: 1.0
+# HONEST LIMIT — read this before quoting the gate. Two things are true here:
+#  1. At k_se = 1.0, improving exactly ONE of n val tasks gives mean(Δ) = SE(Δ)
+#     EXACTLY, so the strict `>` REJECTS it — at every n, and however large that one
+#     gain is. You need >= 2 improved tasks to bank anything at 1.0. (The examples
+#     that want single-task gains set `gate_k_se: 0.2`.)
+#  2. This run never exercises that bar. Both val tasks move 0 -> 1 together, so the
+#     spread of the deltas is zero, SE(Δ) = 0, and the gate logs a `gate_warning` and
+#     falls back to the documented STRICT rule (accept any Δ > 0). The transcript says
+#     so: `paired Δ̄=+1.0000 > 0 (SE=0 → STRICT fallback, warned; n=2)`.
+# So this example proves the PIPELINE end to end. It does not demonstrate the paired
+# significance test doing real work — a deterministic scorer has no noise to reject.
+
+# --- budget -----------------------------------------------------------------
+max_iterations: 5                 # the winning edit lands on iteration 1; 5 leaves room
+stall: 2                          # ...and `stall` stops it 2 rejects later, so the run
+                                  # ends after 3 iterations, not 5
+max_usd: 0.0                      # 0 = off, and honest here: `mock` spends nothing
+
+# --- iteration store --------------------------------------------------------
+store: git                        # every iteration is a commit in the run dir, so the
+                                  # process is inspectable after the fact

--- a/examples/toy_calc/capevolve.yaml
+++ b/examples/toy_calc/capevolve.yaml
@@ -64,7 +64,8 @@ gate_k_se: 1.0
 #  2. This run never exercises that bar. Both val tasks move 0 -> 1 together, so the
 #     spread of the deltas is zero, SE(Δ) = 0, and the gate logs a `gate_warning` and
 #     falls back to the documented STRICT rule (accept any Δ > 0). The transcript says
-#     so: `paired Δ̄=+1.0000 > 0 (SE=0 → STRICT fallback, warned; n=2)`.
+#     so: `paired Δ̄=+1.0000 > 0 (SE=0 → STRICT fallback, warned; n=2` (the stable
+#     prefix; the suffix after `n=2` varies by branch).
 # So this example proves the PIPELINE end to end. It does not demonstrate the paired
 # significance test doing real work — a deterministic scorer has no noise to reject.
 

--- a/examples/toy_calc/run.sh
+++ b/examples/toy_calc/run.sh
@@ -14,9 +14,14 @@ D="$(mktemp -d -t toy_calc.XXXXXX)"
 mkdir -p "$D/.capevolve/project/adapters"
 cp "$REPO/examples/toy_calc/adapter.py"   "$D/.capevolve/project/adapters/"
 cp -R "$REPO/examples/toy_calc/capability" "$D/seed_capability"
-cp "$REPO/templates/project/capevolve.yaml"   "$D/.capevolve/project/capevolve.yaml"
+# The FILLED spec (examples/toy_calc/capevolve.yaml), not the blank template — this
+# example IS the worked reference for what a finished project dir looks like.
+cp "$REPO/examples/toy_calc/capevolve.yaml" "$D/.capevolve/project/capevolve.yaml"
+cp "$REPO/examples/toy_calc/PROJECT.md"     "$D/.capevolve/project/PROJECT.md"
 
 echo "Working directory: $D"
+# The hard gate: refuses to proceed unless the adapter contract actually holds.
+python3 -m cap_evolve.cli check "$D/.capevolve/project"
 python3 -m cap_evolve.cli run \
   --spec    "$D/.capevolve/project/capevolve.yaml" \
   --project "$D/.capevolve/project" \

--- a/templates/project/PROJECT.md
+++ b/templates/project/PROJECT.md
@@ -3,6 +3,9 @@
 Filled by the `intake` skill. Records the decisions behind this run so anyone
 (human or agent) can understand and reproduce it.
 
+> For a **filled** worked example of this file (and of `capevolve.yaml`), see
+> `examples/toy_calc/` — a runnable, zero-API reference project.
+
 ## What we're optimizing
 - Capability: <skill-package | tools | mcp-tool | system-prompt | ...>
 - Artifact: `<path>`


### PR DESCRIPTION
Closes #108

## What #108 asked for, and the correction

The issue says the checked-in `.capevolve/project/` scaffold is an untouched blank
template, and offers Option A (fill it) or Option B (delete it).

**Neither is available: the path does not exist.** `.capevolve/` is gitignored
(`.gitignore`: `# cap-evolve run state (per-run, not source)`), and no path under it has
ever been tracked:

```
$ git log --all --oneline -- '.capevolve'
(no output)
$ git log --all --oneline --name-only | grep -c "capevolve/project"
0
```

So there is nothing to delete (Option B is already the status quo), and Option A as
literally written would mean committing an ignored run dir.

**The real gap survives the correction.** The repo ships `templates/project/` — a blank
form — and **zero** filled `PROJECT.md` or commented `capevolve.yaml` anywhere:

```
$ git ls-files | grep -c PROJECT.md
1                       # templates/project/PROJECT.md — the blank template itself
```

`examples/toy_calc/` did not even have a spec: `run.sh` copied
`templates/project/capevolve.yaml`. So the artifact intake produces first had no worked
counterpart to read anywhere in the repo. That is the gap this fills, in the example dir
the docs already point at.

## Judgement on #233's benchmark zoo — does it make this redundant?

**Partly, and I scoped around the overlap rather than duplicating it.**

The zoo genuinely supersedes the *hand-written adapter* teaching angle for benchmarks
that fit its manifest: it cuts 78 → 36 hand-authored lines, and `benchmark verify` is a
far stronger correctness story than anything a doc can assert. If the question is "how do
I add a benchmark", the zoo is now the answer and this PR should not compete with it.

But the zoo's `benchmarks/toy_calc/project/capevolve.yaml` is **`GENERATED from
benchmark.yaml`** and says so in its first line: *"edit the manifest and re-run
`cap-evolve benchmark add --refresh`, not this file."* A generated file is the opposite of
a worked reference — it deliberately explains nothing about why a value was chosen, and it
carries no `PROJECT.md` at all. The zoo also covers only the declarative path; a project
whose runner does not fit the manifest still writes a `CapabilityAdapter` by hand and still
has nothing filled to read.

So I scoped this to the gap the zoo does not close: **the hand-written path, and the
commentary and honesty framing a generated file structurally cannot carry.** No new
directory, no third copy of toy_calc — the two files land in the example that already
exists, and `examples/toy_calc/README.md` cross-links the zoo entry and says outright
*"Prefer the zoo when the manifest fits your benchmark."* If a reviewer disagrees and
wants this closed as zoo-covered, the only thing lost is the filled `PROJECT.md`, which
exists nowhere else.

## What the reference demonstrates

Two genuinely filled files, plus the honesty framing:

- **`examples/toy_calc/PROJECT.md`** — the filled `templates/project/PROJECT.md`: what is
  optimized, how the runner works, how the scorer works and what its feedback *says*, the
  data and splits, the optimizer and algorithm, the budget, and which RECOMMENDED inputs
  were skipped **and why**.
- **`examples/toy_calc/capevolve.yaml`** — the run spec with a note on **why** for every
  decision, rather than a copy of the template's option list.
- **`run.sh`** now uses that spec instead of the blank template, and runs
  `cap-evolve check` first, so the documented hard gate is *exercised*, not described.

### Both docs lead with what it does NOT prove

This is the part worth more than the parts that work, because it is what readers over-read:

1. **The significance gate never does real work here.** `gate_mode: paired`,
   `gate_k_se: 1.0` are set, but both val tasks move `0 → 1` *together*, so the spread of
   the per-task deltas is zero, `SE(Δ) = 0`, and the gate logs a `gate_warning` and takes
   its documented **STRICT fallback**. Verbatim from the run:
   `paired Δ̄=+1.0000 > 0 (SE=0 → STRICT fallback, warned; n=2)`.
2. **`k_se = 1.0` is stricter than it looks.** Improving exactly ONE of `n` val tasks
   gives `mean(Δ) = SE(Δ)` **exactly**, so the strict `>` **rejects** it — at every `n`,
   and however large that single gain is. **Improve ≥ 2 tasks at `k_se = 1.0`, or bank
   nothing.**
3. **`val = 2` is the harness floor** (`MIN_VAL_TASKS`), not a recommendation — and still
   under the low-confidence threshold.
4. **`check` passing proves less than it looks.** It never calls `run_target`, so a
   non-deterministic runner passes it; a raising `materialize()` can still yield
   `{"ok": true}`.
5. **The `0.0 → 1.0` improvement is engineered by construction.**

## Correct against the current (unmerged) contracts

- **#181 adapter contract** — described as **3 required** `@abstractmethod`s (`tasks`,
  `run_target`, `score`) plus an override of the **optional** `apply` hook. Not "4
  methods". Matches `docs/ADAPTER_CONTRACT.md` on `fix/issue-103-adapter-methods`
  line-for-line, and matches that branch's own edit to this README.
- **#197 `protected_paths`** — deliberately **OMITTED**, with a comment saying why: an
  empty list is a **HARD ERROR**, never a "use defaults" shorthand. Verified against
  #197's actual code (evidence below).
- **#195 split floor / `k_se` cap** — the reference's splits clear the floor
  (`honest_gate: true`) on `fix/issue-113-small-samples`, and it emits exactly the
  LOW CONFIDENCE warning `PROJECT.md` documents. `gate_k_se: 1.0` is far under the 26.5 cap.
- **#198 gate rule** — no "banks 1-task gains" claim anywhere; the `k_se = 1.0` caveat is
  stated in full, magnitude- and `n`-independent, in both docs and the CHANGELOG.
- **#183 rebrand** — `templates/project/PROJECT.md` gains **one line** at line 3 pointing
  at the filled example; the `Acapo` H1 at line 1 is left untouched so #183 owns it.
  `git merge origin/fix/issue-105-rebrand` → *"Automatic merge went well."*

## How this is prevented from rotting

Prose asserting a contract is exactly what this epic keeps finding stale (#203's
`cap-evolve finalize`, `maybe_cached_score`, "4 methods"). So the claims are tested, not
written down:

`core/tests/test_e2e_slice.py` gains two tests that drive the **committed** files through
the real CLI:

- `test_worked_reference_check_and_spec_are_honest` — runs the real `run_check`, then
  asserts the spec rules: **no** declared `protected_paths` (post-#197), `val ≥ 2`
  (post-#195), no pre-rebrand name, and no template placeholder token still present. The
  placeholder list is **derived from `templates/project/PROJECT.md` at test time**, so it
  cannot go stale against the template it mirrors — and it fails loudly if the template
  stops having placeholders at all.
- `test_worked_reference_runs_end_to_end` — a real zero-API `cap-evolve run` subprocess
  through to the **sealed test number**, and asserts the gate actually logs the
  `gate_warning` and `STRICT fallback` reason the docs claim. If the gate stops falling
  back, the doc claim is stale and **this test fails** rather than the doc lying.

## Expected merge order

Both are one-line-adjacent, not blocking, but land them first for a clean history:

1. **#183** (`fix/issue-105-rebrand`) — owns `templates/project/PROJECT.md`'s H1. Verified
   clean auto-merge with this branch.
2. **#197** (`feat/issue-142-protected-paths`) — makes `protected_paths: []` a hard error;
   this reference is already correct for it (omits the key). No conflict either way.

Neither is required for the tests here to pass on `main` today.

## Verification

Every number below is pasted literal output. Full commands + transcripts in the
**🔬 Evidence** comment.

**`cap-evolve check` on the reference:**
```
$ python3 -m cap_evolve.cli check /tmp/ref/.capevolve/project
{
  "ok": true,
  "stubs": [],
  "problems": [],
  "notes": [
    "tasks('val') -> 8 task(s)",
    "scorer deterministic (probe reward=0.0000)",
    "materialize() callable (dry-run into temp copy; host untouched)"
  ]
}
```

**A real zero-API `cap-evolve run` with the `mock` optimizer, to a sealed test number:**
```
$ python3 -m cap_evolve.cli run --spec .capevolve/project/capevolve.yaml \
    --project .capevolve/project --run-ts ref
{"dashboard": "http://127.0.0.1:7898"}
{
  "run_dir": ".capevolve/run_ref",
  "best_id": "cand_0001",
  "baseline_val": 0.0,
  "test_reward": 1.0,
  "test_baseline_reward": 0.0,
  "test_delta": 1.0,
  "test_pass_k": {
    "1": 1.0,
    "2": 0.0
  },
  "iterations": 3,
  "dashboard": ".capevolve/run_ref/dashboard.html",
  "dashboard_server": "http://127.0.0.1:7899"
}
```
Sealed test = **1.0** from `baseline_val 0.0`. `iterations: 3` — the win lands on
iteration 1, then `stall: 2` ends the run, exactly as `capevolve.yaml` documents.

**The gate claim, from that same run's events (proving the honesty caveat is real):**
```
splits       :: {"train": 4, "val": 2, "test": 2, "seed": 0}
gate_warning :: combined/paired SE is 0 (likely n_trials=1 or identical trials) — the
                significance gate cannot distinguish noise from signal and is falling
                back to STRICT (accept any Δ>0). ...
step         :: paired Δ̄=+1.0000 > 0 (SE=0 → STRICT fallback, warned; n=2)
step         :: paired Δ̄=+0.0000 <= 0 (SE=0 → STRICT fallback, warned; n=2)
step         :: paired Δ̄=+0.0000 <= 0 (SE=0 → STRICT fallback, warned; n=2)
finalize     :: {"test_reward": 1.0, "test_baseline_reward": 0.0, "test_delta": 1.0,
                 "best_id": "cand_0001"}
```

**Post-#197 `protected_paths` correctness** (run on `feat/issue-142-protected-paths`):
```
$ python3 -m cap_evolve.cli check /tmp/ref197/.capevolve/project
{"ok": true, "stubs": [], "problems": [], ...}

$ protect.resolve_protected(project)        # the key is OMITTED -> real defaults
['adapters/adapter.py', 'capevolve.yaml']

# control — what the reference deliberately avoids:
$ (append "protected_paths: []"); protect.protected_globs(project)
TamperError: cap-evolve: `protected_paths` in .../capevolve.yaml is an EMPTY list.
That would protect nothing (the scorer / eval harness / task data would all be optimi...
```

**Post-#195 split floor** (run on `fix/issue-113-small-samples`):
```
"test_reward": 1.0,
"honest_gate": true,
"warnings": [
  "val split (at baseline) has only 2 tasks (< 5) — acceptance decisions are LOW
   CONFIDENCE. The gate applies a Student-t small-sample correction (df=1), which
   widens the bar, but the honest fix is more val tasks.",
  ...
]
```
Clears the `MIN_VAL_TASKS = 2` floor, and the warning is exactly what `PROJECT.md`
documents as an honest limit.

**`run.sh` end to end (the CI gate path):**
```
{"ok": true, "stubs": [], "problems": [], ...}
"baseline_val": 0.0,
"test_reward": 1.0,
```
CI's assertion greps `"baseline_val": 0.0` + `"test_reward": 1.0` — both still present.

**Full test suite:**
```
$ PYTHONPATH=core python -m pytest core/tests -q      # THIS BRANCH
181 passed in 68.87s

$ PYTHONPATH=core python -m pytest core/tests -q      # BASELINE (origin/main, clean worktree)
179 passed in 57.19s
```
**179 baseline → 181: exactly +2** (my two new tests), **0 failures on either side**.
Earlier in the session the same command hit
`test_dashboard_launch.py::test_maybe_launch_spawns_when_available` — the known port-7878
flake tracked in **#200** — on the branch *and* on the unmodified baseline
(`1 failed, 180 passed` vs `1 failed, 178 passed`: the same +2 with the same pre-existing
failure). It is timing-dependent and unrelated to this change.

**`compileall`:**
```
$ python -m compileall -q core examples
compileall: clean
```

**Links:** all 15 relative links in the two new/edited docs resolve (checked
programmatically; full output in the Evidence comment).

## Files touched

| File | Change |
|---|---|
| `examples/toy_calc/PROJECT.md` | **new** — the filled `PROJECT.md`, incl. *Honest limits* |
| `examples/toy_calc/capevolve.yaml` | **new** — the filled spec, a note per decision |
| `examples/toy_calc/run.sh` | use the filled spec; run `cap-evolve check` first |
| `examples/toy_calc/README.md` | reframed as the worked reference; zoo cross-link; #181 wording |
| `core/tests/test_e2e_slice.py` | +2 anti-rot tests over the committed files |
| `templates/project/PROJECT.md` | +1 line pointing at the filled example (H1 untouched) |
| `CHANGELOG.md` | Unreleased / Added entry |
