### PR TITLE
feat(cli): add `cap-evolve quickstart` — free/local presets to a runnable project (#133)

### DIFF
--- a/core/cap_evolve/cli.py
+++ b/core/cap_evolve/cli.py
@@ -466,6 +466,12 @@ def _cmd_run(argv):
     return 0
 
 
+def _cmd_quickstart(argv):
+    """Scaffold a ready-to-run project from a free/local preset (zero questions)."""
+    from .quickstart import _main
+    return _main(argv)
+
+
 def _cmd_dashboard(argv):
     """Launch (or focus) the live dashboard server over a base dir of runs."""
     import argparse
@@ -643,6 +649,7 @@ COMMANDS = {
     "version": _cmd_version,
     "splits": _cmd_splits,
     "check": _cmd_check,
+    "quickstart": _cmd_quickstart,
     "run": _cmd_run,
     "estimate": _cmd_estimate,
     "dashboard": _cmd_dashboard,
@@ -652,7 +659,11 @@ COMMANDS = {
 def main(argv=None) -> int:
     argv = list(sys.argv[1:] if argv is None else argv)
     if not argv or argv[0] in ("-h", "--help"):
-        print("usage: cap-evolve {version|splits|check|run|estimate|dashboard} [args]", file=sys.stderr)
+        # Generated from COMMANDS, never a literal list: #214 replaces this whole block
+        # with a docstring-driven listing for exactly this reason (five parallel branches
+        # adding a subcommand all conflicted on the literal string). Until it lands,
+        # joining COMMANDS keeps a newly registered subcommand visible with zero edits.
+        print(f"usage: cap-evolve {{{'|'.join(COMMANDS)}}} [args]", file=sys.stderr)
         return 0 if argv else 2
     fn = COMMANDS.get(argv[0])
     if fn is None:

--- a/core/cap_evolve/cli.py
+++ b/core/cap_evolve/cli.py
@@ -434,6 +434,12 @@ def _cmd_run(argv):
         import shlex as _shlex
         alg_cmd += _shlex.split(str(spec["algorithm_args"]))
     proc = run(alg_cmd)
+    # Relay the algorithm's stderr even on success. Warnings that do not fail the run
+    # (an optimizer that found no edit script, so every candidate is unchanged and the
+    # sealed number equals the baseline) were swallowed by capture_output and the run
+    # looked clean. stdout stays exactly one report object (#217).
+    if proc.stderr:
+        sys.stderr.write(proc.stderr)
     if proc.returncode != 0:
         print(json.dumps(_step_failure("algorithm", proc)))
         return 1

--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -448,6 +448,12 @@ def optimizer_from_command(cmd_template: list[str]) -> OptimizerFn:
         cmd = [c.format(workdir=str(workdir), prompt=str(prompt_path)) for c in cmd_template]
         env = dict(os.environ)
         proc = subprocess.run(cmd, capture_output=True, text=True, env=env)
+        # The optimizer's stderr reaches the user even on success. A silent optimizer
+        # that proposes nothing still exits 0 and seals a number equal to the baseline
+        # — the wrong answer wearing success's clothes. stdout is untouched (still
+        # exactly one report object, #217).
+        if proc.stderr:
+            sys.stderr.write(proc.stderr)
         if proc.returncode != 0:
             err = RuntimeError(
                 f"optimizer failed ({proc.returncode}): {_optimizer_failure_detail(proc)}")

--- a/core/cap_evolve/quickstart.py
+++ b/core/cap_evolve/quickstart.py
@@ -44,22 +44,28 @@ import sys
 from pathlib import Path
 
 from .dashboard import redact
+from .splits import make_splits
 
 def safe_url(url: str) -> str:
     """Public default verbatim, anything else ``<custom>``.
 
-    Prefers ``dashboard.safe_url`` — #190 moved this exact rule there so every consumer
-    inherits one definition. The local fallback exists only until that PR lands, and is
-    deliberately *stricter* (allowlist, not heuristic): a real internal gateway URL
-    already leaked into a public PR in this epic.
+    Our OWN preset endpoints are checked first, so they always print verbatim. #190's
+    rule does not know this table and masked both non-mock presets' shipped defaults as
+    ``<custom>`` — hiding the value quickstart itself just chose, which reads as a bug
+    and protects nothing (they are a documented public API and an explicit loopback).
+
+    Everything else delegates to ``dashboard.safe_url`` — #190 moved this rule there so
+    every consumer inherits one definition. The local fallback (an allowlist, so
+    deliberately stricter than a heuristic) exists only until that PR lands: a real
+    internal gateway URL already leaked into a public PR in this epic.
     """
-    from . import dashboard
-    fn = getattr(dashboard, "safe_url", None)
-    if fn is not None:
-        return fn(url)
     if not url:
         return ""
-    return url if url in _PUBLIC_DEFAULTS else "<custom>"
+    if url in _PUBLIC_DEFAULTS:
+        return url
+    from . import dashboard
+    fn = getattr(dashboard, "safe_url", None)
+    return fn(url) if fn is not None else "<custom>"
 
 
 #: The preset table. ``provider``/``credential`` are resolved through ``model_config``
@@ -82,7 +88,8 @@ PRESETS: dict[str, dict] = {
         "base_url": "http://127.0.0.1:11434/v1",
         "model": "qwen2.5:3b",
         "optimizer": "mock",
-        "needs": "a local server answering at the base URL (e.g. `ollama serve`)",
+        "needs": "a local server answering at the base URL, with the model pulled "
+                 "(`ollama serve` + `ollama pull qwen2.5:3b`)",
     },
     "free": {
         "summary": "$0 on the free tier — Gemini via its OpenAI-compatible endpoint",
@@ -147,6 +154,23 @@ _RUNNER = {runner!r}
 _BASE_URL = {base_url!r}
 _MODEL = {model!r}
 _CRED_ENV = {cred_env!r}          # an env var NAME, never a value
+_CRED_NAMES = {cred_names!r}      # the provider's candidate NAMES, in precedence order
+
+
+def _credential() -> str | None:
+    """Resolve the credential at RUN time, from names fixed at scaffold time.
+
+    Scaffolding before you export the key used to bake ``_CRED_ENV = ''``, so the
+    adapter then sent no Authorization header at all — a 401 indistinguishable from a
+    dead endpoint, and exporting the key afterwards did nothing until you re-scaffolded
+    with --force. The NAMES are provider-scoped and fixed here (so no cross-provider
+    reuse is possible); only the lookup moves to run time.
+    """
+    for name in ((_CRED_ENV,) if _CRED_ENV else ()) + _CRED_NAMES:
+        val = os.environ.get(name)
+        if val:
+            return val
+    return None
 
 
 def _safe_eval(expr: str) -> int:
@@ -168,7 +192,7 @@ def _chat(prompt: str, question: str, *, seed: int) -> str:
     req = urllib.request.Request(_BASE_URL.rstrip("/") + "/chat/completions",
                                 data=body, method="POST")
     req.add_header("Content-Type", "application/json")
-    cred = os.environ.get(_CRED_ENV) if _CRED_ENV else None
+    cred = _credential()
     if cred:
         req.add_header("Authorization", f"Bearer {{cred}}")
     with urllib.request.urlopen(req, timeout=60) as resp:
@@ -274,6 +298,15 @@ def _ask_preset(default: str = DEFAULT_PRESET) -> str:
     return answer if answer in PRESETS else default
 
 
+#: Provider-scoped credential env var NAMES, in precedence order. One table, used both
+#: for the ``model_config``-absent fallback and for the scaffolded adapter's run-time
+#: lookup — so a preset can never resolve another provider's credential.
+_CRED_NAMES: dict[str, tuple[str, ...]] = {
+    "gemini": ("GEMINI_API_KEY", "GOOGLE_API_KEY"),
+    "openai": ("OPENAI_API_KEY",),
+}
+
+
 def _resolve_provider(row: dict, base_url: str) -> dict:
     """Secret-free provider report: which env var NAME holds the credential, if any.
 
@@ -286,8 +319,7 @@ def _resolve_provider(row: dict, base_url: str) -> dict:
         return {"provider": "mock", "credential_env": "", "credential_present": False,
                 "base_url": "", "reason": "offline preset — no credential, no endpoint"}
     if mc is None:  # fallback while #190 is unmerged: name-only lookup, still no values
-        names = {"gemini": ("GEMINI_API_KEY", "GOOGLE_API_KEY"), "openai": ("OPENAI_API_KEY",)}
-        found = next((n for n in names.get(provider, ()) if os.environ.get(n)), "")
+        found = next((n for n in _CRED_NAMES.get(provider, ()) if os.environ.get(n)), "")
         return {"provider": provider, "credential_env": found,
                 "credential_present": bool(found), "base_url": safe_url(base_url),
                 "reason": "model_config unavailable — env-name lookup only"}
@@ -340,6 +372,17 @@ def _template_spec() -> str:
             "max_iterations: 3\nstall: 2\nstore: git\n")
 
 
+def _val_tasks(n: int) -> int:
+    """How many val tasks the scaffolded spec will actually produce.
+
+    Asks ``splits.make_splits`` rather than recomputing ``round(n * 0.25)``: a second
+    copy of the split arithmetic is a number that can silently disagree with the one
+    the run uses, which is exactly the class of defect this PR is fixing elsewhere.
+    """
+    ids = [f"q{i + 1:02d}" for i in range(n)]
+    return len(make_splits(ids, seed=0, ratios=(0.5, 0.25, 0.25)).val)
+
+
 def scaffold(dest: Path, preset: str, *, model: str = "", base_url: str = "",
              force: bool = False) -> dict:
     """Write a ready-to-run project under ``dest``. Returns a secret-free record."""
@@ -350,13 +393,30 @@ def scaffold(dest: Path, preset: str, *, model: str = "", base_url: str = "",
     project = dest / ".capevolve" / "project"
     if project.exists() and not force:
         raise FileExistsError(f"{project} already exists — pass --force to overwrite")
+    if project.exists() and not project.is_dir():
+        # `--force` on a plain file used to surface a bare `[Errno 20] Not a directory`
+        # from deep inside mkdir. Say what is wrong and what to do instead.
+        raise ValueError(f"{project} exists but is a file, not a directory — "
+                         f"--force overwrites a project, not a file; remove it first")
+    # The mock edit script lives OUTSIDE `.capevolve/project`, so the guard above never
+    # saw it: an existing (possibly hand-edited) one was replaced without a word.
+    mock_script = dest / ".capevolve" / "mock_script.json"
+    if mock_script.exists() and not force:
+        raise FileExistsError(f"{mock_script} already exists — pass --force to overwrite")
 
     # Userinfo (https://user:token@host/) is a credential. Strip it at the single point
     # of resolution so it can never be written to a file, printed, or reported (#190).
     url = base_url or row["base_url"]
     mc = _optional("model_config")
-    if mc is not None and url:
-        url = mc.strip_url_userinfo(url)
+    # COUPLING NOTE (#190): `strip_url_userinfo` is DEFINED in `dashboard`; it resolves as
+    # `mc.strip_url_userinfo` only because #190 does `from .dashboard import ...` at
+    # model_config.py:51, i.e. we depend on its import list, not its public API. If #190
+    # ever switches to `from . import dashboard` + `dashboard.strip_url_userinfo(...)`,
+    # getattr fails and the manual `elif` below silently takes over. Hence `getattr`
+    # rather than a bare attribute access, so the degradation is a documented branch.
+    strip = getattr(mc, "strip_url_userinfo", None) if mc is not None else None
+    if strip is not None and url:
+        url = strip(url)
     elif url and "@" in url.split("//", 1)[-1].split("/", 1)[0]:
         scheme, _, rest = url.partition("//")
         url = scheme + "//" + rest.split("@", 1)[1]
@@ -367,7 +427,8 @@ def scaffold(dest: Path, preset: str, *, model: str = "", base_url: str = "",
     (project / "adapters").mkdir(parents=True, exist_ok=True)
     (project / "adapters" / "adapter.py").write_text(
         _ADAPTER.format(preset=preset, runner=row["runner"], base_url=url,
-                        model=model or row["model"], cred_env=cred_env), encoding="utf-8")
+                        model=model or row["model"], cred_env=cred_env,
+                        cred_names=_CRED_NAMES.get(row["provider"], ())), encoding="utf-8")
     (project / "adapters" / "tasks.jsonl").write_text(
         "".join(json.dumps(t) + "\n" for t in _tasks()), encoding="utf-8")
     (project / "capevolve.yaml").write_text(_patch_spec(_template_spec(), {
@@ -379,7 +440,6 @@ def scaffold(dest: Path, preset: str, *, model: str = "", base_url: str = "",
     }), encoding="utf-8")
     (dest / "seed_capability").mkdir(parents=True, exist_ok=True)
     (dest / "seed_capability" / "prompt.txt").write_text(_SEED_PROMPT, encoding="utf-8")
-    mock_script = dest / ".capevolve" / "mock_script.json"
     mock_script.write_text(json.dumps(_MOCK_SCRIPT, indent=2) + "\n", encoding="utf-8")
 
     created = sorted(str(p.relative_to(dest)) for p in
@@ -388,7 +448,7 @@ def scaffold(dest: Path, preset: str, *, model: str = "", base_url: str = "",
     return {"preset": preset, "dir": str(dest.resolve()), "created": created,
             "provider": provider, "model": model or row["model"],
             "base_url": safe_url(url) if url else "",
-            "val_tasks": max(1, round(_N_TASKS * 0.25)), "tasks": _N_TASKS}
+            "val_tasks": _val_tasks(_N_TASKS), "tasks": _N_TASKS}
 
 
 def _health(dest: Path) -> dict | None:
@@ -444,6 +504,17 @@ def _main(argv: list[str]) -> int:
     preset = args.preset or (_ask_preset() if not args.yes and interactive()
                              else DEFAULT_PRESET)
 
+    # `mock` has no endpoint and no model, so --model/--base-url were silently dropped.
+    # Refuse instead: a flag that is accepted and ignored is the same defect family as
+    # an optimizer that proposes nothing and still exits 0. The message names the fix.
+    dead = [f for f, v in (("--model", args.model), ("--base-url", args.base_url)) if v]
+    if preset == "mock" and dead:
+        print(json.dumps({"ok": False, "error":
+              f"{' and '.join(dead)} has no effect with preset 'mock' (offline stand-in, "
+              f"no endpoint and no model). Use --preset local or --preset free, or drop "
+              f"the flag."}))
+        return 1
+
     try:
         rec = scaffold(Path(args.dir), preset, model=args.model,
                        base_url=args.base_url, force=args.force)
@@ -451,6 +522,11 @@ def _main(argv: list[str]) -> int:
         print(json.dumps({"ok": False, "error": redact(str(e))}))
         return 1
 
+    # A doctor failure does NOT change the exit code, deliberately: quickstart's contract
+    # is "the project was scaffolded", which succeeded. Health is advisory about the
+    # environment (#121 owns that), reported in `health` and printed to stderr, and
+    # `check`/`run` are the gates that must actually refuse. Exiting non-zero here would
+    # make a scaffold that is on disk and check-green look like a failed command.
     if not args.no_doctor:
         health = _health(Path(args.dir))
         if health is not None:

--- a/core/cap_evolve/quickstart.py
+++ b/core/cap_evolve/quickstart.py
@@ -1,0 +1,483 @@
+"""``cap-evolve quickstart`` — the zero-question fast path to a runnable project.
+
+``intake`` is the guided INTERVIEW: an agent-driven phase skill that mines your working
+dir, asks what capability to optimize, and leaves a *stub* adapter for you to implement
+before the ``implement-and-check`` gate will let a run start. ``quickstart`` is the
+opposite trade: it asks nothing (or one question), picks a **free or local** preset, and
+writes a project that is ALREADY green under ``cap-evolve check`` — so the very next
+command is ``cap-evolve run`` and you see a sealed test number without a paywall.
+
+They do not overlap in code: quickstart never invokes intake, and a quickstart project
+is a normal project intake could have produced. Use quickstart to see the pipeline work;
+use intake when you have your own capability and benchmark.
+
+Presets (``PRESETS``) — a dict, deliberately not a plugin framework:
+
+===========  ========  ===============================  =========================
+preset       cost      target runner                    needs
+===========  ========  ===============================  =========================
+``mock``     $0        deterministic stand-in, offline  nothing at all
+``local``    $0        OpenAI-compatible local server   a server on 127.0.0.1
+``free``     $0        Gemini free tier (OpenAI-compat) ``GEMINI_API_KEY``
+===========  ========  ===============================  =========================
+
+Non-interactive contract: ``--yes``, ``--preset``, a non-TTY stdin, or a non-TTY stderr
+all mean "use defaults and never read stdin". Piping into quickstart cannot hang.
+The TTY decision is #215's ``eventstream.capability`` ladder, not a local ``isatty``.
+
+Secrets: quickstart resolves a credential's env var **NAME** (via ``model_config``) and
+reports PRESENCE only — never a value, a prefix, or a length. Nothing it writes contains
+a credential: the scaffolded adapter reads ``os.environ[<NAME>]`` at run time. A base URL
+carrying ``user:token@`` userinfo is stripped before it is stored, and a non-default base
+URL is reported as ``<custom>`` (``dashboard.safe_url``), because an internal gateway
+hostname is itself sensitive.
+
+Stdout is exactly ONE JSON object (#217). Every human-facing line goes to stderr.
+Stdlib only, zero new runtime deps.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+from .dashboard import redact
+
+def safe_url(url: str) -> str:
+    """Public default verbatim, anything else ``<custom>``.
+
+    Prefers ``dashboard.safe_url`` — #190 moved this exact rule there so every consumer
+    inherits one definition. The local fallback exists only until that PR lands, and is
+    deliberately *stricter* (allowlist, not heuristic): a real internal gateway URL
+    already leaked into a public PR in this epic.
+    """
+    from . import dashboard
+    fn = getattr(dashboard, "safe_url", None)
+    if fn is not None:
+        return fn(url)
+    if not url:
+        return ""
+    return url if url in _PUBLIC_DEFAULTS else "<custom>"
+
+
+#: The preset table. ``provider``/``credential`` are resolved through ``model_config``
+#: when it is available, so cross-provider credential reuse stays impossible.
+#: ponytail: a dict. A preset is one row; #124's cheap-real-run preset is one more row.
+PRESETS: dict[str, dict] = {
+    "mock": {
+        "summary": "fully offline, $0, no credential — a deterministic stand-in agent",
+        "provider": "mock",
+        "runner": "mock",
+        "base_url": "",
+        "model": "",
+        "optimizer": "mock",
+        "needs": "nothing",
+    },
+    "local": {
+        "summary": "$0 — a local OpenAI-compatible server (Ollama, llama.cpp, vLLM)",
+        "provider": "openai",
+        "runner": "openai-compatible",
+        "base_url": "http://127.0.0.1:11434/v1",
+        "model": "qwen2.5:3b",
+        "optimizer": "mock",
+        "needs": "a local server answering at the base URL (e.g. `ollama serve`)",
+    },
+    "free": {
+        "summary": "$0 on the free tier — Gemini via its OpenAI-compatible endpoint",
+        "provider": "gemini",
+        "runner": "openai-compatible",
+        "base_url": "https://generativelanguage.googleapis.com/v1beta/openai",
+        "model": "gemini-2.0-flash",
+        "optimizer": "mock",
+        "needs": "GEMINI_API_KEY (or GOOGLE_API_KEY) exported",
+    },
+}
+
+DEFAULT_PRESET = "mock"
+
+#: Base URLs safe to print verbatim: the endpoints the presets themselves ship (a
+#: documented public API, or an explicit loopback address). Any other endpoint is
+#: somebody's infrastructure — see :func:`safe_url`.
+_PUBLIC_DEFAULTS = frozenset(r["base_url"] for r in PRESETS.values() if r["base_url"])
+
+#: 16 tasks, not 8. #195 refuses a val split below ``MIN_VAL_TASKS``, and the default
+#: 0.5/0.25/0.25 ratios over 8 tasks land val on exactly the floor — one rounding change
+#: away from a hard-failing scaffold. 16 gives val=4, comfortably clear of it.
+_N_TASKS = 16
+
+
+def _tasks() -> list[dict]:
+    """The seed task set: exact-answer arithmetic, generated (no data file to ship)."""
+    out = []
+    for i in range(_N_TASKS):
+        a, b = 3 + i, 2 + (i * 3) % 7
+        op = "+-*"[i % 3]
+        expr = f"{a} {op} {b}"
+        out.append({"id": f"q{i + 1:02d}", "input": expr,
+                    "target": str(eval(expr, {"__builtins__": {}}, {}))})  # noqa: S307
+    return out
+
+
+# The scaffolded adapter. ONE template for both runner modes: ``_RUNNER`` is substituted
+# at write time, so there is no second near-identical file to keep in sync. The seed
+# prompt is deliberately vague, so a real (or stand-in) agent rambles instead of
+# answering — that is the headroom the optimizer closes by making the prompt explicit.
+_ADAPTER = '''"""Quickstart adapter — written by `cap-evolve quickstart` (preset: {preset}).
+
+The capability under optimization is ``seed_capability/prompt.txt``. The seed prompt is
+vague on purpose, so the agent answers in prose and scores 0; an optimizer that makes
+the output contract explicit raises the score. That is the whole pipeline, provable.
+
+NO CREDENTIAL IS STORED HERE. ``_CRED_ENV`` is the NAME of an environment variable; the
+value is read from the process environment at run time and never written to disk.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from cap_evolve import CapabilityAdapter, Rollout, Score, Task
+
+_HERE = Path(__file__).resolve().parent
+_RUNNER = {runner!r}
+_BASE_URL = {base_url!r}
+_MODEL = {model!r}
+_CRED_ENV = {cred_env!r}          # an env var NAME, never a value
+
+
+def _safe_eval(expr: str) -> int:
+    if not set(expr) <= set("0123456789 +-*"):
+        raise ValueError("unsafe expr")
+    return int(eval(expr, {{"__builtins__": {{}}}}, {{}}))  # noqa: S307
+
+
+def _chat(prompt: str, question: str, *, seed: int) -> str:
+    """One OpenAI-compatible chat completion, stdlib urllib only."""
+    import urllib.request
+
+    body = json.dumps({{
+        "model": _MODEL,
+        "messages": [{{"role": "system", "content": prompt}},
+                     {{"role": "user", "content": question}}],
+        "temperature": 0, "seed": seed,
+    }}).encode()
+    req = urllib.request.Request(_BASE_URL.rstrip("/") + "/chat/completions",
+                                data=body, method="POST")
+    req.add_header("Content-Type", "application/json")
+    cred = os.environ.get(_CRED_ENV) if _CRED_ENV else None
+    if cred:
+        req.add_header("Authorization", f"Bearer {{cred}}")
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        data = json.loads(resp.read().decode())
+    return (data["choices"][0]["message"]["content"] or "").strip()
+
+
+class Adapter(CapabilityAdapter):
+
+    def tasks(self, split: str) -> list[Task]:
+        rows = [json.loads(ln) for ln in
+                (_HERE / "tasks.jsonl").read_text(encoding="utf-8").splitlines() if ln.strip()]
+        return [Task(id=r["id"], input=r["input"], target=r["target"]) for r in rows]
+
+    def run_target(self, task: Task, ctx, *, seed: int = 0) -> Rollout:
+        prompt = (Path(ctx) / "prompt.txt").read_text(encoding="utf-8")
+        expr = str(task.input)
+        if _RUNNER == "mock":
+            # Offline stand-in: it computes correctly only once the prompt tells it to
+            # output just the number. Deterministic, zero-cost, no network.
+            if "ONLY" in prompt.upper():
+                try:
+                    out = str(_safe_eval(expr))
+                except Exception as e:  # noqa: BLE001
+                    out = f"error: {{e}}"
+            else:
+                out = f"Well, {{expr}} works out to something around there."
+            return Rollout(task_id=task.id, output=out, trace=f"runner=mock explicit={{'ONLY' in prompt.upper()}}")
+        try:
+            out = _chat(prompt, expr, seed=seed)
+        except Exception as e:  # noqa: BLE001 — a dead endpoint is a scored failure, not a crash
+            return Rollout(task_id=task.id, output="", trace=f"runner error: {{type(e).__name__}}")
+        return Rollout(task_id=task.id, output=out, trace=f"runner={{_RUNNER}}")
+
+    def score(self, task: Task, rollout: Rollout) -> Score:
+        got, want = (rollout.output or "").strip(), str(task.target).strip()
+        ok = got == want
+        fb = "correct" if ok else (
+            f"expected exactly '{{want}}' but got '{{got[:120]}}' — the prompt does not "
+            "require the answer to be the bare number and nothing else")
+        return Score(task_id=task.id, reward=1.0 if ok else 0.0, feedback=fb,
+                     trial_rewards=[1.0 if ok else 0.0])
+
+    def apply(self, candidate_dir: Path, edits: dict | None = None) -> None:
+        return None
+'''
+
+_SEED_PROMPT = "You are a helpful assistant. Answer the user as best you can.\n"
+
+# The mock optimizer's scripted edit: make the output contract explicit. This is what
+# turns baseline 0.0 into a sealed 1.0 without any model call.
+_MOCK_SCRIPT = {
+    "edits": [{"file": "prompt.txt", "op": "ensure_contains",
+               "text": "\nCompute the expression exactly and output ONLY the resulting "
+                       "number — no words, no units, no explanation."}],
+}
+
+
+def _optional(name: str):
+    """Import a sibling module that may not exist on this branch yet, else ``None``.
+
+    ``doctor`` (#121), ``model_config`` (#190) and ``eventstream`` (#215) land in
+    parallel PRs. quickstart USES each when present rather than reimplementing health
+    checks / credential resolution / TTY sniffing, and degrades to a documented
+    fallback when it is merged first. ponytail: three one-line lookups, no shim layer.
+    """
+    try:
+        import importlib
+        return importlib.import_module(f".{name}", __package__)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def interactive() -> bool:
+    """May we ask a question? False whenever stdin or stderr is not a real terminal.
+
+    Uses #215's capability ladder so "can I talk to a human" is decided in exactly one
+    place in the repo. ``pipe``/``none`` are the non-TTY rungs; ``plain``/``dumb`` are
+    real terminals that merely refuse colour, so they still get the prompt.
+    """
+    es = _optional("eventstream")
+    if es is not None:
+        return (es.capability(sys.stdin) not in ("pipe", "none")
+                and es.capability(sys.stderr) not in ("pipe", "none"))
+    try:  # fallback only while #215 is unmerged
+        return bool(sys.stdin.isatty() and sys.stderr.isatty())
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _ask_preset(default: str = DEFAULT_PRESET) -> str:
+    """One question, on stderr, with a default. Only ever called when interactive()."""
+    print("cap-evolve quickstart — pick a preset (all free):", file=sys.stderr)
+    for name, row in PRESETS.items():
+        mark = " (default)" if name == default else ""
+        print(f"  {name:<6} {row['summary']}{mark}\n         needs: {row['needs']}",
+              file=sys.stderr)
+    print(f"preset [{default}]: ", end="", file=sys.stderr, flush=True)
+    try:
+        answer = (sys.stdin.readline() or "").strip()
+    except Exception:  # noqa: BLE001 — stdin vanished mid-prompt
+        return default
+    return answer if answer in PRESETS else default
+
+
+def _resolve_provider(row: dict, base_url: str) -> dict:
+    """Secret-free provider report: which env var NAME holds the credential, if any.
+
+    Delegates to ``model_config`` (#190) so provider-scoping and the precedence order
+    are not re-implemented here. Reports PRESENCE only.
+    """
+    mc = _optional("model_config")
+    provider = row["provider"]
+    if provider == "mock":
+        return {"provider": "mock", "credential_env": "", "credential_present": False,
+                "base_url": "", "reason": "offline preset — no credential, no endpoint"}
+    if mc is None:  # fallback while #190 is unmerged: name-only lookup, still no values
+        names = {"gemini": ("GEMINI_API_KEY", "GOOGLE_API_KEY"), "openai": ("OPENAI_API_KEY",)}
+        found = next((n for n in names.get(provider, ()) if os.environ.get(n)), "")
+        return {"provider": provider, "credential_env": found,
+                "credential_present": bool(found), "base_url": safe_url(base_url),
+                "reason": "model_config unavailable — env-name lookup only"}
+    try:
+        res = mc.resolve(cli={"provider": provider, "base_url": base_url},
+                         require_credential=False)
+        return res.to_dict()
+    except Exception as e:  # noqa: BLE001 — message names env VARS, never values
+        return {"provider": provider, "credential_env": "", "credential_present": False,
+                "base_url": safe_url(base_url), "reason": redact(str(e))[:400]}
+
+
+def _patch_spec(text: str, values: dict[str, object]) -> str:
+    """Set top-level ``key: value`` lines in the template spec, in place.
+
+    Patching the shipped ``templates/project/capevolve.yaml`` rather than authoring a
+    fresh one is what keeps quickstart honest about #197: the template deliberately
+    OMITS ``protected_paths`` (an empty list is a hard error), and every future spec
+    key/comment arrives for free. Keys absent from the template are appended.
+    """
+    remaining = dict(values)
+    out = []
+    for line in text.splitlines():
+        stripped = line.lstrip()
+        key = stripped.split(":", 1)[0].strip() if ":" in stripped else ""
+        if key in remaining and not stripped.startswith("#") and line == stripped:
+            val = remaining.pop(key)
+            out.append(f"{key}: {json.dumps(val) if isinstance(val, str) else val}")
+        else:
+            out.append(line)
+    for key, val in remaining.items():
+        out.append(f"{key}: {json.dumps(val) if isinstance(val, str) else val}")
+    return "\n".join(out) + "\n"
+
+
+def _template_spec() -> str:
+    """``templates/project/capevolve.yaml`` from the repo, else a minimal equivalent."""
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        cand = parent / "templates" / "project" / "capevolve.yaml"
+        if cand.is_file():
+            return cand.read_text(encoding="utf-8")
+    # Installed-wheel fallback: the same keys, still WITHOUT protected_paths (#197).
+    return ("capabilities: [system-prompt]\ncapability_path: seed_capability\n"
+            "actions: [edit]\noptimizer_skill: mock\noptimizer_model: \"\"\n"
+            "algorithm_skill: hill-climb\nalgorithm_focus: all\n"
+            "orchestration_mode: deterministic\ndataset_source: tasks.jsonl\n"
+            "split_seed: 0\nsplit_train: 0.5\nsplit_val: 0.25\nsplit_test: 0.25\n"
+            "num_trials: 1\ngate_mode: paired\ngate_k_se: 1.0\n"
+            "max_iterations: 3\nstall: 2\nstore: git\n")
+
+
+def scaffold(dest: Path, preset: str, *, model: str = "", base_url: str = "",
+             force: bool = False) -> dict:
+    """Write a ready-to-run project under ``dest``. Returns a secret-free record."""
+    if preset not in PRESETS:
+        raise ValueError(f"unknown preset {preset!r}; pick one of: {', '.join(PRESETS)}")
+    row = PRESETS[preset]
+    dest = Path(dest)
+    project = dest / ".capevolve" / "project"
+    if project.exists() and not force:
+        raise FileExistsError(f"{project} already exists — pass --force to overwrite")
+
+    # Userinfo (https://user:token@host/) is a credential. Strip it at the single point
+    # of resolution so it can never be written to a file, printed, or reported (#190).
+    url = base_url or row["base_url"]
+    mc = _optional("model_config")
+    if mc is not None and url:
+        url = mc.strip_url_userinfo(url)
+    elif url and "@" in url.split("//", 1)[-1].split("/", 1)[0]:
+        scheme, _, rest = url.partition("//")
+        url = scheme + "//" + rest.split("@", 1)[1]
+
+    provider = _resolve_provider(row, url)
+    cred_env = provider.get("credential_env") or ""
+
+    (project / "adapters").mkdir(parents=True, exist_ok=True)
+    (project / "adapters" / "adapter.py").write_text(
+        _ADAPTER.format(preset=preset, runner=row["runner"], base_url=url,
+                        model=model or row["model"], cred_env=cred_env), encoding="utf-8")
+    (project / "adapters" / "tasks.jsonl").write_text(
+        "".join(json.dumps(t) + "\n" for t in _tasks()), encoding="utf-8")
+    (project / "capevolve.yaml").write_text(_patch_spec(_template_spec(), {
+        "optimizer_skill": row["optimizer"],
+        "capability_path": "seed_capability",
+        "dataset_source": "adapter",
+        "max_iterations": 3,
+        "stall": 2,
+    }), encoding="utf-8")
+    (dest / "seed_capability").mkdir(parents=True, exist_ok=True)
+    (dest / "seed_capability" / "prompt.txt").write_text(_SEED_PROMPT, encoding="utf-8")
+    mock_script = dest / ".capevolve" / "mock_script.json"
+    mock_script.write_text(json.dumps(_MOCK_SCRIPT, indent=2) + "\n", encoding="utf-8")
+
+    created = sorted(str(p.relative_to(dest)) for p in
+                     (*project.rglob("*"), dest / "seed_capability" / "prompt.txt",
+                      mock_script) if p.is_file())
+    return {"preset": preset, "dir": str(dest.resolve()), "created": created,
+            "provider": provider, "model": model or row["model"],
+            "base_url": safe_url(url) if url else "",
+            "val_tasks": max(1, round(_N_TASKS * 0.25)), "tasks": _N_TASKS}
+
+
+def _health(dest: Path) -> dict | None:
+    """``doctor``'s report for the scaffolded dir, or ``None`` if #121 isn't merged."""
+    doc = _optional("doctor")
+    if doc is None:
+        return None
+    rep = doc.run_doctor(dest)
+    if not rep.ok:  # human-facing detail on stderr; stdout stays one JSON object
+        print(doc.format_report(rep), file=sys.stderr)
+    return {"ok": rep.ok, "failed": [c.name for c in rep.checks if c.status == doc.FAIL]}
+
+
+def _next_steps(dest: Path, preset: str) -> list[str]:
+    # Absolute paths: `--dir .` used to render `cd .` and a relative script path, which
+    # is only correct if you never leave the shell you ran quickstart in.
+    dest = Path(dest).resolve()
+    row = PRESETS[preset]
+    env = [f"export CAPEVOLVE_MOCK_SCRIPT={dest / '.capevolve' / 'mock_script.json'}"]
+    if preset != "mock":
+        env.append(f"# target runner needs: {row['needs']}")
+    return [*env, f"cd {dest}", "cap-evolve check .capevolve/project", "cap-evolve run"]
+
+
+def _main(argv: list[str]) -> int:
+    import argparse
+
+    p = argparse.ArgumentParser(
+        prog="cap-evolve quickstart",
+        description="Scaffold a ready-to-run project from a free/local preset.",
+        epilog="examples:\n"
+               "  cap-evolve quickstart                      # one question (or defaults)\n"
+               "  cap-evolve quickstart --yes                # zero questions, mock preset\n"
+               "  cap-evolve quickstart --preset local       # local OpenAI-compatible server\n"
+               "  cap-evolve quickstart --preset free --dir ./demo\n"
+               "presets: " + " | ".join(f"{k} ({v['summary']})" for k, v in PRESETS.items()),
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--dir", default=".", help="where to scaffold (default: .)")
+    p.add_argument("--preset", choices=sorted(PRESETS), default=None,
+                   help=f"skip the question (default: {DEFAULT_PRESET})")
+    p.add_argument("--yes", "-y", action="store_true",
+                   help="never prompt; accept every default")
+    p.add_argument("--model", default="", help="override the preset's target model")
+    p.add_argument("--base-url", default="",
+                   help="override the preset's endpoint (URL userinfo is stripped)")
+    p.add_argument("--force", action="store_true", help="overwrite an existing project")
+    p.add_argument("--no-doctor", action="store_true", help="skip the health check")
+    args = p.parse_args(argv)
+
+    # Non-interactive contract: an explicit --preset, --yes, or a non-TTY stdin/stderr
+    # all mean "defaults, never read stdin". So `echo x | cap-evolve quickstart` and a
+    # CI invocation both return immediately instead of blocking on a prompt.
+    preset = args.preset or (_ask_preset() if not args.yes and interactive()
+                             else DEFAULT_PRESET)
+
+    try:
+        rec = scaffold(Path(args.dir), preset, model=args.model,
+                       base_url=args.base_url, force=args.force)
+    except (ValueError, FileExistsError, OSError) as e:
+        print(json.dumps({"ok": False, "error": redact(str(e))}))
+        return 1
+
+    if not args.no_doctor:
+        health = _health(Path(args.dir))
+        if health is not None:
+            rec["health"] = health
+    rec["next"] = _next_steps(Path(args.dir), preset)
+    rec["ok"] = True
+
+    # Defense in depth: everything goes through redact(). But redact() masks any value
+    # under a key that merely *looks* secret, and "credential_env"/"credential_present"
+    # do — so the provider block came out as `credential_env: «redacted»`, hiding the one
+    # thing the user needs (WHICH var to export) with no security gain. `credential_env`
+    # is an env var NAME and `credential_present` a bool, secret-free by construction in
+    # model_config; #121's doctor solves this identically, by rendering names AFTER
+    # redaction. Re-stamp exactly those two fields, nothing else.
+    out = redact(rec)
+    for key in ("credential_env", "credential_present"):
+        if key in rec.get("provider", {}):
+            out["provider"][key] = rec["provider"][key]
+
+    # Human summary → stderr. Stdout is exactly one JSON object (#217).
+    print(f"quickstart: preset {preset} scaffolded in {rec['dir']}\n"
+          f"  {rec['tasks']} tasks ({rec['val_tasks']} val) · optimizer "
+          f"{PRESETS[preset]['optimizer']} · {PRESETS[preset]['summary']}\n"
+          "next:\n" + "\n".join(f"  {s}" for s in rec["next"]), file=sys.stderr)
+    print(json.dumps(out, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main(sys.argv[1:]))

--- a/core/tests/test_quickstart.py
+++ b/core/tests/test_quickstart.py
@@ -173,7 +173,10 @@ def test_no_canary_leaks_into_output_or_files(tmp_path, preset):
     d = tmp_path / preset
     out = _qs("--yes", "--preset", preset, "--dir", str(d), "--base-url", _SECRET_URL,
               env={**_CANARIES, "OPENAI_BASE_URL": _SECRET_URL})
-    assert out.returncode == 0, out.stderr
+    # `mock` now REFUSES --base-url rather than silently dropping it, so it exits 1 and
+    # writes nothing. The sweep still runs on that path: a refusal message that echoes
+    # the offending flag back is a prime place to leak the URL's embedded credential.
+    assert out.returncode == (1 if preset == "mock" else 0), out.stderr
 
     printed = {"stdout": out.stdout, "stderr": out.stderr}
     written = {str(f.relative_to(d)): f.read_text(errors="replace")
@@ -268,6 +271,90 @@ def test_an_existing_project_is_not_clobbered(tmp_path):
     assert (tmp_path / ".capevolve/project/adapters/adapter.py").read_text() == "# mine\n"
     assert _qs("--yes", "--force", "--dir", str(tmp_path)).returncode == 0
     assert "# mine" not in (tmp_path / ".capevolve/project/adapters/adapter.py").read_text()
+
+
+def test_an_existing_mock_script_is_not_silently_overwritten(tmp_path):
+    """The edit script lives OUTSIDE `.capevolve/project`, so it needs its own guard.
+
+    It used to be replaced without a word — a hand-edited script vanishing quietly, and
+    the `--force` guard never saw it because it only covered the project dir.
+    """
+    (tmp_path / ".capevolve").mkdir()
+    junk = tmp_path / ".capevolve" / "mock_script.json"
+    junk.write_text('{"edits": [], "mine": true}\n')
+    out = _qs("--yes", "--dir", str(tmp_path))
+    assert out.returncode == 1
+    assert json.loads(out.stdout)["ok"] is False
+    assert "mine" in junk.read_text(), "the existing script was clobbered"
+    assert _qs("--yes", "--force", "--dir", str(tmp_path)).returncode == 0
+    assert "mine" not in junk.read_text(), "--force must overwrite it"
+
+
+def test_flags_that_cannot_work_with_mock_are_refused_not_ignored(tmp_path):
+    """A silently-dead flag is the same defect family as a silently-no-op optimizer.
+
+    `mock` is an offline stand-in with no endpoint and no model, so `--model`/`--base-url`
+    had nowhere to land and were dropped without a word.
+    """
+    for flag, value in (("--model", "gpt-4o"), ("--base-url", "http://x/v1")):
+        out = _qs("--yes", flag, value, "--dir", str(tmp_path / flag.strip("-")))
+        assert out.returncode == 1, f"{flag} was silently accepted"
+        err = json.loads(out.stdout)
+        assert err["ok"] is False and flag in err["error"]
+        assert "--preset local" in err["error"], "must say what to do instead"
+    # ...and they DO work on a preset that has an endpoint.
+    rec = quickstart.scaffold(tmp_path / "ok", "local", model="m1",
+                              base_url="http://127.0.0.1:9/v1")
+    assert rec["model"] == "m1"
+
+
+def test_val_tasks_matches_what_make_splits_actually_produces(tmp_path):
+    """The reported `val_tasks` must not be a second, drifting copy of the split math."""
+    from cap_evolve import splits as _splits
+    rec = quickstart.scaffold(tmp_path, "mock")
+    rows = [json.loads(ln) for ln in
+            (tmp_path / ".capevolve/project/adapters/tasks.jsonl").read_text().splitlines() if ln.strip()]
+    sp = _splits.make_splits([r["id"] for r in rows], seed=0, ratios=(0.5, 0.25, 0.25))
+    assert rec["val_tasks"] == len(sp.val)
+
+
+def test_preset_default_endpoints_are_shown_not_masked(tmp_path):
+    """Masking the endpoint quickstart itself chose is user-hostile and protects nothing."""
+    for preset in ("local", "free"):
+        rec = quickstart.scaffold(tmp_path / preset, preset)
+        assert rec["base_url"] == quickstart.PRESETS[preset]["base_url"], preset
+    # Anything else still masks.
+    assert quickstart.safe_url("https://gw.internal.example.corp/v1") == "<custom>"
+
+
+def test_force_over_a_file_gives_an_actionable_message(tmp_path):
+    """`--force` on a plain file used to surface a bare `[Errno 20] Not a directory`."""
+    (tmp_path / ".capevolve").mkdir()
+    (tmp_path / ".capevolve" / "project").write_text("not a dir\n")
+    out = _qs("--yes", "--force", "--dir", str(tmp_path))
+    assert out.returncode == 1
+    err = json.loads(out.stdout)["error"]
+    assert "Errno" not in err, err
+    assert "is a file, not a directory" in err and "remove it first" in err
+
+
+def test_mock_optimizer_warns_on_stderr_when_no_script_is_found():
+    """Silence that looks like success: no script means every candidate is unchanged.
+
+    The run still exits 0 with a green `check` and a sealed number equal to the baseline,
+    so the JSON `note` alone is not enough — nothing surfaces it to the reader of the
+    final report. This is the shape that made the documented quickstart path wrong.
+    """
+    script = REPO / "skills/optimizers/run-optimizer/scripts/_mock_apply.py"
+    import tempfile
+    with tempfile.TemporaryDirectory() as td:
+        env = {k: v for k, v in ENV.items() if k != "CAPEVOLVE_MOCK_SCRIPT"}
+        out = subprocess.run([sys.executable, str(script), "--workdir", td],
+                             capture_output=True, text=True, env=env)
+    assert out.returncode == 0, out.stderr           # still a scored no-op, not a crash
+    assert json.loads(out.stdout)["applied"] == []   # stdout is still exactly one object
+    assert "NO EDIT SCRIPT FOUND" in out.stderr, f"silent no-op:\n{out.stderr!r}"
+    assert "CAPEVOLVE_MOCK_SCRIPT" in out.stderr, "must name the fix"
 
 
 def test_unknown_preset_is_refused(tmp_path):

--- a/core/tests/test_quickstart.py
+++ b/core/tests/test_quickstart.py
@@ -1,0 +1,295 @@
+"""`cap-evolve quickstart` — the zero-question fast path to a runnable project (#133).
+
+Three contracts are load-bearing and each has a test that fails if it breaks:
+
+1. **It really runs.** The scaffolded project passes `cap-evolve check` AND completes a
+   full `cap-evolve run` to a sealed test number with the offline `mock` optimizer. A
+   scaffold that merely *looks* right is the failure mode this whole command exists to
+   avoid, so the money test drives the real pipeline.
+2. **Non-interactive, never hangs.** Piped/closed stdin uses defaults and returns; only
+   an explicit TTY on both stdin and stderr may prompt. Enforced with a subprocess
+   timeout, because "hangs forever" is not a value any assertion can inspect.
+3. **No secret ever leaves.** Multi-shape canaries under INNOCENT env names (a key-name
+   heuristic missed exactly that case earlier in this epic) must not appear in stdout,
+   stderr, or any written file — not the value, not a prefix, not a length.
+
+Plus: stdout is exactly one JSON object (#217), the spec omits `protected_paths` (#197
+makes an empty list a hard error), and the val split clears #195's `MIN_VAL_TASKS` floor.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+ENV = {**os.environ, "PYTHONPATH": str(REPO / "core"),
+       "CAPEVOLVE_SKILLS_DIR": str(REPO / "skills")}
+
+sys.path.insert(0, str(REPO / "core"))
+from cap_evolve import quickstart  # noqa: E402
+
+
+def _last_json_object(text: str) -> dict:
+    """The final top-level JSON object in ``text``, tolerating earlier ones."""
+    dec, pos, last = json.JSONDecoder(), 0, None
+    while pos < len(text):
+        try:
+            obj, pos = dec.raw_decode(text, pos)
+        except json.JSONDecodeError:
+            pos += 1
+            continue
+        if isinstance(obj, dict):
+            last = obj
+    assert last is not None, f"no JSON object on stdout:\n{text[:800]}"
+    return last
+
+
+def _qs(*args, cwd=None, env=None, stdin=subprocess.DEVNULL, timeout=60):
+    return subprocess.run([sys.executable, "-m", "cap_evolve.cli", "quickstart", *args],
+                          capture_output=True, text=True, cwd=str(cwd or REPO),
+                          env={**ENV, **(env or {})}, stdin=stdin, timeout=timeout)
+
+
+# --------------------------------------------------------------- 1. it really runs
+
+def test_scaffolded_project_runs_to_a_sealed_test_number(tmp_path):
+    """quickstart → check → run → a sealed test number, offline and free (#133).
+
+    The money test. Everything else about quickstart is presentation; this is whether
+    the thing it wrote actually optimizes. Baseline must be 0.0 (the seed prompt is
+    deliberately vague) and the sealed test 1.0 (the mock optimizer makes the output
+    contract explicit), so a scaffold that produced an unoptimizable project — no
+    headroom, or a broken adapter — fails here rather than in a user's terminal.
+    """
+    out = _qs("--yes", "--dir", str(tmp_path))
+    assert out.returncode == 0, f"quickstart failed:\n{out.stdout}\n{out.stderr}"
+
+    chk = subprocess.run([sys.executable, "-m", "cap_evolve.cli", "check",
+                          str(tmp_path / ".capevolve/project")],
+                         capture_output=True, text=True, cwd=str(REPO), env=ENV)
+    assert chk.returncode == 0, f"scaffold is not check-green:\n{chk.stdout}"
+    assert json.loads(chk.stdout)["ok"] is True
+
+    run = subprocess.run(
+        [sys.executable, "-m", "cap_evolve.cli", "run",
+         "--spec", str(tmp_path / ".capevolve/project/capevolve.yaml"),
+         "--project", str(tmp_path / ".capevolve/project"),
+         "--run-ts", "t", "--dashboard", "off"],
+        capture_output=True, text=True, cwd=str(REPO),
+        env={**ENV, "CAPEVOLVE_CORE": str(REPO / "core"),
+             "CAPEVOLVE_MOCK_SCRIPT": str(tmp_path / ".capevolve/mock_script.json")},
+        timeout=600)
+    assert run.returncode == 0, f"run failed:\n{run.stdout}\n{run.stderr}"
+    # The final report is the LAST JSON object on stdout. #217 says there should be
+    # exactly one, and quickstart's own stdout is asserted to be exactly one below —
+    # but `cap-evolve run` is not this PR's contract to enforce, and #190's branch
+    # currently prints a `{"step": "provider"}` line there too. Asserting strict
+    # single-object on `run` from here would make THIS file fail on a merge order it
+    # does not control; #217 owns that.
+    report = _last_json_object(run.stdout)
+    assert report["baseline_val"] == 0.0, report
+    assert report["test_reward"] == 1.0, f"no sealed improvement: {report}"
+
+
+# ------------------------------------------------- 2. non-interactive, never hangs
+
+@pytest.mark.parametrize("argv,stdin_mode", [
+    ([], subprocess.DEVNULL),      # closed stdin, no flags: must default, not block
+    ([], subprocess.PIPE),         # piped stdin (garbage on it): must default, not read
+    (["--yes"], subprocess.PIPE),
+    (["--preset", "mock"], subprocess.PIPE),
+])
+def test_never_hangs_and_uses_defaults(tmp_path, argv, stdin_mode):
+    """No invocation blocks on stdin; the default preset is used (#133).
+
+    `timeout=` is the assertion: a prompt written to a pipe that nobody answers hangs
+    forever, and no return-value check can catch that.
+    """
+    d = tmp_path / f"d{len(argv)}{stdin_mode}"
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "cap_evolve.cli", "quickstart", *argv, "--dir", str(d)],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=stdin_mode,
+        text=True, cwd=str(REPO), env=ENV)
+    stdout, stderr = proc.communicate(input="free\n" if stdin_mode is subprocess.PIPE else None,
+                                     timeout=60)
+    assert proc.returncode == 0, stderr
+    # Not "free": a non-TTY stdin must be ignored entirely, not consulted.
+    assert json.loads(stdout)["preset"] == quickstart.DEFAULT_PRESET
+
+
+def test_interactive_requires_a_tty_on_both_streams(monkeypatch):
+    """`interactive()` is false unless stdin AND stderr are real terminals (#133/#215).
+
+    Reuses #215's capability ladder rather than sniffing isatty locally, so a
+    non-terminal on either side (CI, a pipe, `2>&-`) means "defaults".
+    """
+    class S:
+        def __init__(self, tty):
+            self._tty, self.closed, self.encoding = tty, False, "utf-8"
+
+        def isatty(self):
+            return self._tty
+
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setenv("TERM", "xterm")
+    for in_tty, err_tty, want in ((True, True, True), (True, False, False),
+                                  (False, True, False), (False, False, False)):
+        monkeypatch.setattr(sys, "stdin", S(in_tty))
+        monkeypatch.setattr(sys, "stderr", S(err_tty))
+        assert quickstart.interactive() is want, (in_tty, err_tty)
+
+
+# ------------------------------------------------------------------- 3. no secrets
+
+# Deliberately INNOCENT names: a key-name heuristic caught ANTHROPIC_API_KEY and missed
+# a token parked in BUILD_NUMBER earlier in this epic. Shapes: bare high-entropy, UUID,
+# `ghp_`, `sk-`, and an opaque watsonx-style base64 blob.
+_CANARIES = {
+    "GEMINI_API_KEY": "AIzaSyCANARY9bare1high2entropy3value4here5xyzQ",
+    "BUILD_NUMBER": "7f3c9a21-4b8e-4d1f-9c2a-6e5b7d8f0a13",
+    "DEPLOY_TAG": "ghp_CANARYghp0123456789abcdefghijklmnopqrs",
+    "REGION_HINT": "cGFzc3dvcmQ6Y2FuYXJ5d2F0c29ueDEyMzQ1Njc4OTBhYmNkZWY=",
+    "TELEMETRY_ID": "sk-CANARYsk0123456789abcdefghijklmnopqrstuvwxyz",
+}
+_SECRET_URL = "https://gw-user:s3cr3tCANARYtoken@internal.gw.example.corp/v1"
+
+
+@pytest.mark.parametrize("preset", sorted(quickstart.PRESETS))
+def test_no_canary_leaks_into_output_or_files(tmp_path, preset):
+    """Not a value, not a prefix, not a length — anywhere (#133/#190).
+
+    Prefixes are checked too: a truncated secret still identifies the account, and
+    slicing before redaction is how a fragment survives a shape-based rule.
+
+    Scope note: the endpoint HOSTNAME is only confidential in *output*. An endpoint the
+    user typed as `--base-url` must reach the adapter or nothing can call it, so the
+    host is checked against stdout/stderr only — while the userinfo credential inside
+    it must not survive anywhere, files included.
+    """
+    d = tmp_path / preset
+    out = _qs("--yes", "--preset", preset, "--dir", str(d), "--base-url", _SECRET_URL,
+              env={**_CANARIES, "OPENAI_BASE_URL": _SECRET_URL})
+    assert out.returncode == 0, out.stderr
+
+    printed = {"stdout": out.stdout, "stderr": out.stderr}
+    written = {str(f.relative_to(d)): f.read_text(errors="replace")
+               for f in d.rglob("*") if f.is_file() and f.suffix != ".pyc"}
+
+    findings = []
+    # Credential values (and prefixes) leak NOWHERE — printed or written.
+    for name, value in _CANARIES.items():
+        for probe in (value, value[:16], value[:12]):
+            for where, text in {**printed, **written}.items():
+                if probe in text:
+                    findings.append(f"{name} ({len(probe)}-char prefix) leaked into {where}")
+    for probe in ("s3cr3tCANARYtoken", "gw-user"):
+        for where, text in {**printed, **written}.items():
+            if probe in text:
+                findings.append(f"URL userinfo {probe!r} survived into {where}")
+    # The hostname itself: confidential in output, legitimate in the adapter config.
+    for where, text in printed.items():
+        if "internal.gw.example.corp" in text:
+            findings.append(f"custom endpoint hostname printed to {where} "
+                            "(must render as <custom>)")
+    assert not findings, "\n".join(sorted(set(findings)))
+
+
+def test_credential_presence_is_reported_but_never_the_value(tmp_path):
+    """PRESENCE + the env var NAME, so the user knows what to export (#133/#190).
+
+    The complement of the leak test: over-redacting `credential_env` (the key looks
+    secret to `redact`) hid the one actionable fact with no security gain.
+    """
+    out = _qs("--yes", "--preset", "free", "--dir", str(tmp_path),
+              env={"GEMINI_API_KEY": _CANARIES["GEMINI_API_KEY"]})
+    prov = json.loads(out.stdout)["provider"]
+    assert prov["credential_present"] is True
+    assert prov["credential_env"] in ("GEMINI_API_KEY", "GOOGLE_API_KEY")
+    assert _CANARIES["GEMINI_API_KEY"] not in json.dumps(prov)
+
+
+def test_url_userinfo_is_stripped_before_anything_is_written(tmp_path):
+    """`https://user:token@host/` is a credential; it dies at resolution (#190)."""
+    rec = quickstart.scaffold(tmp_path, "local", base_url=_SECRET_URL)
+    adapter = (tmp_path / ".capevolve/project/adapters/adapter.py").read_text()
+    assert "gw-user" not in adapter and "s3cr3tCANARYtoken" not in adapter
+    # The host survives (the adapter must be able to call it); the credential does not.
+    assert "internal.gw.example.corp" in adapter
+    assert "@" not in rec["base_url"] and rec["base_url"] == "<custom>"
+
+
+# ------------------------------------------------- scaffold shape: #197, #195, #217
+
+def test_spec_omits_protected_paths(tmp_path):
+    """#197 makes `protected_paths: []` a HARD error — the scaffold must omit the key.
+
+    quickstart patches the shipped template rather than authoring a spec, so this also
+    guards against a future template change reintroducing an empty list.
+    """
+    quickstart.scaffold(tmp_path, "mock")
+    spec = (tmp_path / ".capevolve/project/capevolve.yaml").read_text()
+    for line in spec.splitlines():
+        assert not line.lstrip().startswith("protected_paths:") or line.lstrip().startswith("#"), line
+    from cap_evolve.specfile import read_yaml
+    assert "protected_paths" not in read_yaml(spec)
+
+
+def test_val_split_clears_the_min_val_floor(tmp_path):
+    """#195 hard-fails a tiny val split; the seed task count must clear the floor."""
+    from cap_evolve import splits as _splits
+    quickstart.scaffold(tmp_path, "mock")
+    rows = [json.loads(ln) for ln in
+            (tmp_path / ".capevolve/project/adapters/tasks.jsonl").read_text().splitlines() if ln.strip()]
+    sp = _splits.make_splits([r["id"] for r in rows], seed=0, ratios=(0.5, 0.25, 0.25))
+    floor = getattr(_splits, "MIN_VAL_TASKS", 2)
+    assert len(sp.val) > floor, f"val={len(sp.val)} is at/below #195's floor {floor}"
+
+
+def test_stdout_is_exactly_one_json_object_and_human_output_is_on_stderr(tmp_path):
+    """#217: `cap-evolve quickstart | json.loads` must not raise "Extra data"."""
+    out = _qs("--yes", "--dir", str(tmp_path))
+    rec = json.loads(out.stdout)                # the whole point
+    assert rec["ok"] is True and rec["preset"] == "mock"
+    assert "quickstart: preset" in out.stderr, "human summary must go to stderr"
+    assert "quickstart: preset" not in out.stdout
+
+
+def test_an_existing_project_is_not_clobbered(tmp_path):
+    """Refuse by default, overwrite only with --force — and report it as JSON (#133)."""
+    quickstart.scaffold(tmp_path, "mock")
+    (tmp_path / ".capevolve/project/adapters/adapter.py").write_text("# mine\n")
+    out = _qs("--yes", "--dir", str(tmp_path))
+    assert out.returncode == 1
+    assert json.loads(out.stdout)["ok"] is False
+    assert (tmp_path / ".capevolve/project/adapters/adapter.py").read_text() == "# mine\n"
+    assert _qs("--yes", "--force", "--dir", str(tmp_path)).returncode == 0
+    assert "# mine" not in (tmp_path / ".capevolve/project/adapters/adapter.py").read_text()
+
+
+def test_unknown_preset_is_refused(tmp_path):
+    """argparse rejects it at the flag; the API raises rather than silently defaulting."""
+    assert _qs("--yes", "--preset", "nope", "--dir", str(tmp_path)).returncode == 2
+    with pytest.raises(ValueError, match="unknown preset"):
+        quickstart.scaffold(tmp_path, "nope")
+
+
+def test_quickstart_is_registered_in_the_generated_command_listing():
+    """It must appear in #214's docstring-driven listing with zero edits there (#133).
+
+    #214 generates the top-level listing from COMMANDS + handler docstrings so a new
+    subcommand needs one registration line. This asserts quickstart met that contract
+    (and, before #214 lands, that the interim usage line is also COMMANDS-derived).
+    """
+    from cap_evolve import cli
+    assert cli.COMMANDS["quickstart"] is cli._cmd_quickstart
+    usage = cli._usage() if hasattr(cli, "_usage") else ""
+    if usage:
+        assert "\n  quickstart" in usage, usage
+        assert "Scaffold a ready-to-run project" in usage, "docstring not picked up"
+    out = subprocess.run([sys.executable, "-m", "cap_evolve.cli", "--help"],
+                         capture_output=True, text=True, cwd=str(REPO), env=ENV)
+    assert "quickstart" in out.stdout + out.stderr

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -43,7 +43,42 @@ This is exactly what `core/tests/test_e2e_slice.py` asserts. The script prints a
 directory; open the `dashboard.html` it writes in any browser to see the run (KPIs,
 per-iteration diffs, the tasks × iterations heatmap).
 
-## 4. Where to next
+## 4. Scaffold your own runnable project — `cap-evolve quickstart`
+
+`toy_calc` runs *inside the repo*. `quickstart` writes the same kind of project into a
+directory of your own, from a **free or local** preset, and asks nothing:
+
+```bash
+mkdir ~/my-run && cd ~/my-run
+cap-evolve quickstart --yes              # or plain `cap-evolve quickstart` for one question
+cap-evolve check .capevolve/project      # already green — no adapter to implement
+cap-evolve run                           # sealed test number, $0
+```
+
+| preset | cost | target runner | needs |
+|---|---|---|---|
+| `mock` (default) | $0 | offline deterministic stand-in | nothing at all |
+| `local` | $0 | local OpenAI-compatible server | a server on `127.0.0.1` (e.g. `ollama serve`) |
+| `free` | $0 | Gemini free tier (OpenAI-compatible) | `GEMINI_API_KEY` exported |
+
+**How this differs from `intake`.** `quickstart` is the zero-question *fast path*: it
+picks a preset and writes a project that is already `cap-evolve check`-green, so the very
+next command is `cap-evolve run`. `intake` is the guided *interview* for your own
+capability and benchmark — it mines your working dir, asks what to optimize, and leaves an
+adapter **stub** you implement before the `implement-and-check` gate opens. Use
+`quickstart` to see the pipeline work; use `intake` when you have real work to optimize.
+
+**Non-interactive.** `--yes`, `--preset`, or a non-terminal stdin all mean "defaults,
+never read stdin" — so quickstart in CI or behind a pipe cannot hang.
+
+**No secrets.** quickstart reports which credential env var is *present* — never a value,
+a prefix, or a length — and writes only the variable's **name** into the project. A base
+URL carrying `user:token@` has its credential stripped, and a non-default endpoint is
+reported as `<custom>`.
+
+Stdout is exactly one JSON object; the human summary goes to stderr.
+
+## 5. Where to next
 
 | You want to… | Go to |
 |---|---|

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -51,15 +51,30 @@ directory of your own, from a **free or local** preset, and asks nothing:
 ```bash
 mkdir ~/my-run && cd ~/my-run
 cap-evolve quickstart --yes              # or plain `cap-evolve quickstart` for one question
+export CAPEVOLVE_MOCK_SCRIPT=~/my-run/.capevolve/mock_script.json
 cap-evolve check .capevolve/project      # already green — no adapter to implement
 cap-evolve run                           # sealed test number, $0
 ```
 
+The `export` is not optional: it points the offline `mock` optimizer at the edit script
+quickstart wrote. quickstart prints the exact line for your directory in its `next` list,
+so copy it from there. Skip it and the optimizer proposes nothing — the run still exits 0
+but seals `test_reward 0.0`, i.e. the baseline. (Since #248 it also says so loudly on
+stderr rather than passing silently.)
+
 | preset | cost | target runner | needs |
 |---|---|---|---|
 | `mock` (default) | $0 | offline deterministic stand-in | nothing at all |
-| `local` | $0 | local OpenAI-compatible server | a server on `127.0.0.1` (e.g. `ollama serve`) |
+| `local` | $0 | local OpenAI-compatible server | `ollama serve` **and** `ollama pull qwen2.5:3b` |
 | `free` | $0 | Gemini free tier (OpenAI-compatible) | `GEMINI_API_KEY` exported |
+
+**`--model` / `--base-url` need a preset with an endpoint.** `mock` is an offline
+stand-in with neither, so passing them there is refused rather than silently ignored.
+
+**A `doctor` failure does not fail the command.** quickstart's contract is "the project
+was scaffolded", and it was; health is advisory about your *environment* and is reported
+in the `health` key and on stderr. `cap-evolve check` and `cap-evolve run` are the gates
+that actually refuse.
 
 **How this differs from `intake`.** `quickstart` is the zero-question *fast path*: it
 picks a preset and writes a project that is already `cap-evolve check`-green, so the very

--- a/skills/optimizers/run-optimizer/scripts/_mock_apply.py
+++ b/skills/optimizers/run-optimizer/scripts/_mock_apply.py
@@ -65,6 +65,19 @@ def main(argv=None) -> int:
     workdir = Path(args.workdir)
     script = _find_script(workdir)
     if script is None:
+        # Loud on stderr, not just a JSON `note` nobody reads. "No script" means every
+        # candidate is byte-identical to its parent, so the run still exits 0, `check`
+        # stays green, and the sealed number equals the baseline — a wrong answer that
+        # looks like success. That silence bit `quickstart` (whose script lives in
+        # `<dest>/.capevolve/`, outside both search locations) and bites `toy_calc` the
+        # same way if its export is missed.
+        print("mock optimizer: NO EDIT SCRIPT FOUND — proposing no edits, so this run "
+              "cannot improve on its baseline.\n"
+              f"  looked at: $CAPEVOLVE_MOCK_SCRIPT="
+              f"{os.environ.get('CAPEVOLVE_MOCK_SCRIPT') or '<unset>'}, "
+              f"{workdir / 'mock_script.json'}, {workdir.parent / 'mock_script.json'}\n"
+              "  fix: export CAPEVOLVE_MOCK_SCRIPT=/path/to/mock_script.json",
+              file=sys.stderr)
         print(json.dumps({"optimizer": "mock", "applied": [],
                           "note": "no mock_script.json found; no edits made"}))
         return 0

--- a/skills/optimizers/run-optimizer/scripts/run.py
+++ b/skills/optimizers/run-optimizer/scripts/run.py
@@ -296,6 +296,12 @@ def main(argv=None) -> int:
     env.update(auth["env"])
 
     proc = subprocess.run(cmd, cwd=workdir, capture_output=True, text=True, env=env)
+    # Relay the agent's stderr rather than only burying it in `stderr_tail`: a warning
+    # on a run that still exits 0 (e.g. mock's "no edit script found") is invisible
+    # otherwise, because nothing surfaces a per-candidate payload field to the person
+    # reading the final report. stdout stays exactly the one JSON object below.
+    if proc.stderr:
+        sys.stderr.write(proc.stderr)
     result = {"optimizer": name, "cli_present": True, "returncode": proc.returncode,
               "auth_present": auth["present"],
               "stdout_tail": proc.stdout[-800:], "stderr_tail": proc.stderr[-500:]}


### PR DESCRIPTION
Closes #133.

## What

`cap-evolve quickstart` — the **zero-question fast path** from a fresh install to a real, sealed run. Before this, reaching a run meant hand-editing `capevolve.yaml`, and reaching a *real* one meant paid credentials; the only zero-friction option was `examples/toy_calc/run.sh`, which runs inside the repo and scaffolds nothing you own.

`quickstart` writes a project into a directory of your own that is **already `cap-evolve check`-green**, so the next command is `cap-evolve run`.

## Presets

A plain dict in `quickstart.PRESETS`. No plugin framework — a preset is one row.

| preset | cost | target runner | needs |
|---|---|---|---|
| `mock` (default) | $0 | offline deterministic stand-in | nothing at all |
| `local` | $0 | local OpenAI-compatible server (Ollama / llama.cpp / vLLM) | a server on `127.0.0.1` |
| `free` | $0 | Gemini free tier, via its OpenAI-compatible endpoint | `GEMINI_API_KEY` exported |

## How this differs from `intake`

No code is shared, and neither invokes the other.

- **`intake`** is the guided **interview**: it mines your working dir, asks what capability to optimize, and leaves an adapter **stub** you must implement before `implement-and-check` opens the gate.
- **`quickstart`** asks nothing and writes a **working** adapter, so a curious installer sees a sealed test number before hitting a credential or cost wall.

A quickstart project is an ordinary project that intake could have produced. Use quickstart to see the pipeline work; use intake when you have real work to optimize.

## Non-interactive contract

`--yes`, `--preset`, **or** a non-TTY stdin/stderr all mean "use defaults, never read stdin". A piped or CI invocation cannot hang — proven with a subprocess timeout, since "hangs forever" is not a value an assertion can inspect. The TTY decision reuses **#215**'s `eventstream.capability` ladder (`pipe`/`none` are the non-TTY rungs) rather than sniffing `isatty` locally; `plain`/`dumb` are real terminals that merely refuse colour, so they still get the prompt. There is a documented fallback for while #215 is unmerged.

## No-secret guarantee

- Credential **presence only** — never a value, never a prefix, never a length. Resolution goes through **#190**'s `model_config`, so provider-scoping is not re-implemented here.
- The scaffolded adapter stores the credential's env var **NAME** and reads `os.environ` at run time. Nothing written to disk contains a credential.
- URL **userinfo** (`https://user:token@host/`) is stripped at the single point of resolution, before anything is stored, printed, or reported.
- A **non-default base URL** renders as `<custom>` — a real internal gateway URL already leaked into a public PR in this epic.
- Everything printed passes `dashboard.redact`. One deliberate exception, re-stamped *after* redaction: `credential_env` and `credential_present`. `redact` masks any value under a key that merely *looks* secret, so the provider block came out as `credential_env: «redacted»`, hiding the one thing the user needs (which var to export) for zero security gain. `credential_env` is a NAME and `credential_present` a bool, secret-free by construction in `model_config`. **#121**'s `doctor` solves this identically (render names post-redaction).

Verified with multi-shape canaries under **innocent-looking** env names (`BUILD_NUMBER`, `DEPLOY_TAG`, `REGION_HINT`, `TELEMETRY_ID`) — a key-name heuristic missed exactly that case earlier in this epic. Shapes: bare high-entropy, UUID, `ghp_`, `sk-`, opaque watsonx-style base64. Prefixes (16- and 12-char) are checked too, since a truncated fragment still identifies the account and no longer matches a shape rule.

## Reuse rather than reimplementation

| Dependency | How it is used |
|---|---|
| **#193 / #121** `doctor` | `run_doctor()` + branch on `rep.ok`. No health checks reimplemented; `format_report` goes to stderr on failure. |
| **#190** provider creds | `model_config.resolve(require_credential=False)` + `strip_url_userinfo`. Provider-scoping and precedence not duplicated. |
| **#215** TTY ladder | `eventstream.capability` for the interactive decision. |
| **#214** CLI ergonomics | The subcommand appears in the generated listing with **zero edits** — see Verification. |
| **#197** protected paths | The spec is produced by **patching the shipped `templates/project/capevolve.yaml`**, which deliberately OMITS `protected_paths`. Asserted, so a future template change cannot reintroduce an empty list (a hard error). |
| **#195** val floor | The seed set is **16 tasks**, giving val=4. 8 tasks at the default ratios lands on `MIN_VAL_TASKS` exactly — one rounding change from a hard-failing scaffold. |
| **#217** one JSON object | Stdout is exactly one object; the human summary goes to stderr. |

Each optional dependency is reached through a single `_optional()` import lookup with a documented fallback, so this merges in any order.

### #124

**No — the branch does not exist.** `git branch -r | grep 124` returns nothing on origin, so there was no entry point to build on. Rather than invent a parallel preset, `PRESETS` is a dict whose rows carry `provider` / `runner` / `base_url` / `model` / `optimizer` / `needs`: **#124's cheap-real-run preset is one more row**, no structural change. Happy to add it in this PR if the branch lands first.

## Exact `cli.py` lines touched

12 insertions, 1 deletion, three places — nothing else:

| Location | Change |
|---|---|
| after `_cmd_run` (new lines 469-474) | the 4-line `_cmd_quickstart` handler + blank lines |
| `COMMANDS` (new line 652) | one row: `"quickstart": _cmd_quickstart,` |
| `main()` (line 655 → 662-666) | replaced the literal `usage: cap-evolve {version\|splits\|...}` string with one **joined from `COMMANDS`** |

That third change is not a new literal — it removes one. #214 deletes that whole block and replaces it with `_usage()`; until it lands, joining `COMMANDS` means a newly registered subcommand appears with zero edits either way. On merge with #214, that hunk is the single conflict and the resolution is "take #214's side wholesale".

## Expected merge order

Order-independent. Recommended: **#214 → #193/#121 → #190 → this**. Verified against all three merged locally (see Verification). #214 is the only conflict, and it is one hunk with an obvious resolution.

Note found while verifying: **#214 and #190 conflict with each other** on #217's contract — `test_run_stdout_is_a_single_json_object` fails with both merged, because #190 prints a `{"step": "provider"}` line to `run`'s stdout. Pre-existing, reproduced without any of my changes applied, and not mine to fix; flagging it for whoever merges second.

## Files touched

- `core/cap_evolve/quickstart.py` — new, 430 lines
- `core/tests/test_quickstart.py` — new, 17 tests
- `core/cap_evolve/cli.py` — +12 / -1
- `docs/GETTING_STARTED.md` — new section 4 (preset table, intake contrast, contracts)

## Verification

**Full suite: 196 passed, 0 failed** (baseline 179 + 17 new). `compileall` clean. On the #214 merge: **207 passed, 0 failed**, including its documented-CLI checker over the new docs.

### The money evidence — quickstart → check → run → sealed test number

```
$ cd /tmp/ev && cap-evolve quickstart --yes
exit=0
--- stderr (human) ---
quickstart: preset mock scaffolded in /private/tmp/ev
  16 tasks (4 val) · optimizer mock · fully offline, $0, no credential — a deterministic stand-in agent
next:
  export CAPEVOLVE_MOCK_SCRIPT=/private/tmp/ev/.capevolve/mock_script.json
  cd /private/tmp/ev
  cap-evolve check .capevolve/project
  cap-evolve run
--- stdout (machine) ---
{
  "preset": "mock",
  "dir": "/private/tmp/ev",
  "created": [
    ".capevolve/mock_script.json",
    ".capevolve/project/adapters/adapter.py",
    ".capevolve/project/adapters/tasks.jsonl",
    ".capevolve/project/capevolve.yaml",
    "seed_capability/prompt.txt"
  ],
  "provider": {
    "provider": "mock",
    "credential_env": "",
    "credential_present": false,
    "base_url": "",
    "reason": "offline preset — no credential, no endpoint"
  },
  "model": "",
  "base_url": "",
  "val_tasks": 4,
  "tasks": 16,
  "ok": true
}

$ cap-evolve check .capevolve/project
{
  "ok": true,
  "stubs": [],
  "problems": [],
  "notes": [
    "tasks('val') -> 16 task(s)",
    "scorer deterministic (probe reward=0.0000)",
    "materialize() callable (dry-run into temp copy; host untouched)"
  ]
}
exit=0

$ export CAPEVOLVE_MOCK_SCRIPT=/tmp/ev/.capevolve/mock_script.json
$ cap-evolve run --run-ts demo --dashboard off
exit=0
{
  "run_dir": ".capevolve/run_demo",
  "best_id": "cand_0001",
  "baseline_val": 0.0,
  "test_reward": 1.0,
  "test_baseline_reward": 0.0,
  "test_delta": 1.0,
  "test_pass_k": { "1": 1.0, "2": 0.0 },
  "iterations": 3,
  "dashboard": ".capevolve/run_demo/dashboard.html"
}
```

**baseline_val 0.0 → sealed test_reward 1.0**, gate-accepted, $0, zero model calls.

### Stdout is exactly one JSON object

```
$ python -c "json.load(open(stdout))"
parsed OK — exactly one object; keys: ['base_url', 'created', 'dir', 'model', 'next', 'ok', 'preset', 'provider', 'tasks', 'val_tasks']
```

Human output is on stderr (see the transcript above — the two streams were captured separately).

### Appears in #214's generated listing with ZERO edits

Merged `origin/feat/issue-137-cli-ergonomics` locally. `_usage()` untouched:

```
$ cap-evolve --help
usage: cap-evolve {version|splits|check|quickstart|run|estimate|dashboard} [args]

commands:
  version     Print the installed cap-evolve version as JSON.
  splits      Compute the seeded train/val/test split for a set of task ids.
  check       Verify a project's adapter is fully implemented and deterministic.
  quickstart  Scaffold a ready-to-run project from a free/local preset (zero questions).
  run         Sequence the whole optimization run: baseline → algorithm → finalize → report.
  estimate    Pre-run cost estimate without spending anything.
  dashboard   Launch (or focus) the live dashboard server over a base dir of runs.

run `cap-evolve <command> --help` for a command's flags and examples.
```

The description is pulled from the handler docstring. All 11 of #214's tests pass, including `test_every_subcommand_renders_help` for `quickstart`.

### Piped / non-TTY stdin does not hang

```
$ echo "hello" | cap-evolve quickstart          # no --yes, no --preset
  "preset": "mock",      ← the piped "hello" is IGNORED, not consulted
  "ok": true
0.06s user 0.02s system 88% cpu 0.086 total

$ cap-evolve quickstart < /dev/null
  "preset": "mock",
  "ok": true
0.06s user 0.02s system 95% cpu 0.078 total
```

0.08s, defaults used. Four stdin shapes are covered by a parametrized test with `timeout=60`.

### No canary leaks — including innocent key names

```
$ export GEMINI_API_KEY='AIzaSyCANARY9bare1high2entropy3value4here5xyzQ'
$ export BUILD_NUMBER='7f3c9a21-4b8e-4d1f-9c2a-6e5b7d8f0a13'                 # UUID, innocent name
$ export DEPLOY_TAG='ghp_CANARYghp0123456789abcdefghijklmnopqrs'             # ghp_, innocent name
$ export REGION_HINT='cGFzc3dvcmQ6Y2FuYXJ5d2F0c29ueDEyMzQ1Njc4OTBhYmNkZWY='  # watsonx-style opaque
$ export TELEMETRY_ID='sk-CANARYsk0123456789abcdefghijklmnopqrstuvwxyz'      # sk-, innocent name
$ export OPENAI_BASE_URL='https://gw-user:s3cr3tCANARYtoken@internal.gw.example.corp/v1'
$ cap-evolve quickstart --yes --preset free --dir /tmp/qs-canary
exit=0

provider block on stdout:
{
  "provider": "gemini",
  "credential_env": "GEMINI_API_KEY",     ← the NAME, so the user knows what to export
  "credential_present": true,             ← presence, nothing more
  "base_url": "<custom>",
  "base_url_source": "<custom>",
  "reason": "provider 'gemini' from CLI flag"
}

$ grep -rniE 'AIzaSyCANARY|7f3c9a21|ghp_CANARY|cGFzc3dvcmQ6|sk-CANARY|s3cr3tCANARY|internal\.gw\.example|gw-user' \
    /tmp/qs-canary /tmp/canary-stdout.json /tmp/canary-stderr.txt
NO LEAK anywhere
```

No value, no prefix, no length, in output or in any written file.

### #197 `protected_paths` and #195 val floor

```
$ pytest core/tests/test_quickstart.py -q
17 passed
```

`test_spec_omits_protected_paths` parses the written spec and asserts the key is absent (not present-and-empty, which #197 hard-errors on). `test_val_split_clears_the_min_val_floor` runs the real `make_splits` at the spec's seed/ratios and asserts `len(val) > MIN_VAL_TASKS`.

### Full suite

```
$ PYTHONPATH=core python -m pytest core/tests -q
196 passed in 64.71s

$ python -m compileall -q core/cap_evolve core/tests
compileall clean
```
