### PR TITLE
feat(algorithm): on-demand reasoning skills + an advisory proposal-quality declaration (#140)

### DIFF
--- a/RUN.md
+++ b/RUN.md
@@ -74,7 +74,12 @@ artifact.
 - Acceptance is gated on **val**, never on the data the optimizer edited against.
 - Only the **primary** metric (the scalar reward) gates; shown-only secondaries (e.g. `cost_usd`, `db_match`) are displayed but never affect accept/reject.
 - Multi-trial scoring reports mean + stderr; pass^k is reported when trials > 1.
-- Rejected approaches are remembered and never re-proposed.
+- Rejected approaches are remembered (`rejected.jsonl`) and re-injected into every later
+  proposal prompt as an explicit "already tried & rejected — do not re-propose" constraint
+  block, carrying the exact edit signature and why the gate killed it. Enforcement is
+  **advisory** at the prompt: the optimizer is a black-box agent CLI, so cap-evolve cannot
+  forbid it from re-emitting an edit. What is **hard** is the gate — a re-proposed dead end
+  is still rejected on val, and the repeat is counted in the constraint block.
 
 ## One-command alternative
 If you'd rather not drive it turn-by-turn:

--- a/core/cap_evolve/__init__.py
+++ b/core/cap_evolve/__init__.py
@@ -17,6 +17,7 @@ from .cache import EvalCache, hash_candidate_dir
 from .gate import GateDecision, TrainGateError, decide
 from .lr_schedule import build_schedule
 from .memory import History, RejectedMemory
+from .optimizer_context import OptimizerContext
 from .rundir import Budget, RunDir, Spent
 from .selection import PICKERS, STRATEGIES, pick, validate_strategy
 from .splits import Splits, TestSealError, make_splits
@@ -41,6 +42,7 @@ __all__ = [
     "decide",
     "History",
     "RejectedMemory",
+    "OptimizerContext",
     "Budget",
     "RunDir",
     "Spent",

--- a/core/cap_evolve/__init__.py
+++ b/core/cap_evolve/__init__.py
@@ -4,7 +4,7 @@ This is the *only* shipped code in cap-evolve. Everything user-facing is an
 Agent Skill; those skills' ``run.py`` scripts call into here for the things that
 must be consistent and honest across every run: task/score types, seeded splits
 with a sealed test set, variance-aware statistics, the acceptance gate,
-optimizer memory, the run directory, and the adapter contract.
+the run directory, and the adapter contract.
 
 Import it directly when Python is available, or invoke ``python -m
 cap_evolve <command>`` and parse the JSON it prints.

--- a/core/cap_evolve/cache.py
+++ b/core/cap_evolve/cache.py
@@ -22,13 +22,16 @@ import hashlib
 import json
 from pathlib import Path
 
-from .rundir import SCRATCH_NAMES
+from .rundir import NON_CAPABILITY_NAMES
 
 # Files that are NOT part of the capability (optimizer scratch, memory, vcs); they
 # must not perturb the content hash or every iteration would miss the cache.
-# ``rundir.SCRATCH_NAMES`` is the shared definition (see the note there); INSTRUCTIONS
-# and PROCESS are added because they ARE snapshotted but still are not capability bytes.
-_IGNORE_NAMES = {"INSTRUCTIONS.md", "PROCESS.md"} | set(SCRATCH_NAMES)
+# ``rundir.NON_CAPABILITY_NAMES`` is the shared definition (see the note there): the
+# union of live + legacy scratch plus INSTRUCTIONS/PROCESS, which ARE snapshotted but
+# still are not capability bytes. This is a read-side filter (skip bytes when hashing),
+# so it takes the whole union — including the legacy names, so caches written before
+# they were retired keep resolving.
+_IGNORE_NAMES = set(NON_CAPABILITY_NAMES)
 _IGNORE_DIRS = {".git", "__pycache__", "prior_iterations"}
 
 
@@ -48,9 +51,15 @@ def hash_candidate_dir(candidate_dir: Path) -> str:
     for p in cdir.rglob("*"):
         if not p.is_file():
             continue
-        if p.name in _IGNORE_NAMES:
+        rel = p.relative_to(cdir)
+        # Root-anchored: every ignored name is a root-level framework injection, so a
+        # NESTED file that merely shares one (``src/prompts/STATE.md``) is capability
+        # content and MUST fold into the digest — otherwise deleting it leaves the hash
+        # unchanged and the next iteration serves the parent's cached rewards for a
+        # materially different candidate (a stale hit on a mutilated candidate).
+        if len(rel.parts) == 1 and p.name in _IGNORE_NAMES:
             continue
-        if any(part in _IGNORE_DIRS for part in p.relative_to(cdir).parts):
+        if any(part in _IGNORE_DIRS for part in rel.parts):
             continue
         files.append(p)
     for p in sorted(files, key=lambda x: str(x.relative_to(cdir))):

--- a/core/cap_evolve/cache.py
+++ b/core/cap_evolve/cache.py
@@ -30,7 +30,7 @@ import hashlib
 import json
 from pathlib import Path
 
-from .optimizer_context import INJECTED_DIRS, INJECTED_NAMES
+from .optimizer_context import INJECTED_DIRS, INJECTED_NAMES, SCRATCH_NAMES
 
 # Files that are NOT part of the capability (optimizer scratch, memory, vcs); they
 # must not perturb the content hash or every iteration would miss the cache. The
@@ -39,10 +39,7 @@ from .optimizer_context import INJECTED_DIRS, INJECTED_NAMES
 # definition in ``optimizer_context``, folded in here as a plain constant expression
 # (no import-time set mutation, so there is no import-order dependence to reason about;
 # ``optimizer_context`` imports only ``.loop`` and ``.rundir`` at module level).
-_IGNORE_NAMES = {"MEMORY.md", "STATE.md", "INSTRUCTIONS.md", "REJECTED.md", "FOCUS.md",
-                 "REFLECTION.md",
-                 # cross-iteration state files (clean-ownership redesign) — scratch, not capability
-                 "LEDGER.md", "JOURNAL.md", "PROCESS.md", "RUNMAP.md"} | set(INJECTED_NAMES)
+_IGNORE_NAMES = set(SCRATCH_NAMES) | set(INJECTED_NAMES)
 _IGNORE_DIRS = {".git", "__pycache__"} | set(INJECTED_DIRS)
 
 

--- a/core/cap_evolve/cache.py
+++ b/core/cap_evolve/cache.py
@@ -1,16 +1,18 @@
 """Eval cache — skip a rollout when the same candidate was already scored on a task.
 
 Keyed by ``(hash of the candidate's editable files, task_id) -> {reward, feedback}``
-and persisted in the run dir. The hash is over file CONTENTS, so two byte-identical
-candidates share cache entries even under different ids.
+and persisted in the run dir, so re-evaluating an identical candidate (e.g. a parent
+re-sampled in GEPA, or a resumed run) costs nothing. The hash is over file CONTENTS,
+so two byte-identical candidates share cache entries even under different ids.
 
-**Scope: GEPA only.** The single consumer is ``gepa._eval_minibatch``, where the same
-parent is re-sampled from the Pareto frontier across iterations and re-scored on
-overlapping minibatches — that repetition is what the cache pays for.
-``harness.evaluate_candidate`` (every full-val and sealed-test eval, in every algorithm)
-does NOT consult it and always pays full price, so re-scoring an identical candidate on
-full val — common on ``--resume`` or a seed re-eval — is not deduplicated. Wiring it in
-there is a possible perf win, not existing behavior; there is no flag for it today.
+**Scope: GEPA only** — which bounds the "costs nothing" above. The single consumer is
+``gepa._eval_minibatch``, where the same parent is re-sampled from the Pareto frontier
+across iterations and re-scored on overlapping minibatches; that repetition is what the
+cache pays for. ``harness.evaluate_candidate`` (every full-val and sealed-test eval, in
+every algorithm) does NOT consult it and always pays full price, so re-scoring an
+identical candidate on full val — including on ``--resume`` or a seed re-eval — is NOT
+deduplicated. Wiring it in there is a possible perf win, not existing behavior, and
+there is no flag for it today (``test_w1_engine.py`` guards that claim).
 
 Honesty notes:
   * The cache stores only the SCORE (reward + feedback), never gold answers.

--- a/core/cap_evolve/cache.py
+++ b/core/cap_evolve/cache.py
@@ -1,17 +1,23 @@
 """Eval cache — skip a rollout when the same candidate was already scored on a task.
 
 Keyed by ``(hash of the candidate's editable files, task_id) -> {reward, feedback}``
-and persisted in the run dir, so re-evaluating an identical candidate (e.g. a parent
-re-sampled in GEPA, or a resumed run) costs nothing. The hash is over file CONTENTS,
-so two byte-identical candidates share cache entries even under different ids.
+and persisted in the run dir. The hash is over file CONTENTS, so two byte-identical
+candidates share cache entries even under different ids.
+
+**Scope: GEPA only.** The single consumer is ``gepa._eval_minibatch``, where the same
+parent is re-sampled from the Pareto frontier across iterations and re-scored on
+overlapping minibatches — that repetition is what the cache pays for.
+``harness.evaluate_candidate`` (every full-val and sealed-test eval, in every algorithm)
+does NOT consult it and always pays full price, so re-scoring an identical candidate on
+full val — common on ``--resume`` or a seed re-eval — is not deduplicated. Wiring it in
+there is a possible perf win, not existing behavior; there is no flag for it today.
 
 Honesty notes:
   * The cache stores only the SCORE (reward + feedback), never gold answers.
   * It is keyed on candidate-file content, so an edit (even whitespace) busts the
     key — a stale score can never be served for changed files.
   * It is an optimization, not a source of truth: ``events.jsonl`` still records
-    every evaluation. Wiring into ``evaluate_candidate`` is OFF by default and gated
-    behind a flag (see ``maybe_cached_score``) so it cannot silently change behavior.
+    every evaluation.
 
 Pure stdlib (hashlib + json).
 """

--- a/core/cap_evolve/cache.py
+++ b/core/cap_evolve/cache.py
@@ -22,12 +22,13 @@ import hashlib
 import json
 from pathlib import Path
 
+from .rundir import SCRATCH_NAMES
+
 # Files that are NOT part of the capability (optimizer scratch, memory, vcs); they
 # must not perturb the content hash or every iteration would miss the cache.
-_IGNORE_NAMES = {"MEMORY.md", "STATE.md", "INSTRUCTIONS.md", "REJECTED.md", "FOCUS.md",
-                 "REFLECTION.md",
-                 # cross-iteration state files (clean-ownership redesign) — scratch, not capability
-                 "LEDGER.md", "JOURNAL.md", "PROCESS.md", "RUNMAP.md"}
+# ``rundir.SCRATCH_NAMES`` is the shared definition (see the note there); INSTRUCTIONS
+# and PROCESS are added because they ARE snapshotted but still are not capability bytes.
+_IGNORE_NAMES = {"INSTRUCTIONS.md", "PROCESS.md"} | set(SCRATCH_NAMES)
 _IGNORE_DIRS = {".git", "__pycache__", "prior_iterations"}
 
 

--- a/core/cap_evolve/cache.py
+++ b/core/cap_evolve/cache.py
@@ -31,18 +31,20 @@ import json
 from pathlib import Path
 
 from .optimizer_context import INJECTED_DIRS, INJECTED_NAMES
+from .rundir import NON_CAPABILITY_NAMES
 
 # Files that are NOT part of the capability (optimizer scratch, memory, vcs); they
-# must not perturb the content hash or every iteration would miss the cache. The
-# INJECTED_* halves are the optimizer-context read-context (``trajectories/``,
-# ``guidance/``, the native per-agent skill dirs and instructions files) — one
-# definition in ``optimizer_context``, folded in here as a plain constant expression
-# (no import-time set mutation, so there is no import-order dependence to reason about;
-# ``optimizer_context`` imports only ``.loop`` and ``.rundir`` at module level).
-_IGNORE_NAMES = {"MEMORY.md", "STATE.md", "INSTRUCTIONS.md", "REJECTED.md", "FOCUS.md",
-                 "REFLECTION.md",
-                 # cross-iteration state files (clean-ownership redesign) — scratch, not capability
-                 "LEDGER.md", "JOURNAL.md", "PROCESS.md", "RUNMAP.md"} | set(INJECTED_NAMES)
+# must not perturb the content hash or every iteration would miss the cache.
+# ``rundir.NON_CAPABILITY_NAMES`` is the shared definition (see the tier note there):
+# the union of live + legacy scratch plus INSTRUCTIONS/PROCESS, which ARE snapshotted
+# but still are not capability bytes. This is a read-side filter (skip bytes when
+# hashing), so it takes the whole union — including the legacy names, so caches written
+# before they were retired keep resolving. The INJECTED_* halves are the
+# optimizer-context read-context (``trajectories/``, ``guidance/``, the native per-agent
+# skill dirs and instructions files) — one definition in ``optimizer_context``, folded in
+# here as a plain constant expression (no import-time set mutation, so there is no
+# import-order dependence to reason about).
+_IGNORE_NAMES = set(NON_CAPABILITY_NAMES) | set(INJECTED_NAMES)
 _IGNORE_DIRS = {".git", "__pycache__"} | set(INJECTED_DIRS)
 
 
@@ -62,9 +64,15 @@ def hash_candidate_dir(candidate_dir: Path) -> str:
     for p in cdir.rglob("*"):
         if not p.is_file():
             continue
-        if p.name in _IGNORE_NAMES:
+        rel = p.relative_to(cdir)
+        # Root-anchored: every ignored name is a root-level framework injection, so a
+        # NESTED file that merely shares one (``src/prompts/STATE.md``) is capability
+        # content and MUST fold into the digest — otherwise deleting it leaves the hash
+        # unchanged and the next iteration serves the parent's cached rewards for a
+        # materially different candidate (a stale hit on a mutilated candidate).
+        if len(rel.parts) == 1 and p.name in _IGNORE_NAMES:
             continue
-        if any(part in _IGNORE_DIRS for part in p.relative_to(cdir).parts):
+        if any(part in _IGNORE_DIRS for part in rel.parts):
             continue
         files.append(p)
     for p in sorted(files, key=lambda x: str(x.relative_to(cdir))):

--- a/core/cap_evolve/cache.py
+++ b/core/cap_evolve/cache.py
@@ -5,13 +5,21 @@ and persisted in the run dir, so re-evaluating an identical candidate (e.g. a pa
 re-sampled in GEPA, or a resumed run) costs nothing. The hash is over file CONTENTS,
 so two byte-identical candidates share cache entries even under different ids.
 
+**Scope: GEPA only** — which bounds the "costs nothing" above. The single consumer is
+``gepa._eval_minibatch``, where the same parent is re-sampled from the Pareto frontier
+across iterations and re-scored on overlapping minibatches; that repetition is what the
+cache pays for. ``harness.evaluate_candidate`` (every full-val and sealed-test eval, in
+every algorithm) does NOT consult it and always pays full price, so re-scoring an
+identical candidate on full val — including on ``--resume`` or a seed re-eval — is NOT
+deduplicated. Wiring it in there is a possible perf win, not existing behavior, and
+there is no flag for it today (``test_w1_engine.py`` guards that claim).
+
 Honesty notes:
   * The cache stores only the SCORE (reward + feedback), never gold answers.
   * It is keyed on candidate-file content, so an edit (even whitespace) busts the
     key — a stale score can never be served for changed files.
   * It is an optimization, not a source of truth: ``events.jsonl`` still records
-    every evaluation. Wiring into ``evaluate_candidate`` is OFF by default and gated
-    behind a flag (see ``maybe_cached_score``) so it cannot silently change behavior.
+    every evaluation.
 
 Pure stdlib (hashlib + json).
 """

--- a/core/cap_evolve/cache.py
+++ b/core/cap_evolve/cache.py
@@ -22,29 +22,20 @@ import hashlib
 import json
 from pathlib import Path
 
+from .optimizer_context import INJECTED_DIRS, INJECTED_NAMES
+
 # Files that are NOT part of the capability (optimizer scratch, memory, vcs); they
-# must not perturb the content hash or every iteration would miss the cache.
+# must not perturb the content hash or every iteration would miss the cache. The
+# INJECTED_* halves are the optimizer-context read-context (``trajectories/``,
+# ``guidance/``, the native per-agent skill dirs and instructions files) — one
+# definition in ``optimizer_context``, folded in here as a plain constant expression
+# (no import-time set mutation, so there is no import-order dependence to reason about;
+# ``optimizer_context`` imports only ``.loop`` and ``.rundir`` at module level).
 _IGNORE_NAMES = {"MEMORY.md", "STATE.md", "INSTRUCTIONS.md", "REJECTED.md", "FOCUS.md",
                  "REFLECTION.md",
                  # cross-iteration state files (clean-ownership redesign) — scratch, not capability
-                 "LEDGER.md", "JOURNAL.md", "PROCESS.md", "RUNMAP.md"}
-_IGNORE_DIRS = {".git", "__pycache__"}
-
-
-def _load_injected_ignores() -> None:
-    """Fold in everything the optimizer-context seam injects into a workdir.
-
-    Injected read-context (``trajectories/``, ``guidance/``, the native per-agent skills
-    dirs and instructions files) is NOT capability content, so it must not perturb the
-    hash — otherwise a GEPA minibatch would miss the cache on every iteration. Imported
-    lazily so this module stays at the bottom of the import graph.
-    """
-    from .optimizer_context import INJECTED_DIRS, INJECTED_NAMES
-    _IGNORE_DIRS.update(INJECTED_DIRS)
-    _IGNORE_NAMES.update(INJECTED_NAMES)
-
-
-_load_injected_ignores()
+                 "LEDGER.md", "JOURNAL.md", "PROCESS.md", "RUNMAP.md"} | set(INJECTED_NAMES)
+_IGNORE_DIRS = {".git", "__pycache__"} | set(INJECTED_DIRS)
 
 
 def hash_candidate_dir(candidate_dir: Path) -> str:

--- a/core/cap_evolve/cache.py
+++ b/core/cap_evolve/cache.py
@@ -30,16 +30,21 @@ import hashlib
 import json
 from pathlib import Path
 
-from .optimizer_context import INJECTED_DIRS, INJECTED_NAMES, SCRATCH_NAMES
+from .optimizer_context import INJECTED_DIRS, INJECTED_NAMES
+from .rundir import NON_CAPABILITY_NAMES
 
 # Files that are NOT part of the capability (optimizer scratch, memory, vcs); they
-# must not perturb the content hash or every iteration would miss the cache. The
-# INJECTED_* halves are the optimizer-context read-context (``trajectories/``,
-# ``guidance/``, the native per-agent skill dirs and instructions files) — one
-# definition in ``optimizer_context``, folded in here as a plain constant expression
-# (no import-time set mutation, so there is no import-order dependence to reason about;
-# ``optimizer_context`` imports only ``.loop`` and ``.rundir`` at module level).
-_IGNORE_NAMES = set(SCRATCH_NAMES) | set(INJECTED_NAMES)
+# must not perturb the content hash or every iteration would miss the cache.
+# ``rundir.NON_CAPABILITY_NAMES`` is the shared definition (see the tier note there):
+# the union of live + legacy scratch plus INSTRUCTIONS/PROCESS, which ARE snapshotted
+# but still are not capability bytes. This is a read-side filter (skip bytes when
+# hashing), so it takes the whole union — including the legacy names, so caches written
+# before they were retired keep resolving. The INJECTED_* halves are the
+# optimizer-context read-context (``trajectories/``, ``guidance/``, the native per-agent
+# skill dirs and instructions files) — one definition in ``optimizer_context``, folded in
+# here as a plain constant expression (no import-time set mutation, so there is no
+# import-order dependence to reason about).
+_IGNORE_NAMES = set(NON_CAPABILITY_NAMES) | set(INJECTED_NAMES)
 _IGNORE_DIRS = {".git", "__pycache__"} | set(INJECTED_DIRS)
 
 
@@ -59,9 +64,15 @@ def hash_candidate_dir(candidate_dir: Path) -> str:
     for p in cdir.rglob("*"):
         if not p.is_file():
             continue
-        if p.name in _IGNORE_NAMES:
+        rel = p.relative_to(cdir)
+        # Root-anchored: every ignored name is a root-level framework injection, so a
+        # NESTED file that merely shares one (``src/prompts/STATE.md``) is capability
+        # content and MUST fold into the digest — otherwise deleting it leaves the hash
+        # unchanged and the next iteration serves the parent's cached rewards for a
+        # materially different candidate (a stale hit on a mutilated candidate).
+        if len(rel.parts) == 1 and p.name in _IGNORE_NAMES:
             continue
-        if any(part in _IGNORE_DIRS for part in p.relative_to(cdir).parts):
+        if any(part in _IGNORE_DIRS for part in rel.parts):
             continue
         files.append(p)
     for p in sorted(files, key=lambda x: str(x.relative_to(cdir))):

--- a/core/cap_evolve/cache.py
+++ b/core/cap_evolve/cache.py
@@ -28,7 +28,23 @@ _IGNORE_NAMES = {"MEMORY.md", "STATE.md", "INSTRUCTIONS.md", "REJECTED.md", "FOC
                  "REFLECTION.md",
                  # cross-iteration state files (clean-ownership redesign) — scratch, not capability
                  "LEDGER.md", "JOURNAL.md", "PROCESS.md", "RUNMAP.md"}
-_IGNORE_DIRS = {".git", "__pycache__", "prior_iterations"}
+_IGNORE_DIRS = {".git", "__pycache__"}
+
+
+def _load_injected_ignores() -> None:
+    """Fold in everything the optimizer-context seam injects into a workdir.
+
+    Injected read-context (``trajectories/``, ``guidance/``, the native per-agent skills
+    dirs and instructions files) is NOT capability content, so it must not perturb the
+    hash — otherwise a GEPA minibatch would miss the cache on every iteration. Imported
+    lazily so this module stays at the bottom of the import graph.
+    """
+    from .optimizer_context import INJECTED_DIRS, INJECTED_NAMES
+    _IGNORE_DIRS.update(INJECTED_DIRS)
+    _IGNORE_NAMES.update(INJECTED_NAMES)
+
+
+_load_injected_ignores()
 
 
 def hash_candidate_dir(candidate_dir: Path) -> str:

--- a/core/cap_evolve/cli.py
+++ b/core/cap_evolve/cli.py
@@ -86,6 +86,53 @@ def _resolve_algorithm(name: str) -> tuple[str, str | None]:
     return name, None
 
 
+# Algorithms whose run.py declares the shared optimizer-context flag set (via
+# ``OptimizerContext.add_arguments``). The agent-driven ones (evograph, agent-optimize)
+# have no deterministic loop and only tolerate the base flags, so they are excluded —
+# an explicit list, not a silent per-flag drop (issue #109).
+_OPTIMIZER_CONTEXT_ALGORITHMS = ("hill-climb", "gepa", "skillopt")
+
+
+def _optimizer_context_flags(spec: dict, project: str, optimizer_name: str) -> list[str]:
+    """Build the optimizer-context CLI flags from the spec, for ANY algorithm.
+
+    Every value here is "what context does the optimizer get" — the capability brief +
+    guidance, the intake-authored instructions template, the benchmark repo, supporting
+    source files, the optimizer's own features reference, and the consuming-LLM profile.
+    Paths are resolved project-relative when not absolute.
+    """
+    out: list[str] = []
+
+    def _project_rel(value) -> Path:
+        p = Path(str(value))
+        return p if p.is_absolute() or p.exists() else Path(project) / str(value)
+
+    def _csv(value) -> list[str]:
+        if isinstance(value, str):
+            return [v.strip() for v in value.split(",") if v.strip()]
+        return [str(v).strip() for v in (value or []) if str(v).strip()]
+
+    caps = _csv(spec.get("capabilities"))
+    if caps:
+        out += ["--capabilities", ",".join(caps)]
+    if optimizer_name:
+        out += ["--optimizer-name", str(optimizer_name)]
+    instr_p = _project_rel(spec.get("optimizer_instructions_file")
+                           or "optimizer/INSTRUCTIONS.md")
+    if instr_p.exists():
+        out += ["--instructions-file", str(instr_p)]
+    if spec.get("runner_repo_path"):
+        out += ["--bench-repo", str(_project_rel(spec["runner_repo_path"]))]
+    csrc = _csv(spec.get("capability_sources"))
+    if csrc:
+        out += ["--capability-sources", ",".join(csrc)]
+    if spec.get("target_model"):
+        out += ["--target-model", str(spec["target_model"])]
+    if spec.get("target_profile_file"):
+        out += ["--target-profile-file", str(_project_rel(spec["target_profile_file"]))]
+    return out
+
+
 def _resolve_skills(skills_dir: Path) -> dict:
     manifest = skills_dir / "_registry" / "manifest.json"
     if not manifest.exists():
@@ -345,54 +392,14 @@ def _cmd_run(argv):
         alg_cmd += ["--resume"]
     if algorithm_focus is not None:
         alg_cmd += ["--focus", algorithm_focus]
-    # Surface the selected capability skills to the optimizer prompt so it knows the
-    # allowed edit space (e.g. tools → may add composite tools). hill-climb consumes
-    # --capabilities; algorithms without the flag ignore the extra arg via argparse error,
-    # so only pass it to those that accept it.
-    caps = spec.get("capabilities") or []
-    if isinstance(caps, str):
-        caps = [c.strip() for c in caps.split(",") if c.strip()]
-    if caps and algorithm_name == "hill-climb":
-        alg_cmd += ["--capabilities", ",".join(str(c) for c in caps)]
-    # Thread the resolved optimizer NAME so the harness can copy that optimizer's
-    # features reference (parallel-subagent capabilities etc.) into each iteration's
-    # workdir. Only hill-climb accepts the flag; other algorithms ignore it.
-    if algorithm_name == "hill-climb":
-        alg_cmd += ["--optimizer-name", str(optimizer_name)]
-    # Optimizer-instructions template (intake-authored, per benchmark) + benchmark repo
-    # as read-only optimizer context. Both are resolved project-relative if not absolute.
-    # The instructions file defaults to the scaffolded project/optimizer/INSTRUCTIONS.md.
-    if algorithm_name == "hill-climb":
-        instr = spec.get("optimizer_instructions_file") or "optimizer/INSTRUCTIONS.md"
-        instr_p = Path(instr)
-        if not instr_p.is_absolute() and not instr_p.exists():
-            instr_p = Path(project) / instr
-        if instr_p.exists():
-            alg_cmd += ["--instructions-file", str(instr_p)]
-        repo = spec.get("runner_repo_path")
-        if repo:
-            repo_p = Path(str(repo))
-            if not repo_p.is_absolute() and not repo_p.exists():
-                repo_p = Path(project) / str(repo)
-            alg_cmd += ["--bench-repo", str(repo_p)]
-        # Supporting source files (data models / types the tools import) copied verbatim
-        # into the optimizer's ./guidance/sources/ so it can write correct code. Resolved
-        # project-relative by the harness; we pass them through as given.
-        csrc = spec.get("capability_sources") or []
-        if isinstance(csrc, str):
-            csrc = [c.strip() for c in csrc.split(",") if c.strip()]
-        if csrc:
-            alg_cmd += ["--capability-sources", ",".join(str(c) for c in csrc)]
-        # Consuming/runtime LLM the capabilities are optimized FOR (distinct from the
-        # optimizer model). A model id or a tier keyword; steers the optimizer prompt.
-        if spec.get("target_model"):
-            alg_cmd += ["--target-model", str(spec["target_model"])]
-        tpf = spec.get("target_profile_file")
-        if tpf:
-            tpf_p = Path(str(tpf))
-            if not tpf_p.is_absolute() and not tpf_p.exists():
-                tpf_p = Path(project) / str(tpf)
-            alg_cmd += ["--target-profile-file", str(tpf_p)]
+    # Optimizer-context flags — what the optimizer is GIVEN. These used to be gated
+    # behind `algorithm_name == "hill-climb"`, so a user who configured a capability
+    # brief, an instructions template, a bench repo, capability sources or a target model
+    # had them SILENTLY DROPPED on gepa/skillopt (issue #109). Every deterministic
+    # algorithm now declares the same flag set via
+    # OptimizerContext.add_arguments, so they are passed unconditionally.
+    if algorithm_name in _OPTIMIZER_CONTEXT_ALGORITHMS:
+        alg_cmd += _optimizer_context_flags(spec, project, optimizer_name)
     # gepa treats metric-calls as its PRIMARY budget; forward it explicitly (hill-climb
     # has no such flag and enforces the same cap via run_dir.budget_exhausted()).
     if algorithm_name == "gepa" and spec.get("max_metric_calls"):

--- a/core/cap_evolve/dashboard.py
+++ b/core/cap_evolve/dashboard.py
@@ -281,6 +281,18 @@ def reduce_run(run_dir) -> dict:
             gate_warnings.append({"reason": ev.get("reason"), "context": ev.get("context"),
                                   "mode": ev.get("mode")})
             continue
+        if kind == "proposal_quality":
+            # #140: the per-candidate proposal declaration, surfaced in the existing
+            # annotations stream (no new panel). ADVISORY — it never explains an
+            # accept/reject, so it must not read like a gate outcome.
+            missing = ", ".join(ev.get("missing") or [])
+            text = (f"declared mechanism: {ev.get('mechanism')} | expected observable: "
+                    f"{ev.get('observable')}" if not missing else
+                    f"no mechanism declaration (missing: {missing}) — advisory, "
+                    "the val gate still decided this candidate")
+            diagnoses.append({"kind": kind, "candidate": _step_candidate(ev),
+                              "text": text})
+            continue
         if kind in ("diagnose", "optimizer_error"):
             diagnoses.append({
                 "kind": kind,

--- a/core/cap_evolve/dashboard.py
+++ b/core/cap_evolve/dashboard.py
@@ -52,8 +52,9 @@ import shutil
 import subprocess
 from pathlib import Path
 
-from .optimizer_context import SCRATCH_NAMES as _oc_scratch
-from .rundir import ITERATION_EVENT_KINDS, iteration_candidate as _step_candidate
+from .optimizer_context import INJECTED_DIRS, INJECTED_NAMES
+from .rundir import (ITERATION_EVENT_KINDS, NON_CAPABILITY_NAMES,
+                     iteration_candidate as _step_candidate)
 
 # ---------------------------------------------------------------------------
 # Secret redaction
@@ -588,9 +589,22 @@ def reduce_run(run_dir) -> dict:
 # snapshot but are NOT capability edits — skipped when diffing iterations so the diff
 # shows only the real change. (The big read-context dirs trajectories/ and guidance/
 # are already excluded from the snapshot itself; see harness._SNAPSHOT_IGNORE.)
-# ONE definition (optimizer_context.SCRATCH_NAMES) — this copy had drifted from GEPA's
-# and was missing FOCUS.md/REFLECTION.md, so a GEPA candidate's diff showed scratch.
-_DIFF_SKIP = set(_oc_scratch)
+# Derived from ``rundir.NON_CAPABILITY_NAMES`` — a read-side FILTER like the cache and
+# component lists, so it takes the whole union (live + legacy scratch + the two
+# snapshotted explainability files). It must NOT be shared with
+# ``harness._SNAPSHOT_IGNORE``, which is DESTRUCTIVE and takes ``SCRATCH_NAMES`` only:
+# feeding this list to the snapshot would DELETE PROCESS.md, the explainability record
+# we deliberately keep. Same predicate, different operation. See the tier note in
+# rundir.py; the split is pinned by
+# test_gepa.py::test_scratch_ignores_are_one_shared_definition.
+#
+# The INJECTED_* halves are here for the same reason as in ``harness._CAP_DIFF_SKIP``:
+# the parent side of the diff is a snapshot (injected read-context stripped) and the
+# child side may be a live workdir (it is not), so without them an injected
+# ``CLAUDE.md``/``.claude/skills/`` file reads as a real capability addition. Derived,
+# never enumerated.
+_DIFF_SKIP = set(NON_CAPABILITY_NAMES) | set(INJECTED_NAMES)
+_DIFF_SKIP_DIRS = set(INJECTED_DIRS)
 
 
 def _read_dir_files(d: Path) -> dict[str, str]:
@@ -600,7 +614,7 @@ def _read_dir_files(d: Path) -> dict[str, str]:
     for f in sorted(d.rglob("*")):
         if f.is_file():
             rel = str(f.relative_to(d))
-            if rel in _DIFF_SKIP or rel.split("/", 1)[0] in ("trajectories", "guidance"):
+            if rel in _DIFF_SKIP or rel.split("/", 1)[0] in _DIFF_SKIP_DIRS:
                 continue
             try:
                 out[rel] = f.read_text(encoding="utf-8")

--- a/core/cap_evolve/dashboard.py
+++ b/core/cap_evolve/dashboard.py
@@ -52,6 +52,8 @@ import shutil
 import subprocess
 from pathlib import Path
 
+from .rundir import NON_CAPABILITY_NAMES
+
 # ---------------------------------------------------------------------------
 # Secret redaction
 # ---------------------------------------------------------------------------
@@ -584,8 +586,15 @@ def reduce_run(run_dir) -> dict:
 # snapshot but are NOT capability edits — skipped when diffing iterations so the diff
 # shows only the real change. (The big read-context dirs trajectories/ and guidance/
 # are already excluded from the snapshot itself; see harness._SNAPSHOT_IGNORE.)
-_DIFF_SKIP = {"INSTRUCTIONS.md", "MEMORY.md", "STATE.md",
-              "LEDGER.md", "JOURNAL.md", "PROCESS.md", "RUNMAP.md"}
+# Derived from ``rundir.NON_CAPABILITY_NAMES`` — a read-side FILTER like the cache and
+# component lists, so it takes the whole union (live + legacy scratch + the two
+# snapshotted explainability files). It must NOT be shared with
+# ``harness._SNAPSHOT_IGNORE``, which is DESTRUCTIVE and takes ``SCRATCH_NAMES`` only:
+# feeding this list to the snapshot would DELETE PROCESS.md, the explainability record
+# we deliberately keep. Same predicate, different operation. See the tier note in
+# rundir.py; the split is pinned by
+# test_gepa.py::test_scratch_ignores_are_one_shared_definition.
+_DIFF_SKIP = set(NON_CAPABILITY_NAMES)
 
 
 def _read_dir_files(d: Path) -> dict[str, str]:

--- a/core/cap_evolve/dashboard.py
+++ b/core/cap_evolve/dashboard.py
@@ -52,7 +52,8 @@ import shutil
 import subprocess
 from pathlib import Path
 
-from .rundir import ITERATION_EVENT_KINDS, iteration_candidate as _step_candidate
+from .rundir import (ITERATION_EVENT_KINDS, NON_CAPABILITY_NAMES,
+                     iteration_candidate as _step_candidate)
 
 # ---------------------------------------------------------------------------
 # Secret redaction
@@ -587,8 +588,15 @@ def reduce_run(run_dir) -> dict:
 # snapshot but are NOT capability edits — skipped when diffing iterations so the diff
 # shows only the real change. (The big read-context dirs trajectories/ and guidance/
 # are already excluded from the snapshot itself; see harness._SNAPSHOT_IGNORE.)
-_DIFF_SKIP = {"INSTRUCTIONS.md", "MEMORY.md", "STATE.md",
-              "LEDGER.md", "JOURNAL.md", "PROCESS.md", "RUNMAP.md"}
+# Derived from ``rundir.NON_CAPABILITY_NAMES`` — a read-side FILTER like the cache and
+# component lists, so it takes the whole union (live + legacy scratch + the two
+# snapshotted explainability files). It must NOT be shared with
+# ``harness._SNAPSHOT_IGNORE``, which is DESTRUCTIVE and takes ``SCRATCH_NAMES`` only:
+# feeding this list to the snapshot would DELETE PROCESS.md, the explainability record
+# we deliberately keep. Same predicate, different operation. See the tier note in
+# rundir.py; the split is pinned by
+# test_gepa.py::test_scratch_ignores_are_one_shared_definition.
+_DIFF_SKIP = set(NON_CAPABILITY_NAMES)
 
 
 def _read_dir_files(d: Path) -> dict[str, str]:

--- a/core/cap_evolve/dashboard.py
+++ b/core/cap_evolve/dashboard.py
@@ -52,6 +52,7 @@ import shutil
 import subprocess
 from pathlib import Path
 
+from .optimizer_context import SCRATCH_NAMES as _oc_scratch
 from .rundir import ITERATION_EVENT_KINDS, iteration_candidate as _step_candidate
 
 # ---------------------------------------------------------------------------
@@ -587,8 +588,9 @@ def reduce_run(run_dir) -> dict:
 # snapshot but are NOT capability edits — skipped when diffing iterations so the diff
 # shows only the real change. (The big read-context dirs trajectories/ and guidance/
 # are already excluded from the snapshot itself; see harness._SNAPSHOT_IGNORE.)
-_DIFF_SKIP = {"INSTRUCTIONS.md", "MEMORY.md", "STATE.md",
-              "LEDGER.md", "JOURNAL.md", "PROCESS.md", "RUNMAP.md"}
+# ONE definition (optimizer_context.SCRATCH_NAMES) — this copy had drifted from GEPA's
+# and was missing FOCUS.md/REFLECTION.md, so a GEPA candidate's diff showed scratch.
+_DIFF_SKIP = set(_oc_scratch)
 
 
 def _read_dir_files(d: Path) -> dict[str, str]:

--- a/core/cap_evolve/dashboard.py
+++ b/core/cap_evolve/dashboard.py
@@ -52,6 +52,8 @@ import shutil
 import subprocess
 from pathlib import Path
 
+from .rundir import ITERATION_EVENT_KINDS, iteration_candidate as _step_candidate
+
 # ---------------------------------------------------------------------------
 # Secret redaction
 # ---------------------------------------------------------------------------
@@ -225,8 +227,9 @@ def _git_log(root: Path) -> list[dict]:
 
 # Step-like events carry a candidate, an accept flag, and per-iteration cost/time.
 # Different algorithms name the candidate field differently; normalise here.
-def _step_candidate(ev: dict):
-    return ev.get("candidate") or ev.get("candidate_id")
+# Both live in rundir now (imported at the top), so the dashboard and the
+# LEDGER/RUNMAP/prior_iterations builders read the SAME set — a fourth algorithm
+# kind can't desync a fifth consumer.
 
 
 def reduce_run(run_dir) -> dict:
@@ -283,7 +286,7 @@ def reduce_run(run_dir) -> dict:
                 "text": ev.get("error") or ev.get("summary") or ev.get("note") or "",
             })
             continue
-        if kind not in ("step", "skillopt_step", "gepa_val_gate"):
+        if kind not in ITERATION_EVENT_KINDS:
             continue
 
         cid = _step_candidate(ev)
@@ -392,7 +395,7 @@ def reduce_run(run_dir) -> dict:
     # separately by headless backends as opt_cost_usd when present.
     opt_usd = 0.0
     for ev in events:
-        if ev.get("kind") in ("step", "skillopt_step", "gepa_val_gate"):
+        if ev.get("kind") in ITERATION_EVENT_KINDS:
             opt_usd += float(ev.get("opt_cost_usd") or ev.get("optimizer_cost_usd") or 0.0)
     tokens = sum(int(n.get("tokens") or 0) for n in nodes.values())
     intake_usd = intake_tokens = intake_secs = 0.0

--- a/core/cap_evolve/gepa.py
+++ b/core/cap_evolve/gepa.py
@@ -51,9 +51,11 @@ from pathlib import Path
 from typing import Callable
 
 from . import gate as gate_mod
+from . import optimizer_context as oc
 from . import selection
 from .cache import EvalCache, hash_candidate_dir
 from .harness import (
+    _SNAPSHOT_IGNORE,
     _augment_instructions,
     _init_memory_store,
     _live,
@@ -62,6 +64,9 @@ from .harness import (
     split_result_from_rollouts,
 )
 from .loop import SplitResult, aggregate_scores
+from .optimizer_context import OptimizerContext
+from .optimizer_context import inject as inject_optimizer_context
+from .optimizer_context import render_instructions
 from .rundir import RunDir
 from .types import Rollout, Score
 
@@ -75,7 +80,9 @@ _NON_COMPONENT = {
     # cross-iteration state files (clean-ownership redesign) — scratch, not capability
     "LEDGER.md", "JOURNAL.md", "PROCESS.md", "RUNMAP.md",
 }
-_NON_COMPONENT_DIRS = {".git", "__pycache__", "prior_iterations"}
+_NON_COMPONENT_DIRS = {".git", "__pycache__"} | set(oc.INJECTED_DIRS)
+# The injected agent-instructions files (CLAUDE.md / AGENTS.md / …) are read-context too.
+_NON_COMPONENT |= set(oc.INJECTED_NAMES)
 
 
 # ---- components (editable capability files) -------------------------------
@@ -274,16 +281,24 @@ def _write_focus(workdir: Path, components: list[str], focus: list[str] | None) 
     return ", ".join(focus) if focus else "(all)"
 
 
-def _instructions(reflection_summary: str, focus_label: str, mb_ids: list[str]) -> str:
+def _gepa_block(reflection_summary: str, focus_label: str, mb_ids: list[str]) -> str:
+    """GEPA's own tail block: the reflective-dataset + component-focus pointers.
+
+    This is the ``extra`` passed to ``optimizer_context.render_instructions`` — the
+    GEPA-specific part of the prompt. The shared part (capability brief, failure index,
+    bench repo, parallel note, consuming-LLM reader block, the benchmark-authored
+    template) comes from the seam, so GEPA is no longer prompt-poorer than hill-climb.
+    """
     return (
-        "# GEPA reflective optimization step\n\n"
+        "\n## GEPA reflective optimization step\n\n"
         f"Minibatch task ids: {', '.join(map(str, mb_ids))}\n"
         f"Component focus: {focus_label}\n\n"
         "Read `REFLECTION.md` (the reflective dataset over the parent's failing "
         "minibatch tasks: inputs, the agent's output/trajectory, and feedback) and "
-        "`FOCUS.md` (which component(s) to edit). Diagnose the common root cause and "
-        "make ONE targeted edit to the focused component(s) that should fix the "
-        "general pattern.\n\n"
+        "`FOCUS.md` (which component(s) to edit). `./trajectories/` holds the SAME "
+        "minibatch rollouts VERBATIM and untruncated — read them when REFLECTION.md's "
+        "excerpts are not enough. Diagnose the common root cause and make ONE targeted "
+        "edit to the focused component(s) that should fix the general pattern.\n\n"
         f"Summary: {reflection_summary}\n"
     )
 
@@ -460,6 +475,7 @@ def gepa_loop(
     seed: int = 0,
     store=None,
     resume: bool = False,
+    ctx=None,
 ) -> dict:
     """Run GEPA's sample-efficient reflective Pareto loop.
 
@@ -476,6 +492,10 @@ def gepa_loop(
         frequency-weighted as GEPA prescribes).
     max_merges / merge_cadence : system-aware merge budget + how often to attempt
         a merge (every Nth accept).
+    ctx : an ``optimizer_context.OptimizerContext`` — what the optimizer is GIVEN
+        (capability guidance + brief, trajectories, the benchmark-authored instructions
+        template, bench repo, its own features reference, the consuming-LLM profile).
+        The same bundle hill-climb and SkillOpt use, so all three prompt identically.
 
     Returns a result dict in the same shape as ``hill_climb_loop`` /
     ``hill_climb_loop`` (plus GEPA-specific fields). The run's ``best_id`` is set to the
@@ -483,6 +503,7 @@ def gepa_loop(
     """
     gate_kwargs = dict(gate_kwargs or {})
     rejected, history, store = _init_memory_store(run_dir, store)
+    ctx = ctx or OptimizerContext()
     cache = EvalCache(run_dir.root / "eval_cache.json")
     rng = random.Random(seed)
     run_dir.log_event("gepa_start", seed=seed, minibatch_size=minibatch_size,
@@ -557,6 +578,13 @@ def gepa_loop(
         workdir.parent.mkdir(parents=True, exist_ok=True)
         shutil.copytree(parent_dir, workdir)
 
+        # Optimizer read-context (trajectories + capability/diagnose/optimizer guidance +
+        # native skills), through the SAME seam hill-climb uses. Scoped to the parent's
+        # minibatch tag so ./trajectories/ holds exactly the rollouts REFLECTION.md
+        # summarizes — verbatim and untruncated.
+        inject_optimizer_context(adapter, run_dir, workdir, split="train", ctx=ctx,
+                                 tag=f"mb_p_{n:04d}")
+
         comps = _components(workdir)
         if component_selector == "round_robin" and comps:
             focus = [comps[comp_cursor % len(comps)]]
@@ -565,7 +593,10 @@ def gepa_loop(
             focus = None  # 'all'
         refl_summary = _write_reflection(workdir, parent_mb)
         focus_label = _write_focus(workdir, comps, focus)
-        instructions = _instructions(refl_summary, focus_label, mb)
+        instructions = render_instructions(
+            parent_mb, mb, f"GEPA minibatch of {len(mb)} train task(s)", ctx=ctx,
+            algorithm="gepa", run_dir=run_dir, parent_id=parent["id"],
+            extra=_gepa_block(refl_summary, focus_label, mb))
         instructions = _augment_instructions(instructions, workdir, run_dir, rejected, history)
 
         opt_error = None
@@ -625,7 +656,8 @@ def gepa_loop(
         summary = (f"candidate {cid} (val {cand_val.reward:.3f}, "
                    f"Δ {cand_val.reward - parent_result.reward:+.3f})")
         if accepted:
-            run_dir.snapshot(cid, workdir)
+            # Same exclusions run_step uses: the injected read-context is not capability.
+            run_dir.snapshot(cid, workdir, ignore=_SNAPSHOT_IGNORE)
             child_dir = run_dir.candidate_dir(cid)
             pool.append(_entry(cid, child_dir, cand_val, parent=parent["id"]))
             lineage[cid] = parent["id"]
@@ -784,7 +816,7 @@ def _try_merge(
     run_dir.update_spent(iterations=1, accepted=accepted)
     summary = f"merge {mid} of {a['id']}+{b['id']} (val {cand_val.reward:.3f})"
     if accepted:
-        run_dir.snapshot(mid, workdir)
+        run_dir.snapshot(mid, workdir, ignore=_SNAPSHOT_IGNORE)
         pool.append(_entry(mid, run_dir.candidate_dir(mid), cand_val, parent=base_parent["id"]))
         lineage[mid] = base_parent["id"]
         history.add(mid, summary, cand_val.reward)

--- a/core/cap_evolve/gepa.py
+++ b/core/cap_evolve/gepa.py
@@ -281,24 +281,39 @@ def _write_focus(workdir: Path, components: list[str], focus: list[str] | None) 
     return ", ".join(focus) if focus else "(all)"
 
 
-def _gepa_block(reflection_summary: str, focus_label: str, mb_ids: list[str]) -> str:
+def _gepa_block(reflection_summary: str, focus_label: str, mb_ids: list[str],
+                *, has_trajectories: bool = True) -> str:
     """GEPA's own tail block: the reflective-dataset + component-focus pointers.
 
     This is the ``extra`` passed to ``optimizer_context.render_instructions`` — the
     GEPA-specific part of the prompt. The shared part (capability brief, failure index,
     bench repo, parallel note, consuming-LLM reader block, the benchmark-authored
     template) comes from the seam, so GEPA is no longer prompt-poorer than hill-climb.
+
+    ``has_trajectories`` gates the "``./trajectories/`` holds the SAME minibatch
+    rollouts VERBATIM" claim: a fully-cached minibatch persists no rollout files, and
+    the seam then OMITS the dir rather than substituting another iteration's traces
+    (see ``harness._copy_step_trajectories``). Claiming a dir that isn't there — or
+    worse, one holding a different iteration's traces — is the failure mode this pins.
     """
+    traj = (
+        "`./trajectories/` holds the SAME minibatch rollouts VERBATIM and untruncated "
+        "— read them when REFLECTION.md's excerpts are not enough. "
+        if has_trajectories else
+        "This minibatch was served entirely from the eval cache, so NO rollout files "
+        "were persisted for it: there is no `./trajectories/` for this step and "
+        "REFLECTION.md's excerpts are the whole record. Do not look for traces "
+        "elsewhere in the workdir — any you find belong to a DIFFERENT iteration. "
+    )
     return (
         "\n## GEPA reflective optimization step\n\n"
         f"Minibatch task ids: {', '.join(map(str, mb_ids))}\n"
         f"Component focus: {focus_label}\n\n"
         "Read `REFLECTION.md` (the reflective dataset over the parent's failing "
         "minibatch tasks: inputs, the agent's output/trajectory, and feedback) and "
-        "`FOCUS.md` (which component(s) to edit). `./trajectories/` holds the SAME "
-        "minibatch rollouts VERBATIM and untruncated — read them when REFLECTION.md's "
-        "excerpts are not enough. Diagnose the common root cause and make ONE targeted "
-        "edit to the focused component(s) that should fix the general pattern.\n\n"
+        f"`FOCUS.md` (which component(s) to edit). {traj}Diagnose the common root cause "
+        "and make ONE targeted edit to the focused component(s) that should fix the "
+        "general pattern.\n\n"
         f"Summary: {reflection_summary}\n"
     )
 
@@ -581,9 +596,11 @@ def gepa_loop(
         # Optimizer read-context (trajectories + capability/diagnose/optimizer guidance +
         # native skills), through the SAME seam hill-climb uses. Scoped to the parent's
         # minibatch tag so ./trajectories/ holds exactly the rollouts REFLECTION.md
-        # summarizes — verbatim and untruncated.
+        # summarizes — verbatim and untruncated, or nothing at all when the minibatch
+        # came from the eval cache (never another iteration's traces).
         inject_optimizer_context(adapter, run_dir, workdir, split="train", ctx=ctx,
                                  tag=f"mb_p_{n:04d}")
+        has_traj = (workdir / "trajectories").is_dir()
 
         comps = _components(workdir)
         if component_selector == "round_robin" and comps:
@@ -596,7 +613,7 @@ def gepa_loop(
         instructions = render_instructions(
             parent_mb, mb, f"GEPA minibatch of {len(mb)} train task(s)", ctx=ctx,
             algorithm="gepa", run_dir=run_dir, parent_id=parent["id"],
-            extra=_gepa_block(refl_summary, focus_label, mb))
+            extra=_gepa_block(refl_summary, focus_label, mb, has_trajectories=has_traj))
         instructions = _augment_instructions(instructions, workdir, run_dir, rejected, history)
 
         opt_error = None
@@ -663,6 +680,11 @@ def gepa_loop(
             lineage[cid] = parent["id"]
             history.add(cid, summary, cand_val.reward)
             accepts += 1
+            # Publish the running best NOW, not only at loop exit: LEDGER.md's
+            # "Current best:" line (and every other best_id reader) comes from run
+            # state, so leaving it at "seed" for the whole run told GEPA's optimizer
+            # its best candidate was the seed even after an accept.
+            run_dir.set_best(max(pool, key=lambda c: c["val"])["id"])
             if store is not None:
                 store.commit(f"iter {n+1}: ACCEPT {summary}", tag="best", accepted=True)
         else:

--- a/core/cap_evolve/gepa.py
+++ b/core/cap_evolve/gepa.py
@@ -52,6 +52,7 @@ from typing import Callable
 
 from . import gate as gate_mod
 from . import optimizer_context as oc
+from . import proposal_quality
 from . import selection
 from .cache import EvalCache, hash_candidate_dir
 from .harness import (
@@ -630,6 +631,11 @@ def gepa_loop(
             run_dir.log_event("optimizer_error", candidate=cid, error=opt_error[:500])
         run_dir.update_spent(optimizer_seconds=time.time() - _t0, optimizer_usd=opt_cost_usd,
                              optimizer_tokens=opt_tokens)
+
+        # #140: record the proposal declaration (advisory — GEPA's local + val gates
+        # still decide, unchanged). Logged BEFORE the local gate so a locally-rejected
+        # candidate's declaration is on the record too.
+        proposal_quality.record(run_dir, workdir, cid)
 
         # 6. eval child on the SAME minibatch; cheap LOCAL gate sum(child)>sum(parent).
         child_mb = _eval_minibatch(adapter, workdir, mb, run_dir=run_dir,

--- a/core/cap_evolve/gepa.py
+++ b/core/cap_evolve/gepa.py
@@ -67,22 +67,18 @@ from .loop import SplitResult, aggregate_scores
 from .optimizer_context import OptimizerContext
 from .optimizer_context import inject as inject_optimizer_context
 from .optimizer_context import render_instructions
-from .rundir import RunDir
+from .rundir import NON_CAPABILITY_NAMES, RunDir
 from .types import Rollout, Score
 
 OptimizerFn = Callable[[Path, str], None]
 
 # Optimizer-scratch / non-capability files that must NOT count as editable
 # "components" (they perturb neither the capability nor the content hash).
-_NON_COMPONENT = {
-    "MEMORY.md", "STATE.md", "INSTRUCTIONS.md", "REJECTED.md",
-    "FOCUS.md", "REFLECTION.md",
-    # cross-iteration state files (clean-ownership redesign) — scratch, not capability
-    "LEDGER.md", "JOURNAL.md", "PROCESS.md", "RUNMAP.md",
-}
-_NON_COMPONENT_DIRS = {".git", "__pycache__"} | set(oc.INJECTED_DIRS)
+# ``rundir.NON_CAPABILITY_NAMES`` is the shared definition; INSTRUCTIONS/PROCESS are in it
+# because they ARE snapshotted (explainability) yet are still not editable components.
 # The injected agent-instructions files (CLAUDE.md / AGENTS.md / …) are read-context too.
-_NON_COMPONENT |= set(oc.INJECTED_NAMES)
+_NON_COMPONENT = set(NON_CAPABILITY_NAMES) | set(oc.INJECTED_NAMES)
+_NON_COMPONENT_DIRS = {".git", "__pycache__"} | set(oc.INJECTED_DIRS)
 
 
 # ---- components (editable capability files) -------------------------------
@@ -104,6 +100,10 @@ def _components(candidate_dir: Path) -> list[str]:
         if not p.is_file():
             continue
         rel = p.relative_to(cdir)
+        # ponytail: matches by basename at any depth, unlike cache/snapshot which are
+        # root-anchored. Harmless here (a false positive only costs precision — one
+        # fewer editable component / one uncounted edit, nothing is lost); anchoring it
+        # would change which components GEPA may edit, which is out of scope for #110.
         if p.name in _NON_COMPONENT:
             continue
         if any(part in _NON_COMPONENT_DIRS for part in rel.parts):

--- a/core/cap_evolve/gepa.py
+++ b/core/cap_evolve/gepa.py
@@ -54,6 +54,7 @@ from . import gate as gate_mod
 from . import selection
 from .cache import EvalCache, hash_candidate_dir
 from .harness import (
+    _SNAPSHOT_IGNORE,
     _augment_instructions,
     _init_memory_store,
     _live,
@@ -62,19 +63,16 @@ from .harness import (
     split_result_from_rollouts,
 )
 from .loop import SplitResult, aggregate_scores
-from .rundir import RunDir
+from .rundir import SCRATCH_NAMES, RunDir
 from .types import Rollout, Score
 
 OptimizerFn = Callable[[Path, str], None]
 
 # Optimizer-scratch / non-capability files that must NOT count as editable
 # "components" (they perturb neither the capability nor the content hash).
-_NON_COMPONENT = {
-    "MEMORY.md", "STATE.md", "INSTRUCTIONS.md", "REJECTED.md",
-    "FOCUS.md", "REFLECTION.md",
-    # cross-iteration state files (clean-ownership redesign) — scratch, not capability
-    "LEDGER.md", "JOURNAL.md", "PROCESS.md", "RUNMAP.md",
-}
+# ``rundir.SCRATCH_NAMES`` is the shared definition; INSTRUCTIONS/PROCESS are added
+# because they ARE snapshotted (explainability) yet are still not editable components.
+_NON_COMPONENT = {"INSTRUCTIONS.md", "PROCESS.md"} | set(SCRATCH_NAMES)
 _NON_COMPONENT_DIRS = {".git", "__pycache__", "prior_iterations"}
 
 
@@ -625,7 +623,7 @@ def gepa_loop(
         summary = (f"candidate {cid} (val {cand_val.reward:.3f}, "
                    f"Δ {cand_val.reward - parent_result.reward:+.3f})")
         if accepted:
-            run_dir.snapshot(cid, workdir)
+            run_dir.snapshot(cid, workdir, ignore=_SNAPSHOT_IGNORE)
             child_dir = run_dir.candidate_dir(cid)
             pool.append(_entry(cid, child_dir, cand_val, parent=parent["id"]))
             lineage[cid] = parent["id"]
@@ -784,7 +782,7 @@ def _try_merge(
     run_dir.update_spent(iterations=1, accepted=accepted)
     summary = f"merge {mid} of {a['id']}+{b['id']} (val {cand_val.reward:.3f})"
     if accepted:
-        run_dir.snapshot(mid, workdir)
+        run_dir.snapshot(mid, workdir, ignore=_SNAPSHOT_IGNORE)
         pool.append(_entry(mid, run_dir.candidate_dir(mid), cand_val, parent=base_parent["id"]))
         lineage[mid] = base_parent["id"]
         history.add(mid, summary, cand_val.reward)

--- a/core/cap_evolve/gepa.py
+++ b/core/cap_evolve/gepa.py
@@ -614,7 +614,7 @@ def gepa_loop(
             parent_mb, mb, f"GEPA minibatch of {len(mb)} train task(s)", ctx=ctx,
             algorithm="gepa", run_dir=run_dir, parent_id=parent["id"],
             extra=_gepa_block(refl_summary, focus_label, mb, has_trajectories=has_traj))
-        instructions = _augment_instructions(instructions, workdir, run_dir, rejected, history)
+        instructions = _augment_instructions(instructions, workdir, run_dir)
 
         opt_error = None
         opt_cost_usd, opt_tokens = 0.0, 0

--- a/core/cap_evolve/gepa.py
+++ b/core/cap_evolve/gepa.py
@@ -60,6 +60,7 @@ from .harness import (
     _init_memory_store,
     _live,
     _paired_deltas,
+    approach_signature,
     evaluate_candidate,
     split_result_from_rollouts,
 )
@@ -74,12 +75,7 @@ OptimizerFn = Callable[[Path, str], None]
 
 # Optimizer-scratch / non-capability files that must NOT count as editable
 # "components" (they perturb neither the capability nor the content hash).
-_NON_COMPONENT = {
-    "MEMORY.md", "STATE.md", "INSTRUCTIONS.md", "REJECTED.md",
-    "FOCUS.md", "REFLECTION.md",
-    # cross-iteration state files (clean-ownership redesign) — scratch, not capability
-    "LEDGER.md", "JOURNAL.md", "PROCESS.md", "RUNMAP.md",
-}
+_NON_COMPONENT = set(oc.SCRATCH_NAMES)
 _NON_COMPONENT_DIRS = {".git", "__pycache__"} | set(oc.INJECTED_DIRS)
 # The injected agent-instructions files (CLAUDE.md / AGENTS.md / …) are read-context too.
 _NON_COMPONENT |= set(oc.INJECTED_NAMES)
@@ -650,7 +646,8 @@ def gepa_loop(
             run_dir.update_spent(iterations=1, accepted=False)
             rejected.add(cid, f"candidate {cid} (mb {child_mb.reward:.3f} vs parent "
                               f"{parent_mb.reward:.3f})",
-                         "local minibatch gate: sum(child) <= sum(parent)", child_mb.reward)
+                         "local minibatch gate: sum(child) <= sum(parent)", child_mb.reward,
+                         approach=approach_signature(parent_dir, workdir))
             if store is not None:
                 store.commit(f"iter {n+1}: reject(local) {cid}", accepted=False)
             steps.append(step)
@@ -688,7 +685,8 @@ def gepa_loop(
             if store is not None:
                 store.commit(f"iter {n+1}: ACCEPT {summary}", tag="best", accepted=True)
         else:
-            rejected.add(cid, summary, decision_dict.get("reason", "val gate"), cand_val.reward)
+            rejected.add(cid, summary, decision_dict.get("reason", "val gate"), cand_val.reward,
+                         approach=approach_signature(parent_dir, workdir))
             if store is not None:
                 store.commit(f"iter {n+1}: reject(val) {summary}", accepted=False)
         steps.append(step)
@@ -819,7 +817,8 @@ def _try_merge(
     step = {"candidate_id": mid, "merge_of": [a["id"], b["id"]], "ancestor": anc,
             "origin": report["origin"], "local_gate": local_ok, "accepted": False}
     if not local_ok:
-        rejected.add(mid, f"merge {a['id']}+{b['id']}", "merge local gate: < max(parents)")
+        rejected.add(mid, f"merge {a['id']}+{b['id']}", "merge local gate: < max(parents)",
+                     approach=approach_signature(anc_dir, workdir))
         if store is not None:
             store.commit(f"merge {mid}: reject(local)", accepted=False)
         shutil.rmtree(workdir, ignore_errors=True)
@@ -845,7 +844,8 @@ def _try_merge(
         if store is not None:
             store.commit(f"merge {mid}: ACCEPT {summary}", tag="best", accepted=True)
     else:
-        rejected.add(mid, summary, decision_dict.get("reason", "val gate"), cand_val.reward)
+        rejected.add(mid, summary, decision_dict.get("reason", "val gate"), cand_val.reward,
+                     approach=approach_signature(anc_dir, workdir))
         if store is not None:
             store.commit(f"merge {mid}: reject(val)", accepted=False)
     return step

--- a/core/cap_evolve/gepa.py
+++ b/core/cap_evolve/gepa.py
@@ -63,16 +63,16 @@ from .harness import (
     split_result_from_rollouts,
 )
 from .loop import SplitResult, aggregate_scores
-from .rundir import SCRATCH_NAMES, RunDir
+from .rundir import NON_CAPABILITY_NAMES, RunDir
 from .types import Rollout, Score
 
 OptimizerFn = Callable[[Path, str], None]
 
 # Optimizer-scratch / non-capability files that must NOT count as editable
 # "components" (they perturb neither the capability nor the content hash).
-# ``rundir.SCRATCH_NAMES`` is the shared definition; INSTRUCTIONS/PROCESS are added
+# ``rundir.NON_CAPABILITY_NAMES`` is the shared definition; INSTRUCTIONS/PROCESS are in it
 # because they ARE snapshotted (explainability) yet are still not editable components.
-_NON_COMPONENT = {"INSTRUCTIONS.md", "PROCESS.md"} | set(SCRATCH_NAMES)
+_NON_COMPONENT = set(NON_CAPABILITY_NAMES)
 _NON_COMPONENT_DIRS = {".git", "__pycache__", "prior_iterations"}
 
 
@@ -95,6 +95,10 @@ def _components(candidate_dir: Path) -> list[str]:
         if not p.is_file():
             continue
         rel = p.relative_to(cdir)
+        # ponytail: matches by basename at any depth, unlike cache/snapshot which are
+        # root-anchored. Harmless here (a false positive only costs precision — one
+        # fewer editable component / one uncounted edit, nothing is lost); anchoring it
+        # would change which components GEPA may edit, which is out of scope for #110.
         if p.name in _NON_COMPONENT:
             continue
         if any(part in _NON_COMPONENT_DIRS for part in rel.parts):

--- a/core/cap_evolve/gepa.py
+++ b/core/cap_evolve/gepa.py
@@ -68,17 +68,18 @@ from .loop import SplitResult, aggregate_scores
 from .optimizer_context import OptimizerContext
 from .optimizer_context import inject as inject_optimizer_context
 from .optimizer_context import render_instructions
-from .rundir import RunDir
+from .rundir import NON_CAPABILITY_NAMES, RunDir
 from .types import Rollout, Score
 
 OptimizerFn = Callable[[Path, str], None]
 
 # Optimizer-scratch / non-capability files that must NOT count as editable
 # "components" (they perturb neither the capability nor the content hash).
-_NON_COMPONENT = set(oc.SCRATCH_NAMES)
-_NON_COMPONENT_DIRS = {".git", "__pycache__"} | set(oc.INJECTED_DIRS)
+# ``rundir.NON_CAPABILITY_NAMES`` is the shared definition; INSTRUCTIONS/PROCESS are in it
+# because they ARE snapshotted (explainability) yet are still not editable components.
 # The injected agent-instructions files (CLAUDE.md / AGENTS.md / …) are read-context too.
-_NON_COMPONENT |= set(oc.INJECTED_NAMES)
+_NON_COMPONENT = set(NON_CAPABILITY_NAMES) | set(oc.INJECTED_NAMES)
+_NON_COMPONENT_DIRS = {".git", "__pycache__"} | set(oc.INJECTED_DIRS)
 
 
 # ---- components (editable capability files) -------------------------------
@@ -100,6 +101,10 @@ def _components(candidate_dir: Path) -> list[str]:
         if not p.is_file():
             continue
         rel = p.relative_to(cdir)
+        # ponytail: matches by basename at any depth, unlike cache/snapshot which are
+        # root-anchored. Harmless here (a false positive only costs precision — one
+        # fewer editable component / one uncounted edit, nothing is lost); anchoring it
+        # would change which components GEPA may edit, which is out of scope for #110.
         if p.name in _NON_COMPONENT:
             continue
         if any(part in _NON_COMPONENT_DIRS for part in rel.parts):

--- a/core/cap_evolve/gepa.py
+++ b/core/cap_evolve/gepa.py
@@ -566,7 +566,7 @@ def gepa_loop(
         refl_summary = _write_reflection(workdir, parent_mb)
         focus_label = _write_focus(workdir, comps, focus)
         instructions = _instructions(refl_summary, focus_label, mb)
-        instructions = _augment_instructions(instructions, workdir, run_dir, rejected, history)
+        instructions = _augment_instructions(instructions, workdir, run_dir)
 
         opt_error = None
         opt_cost_usd, opt_tokens = 0.0, 0

--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -14,6 +14,7 @@ builds one from a skill's ``run.py`` so external agents plug in the same way.
 from __future__ import annotations
 
 import contextlib
+import hashlib
 import json
 import os
 import shutil
@@ -28,7 +29,8 @@ from . import gate as gate_mod
 # lazy-imports harness inside its function bodies, so there is no cycle to dodge.
 from . import optimizer_context as _oc
 from .loop import SplitResult, aggregate_scores
-from .rundir import RunDir, _atomic_write, iteration_candidate
+from .rundir import (NON_CAPABILITY_NAMES, SCRATCH_NAMES, RunDir, _atomic_write,
+                     iteration_candidate)
 from .splits import Splits, make_splits
 from .types import Rollout, Score, Task
 
@@ -582,10 +584,25 @@ _PROCESS_SEED = (
 
 
 # State/handover files that are NOT part of the capability — excluded from any
-# capability diff. ONE definition in optimizer_context.SCRATCH_NAMES (this list had
-# drifted from gepa's: it was missing GEPA's FOCUS.md/REFLECTION.md, so a GEPA
-# candidate's "capability diff" showed its reflective scratch as a real edit).
-_CAP_DIFF_SKIP = set(_oc.SCRATCH_NAMES)
+# capability diff (kept in one place; mirrors dashboard._DIFF_SKIP).
+# Derived from ``rundir.NON_CAPABILITY_NAMES`` — a read-side FILTER like the cache and
+# component lists, so it takes the whole union (live + legacy scratch + the two
+# snapshotted explainability files). It must NOT be shared with
+# ``harness._SNAPSHOT_IGNORE``, which is DESTRUCTIVE and takes ``SCRATCH_NAMES`` only:
+# feeding this list to the snapshot would DELETE PROCESS.md, the explainability record
+# we deliberately keep. Same predicate, different operation. See the tier note in
+# rundir.py; the split is pinned by
+# test_gepa.py::test_scratch_ignores_are_one_shared_definition.
+#
+# The INJECTED_* halves matter as much as the scratch half here, for a subtler reason:
+# the PARENT side of a capability diff is a snapshot (``_SNAPSHOT_IGNORE`` stripped the
+# injected read-context) while the CHILD side is the live workdir (it did not) — so
+# without this union every injected ``CLAUDE.md`` / ``.claude/skills/<x>/SKILL.md`` reads
+# as an ADDITION, sorts to the front of the diff, and buries the real edit. Both sets are
+# derived, never enumerated: a hardcoded subset of ``INJECTED_DIRS`` is exactly how the
+# previous four copies drifted.
+_CAP_DIFF_SKIP = set(NON_CAPABILITY_NAMES) | set(_oc.INJECTED_NAMES)
+_CAP_DIFF_SKIP_DIRS = set(_oc.INJECTED_DIRS)
 
 
 def _capability_files(d: Path) -> dict[str, str]:
@@ -601,7 +618,7 @@ def _capability_files(d: Path) -> dict[str, str]:
             continue
         rel = str(f.relative_to(d))
         top = rel.split("/", 1)[0]
-        if rel in _CAP_DIFF_SKIP or top in ("trajectories", "guidance", "prior_iterations"):
+        if rel in _CAP_DIFF_SKIP or top in _CAP_DIFF_SKIP_DIRS:
             continue
         try:
             out[rel] = f.read_text(encoding="utf-8")
@@ -876,7 +893,15 @@ def _build_runmap(workdir: Path, run_dir: RunDir) -> None:
 # hard is the gate — a re-proposed dead end still gets rejected on val. See RUN.md.
 
 _MAX_DEAD_ENDS = 12        # most-recent distinct approaches injected
-_MAX_APPROACH_CHARS = 300  # per-signature budget -> block <~ 5 KB, well under the 60k cap
+_MAX_APPROACH_CHARS = 300  # per-signature budget -> block <8 KB, well under the 60k cap
+# Control chars stripped from a signature: it is quoted into a markdown prompt block and
+# (once #191's format_event / #220's replay read rejected.jsonl) into a terminal writer.
+# Closed here, once, for every present and future consumer rather than per renderer.
+# C0 + DEL are the ANSI/escape half; the bidi overrides are the visual-spoofing half — a
+# capability file can legitimately contain either, a dedupe key quoted into a prompt cannot.
+_CTRL_STRIP = ({c: None for c in range(32)} | {127: None}
+               | {c: None for c in range(0x202A, 0x202F)}      # LRE..PDF bidi embedding
+               | {c: None for c in range(0x2066, 0x206A)})     # LRI..PDI bidi isolates
 
 
 def approach_signature(parent_dir: Path, cand_dir: Path, *,
@@ -890,10 +915,25 @@ def approach_signature(parent_dir: Path, cand_dir: Path, *,
     candidate id, ordering or indentation — which is exactly the "variation on an
     already-failed approach" the optimizer keeps re-proposing.
 
+    The dedupe key must be a FUNCTION OF THE WHOLE EDIT, so when the readable form
+    exceeds ``max_chars`` the overflow is closed with a digest of the full body rather
+    than simply cut: a plain head-truncation makes two different edits that share a long
+    prefix (any realistic SKILL.md or system prompt) collapse to one signature, and the
+    block would then tell the optimizer "re-proposed 2x" about something it never
+    proposed — strictly worse than injecting nothing.
+
     Returns "" when there is no capability diff (e.g. the optimizer errored and the
     workdir is still a verbatim parent copy) — a no-op is not an approach.
+
+    ponytail: re-reads both capability trees (an ``rglob`` + ``read_text`` pass each)
+    rather than threading a cached diff through the five rejection call sites. Negligible
+    next to the rollouts that just ran, and it costs nothing on an ACCEPT. Upgrade path if
+    a repo-sized capability makes it measurable: accept the already-computed
+    ``_diff_capabilities`` text as an optional argument.
     """
-    diff = _diff_capabilities(parent_dir, cand_dir)
+    # Generous diff budget: the signature's digest must cover the whole edit, and
+    # _diff_capabilities' own default (8 KB, for display) would silently cap it.
+    diff = _diff_capabilities(parent_dir, cand_dir, max_chars=200_000)
     parts: list[str] = []
     fname = ""
     for line in diff.splitlines():
@@ -902,14 +942,20 @@ def approach_signature(parent_dir: Path, cand_dir: Path, *,
             continue
         if line[:1] not in ("+", "-") or line.startswith(("+++", "---")):
             continue
-        body = " ".join(line[1:].split())
+        body = " ".join(line[1:].split()).translate(_CTRL_STRIP)
         if not body:
             continue
         parts.append(f"{fname}: {line[0]}{body}")
     if not parts:
         return ""
     sig = " | ".join(parts)
-    return sig if len(sig) <= max_chars else sig[:max_chars - 3] + "..."
+    if len(sig) <= max_chars:
+        return sig
+    # Overflow: keep a readable head, then pin the identity of the WHOLE body with a
+    # digest so distinct edits never share a signature (see the docstring).
+    digest = hashlib.sha256(sig.encode("utf-8")).hexdigest()[:12]
+    tail = f" … [+{len(sig) - max_chars} chars, sha {digest}]"
+    return sig[:max_chars - len(tail)] + tail
 
 
 def dead_end_constraints(run_dir: RunDir, *, limit: int = _MAX_DEAD_ENDS) -> str:
@@ -925,8 +971,10 @@ def dead_end_constraints(run_dir: RunDir, *, limit: int = _MAX_DEAD_ENDS) -> str
     write AND on read), each reason at 200 chars, and only the ``limit`` MOST RECENT
     distinct approaches are injected. Recency, not relevance: the newest rejections are
     the ones the current lineage is closest to re-proposing, and it needs no scoring
-    model. ponytail: no LLM summarization — zero API cost, and a verbatim diff signature
-    is more actionable than a paraphrase.
+    model. Recency means LAST-seen, not first — a re-proposal requeues its row, so the
+    single most predictive entry (the dead end the optimizer just re-emitted) can never be
+    the one evicted in favour of an older one-off. ponytail: no LLM summarization — zero
+    API cost, and a verbatim diff signature is more actionable than a paraphrase.
     """
     recs = []
     try:
@@ -946,12 +994,16 @@ def dead_end_constraints(run_dir: RunDir, *, limit: int = _MAX_DEAD_ENDS) -> str
         approach = (rec.get("approach") or "").strip()[:_MAX_APPROACH_CHARS]
         if not approach:
             continue  # no-op edit or a pre-#129 record: nothing to constrain against
+        cid = rec.get("candidate_id") or "?"
         if approach in seen:
-            seen[approach]["count"] += 1
+            row = seen.pop(approach)  # re-proposed => it IS the most recent; requeue it
+            row["count"] += 1
+            row["latest"] = cid
+            seen[approach] = row
             continue
         seen[approach] = {"approach": approach, "count": 1,
                           "reason": (rec.get("reason") or "gate rejected")[:200],
-                          "cid": rec.get("candidate_id") or "?"}
+                          "cid": cid, "latest": cid}
     if not seen:
         return ""
     rows = list(seen.values())[-limit:]
@@ -965,7 +1017,10 @@ def dead_end_constraints(run_dir: RunDir, *, limit: int = _MAX_DEAD_ENDS) -> str
         "",
     ]
     for r in rows:
-        rep = f", re-proposed {r['count']}x" if r["count"] > 1 else ""
+        # cid = where the approach FIRST died (whose reason is quoted); latest = the most
+        # recent repeat, so "re-proposed 3x" cannot be misread as belonging to cid alone.
+        rep = (f", re-proposed {r['count']}x (latest {r['latest']})"
+               if r["count"] > 1 else "")
         lines.append(f"- **{r['cid']}**{rep} — `{r['approach']}`")
         lines.append(f"  - rejected because: {r['reason']}")
     lines += [
@@ -1020,8 +1075,7 @@ def _augment_instructions(instructions: str, workdir: Path, run_dir: RunDir) -> 
     tail = f"\n{dead_ends}" if dead_ends else ""
     # Re-cap: render_instructions capped its OWN output, but these blocks are appended
     # after it, so the final assembled prompt needs the ceiling applied once more.
-    from .optimizer_context import cap_instructions
-    return cap_instructions(f"{instructions}\n\n{pointer}{tail}\n")
+    return _oc.cap_instructions(f"{instructions}\n\n{pointer}{tail}\n")
 
 
 def _copy_step_trajectories(adapter, run_dir: RunDir, workdir: Path, split: str,
@@ -1705,8 +1759,13 @@ _DEFAULT_INSTRUCTIONS_TEMPLATE = (
 # snapshot and surface via RUNMAP/prior_iterations. LEDGER/JOURNAL/RUNMAP + prior_iterations/
 # are framework-injected read-context (LEDGER/RUNMAP regenerated, JOURNAL is run-level),
 # so they must not bloat candidates/ or pollute diffs.
-_SNAPSHOT_IGNORE = (_oc.INJECTED_DIRS + _oc.INJECTED_NAMES
-                    + ("LEDGER.md", "JOURNAL.md", "RUNMAP.md"))
+#
+# This is the one DESTRUCTIVE consumer of the shared list — snapshot() drops what it
+# names — so it takes ``SCRATCH_NAMES`` (live writers) ONLY, never
+# ``rundir.NON_CAPABILITY_NAMES``. A retired name with no live writer can only refer to
+# a capability file that shares it, and deleting that is silent data loss the eval-cache
+# key can't see. See the tier note in rundir.py.
+_SNAPSHOT_IGNORE = _oc.INJECTED_DIRS + _oc.INJECTED_NAMES + SCRATCH_NAMES
 
 
 def _failures_block(always_fail, flaky, errored) -> str:

--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -1269,8 +1269,9 @@ def _inject_optimizer_context(adapter, run_dir: RunDir, workdir: Path, *, split:
     # 3b) the ON-DEMAND reasoning skills (#140) as local guidance. Tiny skills, each
     # countering ONE named optimizer failure mode at ONE step — mechanism-probe sits at
     # the proposal step. Copied whole so a new reasoning skill needs no wiring here, and
-    # scripts/ is kept (unlike the capability/diagnose copies) because the probe's own
-    # run.py is what the SKILL.md tells the optimizer to run on its PROCESS.md.
+    # ``scripts`` is excluded exactly as for the capability/diagnose copies: the probe's
+    # run.py cannot import ``cap_evolve`` from a candidate workdir (no ``core/`` above it),
+    # so shipping it would only advertise a command that fails. Read-context only.
     reasoning_src = repo_root / "skills" / "reasoning"
     if reasoning_src.is_dir():
         try:
@@ -1278,7 +1279,7 @@ def _inject_optimizer_context(adapter, run_dir: RunDir, workdir: Path, *, split:
             if dst.exists():
                 shutil.rmtree(dst)
             shutil.copytree(reasoning_src, dst,
-                            ignore=shutil.ignore_patterns("__pycache__", "*.pyc"))
+                            ignore=shutil.ignore_patterns("__pycache__", "scripts", "*.pyc"))
         except Exception as e:  # noqa: BLE001
             run_dir.log_event("optimizer_context_warning", what="guidance/reasoning",
                               error=str(e)[:300])

--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -24,8 +24,11 @@ from pathlib import Path
 from typing import Callable
 
 from . import gate as gate_mod
+# Module-level is safe: optimizer_context imports only .loop/.rundir eagerly and
+# lazy-imports harness inside its function bodies, so there is no cycle to dodge.
+from . import optimizer_context as _oc
 from .loop import SplitResult, aggregate_scores
-from .rundir import RunDir, _atomic_write
+from .rundir import RunDir, _atomic_write, iteration_candidate
 from .splits import Splits, make_splits
 from .types import Rollout, Score, Task
 
@@ -627,24 +630,15 @@ def _diff_capabilities(parent_dir: Path, cand_dir: Path, *, max_chars: int = 800
 
 
 def _parent_map(run_dir: RunDir) -> dict[str, str]:
-    """Map each candidate id -> the parent id it was forked from, from ``step`` events.
+    """Map each candidate id -> the parent id it was forked from, from iteration events.
 
-    Falls back to "seed" for any candidate whose parent is unknown. Best-effort: an
-    unreadable/absent events log yields an empty map."""
-    parent_of: dict[str, str] = {}
-    try:
-        if not run_dir.events_path.exists():
-            return {}
-        for line in run_dir.events_path.read_text(encoding="utf-8").splitlines():
-            line = line.strip()
-            if not line:
-                continue
-            rec = json.loads(line)
-            if rec.get("kind") == "step" and rec.get("candidate"):
-                parent_of[str(rec["candidate"])] = str(rec.get("parent") or "seed")
-    except Exception:  # noqa: BLE001
-        return parent_of
-    return parent_of
+    Reads EVERY ``ITERATION_EVENT_KINDS`` event, not just ``step`` — GEPA bypasses
+    ``run_step`` and emits ``gepa_val_gate``, so a ``kind == "step"`` filter here made
+    GEPA's whole cross-iteration history channel (LEDGER/RUNMAP/prior_iterations)
+    permanently empty. Falls back to "seed" when the parent edge is absent."""
+    return {cid: str(rec.get("parent") or rec.get("parent_id") or "seed")
+            for rec in run_dir.iteration_events()
+            if (cid := iteration_candidate(rec))}
 
 
 def _per_task_rewards(run_dir: RunDir, tag: str, split: str = "val") -> dict[str, float]:
@@ -729,25 +723,15 @@ def _build_ledger(workdir: Path, run_dir: RunDir, rejected, history) -> None:
     its outcome + the exact tasks it broke/fixed. Deterministic — the objective record;
     the optimizer's own narrative lives in JOURNAL.md."""
     parent_of = _parent_map(run_dir)
-    # Outcome per candidate from step events (accept/reject + val + parent).
-    rows: list[dict] = []
-    try:
-        if run_dir.events_path.exists():
-            for line in run_dir.events_path.read_text(encoding="utf-8").splitlines():
-                line = line.strip()
-                if not line:
-                    continue
-                rec = json.loads(line)
-                if rec.get("kind") == "step" and rec.get("candidate"):
-                    rows.append(rec)
-    except Exception:  # noqa: BLE001
-        rows = []
+    # Outcome per candidate from EVERY iteration event kind (accept/reject + val +
+    # parent) — see RunDir.iteration_events; "step" alone omits GEPA entirely.
+    rows = run_dir.iteration_events()
 
     table = ["| iter | candidate | parent | outcome | val | Δ vs parent | broke (were passing) | fixed |",
              "| --- | --- | --- | --- | --- | --- | --- | --- |"]
     for i, rec in enumerate(rows, 1):
-        cid = str(rec.get("candidate"))
-        par = str(rec.get("parent") or "seed")
+        cid = str(iteration_candidate(rec))
+        par = str(rec.get("parent") or rec.get("parent_id") or "seed")
         outcome = "ACCEPT" if rec.get("accept") else "reject"
         val = rec.get("val")
         pval = rec.get("parent_val")
@@ -840,25 +824,15 @@ def _build_runmap(workdir: Path, run_dir: RunDir) -> None:
     ``workdir/prior_iterations/<cid>/`` so the optimizer has REAL in-dir access to all
     prior iterations' working dirs (not just the parent's trajectories)."""
     parent_of = _parent_map(run_dir)
-    rows: list[dict] = []
-    try:
-        if run_dir.events_path.exists():
-            for line in run_dir.events_path.read_text(encoding="utf-8").splitlines():
-                line = line.strip()
-                if not line:
-                    continue
-                rec = json.loads(line)
-                if rec.get("kind") == "step" and rec.get("candidate"):
-                    rows.append(rec)
-    except Exception:  # noqa: BLE001
-        rows = []
+    # Every iteration event kind, not just "step" — GEPA emits "gepa_val_gate".
+    rows = run_dir.iteration_events()
 
     prior_root = workdir / "prior_iterations"
     table = ["| iter | candidate | parent | outcome | val | ./prior_iterations/<id>/ |",
              "| --- | --- | --- | --- | --- | --- |"]
     for i, rec in enumerate(rows, 1):
-        cid = str(rec.get("candidate"))
-        par = str(rec.get("parent") or "seed")
+        cid = str(iteration_candidate(rec))
+        par = str(rec.get("parent") or rec.get("parent_id") or "seed")
         outcome = "ACCEPT" if rec.get("accept") else "reject"
         val = rec.get("val")
         vstr = f"{val:.3f}" if isinstance(val, (int, float)) else ""
@@ -975,10 +949,23 @@ def _copy_step_trajectories(adapter, run_dir: RunDir, workdir: Path, split: str,
                               what=f"trajectories/{tag}", error=str(e)[:300])
             return False
 
-    # An explicit tag (GEPA's parent-minibatch eval) wins; otherwise resolve the
-    # best/parent candidate id from run state (the parent this step forks from),
-    # falling back to the seed tag when no candidate has been accepted yet.
-    if tag and _copy_tag(str(tag)):
+    # An explicit tag (GEPA's parent-minibatch eval) is a PIN, not a preference: the
+    # prompt tells the optimizer these are that exact minibatch's rollouts verbatim.
+    # A fully-cached minibatch writes no rollout files (the eval cache stores only
+    # reward+feedback — see #111), so falling through here would hand the optimizer
+    # ANOTHER iteration's traces while still claiming they are this one's. Omit
+    # loudly instead: no trajectories/ dir, a warning event, and the prompt block
+    # is made conditional on the dir existing at the call site.
+    if tag:
+        if _copy_tag(str(tag)):
+            return
+        if dst.exists():
+            shutil.rmtree(dst, ignore_errors=True)
+        run_dir.log_event(
+            "optimizer_context_warning", what=f"trajectories/{tag}",
+            error="no rollouts persisted for the pinned eval tag (fully-cached "
+                  "minibatch); trajectories/ OMITTED rather than substituting another "
+                  "iteration's traces")
         return
     best_id = None
     try:
@@ -1606,12 +1593,8 @@ _DEFAULT_INSTRUCTIONS_TEMPLATE = (
 # snapshot and surface via RUNMAP/prior_iterations. LEDGER/JOURNAL/RUNMAP + prior_iterations/
 # are framework-injected read-context (LEDGER/RUNMAP regenerated, JOURNAL is run-level),
 # so they must not bloat candidates/ or pollute diffs.
-def _snapshot_ignore() -> tuple[str, ...]:
-    from .optimizer_context import INJECTED_DIRS, INJECTED_NAMES
-    return INJECTED_DIRS + INJECTED_NAMES + ("LEDGER.md", "JOURNAL.md", "RUNMAP.md")
-
-
-_SNAPSHOT_IGNORE = _snapshot_ignore()
+_SNAPSHOT_IGNORE = (_oc.INJECTED_DIRS + _oc.INJECTED_NAMES
+                    + ("LEDGER.md", "JOURNAL.md", "RUNMAP.md"))
 
 
 def _failures_block(always_fail, flaky, errored) -> str:
@@ -1776,10 +1759,21 @@ def _focus_instructions(current_val: SplitResult, focus_ids, label: str,
     intake phase per benchmark, with a generic default shipped in ``templates/``. Only
     the per-iteration data (the focus summary, the failure index, the capability/algorithm
     briefs, the benchmark-repo pointer) is computed here and substituted.
+
+    ``focus_ids`` must name tasks that are IN ``current_val`` — it narrows that result,
+    it cannot add to it. Callers passing ids from a different split (SkillOpt handed
+    train minibatch ids against a val result, and splits are disjoint by construction)
+    would otherwise filter the failure index down to nothing and get a confident
+    "0 failing of 0 tasks" prompt. On zero overlap we do NOT filter, and we say so.
     """
     per = current_val.per_task
+    scoped = True
     if focus_ids is not None:
-        per = [pt for pt in per if pt.get("task_id") in set(focus_ids)]
+        known = {pt.get("task_id") for pt in per}
+        if set(focus_ids) & known:
+            per = [pt for pt in per if pt.get("task_id") in set(focus_ids)]
+        else:
+            scoped = False  # disjoint id sets: filtering would empty the failure index
     errored, always_fail, flaky, solid = _classify(per)
     n = len(per)
 
@@ -1787,6 +1781,10 @@ def _focus_instructions(current_val: SplitResult, focus_ids, label: str,
         f"Focus: {label}. Current val reward {current_val.reward:.3f}: "
         f"{len(solid)} solid / {len(flaky)} flaky / {len(always_fail)} failing"
         + (f" / {len(errored)} infra-errored" if errored else "") + f" of {n} tasks."
+        + ("" if scoped else
+           " (The failure index below covers ALL scored tasks: this step's focus ids "
+           "are from a different split than the scored result, so there is no per-focus "
+           "breakdown — fix the shared root cause, which is what generalizes anyway.)")
     )
     failures = _failures_block(always_fail, flaky, errored)
     passing = _passing_block(solid)

--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -582,9 +582,10 @@ _PROCESS_SEED = (
 
 
 # State/handover files that are NOT part of the capability — excluded from any
-# capability diff (kept in one place; mirrors dashboard._DIFF_SKIP).
-_CAP_DIFF_SKIP = {"INSTRUCTIONS.md", "MEMORY.md", "STATE.md",
-                  "LEDGER.md", "JOURNAL.md", "PROCESS.md", "RUNMAP.md"}
+# capability diff. ONE definition in optimizer_context.SCRATCH_NAMES (this list had
+# drifted from gepa's: it was missing GEPA's FOCUS.md/REFLECTION.md, so a GEPA
+# candidate's "capability diff" showed its reflective scratch as a real edit).
+_CAP_DIFF_SKIP = set(_oc.SCRATCH_NAMES)
 
 
 def _capability_files(d: Path) -> dict[str, str]:
@@ -861,6 +862,124 @@ def _build_runmap(workdir: Path, run_dir: RunDir) -> None:
     (workdir / "RUNMAP.md").write_text(text, encoding="utf-8")
 
 
+# ---- rejected-approach constraints (#129) ---------------------------------
+#
+# Rejected candidates were already persisted to ``rejected.jsonl`` (audit + the
+# dashboard's "what not to try" panel) but nothing put them in a proposal prompt, so the
+# optimizer could — and did — re-propose an approach the gate had already killed. These
+# two functions close that: ``approach_signature`` normalizes WHAT an edit did into a
+# stable one-line signature, and ``dead_end_constraints`` renders the deduped
+# signature+reason list as a bounded prompt block.
+#
+# Enforcement is ADVISORY (prompt text), not a hard block: the optimizer is a
+# black-box agent CLI, so the framework cannot forbid it from emitting bytes. What IS
+# hard is the gate — a re-proposed dead end still gets rejected on val. See RUN.md.
+
+_MAX_DEAD_ENDS = 12        # most-recent distinct approaches injected
+_MAX_APPROACH_CHARS = 300  # per-signature budget -> block <~ 5 KB, well under the 60k cap
+
+
+def approach_signature(parent_dir: Path, cand_dir: Path, *,
+                       max_chars: int = _MAX_APPROACH_CHARS) -> str:
+    """A stable, compact signature of WHAT an edit changed — the dedupe key for #129.
+
+    Built from the capability diff (the same ``_diff_capabilities`` source the dashboard
+    and RUNMAP use, so it never picks up injected read-context or algorithm scratch):
+    per touched file, the added/removed content lines, whitespace-collapsed. Two edits
+    that add the same text to the same file produce the same signature regardless of
+    candidate id, ordering or indentation — which is exactly the "variation on an
+    already-failed approach" the optimizer keeps re-proposing.
+
+    Returns "" when there is no capability diff (e.g. the optimizer errored and the
+    workdir is still a verbatim parent copy) — a no-op is not an approach.
+    """
+    diff = _diff_capabilities(parent_dir, cand_dir)
+    parts: list[str] = []
+    fname = ""
+    for line in diff.splitlines():
+        if line.startswith("+++ b/"):
+            fname = line[6:].strip()
+            continue
+        if line[:1] not in ("+", "-") or line.startswith(("+++", "---")):
+            continue
+        body = " ".join(line[1:].split())
+        if not body:
+            continue
+        parts.append(f"{fname}: {line[0]}{body}")
+    if not parts:
+        return ""
+    sig = " | ".join(parts)
+    return sig if len(sig) <= max_chars else sig[:max_chars - 3] + "..."
+
+
+def dead_end_constraints(run_dir: RunDir, *, limit: int = _MAX_DEAD_ENDS) -> str:
+    """The "already tried & rejected (do not repeat)" prompt block, or "" when empty.
+
+    Reads ``rejected.jsonl`` (the live record — #114 kept these writes precisely because
+    they have real readers) and dedupes on ``approach``, keeping the FIRST rejection
+    reason per approach and counting repeats, so an approach the optimizer has already
+    re-proposed twice shows "re-proposed 2x" rather than two rows.
+
+    Bounded three ways so a long run cannot balloon the prompt (#199's
+    ``MAX_INSTRUCTIONS_CHARS``): each signature is capped (``_MAX_APPROACH_CHARS``, on
+    write AND on read), each reason at 200 chars, and only the ``limit`` MOST RECENT
+    distinct approaches are injected. Recency, not relevance: the newest rejections are
+    the ones the current lineage is closest to re-proposing, and it needs no scoring
+    model. ponytail: no LLM summarization — zero API cost, and a verbatim diff signature
+    is more actionable than a paraphrase.
+    """
+    recs = []
+    try:
+        for line in run_dir.rejected_path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line:
+                recs.append(json.loads(line))
+    except (OSError, json.JSONDecodeError):
+        pass  # best-effort: no/partial memory file just means no constraints
+
+    # dedupe by approach, newest-last ordering preserved; count repeats.
+    seen: dict[str, dict] = {}
+    for rec in recs:
+        # Re-cap on READ as well as on write: a record may come from a direct
+        # RejectedMemory caller (or an older/edited file) that never went through
+        # approach_signature, and an unbounded row would defeat the block's budget.
+        approach = (rec.get("approach") or "").strip()[:_MAX_APPROACH_CHARS]
+        if not approach:
+            continue  # no-op edit or a pre-#129 record: nothing to constrain against
+        if approach in seen:
+            seen[approach]["count"] += 1
+            continue
+        seen[approach] = {"approach": approach, "count": 1,
+                          "reason": (rec.get("reason") or "gate rejected")[:200],
+                          "cid": rec.get("candidate_id") or "?"}
+    if not seen:
+        return ""
+    rows = list(seen.values())[-limit:]
+
+    lines = [
+        "## ALREADY TRIED & REJECTED — do not re-propose these (framework, read-only)",
+        "",
+        f"The gate has rejected {len(seen)} distinct approach(es) on this run"
+        + (f" (showing the {len(rows)} most recent)" if len(rows) < len(seen) else "")
+        + ". Each row is the EXACT capability edit that failed and why:",
+        "",
+    ]
+    for r in rows:
+        rep = f", re-proposed {r['count']}x" if r["count"] > 1 else ""
+        lines.append(f"- **{r['cid']}**{rep} — `{r['approach']}`")
+        lines.append(f"  - rejected because: {r['reason']}")
+    lines += [
+        "",
+        "**Constraint:** do NOT propose any of the above again, and do not propose a "
+        "cosmetic variation of one (same text, different wording/placement) — it shares "
+        "the same hidden assumption and will fail the same way. If you believe a rejected "
+        "direction is still right, you MUST state in `PROCESS.md` what is materially "
+        "different this time and which specific lesson above it counters. Otherwise pick "
+        "a genuinely different hypothesis.",
+    ]
+    return "\n".join(lines) + "\n"
+
+
 def _augment_instructions(instructions: str, workdir: Path, run_dir: RunDir) -> str:
     """Give the optimizer its four cross-iteration files + a prompt pointer to each.
 
@@ -870,6 +989,11 @@ def _augment_instructions(instructions: str, workdir: Path, run_dir: RunDir) -> 
       - PROCESS.md — optimizer-authored explainability, fresh each iteration;
       - RUNMAP.md + prior_iterations/ — framework manifest + copies of every prior
         iteration's PROCESS.md and capability diff (real prior-work-dir access).
+
+    Plus the #129 rejected-approach constraint block. This is the ONLY function whose
+    output reaches the optimizer prompt (#114), and all three algorithms route through
+    it — so the constraints land identically for hill-climb, GEPA and SkillOpt with no
+    per-algorithm wiring.
     """
     _build_ledger(workdir, run_dir)
     _seed_journal(workdir, run_dir)
@@ -892,7 +1016,12 @@ def _augment_instructions(instructions: str, workdir: Path, run_dir: RunDir) -> 
         "capability diff, copied in for you. Read the ones targeting your cluster BEFORE "
         "proposing, so you build on prior work instead of repeating it.\n"
     )
-    return f"{instructions}\n\n{pointer}\n"
+    dead_ends = dead_end_constraints(run_dir)
+    tail = f"\n{dead_ends}" if dead_ends else ""
+    # Re-cap: render_instructions capped its OWN output, but these blocks are appended
+    # after it, so the final assembled prompt needs the ceiling applied once more.
+    from .optimizer_context import cap_instructions
+    return cap_instructions(f"{instructions}\n\n{pointer}{tail}\n")
 
 
 def _copy_step_trajectories(adapter, run_dir: RunDir, workdir: Path, split: str,
@@ -1339,7 +1468,10 @@ def run_step(
             history.add(cid, summary, cand_val.reward)
     else:
         if rejected is not None:
-            rejected.add(cid, summary, decision.reason, cand_val.reward)
+            # Record WHAT was tried, not only the score — that signature is what the
+            # next iteration's dead-end constraint block is built from (#129).
+            rejected.add(cid, summary, decision.reason, cand_val.reward,
+                         approach=approach_signature(parent_dir, workdir))
     if store is not None:
         store.commit(f"iter {run_dir.spent.iterations}: "
                      f"{'ACCEPT' if accepted else 'reject'} {summary}",

--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -28,7 +28,8 @@ from . import gate as gate_mod
 # lazy-imports harness inside its function bodies, so there is no cycle to dodge.
 from . import optimizer_context as _oc
 from .loop import SplitResult, aggregate_scores
-from .rundir import RunDir, _atomic_write, iteration_candidate
+from .rundir import (NON_CAPABILITY_NAMES, SCRATCH_NAMES, RunDir, _atomic_write,
+                     iteration_candidate)
 from .splits import Splits, make_splits
 from .types import Rollout, Score, Task
 
@@ -583,8 +584,15 @@ _PROCESS_SEED = (
 
 # State/handover files that are NOT part of the capability — excluded from any
 # capability diff (kept in one place; mirrors dashboard._DIFF_SKIP).
-_CAP_DIFF_SKIP = {"INSTRUCTIONS.md", "MEMORY.md", "STATE.md",
-                  "LEDGER.md", "JOURNAL.md", "PROCESS.md", "RUNMAP.md"}
+# Derived from ``rundir.NON_CAPABILITY_NAMES`` — a read-side FILTER like the cache and
+# component lists, so it takes the whole union (live + legacy scratch + the two
+# snapshotted explainability files). It must NOT be shared with
+# ``harness._SNAPSHOT_IGNORE``, which is DESTRUCTIVE and takes ``SCRATCH_NAMES`` only:
+# feeding this list to the snapshot would DELETE PROCESS.md, the explainability record
+# we deliberately keep. Same predicate, different operation. See the tier note in
+# rundir.py; the split is pinned by
+# test_gepa.py::test_scratch_ignores_are_one_shared_definition.
+_CAP_DIFF_SKIP = set(NON_CAPABILITY_NAMES)
 
 
 def _capability_files(d: Path) -> dict[str, str]:
@@ -1573,8 +1581,13 @@ _DEFAULT_INSTRUCTIONS_TEMPLATE = (
 # snapshot and surface via RUNMAP/prior_iterations. LEDGER/JOURNAL/RUNMAP + prior_iterations/
 # are framework-injected read-context (LEDGER/RUNMAP regenerated, JOURNAL is run-level),
 # so they must not bloat candidates/ or pollute diffs.
-_SNAPSHOT_IGNORE = (_oc.INJECTED_DIRS + _oc.INJECTED_NAMES
-                    + ("LEDGER.md", "JOURNAL.md", "RUNMAP.md"))
+#
+# This is the one DESTRUCTIVE consumer of the shared list — snapshot() drops what it
+# names — so it takes ``SCRATCH_NAMES`` (live writers) ONLY, never
+# ``rundir.NON_CAPABILITY_NAMES``. A retired name with no live writer can only refer to
+# a capability file that shares it, and deleting that is silent data loss the eval-cache
+# key can't see. See the tier note in rundir.py.
+_SNAPSHOT_IGNORE = _oc.INJECTED_DIRS + _oc.INJECTED_NAMES + SCRATCH_NAMES
 
 
 def _failures_block(always_fail, flaky, errored) -> str:

--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -933,7 +933,8 @@ def _augment_instructions(instructions: str, workdir: Path, run_dir: RunDir,
     return f"{instructions}\n\n{pointer}\n"
 
 
-def _copy_step_trajectories(adapter, run_dir: RunDir, workdir: Path, split: str) -> None:
+def _copy_step_trajectories(adapter, run_dir: RunDir, workdir: Path, split: str,
+                            tag: str | None = None) -> None:
     """Copy ONLY the current best/parent candidate's per-tag rollouts for ``split``
     into ``workdir/trajectories/`` — the single step the optimizer builds on.
 
@@ -948,6 +949,10 @@ def _copy_step_trajectories(adapter, run_dir: RunDir, workdir: Path, split: str)
       4. as a last resort, the whole ``rollouts/<split>/`` dir.
     The per-tag copy is preferred even when the adapter returns a native dir, because
     the native dir generally cannot be scoped to one candidate.
+
+    ``tag`` pins the eval tag explicitly instead of resolving the run's best candidate —
+    GEPA needs the PARENT's minibatch traces (tag ``mb_p_NNNN``), which are the step it
+    actually reflects on. The same fallback chain applies if that tag has no rollouts.
     """
     dst = workdir / "trajectories"
 
@@ -970,8 +975,11 @@ def _copy_step_trajectories(adapter, run_dir: RunDir, workdir: Path, split: str)
                               what=f"trajectories/{tag}", error=str(e)[:300])
             return False
 
-    # Resolve the best/parent candidate id from run state (the parent this step forks
-    # from), falling back to the seed tag when no candidate has been accepted yet.
+    # An explicit tag (GEPA's parent-minibatch eval) wins; otherwise resolve the
+    # best/parent candidate id from run state (the parent this step forks from),
+    # falling back to the seed tag when no candidate has been accepted yet.
+    if tag and _copy_tag(str(tag)):
+        return
     best_id = None
     try:
         best_id = run_dir.best_id
@@ -1004,8 +1012,13 @@ def _copy_step_trajectories(adapter, run_dir: RunDir, workdir: Path, split: str)
 
 def _inject_optimizer_context(adapter, run_dir: RunDir, workdir: Path, *, split: str,
                               capabilities=None, optimizer_name: str | None = None,
-                              capability_sources=None, project_dir: Path | None = None) -> None:
+                              capability_sources=None, project_dir: Path | None = None,
+                              tag: str | None = None) -> None:
     """Give the optimizer everything it needs to read, inside its own working dir.
+
+    Call it through ``optimizer_context.inject`` (the shared seam every algorithm uses)
+    rather than directly, so new injected artifacts reach hill-climb, GEPA and SkillOpt
+    at once.
 
     Copies, VERBATIM and without parsing:
       - the CURRENT BEST/PARENT candidate's per-tag trajectories for the most recent
@@ -1027,7 +1040,7 @@ def _inject_optimizer_context(adapter, run_dir: RunDir, workdir: Path, *, split:
     # this split, so the optimizer analyzes the step it builds on (not seed + every
     # rejected candidate mixed together). Always preserves the "something to read"
     # guarantee via per-tag fallback then the native dir.
-    _copy_step_trajectories(adapter, run_dir, workdir, split)
+    _copy_step_trajectories(adapter, run_dir, workdir, split, tag=tag)
 
     # 2) capability skills as local guidance
     caps = [c for c in (capabilities or []) if c]
@@ -1227,8 +1240,13 @@ def run_step(
     optimizer_name: str | None = None,
     capability_sources=None,
     project_dir: Path | None = None,
+    ctx=None,
 ) -> dict:
     """Materialize parent → optimize → evaluate on val → gate → accept/reject.
+
+    ``ctx`` is an ``optimizer_context.OptimizerContext``; when given it supersedes the
+    individual ``capabilities`` / ``optimizer_name`` / ``capability_sources`` /
+    ``project_dir`` kwargs (kept for direct callers).
 
     Returns a dict describing the step. On accept, the candidate is snapshotted
     and becomes the run's best.
@@ -1248,10 +1266,13 @@ def run_step(
     workdir.parent.mkdir(parents=True, exist_ok=True)
     shutil.copytree(parent_dir, workdir)
 
-    # Give the optimizer the full trajectories + capability guidance, in its own dir.
-    _inject_optimizer_context(adapter, run_dir, workdir, split=eval_split,
-                              capabilities=capabilities, optimizer_name=optimizer_name,
-                              capability_sources=capability_sources, project_dir=project_dir)
+    # Give the optimizer the full trajectories + capability guidance, in its own dir —
+    # through the shared seam, so hill-climb / GEPA / SkillOpt inject identically.
+    from .optimizer_context import OptimizerContext, inject as _inject
+    _inject(adapter, run_dir, workdir, split=eval_split,
+            ctx=ctx or OptimizerContext(
+                capabilities=capabilities or [], optimizer_name=optimizer_name,
+                capability_sources=capability_sources or [], project_dir=project_dir))
 
     instructions = _augment_instructions(instructions, workdir, run_dir, rejected, history)
 
@@ -1585,10 +1606,12 @@ _DEFAULT_INSTRUCTIONS_TEMPLATE = (
 # snapshot and surface via RUNMAP/prior_iterations. LEDGER/JOURNAL/RUNMAP + prior_iterations/
 # are framework-injected read-context (LEDGER/RUNMAP regenerated, JOURNAL is run-level),
 # so they must not bloat candidates/ or pollute diffs.
-_SNAPSHOT_IGNORE = ("trajectories", "guidance", "prior_iterations",
-                    "LEDGER.md", "JOURNAL.md", "RUNMAP.md",
-                    ".claude", ".agents", ".gemini", ".opencode", ".bob",
-                    "CLAUDE.md", "AGENTS.md", "GEMINI.md")
+def _snapshot_ignore() -> tuple[str, ...]:
+    from .optimizer_context import INJECTED_DIRS, INJECTED_NAMES
+    return INJECTED_DIRS + INJECTED_NAMES + ("LEDGER.md", "JOURNAL.md", "RUNMAP.md")
+
+
+_SNAPSHOT_IGNORE = _snapshot_ignore()
 
 
 def _failures_block(always_fail, flaky, errored) -> str:
@@ -1848,6 +1871,7 @@ def hill_climb_loop(
     algorithm: str = "hill_climb",
     no_regression: bool = False,
     store=None,
+    ctx=None,
     capabilities=None,
     instructions_file=None,
     bench_repo: str | None = None,
@@ -1864,14 +1888,22 @@ def hill_climb_loop(
     reflection emphasizes — and (for hardest-first) the order. Parent is always
     the current best (global hill-climb). The ``gepa`` algorithm uses its own
     per-instance frontier and parent selection (see ``cap_evolve.gepa``).
+
+    ``ctx`` is an ``optimizer_context.OptimizerContext`` bundling what the optimizer is
+    given (capabilities, instructions template, bench repo, optimizer name, capability
+    sources, consuming-LLM profile) — the same bundle ``gepa_loop`` / ``skillopt_loop``
+    take. The individual kwargs remain for direct callers and build a ctx when none is
+    passed.
     """
     gate_kwargs = dict(gate_kwargs or {})
     rejected, history, store = _init_memory_store(run_dir, store)
 
-    # Resolve the consuming-LLM profile once; its brief steers every iteration's prompt.
-    from . import target_profile as _tp
-    _profile = _tp.resolve(target_model, target_profile_file, project_dir=project_dir)
-    _target_reader = _tp.reader_block(_profile)
+    from .optimizer_context import OptimizerContext, render_instructions
+    ctx = ctx or OptimizerContext(
+        capabilities=capabilities or [], optimizer_name=optimizer_name,
+        instructions_file=instructions_file, bench_repo=bench_repo,
+        capability_sources=capability_sources or [], project_dir=project_dir,
+        target_model=target_model, target_profile_file=target_profile_file)
 
     # establish a focus order over the train tasks when needed
     train_ids = run_dir.read_splits().train
@@ -1895,19 +1927,13 @@ def hill_climb_loop(
             label = f"task {focus_ids[0]}" if focus_ids else "train"
         else:
             focus_ids, label = None, focus
-        seed_empty = _capability_is_empty(capabilities, run_dir.candidate_dir(run_dir.best_id))
-        instructions = _focus_instructions(current_val, focus_ids, label,
-                                            capabilities=capabilities, algorithm=algorithm,
-                                            instructions_file=instructions_file,
-                                            bench_repo=bench_repo, optimizer_name=optimizer_name,
-                                            seed_empty=seed_empty, target_reader=_target_reader)
+        instructions = render_instructions(current_val, focus_ids, label, ctx=ctx,
+                                          algorithm=algorithm, run_dir=run_dir)
         step = run_step(
             adapter, run_dir=run_dir, parent_dir=run_dir.candidate_dir(run_dir.best_id),
             optimizer=optimizer, instructions=instructions, current_val=current_val,
             n_trials=n_trials, gate_kwargs=gate_kwargs, no_regression=no_regression,
-            rejected=rejected, history=history, store=store, capabilities=capabilities,
-            optimizer_name=optimizer_name, capability_sources=capability_sources,
-            project_dir=project_dir,
+            rejected=rejected, history=history, store=store, ctx=ctx,
         )
         steps.append(step)
         if step["accepted"]:

--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -25,7 +25,7 @@ from typing import Callable
 
 from . import gate as gate_mod
 from .loop import SplitResult, aggregate_scores
-from .rundir import SCRATCH_NAMES, RunDir, _atomic_write
+from .rundir import NON_CAPABILITY_NAMES, SCRATCH_NAMES, RunDir, _atomic_write
 from .splits import Splits, make_splits
 from .types import Rollout, Score, Task
 
@@ -580,8 +580,15 @@ _PROCESS_SEED = (
 
 # State/handover files that are NOT part of the capability — excluded from any
 # capability diff (kept in one place; mirrors dashboard._DIFF_SKIP).
-_CAP_DIFF_SKIP = {"INSTRUCTIONS.md", "MEMORY.md", "STATE.md",
-                  "LEDGER.md", "JOURNAL.md", "PROCESS.md", "RUNMAP.md"}
+# Derived from ``rundir.NON_CAPABILITY_NAMES`` — a read-side FILTER like the cache and
+# component lists, so it takes the whole union (live + legacy scratch + the two
+# snapshotted explainability files). It must NOT be shared with
+# ``harness._SNAPSHOT_IGNORE``, which is DESTRUCTIVE and takes ``SCRATCH_NAMES`` only:
+# feeding this list to the snapshot would DELETE PROCESS.md, the explainability record
+# we deliberately keep. Same predicate, different operation. See the tier note in
+# rundir.py; the split is pinned by
+# test_gepa.py::test_scratch_ignores_are_one_shared_definition.
+_CAP_DIFF_SKIP = set(NON_CAPABILITY_NAMES)
 
 
 def _capability_files(d: Path) -> dict[str, str]:
@@ -1585,6 +1592,12 @@ _DEFAULT_INSTRUCTIONS_TEMPLATE = (
 # snapshot and surface via RUNMAP/prior_iterations. LEDGER/JOURNAL/RUNMAP + prior_iterations/
 # are framework-injected read-context (LEDGER/RUNMAP regenerated, JOURNAL is run-level),
 # so they must not bloat candidates/ or pollute diffs.
+#
+# This is the one DESTRUCTIVE consumer of the shared list — snapshot() drops what it
+# names — so it takes ``SCRATCH_NAMES`` (live writers) ONLY, never
+# ``rundir.NON_CAPABILITY_NAMES``. A retired name with no live writer can only refer to
+# a capability file that shares it, and deleting that is silent data loss the eval-cache
+# key can't see. See the tier note in rundir.py.
 _SNAPSHOT_IGNORE = ("trajectories", "guidance", "prior_iterations",
                     ".claude", ".agents", ".gemini", ".opencode", ".bob",
                     "CLAUDE.md", "AGENTS.md", "GEMINI.md") + SCRATCH_NAMES

--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -28,6 +28,7 @@ from . import gate as gate_mod
 # Module-level is safe: optimizer_context imports only .loop/.rundir eagerly and
 # lazy-imports harness inside its function bodies, so there is no cycle to dodge.
 from . import optimizer_context as _oc
+from . import proposal_quality
 from .loop import SplitResult, aggregate_scores
 from .rundir import (NON_CAPABILITY_NAMES, SCRATCH_NAMES, RunDir, _atomic_write,
                      iteration_candidate)
@@ -565,6 +566,16 @@ _PROCESS_SEED = (
     "Fill this in as you work. It is the human-readable record of HOW this iteration was "
     "done and is snapshotted with the candidate, so anyone — and the next iteration via "
     "./prior_iterations/ — can see your reasoning. Be concrete.\n\n"
+    "## Proposal declaration (#140 — fill BEFORE you edit; read ./guidance/reasoning/"
+    "mechanism-probe/SKILL.md first)\n"
+    "- Mechanism: <what now behaves DIFFERENTLY, and why that changes the outcome — a "
+    "knob restates a rule or retunes a value; a mechanism changes what is possible>\n"
+    "- Hypothesis: <which failure cluster this fixes, and why it generalizes past the "
+    "exact failing inputs>\n"
+    "- Expected observable: <what will look different in the NEXT iteration's "
+    "trajectories if this is right>\n"
+    "(Recorded per candidate, NOT enforced — the val gate is still the only thing that "
+    "accepts or rejects.)\n\n"
     "## Ranked issue list (clusters by # failing tasks × trials, biggest first)\n"
     "| rank | cluster | tasks | shared root cause | tag (KNOWLEDGE / BEHAVIORAL / CAPABILITY-GAP) | planned change class |\n"
     "| --- | --- | --- | --- | --- | --- |\n\n"
@@ -1073,6 +1084,9 @@ def _augment_instructions(instructions: str, workdir: Path, run_dir: RunDir) -> 
     )
     dead_ends = dead_end_constraints(run_dir)
     tail = f"\n{dead_ends}" if dead_ends else ""
+    # #140's proposal-quality bar, LAST so it sits in the kept 30% tail alongside the
+    # dead-end constraints. ~1.4 KB; the tail budget is 18 KB at the default ceiling.
+    tail += f"\n{proposal_quality.PROMPT_BLOCK}"
     # Re-cap: render_instructions capped its OWN output, but these blocks are appended
     # after it, so the final assembled prompt needs the ceiling applied once more.
     return _oc.cap_instructions(f"{instructions}\n\n{pointer}{tail}\n")
@@ -1252,6 +1266,23 @@ def _inject_optimizer_context(adapter, run_dir: RunDir, workdir: Path, *, split:
         except Exception as e:  # noqa: BLE001
             run_dir.log_event("optimizer_context_warning", what="guidance/diagnose", error=str(e)[:300])
 
+    # 3b) the ON-DEMAND reasoning skills (#140) as local guidance. Tiny skills, each
+    # countering ONE named optimizer failure mode at ONE step — mechanism-probe sits at
+    # the proposal step. Copied whole so a new reasoning skill needs no wiring here, and
+    # scripts/ is kept (unlike the capability/diagnose copies) because the probe's own
+    # run.py is what the SKILL.md tells the optimizer to run on its PROCESS.md.
+    reasoning_src = repo_root / "skills" / "reasoning"
+    if reasoning_src.is_dir():
+        try:
+            dst = workdir / "guidance" / "reasoning"
+            if dst.exists():
+                shutil.rmtree(dst)
+            shutil.copytree(reasoning_src, dst,
+                            ignore=shutil.ignore_patterns("__pycache__", "*.pyc"))
+        except Exception as e:  # noqa: BLE001
+            run_dir.log_event("optimizer_context_warning", what="guidance/reasoning",
+                              error=str(e)[:300])
+
     # 4) the resolved optimizer's features reference (parallel subagents etc.).
     if optimizer_name:
         ref_src = (repo_root / "skills" / "optimizers" / "run-optimizer"
@@ -1329,6 +1360,18 @@ def _inject_native_skills(run_dir: RunDir, workdir: Path, caps, repo_root: Path,
                 except Exception as e:  # noqa: BLE001
                     run_dir.log_event("optimizer_context_warning",
                                       what=f"{skills_dir}/diagnose", error=str(e)[:300])
+            # ON-DEMAND reasoning skills (#140) — flattened into the native dir so the
+            # agent discovers them the same way it discovers the capability skills.
+            for src in sorted((repo_root / "skills" / "reasoning").glob("*/SKILL.md")):
+                try:
+                    dst = native_root / src.parent.name
+                    if dst.exists():
+                        shutil.rmtree(dst)
+                    shutil.copytree(src.parent, dst, ignore=ignore)
+                except Exception as e:  # noqa: BLE001
+                    run_dir.log_event("optimizer_context_warning",
+                                      what=f"{skills_dir}/{src.parent.name}",
+                                      error=str(e)[:300])
 
         # Always-on instructions file: write a short, generic, idempotent pointer block.
         if instructions_file:
@@ -1458,6 +1501,11 @@ def run_step(
     optimizer_seconds = time.time() - _opt_t0
     run_dir.update_spent(optimizer_seconds=optimizer_seconds, optimizer_usd=opt_cost_usd,
                          optimizer_tokens=opt_tokens)
+
+    # #140: record what the optimizer DECLARED (mechanism/hypothesis/observable) before
+    # the gate judges it. ADVISORY — nothing below branches on this; the candidate goes
+    # to the val gate whether or not it declared anything.
+    proposal_quality.record(run_dir, workdir, cid)
 
     cand_val = evaluate_candidate(adapter, workdir, run_dir=run_dir, split="val",
                                   n_trials=n_trials, tag=cid)

--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -707,18 +707,7 @@ def _journal_tail(workdir: Path) -> str:
     return tail.replace(_JOURNAL_MARK, "").strip()
 
 
-def _latest_journal_note(workdir: Path, *, max_chars: int = 900) -> str | None:
-    """The newest journal entry, capped — stored in the factual ledger as the candidate's
-    one-line lineage note. Returns ``None`` when the optimizer appended nothing."""
-    tail = _journal_tail(workdir)
-    if not tail:
-        return None
-    if len(tail) > max_chars:
-        tail = tail[:max_chars].rstrip() + " …"
-    return tail
-
-
-def _build_ledger(workdir: Path, run_dir: RunDir, rejected, history) -> None:
+def _build_ledger(workdir: Path, run_dir: RunDir) -> None:
     """Write the FACTUAL, framework-owned LEDGER.md: one row per prior iteration with
     its outcome + the exact tasks it broke/fixed. Deterministic — the objective record;
     the optimizer's own narrative lives in JOURNAL.md."""
@@ -872,8 +861,7 @@ def _build_runmap(workdir: Path, run_dir: RunDir) -> None:
     (workdir / "RUNMAP.md").write_text(text, encoding="utf-8")
 
 
-def _augment_instructions(instructions: str, workdir: Path, run_dir: RunDir,
-                          rejected, history) -> str:
+def _augment_instructions(instructions: str, workdir: Path, run_dir: RunDir) -> str:
     """Give the optimizer its four cross-iteration files + a prompt pointer to each.
 
     Clean ownership (see the file-header comment near ``_JOURNAL_SEED``):
@@ -883,7 +871,7 @@ def _augment_instructions(instructions: str, workdir: Path, run_dir: RunDir,
       - RUNMAP.md + prior_iterations/ — framework manifest + copies of every prior
         iteration's PROCESS.md and capability diff (real prior-work-dir access).
     """
-    _build_ledger(workdir, run_dir, rejected, history)
+    _build_ledger(workdir, run_dir)
     _seed_journal(workdir, run_dir)
     if not (workdir / "PROCESS.md").exists():
         (workdir / "PROCESS.md").write_text(_PROCESS_SEED, encoding="utf-8")
@@ -1261,7 +1249,7 @@ def run_step(
                 capabilities=capabilities or [], optimizer_name=optimizer_name,
                 capability_sources=capability_sources or [], project_dir=project_dir))
 
-    instructions = _augment_instructions(instructions, workdir, run_dir, rejected, history)
+    instructions = _augment_instructions(instructions, workdir, run_dir)
 
     optimizer_error = None
     opt_cost_usd, opt_tokens = 0.0, 0
@@ -1336,30 +1324,22 @@ def run_step(
                       opt_cost_usd=round(opt_cost_usd, 6), opt_tokens=opt_tokens)
     run_dir.record_spend_warnings()
 
-    # update optimizer memory + commit the iteration to the version store so the
-    # whole process stays inspectable (git log / LEDGER / JOURNAL). The `note` is the
-    # optimizer's own handover (its approach + lesson), taken from the entry it appended
-    # to JOURNAL.md this iteration so the lineage record carries what was tried, not just Δ/SE.
+    # Record the iteration for the dashboard's Memory/Insights panels + commit it to the
+    # version store, so the whole process stays inspectable (git log / LEDGER / JOURNAL).
     delta = cand_val.reward - current_val.reward
     summary = f"candidate {cid} (val {cand_val.reward:.3f}, Δ {delta:+.3f})"
     # Fold the optimizer's appended JOURNAL entry into the run-level append-only journal
-    # (so handover accumulates across accepted AND rejected iterations), and reuse it as
-    # the candidate's lineage note in the factual ledger.
+    # (so handover accumulates across accepted AND rejected iterations). This is the
+    # channel the NEXT iteration actually reads; _reconcile_journal stamps the objective
+    # outcome + the exact tasks broken/fixed into it.
     _reconcile_journal(workdir, run_dir, cid, accepted=accepted,
                        val=cand_val.reward, delta=delta)
-    note = _latest_journal_note(workdir)
-    # Per-task broke/fixed lists vs the parent (from the rollouts just persisted), so
-    # MEMORY records the SPECIFIC tasks a candidate broke — not just a category — and
-    # the next iteration won't retry the regression. Best-effort; None when not
-    # comparable (e.g. parent rollouts absent).
-    impact = _candidate_task_impact(run_dir, cid, "val",
-                                    parent_of={cid: parent_id})
     if accepted:
         if history is not None:
-            history.add(cid, summary, cand_val.reward, note=note, impact=impact)
+            history.add(cid, summary, cand_val.reward)
     else:
         if rejected is not None:
-            rejected.add(cid, summary, decision.reason, cand_val.reward, note=note, impact=impact)
+            rejected.add(cid, summary, decision.reason, cand_val.reward)
     if store is not None:
         store.commit(f"iter {run_dir.spent.iterations}: "
                      f"{'ACCEPT' if accepted else 'reject'} {summary}",

--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -713,18 +713,7 @@ def _journal_tail(workdir: Path) -> str:
     return tail.replace(_JOURNAL_MARK, "").strip()
 
 
-def _latest_journal_note(workdir: Path, *, max_chars: int = 900) -> str | None:
-    """The newest journal entry, capped — stored in the factual ledger as the candidate's
-    one-line lineage note. Returns ``None`` when the optimizer appended nothing."""
-    tail = _journal_tail(workdir)
-    if not tail:
-        return None
-    if len(tail) > max_chars:
-        tail = tail[:max_chars].rstrip() + " …"
-    return tail
-
-
-def _build_ledger(workdir: Path, run_dir: RunDir, rejected, history) -> None:
+def _build_ledger(workdir: Path, run_dir: RunDir) -> None:
     """Write the FACTUAL, framework-owned LEDGER.md: one row per prior iteration with
     its outcome + the exact tasks it broke/fixed. Deterministic — the objective record;
     the optimizer's own narrative lives in JOURNAL.md."""
@@ -898,8 +887,7 @@ def _build_runmap(workdir: Path, run_dir: RunDir) -> None:
     (workdir / "RUNMAP.md").write_text(text, encoding="utf-8")
 
 
-def _augment_instructions(instructions: str, workdir: Path, run_dir: RunDir,
-                          rejected, history) -> str:
+def _augment_instructions(instructions: str, workdir: Path, run_dir: RunDir) -> str:
     """Give the optimizer its four cross-iteration files + a prompt pointer to each.
 
     Clean ownership (see the file-header comment near ``_JOURNAL_SEED``):
@@ -909,7 +897,7 @@ def _augment_instructions(instructions: str, workdir: Path, run_dir: RunDir,
       - RUNMAP.md + prior_iterations/ — framework manifest + copies of every prior
         iteration's PROCESS.md and capability diff (real prior-work-dir access).
     """
-    _build_ledger(workdir, run_dir, rejected, history)
+    _build_ledger(workdir, run_dir)
     _seed_journal(workdir, run_dir)
     if not (workdir / "PROCESS.md").exists():
         (workdir / "PROCESS.md").write_text(_PROCESS_SEED, encoding="utf-8")
@@ -1253,7 +1241,7 @@ def run_step(
                               capabilities=capabilities, optimizer_name=optimizer_name,
                               capability_sources=capability_sources, project_dir=project_dir)
 
-    instructions = _augment_instructions(instructions, workdir, run_dir, rejected, history)
+    instructions = _augment_instructions(instructions, workdir, run_dir)
 
     optimizer_error = None
     opt_cost_usd, opt_tokens = 0.0, 0
@@ -1328,30 +1316,22 @@ def run_step(
                       opt_cost_usd=round(opt_cost_usd, 6), opt_tokens=opt_tokens)
     run_dir.record_spend_warnings()
 
-    # update optimizer memory + commit the iteration to the version store so the
-    # whole process stays inspectable (git log / LEDGER / JOURNAL). The `note` is the
-    # optimizer's own handover (its approach + lesson), taken from the entry it appended
-    # to JOURNAL.md this iteration so the lineage record carries what was tried, not just Δ/SE.
+    # Record the iteration for the dashboard's Memory/Insights panels + commit it to the
+    # version store, so the whole process stays inspectable (git log / LEDGER / JOURNAL).
     delta = cand_val.reward - current_val.reward
     summary = f"candidate {cid} (val {cand_val.reward:.3f}, Δ {delta:+.3f})"
     # Fold the optimizer's appended JOURNAL entry into the run-level append-only journal
-    # (so handover accumulates across accepted AND rejected iterations), and reuse it as
-    # the candidate's lineage note in the factual ledger.
+    # (so handover accumulates across accepted AND rejected iterations). This is the
+    # channel the NEXT iteration actually reads; _reconcile_journal stamps the objective
+    # outcome + the exact tasks broken/fixed into it.
     _reconcile_journal(workdir, run_dir, cid, accepted=accepted,
                        val=cand_val.reward, delta=delta)
-    note = _latest_journal_note(workdir)
-    # Per-task broke/fixed lists vs the parent (from the rollouts just persisted), so
-    # MEMORY records the SPECIFIC tasks a candidate broke — not just a category — and
-    # the next iteration won't retry the regression. Best-effort; None when not
-    # comparable (e.g. parent rollouts absent).
-    impact = _candidate_task_impact(run_dir, cid, "val",
-                                    parent_of={cid: parent_id})
     if accepted:
         if history is not None:
-            history.add(cid, summary, cand_val.reward, note=note, impact=impact)
+            history.add(cid, summary, cand_val.reward)
     else:
         if rejected is not None:
-            rejected.add(cid, summary, decision.reason, cand_val.reward, note=note, impact=impact)
+            rejected.add(cid, summary, decision.reason, cand_val.reward)
     if store is not None:
         store.commit(f"iter {run_dir.spent.iterations}: "
                      f"{'ACCEPT' if accepted else 'reject'} {summary}",

--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -25,7 +25,7 @@ from typing import Callable
 
 from . import gate as gate_mod
 from .loop import SplitResult, aggregate_scores
-from .rundir import RunDir, _atomic_write
+from .rundir import SCRATCH_NAMES, RunDir, _atomic_write
 from .splits import Splits, make_splits
 from .types import Rollout, Score, Task
 
@@ -1586,9 +1586,8 @@ _DEFAULT_INSTRUCTIONS_TEMPLATE = (
 # are framework-injected read-context (LEDGER/RUNMAP regenerated, JOURNAL is run-level),
 # so they must not bloat candidates/ or pollute diffs.
 _SNAPSHOT_IGNORE = ("trajectories", "guidance", "prior_iterations",
-                    "LEDGER.md", "JOURNAL.md", "RUNMAP.md",
                     ".claude", ".agents", ".gemini", ".opencode", ".bob",
-                    "CLAUDE.md", "AGENTS.md", "GEMINI.md")
+                    "CLAUDE.md", "AGENTS.md", "GEMINI.md") + SCRATCH_NAMES
 
 
 def _failures_block(always_fail, flaky, errored) -> str:

--- a/core/cap_evolve/memory.py
+++ b/core/cap_evolve/memory.py
@@ -1,21 +1,24 @@
 """Optimizer memory: append-only jsonl records of rejected + accepted candidates.
 
-These are **audit/UI records, not optimizer input.** Two append-only files in the run
-dir, one line per candidate:
+Two append-only files in the run dir, one line per candidate:
 
 - ``RejectedMemory`` (``rejected.jsonl``) — every candidate the gate rejected, with the
   reason.
 - ``History`` (``history.jsonl``) — every accepted candidate.
 
-Their only consumer is the dashboard: ``GET /api/runs/{id}/memory``
+The dashboard reads both: ``GET /api/runs/{id}/memory``
 (``dashboard/backend/capevolve_dashboard/memory.py``) serves them to the Memory panel
-and to the Insights "dead ends" grouping, which read exactly
-``{candidate_id, summary, val, reason}`` — nothing else.
+and to the Insights "dead ends" grouping, which read
+``{candidate_id, summary, val, reason}`` plus (rejections only) ``approach``.
 
-They are NOT fed back into any proposal prompt: the framework-owned LEDGER.md /
-JOURNAL.md / RUNMAP.md files (see ``harness._augment_instructions``) are the sole
-cross-iteration channel the optimizer actually reads. Do not add a ``render()`` here
-expecting it to reach a prompt — wire it through ``_augment_instructions`` instead.
+``rejected.jsonl`` additionally feeds the optimizer's **dead-end constraint block**
+(``harness.dead_end_constraints`` -> ``harness._augment_instructions``, issue #129):
+``approach`` carries the normalized signature of the edit that was rejected, so the next
+proposal prompt can name the failed approach instead of only its score. Records written
+before #129 have no ``approach`` and degrade to being skipped.
+
+Nothing here renders a prompt on its own — ``_augment_instructions`` is the only
+function whose output reaches the optimizer (see #114). Wire new prompt content there.
 
 Pure stdlib.
 """
@@ -38,9 +41,16 @@ class RejectedMemory:
         self.path.parent.mkdir(parents=True, exist_ok=True)
 
     def add(self, candidate_id: str, summary: str, reason: str,
-            val: Optional[float] = None) -> None:
+            val: Optional[float] = None, approach: str = "") -> None:
+        """Record one rejection.
+
+        ``approach`` is the normalized signature of the edit that failed (see
+        ``harness.approach_signature``) — the field the #129 dead-end constraint block is
+        built from. Optional so direct callers and pre-#129 records stay valid.
+        """
         _append(self.path, {"candidate_id": candidate_id, "summary": summary.strip(),
-                            "reason": reason.strip(), "val": val})
+                            "reason": reason.strip(), "val": val,
+                            "approach": approach.strip()})
 
 
 class History:

--- a/core/cap_evolve/memory.py
+++ b/core/cap_evolve/memory.py
@@ -1,16 +1,23 @@
-"""Optimizer memory: rejected approaches + accepted history.
+"""Optimizer memory: append-only jsonl records of rejected + accepted candidates.
 
-Two append-only records that survive across iterations:
+These are **audit/UI records, not optimizer input.** Two append-only files in the run
+dir, one line per candidate:
 
-- ``RejectedMemory`` — every candidate the gate rejected, with the reason. Its
-  ``render()`` produces a markdown block fed into the *next* proposal prompt as
-  STEERING: don't re-submit a regressed edit verbatim, but a better-designed version
-  of the same idea may still work — so a high-value cluster is not permanently
-  abandoned (prior agent-optimization work's RejectedMemory / evo-graph's Rejected Memory Store).
-- ``History`` — every accepted candidate, so the loop can show the optimizer
-  what worked and reconstruct the best-so-far lineage.
+- ``RejectedMemory`` (``rejected.jsonl``) — every candidate the gate rejected, with the
+  reason.
+- ``History`` (``history.jsonl``) — every accepted candidate.
 
-Backed by jsonl files in the run dir; pure stdlib.
+Their only consumer is the dashboard: ``GET /api/runs/{id}/memory``
+(``dashboard/backend/capevolve_dashboard/memory.py``) serves them to the Memory panel
+and to the Insights "dead ends" grouping, which read exactly
+``{candidate_id, summary, val, reason}`` — nothing else.
+
+They are NOT fed back into any proposal prompt: the framework-owned LEDGER.md /
+JOURNAL.md / RUNMAP.md files (see ``harness._augment_instructions``) are the sole
+cross-iteration channel the optimizer actually reads. Do not add a ``render()`` here
+expecting it to reach a prompt — wire it through ``_augment_instructions`` instead.
+
+Pure stdlib.
 """
 
 from __future__ import annotations
@@ -20,35 +27,9 @@ from pathlib import Path
 from typing import Optional
 
 
-def _store_impact(rec: dict, impact: Optional[dict]) -> None:
-    """Attach a candidate's per-task broke/fixed lists to its memory record.
-
-    ``impact`` is the dict produced by ``harness._candidate_task_impact``
-    (``{"broke": [...], "fixed": [...], ...}``). Only the non-empty broke/fixed
-    lists are stored, so old records (impact=None) stay byte-identical and the
-    memory file is not bloated when there was no per-task movement."""
-    if not impact:
-        return
-    broke = [str(t) for t in (impact.get("broke") or [])]
-    fixed = [str(t) for t in (impact.get("fixed") or [])]
-    if broke:
-        rec["broke"] = broke
-    if fixed:
-        rec["fixed"] = fixed
-
-
-def _render_impact(e: dict) -> Optional[str]:
-    """One-line per-task impact for a memory entry, or None when there is none."""
-    broke = e.get("broke") or []
-    fixed = e.get("fixed") or []
-    if not broke and not fixed:
-        return None
-    parts = []
-    if broke:
-        parts.append("broke {" + ", ".join(str(t) for t in broke) + "}")
-    if fixed:
-        parts.append("fixed {" + ", ".join(str(t) for t in fixed) + "}")
-    return "per-task impact: " + "; ".join(parts)
+def _append(path: Path, rec: dict) -> None:
+    with path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(rec) + "\n")
 
 
 class RejectedMemory:
@@ -56,53 +37,10 @@ class RejectedMemory:
         self.path = Path(path)
         self.path.parent.mkdir(parents=True, exist_ok=True)
 
-    def add(self, candidate_id: str, summary: str, reason: str, val: Optional[float] = None,
-            note: Optional[str] = None, impact: Optional[dict] = None) -> None:
-        rec = {
-            "candidate_id": candidate_id,
-            "summary": summary.strip(),
-            "reason": reason.strip(),
-            "val": val,
-        }
-        if note and note.strip():
-            rec["note"] = note.strip()
-        _store_impact(rec, impact)
-        with self.path.open("a", encoding="utf-8") as f:
-            f.write(json.dumps(rec) + "\n")
-
-    def entries(self) -> list[dict]:
-        if not self.path.exists():
-            return []
-        out = []
-        for line in self.path.read_text(encoding="utf-8").splitlines():
-            line = line.strip()
-            if line:
-                out.append(json.loads(line))
-        return out
-
-    def render(self, limit: int = 20) -> str:
-        """Markdown block for the proposal prompt: approaches that regressed AS
-        IMPLEMENTED — steering, not a permanent ban-list."""
-        items = self.entries()[-limit:]
-        if not items:
-            return "_No regressed approaches yet._"
-        lines = [
-            "## Approaches that regressed AS IMPLEMENTED",
-            "These exact edits were rejected by the gate. Don't re-submit them verbatim — "
-            "but a better-designed version of the same idea MAY still work, so don't "
-            "permanently abandon a high-value cluster. Each shows its reject reason "
-            "(and per-task impact) so you can redesign rather than repeat.",
-        ]
-        for e in items:
-            v = f" (val={e['val']:.4f})" if e.get("val") is not None else ""
-            lines.append(f"- **{e['summary']}** — rejected: {e['reason']}{v}")
-            note = (e.get("note") or "").strip()
-            if note:
-                lines.append(f"  - approach + lesson: {note}")
-            imp = _render_impact(e)
-            if imp:
-                lines.append(f"  - {imp}")
-        return "\n".join(lines)
+    def add(self, candidate_id: str, summary: str, reason: str,
+            val: Optional[float] = None) -> None:
+        _append(self.path, {"candidate_id": candidate_id, "summary": summary.strip(),
+                            "reason": reason.strip(), "val": val})
 
 
 class History:
@@ -110,36 +48,6 @@ class History:
         self.path = Path(path)
         self.path.parent.mkdir(parents=True, exist_ok=True)
 
-    def add(self, candidate_id: str, summary: str, val: float,
-            note: Optional[str] = None, impact: Optional[dict] = None) -> None:
-        rec = {"candidate_id": candidate_id, "summary": summary.strip(), "val": val}
-        if note and note.strip():
-            rec["note"] = note.strip()
-        _store_impact(rec, impact)
-        with self.path.open("a", encoding="utf-8") as f:
-            f.write(json.dumps(rec) + "\n")
-
-    def entries(self) -> list[dict]:
-        if not self.path.exists():
-            return []
-        out = []
-        for line in self.path.read_text(encoding="utf-8").splitlines():
-            line = line.strip()
-            if line:
-                out.append(json.loads(line))
-        return out
-
-    def render(self, limit: int = 10) -> str:
-        items = self.entries()[-limit:]
-        if not items:
-            return "_No accepted edits yet (this is the baseline)._"
-        lines = ["## Accepted edits so far (what worked)"]
-        for e in items:
-            lines.append(f"- {e['summary']} → val={e['val']:.4f}")
-            note = (e.get("note") or "").strip()
-            if note:
-                lines.append(f"  - approach + lesson: {note}")
-            imp = _render_impact(e)
-            if imp:
-                lines.append(f"  - {imp}")
-        return "\n".join(lines)
+    def add(self, candidate_id: str, summary: str, val: float) -> None:
+        _append(self.path, {"candidate_id": candidate_id, "summary": summary.strip(),
+                            "val": val})

--- a/core/cap_evolve/optimizer_context.py
+++ b/core/cap_evolve/optimizer_context.py
@@ -1,0 +1,218 @@
+"""The ONE optimizer-context seam every algorithm routes through.
+
+Before this module, ``hill-climb`` was the only algorithm that gave its optimizer a
+full working context: ``harness.run_step`` called ``_inject_optimizer_context``
+(trajectories + capability guidance + native-skill placement) and
+``harness._focus_instructions`` rendered the benchmark-authored prompt template with
+the capability brief, the failure index, the bench-repo pointer and the parallel-fan-out
+note. ``gepa`` bypasses ``run_step`` entirely and ``skillopt`` called
+``_focus_instructions`` with no capability/optimizer arguments, so both flagship
+algorithms proposed edits from a thinner prompt than the basic climber.
+
+This module is the shared seam that fixes that, and the extension point for future
+work (see the issue cluster #114/#115/#128/#129/#130/#137/#140):
+
+  * :class:`OptimizerContext` — the per-run bundle of "what context does the optimizer
+    get" knobs, parsed once (from a spec/CLI) and threaded into every algorithm loop as
+    ONE argument instead of eight.
+  * :func:`inject` — the FILE side: everything copied into the optimizer's own workdir
+    (``./trajectories/``, ``./guidance/<cap>/``, ``./guidance/sources/``,
+    ``./guidance/diagnose/``, ``./guidance/optimizer/<name>.md`` and the native
+    per-agent skills dir). Add a new injected artifact HERE and every algorithm gets it.
+  * :func:`render_instructions` — the PROMPT side: the rendered per-iteration
+    INSTRUCTIONS (template + capability brief + failure index + bench repo + parallel
+    note + consuming-LLM reader block), plus an ``extra`` tail for an algorithm's own
+    block (GEPA's reflective dataset pointer, SkillOpt's edit-budget/rejected buffer).
+    Add a new prompt block HERE and every algorithm gets it.
+
+Both functions delegate to the existing honesty-neutral helpers in ``harness`` (imported
+lazily inside the bodies, since ``harness`` calls back into this module) — nothing about
+splits, the gate, or the seal is touched here.
+
+Pure stdlib.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from .loop import SplitResult
+from .rundir import RunDir
+
+
+# Everything :func:`inject` writes into the optimizer's workdir. These are READ-context,
+# never part of the capability, so they must be excluded from: the candidate snapshot
+# (``harness._SNAPSHOT_IGNORE``), GEPA's editable-component list (``gepa._components``)
+# and the eval-cache content hash (``cache.hash_candidate_dir``). One list, three
+# consumers — add a newly injected artifact here and all three stay correct.
+INJECTED_DIRS = ("trajectories", "guidance", "prior_iterations",
+                 ".claude", ".agents", ".gemini", ".opencode", ".bob", ".cursor")
+INJECTED_NAMES = ("CLAUDE.md", "AGENTS.md", "GEMINI.md")
+
+
+def _csv(value) -> list[str]:
+    """Accept a list OR a comma-separated string (the shape CLI flags arrive in)."""
+    if not value:
+        return []
+    if isinstance(value, str):
+        return [v.strip() for v in value.split(",") if v.strip()]
+    return [str(v).strip() for v in value if str(v).strip()]
+
+
+@dataclass
+class OptimizerContext:
+    """What context the optimizer gets — identical for every algorithm.
+
+    Every field was previously hill-climb-only plumbing. Constructing this once and
+    passing it to ``hill_climb_loop`` / ``gepa_loop`` / ``skillopt_loop`` is what makes
+    the three algorithms prompt-equivalent.
+    """
+
+    capabilities: list[str] = field(default_factory=list)
+    optimizer_name: str | None = None
+    instructions_file: str | None = None
+    bench_repo: str | None = None
+    capability_sources: list[str] = field(default_factory=list)
+    project_dir: Path | None = None
+    target_model: str = ""
+    target_profile_file: str | None = None
+
+    def __post_init__(self) -> None:
+        self.capabilities = _csv(self.capabilities)
+        self.capability_sources = _csv(self.capability_sources)
+        if self.project_dir is not None:
+            self.project_dir = Path(self.project_dir)
+        self._reader: str | None = None
+        self._profile = None
+
+    @classmethod
+    def from_args(cls, args) -> OptimizerContext:
+        """Build from an argparse namespace using the standard algorithm flag names.
+
+        Every deterministic algorithm's ``scripts/run.py`` declares the same flag set
+        (``--capabilities --instructions-file --bench-repo --optimizer-name
+        --capability-sources --target-model --target-profile-file``), so this is the one
+        place that maps them onto the context. Missing attributes are tolerated.
+        """
+        get = lambda name, default=None: getattr(args, name, default)  # noqa: E731
+        return cls(
+            capabilities=get("capabilities", "") or "",
+            optimizer_name=get("optimizer_name") or None,
+            instructions_file=get("instructions_file") or None,
+            bench_repo=get("bench_repo") or None,
+            capability_sources=get("capability_sources", "") or "",
+            project_dir=Path(get("project")) if get("project") else None,
+            target_model=get("target_model", "") or "",
+            target_profile_file=get("target_profile_file") or None,
+        )
+
+    @staticmethod
+    def add_arguments(parser) -> None:
+        """Declare the standard optimizer-context flags on an algorithm's argparse.
+
+        Every deterministic algorithm's ``scripts/run.py`` calls this, so ``cap-evolve
+        run`` can pass the flags unconditionally instead of gating them on
+        ``algorithm == "hill-climb"`` (which silently dropped them for GEPA/SkillOpt).
+        """
+        parser.add_argument("--capabilities", default="",
+                            help="comma-separated capability skills under optimization "
+                                 "(e.g. 'system-prompt,tools'); surfaced to the optimizer "
+                                 "so it knows the allowed edit space")
+        parser.add_argument("--instructions-file", default=None,
+                            help="optimizer-instructions template (intake-authored) to "
+                                 "render the per-iteration prompt from; defaults to the "
+                                 "shipped template")
+        parser.add_argument("--bench-repo", default=None,
+                            help="path to the benchmark/runner source, surfaced to the "
+                                 "optimizer as read-only context")
+        parser.add_argument("--optimizer-name", default=None,
+                            help="resolved optimizer name (registry row); used to copy "
+                                 "that optimizer's features reference + native skills "
+                                 "into the optimizer workdir")
+        parser.add_argument("--capability-sources", default="",
+                            help="comma-separated supporting source files (data models / "
+                                 "types the tools import) copied verbatim into the "
+                                 "optimizer's ./guidance/sources/; relative to --project")
+        parser.add_argument("--target-model", default="",
+                            help="consuming/runtime model id or tier keyword "
+                                 "(frontier|strong|mid|weak)")
+        parser.add_argument("--target-profile-file", default=None,
+                            help="optional project-local brief overriding the tier's "
+                                 "built-in brief")
+
+    def profile(self):
+        """The resolved consuming-LLM ``TargetProfile`` (cached)."""
+        if self._profile is None:
+            from . import target_profile as _tp
+            self._profile = _tp.resolve(self.target_model, self.target_profile_file,
+                                        project_dir=self.project_dir)
+        return self._profile
+
+    def target_reader(self) -> str:
+        """The consuming-LLM ("reader") brief block, resolved once and cached."""
+        if self._reader is None:
+            from . import target_profile as _tp
+            self._reader = _tp.reader_block(self.profile())
+        return self._reader
+
+    def log_profile(self, run_dir: RunDir) -> None:
+        """Record the resolved consuming-LLM profile so report + dashboard surface it.
+
+        Called by every algorithm's ``run.py``; previously hill-climb-only.
+        """
+        prof = self.profile()
+        if not prof.is_agnostic:
+            run_dir.log_event("target_profile", model=prof.model, tier=prof.tier,
+                              suggested_num_trials=prof.suggested_num_trials,
+                              resolution_note=prof.resolution_note)
+
+
+def inject(adapter, run_dir: RunDir, workdir: Path, *, split: str,
+           ctx: OptimizerContext | None = None, tag: str | None = None) -> None:
+    """Copy the optimizer's read-context into ``workdir`` (the FILE side of the seam).
+
+    ``tag`` scopes ``./trajectories/`` to a specific eval tag — GEPA needs the *parent's
+    minibatch* traces (not the run's current best), which is exactly the verbatim,
+    untruncated data its ``REFLECTION.md`` only summarizes. Omit it to keep the
+    best/parent-then-seed fallback chain used by hill-climb and SkillOpt.
+    """
+    from . import harness
+    ctx = ctx or OptimizerContext()
+    harness._inject_optimizer_context(
+        adapter, run_dir, workdir, split=split,
+        capabilities=ctx.capabilities, optimizer_name=ctx.optimizer_name,
+        capability_sources=ctx.capability_sources, project_dir=ctx.project_dir,
+        tag=tag,
+    )
+
+
+def render_instructions(current: SplitResult, focus_ids, label: str, *,
+                        ctx: OptimizerContext | None = None,
+                        algorithm: str = "hill-climb",
+                        run_dir: RunDir | None = None,
+                        parent_id: str | None = None,
+                        extra: str = "") -> str:
+    """Render one iteration's INSTRUCTIONS (the PROMPT side of the seam).
+
+    ``current`` is the result the failure index is built from (full val for hill-climb /
+    SkillOpt, the parent's minibatch for GEPA); ``focus_ids`` narrows it; ``extra`` is the
+    algorithm's own tail block. When ``run_dir`` is given the empty-seed signal is
+    computed from the parent candidate (``parent_id``, default the run's best).
+    """
+    from . import harness
+    ctx = ctx or OptimizerContext()
+    seed_empty = None
+    if run_dir is not None:
+        cid = parent_id or run_dir.best_id
+        if cid:
+            seed_empty = harness._capability_is_empty(ctx.capabilities,
+                                                      run_dir.candidate_dir(cid))
+    text = harness._focus_instructions(
+        current, focus_ids, label,
+        capabilities=ctx.capabilities, algorithm=algorithm,
+        instructions_file=ctx.instructions_file, bench_repo=ctx.bench_repo,
+        optimizer_name=ctx.optimizer_name, seed_empty=seed_empty,
+        target_reader=ctx.target_reader(),
+    )
+    return f"{text}\n{extra}" if extra else text

--- a/core/cap_evolve/optimizer_context.py
+++ b/core/cap_evolve/optimizer_context.py
@@ -43,24 +43,25 @@ from .rundir import RunDir
 
 # Everything :func:`inject` writes into the optimizer's workdir. These are READ-context,
 # never part of the capability, so they must be excluded from: the candidate snapshot
-# (``harness._SNAPSHOT_IGNORE``), GEPA's editable-component list (``gepa._components``)
-# and the eval-cache content hash (``cache.hash_candidate_dir``). One list, three
-# consumers — add a newly injected artifact here and all three stay correct.
+# (``harness._SNAPSHOT_IGNORE``), GEPA's editable-component list (``gepa._components``),
+# the eval-cache content hash (``cache.hash_candidate_dir``), the capability-diff filters
+# (``harness._CAP_DIFF_SKIP`` / ``dashboard._DIFF_SKIP``) and SkillOpt's applied-edit count
+# (``skillopt._changed_components``). One list — add a newly injected artifact here and
+# every consumer stays correct.
+#
+# The diff/count consumers need them for a non-obvious reason: their PARENT side is a
+# snapshot (already stripped by ``_SNAPSHOT_IGNORE``) while their CHILD side is the live
+# workdir, so an injected file that is missing from the filter shows up as a real
+# capability ADDITION on every single iteration.
+#
+# The complementary set — framework-WRITTEN scratch, as opposed to this copied-in
+# read-context — lives in ``rundir`` (``SCRATCH_NAMES`` / ``LEGACY_SCRATCH_NAMES`` /
+# ``NON_CAPABILITY_NAMES``), split by OPERATION because the one destructive consumer must
+# not take the retired names. See the tier note there; the read-side filters compose the
+# two sets and ``rundir`` stays unaware of these.
 INJECTED_DIRS = ("trajectories", "guidance", "prior_iterations",
                  ".claude", ".agents", ".gemini", ".opencode", ".bob", ".cursor")
 INJECTED_NAMES = ("CLAUDE.md", "AGENTS.md", "GEMINI.md")
-
-# Framework-written scratch/handover files in the optimizer's workdir that are NOT
-# capability either. Distinct from INJECTED_* (those are copied in by :func:`inject`;
-# these are written by the algorithm/harness), but every consumer that must ignore one
-# must ignore the other. ``cache._IGNORE_NAMES``, ``gepa._NON_COMPONENT``,
-# ``harness._CAP_DIFF_SKIP`` and ``dashboard._DIFF_SKIP`` each had their OWN copy of this
-# list and they had drifted: only GEPA's knew about ``FOCUS.md``/``REFLECTION.md``, so a
-# capability diff of a GEPA candidate showed its reflective scratch as a real edit. One
-# definition, four consumers.
-SCRATCH_NAMES = ("INSTRUCTIONS.md", "MEMORY.md", "STATE.md", "REJECTED.md",
-                 "FOCUS.md", "REFLECTION.md",
-                 "LEDGER.md", "JOURNAL.md", "PROCESS.md", "RUNMAP.md")
 
 
 def _csv(value) -> list[str]:
@@ -260,6 +261,12 @@ def cap_instructions(text: str, max_chars: int = MAX_INSTRUCTIONS_CHARS) -> str:
     Also called by ``harness._augment_instructions``, which appends the cross-iteration
     blocks (LEDGER pointer + #129 rejected-approach constraints) AFTER this module has
     rendered — so the FINAL assembled prompt, not just the rendered half, is capped.
+
+    The kept TAIL is 30% of the budget (18 KB at the default 60 KB ceiling) and those
+    appended blocks live in it, which is why the #129 constraint block survives an
+    overflow whole — header, rows and footer — instead of being cut mid-list: it measures
+    ~7 KB even at 200 rejections. Anything appended after this point must stay well under
+    that 30%, or it starts eating itself rather than the middle.
     """
     if max_chars and len(text) > max_chars:
         # Keep the head (task framing, capability brief, failure index) and the tail

--- a/core/cap_evolve/optimizer_context.py
+++ b/core/cap_evolve/optimizer_context.py
@@ -187,18 +187,41 @@ def inject(adapter, run_dir: RunDir, workdir: Path, *, split: str,
     )
 
 
-def render_instructions(current: SplitResult, focus_ids, label: str, *,
+# Hard ceiling on ONE iteration's assembled INSTRUCTIONS. Every individual block is
+# already bounded (``always_fail[:10]``, ``flaky[:8]``, ``errored[:25]``,
+# ``actionable[:12]``, per-field ``[:800]``) but nothing bounded the SUM — and the
+# cross-iteration blocks (LEDGER/RUNMAP rows, the JOURNAL, the rejected buffer) grow with
+# the run, so a 100-iteration run could balloon the optimizer prompt. 60k chars ≈ 15k
+# tokens, well above every measured render (largest observed: 4,655 B, GEPA iteration 1).
+# ponytail: one global cap; per-block budgets only when a real run actually hits this.
+MAX_INSTRUCTIONS_CHARS = 60_000
+
+
+def render_instructions(scored_result: SplitResult, focus_ids, label: str, *,
                         ctx: OptimizerContext | None = None,
                         algorithm: str = "hill-climb",
                         run_dir: RunDir | None = None,
                         parent_id: str | None = None,
-                        extra: str = "") -> str:
+                        extra: str = "",
+                        max_chars: int = MAX_INSTRUCTIONS_CHARS) -> str:
     """Render one iteration's INSTRUCTIONS (the PROMPT side of the seam).
 
-    ``current`` is the result the failure index is built from (full val for hill-climb /
-    SkillOpt, the parent's minibatch for GEPA); ``focus_ids`` narrows it; ``extra`` is the
-    algorithm's own tail block. When ``run_dir`` is given the empty-seed signal is
-    computed from the parent candidate (``parent_id``, default the run's best).
+    ``scored_result`` is the evaluated result the failure index is built FROM (full val
+    for hill-climb / SkillOpt, the parent's minibatch for GEPA). ``focus_ids`` NARROWS
+    that result, so it must name tasks that are IN it — ids from another split are
+    disjoint by construction and would filter the failure index down to nothing.
+    ``harness._focus_instructions`` refuses to filter on zero overlap and says so in the
+    prompt instead of reporting a confident "0 failing of 0 tasks". The parameter is
+    named ``scored_result`` (not ``current``) so that invariant is visible at every call
+    site rather than living in this docstring.
+
+    ``extra`` is the algorithm's own tail block and stays LAST. Blocks that EVERY
+    algorithm should get belong in the shared body instead — it already receives
+    ``run_dir``, so #128's ``INSIGHTS.md`` and #129's ``rejected.jsonl`` need no
+    signature change.
+
+    When ``run_dir`` is given the empty-seed signal is computed from the parent candidate
+    (``parent_id``, default the run's best). The assembled text is capped at ``max_chars``.
     """
     from . import harness
     ctx = ctx or OptimizerContext()
@@ -209,10 +232,18 @@ def render_instructions(current: SplitResult, focus_ids, label: str, *,
             seed_empty = harness._capability_is_empty(ctx.capabilities,
                                                       run_dir.candidate_dir(cid))
     text = harness._focus_instructions(
-        current, focus_ids, label,
+        scored_result, focus_ids, label,
         capabilities=ctx.capabilities, algorithm=algorithm,
         instructions_file=ctx.instructions_file, bench_repo=ctx.bench_repo,
         optimizer_name=ctx.optimizer_name, seed_empty=seed_empty,
         target_reader=ctx.target_reader(),
     )
-    return f"{text}\n{extra}" if extra else text
+    out = f"{text}\n{extra}" if extra else text
+    if max_chars and len(out) > max_chars:
+        # Keep the head (task framing, capability brief, failure index) and the tail
+        # (the algorithm's own block); elide the middle, which is the part that grows.
+        keep = max(max_chars - 200, 200)
+        head, tail = out[: (keep * 7) // 10], out[-(keep * 3) // 10:]
+        out = (f"{head}\n\n... [{len(out) - keep} chars elided to keep this prompt under "
+               f"{max_chars} chars — the full record is in the run dir] ...\n\n{tail}")
+    return out

--- a/core/cap_evolve/optimizer_context.py
+++ b/core/cap_evolve/optimizer_context.py
@@ -50,6 +50,18 @@ INJECTED_DIRS = ("trajectories", "guidance", "prior_iterations",
                  ".claude", ".agents", ".gemini", ".opencode", ".bob", ".cursor")
 INJECTED_NAMES = ("CLAUDE.md", "AGENTS.md", "GEMINI.md")
 
+# Framework-written scratch/handover files in the optimizer's workdir that are NOT
+# capability either. Distinct from INJECTED_* (those are copied in by :func:`inject`;
+# these are written by the algorithm/harness), but every consumer that must ignore one
+# must ignore the other. ``cache._IGNORE_NAMES``, ``gepa._NON_COMPONENT``,
+# ``harness._CAP_DIFF_SKIP`` and ``dashboard._DIFF_SKIP`` each had their OWN copy of this
+# list and they had drifted: only GEPA's knew about ``FOCUS.md``/``REFLECTION.md``, so a
+# capability diff of a GEPA candidate showed its reflective scratch as a real edit. One
+# definition, four consumers.
+SCRATCH_NAMES = ("INSTRUCTIONS.md", "MEMORY.md", "STATE.md", "REJECTED.md",
+                 "FOCUS.md", "REFLECTION.md",
+                 "LEDGER.md", "JOURNAL.md", "PROCESS.md", "RUNMAP.md")
+
 
 def _csv(value) -> list[str]:
     """Accept a list OR a comma-separated string (the shape CLI flags arrive in)."""
@@ -239,11 +251,21 @@ def render_instructions(scored_result: SplitResult, focus_ids, label: str, *,
         target_reader=ctx.target_reader(),
     )
     out = f"{text}\n{extra}" if extra else text
-    if max_chars and len(out) > max_chars:
+    return cap_instructions(out, max_chars)
+
+
+def cap_instructions(text: str, max_chars: int = MAX_INSTRUCTIONS_CHARS) -> str:
+    """Enforce the one-iteration prompt ceiling, keeping the head and tail.
+
+    Also called by ``harness._augment_instructions``, which appends the cross-iteration
+    blocks (LEDGER pointer + #129 rejected-approach constraints) AFTER this module has
+    rendered — so the FINAL assembled prompt, not just the rendered half, is capped.
+    """
+    if max_chars and len(text) > max_chars:
         # Keep the head (task framing, capability brief, failure index) and the tail
         # (the algorithm's own block); elide the middle, which is the part that grows.
         keep = max(max_chars - 200, 200)
-        head, tail = out[: (keep * 7) // 10], out[-(keep * 3) // 10:]
-        out = (f"{head}\n\n... [{len(out) - keep} chars elided to keep this prompt under "
-               f"{max_chars} chars — the full record is in the run dir] ...\n\n{tail}")
-    return out
+        head, tail = text[: (keep * 7) // 10], text[-(keep * 3) // 10:]
+        text = (f"{head}\n\n... [{len(text) - keep} chars elided to keep this prompt under "
+                f"{max_chars} chars — the full record is in the run dir] ...\n\n{tail}")
+    return text

--- a/core/cap_evolve/proposal_quality.py
+++ b/core/cap_evolve/proposal_quality.py
@@ -35,10 +35,14 @@ FIELDS = ("mechanism", "hypothesis", "observable")
 _LABELS = {
     "mechanism": r"mechanism",
     "hypothesis": r"hypothesis",
-    "observable": r"expected\s+observable",
+    # "Expected observable" is what the seed writes, but a bare "Observable:" is the same
+    # field — requiring the adjective records a real declaration as missing.
+    "observable": r"(?:expected\s+)?observable",
 }
-# A value that is still the seed's angle-bracket prompt, or empty, is not a declaration.
-_PLACEHOLDER_RE = re.compile(r"^\s*(<.*>|[-–—.]*|n/?a|tbd|todo)\s*$", re.I)
+# A value that is still the seed's angle-bracket prompt, or empty/dashes, is not a
+# declaration. The empty case is its own alternative rather than a ``*`` quantifier that
+# happens to also match "".
+_PLACEHOLDER_RE = re.compile(r"^\s*$|^\s*(?:<.*>|[-–—.]+|n/?a|tbd|todo)\s*$", re.I)
 MAX_VALUE_CHARS = 400
 
 
@@ -47,15 +51,20 @@ def _field(text: str, label: str) -> str:
 
     Tolerant of the shapes an agent actually writes: an optional leading list marker or
     bold/emphasis markup, then the label, then ``:``, then the value up to end of line.
+
+    **Every** occurrence is scanned and placeholders are skipped — not just the first
+    match. An agent that appends its filled declaration *below* the seed's ``<...>`` block
+    is a very common shape, and a first-match-only read records that as fully undeclared,
+    inverting the exact signal this module exists to observe. (Same first-match-only
+    defect as #189's guard; ``finditer`` is the right default for this file.)
     """
-    m = re.search(rf"^[ \t]*(?:[-*+][ \t]*)?[*_]{{0,2}}{label}[*_]{{0,2}}[ \t]*:[ \t]*(.*)$",
-                  text, re.I | re.M)
-    if not m:
-        return ""
-    value = m.group(1).strip().strip("*_` ")
-    if _PLACEHOLDER_RE.match(value):
-        return ""
-    return value[:MAX_VALUE_CHARS]
+    for m in re.finditer(
+            rf"^[ \t]*(?:[-*+][ \t]*)?[*_]{{0,2}}{label}[*_]{{0,2}}[ \t]*:[ \t]*(.*)$",
+            text, re.I | re.M):
+        value = m.group(1).strip().strip("*_` ")
+        if not _PLACEHOLDER_RE.match(value):
+            return value[:MAX_VALUE_CHARS]
+    return ""
 
 
 def parse(workdir: Path) -> dict:
@@ -117,6 +126,7 @@ PROMPT_BLOCK = (
     "**How this is judged:** the declaration is RECORDED per candidate, not enforced — a "
     "missing or knob-shaped declaration does NOT reject your edit, and a well-declared one "
     "does not get it accepted. The val significance gate remains the only thing that "
-    "accepts or rejects. Declare it anyway: an edit you cannot state a mechanism and an "
-    "observable for is the edit that historically wasted the iteration.\n"
+    "accepts or rejects. Declare it anyway — our working hypothesis (unmeasured so far; "
+    "this record is how we would test it) is that an edit you cannot state a mechanism "
+    "and an observable for is the edit that wastes the iteration.\n"
 )

--- a/core/cap_evolve/proposal_quality.py
+++ b/core/cap_evolve/proposal_quality.py
@@ -1,0 +1,122 @@
+"""The proposal-quality declaration: what the optimizer said it was doing, and why.
+
+Issue #140 asks for a "mechanism, not knob" gate on proposal quality. Two halves,
+with very different epistemic standing — kept separate on purpose:
+
+  * **The judgement** ("is this a real mechanism change or just a config knob?") is not
+    something pure Python can decide. A regex over a diff cannot tell a one-line guard
+    that fixes a whole failure class from a one-line knob tweak, and a false rejection
+    silently discards a real improvement. So that half is ADVISORY: it lives as a bar in
+    the prompt, carried by the ``mechanism-probe`` reasoning skill that
+    ``optimizer_context.inject`` copies into the optimizer's workdir.
+
+  * **The declaration** ("did the optimizer state a mechanism, a hypothesis and an
+    expected observable?") IS precisely checkable — it is presence of three named
+    fields in the ``PROCESS.md`` the optimizer already writes. That is what this module
+    parses, and it is recorded per candidate as a ``proposal_quality`` event.
+
+**Nothing here rejects a candidate.** ``parse``/``record`` are read-only: they log. The
+val significance gate remains the only thing that can reject an edit, exactly as before
+— the same "advisory at the prompt, hard at the val gate" split #129 settled on. A
+missing declaration is a signal that the iteration skipped its reasoning step, not proof
+that the edit is bad; treating it as proof would throw away real gains invisibly.
+
+Pure stdlib, zero model calls (see #205: every auxiliary step in core is pure Python).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+# The three declared fields, in prompt order. The key is the log field; the pattern is
+# the heading the optimizer writes in PROCESS.md (seeded by ``harness._PROCESS_SEED``).
+FIELDS = ("mechanism", "hypothesis", "observable")
+_LABELS = {
+    "mechanism": r"mechanism",
+    "hypothesis": r"hypothesis",
+    "observable": r"expected\s+observable",
+}
+# A value that is still the seed's angle-bracket prompt, or empty, is not a declaration.
+_PLACEHOLDER_RE = re.compile(r"^\s*(<.*>|[-–—.]*|n/?a|tbd|todo)\s*$", re.I)
+MAX_VALUE_CHARS = 400
+
+
+def _field(text: str, label: str) -> str:
+    """The value the optimizer wrote for one declared field, or "".
+
+    Tolerant of the shapes an agent actually writes: an optional leading list marker or
+    bold/emphasis markup, then the label, then ``:``, then the value up to end of line.
+    """
+    m = re.search(rf"^[ \t]*(?:[-*+][ \t]*)?[*_]{{0,2}}{label}[*_]{{0,2}}[ \t]*:[ \t]*(.*)$",
+                  text, re.I | re.M)
+    if not m:
+        return ""
+    value = m.group(1).strip().strip("*_` ")
+    if _PLACEHOLDER_RE.match(value):
+        return ""
+    return value[:MAX_VALUE_CHARS]
+
+
+def parse(workdir: Path) -> dict:
+    """Read the proposal declaration out of ``workdir/PROCESS.md``.
+
+    Returns ``{declared, missing, mechanism, hypothesis, observable}``. ``declared`` is
+    True only when all three fields carry a real (non-placeholder) value. A missing
+    PROCESS.md yields ``declared=False`` with every field missing — never raises, since
+    a proposal step must not be able to crash a run.
+    """
+    proc = Path(workdir) / "PROCESS.md"
+    try:
+        text = proc.read_text(encoding="utf-8") if proc.is_file() else ""
+    except Exception:  # noqa: BLE001
+        text = ""
+    out = {k: _field(text, _LABELS[k]) for k in FIELDS}
+    out["missing"] = [k for k in FIELDS if not out[k]]
+    out["declared"] = not out["missing"]
+    return out
+
+
+def record(run_dir, workdir: Path, cid: str) -> dict:
+    """Parse the declaration and log it as a ``proposal_quality`` event for ``cid``.
+
+    Called right after the optimizer returns, by every algorithm. ADVISORY ONLY — the
+    return value is informational and no caller branches on it to reject; the candidate
+    goes to the val gate either way.
+    """
+    q = parse(workdir)
+    try:
+        run_dir.log_event("proposal_quality", candidate=cid, declared=q["declared"],
+                          missing=q["missing"], mechanism=q["mechanism"],
+                          hypothesis=q["hypothesis"], observable=q["observable"],
+                          enforcement="advisory")
+    except Exception:  # noqa: BLE001 — logging must never break a step
+        pass
+    return q
+
+
+# The prompt-side half: the bar itself. Appended by ``harness._augment_instructions`` so
+# all three deterministic algorithms get it identically, and capped with everything else
+# by ``optimizer_context.cap_instructions``. Kept SHORT (~1.4 KB) on purpose: it lands in
+# the 30%-of-budget tail that survives an overflow, so it must not crowd out #129's
+# dead-end constraints (~7 KB at 200 rejections) that live there too.
+PROMPT_BLOCK = (
+    "## Proposal quality — declare the MECHANISM, not a knob (advisory bar)\n"
+    "Read `./guidance/reasoning/mechanism-probe/SKILL.md` BEFORE you decide what to edit. "
+    "It counters the failure mode this framework keeps paying for: skipping the analysis "
+    "and shipping a plausible one-line tweak.\n"
+    "Fill the **Proposal declaration** block in `./PROCESS.md` — three fields:\n"
+    "- `Mechanism:` what in the system now behaves differently, and WHY that changes the "
+    "outcome. A *knob* restates an existing rule or retunes a value the agent already "
+    "ignores; a *mechanism* changes what is structurally possible (an in-code guard, a "
+    "computation, a new/composite tool, a narrowed decision rule).\n"
+    "- `Hypothesis:` which failure cluster this fixes and why it generalizes beyond the "
+    "exact failing inputs.\n"
+    "- `Expected observable:` the concrete change you expect in the NEXT iteration's "
+    "trajectories if the hypothesis holds — something a reader could check.\n"
+    "**How this is judged:** the declaration is RECORDED per candidate, not enforced — a "
+    "missing or knob-shaped declaration does NOT reject your edit, and a well-declared one "
+    "does not get it accepted. The val significance gate remains the only thing that "
+    "accepts or rejects. Declare it anyway: an edit you cannot state a mechanism and an "
+    "observable for is the edit that historically wasted the iteration.\n"
+)

--- a/core/cap_evolve/rundir.py
+++ b/core/cap_evolve/rundir.py
@@ -4,8 +4,8 @@ Layout under ``.capevolve/run_<ts>/``::
 
     state.json          # best candidate id, budget, spent, test_used
     splits.json         # the frozen train/val/test partition (sealed test)
-    rejected.jsonl      # RejectedMemory
-    history.jsonl       # accepted History
+    rejected.jsonl      # rejected candidates (dashboard Memory panel)
+    history.jsonl       # accepted candidates (dashboard Memory panel)
     candidates/<id>/    # snapshot of each candidate's capability dir
     rollouts/<split>/<task>__<cand>__t<k>.json
     events.jsonl        # append-only audit log

--- a/core/cap_evolve/rundir.py
+++ b/core/cap_evolve/rundir.py
@@ -27,6 +27,21 @@ from pathlib import Path
 from .splits import Splits
 
 
+# Every event kind that records ONE evaluated iteration (a candidate + its gate
+# outcome + its val score). ``harness.run_step`` emits "step"; GEPA bypasses
+# run_step and emits "gepa_val_gate"; SkillOpt additionally emits "skillopt_step".
+# ONE definition, every consumer (dashboard lineage, LEDGER, RUNMAP,
+# prior_iterations/) — filtering on "step" alone makes GEPA's whole
+# cross-iteration history channel silently empty.
+ITERATION_EVENT_KINDS = ("step", "skillopt_step", "gepa_val_gate")
+
+
+def iteration_candidate(ev: dict) -> str | None:
+    """The candidate id on an iteration event (kinds differ on the field name)."""
+    cid = ev.get("candidate") or ev.get("candidate_id")
+    return str(cid) if cid else None
+
+
 def _atomic_write(path: Path, text: str) -> None:
     """Write ``text`` to ``path`` atomically (tmp file + ``os.replace``).
 
@@ -395,3 +410,26 @@ class RunDir:
         rec = {"t": time.time(), "kind": kind, **fields}
         with self.events_path.open("a", encoding="utf-8") as f:
             f.write(json.dumps(rec, default=str) + "\n")
+
+    def iteration_events(self) -> list[dict]:
+        """Every event that represents ONE evaluated iteration, in order.
+
+        See :data:`ITERATION_EVENT_KINDS` — read this instead of filtering
+        ``kind == "step"`` by hand, or the algorithms that emit their own kind
+        (GEPA, SkillOpt) silently disappear from whatever you are building.
+        Best-effort: an unreadable/absent events log yields whatever parsed.
+        """
+        out: list[dict] = []
+        try:
+            if not self.events_path.exists():
+                return out
+            for line in self.events_path.read_text(encoding="utf-8").splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                rec = json.loads(line)
+                if rec.get("kind") in ITERATION_EVENT_KINDS and iteration_candidate(rec):
+                    out.append(rec)
+        except Exception:  # noqa: BLE001
+            return out
+        return out

--- a/core/cap_evolve/rundir.py
+++ b/core/cap_evolve/rundir.py
@@ -26,6 +26,29 @@ from pathlib import Path
 
 from .splits import Splits
 
+# Framework/optimizer SCRATCH files the harness or an algorithm writes into the
+# optimizer's workdir. They are not capability content, so they must be excluded
+# everywhere a candidate is treated as "the capability": the candidate snapshot
+# (``harness._SNAPSHOT_IGNORE``), the eval-cache content hash
+# (``cache._IGNORE_NAMES``), GEPA's editable-component list (``gepa._NON_COMPONENT``)
+# and the edit-size count (``skillopt._changed_files``). This list lives HERE — at the
+# bottom of the import graph — because it had been copy-pasted into four modules and
+# they desynced: FOCUS.md/REFLECTION.md (GEPA's own scratch) were in the cache and
+# component lists but missing from the snapshot list, so GEPA snapshots stayed dirty
+# (#110) even after LEDGER/JOURNAL/RUNMAP were excluded. One definition, four consumers.
+#
+# NOT here: INSTRUCTIONS.md and PROCESS.md. Those are deliberately KEPT in the snapshot
+# (PROCESS.md is the candidate's explainability record) and filtered at DIFF time only —
+# see ``dashboard._DIFF_SKIP`` / ``harness._CAP_DIFF_SKIP``.
+SCRATCH_NAMES = (
+    # cross-iteration state the harness regenerates every iteration
+    "LEDGER.md", "JOURNAL.md", "RUNMAP.md",
+    # per-iteration algorithm scratch (GEPA's reflective dataset + component focus)
+    "FOCUS.md", "REFLECTION.md",
+    # optimizer rejected-edit memory, and the legacy MEMORY/STATE pair it replaced
+    "REJECTED.md", "MEMORY.md", "STATE.md",
+)
+
 
 def _atomic_write(path: Path, text: str) -> None:
     """Write ``text`` to ``path`` atomically (tmp file + ``os.replace``).

--- a/core/cap_evolve/rundir.py
+++ b/core/cap_evolve/rundir.py
@@ -26,28 +26,50 @@ from pathlib import Path
 
 from .splits import Splits
 
-# Framework/optimizer SCRATCH files the harness or an algorithm writes into the
-# optimizer's workdir. They are not capability content, so they must be excluded
-# everywhere a candidate is treated as "the capability": the candidate snapshot
-# (``harness._SNAPSHOT_IGNORE``), the eval-cache content hash
-# (``cache._IGNORE_NAMES``), GEPA's editable-component list (``gepa._NON_COMPONENT``)
-# and the edit-size count (``skillopt._changed_files``). This list lives HERE — at the
-# bottom of the import graph — because it had been copy-pasted into four modules and
-# they desynced: FOCUS.md/REFLECTION.md (GEPA's own scratch) were in the cache and
-# component lists but missing from the snapshot list, so GEPA snapshots stayed dirty
-# (#110) even after LEDGER/JOURNAL/RUNMAP were excluded. One definition, four consumers.
+# Framework/optimizer SCRATCH files that are not capability content. Defined HERE — at
+# the bottom of the import graph — because the list had been copy-pasted into several
+# modules and they desynced: FOCUS.md/REFLECTION.md (GEPA's own scratch) were in the
+# cache and component lists but missing from the snapshot list, so GEPA snapshots stayed
+# dirty (#110) even after LEDGER/JOURNAL/RUNMAP were excluded.
 #
-# NOT here: INSTRUCTIONS.md and PROCESS.md. Those are deliberately KEPT in the snapshot
-# (PROCESS.md is the candidate's explainability record) and filtered at DIFF time only —
-# see ``dashboard._DIFF_SKIP`` / ``harness._CAP_DIFF_SKIP``.
+# TWO tiers, because the consumers do not all perform the same OPERATION:
+#
+#   SCRATCH_NAMES        — names a live code path actually WRITES. These are the only
+#                          ones safe for the single DESTRUCTIVE consumer,
+#                          ``harness._SNAPSHOT_IGNORE``, which reaches
+#                          ``RunDir.snapshot`` → ``shutil.copytree(ignore=...)`` and so
+#                          DROPS the file permanently — and from every descendant
+#                          iteration too, since the next workdir is copied from the
+#                          snapshot.
+#   LEGACY_SCRATCH_NAMES — retired names with NO live writer anywhere in core/ (the old
+#                          MEMORY/STATE handover pair, and REJECTED.md from before
+#                          rejected-edit memory moved to ``rejected.jsonl``). Kept ONLY
+#                          in the non-destructive read-side filters, so run dirs and
+#                          eval caches produced before they were retired still behave.
+#                          They must NEVER reach the snapshot filter: with no live
+#                          writer, the only thing such a name can refer to on disk is a
+#                          CAPABILITY file that happens to share it, and deleting that
+#                          is silent data loss the cache key cannot even see (the same
+#                          name is ignored when hashing, so the mutilated candidate
+#                          keeps its parent's key → stale hit).
+#
+# NON_CAPABILITY_NAMES is the union, for every consumer whose operation is a read-side
+# FILTER (a false positive only costs precision — nothing is lost): the eval-cache
+# content hash (``cache._IGNORE_NAMES``), GEPA's editable-component list
+# (``gepa._NON_COMPONENT``), the edit-size count (``skillopt._changed_components``) and
+# the capability-diff filters (``dashboard._DIFF_SKIP`` / ``harness._CAP_DIFF_SKIP``).
+# INSTRUCTIONS.md and PROCESS.md are in the union but in neither tuple: they are
+# deliberately KEPT in the snapshot (PROCESS.md is the candidate's explainability
+# record) while still not being capability bytes.
 SCRATCH_NAMES = (
     # cross-iteration state the harness regenerates every iteration
     "LEDGER.md", "JOURNAL.md", "RUNMAP.md",
     # per-iteration algorithm scratch (GEPA's reflective dataset + component focus)
     "FOCUS.md", "REFLECTION.md",
-    # optimizer rejected-edit memory, and the legacy MEMORY/STATE pair it replaced
-    "REJECTED.md", "MEMORY.md", "STATE.md",
 )
+LEGACY_SCRATCH_NAMES = ("REJECTED.md", "MEMORY.md", "STATE.md")
+NON_CAPABILITY_NAMES = frozenset(
+    {"INSTRUCTIONS.md", "PROCESS.md"} | set(SCRATCH_NAMES) | set(LEGACY_SCRATCH_NAMES))
 
 
 def _atomic_write(path: Path, text: str) -> None:
@@ -398,15 +420,25 @@ class RunDir:
     def snapshot(self, candidate_id: str, src_dir: Path, ignore=None) -> Path:
         """Persist ``src_dir`` as candidate ``candidate_id``.
 
-        ``ignore`` is an optional iterable of top-level names to exclude (e.g. the
+        ``ignore`` is an optional iterable of TOP-LEVEL names to exclude (e.g. the
         optimizer's injected scratch — ``trajectories/``, ``guidance/`` — and its
         prompt/memory files) so the stored candidate stays capability-only and
         diffs against the parent show only real edits.
+
+        Root-anchored on purpose. ``shutil.ignore_patterns`` matches by BASENAME at
+        every depth, so a nested capability file that merely shares a name with an
+        entry (``src/prompts/STATE.md``) would be silently deleted from the candidate
+        — and from the whole descendant lineage, since the next iteration's workdir is
+        copied from this snapshot. Every entry in the list is a root-level framework
+        injection, so filtering only at ``src_dir`` itself is both strictly more
+        correct and what this docstring always claimed.
         """
         dst = self.candidates / candidate_id
         if dst.exists():
             shutil.rmtree(dst)
-        ig = shutil.ignore_patterns(*ignore) if ignore else None
+        src_dir = Path(src_dir)
+        names = set(ignore or ())
+        ig = (lambda d, cs: names if Path(d) == src_dir else set()) if names else None
         shutil.copytree(src_dir, dst, ignore=ig)
         return dst
 

--- a/core/cap_evolve/rundir.py
+++ b/core/cap_evolve/rundir.py
@@ -26,6 +26,51 @@ from pathlib import Path
 
 from .splits import Splits
 
+# Framework/optimizer SCRATCH files that are not capability content. Defined HERE — at
+# the bottom of the import graph — because the list had been copy-pasted into several
+# modules and they desynced: FOCUS.md/REFLECTION.md (GEPA's own scratch) were in the
+# cache and component lists but missing from the snapshot list, so GEPA snapshots stayed
+# dirty (#110) even after LEDGER/JOURNAL/RUNMAP were excluded.
+#
+# TWO tiers, because the consumers do not all perform the same OPERATION:
+#
+#   SCRATCH_NAMES        — names a live code path actually WRITES. These are the only
+#                          ones safe for the single DESTRUCTIVE consumer,
+#                          ``harness._SNAPSHOT_IGNORE``, which reaches
+#                          ``RunDir.snapshot`` → ``shutil.copytree(ignore=...)`` and so
+#                          DROPS the file permanently — and from every descendant
+#                          iteration too, since the next workdir is copied from the
+#                          snapshot.
+#   LEGACY_SCRATCH_NAMES — retired names with NO live writer anywhere in core/ (the old
+#                          MEMORY/STATE handover pair, and REJECTED.md from before
+#                          rejected-edit memory moved to ``rejected.jsonl``). Kept ONLY
+#                          in the non-destructive read-side filters, so run dirs and
+#                          eval caches produced before they were retired still behave.
+#                          They must NEVER reach the snapshot filter: with no live
+#                          writer, the only thing such a name can refer to on disk is a
+#                          CAPABILITY file that happens to share it, and deleting that
+#                          is silent data loss the cache key cannot even see (the same
+#                          name is ignored when hashing, so the mutilated candidate
+#                          keeps its parent's key → stale hit).
+#
+# NON_CAPABILITY_NAMES is the union, for every consumer whose operation is a read-side
+# FILTER (a false positive only costs precision — nothing is lost): the eval-cache
+# content hash (``cache._IGNORE_NAMES``), GEPA's editable-component list
+# (``gepa._NON_COMPONENT``), the edit-size count (``skillopt._changed_components``) and
+# the capability-diff filters (``dashboard._DIFF_SKIP`` / ``harness._CAP_DIFF_SKIP``).
+# INSTRUCTIONS.md and PROCESS.md are in the union but in neither tuple: they are
+# deliberately KEPT in the snapshot (PROCESS.md is the candidate's explainability
+# record) while still not being capability bytes.
+SCRATCH_NAMES = (
+    # cross-iteration state the harness regenerates every iteration
+    "LEDGER.md", "JOURNAL.md", "RUNMAP.md",
+    # per-iteration algorithm scratch (GEPA's reflective dataset + component focus)
+    "FOCUS.md", "REFLECTION.md",
+)
+LEGACY_SCRATCH_NAMES = ("REJECTED.md", "MEMORY.md", "STATE.md")
+NON_CAPABILITY_NAMES = frozenset(
+    {"INSTRUCTIONS.md", "PROCESS.md"} | set(SCRATCH_NAMES) | set(LEGACY_SCRATCH_NAMES))
+
 
 # Every event kind that records ONE evaluated iteration (a candidate + its gate
 # outcome + its val score). ``harness.run_step`` emits "step"; GEPA bypasses
@@ -390,15 +435,25 @@ class RunDir:
     def snapshot(self, candidate_id: str, src_dir: Path, ignore=None) -> Path:
         """Persist ``src_dir`` as candidate ``candidate_id``.
 
-        ``ignore`` is an optional iterable of top-level names to exclude (e.g. the
+        ``ignore`` is an optional iterable of TOP-LEVEL names to exclude (e.g. the
         optimizer's injected scratch — ``trajectories/``, ``guidance/`` — and its
         prompt/memory files) so the stored candidate stays capability-only and
         diffs against the parent show only real edits.
+
+        Root-anchored on purpose. ``shutil.ignore_patterns`` matches by BASENAME at
+        every depth, so a nested capability file that merely shares a name with an
+        entry (``src/prompts/STATE.md``) would be silently deleted from the candidate
+        — and from the whole descendant lineage, since the next iteration's workdir is
+        copied from this snapshot. Every entry in the list is a root-level framework
+        injection, so filtering only at ``src_dir`` itself is both strictly more
+        correct and what this docstring always claimed.
         """
         dst = self.candidates / candidate_id
         if dst.exists():
             shutil.rmtree(dst)
-        ig = shutil.ignore_patterns(*ignore) if ignore else None
+        src_dir = Path(src_dir)
+        names = set(ignore or ())
+        ig = (lambda d, cs: names if Path(d) == src_dir else set()) if names else None
         shutil.copytree(src_dir, dst, ignore=ig)
         return dst
 

--- a/core/cap_evolve/skillopt.py
+++ b/core/cap_evolve/skillopt.py
@@ -52,8 +52,8 @@ from pathlib import Path
 from . import harness
 from .lr_schedule import build_schedule
 from .loop import SplitResult
-from .optimizer_context import OptimizerContext, render_instructions
-from .rundir import RunDir
+from .optimizer_context import INJECTED_DIRS, INJECTED_NAMES, OptimizerContext, render_instructions
+from .rundir import NON_CAPABILITY_NAMES, RunDir
 
 # Buffer bounds (PITFALL: the rejected-edit buffer must be reset + bounded per
 # epoch so the optimizer prompt does not balloon).
@@ -396,6 +396,17 @@ def skillopt_loop(
     }
 
 
+# Harness-injected scaffolding that must not count as an applied edit. The fifth
+# read-side consumer of the one shared definition (``rundir.NON_CAPABILITY_NAMES``, see
+# the tier note there) — this list used to be its own pre-drift copy, missing
+# FOCUS.md/REFLECTION.md. The INJECTED_* halves are needed because this walk, like the
+# capability diff, compares a SNAPSHOT parent (injected context stripped) against a LIVE
+# workdir (it is not), so without them every injected CLAUDE.md / .claude/skills file
+# counts as an applied edit and the requested-vs-applied budget log is nonsense.
+_SCAFFOLDING = set(NON_CAPABILITY_NAMES) | set(INJECTED_NAMES)
+_SCAFFOLDING_DIRS = {".git"} | set(INJECTED_DIRS)
+
+
 def _changed_components(parent_dir: Path, workdir: Path) -> int:
     """Best-effort count of files whose content differs between parent and the
     optimized workdir — a proxy for *applied* edits to compare against the
@@ -406,22 +417,24 @@ def _changed_components(parent_dir: Path, workdir: Path) -> int:
         changed = 0
         seen = set()
         for f in workdir.rglob("*"):
-            if not f.is_file() or ".git" in f.parts:
+            if not f.is_file():
                 continue
             rel = f.relative_to(workdir)
             # ignore harness-injected scaffolding files
-            if rel.name in ("INSTRUCTIONS.md", "MEMORY.md", "STATE.md",
-                            "LEDGER.md", "JOURNAL.md", "PROCESS.md", "RUNMAP.md"):
+            # ponytail: matches by basename at any depth, unlike cache/snapshot which are
+            # root-anchored. Harmless here (a false positive only costs precision — one
+            # fewer editable component / one uncounted edit, nothing is lost); anchoring it
+            # would change which components GEPA may edit, which is out of scope for #110.
+            if rel.name in _SCAFFOLDING or set(rel.parts[:-1]) & _SCAFFOLDING_DIRS:
                 continue
             seen.add(rel)
             pf = parent_dir / rel
             if not pf.exists() or pf.read_bytes() != f.read_bytes():
                 changed += 1
         for f in parent_dir.rglob("*"):
-            if f.is_file() and ".git" not in f.parts:
+            if f.is_file():
                 rel = f.relative_to(parent_dir)
-                if rel.name in ("INSTRUCTIONS.md", "MEMORY.md", "STATE.md",
-                            "LEDGER.md", "JOURNAL.md", "PROCESS.md", "RUNMAP.md"):
+                if rel.name in _SCAFFOLDING or set(rel.parts[:-1]) & _SCAFFOLDING_DIRS:
                     continue
                 if rel not in seen:
                     changed += 1  # a deletion

--- a/core/cap_evolve/skillopt.py
+++ b/core/cap_evolve/skillopt.py
@@ -34,8 +34,8 @@ adds three things straight out of the deep-learning analogy:
      bypassing the gate to mutate best.
 
 Everything honesty-critical (materialize → optimize → eval-val → gate →
-accept/reject → snapshot/best, the write-only rejected/history audit jsonl, the sealed
-test) is
+accept/reject → snapshot/best, the rejected/history jsonl (audit + the #129 dead-end
+constraint block), the sealed test) is
 delegated to ``harness.run_step`` / ``harness.evaluate_candidate``; this module
 only owns the *schedule*, the *buffer*, and the *slow update*. The result-dict
 shape mirrors ``hill_climb_loop`` (plus per-epoch stats + slow-update records).

--- a/core/cap_evolve/skillopt.py
+++ b/core/cap_evolve/skillopt.py
@@ -34,7 +34,8 @@ adds three things straight out of the deep-learning analogy:
      bypassing the gate to mutate best.
 
 Everything honesty-critical (materialize → optimize → eval-val → gate →
-accept/reject → snapshot/best, RejectedMemory/History, the sealed test) is
+accept/reject → snapshot/best, the write-only rejected/history audit jsonl, the sealed
+test) is
 delegated to ``harness.run_step`` / ``harness.evaluate_candidate``; this module
 only owns the *schedule*, the *buffer*, and the *slow update*. The result-dict
 shape mirrors ``hill_climb_loop`` (plus per-epoch stats + slow-update records).

--- a/core/cap_evolve/skillopt.py
+++ b/core/cap_evolve/skillopt.py
@@ -51,7 +51,7 @@ from pathlib import Path
 from . import harness
 from .lr_schedule import build_schedule
 from .loop import SplitResult
-from .rundir import RunDir
+from .rundir import SCRATCH_NAMES, RunDir
 
 # Buffer bounds (PITFALL: the rejected-edit buffer must be reset + bounded per
 # epoch so the optimizer prompt does not balloon).
@@ -384,6 +384,11 @@ def skillopt_loop(
     }
 
 
+# Harness-injected scaffolding that must not count as an applied edit.
+# ``rundir.SCRATCH_NAMES`` is the shared definition (see the note there).
+_SCAFFOLDING = frozenset({"INSTRUCTIONS.md", "PROCESS.md"} | set(SCRATCH_NAMES))
+
+
 def _changed_components(parent_dir: Path, workdir: Path) -> int:
     """Best-effort count of files whose content differs between parent and the
     optimized workdir — a proxy for *applied* edits to compare against the
@@ -398,8 +403,7 @@ def _changed_components(parent_dir: Path, workdir: Path) -> int:
                 continue
             rel = f.relative_to(workdir)
             # ignore harness-injected scaffolding files
-            if rel.name in ("INSTRUCTIONS.md", "MEMORY.md", "STATE.md",
-                            "LEDGER.md", "JOURNAL.md", "PROCESS.md", "RUNMAP.md"):
+            if rel.name in _SCAFFOLDING:
                 continue
             seen.add(rel)
             pf = parent_dir / rel
@@ -408,8 +412,7 @@ def _changed_components(parent_dir: Path, workdir: Path) -> int:
         for f in parent_dir.rglob("*"):
             if f.is_file() and ".git" not in f.parts:
                 rel = f.relative_to(parent_dir)
-                if rel.name in ("INSTRUCTIONS.md", "MEMORY.md", "STATE.md",
-                            "LEDGER.md", "JOURNAL.md", "PROCESS.md", "RUNMAP.md"):
+                if rel.name in _SCAFFOLDING:
                     continue
                 if rel not in seen:
                     changed += 1  # a deletion

--- a/core/cap_evolve/skillopt.py
+++ b/core/cap_evolve/skillopt.py
@@ -51,7 +51,7 @@ from pathlib import Path
 from . import harness
 from .lr_schedule import build_schedule
 from .loop import SplitResult
-from .rundir import SCRATCH_NAMES, RunDir
+from .rundir import NON_CAPABILITY_NAMES, RunDir
 
 # Buffer bounds (PITFALL: the rejected-edit buffer must be reset + bounded per
 # epoch so the optimizer prompt does not balloon).
@@ -385,8 +385,8 @@ def skillopt_loop(
 
 
 # Harness-injected scaffolding that must not count as an applied edit.
-# ``rundir.SCRATCH_NAMES`` is the shared definition (see the note there).
-_SCAFFOLDING = frozenset({"INSTRUCTIONS.md", "PROCESS.md"} | set(SCRATCH_NAMES))
+# ``rundir.NON_CAPABILITY_NAMES`` is the shared definition (see the note there).
+_SCAFFOLDING = NON_CAPABILITY_NAMES
 
 
 def _changed_components(parent_dir: Path, workdir: Path) -> int:
@@ -403,6 +403,10 @@ def _changed_components(parent_dir: Path, workdir: Path) -> int:
                 continue
             rel = f.relative_to(workdir)
             # ignore harness-injected scaffolding files
+            # ponytail: matches by basename at any depth, unlike cache/snapshot which are
+            # root-anchored. Harmless here (a false positive only costs precision — one
+            # fewer editable component / one uncounted edit, nothing is lost); anchoring it
+            # would change which components GEPA may edit, which is out of scope for #110.
             if rel.name in _SCAFFOLDING:
                 continue
             seen.add(rel)

--- a/core/cap_evolve/skillopt.py
+++ b/core/cap_evolve/skillopt.py
@@ -52,8 +52,8 @@ from pathlib import Path
 from . import harness
 from .lr_schedule import build_schedule
 from .loop import SplitResult
-from .optimizer_context import OptimizerContext, render_instructions
-from .rundir import RunDir
+from .optimizer_context import INJECTED_DIRS, INJECTED_NAMES, OptimizerContext, render_instructions
+from .rundir import NON_CAPABILITY_NAMES, RunDir
 
 # Buffer bounds (PITFALL: the rejected-edit buffer must be reset + bounded per
 # epoch so the optimizer prompt does not balloon).
@@ -396,6 +396,11 @@ def skillopt_loop(
     }
 
 
+# Harness-injected scaffolding that must not count as an applied edit.
+# ``rundir.NON_CAPABILITY_NAMES`` is the shared definition (see the note there).
+_SCAFFOLDING = NON_CAPABILITY_NAMES
+
+
 def _changed_components(parent_dir: Path, workdir: Path) -> int:
     """Best-effort count of files whose content differs between parent and the
     optimized workdir — a proxy for *applied* edits to compare against the
@@ -410,8 +415,11 @@ def _changed_components(parent_dir: Path, workdir: Path) -> int:
                 continue
             rel = f.relative_to(workdir)
             # ignore harness-injected scaffolding files
-            if rel.name in ("INSTRUCTIONS.md", "MEMORY.md", "STATE.md",
-                            "LEDGER.md", "JOURNAL.md", "PROCESS.md", "RUNMAP.md"):
+            # ponytail: matches by basename at any depth, unlike cache/snapshot which are
+            # root-anchored. Harmless here (a false positive only costs precision — one
+            # fewer editable component / one uncounted edit, nothing is lost); anchoring it
+            # would change which components GEPA may edit, which is out of scope for #110.
+            if rel.name in _SCAFFOLDING:
                 continue
             seen.add(rel)
             pf = parent_dir / rel
@@ -420,8 +428,7 @@ def _changed_components(parent_dir: Path, workdir: Path) -> int:
         for f in parent_dir.rglob("*"):
             if f.is_file() and ".git" not in f.parts:
                 rel = f.relative_to(parent_dir)
-                if rel.name in ("INSTRUCTIONS.md", "MEMORY.md", "STATE.md",
-                            "LEDGER.md", "JOURNAL.md", "PROCESS.md", "RUNMAP.md"):
+                if rel.name in _SCAFFOLDING:
                     continue
                 if rel not in seen:
                     changed += 1  # a deletion

--- a/core/cap_evolve/skillopt.py
+++ b/core/cap_evolve/skillopt.py
@@ -51,6 +51,7 @@ from pathlib import Path
 from . import harness
 from .lr_schedule import build_schedule
 from .loop import SplitResult
+from .optimizer_context import OptimizerContext, render_instructions
 from .rundir import RunDir
 
 # Buffer bounds (PITFALL: the rejected-edit buffer must be reset + bounded per
@@ -213,6 +214,7 @@ def skillopt_loop(
     slow_update_sample: int = 20,
     algorithm: str = "skillopt",
     store=None,
+    ctx=None,
 ) -> dict:
     """Run the SkillOpt epochs × mini-batches climb.
 
@@ -220,11 +222,17 @@ def skillopt_loop(
     ``harness.hill_climb_loop`` (single lineage, parent = current best) and reuses
     ``harness.run_step`` for the honesty-critical materialize→gate→accept cycle.
 
+    ``ctx`` is an ``optimizer_context.OptimizerContext`` — what the optimizer is GIVEN
+    (capability guidance + brief, trajectories, the benchmark-authored instructions
+    template, bench repo, its own features reference, the consuming-LLM profile). The
+    same bundle hill-climb and GEPA use, so all three prompt identically.
+
     Returns a result dict shaped like ``hill_climb_loop``'s, plus ``epochs`` /
     ``edit_budget_schedule`` / ``slow_updates`` / per-epoch ``epoch_stats``.
     """
     gate_kwargs = dict(gate_kwargs or {})
     rejected, history, store = harness._init_memory_store(run_dir, store)
+    ctx = ctx or OptimizerContext()
 
     train_ids = list(run_dir.read_splits().train)
     n_train = len(train_ids)
@@ -287,8 +295,10 @@ def skillopt_loop(
 
             label = f"epoch {epoch}/{epochs} step {s + 1}/{steps_per_epoch} "
             label += f"(mini-batch of {len(minibatch_ids)} train tasks, L={L})"
-            instructions = harness._focus_instructions(current_val, minibatch_ids, label)
-            instructions += "\n" + _buffer_block(L, step_buffer, rejected_this_epoch)
+            instructions = render_instructions(
+                current_val, minibatch_ids, label, ctx=ctx, algorithm=algorithm,
+                run_dir=run_dir,
+                extra=_buffer_block(L, step_buffer, rejected_this_epoch))
 
             cid = f"so_e{epoch:02d}s{s + 1:02d}"
             parent_dir = run_dir.candidate_dir(run_dir.best_id)  # single lineage: always best
@@ -297,6 +307,7 @@ def skillopt_loop(
                 optimizer=optimizer, instructions=instructions, current_val=current_val,
                 n_trials=n_trials, gate_kwargs=gate_kwargs, candidate_id=cid,
                 no_regression=no_regression, rejected=rejected, history=history, store=store,
+                ctx=ctx,
             )
             cand_val = SplitResult.from_dict(step["candidate_val"])
             accepted = bool(step["accepted"])
@@ -348,7 +359,7 @@ def skillopt_loop(
                 prev_epoch_skill=prev_epoch_skill, prev_epoch_best_id=prev_epoch_best_id,
                 epoch=epoch, sample=slow_update_sample, edit_budget=schedule[-1] if schedule else edit_budget,
                 n_trials=n_trials, gate_kwargs=gate_kwargs, no_regression=no_regression,
-                rejected=rejected, history=history, store=store,
+                rejected=rejected, history=history, store=store, ctx=ctx,
             )
             if slow_rec is not None:
                 slow_updates.append(slow_rec)
@@ -422,7 +433,7 @@ def _run_slow_update(
     adapter, *, run_dir: RunDir, optimizer, current_val: SplitResult,
     prev_epoch_skill: SplitResult, prev_epoch_best_id, epoch: int, sample: int,
     edit_budget: int, n_trials: int, gate_kwargs: dict, no_regression: bool,
-    rejected, history, store,
+    rejected, history, store, ctx=None,
 ) -> dict | None:
     """Re-evaluate the epoch-start skill vs current best on a small TRAIN subset,
     categorize, and run ONE extra gated step. Counted in budget; sample is small
@@ -461,8 +472,15 @@ def _run_slow_update(
                       stable_success=len(categories["stable_success"]),
                       improved=len(categories["improved"]))
 
-    instructions = _slow_update_instructions(epoch, categories)
-    instructions += "\n" + _buffer_block(edit_budget, [], [])  # carry the consolidating L budget
+    # The longitudinal block is this step's own framing; the shared seam still supplies
+    # the capability brief / edit space / bench repo / reader block around it, so the slow
+    # update is not prompt-poorer than a normal step.
+    extra = (_slow_update_instructions(epoch, categories) + "\n"
+             + _buffer_block(edit_budget, [], []))  # carry the consolidating L budget
+    instructions = render_instructions(
+        current_val, sample_ids, f"epoch {epoch} slow/meta update "
+        f"({len(sample_ids)} sampled train tasks)", ctx=ctx, algorithm="skillopt",
+        run_dir=run_dir, extra=extra)
 
     cid = f"so_e{epoch:02d}_slow"
     step = harness.run_step(
@@ -470,6 +488,7 @@ def _run_slow_update(
         optimizer=optimizer, instructions=instructions, current_val=current_val,
         n_trials=n_trials, gate_kwargs=gate_kwargs, candidate_id=cid,
         no_regression=no_regression, rejected=rejected, history=history, store=store,
+        ctx=ctx,
     )
     step["epoch"] = epoch
     step["step_in_epoch"] = "slow"

--- a/core/tests/test_core.py
+++ b/core/tests/test_core.py
@@ -1,7 +1,7 @@
 """Tests for the honest-evaluation substrate.
 
 These encode the non-negotiable guarantees: deterministic splits, a sealed test
-set, the significance gate, pass^k math, and rejected-memory rendering.
+set, the significance gate, pass^k math, and the memory jsonl record shape.
 """
 
 import math
@@ -122,16 +122,29 @@ def test_combined_stderr_zero_for_single_certain_task():
     assert stats.combined_stderr([1.0], [0.0]) == 0.0
 
 
-# ---- rejected memory ------------------------------------------------------
+# ---- memory jsonl records (the dashboard's Memory panel contract) ----------
 
-def test_rejected_memory_roundtrip_and_render(tmp_path):
-    rm = RejectedMemory(tmp_path / "rejected.jsonl")
+def test_memory_jsonl_record_shape_matches_dashboard_contract(tmp_path):
+    """The jsonl records are consumed by the dashboard's ``/api/runs/{id}/memory``
+    (Memory panel + Insights dead-ends), which reads exactly these keys. Writing an
+    extra/renamed key silently breaks that UI, so pin the shape."""
+    import json
+
+    from cap_evolve import History
+
+    rp = tmp_path / "rejected.jsonl"
+    rm = RejectedMemory(rp)
     rm.add("c1", "added verbose preamble", "Δ<=0 on val", val=0.41)
     rm.add("c2", "removed the schema hint", "regressed val", val=0.30)
-    assert len(rm.entries()) == 2
-    rendered = rm.render()
-    assert "added verbose preamble" in rendered
-    # The block is reframed as STEERING (regressed-as-implemented), not a hard ban:
-    # it must still steer the optimizer away from re-submitting the rejected edit.
-    low = rendered.lower()
-    assert "regressed" in low and "re-submit" in low
+    recs = [json.loads(l) for l in rp.read_text().splitlines() if l.strip()]
+    assert len(recs) == 2
+    assert set(recs[0]) == {"candidate_id", "summary", "reason", "val"}
+    assert recs[0] == {"candidate_id": "c1", "summary": "added verbose preamble",
+                       "reason": "Δ<=0 on val", "val": 0.41}
+
+    hp = tmp_path / "history.jsonl"
+    History(hp).add("c3", "tightened the output contract", 0.62)
+    hrec = json.loads(hp.read_text().strip())
+    assert set(hrec) == {"candidate_id", "summary", "val"}
+    assert hrec == {"candidate_id": "c3", "summary": "tightened the output contract",
+                    "val": 0.62}

--- a/core/tests/test_core.py
+++ b/core/tests/test_core.py
@@ -127,20 +127,27 @@ def test_combined_stderr_zero_for_single_certain_task():
 def test_memory_jsonl_record_shape_matches_dashboard_contract(tmp_path):
     """The jsonl records are consumed by the dashboard's ``/api/runs/{id}/memory``
     (Memory panel + Insights dead-ends), which reads exactly these keys. Writing an
-    extra/renamed key silently breaks that UI, so pin the shape."""
+    extra/renamed key silently breaks that UI, so pin the shape.
+
+    ``approach`` (#129) is part of the contract: the optimizer's dead-end constraint block
+    is built from it, and the dashboard's dead-ends panel now shows it. It defaults to ""
+    so a caller that omits it (and every pre-#129 record) stays valid."""
     import json
 
     from cap_evolve import History
 
     rp = tmp_path / "rejected.jsonl"
     rm = RejectedMemory(rp)
-    rm.add("c1", "added verbose preamble", "Δ<=0 on val", val=0.41)
+    rm.add("c1", "added verbose preamble", "Δ<=0 on val", val=0.41,
+           approach="prompt.txt: +Think step by step before answering.")
     rm.add("c2", "removed the schema hint", "regressed val", val=0.30)
     recs = [json.loads(l) for l in rp.read_text().splitlines() if l.strip()]
     assert len(recs) == 2
-    assert set(recs[0]) == {"candidate_id", "summary", "reason", "val"}
+    assert set(recs[0]) == {"candidate_id", "summary", "reason", "val", "approach"}
     assert recs[0] == {"candidate_id": "c1", "summary": "added verbose preamble",
-                       "reason": "Δ<=0 on val", "val": 0.41}
+                       "reason": "Δ<=0 on val", "val": 0.41,
+                       "approach": "prompt.txt: +Think step by step before answering."}
+    assert recs[1]["approach"] == "", "approach must default to empty, not be absent"
 
     hp = tmp_path / "history.jsonl"
     History(hp).add("c3", "tightened the output contract", 0.62)

--- a/core/tests/test_failure_memory.py
+++ b/core/tests/test_failure_memory.py
@@ -197,6 +197,70 @@ def test_constraints_bounded_on_a_long_run(tmp_path):
     assert len(block) < MAX_INSTRUCTIONS_CHARS
 
 
+def test_a_re_proposed_dead_end_is_never_the_one_evicted(tmp_path):
+    """Recency is LAST-seen, not first-seen.
+
+    With more distinct dead ends than the cap, the row the optimizer JUST re-proposed is
+    the single most predictive one — evicting it in favour of a newer one-off drops exactly
+    the constraint that was about to be violated again, and falsifies the block's own
+    "12 most recent" wording. A 50-distinct-approach bound test cannot catch this because
+    it contains no repeat."""
+    from cap_evolve import Budget, RunDir
+    from cap_evolve.harness import _MAX_DEAD_ENDS, dead_end_constraints
+    from cap_evolve.memory import RejectedMemory
+    run_dir = RunDir.create(tmp_path / ".capevolve", ts="evict", budget=Budget())
+    mem = RejectedMemory(run_dir.rejected_path)
+    old = "prompt.txt: +THE OLD IDEA"
+    mem.add("c000", "first", "gate said no", 0.1, approach=old)
+    for i in range(1, _MAX_DEAD_ENDS + 3):          # push the old row well past the cap
+        mem.add(f"c{i:03d}", "x", "gate said no", 0.1, approach=f"prompt.txt: +IDEA {i}")
+    mem.add("c099", "repeat", "gate said no", 0.1, approach=old)   # re-proposed NOW
+
+    block = dead_end_constraints(run_dir)
+    assert "THE OLD IDEA" in block, "the just-re-proposed dead end was evicted"
+    assert "re-proposed 2x" in block, "the repeat was not counted"
+    assert "(latest c099)" in block, "the repeat's latest candidate id is not shown"
+    assert block.count("- **c") == _MAX_DEAD_ENDS
+    assert "IDEA 1`" not in block, "displaced a newer one-off instead of the oldest"
+
+
+def test_signature_is_distinct_for_edits_sharing_a_long_prefix(tmp_path):
+    """The dedupe key must be a function of the WHOLE edit.
+
+    A plain head truncation makes two genuinely different edits that share a long prefix
+    (any realistic SKILL.md or system prompt) produce ONE signature — the block would then
+    tell the optimizer "re-proposed 2x" about an approach it never proposed, which is
+    strictly worse than injecting no constraint at all."""
+    from cap_evolve.harness import _MAX_APPROACH_CHARS, approach_signature
+    shared = "\n".join(f"RULE {i}: a fairly long boilerplate rule line here" for i in range(20))
+    parent = tmp_path / "p"
+    parent.mkdir()
+    (parent / "prompt.txt").write_text("seed\n")
+    sigs = []
+    for tag in ("ALPHA", "OMEGA"):
+        child = tmp_path / f"c_{tag}"
+        child.mkdir()
+        (child / "prompt.txt").write_text(f"seed\n{shared}\nFINAL: {tag}\n")
+        sigs.append(approach_signature(parent, child))
+    assert len(sigs[0]) == _MAX_APPROACH_CHARS, "prefix too short to exercise the overflow"
+    assert sigs[0] != sigs[1], f"different edits collapsed to one signature: {sigs[0]!r}"
+
+
+def test_signature_strips_control_and_bidi_characters(tmp_path):
+    """``approach`` is quoted into a markdown prompt and (once #191/#220 land) into a
+    terminal writer. Strip the ANSI/C0 half AND the bidi-override half once here rather
+    than in every future consumer. Legitimate content (emoji, non-latin text) survives."""
+    from cap_evolve.harness import approach_signature
+    parent, child = tmp_path / "p", tmp_path / "c"
+    parent.mkdir(), child.mkdir()
+    (parent / "prompt.txt").write_text("seed\n")
+    (child / "prompt.txt").write_text("seed\n\x1b[31mRED\x07 ‮RTL ⁦iso⁩ 😀 עברית\n")
+    sig = approach_signature(parent, child)
+    assert "RED" in sig and "😀" in sig and "עברית" in sig, repr(sig)
+    banned = set(range(32)) | {127} | set(range(0x202A, 0x202F)) | set(range(0x2066, 0x206A))
+    assert not any(ord(ch) in banned for ch in sig), repr(sig)
+
+
 # ---- reaches the prompt, for all three algorithms -------------------------
 
 def _seed_rejection(run_dir, approach="prompt.txt: +DEAD END APPROACH"):
@@ -275,6 +339,41 @@ def test_a_real_rejection_records_its_approach_signature(tmp_path):
     assert "[CALC]" in approach, f"signature does not carry the mock's edit: {approach}"
     # and it is immediately usable as a constraint
     assert "[CALC]" in harness.dead_end_constraints(run_dir)
+
+
+def test_signature_names_the_real_edit_under_a_native_skills_optimizer(tmp_path):
+    """The regression the ``mock`` optimizer structurally cannot show.
+
+    ``mock`` has no ``skills_dir``/``instructions_file`` registry row, so nothing is
+    injected and any skip-list gap stays invisible. Every REAL agent optimizer
+    (claude-code, codex, gemini-cli, opencode, ibm-bob, cursor) gets ``CLAUDE.md`` +
+    ``.claude/skills/<cap>/SKILL.md`` written into its workdir — and because the PARENT
+    side of the capability diff is a snapshot (already stripped by ``_SNAPSHOT_IGNORE``)
+    while the CHILD side is the live workdir, each of those files used to read as a
+    capability addition, sort ahead of the real edit, and truncate it away entirely."""
+    import json
+
+    from cap_evolve import harness
+    adapter, run_dir, base = _setup(tmp_path, "native", max_iterations=1, stall=3)
+    harness.hill_climb_loop(
+        adapter, run_dir=run_dir, optimizer=_optimizer(), current_val=base,
+        focus="all", max_iterations=1, capabilities=["system-prompt"],
+        optimizer_name="claude-code",          # <- the only difference from the mock case
+        gate_kwargs={"mode": "threshold", "threshold": 1e9}, algorithm="hill-climb")
+
+    workdir = next((run_dir.root / "work").iterdir())
+    injected = sorted(p.name for p in workdir.iterdir())
+    assert ".claude" in injected or "CLAUDE.md" in injected, \
+        f"native injection did not happen, so this test proves nothing: {injected}"
+
+    recs = [json.loads(ln) for ln in
+            run_dir.rejected_path.read_text(encoding="utf-8").splitlines() if ln.strip()]
+    assert recs, "no rejection recorded"
+    approach = recs[-1]["approach"]
+    assert "prompt.txt" in approach and "[CALC]" in approach, \
+        f"signature does not carry the real edit: {approach}"
+    for leak in (".claude", "CLAUDE.md", "SKILL.md", "AGENTS.md"):
+        assert leak not in approach, f"injected read-context {leak} leaked in: {approach}"
 
 
 def test_no_val_or_test_ground_truth_in_the_constraint_block(tmp_path):

--- a/core/tests/test_failure_memory.py
+++ b/core/tests/test_failure_memory.py
@@ -1,0 +1,293 @@
+"""Issue #129 — rejected approaches become a CONSTRAINT in the optimizer prompt.
+
+Before this change ``rejected.jsonl`` was audit/UI-only (see #114): the optimizer never
+saw what the gate had already killed, so it could re-propose a dead end and burn another
+full-val eval on it. RUN.md nonetheless claimed "rejected approaches are remembered and
+never re-proposed" — false on both halves (nothing re-injected them; nothing could stop a
+re-proposal). These tests pin the real behavior:
+
+  * ``approach_signature`` normalizes WHAT an edit changed (capability diff only, never
+    the injected read-context), so cosmetic re-proposals collapse to one signature;
+  * ``dead_end_constraints`` renders the deduped block, bounded on a long run;
+  * ``_augment_instructions`` — the one path all three algorithms share (#114) — carries
+    it into the prompt for hill-climb, GEPA and SkillOpt alike;
+  * the constraint text is ADVISORY: it names the failed edit and demands justification.
+    The hard half is the gate, which still rejects a repeat and counts it.
+"""
+
+import os
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+CORE = REPO / "core"
+EXAMPLE = REPO / "examples" / "toy_calc"
+MOCK_RUN = REPO / "skills" / "optimizers" / "run-optimizer" / "scripts" / "run.py"
+
+sys.path.insert(0, str(CORE))
+
+
+@pytest.fixture(autouse=True)
+def _env():
+    old = dict(os.environ)
+    os.environ["CAPEVOLVE_CORE"] = str(CORE)
+    os.environ["CAPEVOLVE_TOY_DATA"] = str(EXAMPLE)
+    os.environ["CAPEVOLVE_MOCK_SCRIPT"] = str(EXAMPLE / "mock_script.json")
+    yield
+    os.environ.clear()
+    os.environ.update(old)
+
+
+def _toy_adapter():
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("toy_fail_mem", EXAMPLE / "adapter.py")
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m.Adapter()
+
+
+def _setup(tmp_path, ts, **budget):
+    from cap_evolve import Budget, RunDir, harness
+    adapter = _toy_adapter()
+    seed = tmp_path / f"seed_{ts}"
+    shutil.copytree(EXAMPLE / "capability", seed)
+    run_dir = RunDir.create(tmp_path / ".capevolve", ts=ts, budget=Budget(**budget))
+    harness.ensure_splits(adapter, run_dir, seed=0)
+    base = harness.baseline(adapter, seed, run_dir=run_dir)
+    return adapter, run_dir, base
+
+
+def _optimizer():
+    from cap_evolve import harness
+    return harness.optimizer_from_command(
+        ["python3", str(MOCK_RUN), "--name", "mock", "--workdir", "{workdir}",
+         "--prompt", "{prompt}"])
+
+
+# ---- approach_signature ---------------------------------------------------
+
+def test_signature_captures_the_edit_and_ignores_injected_context(tmp_path):
+    """The signature is built from the CAPABILITY diff only.
+
+    Injected read-context (trajectories/, guidance/, LEDGER.md, …) must not appear —
+    otherwise every candidate would get a unique signature and dedupe would never fire.
+    """
+    from cap_evolve.harness import approach_signature
+    parent, child = tmp_path / "p", tmp_path / "c"
+    parent.mkdir(), child.mkdir()
+    (parent / "prompt.txt").write_text("base\n", encoding="utf-8")
+    (child / "prompt.txt").write_text("base\nBE TERSE\n", encoding="utf-8")
+    # injected read-context that must be invisible to the signature
+    (child / "LEDGER.md").write_text("| iter | candidate |\n", encoding="utf-8")
+    (child / "trajectories").mkdir()
+    (child / "trajectories" / "t.json").write_text('{"secret": 1}', encoding="utf-8")
+
+    sig = approach_signature(parent, child)
+    assert "prompt.txt: +BE TERSE" in sig, sig
+    assert "LEDGER" not in sig and "secret" not in sig, f"read-context leaked: {sig}"
+
+
+def test_signature_is_stable_across_cosmetic_variation(tmp_path):
+    """Whitespace/indent-only differences collapse to ONE signature — that is what makes
+    "a cosmetic variation of an already-failed approach" dedupe instead of piling up."""
+    from cap_evolve.harness import approach_signature
+    parent = tmp_path / "p"
+    parent.mkdir()
+    (parent / "prompt.txt").write_text("base\n", encoding="utf-8")
+    sigs = set()
+    for i, text in enumerate(("base\nBE TERSE\n", "base\n   BE    TERSE   \n")):
+        c = tmp_path / f"c{i}"
+        c.mkdir()
+        (c / "prompt.txt").write_text(text, encoding="utf-8")
+        sigs.add(approach_signature(parent, c))
+    assert len(sigs) == 1, f"cosmetic variants produced distinct signatures: {sigs}"
+
+
+def test_signature_empty_for_a_noop_edit(tmp_path):
+    """An optimizer that errored leaves the workdir a verbatim parent copy. A no-op is
+    not an approach, so it must not be injected as a constraint."""
+    from cap_evolve.harness import approach_signature
+    parent, child = tmp_path / "p", tmp_path / "c"
+    parent.mkdir(), child.mkdir()
+    for d in (parent, child):
+        (d / "prompt.txt").write_text("same\n", encoding="utf-8")
+    assert approach_signature(parent, child) == ""
+
+
+# ---- dead_end_constraints ------------------------------------------------
+
+def test_constraints_block_names_the_edit_and_the_reason(tmp_path):
+    """FAILS BEFORE THE FIX (no dead_end_constraints, nothing read rejected.jsonl)."""
+    from cap_evolve import Budget, RunDir
+    from cap_evolve.harness import dead_end_constraints
+    from cap_evolve.memory import RejectedMemory
+    run_dir = RunDir.create(tmp_path / ".capevolve", ts="de", budget=Budget())
+    RejectedMemory(run_dir.rejected_path).add(
+        "cand_0001", "candidate cand_0001 (val 0.400, Δ -0.200)",
+        "not significant: Δ -0.200 <= 1.0*SE 0.050", 0.4,
+        approach="prompt.txt: +ALWAYS answer in one word")
+
+    block = dead_end_constraints(run_dir)
+    assert "ALREADY TRIED & REJECTED" in block
+    assert "prompt.txt: +ALWAYS answer in one word" in block, "edit signature missing"
+    assert "not significant" in block, "rejection reason missing"
+    assert "cand_0001" in block
+    # the actual constraint instruction, not just a log line
+    assert "do NOT propose any of the above again" in block
+    assert "materially different" in block
+
+
+def test_constraints_empty_without_rejections(tmp_path):
+    from cap_evolve import Budget, RunDir
+    from cap_evolve.harness import dead_end_constraints
+    run_dir = RunDir.create(tmp_path / ".capevolve", ts="e0", budget=Budget())
+    assert dead_end_constraints(run_dir) == ""
+
+
+def test_constraints_dedupe_and_count_repeats(tmp_path):
+    """A re-proposed approach is ONE row with a repeat count, not N rows."""
+    from cap_evolve import Budget, RunDir
+    from cap_evolve.harness import dead_end_constraints
+    from cap_evolve.memory import RejectedMemory
+    run_dir = RunDir.create(tmp_path / ".capevolve", ts="dd", budget=Budget())
+    mem = RejectedMemory(run_dir.rejected_path)
+    for cid in ("c1", "c2", "c3"):
+        mem.add(cid, f"candidate {cid}", "val gate", 0.4,
+                approach="prompt.txt: +SAME IDEA")
+    block = dead_end_constraints(run_dir)
+    assert block.count("prompt.txt: +SAME IDEA") == 1, "not deduped"
+    assert "re-proposed 3x" in block, block
+    assert "rejected 1 distinct approach(es)" in block
+
+
+def test_pre_129_records_without_approach_are_skipped(tmp_path):
+    """Runs recorded before this change have no ``approach`` field — degrade quietly."""
+    from cap_evolve import Budget, RunDir
+    from cap_evolve.harness import dead_end_constraints
+    run_dir = RunDir.create(tmp_path / ".capevolve", ts="old", budget=Budget())
+    run_dir.rejected_path.write_text(
+        '{"candidate_id": "c1", "summary": "s", "reason": "val gate", "val": 0.1}\n'
+        "not json at all\n",
+        encoding="utf-8")
+    assert dead_end_constraints(run_dir) == ""
+
+
+def test_constraints_bounded_on_a_long_run(tmp_path):
+    """50 distinct rejections must NOT produce 50 verbatim constraints, and the assembled
+    prompt must stay under #199's MAX_INSTRUCTIONS_CHARS."""
+    from cap_evolve import Budget, RunDir
+    from cap_evolve.harness import _MAX_DEAD_ENDS, dead_end_constraints
+    from cap_evolve.memory import RejectedMemory
+    from cap_evolve.optimizer_context import MAX_INSTRUCTIONS_CHARS
+    run_dir = RunDir.create(tmp_path / ".capevolve", ts="big", budget=Budget())
+    mem = RejectedMemory(run_dir.rejected_path)
+    for i in range(50):
+        mem.add(f"c{i:03d}", f"candidate c{i:03d}", "x" * 5000 + f" reason {i}", 0.1,
+                approach=f"prompt.txt: +approach number {i} " + "y" * 5000)
+
+    block = dead_end_constraints(run_dir)
+    assert block.count("- **c") == _MAX_DEAD_ENDS, "injection not bounded to the cap"
+    assert "showing the 12 most recent" in block
+    assert "c049" in block and "c000" not in block, "kept the OLDEST, not the newest"
+    # per-row budgets hold: signature <= 300, reason <= 200 → block stays small
+    assert len(block) < 8_000, f"block ballooned to {len(block)} chars"
+    assert len(block) < MAX_INSTRUCTIONS_CHARS
+
+
+# ---- reaches the prompt, for all three algorithms -------------------------
+
+def _seed_rejection(run_dir, approach="prompt.txt: +DEAD END APPROACH"):
+    from cap_evolve.memory import RejectedMemory
+    RejectedMemory(run_dir.rejected_path).add(
+        "prior_0001", "candidate prior_0001 (val 0.100, Δ -0.300)",
+        "not significant: Δ -0.300", 0.1, approach=approach)
+
+
+def _assert_constraint_in_prompt(workdir: Path):
+    instr = (workdir / "INSTRUCTIONS.md").read_text(encoding="utf-8")
+    assert "ALREADY TRIED & REJECTED" in instr, "constraint block never reached the prompt"
+    assert "DEAD END APPROACH" in instr, "the rejected edit is not named in the prompt"
+    return instr
+
+
+def test_hill_climb_prompt_carries_the_constraints(tmp_path):
+    """FAILS BEFORE THE FIX: nothing injected rejected.jsonl into the prompt."""
+    from cap_evolve import harness
+    adapter, run_dir, base = _setup(tmp_path, "hc", max_iterations=1, stall=3)
+    _seed_rejection(run_dir)
+    harness.hill_climb_loop(
+        adapter, run_dir=run_dir, optimizer=_optimizer(), current_val=base,
+        focus="all", max_iterations=1, gate_kwargs={"mode": "significant", "k_se": 1.0},
+        algorithm="hill-climb")
+    _assert_constraint_in_prompt(run_dir.root / "work" / "cand_0001")
+
+
+def test_gepa_prompt_carries_the_constraints(tmp_path):
+    """GEPA specifically — the algorithm whose cross-iteration channel was silently
+    empty before #199 (it emits ``gepa_val_gate``, not ``step``)."""
+    from cap_evolve import gepa
+    adapter, run_dir, base = _setup(tmp_path, "gp", max_iterations=1, stall=5)
+    _seed_rejection(run_dir)
+    gepa.gepa_loop(adapter, run_dir=run_dir, optimizer=_optimizer(), seed_val=base,
+                   max_iterations=1, minibatch_size=3, max_merges=0,
+                   gate_kwargs={"mode": "significant", "k_se": 1.0})
+    _assert_constraint_in_prompt(run_dir.root / "work" / "gepa_0001")
+
+
+def test_skillopt_prompt_carries_the_constraints(tmp_path):
+    from cap_evolve import skillopt
+    adapter, run_dir, base = _setup(tmp_path, "so", max_iterations=1, stall=5)
+    _seed_rejection(run_dir)
+    skillopt.skillopt_loop(adapter, run_dir=run_dir, optimizer=_optimizer(),
+                           current_val=base, epochs=1, batch_size=4,
+                           gate_kwargs={"mode": "significant", "k_se": 1.0},
+                           slow_update=False)
+    workdir = next((run_dir.root / "work").glob("so_e01s01"))
+    _assert_constraint_in_prompt(workdir)
+
+
+# ---- the loop actually records signatures (not just the test seeding them) ----
+
+def test_a_real_rejection_records_its_approach_signature(tmp_path):
+    """End-to-end: the mock optimizer's edit is rejected by a strict gate, and the
+    signature of that exact edit lands in rejected.jsonl — so the NEXT iteration's
+    prompt constrains against it. This is the whole point of the issue."""
+    import json
+
+    from cap_evolve import harness
+    adapter, run_dir, base = _setup(tmp_path, "rec", max_iterations=1, stall=3)
+    harness.hill_climb_loop(
+        adapter, run_dir=run_dir, optimizer=_optimizer(), current_val=base,
+        focus="all", max_iterations=1,
+        # threshold mode with an unreachable margin → guaranteed rejection. (A huge k_se
+        # would NOT work: n_trials=1 collapses SE to 0 and the gate documents a strict
+        # fallback, which accepts the mock's improvement.)
+        gate_kwargs={"mode": "threshold", "threshold": 1e9}, algorithm="hill-climb")
+
+    recs = [json.loads(ln) for ln in
+            run_dir.rejected_path.read_text(encoding="utf-8").splitlines() if ln.strip()]
+    assert recs, "no rejection recorded"
+    approach = recs[-1]["approach"]
+    assert "prompt.txt" in approach, f"signature does not name the edited file: {approach}"
+    assert "[CALC]" in approach, f"signature does not carry the mock's edit: {approach}"
+    # and it is immediately usable as a constraint
+    assert "[CALC]" in harness.dead_end_constraints(run_dir)
+
+
+def test_no_val_or_test_ground_truth_in_the_constraint_block(tmp_path):
+    """The block is built from the capability diff + gate reason only — never from task
+    data. Prove no split id (val OR sealed test) appears in it."""
+    from cap_evolve import harness
+    adapter, run_dir, base = _setup(tmp_path, "leak", max_iterations=1, stall=3)
+    harness.hill_climb_loop(
+        adapter, run_dir=run_dir, optimizer=_optimizer(), current_val=base,
+        focus="all", max_iterations=1,
+        gate_kwargs={"mode": "threshold", "threshold": 1e9}, algorithm="hill-climb")
+    block = harness.dead_end_constraints(run_dir)
+    assert block, "expected a constraint block to inspect"
+    splits = run_dir.read_splits()
+    leaked = [t for t in (list(splits.test) + list(splits.val)) if t in block]
+    assert not leaked, f"split ids leaked into the optimizer prompt: {leaked}"

--- a/core/tests/test_gepa.py
+++ b/core/tests/test_gepa.py
@@ -292,14 +292,17 @@ def test_scratch_ignores_are_one_shared_definition():
     assert NON_CAPABILITY_NAMES == scratch | set(LEGACY_SCRATCH_NAMES) | {
         "INSTRUCTIONS.md", "PROCESS.md"}
     # The DESTRUCTIVE consumer takes the live-writer subset; every read-side FILTER
-    # takes the whole union, so none of them can desync again.
+    # takes the whole union, so none of them can desync again. Superset, not equality:
+    # a filter may add its own extra read-context names (e.g. the optimizer-context
+    # INJECTED_NAMES) — what must never happen is one of them DROPPING a shared name.
     assert scratch <= set(harness._SNAPSHOT_IGNORE)
     for name, have in (("cache._IGNORE_NAMES", cache._IGNORE_NAMES),
                        ("gepa._NON_COMPONENT", gepa._NON_COMPONENT),
                        ("skillopt._SCAFFOLDING", set(skillopt._SCAFFOLDING)),
                        ("dashboard._DIFF_SKIP", set(dashboard._DIFF_SKIP)),
                        ("harness._CAP_DIFF_SKIP", set(harness._CAP_DIFF_SKIP))):
-        assert have == set(NON_CAPABILITY_NAMES), f"{name} desynced: {sorted(have)}"
+        assert set(NON_CAPABILITY_NAMES) <= have, \
+            f"{name} desynced, missing {sorted(set(NON_CAPABILITY_NAMES) - have)}"
     # PROCESS.md is deliberately snapshotted (explainability), so it is NOT scratch.
     assert "PROCESS.md" not in scratch
     assert "PROCESS.md" not in set(harness._SNAPSHOT_IGNORE)

--- a/core/tests/test_gepa.py
+++ b/core/tests/test_gepa.py
@@ -274,3 +274,105 @@ def test_merge_skips_gracefully_monolith(tmp_path):
         if "merge_of" in s:
             assert "accepted" in s and "local_gate" in s
     assert res["best_val"] == 1.0
+
+
+# ---- #110: candidate snapshots must be clean, identically for every algorithm ----
+
+def test_scratch_ignores_are_one_shared_definition():
+    """FAILS BEFORE THE FIX: the scratch-file list was copy-pasted into four modules
+    and desynced — FOCUS.md/REFLECTION.md were in the cache + component lists but
+    MISSING from harness._SNAPSHOT_IGNORE, so GEPA snapshots stayed dirty (#110).
+    Pin that every consumer derives from rundir, AND that the destructive consumer
+    takes the live-writer subset only (see test_snapshot_ignore_excludes_legacy)."""
+    from cap_evolve import cache, dashboard, gepa, harness, skillopt
+    from cap_evolve.rundir import (LEGACY_SCRATCH_NAMES, NON_CAPABILITY_NAMES,
+                                   SCRATCH_NAMES)
+    scratch = set(SCRATCH_NAMES)
+    assert scratch == {"FOCUS.md", "REFLECTION.md", "LEDGER.md", "JOURNAL.md", "RUNMAP.md"}
+    assert NON_CAPABILITY_NAMES == scratch | set(LEGACY_SCRATCH_NAMES) | {
+        "INSTRUCTIONS.md", "PROCESS.md"}
+    # The DESTRUCTIVE consumer takes the live-writer subset; every read-side FILTER
+    # takes the whole union, so none of them can desync again. Superset, not equality:
+    # a filter may add its own extra read-context names (e.g. the optimizer-context
+    # INJECTED_NAMES) — what must never happen is one of them DROPPING a shared name.
+    assert scratch <= set(harness._SNAPSHOT_IGNORE)
+    for name, have in (("cache._IGNORE_NAMES", cache._IGNORE_NAMES),
+                       ("gepa._NON_COMPONENT", gepa._NON_COMPONENT),
+                       ("skillopt._SCAFFOLDING", set(skillopt._SCAFFOLDING)),
+                       ("dashboard._DIFF_SKIP", set(dashboard._DIFF_SKIP)),
+                       ("harness._CAP_DIFF_SKIP", set(harness._CAP_DIFF_SKIP))):
+        assert set(NON_CAPABILITY_NAMES) <= have, \
+            f"{name} desynced, missing {sorted(set(NON_CAPABILITY_NAMES) - have)}"
+    # PROCESS.md is deliberately snapshotted (explainability), so it is NOT scratch.
+    assert "PROCESS.md" not in scratch
+    assert "PROCESS.md" not in set(harness._SNAPSHOT_IGNORE)
+
+
+def test_snapshot_ignore_excludes_legacy_names_and_is_root_anchored(tmp_path):
+    """FAILS BEFORE THE FIX: snapshot exclusion is DESTRUCTIVE (shutil.ignore_patterns
+    inside copytree), and it matches by BASENAME AT EVERY DEPTH. Folding the retired
+    MEMORY/STATE/REJECTED names — which no live code path writes — into
+    harness._SNAPSHOT_IGNORE meant a *capability* file that merely shared one of those
+    names was silently deleted from the candidate, from every descendant iteration, and
+    WITHOUT busting the eval-cache key (cache ignores the same name), i.e. a stale hit
+    on a mutilated candidate."""
+    from cap_evolve import harness
+    from cap_evolve.cache import hash_candidate_dir
+    from cap_evolve.rundir import RunDir
+
+    # Names spelled out, not imported, so this fails BEHAVIOURALLY on any base rev.
+    LEGACY = ("REJECTED.md", "MEMORY.md", "STATE.md")
+    snap_ignore = set(harness._SNAPSHOT_IGNORE)
+    assert not (set(LEGACY) & snap_ignore), (
+        "retired names with no live writer must not reach the DESTRUCTIVE snapshot "
+        f"filter: {sorted(set(LEGACY) & snap_ignore)}")
+
+    work = tmp_path / "work"
+    (work / "src" / "prompts").mkdir(parents=True)
+    (work / "prompt.txt").write_text("cap")
+    (work / "LEDGER.md").write_text("scratch")           # live scratch, root: dropped
+    (work / "src" / "LEDGER.md").write_text("capability")  # nested: root-anchored, kept
+    for n in (*LEGACY, "keep.txt"):
+        (work / "src" / "prompts" / n).write_text(f"capability {n}")
+
+    rd = RunDir.create(tmp_path / "run")
+    snap = rd.snapshot("c1", work, ignore=harness._SNAPSHOT_IGNORE)
+    got = sorted(str(p.relative_to(snap)) for p in snap.rglob("*") if p.is_file())
+    assert got == ["prompt.txt", "src/LEDGER.md",
+                   *sorted(f"src/prompts/{n}" for n in (*LEGACY, "keep.txt"))]
+
+    # …and removing one of those capability files DOES change the cache key.
+    before = hash_candidate_dir(snap)
+    (snap / "src" / "prompts" / "STATE.md").unlink()
+    assert hash_candidate_dir(snap) != before, "capability deletion did not bust the key"
+
+
+@pytest.mark.parametrize("algo", ["gepa", "hill-climb"])
+def test_candidate_snapshots_are_clean_for_every_algorithm(tmp_path, algo):
+    """FAILS BEFORE THE FIX for algo='gepa': both gepa.py snapshot calls omitted
+    ``ignore=``, so FOCUS.md / REFLECTION.md / LEDGER.md / JOURNAL.md / RUNMAP.md and
+    prior_iterations/ landed in every candidate, bloating candidates/ and polluting the
+    dashboard diff. Hill-climb was already clean — this pins that they now AGREE."""
+    from cap_evolve import gepa, harness
+    adapter, run_dir, base = _setup(tmp_path, f"sn_{algo[:2]}", max_iterations=4,
+                                   max_metric_calls=2000)
+    optimizer = harness.optimizer_from_command(
+        ["python3", str(MOCK_RUN), "--name", "mock", "--workdir", "{workdir}",
+         "--prompt", "{prompt}"])
+    if algo == "gepa":
+        gepa.gepa_loop(adapter, run_dir=run_dir, optimizer=optimizer, seed_val=base,
+                       max_metric_calls=1500, max_iterations=3, minibatch_size=3,
+                       max_merges=0, seed=0,
+                       gate_kwargs={"mode": "significant", "k_se": 1.0})
+    else:
+        harness.hill_climb_loop(adapter, run_dir=run_dir, optimizer=optimizer,
+                                current_val=base, max_iterations=3, focus="all",
+                                gate_kwargs={"mode": "significant", "k_se": 1.0})
+
+    cands = [d for d in run_dir.candidates.iterdir() if d.is_dir() and d.name != "seed"]
+    assert cands, f"{algo} produced no candidate snapshot to inspect"
+    # The exact-set assertion below subsumes any "is it dirty?" check — it catches
+    # over- AND under-exclusion, which is the property that matters.
+    for d in cands:
+        got = sorted(str(p.relative_to(d)) for p in d.rglob("*") if p.is_file())
+        assert got == ["INSTRUCTIONS.md", "PROCESS.md", "prompt.txt"], f"{d.name}: {got}"

--- a/core/tests/test_gepa.py
+++ b/core/tests/test_gepa.py
@@ -274,3 +274,59 @@ def test_merge_skips_gracefully_monolith(tmp_path):
         if "merge_of" in s:
             assert "accepted" in s and "local_gate" in s
     assert res["best_val"] == 1.0
+
+
+# ---- #110: candidate snapshots must be clean, identically for every algorithm ----
+
+def test_scratch_ignores_are_one_shared_definition():
+    """FAILS BEFORE THE FIX: the scratch-file list was copy-pasted into four modules
+    and desynced — FOCUS.md/REFLECTION.md were in the cache + component lists but
+    MISSING from harness._SNAPSHOT_IGNORE, so GEPA snapshots stayed dirty (#110).
+    Pin that all four consumers derive from rundir.SCRATCH_NAMES."""
+    from cap_evolve import cache, gepa, harness, skillopt
+    from cap_evolve.rundir import SCRATCH_NAMES
+    scratch = set(SCRATCH_NAMES)
+    assert {"FOCUS.md", "REFLECTION.md", "LEDGER.md", "JOURNAL.md", "RUNMAP.md"} <= scratch
+    for name, have in (("_SNAPSHOT_IGNORE", set(harness._SNAPSHOT_IGNORE)),
+                       ("cache._IGNORE_NAMES", cache._IGNORE_NAMES),
+                       ("gepa._NON_COMPONENT", gepa._NON_COMPONENT),
+                       ("skillopt._SCAFFOLDING", set(skillopt._SCAFFOLDING))):
+        assert scratch <= have, f"{name} is missing {sorted(scratch - have)}"
+    # PROCESS.md is deliberately snapshotted (explainability), so it is NOT scratch.
+    assert "PROCESS.md" not in scratch
+    assert "PROCESS.md" not in set(harness._SNAPSHOT_IGNORE)
+
+
+@pytest.mark.parametrize("algo", ["gepa", "hill-climb"])
+def test_candidate_snapshots_are_clean_for_every_algorithm(tmp_path, algo):
+    """FAILS BEFORE THE FIX for algo='gepa': both gepa.py snapshot calls omitted
+    ``ignore=``, so FOCUS.md / REFLECTION.md / LEDGER.md / JOURNAL.md / RUNMAP.md and
+    prior_iterations/ landed in every candidate, bloating candidates/ and polluting the
+    dashboard diff. Hill-climb was already clean — this pins that they now AGREE."""
+    from cap_evolve import gepa, harness
+    adapter, run_dir, base = _setup(tmp_path, f"sn_{algo[:2]}", max_iterations=4,
+                                   max_metric_calls=2000)
+    optimizer = harness.optimizer_from_command(
+        ["python3", str(MOCK_RUN), "--name", "mock", "--workdir", "{workdir}",
+         "--prompt", "{prompt}"])
+    if algo == "gepa":
+        gepa.gepa_loop(adapter, run_dir=run_dir, optimizer=optimizer, seed_val=base,
+                       max_metric_calls=1500, max_iterations=3, minibatch_size=3,
+                       max_merges=0, seed=0,
+                       gate_kwargs={"mode": "significant", "k_se": 1.0})
+    else:
+        harness.hill_climb_loop(adapter, run_dir=run_dir, optimizer=optimizer,
+                                current_val=base, max_iterations=3, focus="all",
+                                gate_kwargs={"mode": "significant", "k_se": 1.0})
+
+    cands = [d for d in run_dir.candidates.iterdir() if d.is_dir() and d.name != "seed"]
+    assert cands, f"{algo} produced no candidate snapshot to inspect"
+    dirty = {d.name: sorted(str(p.relative_to(d)) for p in d.rglob("*")
+                            if p.name in set(harness._SNAPSHOT_IGNORE)
+                            or p.parts[len(d.parts)] in set(harness._SNAPSHOT_IGNORE))
+             for d in cands}
+    assert not any(dirty.values()), f"{algo} snapshots carry scratch: {dirty}"
+    # …and only the capability + the two deliberately-kept explainability files remain.
+    for d in cands:
+        got = sorted(str(p.relative_to(d)) for p in d.rglob("*") if p.is_file())
+        assert got == ["INSTRUCTIONS.md", "PROCESS.md", "prompt.txt"], f"{d.name}: {got}"

--- a/core/tests/test_gepa.py
+++ b/core/tests/test_gepa.py
@@ -282,19 +282,66 @@ def test_scratch_ignores_are_one_shared_definition():
     """FAILS BEFORE THE FIX: the scratch-file list was copy-pasted into four modules
     and desynced — FOCUS.md/REFLECTION.md were in the cache + component lists but
     MISSING from harness._SNAPSHOT_IGNORE, so GEPA snapshots stayed dirty (#110).
-    Pin that all four consumers derive from rundir.SCRATCH_NAMES."""
-    from cap_evolve import cache, gepa, harness, skillopt
-    from cap_evolve.rundir import SCRATCH_NAMES
+    Pin that every consumer derives from rundir, AND that the destructive consumer
+    takes the live-writer subset only (see test_snapshot_ignore_excludes_legacy)."""
+    from cap_evolve import cache, dashboard, gepa, harness, skillopt
+    from cap_evolve.rundir import (LEGACY_SCRATCH_NAMES, NON_CAPABILITY_NAMES,
+                                   SCRATCH_NAMES)
     scratch = set(SCRATCH_NAMES)
-    assert {"FOCUS.md", "REFLECTION.md", "LEDGER.md", "JOURNAL.md", "RUNMAP.md"} <= scratch
-    for name, have in (("_SNAPSHOT_IGNORE", set(harness._SNAPSHOT_IGNORE)),
-                       ("cache._IGNORE_NAMES", cache._IGNORE_NAMES),
+    assert scratch == {"FOCUS.md", "REFLECTION.md", "LEDGER.md", "JOURNAL.md", "RUNMAP.md"}
+    assert NON_CAPABILITY_NAMES == scratch | set(LEGACY_SCRATCH_NAMES) | {
+        "INSTRUCTIONS.md", "PROCESS.md"}
+    # The DESTRUCTIVE consumer takes the live-writer subset; every read-side FILTER
+    # takes the whole union, so none of them can desync again.
+    assert scratch <= set(harness._SNAPSHOT_IGNORE)
+    for name, have in (("cache._IGNORE_NAMES", cache._IGNORE_NAMES),
                        ("gepa._NON_COMPONENT", gepa._NON_COMPONENT),
-                       ("skillopt._SCAFFOLDING", set(skillopt._SCAFFOLDING))):
-        assert scratch <= have, f"{name} is missing {sorted(scratch - have)}"
+                       ("skillopt._SCAFFOLDING", set(skillopt._SCAFFOLDING)),
+                       ("dashboard._DIFF_SKIP", set(dashboard._DIFF_SKIP)),
+                       ("harness._CAP_DIFF_SKIP", set(harness._CAP_DIFF_SKIP))):
+        assert have == set(NON_CAPABILITY_NAMES), f"{name} desynced: {sorted(have)}"
     # PROCESS.md is deliberately snapshotted (explainability), so it is NOT scratch.
     assert "PROCESS.md" not in scratch
     assert "PROCESS.md" not in set(harness._SNAPSHOT_IGNORE)
+
+
+def test_snapshot_ignore_excludes_legacy_names_and_is_root_anchored(tmp_path):
+    """FAILS BEFORE THE FIX: snapshot exclusion is DESTRUCTIVE (shutil.ignore_patterns
+    inside copytree), and it matches by BASENAME AT EVERY DEPTH. Folding the retired
+    MEMORY/STATE/REJECTED names — which no live code path writes — into
+    harness._SNAPSHOT_IGNORE meant a *capability* file that merely shared one of those
+    names was silently deleted from the candidate, from every descendant iteration, and
+    WITHOUT busting the eval-cache key (cache ignores the same name), i.e. a stale hit
+    on a mutilated candidate."""
+    from cap_evolve import harness
+    from cap_evolve.cache import hash_candidate_dir
+    from cap_evolve.rundir import RunDir
+
+    # Names spelled out, not imported, so this fails BEHAVIOURALLY on any base rev.
+    LEGACY = ("REJECTED.md", "MEMORY.md", "STATE.md")
+    snap_ignore = set(harness._SNAPSHOT_IGNORE)
+    assert not (set(LEGACY) & snap_ignore), (
+        "retired names with no live writer must not reach the DESTRUCTIVE snapshot "
+        f"filter: {sorted(set(LEGACY) & snap_ignore)}")
+
+    work = tmp_path / "work"
+    (work / "src" / "prompts").mkdir(parents=True)
+    (work / "prompt.txt").write_text("cap")
+    (work / "LEDGER.md").write_text("scratch")           # live scratch, root: dropped
+    (work / "src" / "LEDGER.md").write_text("capability")  # nested: root-anchored, kept
+    for n in (*LEGACY, "keep.txt"):
+        (work / "src" / "prompts" / n).write_text(f"capability {n}")
+
+    rd = RunDir.create(tmp_path / "run")
+    snap = rd.snapshot("c1", work, ignore=harness._SNAPSHOT_IGNORE)
+    got = sorted(str(p.relative_to(snap)) for p in snap.rglob("*") if p.is_file())
+    assert got == ["prompt.txt", "src/LEDGER.md",
+                   *sorted(f"src/prompts/{n}" for n in (*LEGACY, "keep.txt"))]
+
+    # …and removing one of those capability files DOES change the cache key.
+    before = hash_candidate_dir(snap)
+    (snap / "src" / "prompts" / "STATE.md").unlink()
+    assert hash_candidate_dir(snap) != before, "capability deletion did not bust the key"
 
 
 @pytest.mark.parametrize("algo", ["gepa", "hill-climb"])
@@ -321,12 +368,8 @@ def test_candidate_snapshots_are_clean_for_every_algorithm(tmp_path, algo):
 
     cands = [d for d in run_dir.candidates.iterdir() if d.is_dir() and d.name != "seed"]
     assert cands, f"{algo} produced no candidate snapshot to inspect"
-    dirty = {d.name: sorted(str(p.relative_to(d)) for p in d.rglob("*")
-                            if p.name in set(harness._SNAPSHOT_IGNORE)
-                            or p.parts[len(d.parts)] in set(harness._SNAPSHOT_IGNORE))
-             for d in cands}
-    assert not any(dirty.values()), f"{algo} snapshots carry scratch: {dirty}"
-    # …and only the capability + the two deliberately-kept explainability files remain.
+    # The exact-set assertion below subsumes any "is it dirty?" check — it catches
+    # over- AND under-exclusion, which is the property that matters.
     for d in cands:
         got = sorted(str(p.relative_to(d)) for p in d.rglob("*") if p.is_file())
         assert got == ["INSTRUCTIONS.md", "PROCESS.md", "prompt.txt"], f"{d.name}: {got}"

--- a/core/tests/test_gepa.py
+++ b/core/tests/test_gepa.py
@@ -274,3 +274,123 @@ def test_merge_skips_gracefully_monolith(tmp_path):
         if "merge_of" in s:
             assert "accepted" in s and "local_gate" in s
     assert res["best_val"] == 1.0
+
+
+# ---- #110: candidate snapshots must be clean, identically for every algorithm ----
+
+def test_scratch_ignores_are_one_shared_definition():
+    """FAILS BEFORE THE FIX: the scratch-file list was copy-pasted into four modules
+    and desynced — FOCUS.md/REFLECTION.md were in the cache + component lists but
+    MISSING from harness._SNAPSHOT_IGNORE, so GEPA snapshots stayed dirty (#110).
+    Pin that every consumer derives from rundir, AND that the destructive consumer
+    takes the live-writer subset only (see test_snapshot_ignore_excludes_legacy)."""
+    from cap_evolve import cache, dashboard, gepa, harness, skillopt
+    from cap_evolve.rundir import (LEGACY_SCRATCH_NAMES, NON_CAPABILITY_NAMES,
+                                   SCRATCH_NAMES)
+    scratch = set(SCRATCH_NAMES)
+    assert scratch == {"FOCUS.md", "REFLECTION.md", "LEDGER.md", "JOURNAL.md", "RUNMAP.md"}
+    assert NON_CAPABILITY_NAMES == scratch | set(LEGACY_SCRATCH_NAMES) | {
+        "INSTRUCTIONS.md", "PROCESS.md"}
+    # The DESTRUCTIVE consumer takes the live-writer subset; every read-side FILTER
+    # takes the whole union, so none of them can desync again. Superset, not equality:
+    # a filter may add its own extra read-context names (e.g. the optimizer-context
+    # INJECTED_NAMES) — what must never happen is one of them DROPPING a shared name.
+    assert scratch <= set(harness._SNAPSHOT_IGNORE)
+    for name, have in (("cache._IGNORE_NAMES", cache._IGNORE_NAMES),
+                       ("gepa._NON_COMPONENT", gepa._NON_COMPONENT),
+                       ("skillopt._SCAFFOLDING", set(skillopt._SCAFFOLDING)),
+                       ("dashboard._DIFF_SKIP", set(dashboard._DIFF_SKIP)),
+                       ("harness._CAP_DIFF_SKIP", set(harness._CAP_DIFF_SKIP))):
+        assert set(NON_CAPABILITY_NAMES) <= have, \
+            f"{name} desynced, missing {sorted(set(NON_CAPABILITY_NAMES) - have)}"
+    # #129/B1: the INJECTED_* half is not optional for the read-side filters either. Their
+    # PARENT side is a snapshot (already stripped by _SNAPSHOT_IGNORE) while their CHILD
+    # side is the LIVE workdir, so an injected CLAUDE.md / .claude/skills/<x>/SKILL.md that
+    # is missing here reads as a real capability ADDITION on every iteration — which
+    # silently poisoned the #129 approach signature, the RUNMAP diff and the dashboard diff
+    # panel for every non-mock optimizer. Both sets must be DERIVED: the dir list that broke
+    # was a hardcoded 3-of-9 subset of INJECTED_DIRS.
+    from cap_evolve.optimizer_context import INJECTED_DIRS, INJECTED_NAMES
+    for name, names, dirs in (
+            ("cache", cache._IGNORE_NAMES, cache._IGNORE_DIRS),
+            ("gepa", gepa._NON_COMPONENT, gepa._NON_COMPONENT_DIRS),
+            ("skillopt", skillopt._SCAFFOLDING, skillopt._SCAFFOLDING_DIRS),
+            ("dashboard", dashboard._DIFF_SKIP, dashboard._DIFF_SKIP_DIRS),
+            ("harness_capdiff", harness._CAP_DIFF_SKIP, harness._CAP_DIFF_SKIP_DIRS)):
+        assert set(INJECTED_NAMES) <= set(names), \
+            f"{name} misses injected names {sorted(set(INJECTED_NAMES) - set(names))}"
+        assert set(INJECTED_DIRS) <= set(dirs), \
+            f"{name} misses injected dirs {sorted(set(INJECTED_DIRS) - set(dirs))}"
+    # PROCESS.md is deliberately snapshotted (explainability), so it is NOT scratch.
+    assert "PROCESS.md" not in scratch
+    assert "PROCESS.md" not in set(harness._SNAPSHOT_IGNORE)
+
+
+def test_snapshot_ignore_excludes_legacy_names_and_is_root_anchored(tmp_path):
+    """FAILS BEFORE THE FIX: snapshot exclusion is DESTRUCTIVE (shutil.ignore_patterns
+    inside copytree), and it matches by BASENAME AT EVERY DEPTH. Folding the retired
+    MEMORY/STATE/REJECTED names — which no live code path writes — into
+    harness._SNAPSHOT_IGNORE meant a *capability* file that merely shared one of those
+    names was silently deleted from the candidate, from every descendant iteration, and
+    WITHOUT busting the eval-cache key (cache ignores the same name), i.e. a stale hit
+    on a mutilated candidate."""
+    from cap_evolve import harness
+    from cap_evolve.cache import hash_candidate_dir
+    from cap_evolve.rundir import RunDir
+
+    # Names spelled out, not imported, so this fails BEHAVIOURALLY on any base rev.
+    LEGACY = ("REJECTED.md", "MEMORY.md", "STATE.md")
+    snap_ignore = set(harness._SNAPSHOT_IGNORE)
+    assert not (set(LEGACY) & snap_ignore), (
+        "retired names with no live writer must not reach the DESTRUCTIVE snapshot "
+        f"filter: {sorted(set(LEGACY) & snap_ignore)}")
+
+    work = tmp_path / "work"
+    (work / "src" / "prompts").mkdir(parents=True)
+    (work / "prompt.txt").write_text("cap")
+    (work / "LEDGER.md").write_text("scratch")           # live scratch, root: dropped
+    (work / "src" / "LEDGER.md").write_text("capability")  # nested: root-anchored, kept
+    for n in (*LEGACY, "keep.txt"):
+        (work / "src" / "prompts" / n).write_text(f"capability {n}")
+
+    rd = RunDir.create(tmp_path / "run")
+    snap = rd.snapshot("c1", work, ignore=harness._SNAPSHOT_IGNORE)
+    got = sorted(str(p.relative_to(snap)) for p in snap.rglob("*") if p.is_file())
+    assert got == ["prompt.txt", "src/LEDGER.md",
+                   *sorted(f"src/prompts/{n}" for n in (*LEGACY, "keep.txt"))]
+
+    # …and removing one of those capability files DOES change the cache key.
+    before = hash_candidate_dir(snap)
+    (snap / "src" / "prompts" / "STATE.md").unlink()
+    assert hash_candidate_dir(snap) != before, "capability deletion did not bust the key"
+
+
+@pytest.mark.parametrize("algo", ["gepa", "hill-climb"])
+def test_candidate_snapshots_are_clean_for_every_algorithm(tmp_path, algo):
+    """FAILS BEFORE THE FIX for algo='gepa': both gepa.py snapshot calls omitted
+    ``ignore=``, so FOCUS.md / REFLECTION.md / LEDGER.md / JOURNAL.md / RUNMAP.md and
+    prior_iterations/ landed in every candidate, bloating candidates/ and polluting the
+    dashboard diff. Hill-climb was already clean — this pins that they now AGREE."""
+    from cap_evolve import gepa, harness
+    adapter, run_dir, base = _setup(tmp_path, f"sn_{algo[:2]}", max_iterations=4,
+                                   max_metric_calls=2000)
+    optimizer = harness.optimizer_from_command(
+        ["python3", str(MOCK_RUN), "--name", "mock", "--workdir", "{workdir}",
+         "--prompt", "{prompt}"])
+    if algo == "gepa":
+        gepa.gepa_loop(adapter, run_dir=run_dir, optimizer=optimizer, seed_val=base,
+                       max_metric_calls=1500, max_iterations=3, minibatch_size=3,
+                       max_merges=0, seed=0,
+                       gate_kwargs={"mode": "significant", "k_se": 1.0})
+    else:
+        harness.hill_climb_loop(adapter, run_dir=run_dir, optimizer=optimizer,
+                                current_val=base, max_iterations=3, focus="all",
+                                gate_kwargs={"mode": "significant", "k_se": 1.0})
+
+    cands = [d for d in run_dir.candidates.iterdir() if d.is_dir() and d.name != "seed"]
+    assert cands, f"{algo} produced no candidate snapshot to inspect"
+    # The exact-set assertion below subsumes any "is it dirty?" check — it catches
+    # over- AND under-exclusion, which is the property that matters.
+    for d in cands:
+        got = sorted(str(p.relative_to(d)) for p in d.rglob("*") if p.is_file())
+        assert got == ["INSTRUCTIONS.md", "PROCESS.md", "prompt.txt"], f"{d.name}: {got}"

--- a/core/tests/test_optimizer_context_parity.py
+++ b/core/tests/test_optimizer_context_parity.py
@@ -1,0 +1,267 @@
+"""Issue #109 — GEPA and SkillOpt get the SAME optimizer context as hill-climb.
+
+Before the fix:
+  * ``gepa_loop`` bypassed ``run_step``, so its optimizer workdir had no
+    ``./trajectories/``, no ``./guidance/<cap>/`` and no native-skill injection, and its
+    prompt was a hand-rolled string with no capability brief / bench repo / reader block;
+  * ``skillopt_loop`` had no capability/optimizer parameters at all and called
+    ``_focus_instructions`` bare, so ``CAP_BRIEF`` was empty and the ``PARALLEL`` note
+    always claimed a sequential optimizer;
+  * ``cap-evolve run`` gated ``--capabilities / --instructions-file / --bench-repo /
+    --optimizer-name / --capability-sources / --target-model / --target-profile-file``
+    behind ``algorithm == "hill-climb"``, silently dropping them for the other two.
+
+These tests assert the injected FILES, the rendered PROMPT and the CLI flag plumbing for
+all three algorithms.
+"""
+
+import os
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+CORE = REPO / "core"
+EXAMPLE = REPO / "examples" / "toy_calc"
+MOCK_RUN = REPO / "skills" / "optimizers" / "run-optimizer" / "scripts" / "run.py"
+
+sys.path.insert(0, str(CORE))
+
+
+@pytest.fixture(autouse=True)
+def _env():
+    old = dict(os.environ)
+    os.environ["CAPEVOLVE_CORE"] = str(CORE)
+    os.environ["CAPEVOLVE_TOY_DATA"] = str(EXAMPLE)
+    os.environ["CAPEVOLVE_MOCK_SCRIPT"] = str(EXAMPLE / "mock_script.json")
+    yield
+    os.environ.clear()
+    os.environ.update(old)
+
+
+def _toy_adapter():
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("toy_ctx_parity", EXAMPLE / "adapter.py")
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m.Adapter()
+
+
+def _setup(tmp_path, ts, **budget):
+    from cap_evolve import Budget, RunDir, harness
+    adapter = _toy_adapter()
+    seed = tmp_path / f"seed_{ts}"
+    shutil.copytree(EXAMPLE / "capability", seed)
+    run_dir = RunDir.create(tmp_path / ".capevolve", ts=ts, budget=Budget(**budget))
+    harness.ensure_splits(adapter, run_dir, seed=0)
+    base = harness.baseline(adapter, seed, run_dir=run_dir)
+    return adapter, run_dir, base
+
+
+def _ctx(tmp_path):
+    """The full optimizer context a real run configures, with a custom template so we
+    can prove the intake-authored instructions file is honored per-algorithm."""
+    from cap_evolve.optimizer_context import OptimizerContext
+    tmpl = tmp_path / "INSTRUCTIONS.tmpl.md"
+    tmpl.write_text(
+        "CUSTOM-TEMPLATE-MARKER\n{{FOCUS_SUMMARY}}\n{{CAP_BRIEF}}\n{{ALGO_BRIEF}}\n"
+        "{{BENCH_REPO}}\n{{PARALLEL_NOTE}}\n{{FAILURES}}\n{{PASSING}}\n"
+        "{{EMPTY_SEED}}\n{{TARGET_READER}}\n./trajectories/\n",
+        encoding="utf-8")
+    src = tmp_path / "models.py"
+    src.write_text("# the data model the tools import\nVERSION = 1\n", encoding="utf-8")
+    return OptimizerContext(
+        capabilities="system-prompt", optimizer_name="claude-code",
+        instructions_file=str(tmpl), bench_repo="/tmp/somebench",
+        capability_sources=str(src), project_dir=tmp_path,
+        target_model="weak")
+
+
+def _assert_full_context(workdir: Path):
+    """Every artifact + prompt block that used to be hill-climb-only."""
+    # --- injected FILES
+    assert (workdir / "trajectories").is_dir(), "no ./trajectories/ injected"
+    assert any((workdir / "trajectories").iterdir()), "./trajectories/ is empty"
+    assert (workdir / "guidance" / "system-prompt" / "SKILL.md").exists(), \
+        "capability skill not copied to ./guidance/<cap>/"
+    assert (workdir / "guidance" / "diagnose" / "SKILL.md").exists(), \
+        "diagnose skill not copied to ./guidance/diagnose/"
+    assert (workdir / "guidance" / "sources" / "models.py").exists(), \
+        "capability_sources not copied to ./guidance/sources/"
+    assert (workdir / "guidance" / "optimizer" / "claude-code.md").exists(), \
+        "optimizer features reference not copied"
+    # native per-agent skill placement (claude-code row of the registry)
+    assert (workdir / ".claude" / "skills" / "system-prompt" / "SKILL.md").exists(), \
+        "native skills dir not populated"
+    assert "cap-evolve:native-skills" in (workdir / "CLAUDE.md").read_text(encoding="utf-8")
+
+    # --- rendered PROMPT
+    instr = (workdir / "INSTRUCTIONS.md").read_text(encoding="utf-8")
+    assert "{{" not in instr, "template placeholder left unrendered"
+    assert "CUSTOM-TEMPLATE-MARKER" in instr, "--instructions-file template ignored"
+    assert "What you are editing (the allowed edit space)" in instr, "no CAP_BRIEF"
+    assert "./guidance/system-prompt/SKILL.md" in instr, "CAP_BRIEF has no capability"
+    assert "/tmp/somebench" in instr, "no bench-repo pointer"
+    assert "fan out" in instr.lower(), "PARALLEL note not adapted to a parallel optimizer"
+    assert "./trajectories/" in instr, "no trajectories read-pointer"
+    return instr
+
+
+def test_hill_climb_full_context_baseline(tmp_path):
+    """The reference behavior GEPA/SkillOpt must match."""
+    from cap_evolve import harness
+    adapter, run_dir, base = _setup(tmp_path, "hc", max_iterations=1, stall=3)
+    optimizer = harness.optimizer_from_command(
+        ["python3", str(MOCK_RUN), "--name", "mock", "--workdir", "{workdir}",
+         "--prompt", "{prompt}"])
+    harness.hill_climb_loop(
+        adapter, run_dir=run_dir, optimizer=optimizer, current_val=base,
+        focus="all", max_iterations=1, gate_kwargs={"mode": "significant", "k_se": 1.0},
+        algorithm="hill-climb", ctx=_ctx(tmp_path))
+    _assert_full_context(run_dir.root / "work" / "cand_0001")
+
+
+def test_gepa_optimizer_gets_full_context(tmp_path):
+    """FAILS BEFORE THE FIX: gepa_loop had no ctx param and never injected."""
+    from cap_evolve import gepa, harness
+    adapter, run_dir, base = _setup(tmp_path, "gp", max_iterations=1, stall=5)
+    optimizer = harness.optimizer_from_command(
+        ["python3", str(MOCK_RUN), "--name", "mock", "--workdir", "{workdir}",
+         "--prompt", "{prompt}"])
+    gepa.gepa_loop(adapter, run_dir=run_dir, optimizer=optimizer, seed_val=base,
+                   max_iterations=1, minibatch_size=3, max_merges=0,
+                   gate_kwargs={"mode": "significant", "k_se": 1.0},
+                   ctx=_ctx(tmp_path))
+    instr = _assert_full_context(run_dir.root / "work" / "gepa_0001")
+    # GEPA keeps its own reflective block ON TOP of the shared context
+    assert "GEPA reflective optimization step" in instr
+    assert (run_dir.root / "work" / "gepa_0001" / "REFLECTION.md").exists()
+    assert (run_dir.root / "work" / "gepa_0001" / "FOCUS.md").exists()
+
+
+def test_gepa_trajectories_scoped_to_parent_minibatch(tmp_path):
+    """./trajectories/ carries the VERBATIM rollouts REFLECTION.md only summarizes."""
+    from cap_evolve import gepa, harness
+    adapter, run_dir, base = _setup(tmp_path, "gt", max_iterations=1, stall=5)
+    optimizer = harness.optimizer_from_command(
+        ["python3", str(MOCK_RUN), "--name", "mock", "--workdir", "{workdir}",
+         "--prompt", "{prompt}"])
+    gepa.gepa_loop(adapter, run_dir=run_dir, optimizer=optimizer, seed_val=base,
+                   max_iterations=1, minibatch_size=3, max_merges=0,
+                   gate_kwargs={"mode": "significant", "k_se": 1.0},
+                   ctx=_ctx(tmp_path))
+    names = [p.name for p in (run_dir.root / "work" / "gepa_0001" / "trajectories").iterdir()]
+    assert names and all("__mb_p_0000__" in n for n in names), \
+        f"trajectories not scoped to the parent minibatch tag: {names}"
+
+
+def test_gepa_injected_context_excluded_from_component_list_and_snapshot(tmp_path):
+    """Injected read-context must not become an editable 'component', must not bust the
+    eval-cache hash, and must not be snapshotted as part of the candidate."""
+    from cap_evolve import gepa, harness
+    from cap_evolve.cache import hash_candidate_dir
+    adapter, run_dir, base = _setup(tmp_path, "gc", max_iterations=1, stall=5)
+    optimizer = harness.optimizer_from_command(
+        ["python3", str(MOCK_RUN), "--name", "mock", "--workdir", "{workdir}",
+         "--prompt", "{prompt}"])
+    gepa.gepa_loop(adapter, run_dir=run_dir, optimizer=optimizer, seed_val=base,
+                   max_iterations=1, minibatch_size=3, max_merges=0,
+                   gate_kwargs={"mode": "significant", "k_se": 1.0},
+                   ctx=_ctx(tmp_path))
+    workdir = run_dir.root / "work" / "gepa_0001"
+    comps = gepa._components(workdir)
+    assert comps == ["prompt.txt"], f"injected context leaked into components: {comps}"
+    # hash ignores the injected dirs: a bare copy of the capability hashes the same
+    bare = tmp_path / "bare"
+    bare.mkdir()
+    shutil.copyfile(workdir / "prompt.txt", bare / "prompt.txt")
+    assert hash_candidate_dir(workdir) == hash_candidate_dir(bare)
+    snap = run_dir.candidate_dir("gepa_0001")
+    if snap.exists():  # only if the candidate was accepted
+        assert not (snap / "trajectories").exists()
+        assert not (snap / "guidance").exists()
+
+
+def test_skillopt_optimizer_gets_full_context(tmp_path):
+    """FAILS BEFORE THE FIX: skillopt_loop had no capabilities/optimizer_name params."""
+    from cap_evolve import harness, skillopt
+    adapter, run_dir, base = _setup(tmp_path, "so", max_iterations=1, stall=5)
+    optimizer = harness.optimizer_from_command(
+        ["python3", str(MOCK_RUN), "--name", "mock", "--workdir", "{workdir}",
+         "--prompt", "{prompt}"])
+    skillopt.skillopt_loop(adapter, run_dir=run_dir, optimizer=optimizer,
+                           current_val=base, epochs=1, batch_size=4,
+                           gate_kwargs={"mode": "significant", "k_se": 1.0},
+                           slow_update=False, ctx=_ctx(tmp_path))
+    instr = _assert_full_context(run_dir.root / "work" / "so_e01s01")
+    # SkillOpt keeps its textual learning rate block ON TOP of the shared context
+    assert "SkillOpt step budget (textual learning rate)" in instr
+
+
+def test_optimizer_context_from_args_and_flag_declaration():
+    """The shared flag set parses into an equivalent context (the seam the CLI uses)."""
+    import argparse
+    from cap_evolve.optimizer_context import OptimizerContext
+
+    p = argparse.ArgumentParser()
+    p.add_argument("--project")
+    OptimizerContext.add_arguments(p)
+    args = p.parse_args([
+        "--project", "/proj", "--capabilities", "system-prompt,tools",
+        "--instructions-file", "/tmp/t.md", "--bench-repo", "/tmp/bench",
+        "--optimizer-name", "claude-code", "--capability-sources", "a.py,b.py",
+        "--target-model", "weak", "--target-profile-file", "/tmp/p.md"])
+    ctx = OptimizerContext.from_args(args)
+    assert ctx.capabilities == ["system-prompt", "tools"]
+    assert ctx.capability_sources == ["a.py", "b.py"]
+    assert ctx.optimizer_name == "claude-code"
+    assert ctx.instructions_file == "/tmp/t.md"
+    assert ctx.bench_repo == "/tmp/bench"
+    assert ctx.target_model == "weak"
+    assert ctx.target_profile_file == "/tmp/p.md"
+    assert ctx.project_dir == Path("/proj")
+
+
+@pytest.mark.parametrize("algorithm", ["hill-climb", "gepa", "skillopt"])
+def test_every_algorithm_run_py_accepts_the_context_flags(algorithm):
+    """FAILS BEFORE THE FIX for gepa/skillopt: argparse rejected the flags entirely,
+    which is why cli.py gated them behind hill-climb."""
+    import subprocess
+    run_py = REPO / "skills" / "algorithms" / algorithm / "scripts" / "run.py"
+    out = subprocess.run([sys.executable, str(run_py), "--help"],
+                         capture_output=True, text=True,
+                         env={**os.environ, "CAPEVOLVE_CORE": str(CORE)})
+    assert out.returncode == 0, out.stderr
+    for flag in ("--capabilities", "--instructions-file", "--bench-repo",
+                 "--optimizer-name", "--capability-sources", "--target-model",
+                 "--target-profile-file"):
+        assert flag in out.stdout, f"{algorithm} run.py does not accept {flag}"
+
+
+@pytest.mark.parametrize("algorithm", ["hill-climb", "gepa", "skillopt"])
+def test_cli_passes_context_flags_to_every_algorithm(algorithm):
+    """FAILS BEFORE THE FIX: cli.py only emitted these for hill-climb."""
+    from cap_evolve import cli
+    assert algorithm in cli._OPTIMIZER_CONTEXT_ALGORITHMS
+    spec = {"capabilities": ["system-prompt", "tools"],
+            "runner_repo_path": "/tmp/bench",
+            "capability_sources": ["models.py"],
+            "target_model": "weak",
+            "target_profile_file": "/tmp/prof.md"}
+    flags = cli._optimizer_context_flags(spec, "/proj", "claude-code")
+    assert flags[flags.index("--capabilities") + 1] == "system-prompt,tools"
+    assert flags[flags.index("--optimizer-name") + 1] == "claude-code"
+    assert flags[flags.index("--bench-repo") + 1] == "/tmp/bench"
+    assert flags[flags.index("--capability-sources") + 1] == "models.py"
+    assert flags[flags.index("--target-model") + 1] == "weak"
+    assert flags[flags.index("--target-profile-file") + 1] == "/tmp/prof.md"
+
+
+def test_agent_driven_algorithms_are_not_sent_context_flags():
+    """evograph / agent-optimize have no deterministic loop — excluded on purpose,
+    not silently dropped per-flag."""
+    from cap_evolve import cli
+    assert "evograph" not in cli._OPTIMIZER_CONTEXT_ALGORITHMS
+    assert "agent-optimize" not in cli._OPTIMIZER_CONTEXT_ALGORITHMS

--- a/core/tests/test_optimizer_context_parity.py
+++ b/core/tests/test_optimizer_context_parity.py
@@ -265,3 +265,177 @@ def test_agent_driven_algorithms_are_not_sent_context_flags():
     from cap_evolve import cli
     assert "evograph" not in cli._OPTIMIZER_CONTEXT_ALGORITHMS
     assert "agent-optimize" not in cli._OPTIMIZER_CONTEXT_ALGORITHMS
+
+
+# ---------------------------------------------------------------------------
+# Review-round regressions (PR #199): the three blocking findings.
+# ---------------------------------------------------------------------------
+
+def test_gepa_gets_a_populated_history_channel_and_its_true_best(tmp_path):
+    """BLOCKING 1: LEDGER/RUNMAP/prior_iterations were EMPTY for GEPA.
+
+    ``_parent_map`` / ``_build_ledger`` / ``_build_runmap`` filtered ``kind == "step"``,
+    but GEPA bypasses ``run_step`` and emits ``gepa_val_gate`` — so its whole
+    cross-iteration memory channel stayed empty while the prompt told the optimizer to
+    read it, and ``run_dir.best_id`` stayed "seed" until loop exit. #128/#129/#130 all
+    read exactly this channel.
+    """
+    from cap_evolve import gepa, harness
+    adapter, run_dir, base = _setup(tmp_path, "gh", max_iterations=2, stall=5)
+    optimizer = harness.optimizer_from_command(
+        ["python3", str(MOCK_RUN), "--name", "mock", "--workdir", "{workdir}",
+         "--prompt", "{prompt}"])
+    gepa.gepa_loop(adapter, run_dir=run_dir, optimizer=optimizer, seed_val=base,
+                   max_iterations=2, minibatch_size=3, max_merges=0,
+                   gate_kwargs={"mode": "significant", "k_se": 1.0},
+                   ctx=_ctx(tmp_path))
+
+    # The shared kind set must include GEPA's kind, for every consumer.
+    from cap_evolve.rundir import ITERATION_EVENT_KINDS
+    assert "gepa_val_gate" in ITERATION_EVENT_KINDS
+    evs = run_dir.iteration_events()
+    assert evs, "no iteration events recognised for a GEPA run"
+    assert any(e["kind"] == "gepa_val_gate" for e in evs)
+
+    # iteration 2's workdir must SEE iteration 1.
+    wd2 = run_dir.root / "work" / "gepa_0002"
+    ledger = (wd2 / "LEDGER.md").read_text(encoding="utf-8")
+    runmap = (wd2 / "RUNMAP.md").read_text(encoding="utf-8")
+    assert "(baseline only)" not in ledger, f"LEDGER still empty for GEPA:\n{ledger}"
+    assert "gepa_0001" in ledger, f"iteration 1 missing from LEDGER:\n{ledger}"
+    assert "(no prior iterations yet)" not in runmap, f"RUNMAP still empty:\n{runmap}"
+    assert "gepa_0001" in runmap
+    prior = wd2 / "prior_iterations" / "gepa_0001"
+    assert prior.is_dir() and any(prior.iterdir()), "prior_iterations/ never populated"
+
+    # ...and must be told its TRUE best, not "seed", once an accept happened.
+    assert run_dir.best_id == "gepa_0001", f"best_id is {run_dir.best_id!r}"
+    assert "## Current best: gepa_0001" in ledger
+
+
+def test_gepa_cache_hit_never_substitutes_another_iterations_trajectories(tmp_path):
+    """BLOCKING 2: the pinned ``tag=`` fell through on a cache hit.
+
+    A fully-cached minibatch persists no rollout files, so ``_copy_tag`` failed and the
+    chain silently handed the optimizer the PREVIOUS iteration's traces (including
+    ``mb_c_*`` child rollouts) while the prompt claimed they were "the SAME minibatch
+    VERBATIM". A pin must be honoured or omitted loudly — never substituted.
+    """
+    from cap_evolve import harness
+    adapter, run_dir, _ = _setup(tmp_path, "ct", max_iterations=1, stall=5)
+    workdir = tmp_path / "wd"
+    workdir.mkdir()
+    stale = workdir / "trajectories"
+    stale.mkdir()
+    (stale / "a1__mb_p_0000__t0.json").write_text("{}", encoding="utf-8")
+
+    # Pin a tag that has NO persisted rollouts (exactly the cache-hit case).
+    harness._copy_step_trajectories(adapter, run_dir, workdir, "train",
+                                    tag="mb_p_0007")
+    assert not stale.exists(), "stale trajectories/ left in place for an unmet pin"
+
+    kinds = [e for e in run_dir.iteration_events()]  # touch the reader too
+    warn = [json_line for json_line in
+            run_dir.events_path.read_text(encoding="utf-8").splitlines()
+            if "optimizer_context_warning" in json_line and "mb_p_0007" in json_line]
+    assert warn, "unmet trajectory pin failed SILENTLY (no warning event)"
+    assert "OMITTED" in warn[0]
+    assert kinds == kinds  # no-op; keeps the reader exercised without asserting count
+
+    # ...and the prompt block must not claim a dir that isn't there.
+    from cap_evolve import gepa
+    with_traj = gepa._gepa_block("s", "prompt.txt", ["a1"], has_trajectories=True)
+    without = gepa._gepa_block("s", "prompt.txt", ["a1"], has_trajectories=False)
+    assert "SAME minibatch rollouts VERBATIM" in with_traj
+    assert "SAME minibatch rollouts VERBATIM" not in without
+    assert "served entirely from the eval cache" in without
+
+
+def test_focus_ids_from_a_disjoint_split_do_not_empty_the_failure_index(tmp_path):
+    """BLOCKING 3: SkillOpt's failure index was always "of 0 tasks".
+
+    ``render_instructions`` got a VAL result narrowed by TRAIN ids — disjoint by
+    construction — so the intersection was always empty and the optimizer was told
+    there was nothing to fix. Zero overlap must fall back to the unfiltered index and
+    say so, not report a confident empty one.
+    """
+    from cap_evolve import skillopt, harness
+    from cap_evolve.optimizer_context import render_instructions
+    adapter, run_dir, base = _setup(tmp_path, "fi", max_iterations=2, stall=5)
+
+    # Unit: val result + train-shaped ids => full index, with the caveat sentence.
+    train_ids = list(run_dir.read_splits().train)
+    val_ids = {pt["task_id"] for pt in base.per_task}
+    assert not (set(train_ids) & val_ids), "fixture splits are not disjoint"
+    out = render_instructions(base, train_ids, "mb", ctx=_ctx(tmp_path))
+    assert " of 0 tasks." not in out, f"failure index emptied by disjoint ids:\n{out[:400]}"
+    assert "ALWAYS-failing task(s)" in out, "no failure index rendered"
+    assert "different split than the scored result" in out, "silent fallback (no caveat)"
+
+    # End to end: a real SkillOpt step's INSTRUCTIONS.md has a non-empty index.
+    optimizer = harness.optimizer_from_command(
+        ["python3", str(MOCK_RUN), "--name", "mock", "--workdir", "{workdir}",
+         "--prompt", "{prompt}"])
+    skillopt.skillopt_loop(adapter, run_dir=run_dir, optimizer=optimizer,
+                           current_val=base, epochs=1, batch_size=2,
+                           edit_budget=2,
+                           gate_kwargs={"mode": "significant", "k_se": 1.0},
+                           ctx=_ctx(tmp_path))
+    step_dirs = sorted((run_dir.root / "work").glob("so_*"))
+    assert step_dirs, "no skillopt workdir"
+    instr = (step_dirs[0] / "INSTRUCTIONS.md").read_text(encoding="utf-8")
+    assert " of 0 tasks." not in instr, f"SkillOpt index still empty:\n{instr[:400]}"
+    assert "ALWAYS-failing task(s)" in instr
+    assert "No actionable failures in focus" not in instr
+
+
+def test_assembled_instructions_are_globally_capped():
+    """Non-blocking 7: every block was bounded, the SUM was not."""
+    from cap_evolve.loop import SplitResult
+    from cap_evolve.optimizer_context import MAX_INSTRUCTIONS_CHARS, render_instructions
+    res = SplitResult(split="val", reward=0.0, stderr=0.0, per_task=[
+        {"task_id": "a1", "reward": 0.0, "feedback": "x" * 200, "trial_rewards": [0.0]}])
+    out = render_instructions(res, None, "all", extra="Z" * 200_000, max_chars=5_000)
+    assert len(out) <= 5_000 + 300, len(out)
+    assert "chars elided to keep this prompt under" in out
+    assert MAX_INSTRUCTIONS_CHARS >= 10_000  # a normal render must never be truncated
+
+
+@pytest.mark.parametrize("algo", ["hill-climb", "gepa", "skillopt"])
+def test_target_profile_file_reaches_every_algorithms_prompt(tmp_path, algo):
+    """Non-blocking 8: ``--target-profile-file`` was only covered by a unit test.
+
+    Real fixture profile file, real loop, all three algorithms: the project-local brief
+    must OVERRIDE the tier's built-in brief in the rendered prompt.
+    """
+    from cap_evolve import gepa, harness, skillopt
+    from cap_evolve.optimizer_context import OptimizerContext
+    prof = tmp_path / "reader.md"
+    prof.write_text("FIXTURE-READER-BRIEF-199: the consuming model needs explicit rules.",
+                    encoding="utf-8")
+    tmpl = tmp_path / "t.md"
+    tmpl.write_text("{{FOCUS_SUMMARY}}\n{{TARGET_READER}}\n{{FAILURES}}\n", encoding="utf-8")
+    ctx = OptimizerContext(capabilities="system-prompt", instructions_file=str(tmpl),
+                           target_model="mid", target_profile_file=str(prof),
+                           project_dir=tmp_path)
+    adapter, run_dir, base = _setup(tmp_path, f"tp{abs(hash(algo)) % 997}",
+                                   max_iterations=1, stall=5)
+    optimizer = harness.optimizer_from_command(
+        ["python3", str(MOCK_RUN), "--name", "mock", "--workdir", "{workdir}",
+         "--prompt", "{prompt}"])
+    common = dict(run_dir=run_dir, optimizer=optimizer, ctx=ctx,
+                  gate_kwargs={"mode": "significant", "k_se": 1.0})
+    if algo == "hill-climb":
+        harness.hill_climb_loop(adapter, current_val=base, focus="all",
+                                max_iterations=1, algorithm="hill-climb", **common)
+    elif algo == "gepa":
+        gepa.gepa_loop(adapter, seed_val=base, max_iterations=1, minibatch_size=3,
+                       max_merges=0, **common)
+    else:
+        skillopt.skillopt_loop(adapter, current_val=base, epochs=1, batch_size=2,
+                               edit_budget=2, **common)
+    instrs = [p.read_text(encoding="utf-8")
+              for p in (run_dir.root / "work").glob("*/INSTRUCTIONS.md")]
+    assert instrs, f"no INSTRUCTIONS.md written for {algo}"
+    assert any("FIXTURE-READER-BRIEF-199" in i for i in instrs), \
+        f"--target-profile-file brief never reached {algo}'s prompt"

--- a/core/tests/test_per_task_impact.py
+++ b/core/tests/test_per_task_impact.py
@@ -33,7 +33,6 @@ def test_per_task_impact_lists_broken_task():
     """A candidate that regressed a previously-passing task must be reported in the
     per-task impact block as having BROKEN that task."""
     from cap_evolve import RunDir, harness
-    from cap_evolve.memory import RejectedMemory
     import tempfile
 
     tmp = Path(tempfile.mkdtemp())
@@ -48,15 +47,13 @@ def test_per_task_impact_lists_broken_task():
 
     # Lineage: cand_0001 forked from seed (a step event), and it was rejected.
     rd.log_event("step", candidate="cand_0001", parent="seed", accept=False)
-    rejected = RejectedMemory(rd.rejected_path)
-    rejected.add("cand_0001", "candidate cand_0001 (val 0.667)", "no significant gain", 0.667)
 
     # The per-task broke/fixed signal reaches the optimizer via the framework-owned
     # factual LEDGER.md (built each iteration). Build it into a workdir and assert the
     # broken/fixed task ids are surfaced in cand_0001's row.
     import tempfile as _tf
     workdir = Path(_tf.mkdtemp())
-    harness._build_ledger(workdir, rd, rejected, None)
+    harness._build_ledger(workdir, rd)
     ledger = (workdir / "LEDGER.md").read_text(encoding="utf-8")
     assert "cand_0001" in ledger
     # Row format: | iter | candidate | parent | outcome | val | Δ | broke {..} | fixed {..} |
@@ -64,7 +61,7 @@ def test_per_task_impact_lists_broken_task():
     assert "{2}" in row   # BROKE task 2 (was passing)
     assert "{3}" in row   # FIXED task 3
 
-    # And the memory record carries the localized broke/fixed lists (C4).
+    # And the underlying signal localizes the broke/fixed task ids (C4).
     impact = harness._candidate_task_impact(rd, "cand_0001", "val",
                                             parent_of={"cand_0001": "seed"})
     assert impact["broke"] == ["2"]

--- a/core/tests/test_proposal_quality.py
+++ b/core/tests/test_proposal_quality.py
@@ -130,6 +130,38 @@ def test_markup_and_marker_variants_still_parse(tmp_path):
     assert "apply_discount" in q["mechanism"]
 
 
+def test_a_declaration_appended_below_the_seed_placeholders_still_counts(tmp_path):
+    """The most likely agent shape: leave the seed block alone, append the filled one
+    below it. A first-match-only read records that as fully UNDECLARED — inverting the
+    exact signal this module exists to observe. Every occurrence must be scanned."""
+    from cap_evolve import proposal_quality
+    (tmp_path / "PROCESS.md").write_text(
+        "## Proposal declaration\n"
+        "- Mechanism: <what now behaves differently, and why>\n"
+        "- Hypothesis: <which cluster this fixes>\n"
+        "- Expected observable: <what will look different next iteration>\n"
+        "\n### My declaration\n" + DECLARED.split("## Proposal declaration\n", 1)[1],
+        encoding="utf-8")
+    q = proposal_quality.parse(tmp_path)
+    assert q["declared"] is True, (
+        "a filled declaration appended BELOW the seed placeholders read as undeclared "
+        f"— the signal is inverted: {q}")
+    assert "quote_price" in q["mechanism"] and "get_total" in q["observable"], q
+
+
+def test_a_bare_observable_label_is_the_same_field(tmp_path):
+    """``Expected observable`` is what the seed writes, but agents shorten it. Requiring
+    the adjective recorded a real declaration as missing."""
+    from cap_evolve import proposal_quality
+    (tmp_path / "PROCESS.md").write_text(
+        "- Mechanism: in-body guard in apply_discount\n"
+        "- Hypothesis: the rounding cluster, one root cause\n"
+        "- Observable: no off-by-one cents in the next trajectories\n", encoding="utf-8")
+    q = proposal_quality.parse(tmp_path)
+    assert q["declared"] is True, q
+    assert "off-by-one" in q["observable"], q
+
+
 def test_a_missing_process_md_never_raises(tmp_path):
     from cap_evolve import proposal_quality
     q = proposal_quality.parse(tmp_path / "nope")
@@ -187,6 +219,48 @@ def test_an_undeclared_proposal_is_also_not_rejected(tmp_path):
     ev = _events(run_dir, "proposal_quality")
     assert ev and ev[-1]["declared"] is False, ev
     assert ev[-1]["enforcement"] == "advisory", ev[-1]
+
+
+def test_gepas_local_gate_is_not_enforcing_the_declaration(tmp_path):
+    """PER-ALGORITHM probe. The hill-climb pair above only pins ``run_step``; an
+    enforcement injected into GEPA's *local* gate passes them all and surfaces only as
+    confusing failures in test_gepa.py. Assert here, on GEPA's own event, that an
+    UNDECLARED candidate passed the local gate on rewards alone."""
+    from cap_evolve import gepa
+    adapter, run_dir, base = _setup(tmp_path, "gpadv", max_iterations=1, stall=5)
+    gepa.gepa_loop(adapter, run_dir=run_dir, optimizer=_optimizer(), seed_val=base,
+                   max_iterations=1, minibatch_size=3, max_merges=0,
+                   gate_kwargs={"mode": "significant", "k_se": 1.0})
+    pq = _events(run_dir, "proposal_quality")
+    assert pq and pq[-1]["declared"] is False, pq
+    lg = _events(run_dir, "gepa_local_gate")
+    assert lg, "GEPA logged no local gate — the probe would be vacuous"
+    assert lg[-1]["passed"] is True, (
+        "an UNDECLARED candidate was stopped at GEPA's LOCAL gate — the advisory "
+        f"guarantee is broken for gepa: {lg[-1]}")
+    # and the local gate's verdict is exactly the reward comparison, nothing else.
+    assert (lg[-1]["child_sum"] > lg[-1]["parent_sum"]) is lg[-1]["passed"], lg[-1]
+
+
+def test_skillopts_step_does_not_enforce_the_declaration(tmp_path):
+    """PER-ALGORITHM probe, SkillOpt. It delegates to ``run_step`` today, but that is an
+    implementation detail the advisory guarantee should not depend on — pin the outcome
+    on SkillOpt's own step record for an UNDECLARED candidate."""
+    from cap_evolve import skillopt
+    adapter, run_dir, base = _setup(tmp_path, "soadv", max_iterations=2, stall=5)
+    out = skillopt.skillopt_loop(adapter, run_dir=run_dir, optimizer=_optimizer(),
+                                 current_val=base, epochs=1, batch_size=4,
+                                 gate_kwargs={"mode": "significant", "k_se": 1.0},
+                                 slow_update=False)
+    pq = _events(run_dir, "proposal_quality")
+    assert pq and pq[-1]["declared"] is False, pq
+    step = out["steps"][-1]
+    assert step["accepted"] is True, (
+        "an UNDECLARED candidate was rejected under skillopt — the advisory guarantee is "
+        f"broken for skillopt: decision={step.get('decision')}")
+    reason = str(step["decision"]["reason"]).lower()
+    for word in ("mechanism", "knob", "declar", "proposal quality"):
+        assert word not in reason, f"#140 leaked into skillopt's gate reason: {reason}"
 
 
 def test_the_bar_states_it_is_recorded_not_enforced():

--- a/core/tests/test_proposal_quality.py
+++ b/core/tests/test_proposal_quality.py
@@ -1,0 +1,428 @@
+"""Issue #140 — on-demand reasoning skills + the "mechanism-not-knob" proposal gate.
+
+Two halves with deliberately different epistemic standing, and these tests pin BOTH
+plus the boundary between them:
+
+  * the ``mechanism-probe`` reasoning skill reaches the optimizer's workdir for all three
+    deterministic algorithms (via #199's shared ``inject`` seam), byte-identical to
+    source, and the bar's text is in the rendered prompt;
+  * the DECLARATION (three named fields in PROCESS.md) parses precisely, with the seed's
+    placeholders counting as missing — no vacuous pass;
+  * the gate is **ADVISORY**: the false-rejection probe proves a genuine mechanism-style
+    proposal is accepted exactly as it would have been without #140, and an UNDECLARED
+    proposal is not rejected either. Nothing but the val gate can reject a candidate.
+  * the composed prompt (#219 INSIGHTS + #221 diversify + #222 dead-ends + #140's bar)
+    stays under ``MAX_INSTRUCTIONS_CHARS``, and an overflow never silently drops #140's
+    block — it lives in the kept tail.
+  * no sealed test-split id reaches any injected workdir file.
+"""
+
+import json
+import os
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+CORE = REPO / "core"
+EXAMPLE = REPO / "examples" / "toy_calc"
+MOCK_RUN = REPO / "skills" / "optimizers" / "run-optimizer" / "scripts" / "run.py"
+PROBE_SRC = REPO / "skills" / "reasoning" / "mechanism-probe"
+
+sys.path.insert(0, str(CORE))
+
+
+@pytest.fixture(autouse=True)
+def _env():
+    old = dict(os.environ)
+    os.environ["CAPEVOLVE_CORE"] = str(CORE)
+    os.environ["CAPEVOLVE_TOY_DATA"] = str(EXAMPLE)
+    os.environ["CAPEVOLVE_MOCK_SCRIPT"] = str(EXAMPLE / "mock_script.json")
+    yield
+    os.environ.clear()
+    os.environ.update(old)
+
+
+def _toy_adapter():
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("toy_pq", EXAMPLE / "adapter.py")
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m.Adapter()
+
+
+def _setup(tmp_path, ts, **budget):
+    from cap_evolve import Budget, RunDir, harness
+    adapter = _toy_adapter()
+    seed = tmp_path / f"seed_{ts}"
+    shutil.copytree(EXAMPLE / "capability", seed)
+    run_dir = RunDir.create(tmp_path / ".capevolve", ts=ts, budget=Budget(**budget))
+    harness.ensure_splits(adapter, run_dir, seed=0)
+    base = harness.baseline(adapter, seed, run_dir=run_dir)
+    return adapter, run_dir, base
+
+
+def _optimizer():
+    from cap_evolve import harness
+    return harness.optimizer_from_command(
+        ["python3", str(MOCK_RUN), "--name", "mock", "--workdir", "{workdir}",
+         "--prompt", "{prompt}"])
+
+
+DECLARED = (
+    "# PROCESS\n\n## Proposal declaration\n"
+    "- Mechanism: quote_price recomputes the total in-body and refuses a mismatch with "
+    "an actionable error, so answering from memory is impossible rather than discouraged.\n"
+    "- Hypothesis: the four tax-line failures share one root cause — the total is derived "
+    "by the agent instead of by code, so any task with a remembered line hits it.\n"
+    "- Expected observable: get_total precedes every quote_price call and the "
+    "'expected N got M' feedback disappears from these tasks.\n"
+)
+
+
+# ---- the declaration parses precisely ------------------------------------
+
+def test_a_filled_declaration_parses_all_three_fields(tmp_path):
+    from cap_evolve import proposal_quality
+    (tmp_path / "PROCESS.md").write_text(DECLARED, encoding="utf-8")
+    q = proposal_quality.parse(tmp_path)
+    assert q["declared"] is True and q["missing"] == []
+    assert "quote_price" in q["mechanism"]
+    assert "tax-line" in q["hypothesis"]
+    assert "get_total" in q["observable"]
+
+
+def test_the_seeded_placeholders_count_as_missing(tmp_path):
+    """The seed ships ``<...>`` prompts. If those parsed as values the gate would report
+    every untouched iteration as fully declared — a vacuous pass."""
+    from cap_evolve import harness, proposal_quality
+    (tmp_path / "PROCESS.md").write_text(harness._PROCESS_SEED, encoding="utf-8")
+    q = proposal_quality.parse(tmp_path)
+    assert q["declared"] is False
+    assert sorted(q["missing"]) == ["hypothesis", "mechanism", "observable"], q
+
+
+def test_partial_and_placeholder_values_are_reported_field_by_field(tmp_path):
+    from cap_evolve import proposal_quality
+    (tmp_path / "PROCESS.md").write_text(
+        "- Mechanism: in-body guard on quote_price\n"
+        "- Hypothesis: n/a\n"
+        "- Expected observable: <what will look different>\n", encoding="utf-8")
+    q = proposal_quality.parse(tmp_path)
+    assert q["declared"] is False
+    assert sorted(q["missing"]) == ["hypothesis", "observable"], q
+    assert q["mechanism"] == "in-body guard on quote_price"
+
+
+def test_markup_and_marker_variants_still_parse(tmp_path):
+    """Agents write these headings several ways; the parser must not be brittle about
+    bold markers or list bullets, or the record would be empty for a real declaration."""
+    from cap_evolve import proposal_quality
+    (tmp_path / "PROCESS.md").write_text(
+        "* **Mechanism**: in-body validation in `apply_discount`\n"
+        "Hypothesis: the rounding cluster\n"
+        "  - Expected Observable: no more off-by-one cents in the traces\n",
+        encoding="utf-8")
+    q = proposal_quality.parse(tmp_path)
+    assert q["declared"] is True, q
+    assert "apply_discount" in q["mechanism"]
+
+
+def test_a_missing_process_md_never_raises(tmp_path):
+    from cap_evolve import proposal_quality
+    q = proposal_quality.parse(tmp_path / "nope")
+    assert q["declared"] is False and len(q["missing"]) == 3
+
+
+# ---- ADVISORY: the false-rejection probe ---------------------------------
+
+def test_a_genuine_mechanism_proposal_is_not_rejected(tmp_path):
+    """THE test that matters. A real mechanism-style improvement must reach the val gate
+    and be accepted on its merits — #140 must not be able to discard a real gain.
+
+    The mock optimizer's edit is a genuine improvement on toy_calc (it raises val), and
+    it declares a mechanism. Assert the step ACCEPTED it: the gate outcome is decided by
+    the val delta, and #140 contributed no veto.
+    """
+    from cap_evolve import harness
+    adapter, run_dir, base = _setup(tmp_path, "fr", max_iterations=1, stall=3)
+
+    # Wrap the optimizer so the candidate ALSO carries a real declaration, exactly as a
+    # mechanism-probe-following optimizer would leave it.
+    inner = _optimizer()
+
+    def declaring(workdir, instructions):
+        out = inner(workdir, instructions)
+        (Path(workdir) / "PROCESS.md").write_text(DECLARED, encoding="utf-8")
+        return out
+
+    out = harness.hill_climb_loop(
+        adapter, run_dir=run_dir, optimizer=declaring, current_val=base,
+        focus="all", max_iterations=1, gate_kwargs={"mode": "significant", "k_se": 1.0},
+        algorithm="hill-climb")
+    step = out["steps"][-1]
+    assert step["accepted"] is True, (
+        "FALSE REJECTION: a declared, genuinely-improving mechanism edit was rejected — "
+        f"decision={step['decision']}")
+    # and the reason is purely the val gate's, with no #140 vocabulary in it.
+    reason = step["decision"]["reason"].lower()
+    for word in ("mechanism", "knob", "declar", "proposal quality"):
+        assert word not in reason, f"#140 leaked into the gate reason: {reason}"
+
+
+def test_an_undeclared_proposal_is_also_not_rejected(tmp_path):
+    """The symmetric half: a missing declaration is a SIGNAL, not a verdict. The bare
+    mock edit (no PROCESS.md declaration at all) must be accepted on its val delta —
+    otherwise #140 would be silently discarding improvements."""
+    from cap_evolve import harness
+    adapter, run_dir, base = _setup(tmp_path, "un", max_iterations=1, stall=3)
+    out = harness.hill_climb_loop(
+        adapter, run_dir=run_dir, optimizer=_optimizer(), current_val=base,
+        focus="all", max_iterations=1, gate_kwargs={"mode": "significant", "k_se": 1.0},
+        algorithm="hill-climb")
+    assert out["steps"][-1]["accepted"] is True, (
+        "an UNDECLARED proposal was rejected — the gate is not advisory")
+    ev = _events(run_dir, "proposal_quality")
+    assert ev and ev[-1]["declared"] is False, ev
+    assert ev[-1]["enforcement"] == "advisory", ev[-1]
+
+
+def test_the_bar_states_it_is_recorded_not_enforced():
+    """Honest wording (the #222 lesson: don't claim enforcement nothing enforces)."""
+    from cap_evolve import proposal_quality
+    block = proposal_quality.PROMPT_BLOCK
+    assert "RECORDED per candidate, not enforced" in block
+    assert "does NOT reject your edit" in block
+    assert "val significance gate remains the only thing that" in block
+
+
+# ---- the declaration is persisted per candidate --------------------------
+
+def _events(run_dir, kind):
+    return [json.loads(ln) for ln in
+            run_dir.events_path.read_text(encoding="utf-8").splitlines()
+            if json.loads(ln).get("kind") == kind]
+
+
+def test_the_declaration_is_recorded_per_candidate(tmp_path):
+    """FAILS BEFORE THE FIX: no proposal_quality event existed."""
+    from cap_evolve import harness
+    adapter, run_dir, base = _setup(tmp_path, "rec", max_iterations=1, stall=3)
+    inner = _optimizer()
+
+    def declaring(workdir, instructions):
+        out = inner(workdir, instructions)
+        (Path(workdir) / "PROCESS.md").write_text(DECLARED, encoding="utf-8")
+        return out
+
+    harness.hill_climb_loop(
+        adapter, run_dir=run_dir, optimizer=declaring, current_val=base,
+        focus="all", max_iterations=1, gate_kwargs={"mode": "significant", "k_se": 1.0},
+        algorithm="hill-climb")
+    ev = _events(run_dir, "proposal_quality")
+    assert len(ev) == 1, ev
+    assert ev[0]["candidate"] == "cand_0001"
+    assert ev[0]["declared"] is True and ev[0]["missing"] == []
+    assert "quote_price" in ev[0]["mechanism"]
+    assert ev[0]["enforcement"] == "advisory"
+
+
+def test_the_declaration_is_surfaced_in_the_dashboard(tmp_path):
+    """The issue asks for it to be visible. It rides the EXISTING annotations stream,
+    and must not read like a gate outcome (it never explains an accept/reject)."""
+    from cap_evolve import dashboard, harness
+    adapter, run_dir, base = _setup(tmp_path, "dash", max_iterations=1, stall=3)
+    inner = _optimizer()
+
+    def declaring(workdir, instructions):
+        out = inner(workdir, instructions)
+        (Path(workdir) / "PROCESS.md").write_text(DECLARED, encoding="utf-8")
+        return out
+
+    harness.hill_climb_loop(
+        adapter, run_dir=run_dir, optimizer=declaring, current_val=base,
+        focus="all", max_iterations=1, gate_kwargs={"mode": "significant", "k_se": 1.0},
+        algorithm="hill-climb")
+    state = dashboard.reduce_run(run_dir)["summary"]
+    rows = [d for d in state["diagnoses"] if d["kind"] == "proposal_quality"]
+    assert len(rows) == 1, state["diagnoses"]
+    assert rows[0]["candidate"] == "cand_0001"
+    assert "quote_price" in rows[0]["text"] and "expected observable" in rows[0]["text"]
+    # and the undeclared case names itself advisory rather than implying a rejection.
+    adapter2, rd2, base2 = _setup(tmp_path, "dash2", max_iterations=1, stall=3)
+    harness.hill_climb_loop(
+        adapter2, run_dir=rd2, optimizer=_optimizer(), current_val=base2,
+        focus="all", max_iterations=1, gate_kwargs={"mode": "significant", "k_se": 1.0},
+        algorithm="hill-climb")
+    row = [d for d in dashboard.reduce_run(rd2)["summary"]["diagnoses"]
+           if d["kind"] == "proposal_quality"][0]
+    assert "advisory" in row["text"] and "the val gate still decided" in row["text"]
+
+
+# ---- the skill reaches the optimizer for ALL THREE algorithms ------------
+
+def _assert_probe_in_workdir(workdir: Path):
+    """The skill is present, byte-identical to source, and the prompt names it."""
+    dst = workdir / "guidance" / "reasoning" / "mechanism-probe" / "SKILL.md"
+    assert dst.is_file(), f"mechanism-probe never reached {workdir}"
+    assert dst.read_bytes() == (PROBE_SRC / "SKILL.md").read_bytes(), \
+        "injected SKILL.md differs from source"
+    instr = (workdir / "INSTRUCTIONS.md").read_text(encoding="utf-8")
+    assert "guidance/reasoning/mechanism-probe/SKILL.md" in instr, \
+        "the prompt never points at the reasoning skill"
+    assert "Mechanism:" in instr and "Expected observable:" in instr
+    # the honest wording reaches the actual prompt, not just the constant
+    assert "RECORDED per candidate, not enforced" in instr
+    # and the PROCESS.md the optimizer fills carries the declaration block
+    assert "Proposal declaration" in (workdir / "PROCESS.md").read_text(encoding="utf-8")
+    return instr
+
+
+def test_hill_climb_gets_the_reasoning_skill(tmp_path):
+    """FAILS BEFORE THE FIX: skills/reasoning/ did not exist and nothing injected it."""
+    from cap_evolve import harness
+    adapter, run_dir, base = _setup(tmp_path, "hc", max_iterations=1, stall=3)
+    harness.hill_climb_loop(
+        adapter, run_dir=run_dir, optimizer=_optimizer(), current_val=base,
+        focus="all", max_iterations=1, gate_kwargs={"mode": "significant", "k_se": 1.0},
+        algorithm="hill-climb")
+    _assert_probe_in_workdir(run_dir.root / "work" / "cand_0001")
+
+
+def test_gepa_gets_the_reasoning_skill(tmp_path):
+    from cap_evolve import gepa
+    adapter, run_dir, base = _setup(tmp_path, "gp", max_iterations=1, stall=5)
+    gepa.gepa_loop(adapter, run_dir=run_dir, optimizer=_optimizer(), seed_val=base,
+                   max_iterations=1, minibatch_size=3, max_merges=0,
+                   gate_kwargs={"mode": "significant", "k_se": 1.0})
+    _assert_probe_in_workdir(run_dir.root / "work" / "gepa_0001")
+    assert _events(run_dir, "proposal_quality"), "GEPA logged no declaration"
+
+
+def test_skillopt_gets_the_reasoning_skill(tmp_path):
+    from cap_evolve import skillopt
+    adapter, run_dir, base = _setup(tmp_path, "so", max_iterations=1, stall=5)
+    skillopt.skillopt_loop(adapter, run_dir=run_dir, optimizer=_optimizer(),
+                           current_val=base, epochs=1, batch_size=4,
+                           gate_kwargs={"mode": "significant", "k_se": 1.0},
+                           slow_update=False)
+    _assert_probe_in_workdir(next((run_dir.root / "work").glob("so_e01s01")))
+
+
+# ---- the injected skill is read-context, not a capability edit ------------
+
+def test_the_reasoning_skill_is_not_mistaken_for_a_capability_edit(tmp_path):
+    """``guidance/`` is already in INJECTED_DIRS, so the new subtree must be invisible to
+    the snapshot, the eval-cache hash and GEPA's component list. If it were not, every
+    candidate would look edited and the cache would never hit."""
+    from cap_evolve.cache import hash_candidate_dir
+    from cap_evolve.gepa import _components
+    from cap_evolve.harness import _SNAPSHOT_IGNORE
+    a, b = tmp_path / "a", tmp_path / "b"
+    for d in (a, b):
+        d.mkdir()
+        (d / "prompt.txt").write_text("same\n", encoding="utf-8")
+    shutil.copytree(PROBE_SRC, b / "guidance" / "reasoning" / "mechanism-probe")
+    assert hash_candidate_dir(a) == hash_candidate_dir(b), \
+        "the injected reasoning skill perturbed the eval-cache hash"
+    assert _components(a) == _components(b), \
+        "the injected reasoning skill became an editable GEPA component"
+    assert "guidance" in _SNAPSHOT_IGNORE
+
+
+# ---- the composed prompt stays under the cap -----------------------------
+
+def test_the_composed_prompt_is_measured_and_under_the_cap(tmp_path):
+    """All four appended blocks (#219 INSIGHTS pointer, #221 diversify, #222 dead-ends,
+    #140's bar) plus the rendered template, in one real render."""
+    from cap_evolve import harness
+    from cap_evolve.optimizer_context import MAX_INSTRUCTIONS_CHARS
+    adapter, run_dir, base = _setup(tmp_path, "cap", max_iterations=1, stall=3)
+    harness.hill_climb_loop(
+        adapter, run_dir=run_dir, optimizer=_optimizer(), current_val=base,
+        focus="all", max_iterations=1, gate_kwargs={"mode": "significant", "k_se": 1.0},
+        algorithm="hill-climb")
+    instr = (run_dir.root / "work" / "cand_0001" / "INSTRUCTIONS.md").read_text(
+        encoding="utf-8")
+    assert len(instr) < MAX_INSTRUCTIONS_CHARS, (
+        f"composed prompt {len(instr)} >= cap {MAX_INSTRUCTIONS_CHARS}")
+    # #140's own contribution, measured.
+    from cap_evolve import proposal_quality
+    assert len(proposal_quality.PROMPT_BLOCK) < 2000, \
+        f"the bar is {len(proposal_quality.PROMPT_BLOCK)} chars — too big for the kept tail"
+
+
+def test_an_overflowing_prompt_keeps_the_bar_whole(tmp_path):
+    """CROSSES THE BOUND (the #219 lesson: a pinning test whose fixture never overflows
+    proves nothing). Force an overflow through the real ``_augment_instructions`` path and
+    assert #140's block survives ENTIRE — header, all three fields, and the honest
+    'not enforced' wording — rather than being cut mid-list.
+    """
+    from cap_evolve import Budget, RunDir, harness, proposal_quality
+    from cap_evolve.optimizer_context import MAX_INSTRUCTIONS_CHARS
+    run_dir = RunDir.create(tmp_path / ".capevolve", ts="ov", budget=Budget())
+    workdir = tmp_path / "wd"
+    workdir.mkdir()
+
+    huge = "x" * (MAX_INSTRUCTIONS_CHARS + 50_000)
+    out = harness._augment_instructions(huge, workdir, run_dir)
+    assert len(out) <= MAX_INSTRUCTIONS_CHARS, f"cap not applied: {len(out)}"
+    assert "chars elided to keep this prompt under" in out, "no elision notice"
+    # the whole block, not a fragment.
+    assert proposal_quality.PROMPT_BLOCK in out, \
+        "#140's bar was truncated mid-block by the overflow elision"
+
+
+def test_the_bar_is_capped_by_the_shared_cap_not_a_second_one():
+    """#222's lesson: ``_augment_instructions`` appends AFTER ``render_instructions``'
+    cap, so it must route through the ONE shared ``cap_instructions``. A second private
+    cap would let the composed prompt exceed the ceiling again."""
+    import inspect
+
+    from cap_evolve import harness
+    src = inspect.getsource(harness._augment_instructions)
+    assert "_oc.cap_instructions" in src, "the composed prompt bypasses the shared cap"
+    assert src.count("cap_instructions") == 1, \
+        f"more than one cap applied in _augment_instructions:\n{src}"
+
+
+# ---- no sealed-test leak --------------------------------------------------
+
+def test_no_test_split_id_reaches_any_injected_workdir_file(tmp_path):
+    """#199's reviewer verified test ids appear in 0 workdir files. The new injected
+    subtree + the new prompt block must preserve that."""
+    from cap_evolve import harness
+    adapter, run_dir, base = _setup(tmp_path, "leak", max_iterations=1, stall=3)
+    harness.hill_climb_loop(
+        adapter, run_dir=run_dir, optimizer=_optimizer(), current_val=base,
+        focus="all", max_iterations=1, gate_kwargs={"mode": "significant", "k_se": 1.0},
+        algorithm="hill-climb")
+    test_ids = [str(t) for t in run_dir.read_splits().test]
+    assert test_ids, "no sealed test ids to check against — the probe would be vacuous"
+    hits = []
+    for f in (run_dir.root / "work" / "cand_0001").rglob("*"):
+        if not f.is_file():
+            continue
+        try:
+            text = f.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+        hits += [(str(f.relative_to(run_dir.root)), tid)
+                 for tid in test_ids if tid in text]
+    assert hits == [], f"sealed test ids leaked into the optimizer workdir: {hits}"
+
+
+# ---- zero model calls ----------------------------------------------------
+
+def test_the_gate_makes_no_model_call():
+    """#205: every auxiliary step in core is pure Python. The declaration parser must
+    not reach for a model, an API client or the network."""
+    import inspect
+
+    from cap_evolve import proposal_quality
+    src = inspect.getsource(proposal_quality)
+    for banned in ("anthropic", "openai", "requests", "urllib.request", "http.client",
+                   "aux_model", "subprocess"):
+        assert banned not in src, f"proposal_quality reaches for {banned!r}"

--- a/core/tests/test_w1_engine.py
+++ b/core/tests/test_w1_engine.py
@@ -472,3 +472,16 @@ def test_cache_get_put_roundtrip(tmp_path):
     # persisted: a fresh instance reads it back
     c2 = EvalCache(tmp_path / "cache.json")
     assert c2.get("h", "t0")["reward"] == 0.7
+
+
+def test_no_docs_cite_a_nonexistent_cache_flag():
+    """#114: ``cache.py``'s docstring long claimed the cache was gated behind a flag
+    named ``maybe_cached_score`` — a function that exists nowhere. Docs that name
+    fictional symbols mislead readers into wiring against them, so pin the absence
+    repo-wide (a revert of the docstring fix, or a re-add elsewhere, fails here)."""
+    root = Path(__file__).resolve().parents[2]
+    me = Path(__file__).resolve()
+    hits = [str(f) for pat in ("core/**/*.py", "core/**/*.md", "skills/**/*.py", "skills/**/*.md")
+            for f in root.glob(pat)
+            if f.resolve() != me and "maybe_cached_score" in f.read_text(errors="ignore")]
+    assert hits == [], f"docs cite a nonexistent cache flag: {hits}"

--- a/dashboard/frontend/src/components/Insights.tsx
+++ b/dashboard/frontend/src/components/Insights.tsx
@@ -71,6 +71,11 @@ export function Insights({ runId, detail }: { runId: string; detail: RunDetail }
                   {d.count > 1 && <span className="tnum text-xs text-rejected">×{d.count}</span>}
                 </div>
                 <div className="text-xs text-foreground/80">{d.reason}</div>
+                {d.approaches.map((a, j) => (
+                  <div key={j} className="mt-1 break-all font-mono text-[10px] text-muted">
+                    {a}
+                  </div>
+                ))}
               </li>
             ))}
           </ul>

--- a/dashboard/frontend/src/components/MemoryPanel.tsx
+++ b/dashboard/frontend/src/components/MemoryPanel.tsx
@@ -7,8 +7,8 @@ import { pct } from '../lib/format'
 import { Card } from './ui/Card'
 import { Skeleton } from './ui/Skeleton'
 
-/** Run audit records: accepted history, rejected candidates (an audit trail — nothing
- * re-reads it to avoid re-proposing; see core/cap_evolve/memory.py), and the
+/** Run memory: accepted history, rejected candidates (also re-injected into every later
+ * optimizer prompt as "do not re-propose" constraints; see core/cap_evolve/memory.py), and the
  * per-candidate snapshot files (PROCESS.md explainability / INSTRUCTIONS.md / the
  * capability files). */
 export function MemoryPanel({ runId, graph }: { runId: string; graph: RunGraph }) {

--- a/dashboard/frontend/src/components/MemoryPanel.tsx
+++ b/dashboard/frontend/src/components/MemoryPanel.tsx
@@ -7,7 +7,8 @@ import { pct } from '../lib/format'
 import { Card } from './ui/Card'
 import { Skeleton } from './ui/Skeleton'
 
-/** Optimizer memory: accepted history, rejected ("do-not-re-propose"), and the
+/** Run audit records: accepted history, rejected candidates (an audit trail — nothing
+ * re-reads it to avoid re-proposing; see core/cap_evolve/memory.py), and the
  * per-candidate snapshot files (PROCESS.md explainability / INSTRUCTIONS.md / the
  * capability files). */
 export function MemoryPanel({ runId, graph }: { runId: string; graph: RunGraph }) {

--- a/dashboard/frontend/src/lib/insights.ts
+++ b/dashboard/frontend/src/lib/insights.ts
@@ -25,16 +25,22 @@ export interface DeadEnd {
   reason: string
   count: number
   examples: string[]
+  /** Distinct rejected-edit signatures behind this reason (#129); [] on pre-#129 runs. */
+  approaches: string[]
 }
 
-/** Rejected reasons, deduped with occurrence counts (the "what not to try" list). */
+/** Rejected reasons, deduped with occurrence counts (the "what not to try" list).
+ *  Carries the rejected-edit signatures the optimizer is constrained against (#129),
+ *  so the panel shows WHAT failed and not only why. */
 export function deadEnds(rejected: MemoryResult['rejected']): DeadEnd[] {
   const map = new Map<string, DeadEnd>()
   for (const r of rejected) {
     const key = normalizeReason(r.reason)
-    const cur = map.get(key) ?? { reason: key, count: 0, examples: [] }
+    const cur = map.get(key) ?? { reason: key, count: 0, examples: [], approaches: [] }
     cur.count += 1
     if (cur.examples.length < 3) cur.examples.push(r.candidate_id)
+    const a = (r.approach ?? '').trim()
+    if (a && cur.approaches.length < 3 && !cur.approaches.includes(a)) cur.approaches.push(a)
     map.set(key, cur)
   }
   return [...map.values()].sort((a, b) => b.count - a.count)

--- a/dashboard/frontend/src/lib/types.ts
+++ b/dashboard/frontend/src/lib/types.ts
@@ -190,6 +190,8 @@ export interface RejectedEntry {
   summary: string
   reason: string
   val: number | null
+  /** Normalized signature of the edit that failed (#129). Absent on pre-#129 runs. */
+  approach?: string
 }
 export interface MemoryResult {
   history: HistoryEntry[]

--- a/dashboard/frontend/src/test/insights.test.ts
+++ b/dashboard/frontend/src/test/insights.test.ts
@@ -38,6 +38,23 @@ describe('normalizeReason + deadEnds', () => {
     expect(out[0].count).toBe(2) // the two numeric gate rejections collapse
     expect(out[0].examples).toEqual(['a', 'b'])
   })
+
+  it('collects distinct rejected-edit signatures, deduped and capped at 3 (#129)', () => {
+    const out = deadEnds([
+      { candidate_id: 'a', summary: '', reason: 'same gate', val: 0, approach: 'prompt.txt: +A' },
+      { candidate_id: 'b', summary: '', reason: 'same gate', val: 0, approach: 'prompt.txt: +A' },
+      { candidate_id: 'c', summary: '', reason: 'same gate', val: 0, approach: 'prompt.txt: +B' },
+      { candidate_id: 'd', summary: '', reason: 'same gate', val: 0, approach: 'prompt.txt: +C' },
+      { candidate_id: 'e', summary: '', reason: 'same gate', val: 0, approach: 'prompt.txt: +D' },
+    ])
+    expect(out[0].count).toBe(5)
+    expect(out[0].approaches).toEqual(['prompt.txt: +A', 'prompt.txt: +B', 'prompt.txt: +C'])
+  })
+
+  it('leaves approaches empty on pre-#129 records with no approach field', () => {
+    const out = deadEnds([{ candidate_id: 'a', summary: '', reason: 'old record', val: 0 }])
+    expect(out[0].approaches).toEqual([])
+  })
 })
 
 describe('toolUsage', () => {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -47,6 +47,17 @@ identical context. Add an artifact or a prompt block there and all three inherit
   them. Each carries a "What you can change here" menu and edit boundaries.
 - **The diagnose method** (`./guidance/diagnose/`) — how to cluster failures into a
   reflective dataset (per failing task: Inputs, Generated Outputs, Feedback).
+- **On-demand reasoning skills** (`./guidance/reasoning/<skill>/`, also placed natively) —
+  tiny skills loaded at ONE step to counter ONE named optimizer failure mode. Today:
+  `mechanism-probe` at the proposal step (skipping analysis and shipping a plausible
+  one-line knob tweak). It asks for a three-field **proposal declaration** — mechanism,
+  hypothesis, expected observable — in `PROCESS.md`, which the harness records per
+  candidate as a `proposal_quality` event. **Advisory: the declaration is recorded, never
+  enforced** — no missing or knob-shaped declaration rejects a candidate; the val
+  significance gate remains the only thing that accepts or rejects. "Mechanism or knob?"
+  is a judgement no heuristic can make, and a false rejection would discard a real
+  improvement invisibly, so the bar lives in the prompt and the hard decision stays on
+  val (the same split #129 settled on).
 - **Only the current best step's full trajectories** (`./trajectories/`) — the runner's
   verbatim traces of the candidate it builds on, never the seed + every rejected attempt.
 - **Supporting sources / data model** (`./guidance/sources/`) — the `capability_sources`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -36,7 +36,11 @@ See [`HONEST_EVAL.md`](HONEST_EVAL.md) for the splitting / gating / sealing guar
 ## What the optimizer receives each iteration
 
 The harness assembles a **capability-scoped** working dir per iteration, then runs your
-chosen coding-agent CLI in it:
+chosen coding-agent CLI in it. This is assembled by **one shared seam**,
+[`core/cap_evolve/optimizer_context.py`](../core/cap_evolve/optimizer_context.py)
+(`inject()` = the files, `render_instructions()` = the prompt), and **every deterministic
+algorithm — `hill-climb`, `gepa`, `skillopt` — routes through it**, so all three get the
+identical context. Add an artifact or a prompt block there and all three inherit it:
 
 - **The selected capability skill(s)** — both as `./guidance/<cap>/` *and* placed natively
   in the agent's own skills dir (e.g. `.claude/skills/`) so a headless agent auto-loads
@@ -59,6 +63,11 @@ chosen coding-agent CLI in it:
 | `JOURNAL.md` | optimizer | append-only HANDOVER across the run (tried / worked / regressed / refuted / focus-next) |
 | `PROCESS.md` | optimizer | EXPLAINABILITY, snapshotted per candidate |
 | `RUNMAP.md` + `prior_iterations/` | framework | a manifest plus every prior iteration's PROCESS.md and capability diff, for real prior-work access |
+
+These are built from the run's iteration events. The recognised kinds live in ONE place —
+`rundir.ITERATION_EVENT_KINDS` (`step`, `skillopt_step`, `gepa_val_gate`), read via
+`RunDir.iteration_events()` — because algorithms that emit their own kind (GEPA bypasses
+`run_step`) would otherwise be invisible to these builders and get an empty history.
 
 Because it sees all failure clusters, the protect-set, and the prior causal impact at once,
 the optimizer produces **one bold, multi-part candidate per iteration that addresses every

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -36,7 +36,8 @@ effort; ❌ = not a goal.
 - **Onboard from a single prompt** — one intake brief installs the benchmark, wires the
   adapter, and passes `cap-evolve check` before any budget is spent.
 - **Git-versioned iterations + memory** — every candidate is a commit; rejected approaches
-  are remembered and never re-proposed.
+  are re-injected into every later proposal prompt as explicit "do not re-propose"
+  constraints (advisory at the prompt, hard at the val gate). See [`RUN.md`](../RUN.md).
 - **Live cost-aware dashboard** — per-iteration optimizer & runner cost + time, lineage,
   diffs, and a tasks × iterations heatmap.
 - **Zero runtime dependencies** — the core is pure Python stdlib.

--- a/skills/_registry/build_manifest.py
+++ b/skills/_registry/build_manifest.py
@@ -22,7 +22,11 @@ from pathlib import Path
 # Components are SINGULAR (matching what meta.yaml actually carries); the old list
 # had plurals that matched nothing, so validation was dead. The directory layout
 # uses the plural (skills/<plural>/<skill>/) but the meta `component` is singular.
-COMPONENTS = {"phase", "capability", "algorithm", "optimizer", "orchestrate"}
+# "reasoning" (#140) is an ON-DEMAND component: unlike a phase it is never sequenced by
+# the orchestrate DAG — it is loaded at ONE step (the proposal step) to counter ONE named
+# optimizer failure mode, and reaches the optimizer as injected read-context rather than
+# as a subprocess. It still registers and validates like every other skill.
+COMPONENTS = {"phase", "capability", "algorithm", "optimizer", "orchestrate", "reasoning"}
 
 # The needs/provides token vocabulary. Every needs/provides entry must be one of
 # these; a misspelling ("score" for "scores") fails the build instead of silently

--- a/skills/_registry/manifest.json
+++ b/skills/_registry/manifest.json
@@ -514,6 +514,31 @@
           "*"
         ]
       }
+    },
+    "mechanism-probe": {
+      "component": "reasoning",
+      "path": "reasoning/mechanism-probe",
+      "summary": "On-demand reasoning skill loaded at the proposal step \u2014 forces the optimizer to name the mechanism (not a knob), its hypothesis and its expected observable before editing. Advisory: the declaration is recorded per candidate, never enforced.",
+      "entry": "scripts/run.py",
+      "abstract": null,
+      "check": "scripts/check.py",
+      "prompt": null,
+      "inputs": null,
+      "needs": [
+        "traces"
+      ],
+      "provides": [],
+      "compatible_with": {
+        "capabilities": [
+          "*"
+        ],
+        "optimizers": [
+          "*"
+        ],
+        "algorithms": [
+          "*"
+        ]
+      }
     }
   },
   "errors": []

--- a/skills/algorithms/gepa/SKILL.md
+++ b/skills/algorithms/gepa/SKILL.md
@@ -105,6 +105,23 @@ test stays sealed for `finalize`.
 ## Agent-mode loop
 When `orchestration_mode: agent`, drive gepa yourself: maintain the candidate pool/Pareto frontier; each round pick a parent (per gepa's selection), reflect on its val feedback to propose an edit, evaluate on **val** via cap-evolve, gate Δ>k·SE, accept→snapshot & add to the frontier / reject→drop. Metric-calls is the primary budget. Log rounds to the run dir; between rounds verify rollouts+results landed so the dashboard reflects the frontier. Re-read `stop_condition`; stop on it/budget. Seal once with `cap-evolve finalize`, then `report`.
 
+
+## What the optimizer receives each iteration
+
+Identical for all three deterministic algorithms — one shared seam,
+`core/cap_evolve/optimizer_context.py` (`inject()` writes the files, `render_instructions()`
+renders the prompt): the per-iteration `INSTRUCTIONS.md` rendered from the intake-authored
+template (`--instructions-file`) with the capability brief (`--capabilities`), the failure
+index, the bench-repo pointer (`--bench-repo`), the parallel-fan-out note and the
+consuming-LLM reader block (`--target-model` / `--target-profile-file`); plus
+`./trajectories/`, `./guidance/<cap>/`, `./guidance/diagnose/`, `./guidance/sources/`
+(`--capability-sources`), `./guidance/optimizer/<name>.md` (`--optimizer-name`), the
+native per-agent skills dir, and the cross-iteration
+`LEDGER.md` / `JOURNAL.md` / `RUNMAP.md` + `prior_iterations/`. `cap-evolve run` passes
+every one of those flags to this algorithm — see `docs/ARCHITECTURE.md`.
+
+This algorithm adds its own tail block on top (`REFLECTION.md` + `FOCUS.md` pointers).
+
 ## References
 
 - `references/concepts.md` — the GEPA economy, reflective dataset / actionable side

--- a/skills/algorithms/gepa/scripts/run.py
+++ b/skills/algorithms/gepa/scripts/run.py
@@ -20,6 +20,7 @@ import _bootstrap  # noqa: F401
 from cap_evolve import RunDir, gepa, harness
 from cap_evolve.check import load_adapter
 from cap_evolve.loop import SplitResult
+from cap_evolve.optimizer_context import OptimizerContext
 from cap_evolve.store import make_store
 
 ALGO = "gepa"
@@ -54,9 +55,12 @@ def main(argv=None) -> int:
     p.add_argument("--resume", action="store_true",
                    help="reconstruct the pool/frontier from the run dir and continue the "
                         "search instead of restarting from the seed")
+    OptimizerContext.add_arguments(p)
     args = p.parse_args(argv)
 
     run_dir = RunDir.open(Path(args.run_dir))
+    ctx = OptimizerContext.from_args(args)
+    ctx.log_profile(run_dir)   # consuming-LLM profile -> report + dashboard
     store = make_store({"store": args.store, "store_commit_cmd": args.store_commit_cmd}, run_dir.root)
     adapter = load_adapter(Path(args.project))
     optimizer = harness.optimizer_from_command(shlex.split(args.optimizer))
@@ -73,7 +77,7 @@ def main(argv=None) -> int:
         gate_kwargs=({"k_se": args.k_se} if args.gate_mode == "auto"
                      else {"mode": args.gate_mode, "k_se": args.k_se}),
         no_regression=args.no_regression, seed=args.seed, store=store,
-        resume=args.resume,
+        resume=args.resume, ctx=ctx,
     )
     print(json.dumps(result, indent=2))
     return 0

--- a/skills/algorithms/hill-climb/SKILL.md
+++ b/skills/algorithms/hill-climb/SKILL.md
@@ -52,5 +52,20 @@ Back-compat: `--focus all-at-once` is accepted and treated as `all`.
 ## Agent-mode loop
 When `orchestration_mode: agent`, drive hill-climb yourself: from the baseline best, each iteration — propose ONE edit to the capability (per `--focus`: all / cyclic / hardest-first), evaluate the candidate on **val** via cap-evolve (writes rollouts+results), gate Δ>k·SE, accept→snapshot via the store / reject→revert. Log each iteration to the run dir's event log. Re-read `stop_condition`; stop on it or on stall/budget. Between iterations, confirm the run dir got this iteration's rollouts + event so the dashboard stays current. Seal once with `cap-evolve finalize`, then `report`.
 
+
+## What the optimizer receives each iteration
+
+Identical for all three deterministic algorithms — one shared seam,
+`core/cap_evolve/optimizer_context.py` (`inject()` writes the files, `render_instructions()`
+renders the prompt): the per-iteration `INSTRUCTIONS.md` rendered from the intake-authored
+template (`--instructions-file`) with the capability brief (`--capabilities`), the failure
+index, the bench-repo pointer (`--bench-repo`), the parallel-fan-out note and the
+consuming-LLM reader block (`--target-model` / `--target-profile-file`); plus
+`./trajectories/`, `./guidance/<cap>/`, `./guidance/diagnose/`, `./guidance/sources/`
+(`--capability-sources`), `./guidance/optimizer/<name>.md` (`--optimizer-name`), the
+native per-agent skills dir, and the cross-iteration
+`LEDGER.md` / `JOURNAL.md` / `RUNMAP.md` + `prior_iterations/`. `cap-evolve run` passes
+every one of those flags to this algorithm — see `docs/ARCHITECTURE.md`.
+
 ## References
 - `references/focus-schedules.md` — how each schedule builds its focus set.

--- a/skills/algorithms/hill-climb/scripts/run.py
+++ b/skills/algorithms/hill-climb/scripts/run.py
@@ -27,6 +27,7 @@ from cap_evolve import RunDir, harness
 from cap_evolve.store import make_store
 from cap_evolve.check import load_adapter
 from cap_evolve.loop import SplitResult
+from cap_evolve.optimizer_context import OptimizerContext
 
 FOCUS_CHOICES = ("all", "cyclic", "hardest-first")
 ALGO = "hill-climb"
@@ -54,27 +55,7 @@ def main(argv=None) -> int:
     p.add_argument("--resume", action="store_true",
                    help="continue from the run's current best candidate (read its val "
                         "from rollouts) instead of baseline")
-    p.add_argument("--capabilities", default="",
-                   help="comma-separated capability skills under optimization (e.g. "
-                        "'system-prompt,tools'); surfaced to the optimizer so it knows "
-                        "the allowed edit space")
-    p.add_argument("--instructions-file", default=None,
-                   help="optimizer-instructions template (intake-authored) to render the "
-                        "per-iteration prompt from; defaults to the shipped template")
-    p.add_argument("--bench-repo", default=None,
-                   help="path to the benchmark/runner source, surfaced to the optimizer "
-                        "as read-only context")
-    p.add_argument("--optimizer-name", default=None,
-                   help="resolved optimizer name (registry row); used to copy that "
-                        "optimizer's features reference into the optimizer workdir")
-    p.add_argument("--capability-sources", default="",
-                   help="comma-separated supporting source files (data models / types "
-                        "the tools import) copied verbatim into the optimizer's "
-                        "./guidance/sources/; resolved relative to --project")
-    p.add_argument("--target-model", default="",
-                   help="consuming/runtime model id or tier keyword (frontier|strong|mid|weak)")
-    p.add_argument("--target-profile-file", default=None,
-                   help="optional project-local brief overriding the tier's built-in brief")
+    OptimizerContext.add_arguments(p)
     args = p.parse_args(argv)
 
     focus = _LEGACY_FOCUS.get(args.focus, args.focus)
@@ -83,13 +64,8 @@ def main(argv=None) -> int:
         return 2
 
     run_dir = RunDir.open(Path(args.run_dir))
-    # Record the resolved consuming-LLM profile so report + dashboard can surface it.
-    from cap_evolve import target_profile as _tp
-    _prof = _tp.resolve(args.target_model, args.target_profile_file, project_dir=args.project)
-    if not _prof.is_agnostic:
-        run_dir.log_event("target_profile", model=_prof.model, tier=_prof.tier,
-                          suggested_num_trials=_prof.suggested_num_trials,
-                          resolution_note=_prof.resolution_note)
+    ctx = OptimizerContext.from_args(args)
+    ctx.log_profile(run_dir)   # consuming-LLM profile -> report + dashboard
     store = make_store({"store": args.store, "store_commit_cmd": args.store_commit_cmd}, run_dir.root)
     adapter = load_adapter(Path(args.project))
     optimizer = harness.optimizer_from_command(shlex.split(args.optimizer))
@@ -105,13 +81,7 @@ def main(argv=None) -> int:
         gate_kwargs=({"k_se": args.k_se} if args.gate_mode == "auto"
                      else {"mode": args.gate_mode, "k_se": args.k_se}),
         algorithm=f"{ALGO}:{focus}", no_regression=args.no_regression, store=store,
-        capabilities=[c.strip() for c in args.capabilities.split(",") if c.strip()],
-        instructions_file=args.instructions_file, bench_repo=args.bench_repo,
-        optimizer_name=args.optimizer_name,
-        capability_sources=[s.strip() for s in args.capability_sources.split(",") if s.strip()],
-        project_dir=Path(args.project),
-        target_model=args.target_model,
-        target_profile_file=args.target_profile_file,
+        ctx=ctx,
     )
     print(json.dumps(result, indent=2))
     return 0

--- a/skills/algorithms/skillopt/SKILL.md
+++ b/skills/algorithms/skillopt/SKILL.md
@@ -82,6 +82,23 @@ budget (toggle with `--no-slow-update`).
 ## Agent-mode loop
 When `orchestration_mode: agent`, drive skillopt yourself: single-lineage climb with a textual learning rate over epochs/minibatches — each step propose an edit sized to the current LR, evaluate on **val** (minibatch then full as skillopt prescribes) via cap-evolve, gate Δ>k·SE, accept→snapshot / reject→revert & decay. Log steps to the run dir; between steps verify rollouts+results landed for the dashboard. Re-read `stop_condition`; stop on it/stall/budget. Seal once with `cap-evolve finalize`, then `report`.
 
+
+## What the optimizer receives each iteration
+
+Identical for all three deterministic algorithms — one shared seam,
+`core/cap_evolve/optimizer_context.py` (`inject()` writes the files, `render_instructions()`
+renders the prompt): the per-iteration `INSTRUCTIONS.md` rendered from the intake-authored
+template (`--instructions-file`) with the capability brief (`--capabilities`), the failure
+index, the bench-repo pointer (`--bench-repo`), the parallel-fan-out note and the
+consuming-LLM reader block (`--target-model` / `--target-profile-file`); plus
+`./trajectories/`, `./guidance/<cap>/`, `./guidance/diagnose/`, `./guidance/sources/`
+(`--capability-sources`), `./guidance/optimizer/<name>.md` (`--optimizer-name`), the
+native per-agent skills dir, and the cross-iteration
+`LEDGER.md` / `JOURNAL.md` / `RUNMAP.md` + `prior_iterations/`. `cap-evolve run` passes
+every one of those flags to this algorithm — see `docs/ARCHITECTURE.md`.
+
+This algorithm adds its own tail block on top (the L edit budget + the rejected/failure-pattern buffer).
+
 ## References
 - `references/concepts.md` — the SkillOpt loop in detail, the textual-LR schedule,
   the buffer/slow-update mechanics, and citations (arXiv:2605.23904).

--- a/skills/algorithms/skillopt/SKILL.md
+++ b/skills/algorithms/skillopt/SKILL.md
@@ -25,8 +25,9 @@ hill-climb) but adds three things from the DL analogy:
   without breaking stable successes.
 
 Every step calls the shared `run_step` (materialize → optimize → eval-VAL →
-significance gate → accept/reject → snapshot/best, and writes the dashboard's
-`rejected.jsonl`/`history.jsonl` audit records — write-only, they never reach a prompt);
+significance gate → accept/reject → snapshot/best, and writes
+`rejected.jsonl`/`history.jsonl` — the dashboard's audit trail AND the source of the
+run-wide "already tried & rejected" constraint block in every later prompt);
 this skill only owns the schedule, the buffer, and the slow update. Gated on val;
 test stays sealed (that's `finalize`).
 

--- a/skills/algorithms/skillopt/SKILL.md
+++ b/skills/algorithms/skillopt/SKILL.md
@@ -25,7 +25,8 @@ hill-climb) but adds three things from the DL analogy:
   without breaking stable successes.
 
 Every step calls the shared `run_step` (materialize → optimize → eval-VAL →
-significance gate → accept/reject → snapshot/best, with RejectedMemory/History);
+significance gate → accept/reject → snapshot/best, and writes the dashboard's
+`rejected.jsonl`/`history.jsonl` audit records — write-only, they never reach a prompt);
 this skill only owns the schedule, the buffer, and the slow update. Gated on val;
 test stays sealed (that's `finalize`).
 

--- a/skills/algorithms/skillopt/references/concepts.md
+++ b/skills/algorithms/skillopt/references/concepts.md
@@ -35,9 +35,11 @@ without gepa's frontier bookkeeping.
    avoid this epoch, the unsolved failure patterns). Parent is **always the
    current best** (single lineage). Call `harness.run_step(...)` — it materializes
    the parent, runs the optimizer, evaluates on VAL, applies the significance
-   gate, snapshots + sets best on accept, and writes the dashboard's
-   `rejected.jsonl`/`history.jsonl` audit records (write-only; the only reject signal
-   that reaches the prompt is SkillOpt's own within-epoch buffer, below).
+   gate, snapshots + sets best on accept, and writes
+   `rejected.jsonl`/`history.jsonl`. Two reject signals reach the prompt: the run-wide
+   "already tried & rejected" constraint block `run_step` builds from `rejected.jsonl`
+   (deduped edit signature + gate reason, whole run), and SkillOpt's own within-epoch
+   buffer below (candidate ids + val deltas, reset each epoch).
 4. Append a bounded record to `step_buffer`
    (`{step, epoch, accepted, n_fail, failure_patterns, rejected id + val Δ}`),
    capped (≤ 3 task ids per pattern, ≤ ~10 patterns, ≤ 12 steps) and **reset each

--- a/skills/algorithms/skillopt/references/concepts.md
+++ b/skills/algorithms/skillopt/references/concepts.md
@@ -35,7 +35,9 @@ without gepa's frontier bookkeeping.
    avoid this epoch, the unsolved failure patterns). Parent is **always the
    current best** (single lineage). Call `harness.run_step(...)` — it materializes
    the parent, runs the optimizer, evaluates on VAL, applies the significance
-   gate, snapshots + sets best on accept, and writes RejectedMemory/History.
+   gate, snapshots + sets best on accept, and writes the dashboard's
+   `rejected.jsonl`/`history.jsonl` audit records (write-only; the only reject signal
+   that reaches the prompt is SkillOpt's own within-epoch buffer, below).
 4. Append a bounded record to `step_buffer`
    (`{step, epoch, accepted, n_fail, failure_patterns, rejected id + val Δ}`),
    capped (≤ 3 task ids per pattern, ≤ ~10 patterns, ≤ 12 steps) and **reset each
@@ -62,8 +64,9 @@ best-effort file-diff count) to surface an optimizer that ignores its budget.
 Two per-epoch, bounded structures injected into the next step's prompt:
 
 - **rejected-edit buffer** — every rejected candidate's id + val Δ, so the
-  optimizer does not re-propose a dead end *this epoch* (the global RejectedMemory
-  in `run_step` still records all rejects across the run).
+  optimizer does not re-propose a dead end *this epoch*. This buffer is the only
+  reject signal that reaches the prompt; `run_step`'s `rejected.jsonl` is an audit
+  record for the dashboard, not prompt input.
 - **failure-pattern block** — the focus tasks' failing feedback clustered by a
   normalized prefix signature (infra-errored tasks excluded via the structured
   `raw.errored` flag), so the prompt carries *patterns* not raw prose.

--- a/skills/algorithms/skillopt/references/concepts.md
+++ b/skills/algorithms/skillopt/references/concepts.md
@@ -62,8 +62,9 @@ best-effort file-diff count) to surface an optimizer that ignores its budget.
 Two per-epoch, bounded structures injected into the next step's prompt:
 
 - **rejected-edit buffer** — every rejected candidate's id + val Δ, so the
-  optimizer does not re-propose a dead end *this epoch* (the global RejectedMemory
-  in `run_step` still records all rejects across the run).
+  optimizer does not re-propose a dead end *this epoch*. This buffer is the only
+  reject signal that reaches the prompt; `run_step`'s `rejected.jsonl` is an audit
+  record for the dashboard, not prompt input.
 - **failure-pattern block** — the focus tasks' failing feedback clustered by a
   normalized prefix signature (infra-errored tasks excluded via the structured
   `raw.errored` flag), so the prompt carries *patterns* not raw prose.

--- a/skills/algorithms/skillopt/references/concepts.md
+++ b/skills/algorithms/skillopt/references/concepts.md
@@ -35,7 +35,9 @@ without gepa's frontier bookkeeping.
    avoid this epoch, the unsolved failure patterns). Parent is **always the
    current best** (single lineage). Call `harness.run_step(...)` — it materializes
    the parent, runs the optimizer, evaluates on VAL, applies the significance
-   gate, snapshots + sets best on accept, and writes RejectedMemory/History.
+   gate, snapshots + sets best on accept, and writes the dashboard's
+   `rejected.jsonl`/`history.jsonl` audit records (write-only; the only reject signal
+   that reaches the prompt is SkillOpt's own within-epoch buffer, below).
 4. Append a bounded record to `step_buffer`
    (`{step, epoch, accepted, n_fail, failure_patterns, rejected id + val Δ}`),
    capped (≤ 3 task ids per pattern, ≤ ~10 patterns, ≤ 12 steps) and **reset each

--- a/skills/algorithms/skillopt/scripts/run.py
+++ b/skills/algorithms/skillopt/scripts/run.py
@@ -24,6 +24,7 @@ import _bootstrap  # noqa: F401
 from cap_evolve import RunDir, harness, skillopt
 from cap_evolve.check import load_adapter
 from cap_evolve.loop import SplitResult
+from cap_evolve.optimizer_context import OptimizerContext
 from cap_evolve.store import make_store
 
 ALGO = "skillopt"
@@ -69,9 +70,12 @@ def main(argv=None) -> int:
     p.add_argument("--store-commit-cmd", default=None)
     p.add_argument("--resume", action="store_true",
                    help="continue from the run's current best instead of baseline")
+    OptimizerContext.add_arguments(p)
     args = p.parse_args(argv)
 
     run_dir = RunDir.open(Path(args.run_dir))
+    ctx = OptimizerContext.from_args(args)
+    ctx.log_profile(run_dir)   # consuming-LLM profile -> report + dashboard
     store = make_store({"store": args.store, "store_commit_cmd": args.store_commit_cmd}, run_dir.root)
     adapter = load_adapter(Path(args.project))
     optimizer = harness.optimizer_from_command(shlex.split(args.optimizer))
@@ -90,6 +94,7 @@ def main(argv=None) -> int:
                      else {"mode": args.gate_mode, "k_se": args.k_se}),
         no_regression=args.no_regression, slow_update=args.slow_update,
         slow_update_sample=args.slow_update_sample, algorithm=ALGO, store=store,
+        ctx=ctx,
     )
     print(json.dumps(result, indent=2))
     return 0

--- a/skills/reasoning/mechanism-probe/SKILL.md
+++ b/skills/reasoning/mechanism-probe/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: mechanism-probe
+description: Force a proposal to name its mechanism before it is written. Use when you are at the ideation step of an optimization iteration — after diagnosing failure clusters, before editing any file. Counters the failure mode where the optimizer skips analysis and ships a plausible one-line knob tweak — restating a rule the agent already ignores, retuning a threshold, or rewording a docstring — instead of changing what the system can structurally do. Produces the three-field proposal declaration (mechanism, hypothesis, expected observable) that cap-evolve records per candidate.
+component: reasoning
+argument-hint: "[--process PROCESS.md]"
+allowed-tools: Read, Bash
+sources: [arbor]
+---
+
+# mechanism-probe — declare the mechanism before you edit
+
+**The failure mode this counters.** An optimization iteration is expensive: one
+proposal, one full-val evaluation, one accept/reject. The recurring waste is not a bad
+idea — it is a *skipped step*. The optimizer reads a few traces, recognizes a familiar
+shape, and ships the first plausible edit: another prose rule, a retuned number, a
+reworded docstring. It scores net-zero, the gate rejects it, and the iteration is gone.
+Prior runs in this repo lost iterations exactly this way (see any run's `LEDGER.md`).
+
+The probe is one question asked *before* the edit exists, when it is still cheap to
+throw away:
+
+> **Could this whole proposal be replaced by changing one existing value or restating one
+> existing rule? If yes, it is a knob. Find the mechanism instead.**
+
+## Knob vs mechanism
+
+A **knob** leaves the system's behaviour space unchanged. It adjusts a dial the agent
+already has, or repeats an instruction it already had and already skipped:
+
+- another prose rule for a rule the traces show the agent *knows* and *skips*
+- a retuned threshold, temperature, retry count, or budget
+- a reworded tool description or docstring, same semantics
+- a longer preamble telling the agent to be more careful
+
+A **mechanism** changes what is structurally possible or impossible:
+
+- an in-body guard or validation in the tool the rule governs, raising an actionable
+  error on exactly the violating condition — the rule can no longer be skipped
+- a computation moved out of the agent's head and into code (a total, a date, a unit
+  conversion it kept getting wrong)
+- a new or composite tool that performs a whole action atomically, so a multi-step
+  sequence the agent kept getting out of order becomes one call
+- a **narrowed decision rule**: replacing "usually do X" with the discriminating
+  condition the traces reveal, so the agent stops guessing
+- removing a tool or option that the traces show is mis-selected
+
+The test is not size. A one-line in-body guard is a mechanism; a fifty-line prompt
+section restating known rules is a knob.
+
+## The three-field declaration
+
+Write these into `./PROCESS.md` under **Proposal declaration** before you edit. Each has
+a job; the middle one is where knobs get caught.
+
+| field | the question it answers | fails when |
+| --- | --- | --- |
+| `Mechanism:` | What now behaves differently, and why does that change the outcome? | the answer is "the prompt now says X" for an X it already said |
+| `Hypothesis:` | Which failure cluster does this fix, and why does it generalize past the exact failing inputs? | it only explains the specific inputs you read |
+| `Expected observable:` | What will be different in the NEXT iteration's trajectories if this is right? | you cannot name anything a reader could check |
+
+The observable field is the honest one. If you cannot state what would look different —
+which tool call now appears, which error no longer does, which computed value is now
+right — you do not have a hypothesis, you have a hope, and there is nothing to learn
+from the result either way.
+
+## Worked example
+
+Traces show four tasks failing because the agent answered a total from memory instead of
+calling the pricing tool, each off by the tax line.
+
+**Knob version** — prompt gains "ALWAYS call `get_total` before quoting a price." The
+agent already had "call `get_total` to compute totals" and skipped it four times; a
+louder restatement of a skipped rule changes nothing. Mechanism field would read "the
+prompt now says it more forcefully", which is the tell.
+
+**Mechanism version** — `quote_price` gains an in-body check: if the caller passes a
+total that does not match `get_total`'s result for those line items, it raises
+`"total mismatch: expected {computed}, got {given} — call get_total first"`. The
+behaviour is no longer optional.
+
+- `Mechanism:` `quote_price` now recomputes the total in-body and refuses a mismatched
+  one with an actionable error, so answering from memory becomes impossible rather than
+  discouraged.
+- `Hypothesis:` the four tax-line failures share one root cause — the total is derived
+  by the agent instead of by code. Any task whose total includes a line the agent must
+  remember hits the same path, so the fix generalizes beyond these four.
+- `Expected observable:` next iteration's trajectories show a `get_total` call preceding
+  every `quote_price` on these tasks, and no "expected N got M" scoring feedback on the
+  tax line.
+
+Blast radius: the guard fires only on the mismatch condition, so passing tasks (which
+already agreed with `get_total`) take an unchanged path.
+
+## How this is judged — advisory, not enforcing
+
+cap-evolve **records** your declaration as a `proposal_quality` event alongside the
+candidate. It does **not** reject on it. A missing declaration does not reject your
+edit, and a beautifully-worded one does not get it accepted — the val significance gate
+remains the only thing that accepts or rejects a candidate.
+
+That split is deliberate. "Is this a mechanism or a knob?" is a judgement no regex can
+make: a heuristic strict enough to reject knobs would also reject real one-line
+mechanism fixes, and a false rejection throws away a genuine improvement *invisibly* —
+nobody sees the gain that never happened. So the bar lives here, in the prompt, where it
+shapes the proposal, and the hard decision stays where it can be made honestly: on the
+val split, against the noise bar.
+
+Declare it anyway. The declaration is the cheapest part of the iteration and the part
+that makes the expensive part legible: whether the candidate is accepted or rejected,
+the next iteration reads what you predicted and whether it happened.
+
+## Checking your own declaration
+
+```bash
+python skills/reasoning/mechanism-probe/scripts/run.py --process ./PROCESS.md
+```
+
+Prints which of the three fields are present and which are still empty or placeholders.
+Presence is all it can check — it cannot tell a mechanism from a knob, which is exactly
+why the gate is advisory.

--- a/skills/reasoning/mechanism-probe/SKILL.md
+++ b/skills/reasoning/mechanism-probe/SKILL.md
@@ -14,7 +14,11 @@ proposal, one full-val evaluation, one accept/reject. The recurring waste is not
 idea — it is a *skipped step*. The optimizer reads a few traces, recognizes a familiar
 shape, and ships the first plausible edit: another prose rule, a retuned number, a
 reworded docstring. It scores net-zero, the gate rejects it, and the iteration is gone.
-Prior runs in this repo lost iterations exactly this way (see any run's `LEDGER.md`).
+
+**This is an unvalidated hypothesis, stated as one:** we believe an edit whose mechanism
+cannot be stated is the edit that wastes the iteration, but nothing in this repo has
+measured knob-shaped versus mechanism-shaped edit outcomes — the `proposal_quality` event
+this skill produces is the instrument that would test it, and it currently has zero rows.
 
 The probe is one question asked *before* the edit exists, when it is still cheap to
 throw away:
@@ -111,10 +115,7 @@ the next iteration reads what you predicted and whether it happened.
 
 ## Checking your own declaration
 
-```bash
-python skills/reasoning/mechanism-probe/scripts/run.py --process ./PROCESS.md
-```
-
-Prints which of the three fields are present and which are still empty or placeholders.
-Presence is all it can check — it cannot tell a mechanism from a knob, which is exactly
-why the gate is advisory.
+Re-read the three fields before you edit anything: is each one filled, and is the
+`Mechanism:` line something other than "the prompt now says X"? Presence is all any
+checker could verify anyway — nothing can tell a mechanism from a knob mechanically,
+which is exactly why the gate is advisory.

--- a/skills/reasoning/mechanism-probe/meta.yaml
+++ b/skills/reasoning/mechanism-probe/meta.yaml
@@ -1,0 +1,11 @@
+component: reasoning
+name: mechanism-probe
+summary: On-demand reasoning skill loaded at the proposal step — forces the optimizer to name the mechanism (not a knob), its hypothesis and its expected observable before editing. Advisory: the declaration is recorded per candidate, never enforced.
+entry: scripts/run.py
+check: scripts/check.py
+needs: [traces]
+provides: []
+compatible_with:
+  capabilities: ["*"]
+  optimizers: ["*"]
+  algorithms: ["*"]

--- a/skills/reasoning/mechanism-probe/scripts/_bootstrap.py
+++ b/skills/reasoning/mechanism-probe/scripts/_bootstrap.py
@@ -1,0 +1,44 @@
+"""Thin shim: locate cap_evolve, then defer to cap_evolve._bootstrap.
+
+Skill scripts ``import _bootstrap`` first. The real path-resolution logic lives
+ONCE in ``cap_evolve._bootstrap`` (so it can't drift across skills); this shim
+only has to find that package, which means a minimal upward walk for ``core/`` —
+the single bit of bootstrapping that genuinely must run before cap_evolve is
+importable. Everything else delegates.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+
+def _seed_path() -> None:
+    """Minimal: put a dir containing the cap_evolve package on sys.path."""
+    try:
+        import cap_evolve  # noqa: F401
+        return
+    except Exception:
+        pass
+    cands = []
+    env = os.environ.get("CAPEVOLVE_CORE")
+    if env:
+        cands.append(Path(env))
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        cands.append(parent / "core")
+        cands.append(parent)
+    for c in cands:
+        if (c / "cap_evolve" / "__init__.py").exists():
+            p = str(c)
+            if p not in sys.path:
+                sys.path.insert(0, p)
+            return
+
+
+_seed_path()
+from cap_evolve._bootstrap import ensure_core  # noqa: E402
+
+# Anchor the upward walk at THIS skill script's location (not the core module's).
+ensure_core(Path(__file__).resolve())

--- a/skills/reasoning/mechanism-probe/scripts/check.py
+++ b/skills/reasoning/mechanism-probe/scripts/check.py
@@ -1,0 +1,92 @@
+"""Contract: the probe reports presence of the three declared fields, and NEVER rejects.
+
+The behavioral bar, in three parts:
+  1. a filled declaration parses all three fields;
+  2. the seed's ``<...>`` placeholders count as MISSING (otherwise the check would pass
+     vacuously on an untouched PROCESS.md);
+  3. a genuine mechanism-style declaration is NOT rejected — there is no reject path at
+     all. This is the false-rejection probe: the gate is advisory by construction.
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+import _bootstrap  # noqa: F401
+
+from cap_evolve import proposal_quality
+from cap_evolve.skillcheck import Checker, import_run
+
+
+class StubRunDir:
+    """Minimal log_event sink — the check asserts on the event, not on a real run dir."""
+
+    def __init__(self):
+        self.logged: list[dict] = []
+
+    def log_event(self, kind: str, **fields) -> None:
+        self.logged.append({"kind": kind, **fields})
+
+
+def main() -> int:
+    c = Checker("mechanism-probe")
+    run = import_run()
+    c.require_main(run)
+
+    with tempfile.TemporaryDirectory() as d:
+        wd = Path(d)
+
+        # 1. a real declaration parses all three fields.
+        (wd / "PROCESS.md").write_text(
+            "# PROCESS\n\n## Proposal declaration\n"
+            "- Mechanism: quote_price recomputes the total in-body and refuses a "
+            "mismatch with an actionable error.\n"
+            "- Hypothesis: the four tax-line failures share one root cause — the total "
+            "is derived by the agent, not by code.\n"
+            "- Expected observable: get_total precedes every quote_price call and the "
+            "'expected N got M' feedback disappears.\n", encoding="utf-8")
+        q = proposal_quality.parse(wd)
+        c.check(q["declared"] and not q["missing"],
+                f"a filled declaration did not parse as declared: {q}",
+                note="all three declared fields parse from PROCESS.md")
+        c.check("quote_price" in q["mechanism"] and "get_total" in q["observable"],
+                f"field values not carried through: {q}")
+
+        # 3. FALSE-REJECTION PROBE — a genuine mechanism-style proposal must not be
+        # rejected. record() returns advisory metadata and there is no reject path.
+        rd = StubRunDir()
+        out = proposal_quality.record(rd, wd, "cand_0001")
+        c.check(out["declared"] is True and "reject" not in str(out).lower(),
+                f"record() produced a rejection signal for a genuine mechanism: {out}",
+                note="false-rejection probe: a real mechanism proposal is never rejected")
+        ev = rd.logged[-1] if rd.logged else {}
+        c.check(ev.get("kind") == "proposal_quality"
+                and ev.get("enforcement") == "advisory"
+                and ev.get("declared") is True,
+                f"the logged event is not an advisory proposal_quality record: {ev}",
+                note="declaration is recorded per candidate as advisory")
+
+        # 2. the seed's placeholders are MISSING, not a vacuous pass.
+        (wd / "PROCESS.md").write_text(
+            "## Proposal declaration\n"
+            "- Mechanism: <what now behaves differently, and why>\n"
+            "- Hypothesis: <which cluster this fixes>\n"
+            "- Expected observable: \n", encoding="utf-8")
+        q2 = proposal_quality.parse(wd)
+        c.check(not q2["declared"] and sorted(q2["missing"]) ==
+                ["hypothesis", "mechanism", "observable"],
+                f"seed placeholders were accepted as a declaration: {q2}",
+                note="unfilled placeholders count as missing (no vacuous pass)")
+
+        # a missing PROCESS.md must not raise.
+        (wd / "PROCESS.md").unlink()
+        c.check(proposal_quality.parse(wd)["declared"] is False,
+                "a missing PROCESS.md did not degrade to declared=False")
+
+    return c.emit()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/reasoning/mechanism-probe/scripts/run.py
+++ b/skills/reasoning/mechanism-probe/scripts/run.py
@@ -1,0 +1,33 @@
+"""mechanism-probe entry — report which proposal-declaration fields a PROCESS.md carries.
+
+Presence only, by design: ``cap_evolve.proposal_quality`` is the single parser (the same
+one the harness logs from), and it cannot tell a mechanism from a knob. That judgement
+stays in the prompt (SKILL.md) where it shapes the proposal, not in a heuristic that
+could reject a real improvement.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import _bootstrap  # noqa: F401
+
+from cap_evolve import proposal_quality
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(prog="mechanism-probe")
+    p.add_argument("--process", default="PROCESS.md",
+                   help="the PROCESS.md carrying the proposal declaration")
+    args = p.parse_args(argv)
+    proc = Path(args.process)
+    q = proposal_quality.parse(proc.parent if proc.name == "PROCESS.md" else proc)
+    print(json.dumps({"enforcement": "advisory", **q}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/templates/project/capevolve.yaml
+++ b/templates/project/capevolve.yaml
@@ -36,7 +36,9 @@ algorithm_skill: hill-climb              # algorithms/<skill>: hill-climb | gepa
 algorithm_focus: all                     # hill-climb schedule: all | cyclic | hardest-first
 orchestration_mode: deterministic        # deterministic (cap-evolve sequences the loop) | agent (the coding agent drives the loop via cap-evolve primitives, sealing with `cap-evolve finalize`)
 
-# --- what context the optimizer gets (hill-climb) ---------------------------
+# --- what context the optimizer gets (ALL algorithms) -----------------------
+# Applies identically to hill-climb, gepa and skillopt — they share one injection
+# seam (core/cap_evolve/optimizer_context.py).
 # The per-iteration optimizer prompt is RENDERED from this template (intake authors it,
 # customized per benchmark). Defaults to the scaffolded optimizer/INSTRUCTIONS.md.
 optimizer_instructions_file: optimizer/INSTRUCTIONS.md


### PR DESCRIPTION
Closes #140

Builds on **#199** (the algorithm hub) and stacks on **#222** (`feat/issue-129-failure-memory`, whose base already carries #199 + #212). The reviewer's "✅ one `copytree`" assessment held: the file half of this is literally one `copytree` on #199's `inject` seam.

## What the skills are and when they load

A new **`reasoning` skill component**: tiny skills loaded at ONE step to counter ONE named optimizer failure mode. Unlike a phase they are never sequenced by the orchestrate DAG — they reach the optimizer as injected read-context, at `./guidance/reasoning/<skill>/`, plus native placement in the agent's own skills dir (`.claude/skills/…`) so a headless CLI auto-loads them.

**One skill, `mechanism-probe`, loaded at the proposal step.** The failure mode it counters is the one this framework keeps paying for: the optimizer reads a few traces, recognizes a familiar shape, and ships the first plausible edit — another prose rule for a rule the agent already skips, a retuned threshold, a reworded docstring. It asks one question while the edit is still cheap to throw away: *could this whole proposal be replaced by changing one existing value or restating one existing rule? If yes, it is a knob.*

I did **not** add a second `first-principles` skill. Nothing loads it and nothing would; a registered skill with no caller is a knob of its own. Add it when a second named failure mode actually needs it.

## Whether the gate is advisory or enforcing

**Advisory.** Nothing in this PR can reject a candidate. The exact honest wording, verbatim from the prompt every optimizer receives:

> **How this is judged:** the declaration is RECORDED per candidate, not enforced — a missing or knob-shaped declaration does NOT reject your edit, and a well-declared one does not get it accepted. The val significance gate remains the only thing that accepts or rejects. Declare it anyway: an edit you cannot state a mechanism and an observable for is the edit that historically wasted the iteration.

Why not enforcing: "is this a mechanism or a knob?" is a judgement no regex can make. A heuristic strict enough to reject knobs would also reject a real one-line in-body guard, and **a false rejection discards a genuine improvement invisibly** — nobody sees the gain that never happened. So this adopts #129's resolution exactly: **advisory at the prompt, hard at the val gate.** `RUN.md` and `docs/ARCHITECTURE.md` say "recorded, never enforced", not "rejects low-quality proposals" — the #222 lesson about not claiming enforcement nothing enforces.

What *is* precisely checkable is the **declaration**: presence of three named fields (`Mechanism:` / `Hypothesis:` / `Expected observable:`) in the `PROCESS.md` the optimizer already writes. `cap_evolve.proposal_quality` parses those and logs a `proposal_quality` event per candidate, surfaced in the dashboard's existing annotations stream.

### False-rejection probe

The test that matters, pinned from both sides:

- `test_a_genuine_mechanism_proposal_is_not_rejected` — a declared, genuinely-improving edit is **accepted**, and the gate reason contains none of `mechanism` / `knob` / `declar` / `proposal quality`.
- `test_an_undeclared_proposal_is_also_not_rejected` — the bare mock edit, with **no declaration at all**, is also accepted on its val delta. A missing declaration is a signal, not a verdict.

`mechanism-probe`'s own `check.py` carries the same probe as a behavioral contract.

## LLM calls

**Zero.** Pure stdlib regex over a markdown file — #205's rule that every auxiliary step in core is pure Python is preserved, and `test_the_gate_makes_no_model_call` pins it (no `anthropic`/`openai`/`requests`/`urllib`/`aux_model`/`subprocess` in the module). No `aux_model` tier needed.

## Composed-prompt measurement

Routed through **#222's single shared `cap_instructions`** — no second cap. `test_the_bar_is_capped_by_the_shared_cap_not_a_second_one` asserts `_augment_instructions` applies `cap_instructions` exactly once.

```
rendered template + #222 dead-ends (200 rejections) + #140 bar  :  24416
  of which #140's PROMPT_BLOCK                                  :   1320
  of which #222's dead-end block @ 200 rejections               :   2251
+ #219's INSIGHTS pointer bullet                                :    463
+ #221's diversify block (39 lineages -> bounded to 6)          :    887
-------------------------------------------------------------------------------
COMPOSED TOTAL (#219 + #221 + #222 + #140)                      :  25766
CAP (MAX_INSTRUCTIONS_CHARS)                                    :  60000
headroom                                                        :  34234  (42.9% of cap)
```

**Truncation never silently drops a whole block.** The block is 1,320 chars and sits LAST, inside the kept 30% tail (18 KB at the default ceiling), next to #222's constraints. `test_an_overflowing_prompt_keeps_the_bar_whole` **crosses the bound** (the #219 lesson — a pinning test whose fixture never overflows proves nothing): it feeds 110,000 chars through the real `_augment_instructions` and asserts the composed output is ≤ cap, the elision notice is present, and *both* #140's and #222's blocks survive **entire**.

## Per-algorithm evidence

Real `cap-evolve run` on `examples/toy_calc` with the `mock` optimizer, **zero API cost**, all three deterministic algorithms. `diff -r` against source is rc=0 for every one:

| algorithm | workdir | `diff -r` vs source | composed prompt | bar in prompt | `proposal_quality` logged |
|---|---|---|---|---|---|
| hill-climb | `cand_0001` | **rc=0 (identical)** | 22,265 | ✅ | ✅ |
| gepa | `gepa_0001` | **rc=0 (identical)** | 23,634 | ✅ | ✅ |
| skillopt | `so_e01s01` | **rc=0 (identical)** | 22,793 | ✅ | ✅ |

## No-leak proof

`grep` for each sealed test id across every file in each optimizer workdir: **0 files** for all three algorithms. `test_no_test_split_id_reaches_any_injected_workdir_file` pins it, and asserts the test-id list is non-empty first so the probe cannot be vacuous.

The injected subtree is also invisible to the snapshot / eval-cache hash / GEPA component list — `guidance/` is already in #199's `INJECTED_DIRS`, and `test_the_reasoning_skill_is_not_mistaken_for_a_capability_edit` proves the hash and component list are unchanged by its presence.

## Expected merge order

`#199` → `#212` → `#211` → `#219` / `#221` / **#222** → **this**. This branch is cut from `origin/feat/issue-129-failure-memory` because it must route through #222's `cap_instructions`. #219 and #221 touch `_augment_instructions` / the same prompt tail; whichever lands second resolves a small conflict in that one function. #213's skill lint should land before or with this so the new skill is linted in CI from day one (it already passes).

## Verification

```
$ PYTHONPATH=core python -m pytest core/tests -q
240 passed in 103.91s
```
214 on the #222 base + 19 new + 7 `test_dashboard_launch` (which passed here). **0 failed.**

```
$ python -m compileall -q core/cap_evolve core/tests skills
rc=0

$ python skills/_registry/build_manifest.py skills
wrote skills/_registry/manifest.json (21 skill(s))
  reasoning: mechanism-probe

$ python skills/_registry/lint_skills.py skills      # #213's lint
skill authoring lint — 21 skill package(s)
  # zero errors AND zero advisories for reasoning/mechanism-probe
  # the 3 remaining errors (capabilities/tools body size, using-cap-evolve XML tags)
  # are pre-existing on this base and are exactly what #213 fixes on its own branch.

$ for f in skills/*/*/scripts/check.py; do ...; done
rc=0 ok=True   × 21 / 21   (including skills/reasoning/mechanism-probe)
```

**Fail-before / pass-after** — test file present, implementation stashed:
```
15 failed, 3 passed in 9.80s
```
then restored: `19 passed`.
