### PR TITLE
feat(dashboard): cross-link candidates/rollouts and consolidate the overlapping diff & file tabs

### DIFF
--- a/dashboard/frontend/src/components/BestCurveChart.tsx
+++ b/dashboard/frontend/src/components/BestCurveChart.tsx
@@ -21,8 +21,21 @@ const COLOR: Record<GraphNode['status'], string> = {
   failed: 'var(--muted)',
 }
 
-/** Per-iteration val scatter under the amber cumulative-best stair. */
-export function BestCurveChart({ nodes }: { nodes: GraphNode[] }) {
+/** Per-iteration val scatter under the amber cumulative-best stair.
+ *
+ * `onSelect` (#139) is the cross-link: picking a candidate jumps to its trajectories and
+ * its diff. It is wired to the recharts `Scatter` onClick for the mouse AND to a real
+ * `<button>` per row of the data table below for the keyboard — an SVG scatter shape is
+ * not a focusable control, and that table already existed as the accessible alternative,
+ * so it becomes the keyboard path to the same link rather than a second widget.
+ */
+export function BestCurveChart({
+  nodes,
+  onSelect,
+}: {
+  nodes: GraphNode[]
+  onSelect?: (candidateId: string) => void
+}) {
   const data = cumulativeBest(nodes)
   const reduce = prefersReducedMotion()
 
@@ -77,15 +90,24 @@ export function BestCurveChart({ nodes }: { nodes: GraphNode[] }) {
             <Scatter
               dataKey="val"
               isAnimationActive={!reduce}
+              cursor={onSelect ? 'pointer' : undefined}
+              onClick={(p: unknown) => {
+                const id = (p as { payload?: CurvePoint })?.payload?.id
+                if (id && onSelect) onSelect(id)
+              }}
               shape={(props: unknown) => <CandidateDot {...(props as DotProps)} championBest={championBest} />}
             />
           </ComposedChart>
         </ResponsiveContainer>
       </div>
 
-      {/* Accessible table alternative */}
-      <details className="mt-2">
-        <summary className="cursor-pointer text-xs text-muted">View data table</summary>
+      {/* Accessible alternative to the scatter — and, when onSelect is wired, the keyboard
+          path to the same cross-link the dots offer the mouse. Open by default in that
+          case: a link that only exists inside a collapsed <details> is not discoverable. */}
+      <details className="mt-2" open={!!onSelect}>
+        <summary className="cursor-pointer text-xs text-muted">
+          {onSelect ? 'Candidates — select one to inspect its rollouts and diff' : 'View data table'}
+        </summary>
         <table className="mt-2 w-full text-left text-xs">
           <thead className="text-muted">
             <tr>
@@ -99,7 +121,20 @@ export function BestCurveChart({ nodes }: { nodes: GraphNode[] }) {
             {data.map((d) => (
               <tr key={d.id} className="border-t border-border">
                 <td className="py-1 pr-3">{d.iteration}</td>
-                <td className="py-1 pr-3">{d.id}</td>
+                <td className="py-1 pr-3">
+                  {onSelect ? (
+                    <button
+                      type="button"
+                      onClick={() => onSelect(d.id)}
+                      aria-label={`Inspect ${d.id}: its per-task rollouts and its diff`}
+                      className="rounded text-left underline decoration-dotted underline-offset-2 hover:text-primary"
+                    >
+                      {d.id}
+                    </button>
+                  ) : (
+                    d.id
+                  )}
+                </td>
                 <td className="py-1 pr-3">{pct(d.val)}</td>
                 <td className="py-1">{pct(d.best)}</td>
               </tr>

--- a/dashboard/frontend/src/components/BestCurveChart.tsx
+++ b/dashboard/frontend/src/components/BestCurveChart.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react'
 import {
   CartesianGrid,
   ComposedChart,
@@ -102,12 +103,13 @@ export function BestCurveChart({
       </div>
 
       {/* Accessible alternative to the scatter — and, when onSelect is wired, the keyboard
-          path to the same cross-link the dots offer the mouse. Open by default in that
-          case: a link that only exists inside a collapsed <details> is not discoverable. */}
-      <details className="mt-2" open={!!onSelect}>
-        <summary className="cursor-pointer text-xs text-muted">
-          {onSelect ? 'Candidates — select one to inspect its rollouts and diff' : 'View data table'}
-        </summary>
+          path to the same cross-link the dots offer the mouse. A cross-link inside a
+          collapsed <details> is not discoverable, and a <details> that is never closed is
+          just a heading wearing a disclosure triangle — so use an actual heading there. */}
+      <Disclosure
+        summary={onSelect ? 'Candidates — select one to inspect its rollouts and diff' : 'View data table'}
+        alwaysOpen={!!onSelect}
+      >
         <table className="mt-2 w-full text-left text-xs">
           <thead className="text-muted">
             <tr>
@@ -141,8 +143,34 @@ export function BestCurveChart({
             ))}
           </tbody>
         </table>
-      </details>
+      </Disclosure>
     </Card>
+  )
+}
+
+/** A heading + content when the content must always be visible, a real <details> when it
+ *  is genuinely collapsible. */
+function Disclosure({
+  summary,
+  alwaysOpen,
+  children,
+}: {
+  summary: string
+  alwaysOpen: boolean
+  children: ReactNode
+}) {
+  if (alwaysOpen)
+    return (
+      <div className="mt-2">
+        <h4 className="text-xs text-muted">{summary}</h4>
+        {children}
+      </div>
+    )
+  return (
+    <details className="mt-2">
+      <summary className="cursor-pointer text-xs text-muted">{summary}</summary>
+      {children}
+    </details>
   )
 }
 

--- a/dashboard/frontend/src/components/ChangesPanel.tsx
+++ b/dashboard/frontend/src/components/ChangesPanel.tsx
@@ -1,0 +1,64 @@
+import { Tabs, type TabDef } from './ui/Tabs'
+import { IterationsDiff } from './IterationsDiff'
+import { GitDiff } from './GitDiff'
+import { MemoryPanel } from './MemoryPanel'
+import { FileTree } from './FileTree'
+import type { RunGraph } from '../lib/types'
+
+/**
+ * "Changes & files" (#139): the one place to inspect what a candidate changed.
+ *
+ * Four top-level tabs — Iterations (candidate-vs-parent snapshot diff), Git diffs
+ * (commit-to-commit), Memory (accepted/rejected history + candidate scratch), Files (the
+ * raw run dir) — were four different file/diff surfaces the reader had to disambiguate
+ * before knowing which one answered "what did this edit do". They are now sub-modes here,
+ * in increasing distance from the edit itself: the diff, the commit, the optimizer's
+ * memory of it, the bytes on disk.
+ *
+ * Nothing is deleted. Every panel still mounts, so every backend field it read still has
+ * a reader — including `rejected.jsonl` / `history.jsonl` via MemoryPanel, which #212
+ * confirmed are live consumers.
+ */
+const MODES: TabDef[] = [
+  { id: 'candidate', label: 'Candidate diff' },
+  { id: 'commit', label: 'Commit diff' },
+  { id: 'memory', label: 'Memory' },
+  { id: 'files', label: 'Raw files' },
+]
+
+export function ChangesPanel({
+  runId,
+  graph,
+  candidate,
+  mode,
+  onModeChange,
+}: {
+  runId: string
+  graph: RunGraph
+  /** #139 cross-link: the candidate to preselect in the diff/memory sub-modes. */
+  candidate?: string | null
+  mode?: string
+  onModeChange?: (mode: string) => void
+}) {
+  return (
+    <div className="space-y-3">
+      <p className="text-xs text-muted">
+        Everything a candidate changed — its diff against its parent, the real commit, what
+        the optimizer remembered about it, and the raw run directory.
+      </p>
+      <Tabs tabs={MODES} value={mode} onChange={onModeChange}>
+        {(active) =>
+          active === 'commit' ? (
+            <GitDiff runId={runId} />
+          ) : active === 'memory' ? (
+            <MemoryPanel runId={runId} graph={graph} candidate={candidate} />
+          ) : active === 'files' ? (
+            <FileTree runId={runId} />
+          ) : (
+            <IterationsDiff runId={runId} graph={graph} candidate={candidate} />
+          )
+        }
+      </Tabs>
+    </div>
+  )
+}

--- a/dashboard/frontend/src/components/ChangesPanel.tsx
+++ b/dashboard/frontend/src/components/ChangesPanel.tsx
@@ -6,7 +6,7 @@ import { FileTree } from './FileTree'
 import type { RunGraph } from '../lib/types'
 
 /**
- * "Changes & files" (#139): the one place to inspect what a candidate changed.
+ * "Changes, memory & files" (#139): the one place to inspect what a candidate changed.
  *
  * Four top-level tabs — Iterations (candidate-vs-parent snapshot diff), Git diffs
  * (commit-to-commit), Memory (accepted/rejected history + candidate scratch), Files (the
@@ -46,7 +46,7 @@ export function ChangesPanel({
         Everything a candidate changed — its diff against its parent, the real commit, what
         the optimizer remembered about it, and the raw run directory.
       </p>
-      <Tabs tabs={MODES} value={mode} onChange={onModeChange}>
+      <Tabs tabs={MODES} label="Change surfaces" value={mode} onChange={onModeChange}>
         {(active) =>
           active === 'commit' ? (
             <GitDiff runId={runId} />

--- a/dashboard/frontend/src/components/IterationsDiff.tsx
+++ b/dashboard/frontend/src/components/IterationsDiff.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { api } from '../lib/api'
 import type { RunGraph } from '../lib/types'
@@ -7,8 +7,19 @@ import { Card } from './ui/Card'
 import { Skeleton } from './ui/Skeleton'
 import { DiffFileView } from './DiffRows'
 
-/** Per-candidate diff vs parent — what changed each iteration, and did it help. */
-export function IterationsDiff({ runId, graph }: { runId: string; graph: RunGraph }) {
+/** Per-candidate diff vs parent — what changed each iteration, and did it help.
+ *
+ * `candidate` (#139) preselects a candidate so the fitness-curve cross-link lands on the
+ * right diff; the picker still overrides it from there. */
+export function IterationsDiff({
+  runId,
+  graph,
+  candidate,
+}: {
+  runId: string
+  graph: RunGraph
+  candidate?: string | null
+}) {
   // Candidates with a parent (i.e. an actual change), newest first.
   const candidates = useMemo(
     () =>
@@ -18,7 +29,13 @@ export function IterationsDiff({ runId, graph }: { runId: string; graph: RunGrap
     [graph.nodes],
   )
   const byId = useMemo(() => new Map(graph.nodes.map((n) => [n.id, n])), [graph.nodes])
-  const [cid, setCid] = useState<string | undefined>(candidates[0]?.id)
+  const [picked, setCid] = useState<string | undefined>(undefined)
+  // The cross-linked candidate wins until the user picks another; a NEW cross-link then
+  // wins again (otherwise a second dot click would silently show the earlier pick). The
+  // seed has no parent so it has no diff — fall back to the newest candidate that does.
+  const linked = candidate && candidates.some((c) => c.id === candidate) ? candidate : undefined
+  useEffect(() => setCid(undefined), [linked])
+  const cid = picked ?? linked ?? candidates[0]?.id
 
   const { data, isLoading } = useQuery({
     queryKey: ['diff', runId, cid],

--- a/dashboard/frontend/src/components/MemoryPanel.tsx
+++ b/dashboard/frontend/src/components/MemoryPanel.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, type ReactNode } from 'react'
+import { useEffect, useMemo, useState, type ReactNode } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { CheckCircle2, FileText, XCircle } from 'lucide-react'
 import { api } from '../lib/api'
@@ -10,7 +10,16 @@ import { Skeleton } from './ui/Skeleton'
 /** Optimizer memory: accepted history, rejected ("do-not-re-propose"), and the
  * per-candidate snapshot files (PROCESS.md explainability / INSTRUCTIONS.md / the
  * capability files). */
-export function MemoryPanel({ runId, graph }: { runId: string; graph: RunGraph }) {
+export function MemoryPanel({
+  runId,
+  graph,
+  candidate,
+}: {
+  runId: string
+  graph: RunGraph
+  /** #139 cross-link: preselect this candidate's scratch files. */
+  candidate?: string | null
+}) {
   const { data, isLoading } = useQuery({
     queryKey: ['memory', runId],
     queryFn: ({ signal }) => api.memory(runId, signal),
@@ -20,7 +29,10 @@ export function MemoryPanel({ runId, graph }: { runId: string; graph: RunGraph }
     () => graph.nodes.map((n) => n.id).filter((id) => id !== graph.root || id === 'seed'),
     [graph],
   )
-  const [cid, setCid] = useState<string>(graph.best_id ?? graph.nodes[0]?.id ?? 'seed')
+  const [picked, setCid] = useState<string | undefined>(undefined)
+  const linked = candidate && candidateIds.includes(candidate) ? candidate : undefined
+  useEffect(() => setCid(undefined), [linked])
+  const cid = picked ?? linked ?? graph.best_id ?? graph.nodes[0]?.id ?? 'seed'
 
   return (
     <div className="space-y-4">

--- a/dashboard/frontend/src/components/TaskHeatmap.tsx
+++ b/dashboard/frontend/src/components/TaskHeatmap.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useMemo, useRef, useState, type KeyboardEvent } from 'react'
 import type { GraphNode } from '../lib/types'
 import { pct } from '../lib/format'
 import { Card } from './ui/Card'
@@ -14,9 +14,13 @@ import { cn } from '../lib/cn'
  * to that task's rollout for that candidate.
  *
  * Rendered as a real `<table>` of `<button>` cells rather than SVG rects, so cell
- * activation is keyboard-native (Tab/Enter/Space, visible focus ring from index.css)
- * without re-implementing any of it. Each cell states its outcome as a glyph and an
- * aria-label as well as a colour — colour is never the only signal.
+ * activation is keyboard-native (Enter/Space, visible focus ring from index.css) without
+ * re-implementing any of it. Each cell states its outcome as a glyph and an aria-label as
+ * well as a colour — colour is never the only signal.
+ *
+ * The WAI-ARIA *grid* pattern, not one tab stop per cell: a 50×50 run is 2500 cells, and
+ * 2500 tab stops is a keyboard trap in practice. Roving tabIndex gives the whole grid one
+ * stop; Arrow/Home/End move the active cell inside it.
  */
 
 type Outcome = 'pass' | 'fail' | 'partial' | 'skip'
@@ -63,6 +67,39 @@ export function TaskHeatmap({
     return [...tasks].sort((a, b) => mean(a) - mean(b))
   }, [tasks, iters])
 
+  // Roving tabIndex over the grid: one tab stop, arrows move within.
+  const [pos, setAt] = useState<[number, number]>([0, 0])
+  // Clamp on read: rows/iters can shrink under a live run and a stale index would leave the
+  // grid with no tab stop at all.
+  const at: [number, number] = [
+    Math.min(pos[0], Math.max(0, rows.length - 1)),
+    Math.min(pos[1], Math.max(0, iters.length - 1)),
+  ]
+  const gridRef = useRef<HTMLTableSectionElement>(null)
+  const focusCell = (r: number, c: number) => {
+    const rr = Math.max(0, Math.min(rows.length - 1, r))
+    const cc = Math.max(0, Math.min(iters.length - 1, c))
+    setAt([rr, cc])
+    gridRef.current?.querySelector<HTMLElement>(`[data-cell="${rr}-${cc}"]`)?.focus()
+  }
+  const onGridKeyDown = (e: KeyboardEvent) => {
+    const [r, c] = at
+    const move: Record<string, [number, number]> = {
+      ArrowRight: [r, c + 1],
+      ArrowLeft: [r, c - 1],
+      ArrowDown: [r + 1, c],
+      ArrowUp: [r - 1, c],
+      Home: [r, 0],
+      End: [r, iters.length - 1],
+      PageUp: [0, c],
+      PageDown: [rows.length - 1, c],
+    }
+    const next = move[e.key]
+    if (!next) return
+    e.preventDefault()
+    focusCell(next[0], next[1])
+  }
+
   if (rows.length === 0 || iters.length === 0) {
     return (
       <Card>
@@ -78,12 +115,12 @@ export function TaskHeatmap({
       <div className="mb-2 flex flex-wrap items-center gap-x-4 gap-y-1">
         <h3 className="text-sm font-medium">Per-task pass/fail across iterations</h3>
         <span className="text-xs text-muted">
-          rows worst-first · select a cell to open that rollout
+          rows worst-first · arrow keys move, Enter opens that rollout
         </span>
       </div>
 
       <div className="overflow-x-auto">
-        <table className="text-left text-xs" data-testid="task-heatmap">
+        <table role="grid" className="text-left text-xs" data-testid="task-heatmap">
           <caption className="sr-only">
             Per-task reward for every evaluated candidate. Rows are tasks, worst mean reward
             first; columns are iterations. Each cell states pass, fail, partial or not run.
@@ -105,8 +142,8 @@ export function TaskHeatmap({
               ))}
             </tr>
           </thead>
-          <tbody>
-            {rows.map((t) => (
+          <tbody ref={gridRef} onKeyDown={onGridKeyDown}>
+            {rows.map((t, ri) => (
               <tr key={t}>
                 <th
                   scope="row"
@@ -115,7 +152,7 @@ export function TaskHeatmap({
                 >
                   {t}
                 </th>
-                {iters.map((it) => {
+                {iters.map((it, ci) => {
                   const v = it.per_task?.[t]
                   const o = outcome(v)
                   const { glyph, word, cls } = CELL[o]
@@ -125,12 +162,17 @@ export function TaskHeatmap({
                   }${fb ? ` — ${fb}` : ''}`
                   const linkable = o !== 'skip' && !!onOpenRollout
                   return (
-                    <td key={it.id} className="p-[1px]">
+                    <td key={it.id} role="gridcell" className="p-[1px]">
+                      {/* aria-disabled, not `disabled`: a disabled button is unfocusable,
+                          which would punch holes in the arrow-key walk. */}
                       <button
                         type="button"
+                        data-cell={`${ri}-${ci}`}
                         aria-label={label}
                         title={label}
-                        disabled={!linkable}
+                        aria-disabled={!linkable}
+                        tabIndex={at[0] === ri && at[1] === ci ? 0 : -1}
+                        onFocus={() => setAt([ri, ci])}
                         onClick={() => linkable && onOpenRollout(t, it.id)}
                         className={cn(
                           'flex h-4 w-5 items-center justify-center rounded-[2px] text-[9px] leading-none',

--- a/dashboard/frontend/src/components/TaskHeatmap.tsx
+++ b/dashboard/frontend/src/components/TaskHeatmap.tsx
@@ -1,0 +1,167 @@
+import { useMemo } from 'react'
+import type { GraphNode } from '../lib/types'
+import { pct } from '../lib/format'
+import { Card } from './ui/Card'
+import { cn } from '../lib/cn'
+
+/**
+ * tasks × iterations pass/fail grid (#139).
+ *
+ * The single-file static dashboard (core/cap_evolve/dashboard.py §3) has had this chart
+ * since day one; the SPA never did, which left `GraphNode.per_task` and
+ * `GraphNode.feedback` exported by the backend with no reader in the SPA at all. This is
+ * that reader, and it is the cross-link source the issue asks for: clicking a cell jumps
+ * to that task's rollout for that candidate.
+ *
+ * Rendered as a real `<table>` of `<button>` cells rather than SVG rects, so cell
+ * activation is keyboard-native (Tab/Enter/Space, visible focus ring from index.css)
+ * without re-implementing any of it. Each cell states its outcome as a glyph and an
+ * aria-label as well as a colour — colour is never the only signal.
+ */
+
+type Outcome = 'pass' | 'fail' | 'partial' | 'skip'
+
+const CELL: Record<Outcome, { glyph: string; word: string; cls: string }> = {
+  pass: { glyph: '✓', word: 'pass', cls: 'bg-accepted/25 text-accepted' },
+  fail: { glyph: '✗', word: 'fail', cls: 'bg-rejected/25 text-rejected' },
+  partial: { glyph: '~', word: 'partial', cls: 'bg-accent/25 text-accent' },
+  skip: { glyph: '·', word: 'not run', cls: 'bg-surface-2 text-muted' },
+}
+
+function outcome(v: number | undefined): Outcome {
+  if (v == null) return 'skip'
+  if (v >= 0.999) return 'pass'
+  if (v <= 0.001) return 'fail'
+  return 'partial'
+}
+
+export function TaskHeatmap({
+  nodes,
+  tasks,
+  onOpenRollout,
+}: {
+  nodes: GraphNode[]
+  tasks: string[]
+  /** Cross-link: open this task's rollout for this candidate in the Trajectories drawer. */
+  onOpenRollout?: (task: string, candidate: string) => void
+}) {
+  // Only candidates that were actually scored per-task, oldest-first (left to right).
+  const iters = useMemo(
+    () =>
+      nodes
+        .filter((n) => n.per_task && Object.keys(n.per_task).length > 0)
+        .sort((a, b) => (a.iteration ?? 0) - (b.iteration ?? 0)),
+    [nodes],
+  )
+
+  // Worst-first rows: the tasks that keep failing are the ones worth looking at.
+  const rows = useMemo(() => {
+    const mean = (t: string) => {
+      const vals = iters.map((it) => it.per_task?.[t]).filter((v): v is number => v != null)
+      return vals.length ? vals.reduce((a, b) => a + b, 0) / vals.length : 0
+    }
+    return [...tasks].sort((a, b) => mean(a) - mean(b))
+  }, [tasks, iters])
+
+  if (rows.length === 0 || iters.length === 0) {
+    return (
+      <Card>
+        <div className="px-4 py-12 text-center text-sm text-muted">
+          No per-task scores yet — the pass/fail grid appears once a candidate is evaluated.
+        </div>
+      </Card>
+    )
+  }
+
+  return (
+    <Card className="p-4">
+      <div className="mb-2 flex flex-wrap items-center gap-x-4 gap-y-1">
+        <h3 className="text-sm font-medium">Per-task pass/fail across iterations</h3>
+        <span className="text-xs text-muted">
+          rows worst-first · select a cell to open that rollout
+        </span>
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="text-left text-xs" data-testid="task-heatmap">
+          <caption className="sr-only">
+            Per-task reward for every evaluated candidate. Rows are tasks, worst mean reward
+            first; columns are iterations. Each cell states pass, fail, partial or not run.
+          </caption>
+          <thead>
+            <tr>
+              <th scope="col" className="px-1 py-1 font-medium text-muted">
+                task
+              </th>
+              {iters.map((it) => (
+                <th
+                  key={it.id}
+                  scope="col"
+                  className="tnum px-0.5 py-1 text-center font-medium text-muted"
+                  title={`${it.id} · ${it.status} · val ${pct(it.val)}`}
+                >
+                  {it.iteration ?? '—'}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((t) => (
+              <tr key={t}>
+                <th
+                  scope="row"
+                  className="max-w-[18ch] truncate py-0.5 pr-2 font-mono text-[11px] font-normal text-muted"
+                  title={t}
+                >
+                  {t}
+                </th>
+                {iters.map((it) => {
+                  const v = it.per_task?.[t]
+                  const o = outcome(v)
+                  const { glyph, word, cls } = CELL[o]
+                  const fb = it.feedback?.[t]
+                  const label = `${t} at iteration ${it.iteration ?? '?'} (${it.id}): ${word}${
+                    v != null ? `, reward ${v.toFixed(3)}` : ''
+                  }${fb ? ` — ${fb}` : ''}`
+                  const linkable = o !== 'skip' && !!onOpenRollout
+                  return (
+                    <td key={it.id} className="p-[1px]">
+                      <button
+                        type="button"
+                        aria-label={label}
+                        title={label}
+                        disabled={!linkable}
+                        onClick={() => linkable && onOpenRollout(t, it.id)}
+                        className={cn(
+                          'flex h-4 w-5 items-center justify-center rounded-[2px] text-[9px] leading-none',
+                          cls,
+                          linkable ? 'hover:ring-1 hover:ring-primary' : 'cursor-default',
+                        )}
+                      >
+                        <span aria-hidden>{glyph}</span>
+                      </button>
+                    </td>
+                  )
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="mt-2 flex flex-wrap gap-x-3 gap-y-1 text-[11px] text-muted">
+        {(['pass', 'fail', 'partial', 'skip'] as Outcome[]).map((o) => (
+          <span key={o} className="inline-flex items-center gap-1">
+            <span
+              aria-hidden
+              className={cn('inline-flex h-4 w-5 items-center justify-center rounded-[2px] text-[9px]', CELL[o].cls)}
+            >
+              {CELL[o].glyph}
+            </span>
+            {CELL[o].word}
+          </span>
+        ))}
+      </div>
+    </Card>
+  )
+}

--- a/dashboard/frontend/src/components/Trajectories.tsx
+++ b/dashboard/frontend/src/components/Trajectories.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, type ReactNode } from 'react'
+import { useEffect, useMemo, useRef, useState, type KeyboardEvent, type ReactNode } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { CheckCircle2, Wrench, XCircle, X } from 'lucide-react'
 import { api } from '../lib/api'
@@ -7,39 +7,95 @@ import { Card } from './ui/Card'
 import { Skeleton } from './ui/Skeleton'
 import { cn } from '../lib/cn'
 
+/** A cross-link target (#139): open this task's rollout for this candidate. */
+export interface RolloutFocus {
+  task: string
+  candidate: string
+}
+
 /** Per-task rollouts, worst-first, with a detail drawer (trace + tools used). */
-export function Trajectories({ runId }: { runId: string }) {
+export function Trajectories({
+  runId,
+  candidate,
+  focus,
+  onClearFocus,
+}: {
+  runId: string
+  /** Cross-link from the fitness curve: show only this candidate's rollouts. */
+  candidate?: string | null
+  /** Cross-link from the heatmap: auto-open this rollout's drawer. */
+  focus?: RolloutFocus | null
+  onClearFocus?: () => void
+}) {
   const [split, setSplit] = useState<string>('val')
   const [openFile, setOpenFile] = useState<string | null>(null)
 
+  // A cross-link may point at a rollout in another split, so a focused view fetches every
+  // split and filters client-side. Unfocused behaviour is unchanged (one split fetched).
+  const wide = !!focus
   const { data, isLoading } = useQuery({
-    queryKey: ['rollouts', runId, split],
-    queryFn: ({ signal }) => api.rollouts(runId, split, signal),
+    queryKey: ['rollouts', runId, wide ? undefined : split],
+    queryFn: ({ signal }) => api.rollouts(runId, wide ? undefined : split, signal),
   })
 
-  const rows = useMemo(
-    () => [...(data ?? [])].sort((a, b) => (a.reward ?? 0) - (b.reward ?? 0)),
-    [data],
-  )
+  const rows = useMemo(() => {
+    let r = [...(data ?? [])]
+    if (wide) r = r.filter((x) => x.split === split)
+    if (candidate) r = r.filter((x) => x.candidate === candidate)
+    return r.sort((a, b) => (a.reward ?? 0) - (b.reward ?? 0))
+  }, [data, candidate, wide, split])
+
   const splits = useMemo(() => {
     const s = new Set<string>(['val', 'test'])
     ;(data ?? []).forEach((r) => s.add(r.split))
     return [...s]
   }, [data])
 
+  // Resolve the cross-link to a real rollout file rather than guessing the filename, and
+  // switch the split selector to wherever the target actually lives.
+  useEffect(() => {
+    if (!focus || !data) return
+    const hit = data.find((r) => r.task_id === focus.task && r.candidate === focus.candidate)
+    if (!hit) return
+    setSplit(hit.split)
+    setOpenFile(hit.file)
+  }, [focus, data])
+
+  const missing =
+    focus && data && !data.some((r) => r.task_id === focus.task && r.candidate === focus.candidate)
+
   return (
     <Card className="p-4">
-      <div className="mb-3 flex items-center gap-2">
+      <div className="mb-3 flex flex-wrap items-center gap-2">
         <h3 className="text-sm font-medium">Trajectories</h3>
+        {candidate && (
+          <span className="inline-flex items-center gap-1.5 rounded bg-surface-2 px-2 py-0.5 text-xs">
+            <span className="text-muted">candidate</span>
+            <span className="font-mono">{candidate}</span>
+            {onClearFocus && (
+              <button
+                type="button"
+                onClick={onClearFocus}
+                className="rounded text-muted hover:text-foreground"
+                aria-label={`Clear the ${candidate} filter and show all candidates`}
+              >
+                <X size={12} aria-hidden />
+              </button>
+            )}
+          </span>
+        )}
         <div className="ml-auto flex gap-1">
           {splits.map((s) => (
             <button
               key={s}
               type="button"
+              aria-pressed={s === split}
               onClick={() => setSplit(s)}
               className={cn(
                 'rounded px-2 py-1 text-xs transition-colors',
-                s === split ? 'bg-surface-2 text-foreground' : 'text-muted hover:text-foreground',
+                s === split
+                  ? 'bg-surface-2 font-semibold text-foreground'
+                  : 'text-muted hover:text-foreground',
               )}
             >
               {s}
@@ -48,9 +104,19 @@ export function Trajectories({ runId }: { runId: string }) {
         </div>
       </div>
 
+      {missing && (
+        <p className="mb-3 rounded border border-border bg-surface-2 px-2 py-1.5 text-xs text-muted">
+          No stored rollout for <span className="font-mono">{focus.task}</span> ·{' '}
+          <span className="font-mono">{focus.candidate}</span> — the per-task score exists but
+          its trajectory file wasn’t kept.
+        </p>
+      )}
+
       {isLoading && <Skeleton className="h-40 w-full" />}
       {data && rows.length === 0 && (
-        <p className="py-8 text-center text-sm text-muted">No rollouts for “{split}”.</p>
+        <p className="py-8 text-center text-sm text-muted">
+          No rollouts for “{split}”{candidate ? ` and candidate ${candidate}` : ''}.
+        </p>
       )}
 
       {rows.length > 0 && (
@@ -73,7 +139,19 @@ export function Trajectories({ runId }: { runId: string }) {
                 <td className="py-1.5 pr-3">
                   <span className="inline-flex items-center gap-1.5">
                     <PassIcon reward={r.reward} />
-                    {r.task_id}
+                    {/* The row is the mouse target; this button is the keyboard one, so a
+                        rollout is openable without a pointer. */}
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        setOpenFile(r.file)
+                      }}
+                      aria-label={`Open the trajectory for ${r.task_id}`}
+                      className="rounded text-left hover:text-primary"
+                    >
+                      {r.task_id}
+                    </button>
                   </span>
                 </td>
                 <td className="py-1.5 pr-3 text-muted">{r.candidate}</td>
@@ -111,14 +189,65 @@ function RolloutDrawer({ runId, file, onClose }: { runId: string; file: string; 
     return acc
   }, {})
 
+  // #196: focus must not escape behind an open drawer. Move focus in on open, cycle Tab
+  // inside the panel, close on Escape, and hand focus back to whatever opened it.
+  const panel = useRef<HTMLDivElement>(null)
+  const closeBtn = useRef<HTMLButtonElement>(null)
+  useEffect(() => {
+    const active = document.activeElement as HTMLElement | null
+    // A cross-linked drawer has no live opener: the heatmap cell that triggered it lives on
+    // another tab and was unmounted by the navigation, so `activeElement` is already
+    // <body>. Restoring to <body> — or to a detached node — silently drops the keyboard
+    // user back to the top of the document, so fall back to the surrounding tabpanel.
+    const opener = active && active !== document.body ? active : null
+    const fallback = panel.current?.closest<HTMLElement>('[role="tabpanel"]') ?? null
+    closeBtn.current?.focus()
+    return () => {
+      if (opener?.isConnected) opener.focus()
+      else fallback?.focus()
+    }
+  }, [])
+
+  const onKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      e.stopPropagation()
+      onClose()
+      return
+    }
+    if (e.key !== 'Tab') return
+    const f = panel.current?.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), input, select, textarea, [tabindex]:not([tabindex="-1"])',
+    )
+    if (!f || f.length === 0) return
+    const first = f[0]
+    const last = f[f.length - 1]
+    if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault()
+      first.focus()
+    } else if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault()
+      last.focus()
+    }
+  }
+
   return (
-    <div className="fixed inset-0 z-40 flex justify-end" role="dialog" aria-modal="true">
-      <button aria-label="Close" className="absolute inset-0 bg-black/50" onClick={onClose} />
-      <div className="relative h-full w-full max-w-xl overflow-y-auto border-l border-border bg-surface p-5 shadow-xl">
+    <div className="fixed inset-0 z-40 flex justify-end" role="dialog" aria-modal="true" onKeyDown={onKeyDown}>
+      {/* Backdrop: presentational, and NOT in the tab order — a focusable backdrop is
+          exactly how focus lands "behind" the panel (#196). Escape and the × close it. */}
+      <div aria-hidden className="absolute inset-0 bg-black/50" onClick={onClose} />
+      <div
+        ref={panel}
+        className="relative h-full w-full max-w-xl overflow-y-auto border-l border-border bg-surface p-5 shadow-xl"
+      >
         <div className="mb-3 flex items-center justify-between">
           <h4 className="font-mono text-sm">{file}</h4>
-          <button onClick={onClose} aria-label="Close" className="text-muted hover:text-foreground">
-            <X size={18} />
+          <button
+            ref={closeBtn}
+            onClick={onClose}
+            aria-label="Close (Escape)"
+            className="rounded text-muted hover:text-foreground"
+          >
+            <X size={18} aria-hidden />
           </button>
         </div>
         {isLoading && <Skeleton className="h-64 w-full" />}

--- a/dashboard/frontend/src/components/Trajectories.tsx
+++ b/dashboard/frontend/src/components/Trajectories.tsx
@@ -19,6 +19,7 @@ export function Trajectories({
   candidate,
   focus,
   onClearFocus,
+  onCloseRollout,
 }: {
   runId: string
   /** Cross-link from the fitness curve: show only this candidate's rollouts. */
@@ -26,6 +27,10 @@ export function Trajectories({
   /** Cross-link from the heatmap: auto-open this rollout's drawer. */
   focus?: RolloutFocus | null
   onClearFocus?: () => void
+  /** Closing the drawer clears `?task` — opening writes the URL, so closing must unwrite
+   *  it, or the link records a state the user dismissed and the drawer resurrects itself
+   *  on the next remount. */
+  onCloseRollout?: () => void
 }) {
   const [split, setSplit] = useState<string>('val')
   const [openFile, setOpenFile] = useState<string | null>(null)
@@ -163,7 +168,16 @@ export function Trajectories({
         </table>
       )}
 
-      {openFile && <RolloutDrawer runId={runId} file={openFile} onClose={() => setOpenFile(null)} />}
+      {openFile && (
+        <RolloutDrawer
+          runId={runId}
+          file={openFile}
+          onClose={() => {
+            setOpenFile(null)
+            onCloseRollout?.()
+          }}
+        />
+      )}
     </Card>
   )
 }

--- a/dashboard/frontend/src/components/ui/Tabs.tsx
+++ b/dashboard/frontend/src/components/ui/Tabs.tsx
@@ -1,4 +1,4 @@
-import { useId, useRef, useState, type KeyboardEvent, type ReactNode } from 'react'
+import { useEffect, useId, useRef, useState, type KeyboardEvent, type ReactNode } from 'react'
 import { motion } from 'framer-motion'
 import { cn } from '../../lib/cn'
 
@@ -26,21 +26,31 @@ export function Tabs({
   initial,
   value,
   onChange,
+  label,
   children,
 }: {
   tabs: TabDef[]
   initial?: string
   value?: string
   onChange?: (id: string) => void
+  /** Accessible name for the tablist — two nested tablists with no names are
+   *  indistinguishable to a screen reader. */
+  label?: string
   children: (active: string) => ReactNode
 }) {
   const firstEnabled = tabs.find((t) => !t.disabled)?.id ?? tabs[0]?.id
   const [internal, setInternal] = useState(initial ?? firstEnabled)
   // An unknown `value` (e.g. a stale ?tab= in a shared URL) falls back to the first tab
   // rather than rendering an empty panel.
-  const active =
-    value == null ? internal : tabs.some((t) => t.id === value) ? value : firstEnabled
+  const unknown = value != null && !tabs.some((t) => t.id === value)
+  const active = value == null ? internal : unknown ? firstEnabled : value
   const select = (id: string) => (onChange ? onChange(id) : setInternal(id))
+
+  // ...and normalise the URL to what is actually rendered, so a bad param doesn't sit in a
+  // link that otherwise looks fine.
+  useEffect(() => {
+    if (unknown && firstEnabled) onChange?.(firstEnabled)
+  }, [unknown, firstEnabled, onChange])
 
   // Unique per instance so nested Tabs don't share a framer layoutId (two underlines
   // fighting over one animated element) or duplicate DOM ids.
@@ -70,6 +80,7 @@ export function Tabs({
       <div
         ref={listRef}
         role="tablist"
+        aria-label={label}
         onKeyDown={onKeyDown}
         className="flex flex-wrap gap-1 border-b border-border"
       >
@@ -79,6 +90,7 @@ export function Tabs({
             <button
               key={t.id}
               data-tab-id={t.id}
+              id={`${uid}-tab-${t.id}`}
               role="tab"
               type="button"
               aria-selected={isActive}
@@ -113,7 +125,13 @@ export function Tabs({
       </div>
       {/* tabIndex=-1: not a tab stop, but a programmatic focus target — closing an overlay
           whose opener has unmounted hands focus here instead of dropping it to <body>. */}
-      <div id={`${uid}-panel`} role="tabpanel" tabIndex={-1} className="pt-4">
+      <div
+        id={`${uid}-panel`}
+        role="tabpanel"
+        aria-labelledby={active ? `${uid}-tab-${active}` : undefined}
+        tabIndex={-1}
+        className="pt-4"
+      >
         {children(active)}
       </div>
     </div>

--- a/dashboard/frontend/src/components/ui/Tabs.tsx
+++ b/dashboard/frontend/src/components/ui/Tabs.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode } from 'react'
+import { useId, useRef, useState, type KeyboardEvent, type ReactNode } from 'react'
 import { motion } from 'framer-motion'
 import { cn } from '../../lib/cn'
 
@@ -9,38 +9,89 @@ export interface TabDef {
   badge?: string
 }
 
-/** Lightweight accessible tabs with an animated active underline. */
+/**
+ * Lightweight accessible tabs with an animated active underline.
+ *
+ * Controlled when `value` + `onChange` are passed (RunDeepDive drives them from the URL
+ * so a tab is deep-linkable and the browser back button works), uncontrolled otherwise.
+ *
+ * Keyboard contract (WAI-ARIA tabs pattern — required for the #139 cross-links to be
+ * reachable without a mouse): a single tab stop for the whole tablist (roving tabindex),
+ * then Left/Right/Home/End to move between tabs. Enter/Space are native `<button>`
+ * activation and need no handler. Disabled tabs are skipped. Selection is never conveyed
+ * by colour alone — the active tab is also bold and carries aria-selected.
+ */
 export function Tabs({
   tabs,
   initial,
+  value,
+  onChange,
   children,
 }: {
   tabs: TabDef[]
   initial?: string
+  value?: string
+  onChange?: (id: string) => void
   children: (active: string) => ReactNode
 }) {
   const firstEnabled = tabs.find((t) => !t.disabled)?.id ?? tabs[0]?.id
-  const [active, setActive] = useState(initial ?? firstEnabled)
+  const [internal, setInternal] = useState(initial ?? firstEnabled)
+  // An unknown `value` (e.g. a stale ?tab= in a shared URL) falls back to the first tab
+  // rather than rendering an empty panel.
+  const active =
+    value == null ? internal : tabs.some((t) => t.id === value) ? value : firstEnabled
+  const select = (id: string) => (onChange ? onChange(id) : setInternal(id))
+
+  // Unique per instance so nested Tabs don't share a framer layoutId (two underlines
+  // fighting over one animated element) or duplicate DOM ids.
+  const uid = useId()
+  const listRef = useRef<HTMLDivElement>(null)
+
+  const onKeyDown = (e: KeyboardEvent) => {
+    const enabled = tabs.filter((t) => !t.disabled)
+    if (!enabled.length) return
+    const delta = e.key === 'ArrowRight' ? 1 : e.key === 'ArrowLeft' ? -1 : 0
+    let next: string | undefined
+    if (delta !== 0) {
+      const i = enabled.findIndex((t) => t.id === active)
+      next = enabled[(i + delta + enabled.length) % enabled.length].id
+    } else if (e.key === 'Home') next = enabled[0].id
+    else if (e.key === 'End') next = enabled[enabled.length - 1].id
+    if (!next) return
+    e.preventDefault()
+    select(next)
+    // Move focus with selection: an automatic-activation tablist keeps focus and
+    // selection on the same tab.
+    listRef.current?.querySelector<HTMLElement>(`[data-tab-id="${next}"]`)?.focus()
+  }
 
   return (
     <div>
-      <div role="tablist" className="flex flex-wrap gap-1 border-b border-border">
+      <div
+        ref={listRef}
+        role="tablist"
+        onKeyDown={onKeyDown}
+        className="flex flex-wrap gap-1 border-b border-border"
+      >
         {tabs.map((t) => {
           const isActive = t.id === active
           return (
             <button
               key={t.id}
+              data-tab-id={t.id}
               role="tab"
               type="button"
               aria-selected={isActive}
+              aria-controls={`${uid}-panel`}
+              tabIndex={isActive ? 0 : -1}
               disabled={t.disabled}
-              onClick={() => !t.disabled && setActive(t.id)}
+              onClick={() => !t.disabled && select(t.id)}
               className={cn(
                 'relative px-3 py-2 text-sm transition-colors duration-150',
                 t.disabled
                   ? 'cursor-not-allowed text-muted/40'
                   : isActive
-                    ? 'text-foreground'
+                    ? 'font-semibold text-foreground'
                     : 'text-muted hover:text-foreground',
               )}
             >
@@ -52,7 +103,7 @@ export function Tabs({
               )}
               {isActive && (
                 <motion.span
-                  layoutId="tab-underline"
+                  layoutId={`tab-underline-${uid}`}
                   className="absolute inset-x-2 -bottom-px h-0.5 rounded-full bg-primary"
                 />
               )}
@@ -60,7 +111,11 @@ export function Tabs({
           )
         })}
       </div>
-      <div className="pt-4">{children(active)}</div>
+      {/* tabIndex=-1: not a tab stop, but a programmatic focus target — closing an overlay
+          whose opener has unmounted hands focus here instead of dropping it to <body>. */}
+      <div id={`${uid}-panel`} role="tabpanel" tabIndex={-1} className="pt-4">
+        {children(active)}
+      </div>
     </div>
   )
 }

--- a/dashboard/frontend/src/routes/RunDeepDive.tsx
+++ b/dashboard/frontend/src/routes/RunDeepDive.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useRef } from 'react'
-import { Link, useParams } from 'react-router-dom'
+import { Link, useParams, useSearchParams } from 'react-router-dom'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { ArrowLeft } from 'lucide-react'
 import { api, LivePendingError } from '../lib/api'
@@ -11,33 +11,57 @@ import { Tabs, type TabDef } from '../components/ui/Tabs'
 import { StatusBadge } from '../components/StatusBadge'
 import { KpiStrip } from '../components/KpiStrip'
 import { BestCurveChart } from '../components/BestCurveChart'
+import { TaskHeatmap } from '../components/TaskHeatmap'
 import { LineageTree } from '../components/LineageTree'
 import { PhasesTimeline } from '../components/PhasesTimeline'
 import { Trajectories } from '../components/Trajectories'
-import { IterationsDiff } from '../components/IterationsDiff'
-import { MemoryPanel } from '../components/MemoryPanel'
+import { ChangesPanel } from '../components/ChangesPanel'
 import { Insights } from '../components/Insights'
 import { CostPanel } from '../components/CostPanel'
-import { FileTree } from '../components/FileTree'
-import { GitDiff } from '../components/GitDiff'
 import type { RunStatus } from '../lib/types'
 
+/**
+ * #139 consolidated ten tabs into seven. The four overlapping file/diff surfaces
+ * (Iterations · Git diffs · Memory · Files) are now sub-modes of `changes`; `overview`
+ * became `fitness` and carries both candidate-selection charts, because those are the
+ * sources of the cross-links rather than a tab spent on one chart.
+ */
 const TABS: TabDef[] = [
-  { id: 'overview', label: 'Overview' },
+  { id: 'fitness', label: 'Fitness' },
   { id: 'cost', label: 'Cost' },
   { id: 'phases', label: 'Phases' },
   { id: 'lineage', label: 'Lineage' },
   { id: 'trajectories', label: 'Trajectories' },
-  { id: 'iterations', label: 'Iterations' },
-  { id: 'git', label: 'Git diffs' },
-  { id: 'memory', label: 'Memory' },
-  { id: 'files', label: 'Files' },
+  { id: 'changes', label: 'Changes & files' },
   { id: 'insights', label: 'Insights' },
 ]
 
 export function RunDeepDive() {
   const { id } = useParams<{ id: string }>()
   const queryClient = useQueryClient()
+
+  // Tab + cross-link state lives in the URL, not component state: a cross-link must change
+  // the tab AND what that tab shows in one navigation, the back button must undo it, and
+  // "look at this candidate" should be a shareable link.
+  const [params, setParams] = useSearchParams()
+  const tab = params.get('tab') ?? undefined
+  const candidate = params.get('candidate')
+  const focusTask = params.get('task')
+  const focus = focusTask && candidate ? { task: focusTask, candidate } : null
+
+  const goto = useCallback(
+    (next: Record<string, string | null | undefined>) => {
+      setParams((prev) => {
+        const p = new URLSearchParams(prev)
+        for (const [k, v] of Object.entries(next)) {
+          if (v == null) p.delete(k)
+          else p.set(k, v)
+        }
+        return p
+      })
+    },
+    [setParams],
+  )
 
   const { data, isLoading, isError, error } = useQuery({
     queryKey: ['run', id],
@@ -129,10 +153,23 @@ export function RunDeepDive() {
         {data && (
           <div className="space-y-5">
             <KpiStrip summary={data.summary} />
-            <Tabs tabs={tabs}>
+            <Tabs tabs={tabs} value={tab} onChange={(next) => goto({ tab: next })}>
               {(active) =>
-                active === 'overview' ? (
-                  <BestCurveChart nodes={data.graph.nodes} />
+                active === 'fitness' ? (
+                  <div className="space-y-4">
+                    <BestCurveChart
+                      nodes={data.graph.nodes}
+                      // Cross-link: a candidate goes to its rollouts; its diff is one click
+                      // further, preselected to the same id.
+                      onSelect={(cid) => goto({ tab: 'trajectories', candidate: cid, task: null })}
+                    />
+                    <TaskHeatmap
+                      nodes={data.graph.nodes}
+                      tasks={data.summary.tasks ?? []}
+                      // Cross-link: a cell opens that task's rollout drawer directly.
+                      onOpenRollout={(task, cid) => goto({ tab: 'trajectories', candidate: cid, task })}
+                    />
+                  </div>
                 ) : active === 'cost' ? (
                   <CostPanel summary={data.summary} />
                 ) : active === 'phases' ? (
@@ -140,15 +177,42 @@ export function RunDeepDive() {
                 ) : active === 'lineage' ? (
                   <LineageTree graph={data.graph} />
                 ) : active === 'trajectories' ? (
-                  <Trajectories runId={id!} />
-                ) : active === 'iterations' ? (
-                  <IterationsDiff runId={id!} graph={data.graph} />
-                ) : active === 'git' ? (
-                  <GitDiff runId={id!} />
-                ) : active === 'memory' ? (
-                  <MemoryPanel runId={id!} graph={data.graph} />
-                ) : active === 'files' ? (
-                  <FileTree runId={id!} />
+                  <div className="space-y-3">
+                    {candidate && (
+                      <button
+                        type="button"
+                        onClick={() => goto({ tab: 'changes', mode: 'candidate', task: null })}
+                        className="rounded text-xs text-primary underline decoration-dotted underline-offset-2"
+                      >
+                        See what {candidate} changed →
+                      </button>
+                    )}
+                    <Trajectories
+                      runId={id!}
+                      candidate={candidate}
+                      focus={focus}
+                      onClearFocus={() => goto({ candidate: null, task: null })}
+                    />
+                  </div>
+                ) : active === 'changes' ? (
+                  <div className="space-y-3">
+                    {candidate && (
+                      <button
+                        type="button"
+                        onClick={() => goto({ tab: 'trajectories', task: null })}
+                        className="rounded text-xs text-primary underline decoration-dotted underline-offset-2"
+                      >
+                        ← See how {candidate} scored per task
+                      </button>
+                    )}
+                    <ChangesPanel
+                      runId={id!}
+                      graph={data.graph}
+                      candidate={candidate}
+                      mode={params.get('mode') ?? undefined}
+                      onModeChange={(m) => goto({ mode: m })}
+                    />
+                  </div>
                 ) : active === 'insights' ? (
                   <Insights runId={id!} detail={data} />
                 ) : active === 'custom' && customUrl ? (

--- a/dashboard/frontend/src/routes/RunDeepDive.tsx
+++ b/dashboard/frontend/src/routes/RunDeepDive.tsx
@@ -32,7 +32,9 @@ const TABS: TabDef[] = [
   { id: 'phases', label: 'Phases' },
   { id: 'lineage', label: 'Lineage' },
   { id: 'trajectories', label: 'Trajectories' },
-  { id: 'changes', label: 'Changes & files' },
+  // Named for all four sub-modes, not just the diffs: Memory and Files were never diff
+  // surfaces, so a label that says only "changes" hides them.
+  { id: 'changes', label: 'Changes, memory & files' },
   { id: 'insights', label: 'Insights' },
 ]
 
@@ -75,6 +77,12 @@ export function RunDeepDive() {
     refetchInterval: (query) => (query.state.error instanceof LivePendingError ? 10_000 : false),
   })
   const isLivePending = error instanceof LivePendingError
+
+  // A stale or typo'd `?candidate` must not be *named* by the cross-link headers: the
+  // panels below already fall back to a real candidate, so claiming the bad id would make
+  // the page assert it is showing something it isn't.
+  const knownCandidate =
+    candidate && data?.graph.nodes.some((n) => n.id === candidate) ? candidate : null
 
   // Optional algorithm-shipped custom view (e.g. evo-graph's weakness graph),
   // mounted as an extra iframe tab when the run declares one. Absent -> no tab.
@@ -153,7 +161,12 @@ export function RunDeepDive() {
         {data && (
           <div className="space-y-5">
             <KpiStrip summary={data.summary} />
-            <Tabs tabs={tabs} value={tab} onChange={(next) => goto({ tab: next })}>
+            <Tabs
+              tabs={tabs}
+              label="Run views"
+              value={tab}
+              onChange={(next) => goto({ tab: next })}
+            >
               {(active) =>
                 active === 'fitness' ? (
                   <div className="space-y-4">
@@ -178,13 +191,13 @@ export function RunDeepDive() {
                   <LineageTree graph={data.graph} />
                 ) : active === 'trajectories' ? (
                   <div className="space-y-3">
-                    {candidate && (
+                    {knownCandidate && (
                       <button
                         type="button"
                         onClick={() => goto({ tab: 'changes', mode: 'candidate', task: null })}
                         className="rounded text-xs text-primary underline decoration-dotted underline-offset-2"
                       >
-                        See what {candidate} changed →
+                        See what {knownCandidate} changed →
                       </button>
                     )}
                     <Trajectories
@@ -192,18 +205,25 @@ export function RunDeepDive() {
                       candidate={candidate}
                       focus={focus}
                       onClearFocus={() => goto({ candidate: null, task: null })}
+                      onCloseRollout={() => goto({ task: null })}
                     />
                   </div>
                 ) : active === 'changes' ? (
                   <div className="space-y-3">
-                    {candidate && (
+                    {knownCandidate && (
                       <button
                         type="button"
                         onClick={() => goto({ tab: 'trajectories', task: null })}
                         className="rounded text-xs text-primary underline decoration-dotted underline-offset-2"
                       >
-                        ← See how {candidate} scored per task
+                        ← See how {knownCandidate} scored per task
                       </button>
+                    )}
+                    {candidate && !knownCandidate && (
+                      <p className="text-xs text-muted">
+                        No candidate <span className="font-mono">{candidate}</span> in this run —
+                        showing the newest one instead.
+                      </p>
                     )}
                     <ChangesPanel
                       runId={id!}

--- a/dashboard/frontend/src/test/CrossLink.test.tsx
+++ b/dashboard/frontend/src/test/CrossLink.test.tsx
@@ -115,27 +115,20 @@ async function mountDeepDive() {
 }
 
 describe('#139 tab consolidation', () => {
-  it('exposes seven tabs, with the four diff/file surfaces folded into Changes & files', async () => {
+  it('folds the four diff/file surfaces into one Changes & files tab', async () => {
     await mountDeepDive()
     const list = await screen.findByRole('tablist')
     const labels = within(list)
       .getAllByRole('tab')
       .map((t) => t.textContent)
-    expect(labels).toEqual([
-      'Fitness',
-      'Cost',
-      'Phases',
-      'Lineage',
-      'Trajectories',
-      'Changes & files',
-      'Insights',
-    ])
-    // The old top-level tabs are gone from the TOP list, not from the app.
-    expect(labels).not.toContain('Iterations')
-    expect(labels).not.toContain('Git diffs')
-    expect(labels).not.toContain('Memory')
-    expect(labels).not.toContain('Files')
-    expect(labels).not.toContain('Overview')
+    // Asserted as a subset, not an exact list: sibling PRs in this epic legitimately add
+    // top-level tabs (#204's Events), and pinning the exact array would fail the merge
+    // for a reason that has nothing to do with consolidation.
+    expect(labels).toEqual(expect.arrayContaining(['Fitness', 'Trajectories', 'Changes & files']))
+    // The four overlapping surfaces are gone from the TOP list, not from the app.
+    for (const gone of ['Iterations', 'Git diffs', 'Memory', 'Files', 'Overview']) {
+      expect(labels).not.toContain(gone)
+    }
   })
 
   it('Changes & files still reaches candidate diff, commit diff, memory and raw files', async () => {
@@ -197,11 +190,16 @@ describe('#139 accessibility', () => {
     // Selection is bold + aria-selected, not colour alone.
     expect(tabs[0].className).toContain('font-semibold')
 
+    // Arrow keys move selection AND focus together; asserted by position rather than by
+    // tab name so a sibling PR inserting a tab (#204's Events) doesn't fail this.
+    const names = tabs.map((t) => t.textContent!)
     tabs[0].focus()
     await user.keyboard('{ArrowRight}')
-    expect(await screen.findByRole('tab', { name: 'Cost', selected: true })).toHaveFocus()
+    expect(await screen.findByRole('tab', { name: names[1], selected: true })).toHaveFocus()
     await user.keyboard('{End}')
-    expect(await screen.findByRole('tab', { name: 'Insights', selected: true })).toHaveFocus()
+    expect(await screen.findByRole('tab', { name: names[names.length - 1], selected: true })).toHaveFocus()
+    await user.keyboard('{Home}')
+    expect(await screen.findByRole('tab', { name: names[0], selected: true })).toHaveFocus()
   })
 
   it('the rollout drawer traps focus, closes on Escape, and returns focus to its opener', async () => {

--- a/dashboard/frontend/src/test/CrossLink.test.tsx
+++ b/dashboard/frontend/src/test/CrossLink.test.tsx
@@ -9,7 +9,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { MemoryRouter, Route, Routes, useSearchParams } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { RunDeepDive } from '../routes/RunDeepDive'
 import { TaskHeatmap } from '../components/TaskHeatmap'
@@ -82,7 +82,15 @@ vi.mock('../lib/useRunStream', () => ({
 
 afterEach(() => vi.restoreAllMocks())
 
-async function mountDeepDive() {
+/** The live URL, read back out of the router so a test can assert what a user would copy
+ *  out of the address bar. */
+function UrlProbe() {
+  const [p] = useSearchParams()
+  return <span data-testid="url">{`?${p.toString()}`}</span>
+}
+const url = () => screen.getByTestId('url').textContent
+
+async function mountDeepDive(entry = '/runs/run_demo') {
   const { api } = await import('../lib/api')
   vi.mocked(api.run).mockResolvedValue(DETAIL)
   vi.mocked(api.rollouts).mockImplementation(async (_id, split) =>
@@ -104,9 +112,17 @@ async function mountDeepDive() {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   render(
     <QueryClientProvider client={qc}>
-      <MemoryRouter initialEntries={['/runs/run_demo']}>
+      <MemoryRouter initialEntries={[entry]}>
         <Routes>
-          <Route path="/runs/:id" element={<RunDeepDive />} />
+          <Route
+            path="/runs/:id"
+            element={
+              <>
+                <UrlProbe />
+                <RunDeepDive />
+              </>
+            }
+          />
         </Routes>
       </MemoryRouter>
     </QueryClientProvider>,
@@ -115,7 +131,7 @@ async function mountDeepDive() {
 }
 
 describe('#139 tab consolidation', () => {
-  it('folds the four diff/file surfaces into one Changes & files tab', async () => {
+  it('folds the four diff/file surfaces into one Changes, memory & files tab', async () => {
     await mountDeepDive()
     const list = await screen.findByRole('tablist')
     const labels = within(list)
@@ -124,16 +140,16 @@ describe('#139 tab consolidation', () => {
     // Asserted as a subset, not an exact list: sibling PRs in this epic legitimately add
     // top-level tabs (#204's Events), and pinning the exact array would fail the merge
     // for a reason that has nothing to do with consolidation.
-    expect(labels).toEqual(expect.arrayContaining(['Fitness', 'Trajectories', 'Changes & files']))
+    expect(labels).toEqual(expect.arrayContaining(['Fitness', 'Trajectories', 'Changes, memory & files']))
     // The four overlapping surfaces are gone from the TOP list, not from the app.
     for (const gone of ['Iterations', 'Git diffs', 'Memory', 'Files', 'Overview']) {
       expect(labels).not.toContain(gone)
     }
   })
 
-  it('Changes & files still reaches candidate diff, commit diff, memory and raw files', async () => {
+  it('Changes, memory & files still reaches candidate diff, commit diff, memory and raw files', async () => {
     const user = await mountDeepDive()
-    await user.click(await screen.findByRole('tab', { name: 'Changes & files' }))
+    await user.click(await screen.findByRole('tab', { name: 'Changes, memory & files' }))
     const lists = await screen.findAllByRole('tablist')
     const sub = within(lists[1])
       .getAllByRole('tab')
@@ -160,7 +176,7 @@ describe('#139 cross-links', () => {
     expect(screen.queryByText('seed')).not.toBeInTheDocument()
 
     await user.click(screen.getByRole('button', { name: /See what cand_0001 changed/ }))
-    expect(await screen.findByRole('tab', { name: 'Changes & files', selected: true })).toBeInTheDocument()
+    expect(await screen.findByRole('tab', { name: 'Changes, memory & files', selected: true })).toBeInTheDocument()
     // The diff is preselected to the cross-linked candidate, not the default.
     const picker = await screen.findByLabelText('candidate')
     expect((picker as HTMLSelectElement).value).toBe('cand_0001')
@@ -179,7 +195,103 @@ describe('#139 cross-links', () => {
   })
 })
 
+describe('#139 URL is state, not a write-only log', () => {
+  it('closing the drawer clears ?task, and it stays closed across a tab round-trip', async () => {
+    // Deep-linked open: exactly the link a recipient would receive.
+    const user = await mountDeepDive('/runs/run_demo?tab=trajectories&candidate=seed&task=t2')
+    expect(await screen.findByRole('dialog')).toBeInTheDocument()
+
+    await user.keyboard('{Escape}')
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
+    // The URL a user would now copy no longer records the state they dismissed.
+    expect(url()).not.toContain('task=t2')
+
+    // ...and the drawer does not resurrect itself on the next remount of the panel.
+    await user.click(screen.getByRole('tab', { name: 'Cost' }))
+    expect(url()).not.toContain('task=')
+    await user.click(screen.getByRole('tab', { name: 'Trajectories' }))
+    await waitFor(() => expect(screen.getAllByText('t2').length).toBeGreaterThan(0))
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('deep-links straight into a ?mode sub-surface', async () => {
+    await mountDeepDive('/runs/run_demo?tab=changes&candidate=cand_0001&mode=memory')
+    expect(await screen.findByRole('tab', { name: 'Memory', selected: true })).toBeInTheDocument()
+    expect(await screen.findByText('Accepted history')).toBeInTheDocument()
+  })
+
+  it('normalises an unknown ?tab / ?mode out of the URL instead of leaving a bad param', async () => {
+    await mountDeepDive('/runs/run_demo?tab=nope')
+    expect(await screen.findByRole('tab', { name: 'Fitness', selected: true })).toBeInTheDocument()
+    await waitFor(() => expect(url()).toContain('tab=fitness'))
+
+    screen.getByTestId('url') // sanity: probe mounted
+  })
+
+  it('does not claim a candidate it is not showing', async () => {
+    await mountDeepDive('/runs/run_demo?tab=changes&candidate=cand_9999&mode=candidate')
+    expect(await screen.findByText(/No candidate/)).toBeInTheDocument()
+    expect(screen.queryByText(/cand_9999 scored per task/)).not.toBeInTheDocument()
+    // The panel below falls back to a real candidate, and the header agrees with it.
+    const picker = (await screen.findByLabelText('candidate')) as HTMLSelectElement
+    expect(picker.value).toBe('cand_0001')
+  })
+})
+
 describe('#139 accessibility', () => {
+  it('the heatmap is one tab stop with arrow-key navigation, not one stop per cell', () => {
+    // 30 tasks × 20 iterations = 600 cells: the scale at which per-cell tab stops become a
+    // keyboard trap.
+    const tasks = Array.from({ length: 30 }, (_, i) => `t${i}`)
+    const nodes: GraphNode[] = Array.from({ length: 20 }, (_, i) => ({
+      id: `c${i}`,
+      parent: null,
+      children: [],
+      status: 'accepted' as const,
+      val: 0.5,
+      iteration: i,
+      per_task: Object.fromEntries(tasks.map((t) => [t, 1])),
+    }))
+    render(<TaskHeatmap nodes={nodes} tasks={tasks} onOpenRollout={() => {}} />)
+    const grid = screen.getByTestId('task-heatmap')
+    const cells = grid.querySelectorAll('button')
+    expect(cells.length).toBe(600)
+    // One tab stop for 600 cells.
+    expect(grid.querySelectorAll('button[tabindex="0"]').length).toBe(1)
+    expect(grid).toHaveAttribute('role', 'grid')
+    expect(grid.querySelectorAll('[role="gridcell"]').length).toBe(600)
+  })
+
+  it('arrow keys move the heatmap’s active cell', async () => {
+    const user = userEvent.setup()
+    render(<TaskHeatmap nodes={NODES} tasks={['t1', 't2']} onOpenRollout={() => {}} />)
+    const grid = screen.getByTestId('task-heatmap')
+    const cell = (r: number, c: number) => grid.querySelector(`[data-cell="${r}-${c}"]`)!
+    ;(cell(0, 0) as HTMLElement).focus()
+    expect(cell(0, 0)).toHaveFocus()
+    await user.keyboard('{ArrowRight}')
+    expect(cell(0, 1)).toHaveFocus()
+    await user.keyboard('{ArrowDown}')
+    expect(cell(1, 1)).toHaveFocus()
+    await user.keyboard('{Home}')
+    expect(cell(1, 0)).toHaveFocus()
+    await user.keyboard('{End}')
+    expect(cell(1, 1)).toHaveFocus()
+    // Roving: still exactly one tab stop, and it followed the arrows.
+    expect(grid.querySelectorAll('button[tabindex="0"]').length).toBe(1)
+    expect(cell(1, 1)).toHaveAttribute('tabindex', '0')
+  })
+
+  it('both tablists have accessible names so the nested one is announceable', async () => {
+    const user = await mountDeepDive()
+    expect(await screen.findByRole('tablist', { name: 'Run views' })).toBeInTheDocument()
+    await user.click(screen.getByRole('tab', { name: 'Changes, memory & files' }))
+    expect(await screen.findByRole('tablist', { name: 'Change surfaces' })).toBeInTheDocument()
+    // ...and the panel is named by its own tab, not left anonymous.
+    const panels = screen.getAllByRole('tabpanel')
+    for (const p of panels) expect(p).toHaveAttribute('aria-labelledby')
+  })
+
   it('tabs are a single tab stop with arrow-key navigation and a non-colour selected state', async () => {
     const user = await mountDeepDive()
     const list = await screen.findByRole('tablist')

--- a/dashboard/frontend/src/test/CrossLink.test.tsx
+++ b/dashboard/frontend/src/test/CrossLink.test.tsx
@@ -1,0 +1,264 @@
+/** #139: the cross-links and the consolidated tabs.
+ *
+ * These assert the two behaviours the issue names as the acceptance test — clicking a
+ * candidate routes to its trajectory/diff view, and a heatmap cell opens the correct
+ * rollout drawer — plus the a11y contract the epic has already broken twice: keyboard
+ * activation, roving-tabindex tab nav, no focus escaping behind the drawer, and state
+ * never carried by colour alone.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { RunDeepDive } from '../routes/RunDeepDive'
+import { TaskHeatmap } from '../components/TaskHeatmap'
+import type { GraphNode, RolloutRow, RunDetail } from '../lib/types'
+
+const NODES: GraphNode[] = [
+  {
+    id: 'seed',
+    parent: null,
+    children: ['cand_0001'],
+    status: 'seed',
+    val: 0.4,
+    iteration: 0,
+    per_task: { t1: 1, t2: 0 },
+    feedback: { t2: 'wrong answer' },
+  },
+  {
+    id: 'cand_0001',
+    parent: 'seed',
+    children: [],
+    status: 'accepted',
+    val: 0.9,
+    iteration: 1,
+    per_task: { t1: 1, t2: 1 },
+  },
+]
+
+const DETAIL: RunDetail = {
+  run_id: 'run_demo',
+  path: '/tmp/run_demo',
+  graph: { nodes: NODES, root: 'seed', best_id: 'cand_0001' },
+  summary: {
+    baseline_val: 0.4,
+    best_val: 0.9,
+    delta_pct: 1.25,
+    test_reward: null,
+    tasks: ['t1', 't2'],
+  },
+}
+
+const ROLLOUTS: RolloutRow[] = [
+  { task_id: 't1', candidate: 'seed', trial: 0, split: 'val', reward: 1, feedback: 'ok', file: 't1__seed__t0.json' },
+  { task_id: 't2', candidate: 'seed', trial: 0, split: 'val', reward: 0, feedback: 'wrong answer', file: 't2__seed__t0.json' },
+  { task_id: 't1', candidate: 'cand_0001', trial: 0, split: 'val', reward: 1, feedback: 'ok', file: 't1__cand_0001__t0.json' },
+  { task_id: 't2', candidate: 'cand_0001', trial: 0, split: 'val', reward: 1, feedback: 'ok', file: 't2__cand_0001__t0.json' },
+]
+
+vi.mock('../lib/api', async () => {
+  const actual = await vi.importActual<typeof import('../lib/api')>('../lib/api')
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      run: vi.fn(),
+      rollouts: vi.fn(),
+      rollout: vi.fn(),
+      diff: vi.fn(),
+      memory: vi.fn(),
+      customView: vi.fn(),
+      gitLog: vi.fn(),
+      tree: vi.fn(),
+      candidateFiles: vi.fn(),
+    },
+  }
+})
+
+vi.mock('../lib/useRunStream', () => ({
+  useRunStream: () => ({ status: 'done', count: 0, log: [] }),
+}))
+
+afterEach(() => vi.restoreAllMocks())
+
+async function mountDeepDive() {
+  const { api } = await import('../lib/api')
+  vi.mocked(api.run).mockResolvedValue(DETAIL)
+  vi.mocked(api.rollouts).mockImplementation(async (_id, split) =>
+    split ? ROLLOUTS.filter((r) => r.split === split) : ROLLOUTS,
+  )
+  vi.mocked(api.rollout).mockResolvedValue({
+    file: 't2__seed__t0.json',
+    input: { q: '2+2' },
+    score: { reward: 0, feedback: 'wrong answer' },
+    rollout: { output: '5', tool_calls: [] },
+  } as unknown as Awaited<ReturnType<typeof api.rollout>>)
+  vi.mocked(api.diff).mockResolvedValue({ candidate: 'cand_0001', parent: 'seed', files: [] })
+  vi.mocked(api.memory).mockResolvedValue({ history: [], rejected: [] })
+  vi.mocked(api.customView).mockRejectedValue(new Error('404'))
+  vi.mocked(api.gitLog).mockResolvedValue([])
+  vi.mocked(api.tree).mockResolvedValue({ path: '', entries: [], truncated: false })
+  vi.mocked(api.candidateFiles).mockResolvedValue([])
+
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={['/runs/run_demo']}>
+        <Routes>
+          <Route path="/runs/:id" element={<RunDeepDive />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+  return userEvent.setup()
+}
+
+describe('#139 tab consolidation', () => {
+  it('exposes seven tabs, with the four diff/file surfaces folded into Changes & files', async () => {
+    await mountDeepDive()
+    const list = await screen.findByRole('tablist')
+    const labels = within(list)
+      .getAllByRole('tab')
+      .map((t) => t.textContent)
+    expect(labels).toEqual([
+      'Fitness',
+      'Cost',
+      'Phases',
+      'Lineage',
+      'Trajectories',
+      'Changes & files',
+      'Insights',
+    ])
+    // The old top-level tabs are gone from the TOP list, not from the app.
+    expect(labels).not.toContain('Iterations')
+    expect(labels).not.toContain('Git diffs')
+    expect(labels).not.toContain('Memory')
+    expect(labels).not.toContain('Files')
+    expect(labels).not.toContain('Overview')
+  })
+
+  it('Changes & files still reaches candidate diff, commit diff, memory and raw files', async () => {
+    const user = await mountDeepDive()
+    await user.click(await screen.findByRole('tab', { name: 'Changes & files' }))
+    const lists = await screen.findAllByRole('tablist')
+    const sub = within(lists[1])
+      .getAllByRole('tab')
+      .map((t) => t.textContent)
+    expect(sub).toEqual(['Candidate diff', 'Commit diff', 'Memory', 'Raw files'])
+
+    // Memory sub-mode still mounts MemoryPanel — the live reader of rejected.jsonl /
+    // history.jsonl that #212 confirmed must not be orphaned.
+    await user.click(within(lists[1]).getByRole('tab', { name: 'Memory' }))
+    expect(await screen.findByText('Accepted history')).toBeInTheDocument()
+    expect(screen.getByText('Rejected memory')).toBeInTheDocument()
+  })
+})
+
+describe('#139 cross-links', () => {
+  it('selecting a candidate on the fitness curve routes to that candidate’s trajectories, and one click further to its diff', async () => {
+    const user = await mountDeepDive()
+    // The candidate table is the keyboard path to the same link the scatter dots offer.
+    await user.click(await screen.findByRole('button', { name: /Inspect cand_0001/ }))
+
+    expect(await screen.findByRole('tab', { name: 'Trajectories', selected: true })).toBeInTheDocument()
+    // Filtered to the linked candidate: t1/t2 for cand_0001 only, not seed's rows.
+    await waitFor(() => expect(screen.getAllByText('cand_0001').length).toBeGreaterThan(0))
+    expect(screen.queryByText('seed')).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /See what cand_0001 changed/ }))
+    expect(await screen.findByRole('tab', { name: 'Changes & files', selected: true })).toBeInTheDocument()
+    // The diff is preselected to the cross-linked candidate, not the default.
+    const picker = await screen.findByLabelText('candidate')
+    expect((picker as HTMLSelectElement).value).toBe('cand_0001')
+  })
+
+  it('a failing heatmap cell opens that exact rollout in the drawer', async () => {
+    const user = await mountDeepDive()
+    // seed failed t2 — that is the cell an investigator clicks.
+    await user.click(await screen.findByRole('button', { name: /^t2 at iteration 0 \(seed\): fail/ }))
+
+    const drawer = await screen.findByRole('dialog')
+    // The drawer resolved the (task, candidate) pair to the real rollout FILE rather
+        // than guessing a filename.
+    expect(within(drawer).getByText('t2__seed__t0.json')).toBeInTheDocument()
+    expect(await within(drawer).findByText('wrong answer')).toBeInTheDocument()
+  })
+})
+
+describe('#139 accessibility', () => {
+  it('tabs are a single tab stop with arrow-key navigation and a non-colour selected state', async () => {
+    const user = await mountDeepDive()
+    const list = await screen.findByRole('tablist')
+    const tabs = within(list).getAllByRole('tab')
+    // Roving tabindex: exactly one tab stop for the whole tablist.
+    expect(tabs.filter((t) => t.getAttribute('tabindex') === '0')).toHaveLength(1)
+    expect(tabs[0]).toHaveAttribute('aria-selected', 'true')
+    // Selection is bold + aria-selected, not colour alone.
+    expect(tabs[0].className).toContain('font-semibold')
+
+    tabs[0].focus()
+    await user.keyboard('{ArrowRight}')
+    expect(await screen.findByRole('tab', { name: 'Cost', selected: true })).toHaveFocus()
+    await user.keyboard('{End}')
+    expect(await screen.findByRole('tab', { name: 'Insights', selected: true })).toHaveFocus()
+  })
+
+  it('the rollout drawer traps focus, closes on Escape, and returns focus to its opener', async () => {
+    const user = await mountDeepDive()
+    const cell = await screen.findByRole('button', { name: /^t2 at iteration 0 \(seed\): fail/ })
+    await user.click(cell)
+
+    const drawer = await screen.findByRole('dialog')
+    const close = within(drawer).getByRole('button', { name: /Close/ })
+    expect(close).toHaveFocus() // focus moved INTO the drawer
+
+    // The backdrop is aria-hidden and unfocusable, so Tab cannot land behind the panel
+    // (#196). The only focusable thing in this drawer is Close, so Tab cycles to itself.
+    await user.tab()
+    expect(drawer.contains(document.activeElement)).toBe(true)
+
+    await user.keyboard('{Escape}')
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
+    // The opener here was a heatmap cell on the Fitness tab, which the cross-link
+    // unmounted; focus lands on the surrounding tabpanel rather than dropping to <body>.
+    expect(cell.isConnected).toBe(false)
+    expect(document.activeElement).toHaveAttribute('role', 'tabpanel')
+  })
+
+  it('returns focus to the opener when the opener is still mounted', async () => {
+    const user = await mountDeepDive()
+    await user.click(await screen.findByRole('tab', { name: 'Trajectories' }))
+    // Two candidates ran t2; either row's button is a valid opener.
+    const open = (await screen.findAllByRole('button', { name: 'Open the trajectory for t2' }))[0]
+    await user.click(open)
+    const drawer = await screen.findByRole('dialog')
+    await user.keyboard('{Escape}')
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
+    expect(drawer).not.toBeInTheDocument()
+    expect(open).toHaveFocus()
+  })
+})
+
+describe('TaskHeatmap outcomes are not colour-only', () => {
+  it('every cell carries a glyph and a worded aria-label', () => {
+    render(
+      <TaskHeatmap
+        nodes={NODES}
+        tasks={['t1', 't2']}
+        onOpenRollout={() => {}}
+      />,
+    )
+    // pass / fail are worded, and a cell with no score reads "not run".
+    expect(screen.getByRole('button', { name: /^t2 at iteration 0 \(seed\): fail, reward 0\.000 — wrong answer$/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^t1 at iteration 0 \(seed\): pass, reward 1\.000$/ })).toBeInTheDocument()
+    // The legend names each outcome in words too.
+    const grid = screen.getByTestId('task-heatmap')
+    expect(grid.querySelectorAll('button').length).toBe(4) // 2 tasks × 2 iterations
+  })
+
+  it('renders an honest empty state rather than a blank grid when no candidate has per-task scores', () => {
+    render(<TaskHeatmap nodes={[{ ...NODES[0], per_task: undefined }]} tasks={['t1']} />)
+    expect(screen.getByText(/No per-task scores yet/)).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Closes #139.

The DeepDive had **ten** top-level tabs and no cross-linking. Four of those tabs were
different file/diff surfaces the reader had to disambiguate *before* knowing which one
answered "what did this edit change", and there was no path from "cand_0002 regressed"
to either the edit or the failing task.

## Tab decisions

| Tab | Decision | What the user loses | Where its data now lives |
|---|---|---|---|
| **Overview** (one chart) | **merged → Fitness** | Nothing. The chart is unchanged and now sits beside the heatmap in a tab named for what it shows. #138's evidence header answers the at-a-glance questions above the tabs; this tab is where you *pick a candidate*, which the header does not do. | `?tab=fitness` — `BestCurveChart` + the new `TaskHeatmap` |
| **Iterations** (candidate↔parent diff) | **merged → Changes & files / “Candidate diff”** | One extra click from the top bar. Gains a preselected candidate when arrived at via a cross-link. | `?tab=changes&mode=candidate` — `IterationsDiff`, unchanged, `+candidate` prop |
| **Git diffs** (commit↔commit) | **merged → Changes & files / “Commit diff”** | One extra click. | `?tab=changes&mode=commit` — `GitDiff`, unchanged |
| **Memory** | **merged → Changes & files / “Memory”** | One extra click. | `?tab=changes&mode=memory` — `MemoryPanel`, unchanged, `+candidate` prop |
| **Files** (raw run dir) | **merged → Changes & files / “Raw files”** | One extra click. | `?tab=changes&mode=files` — `FileTree`, unchanged |
| Cost · Phases · Lineage · Trajectories · Insights · Custom view | **kept** | — | unchanged |
| — | **added: the tasks × iterations heatmap** | — | `?tab=fitness` — new `TaskHeatmap` |

**Nothing was removed, and no tab lost its panel.** All four surfaces still mount, as
sub-modes, in increasing distance from the edit itself: the diff → the commit → the
optimizer's memory of it → the bytes on disk. Ten tabs → seven, with four sub-modes.

### Why consolidate rather than delete

Deleting any of the four would orphan a backend field. Consolidating orphans nothing —
verified below. In particular `MemoryPanel` is the live reader of `rejected.jsonl` and
`history.jsonl` that **#212** confirmed must not lose its consumer, so it is a sub-mode,
not a casualty. The one thing #234's evidence header genuinely made redundant is a
*top-level tab* spent on a single chart — so "Overview" became "Fitness" and earned its
place by carrying the two candidate-selection charts, which the header cannot replace.

### No orphaned data — every field still has a reader

| Data | Reader before | Reader after |
|---|---|---|
| `/diff/{candidate}` | `IterationsDiff` | same, in `mode=candidate` |
| `/git/log`, `/git/diff` | `GitDiff` | same, in `mode=commit` |
| `/memory` → `history` / `rejected` (`history.jsonl`, `rejected.jsonl`) | `MemoryPanel` **and** `insights.ts::deadEnds` (#212) | **both unchanged** — `mode=memory` and the Insights tab |
| `/candidate/{cid}/files` | `MemoryPanel` | same, in `mode=memory` |
| `/tree`, `/file` | `FileTree` | same, in `mode=files` |
| `/rollouts`, `/rollout/{file}` | `Trajectories`, `Insights` | same, plus the heatmap cross-link resolves through `/rollouts` |
| `graph.nodes[].per_task`, `graph.nodes[].feedback` | **NOTHING in the SPA** — exported by the backend, read only by the single-file static `dashboard.py` | **new `TaskHeatmap`** |
| `summary.tasks` | `dashboard.py` only | **new `TaskHeatmap`** |

Net: **zero fields orphaned, two previously-orphaned fields gained a reader.** No backend
field is marked for removal by this PR.

## Cross-link map

All cross-links are URL state, so one link = one navigation, the back button undoes it,
and "look at this candidate" is a shareable URL.

| From | Interaction | To |
|---|---|---|
| `BestCurveChart` scatter dot | click | `?tab=trajectories&candidate=<id>` — that candidate's rollouts only |
| `BestCurveChart` candidate table | Tab → Enter/Space | same (the keyboard path — an SVG scatter shape is not focusable) |
| Trajectories, when cross-linked | "See what `<id>` changed →" | `?tab=changes&mode=candidate&candidate=<id>` — diff preselected |
| Changes, when cross-linked | "← See how `<id>` scored per task" | `?tab=trajectories&candidate=<id>` |
| `TaskHeatmap` cell | click / Enter / Space | `?tab=trajectories&candidate=<cid>&task=<t>` → opens **that** rollout's drawer |
| Trajectories candidate chip | × | clears the filter |

The heatmap cell resolves `(task, candidate)` through the `/rollouts` index rather than
guessing a filename, and switches the split selector to wherever the rollout actually
lives. When a per-task score exists but its trajectory file wasn't kept, it says so
instead of opening an empty drawer.

## Accessibility

This epic has already caught colour-only accept/reject chips (#204) and focus escaping
behind a drawer (#196), so:

- **Tabs follow the WAI-ARIA pattern.** One tab stop per tablist (roving tabindex) —
  measured `["0","-1","-1","-1","-1","-1","-1"]` — then Left/Right/Home/End move selection
  *and* focus together. Enter/Space are native `<button>` activation.
- **No state is colour-only.** Active tab = **bold** + `aria-selected`, not colour. Every
  heatmap cell carries a glyph (`✓ ✗ ~ ·`) *and* a worded `aria-label`
  (`"a1 at iteration 0 (seed): fail, reward 0.000 — expected '7' but agent produced …"`),
  and the legend names each outcome in words. Same icon+word contract as `StatusBadge`.
- **Visible focus everywhere.** Measured `outline: 2px solid rgb(59,130,246)` with a 2px
  offset on tabs, heatmap cells and cross-links, reached by real `Tab`
  (`matches(':focus-visible') === true`).
- **The drawer no longer leaks focus.** Its backdrop was a focusable `<button>` — exactly
  how focus lands *behind* an open panel. It is now `aria-hidden` and unfocusable; focus
  moves into the panel on open, Tab/Shift+Tab cycle inside it, Escape closes it, and focus
  returns to the opener — or, when a cross-link already unmounted the opener, to the
  surrounding `tabpanel` rather than dropping to `<body>`.
- The heatmap is a real `<table>` of `<button>` cells with a `<caption>`, scoped headers
  and per-cell labels — not SVG rects — so cell activation is keyboard-native rather than
  re-implemented.

## Merge order & merged-tree result

Expected order — this PR is happiest **last** among the SPA PRs:
**#194 → #212 → #218 → #221 → #204 → #234 → #139**.

Merged locally with **#204 + #234 + #218 + #221** all applied:

| | control (4 PRs, **no** #139) | with #139 |
|---|---|---|
| `pytest core/tests` | **32 failed / 274 passed** | **32 failed / 274 passed** — identical |
| `tsc -b --noEmit` | — | clean |
| `vite build` | — | clean |
| `vitest` | — | **89 passed / 89** |

The 32 python failures are **pre-existing in the sibling merge and identical without this
PR** — they come from resolving the #204↔#218 conflict in `eventstream.py` / `app.py` /
`cli.py` by hand (those PRs disagree about the SSE offset and the tail exit codes, and
each owns half). #139 contributes **zero** conflicts and **zero** regressions: its only
merge conflict is one hunk of the `TABS` array against #204's Events tab, resolved by
keeping both.

On this branch alone: **179 passed / 179, 0 failed** and **54 vitest passed / 54**.

`dashboard/frontend/dist/` is **NOT committed** (#188) — built to verify, then reverted;
`git status -- dashboard/frontend/dist` is empty.

## Verification

Exercised against a **real** zero-API `examples/toy_calc` + `mock` run
(`baseline_val 0.0 → test_reward 1.0`, 3 iterations, `cand_0001` accepted, `cand_0002`/
`cand_0003` rejected), served by the real FastAPI backend against the real run dir with
the freshly-built SPA. Full command log and complete output in the **🔬 Evidence**
comment; the load-bearing excerpts:

```
$ curl -s http://127.0.0.1:7979/api/health
{"ok":true,"base_dir":"/tmp/toy139/.capevolve"}

===== TOP TABLIST =====
["Fitness","Cost","Phases","Lineage","Trajectories","Changes & files","Insights"]
roving tabindex (should be exactly one "0"): ["0","-1","-1","-1","-1","-1","-1"]

===== VIEW: Fitness — real data, real per_task =====
Per-task pass/fail across iterations
rows worst-first · select a cell to open that rollout
task	0	1	2	3
a1	✗	✓	✓	✓
a4	✗	✓	✓	✓
✓ pass   ✗ fail   ~ partial   · not run

===== CROSS-LINK 1: candidate -> trajectories =====
URL: .../runs/run_demo?tab=trajectories&candidate=cand_0001
selected tab: Trajectories
task	candidate	reward	feedback
a1	cand_0001	100.0%	correct
a4	cand_0001	100.0%	correct

===== CROSS-LINK 2: trajectories -> that candidate's diff =====
URL: .../runs/run_demo?tab=changes&candidate=cand_0001&mode=candidate
sub-tabs: ["Candidate diff","Commit diff","Memory","Raw files"]
vs seed · Δ 100.0%
prompt.txt  +2 −0
+[CALC] Compute the arithmetic expression exactly and output ONLY the resulting number.

===== CROSS-LINK 3: heatmap cell -> rollout drawer =====
cell aria-label: a1 at iteration 0 (seed): fail, reward 0.000 — expected '7' but agent
  produced 'I think 3 + 4 is roughly some number.'; the prompt likely lacks an explicit
  instruction to compute and output only the number
URL: .../runs/run_demo?tab=trajectories&candidate=seed&task=a1
drawer: a1__seed__t0.json
  REWARD 0.0%   INPUT 3 + 4   OUTPUT I think 3 + 4 is roughly some number.
  TRACE prompt_had_calc=False
focus in drawer on open: { tag: 'BUTTON', label: 'Close (Escape)' }

===== KEYBOARD =====
ArrowRight  -> selected=Cost      focused=Cost      url=?tab=cost
ArrowRight  -> selected=Phases    focused=Phases    url=?tab=phases
End         -> selected=Insights  focused=Insights  url=?tab=insights
Home        -> selected=Fitness   focused=Fitness   url=?tab=fitness
Space on a heatmap cell -> drawer open: 1 | file: a4__seed__t0.json
Shift+Tab inside drawer -> { inDrawer: true }
Escape -> drawer count: 0 | focus after close: { tag:'DIV', role:'tabpanel' }   # not <body>
back button: ?tab=trajectories&candidate=cand_0001  ->  back  ->  ?tab=fitness

first heatmap cell reached by real Tab:
  { matchesFocusVisible: true, outline: "2px solid rgb(59, 130, 246)", offset: "2px" }
first tab button reached by real Tab:
  { matchesFocusVisible: true, outline: "2px solid rgb(59, 130, 246)", fontWeight: "600" }
```

```
$ PYTHONPATH=core python -m pytest core/tests -q
179 passed in 63.95s

$ python -m compileall -q core dashboard   # clean, exit 0
$ npx tsc -b --noEmit                      # clean, exit 0
$ npm run build                            # ✓ built in 739ms
$ npm test
  Test Files  14 passed (14)
       Tests  54 passed (54)

$ git status --porcelain -- dashboard/frontend/dist   # empty
```

### Known pre-existing issue (not this PR)

A hard load of a deep path (`/runs/<id>`) 404s on the live backend: `app.py` mounts
`StaticFiles` with no SPA fallback, so client-side routes only resolve when entered from
`/`. Unrelated to this change (the static export uses `HashRouter` and is unaffected), so
it is left alone here — the evidence run enters via the Hub, which also exercises that
link. Worth its own issue.
