### PR TITLE
fix(core): guard the scoring phase's stdout so a printing scorer can't kill a finished run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ All notable changes to cap-evolve are documented here. The format follows
 
 ## [Unreleased]
 ### Fixed
+- **A printing scorer no longer destroys a completed run (`cap-evolve run` stdout contract).**
+  `harness.evaluate_candidate` now wraps the whole run+score body in
+  `redirect_stdout(sys.stderr)`, not just the rollout pool. Only the RUN phase was guarded
+  (`run_trials_pool`, for tau2's progress output); SCORING was free to print, and
+  SpreadsheetBench's vendored comparator prints `"Cell values in the specified range are
+  identical."` on every *passing* check (its LibreOffice recalc helper prints on every
+  failure path). That prose landed on the baseline phase's stdout, so `cap-evolve run`'s
+  `json.loads(proc.stdout)` died with `Expecting value: line 1 column 1` — *after* an
+  11-minute, $2.65 baseline had already succeeded and been written to disk, and before any
+  optimization iteration ran ([run 30553822478](https://github.com/skillberry-ai/cap-evolve/actions/runs/30553822478)).
+  The bug was latent until spreadsheetbench first scored above zero: no passing comparison,
+  no print. As a second line of defense, `cli._json_payload` now extracts a phase's JSON
+  payload from stdout newest-object-first instead of assuming the buffer is pure JSON, so
+  one stray `print` anywhere under an adapter can no longer discard finished work — while
+  stdout carrying no JSON at all still fails loudly.
 - **Benchmark CI robustness (skillberry-1 self-hosted runner).** Three fixes so a broken
   runner or gateway is *loud*, not a silent all-0.000 "success": (1) `ci_setup.sh` now
   installs + hard-verifies the `claude-code` optimizer CLI — when it was missing the

--- a/core/cap_evolve/cli.py
+++ b/core/cap_evolve/cli.py
@@ -18,6 +18,7 @@ already resolves the manifest and validates the spec so the wiring is testable.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import signal
@@ -119,6 +120,43 @@ def _step_failure(step: str, proc) -> dict:
     if proc.stdout:
         rec["stdout_tail"] = proc.stdout[-2000:]
     return rec
+
+
+def _json_payload(text: str) -> dict:
+    """Extract a phase subprocess's JSON payload from its captured stdout.
+
+    Phases are *supposed* to print nothing but their JSON object; the harness
+    redirects adapter output to stderr to keep that true. This is the second line of
+    defense: one stray ``print`` anywhere under an adapter used to take down the whole
+    run with ``JSONDecodeError: Expecting value: line 1 column 1`` — after the
+    expensive part had already succeeded and been written to disk. Losing an 11-minute
+    baseline to a log line is not a reasonable failure mode.
+
+    A phase prints its payload LAST, so candidate object starts are tried newest-first
+    and the first one that decodes wins. Raises ``json.JSONDecodeError`` when stdout
+    holds no JSON object at all, so a genuinely broken phase still fails loudly.
+    """
+    text = text or ""
+    with contextlib.suppress(json.JSONDecodeError):
+        return json.loads(text)
+
+    decoder = json.JSONDecoder()
+    # Candidate starts: every line that begins a JSON object, newest first. Matching on
+    # line starts (not every "{" in the buffer) keeps this linear and avoids decoding
+    # from inside a nested object, which would return a fragment of the real payload.
+    starts, offset = [], 0
+    for line in text.splitlines(keepends=True):
+        if line.lstrip().startswith("{"):
+            starts.append(offset + (len(line) - len(line.lstrip())))
+        offset += len(line)
+    for start in reversed(starts):
+        try:
+            obj, _ = decoder.raw_decode(text, start)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict):
+            return obj
+    raise json.JSONDecodeError("no JSON object found in phase stdout", text, 0)
 
 
 def _cmd_run(argv):
@@ -317,7 +355,7 @@ def _cmd_run(argv):
     if proc.returncode != 0:
         print(json.dumps({"step": "baseline", "error": proc.stderr[-1500:]}))
         return 1
-    run_dir = json.loads(proc.stdout)["run_dir"]
+    run_dir = _json_payload(proc.stdout)["run_dir"]
 
     # Resume: explicit budget flags EXTEND the reopened run (e.g. bump max_iterations to
     # keep climbing past the original cap). Without an override the frozen budget stands.

--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -260,7 +260,19 @@ def evaluate_candidate(
     # context manager (instead of a bare global ``apply``) means the live state is
     # scoped + torn down per evaluation, which is what lets independent candidates be
     # evaluated without clobbering a single shared global slot.
-    with _live(adapter, candidate_dir) as ctx:
+    #
+    # The whole run+score body is wrapped in redirect_stdout(sys.stderr) because the
+    # phase skills' stdout is a pure-JSON contract (`cap-evolve run` parses it), and
+    # BOTH halves of this body print: runners emit progress (tau2's run_batch), and
+    # scorers emit comparison chatter (SpreadsheetBench's vendored comparator prints
+    # "Cell values in the specified range are identical." on every PASSING check, and
+    # its LibreOffice recalc helper prints on every failure path). Guarding only the
+    # rollout pool — as run_trials_pool does internally — left scoring free to corrupt
+    # the payload, which killed a run right after a successful 11-minute baseline the
+    # first time spreadsheetbench actually scored above zero. Wrapping here also makes
+    # real stdout never the "current" redirect target inside the thread pool, which is
+    # exactly the invariant run_trials_pool documents for its own thread-safety.
+    with contextlib.redirect_stdout(sys.stderr), _live(adapter, candidate_dir) as ctx:
         if has_run_trials:
             # Adapter-owned fast path: ask for ALL trials in one batch
             # ({task_id: [rollout_t0, rollout_t1, ...]}, trial-ordered), then run the

--- a/core/tests/test_scoring_stdout_contract.py
+++ b/core/tests/test_scoring_stdout_contract.py
@@ -1,0 +1,114 @@
+"""The stdout JSON contract must survive a *scoring* phase that prints.
+
+``run_trials_pool`` already shields the caller's stdout during the RUN phase
+(see test_trials.py) because adapters' runners print progress. Scoring was left
+unguarded, and it prints too: SpreadsheetBench's vendored comparator does
+``print("Cell values in the specified range are identical.")`` on every PASSING
+comparison, and its LibreOffice recalculation helper prints on every failure
+path. Those land on the phase subprocess's real stdout, so
+``cap-evolve run``'s ``json.loads(proc.stdout)`` sees prose at char 0 and the
+whole run dies right after a successful (expensive) baseline.
+
+Two independent layers are asserted here:
+  1. the harness never lets an adapter's ``score``/``score_batch`` output reach
+     the caller's stdout, and
+  2. the CLI still finds its JSON payload even when a subprocess does print.
+"""
+
+import contextlib
+import io
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+CORE = REPO / "core"
+sys.path.insert(0, str(CORE))
+
+NOISE = "Cell values in the specified range are identical."
+
+
+class _NoisyScoreAdapter:
+    """Scores fine but prints to stdout while doing it (the vendored-comparator case)."""
+
+    def tasks(self, split):
+        from cap_evolve import Task
+        return [Task(id="t0"), Task(id="t1")]
+
+    def run_target(self, task, ctx, *, seed=0):
+        from cap_evolve import Rollout
+        return Rollout(task_id=task.id, output="ok")
+
+    def score(self, task, rollout):
+        from cap_evolve import Score
+        print(NOISE)
+        return Score(task_id=task.id, reward=1.0, feedback="ok")
+
+    def apply(self, candidate_dir, edits=None):
+        return None
+
+
+class _NoisyScoreBatchAdapter(_NoisyScoreAdapter):
+    """Same leak, via the batch-scoring hook (swebench-style adapters)."""
+
+    def score_batch(self, tasks, rollouts):
+        from cap_evolve import Score
+        print(NOISE)
+        return {t.id: Score(task_id=t.id, reward=1.0, feedback="batched") for t in tasks}
+
+
+def _evaluate(adapter, tmp_path, tag):
+    from cap_evolve import RunDir, harness
+    from cap_evolve.splits import Splits
+    rd = RunDir.create(tmp_path / ".capevolve", ts=tag)
+    rd.write_splits(Splits(train=[], val=["t0", "t1"], test=[], seed=0))
+    cand = tmp_path / "c"
+    cand.mkdir()
+    rd.snapshot(tag, cand)
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        res = harness.evaluate_candidate(adapter, rd.candidate_dir(tag), run_dir=rd,
+                                         split="val", n_trials=2, tag=tag)
+    return res, buf.getvalue()
+
+
+def test_score_output_does_not_leak_to_caller_stdout(tmp_path):
+    res, leaked = _evaluate(_NoisyScoreAdapter(), tmp_path, "noisy")
+    assert leaked == "", f"adapter.score() leaked to the caller's stdout: {leaked!r}"
+    assert res.reward == 1.0  # and the scores still landed
+
+
+def test_score_batch_output_does_not_leak_to_caller_stdout(tmp_path):
+    res, leaked = _evaluate(_NoisyScoreBatchAdapter(), tmp_path, "noisybatch")
+    assert leaked == "", f"adapter.score_batch() leaked to the caller's stdout: {leaked!r}"
+    assert res.reward == 1.0
+
+
+# ---- layer 2: the CLI tolerates a printing subprocess ---------------------
+
+def test_json_payload_skips_non_json_prefix():
+    """A phase subprocess that printed prose before its JSON is still parseable."""
+    from cap_evolve.cli import _json_payload
+    payload = '{\n  "run_dir": ".capevolve/run_x",\n  "splits": {"val": 2}\n}'
+    assert _json_payload(f"{NOISE}\n{NOISE}\n{payload}\n")["run_dir"] == ".capevolve/run_x"
+
+
+def test_json_payload_reads_clean_stdout_unchanged():
+    from cap_evolve.cli import _json_payload
+    assert _json_payload('{"run_dir": "x"}')["run_dir"] == "x"
+
+
+def test_json_payload_prefers_the_last_json_object():
+    """Phases print their own payload last; earlier JSON-ish noise must not win."""
+    from cap_evolve.cli import _json_payload
+    text = '{"run_dir": "stale"}\nsome prose\n{"run_dir": "real"}\n'
+    assert _json_payload(text)["run_dir"] == "real"
+
+
+def test_json_payload_raises_on_stdout_with_no_json():
+    from cap_evolve.cli import _json_payload
+    import json as _json
+    try:
+        _json_payload(f"{NOISE}\n")
+    except _json.JSONDecodeError:
+        return
+    raise AssertionError("expected JSONDecodeError when stdout carries no JSON at all")


### PR DESCRIPTION
## The failure

[Run 30553822478](https://github.com/skillberry-ai/cap-evolve/actions/runs/30553822478) (`smoke / spreadsheetbench`) completed its baseline — 10 tasks × 5 trials, **11m27s, \$2.65, val reward 0.293** — then died before iteration 1:

```
File ".../core/cap_evolve/cli.py", line 320, in _cmd_run
    run_dir = json.loads(proc.stdout)["run_dir"]
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

0 of 3 optimization iterations ran. `assert_run.py --min-iterations 1` correctly failed the job.

## Root cause

`cap-evolve run` parses each phase subprocess's stdout as pure JSON. The harness shielded only the **run** phase — `run_trials_pool`'s internal `redirect_stdout(sys.stderr)`, added for tau2's progress output. **Scoring was unguarded**, and scorers print too: SpreadsheetBench's vendored comparator does

```python
    print("Cell values in the specified range are identical.")   # evaluation.py:151
    return True, ""
```

on every **passing** check, and `just_open_libreoffice` prints on every failure path. `adapter.score()` is called from `_persist_trial`, outside any redirect — so prose landed at char 0 of the baseline's stdout.

**Latent until spreadsheetbench first scored above zero.** No passing comparison, no print. Every earlier all-0.000 run dodged it; the fix that made scoring work is what exposed this.

## The fix

1. **`harness.evaluate_candidate`** — wrap the whole run+score body in `redirect_stdout(sys.stderr)`, not just the pool. Also establishes the invariant `run_trials_pool` documents for its own thread-safety: real stdout is never the "current" redirect target inside the threads.
2. **`cli._json_payload`** — extract the payload newest-object-first instead of assuming the buffer is pure JSON. Losing an 11-minute baseline to a log line is not a reasonable failure mode. stdout with no JSON at all still raises.

Fixing only the vendored `print` would leave the next printing adapter to rediscover this; both fixes are adapter-agnostic.

## Verification

- `185 passed` (179 + 6 new). Note: an editable install pins `cap_evolve` to the main checkout, so worktree runs need `PYTHONPATH=$PWD/core` to test the right tree.
- New tests cover both layers: `score`/`score_batch` leaks, and prefix / last-object / no-JSON parsing.
- End-to-end against the **real** vendored comparator: 3 comparator lines go to stderr, stdout is `{"run_dir": ...}` alone, reward still 1.0, `_json_payload` parses it.

## Known adjacent issues, deliberately not in scope

- **A failed suite is published to history as `success`.** `Write run metadata` runs before `Assert the suite run completed`, so `"conclusion": "${{ job.status }}"` ([benchmarks.yml:247](https://github.com/skillberry-ai/cap-evolve/blob/main/.github/workflows/benchmarks.yml#L247)) is still `success`. Run 30553822478 is recorded that way on `benchmark-history`. Workflow-ordering fix, filed separately to keep this diff to the crash.
- A stale WIP in a local worktree proposed `OPTIMIZER_MODEL` → `aws/claude-opus-4-8`. Not taken: the unprefixed id is used consistently across the workflow dropdown, `target_profile.MODEL_MAP`, `metrics.py`, and the examples, the default is dead in CI (benchmarks.yml sets it explicitly), and there's no evidence the prefixed form is a valid gateway id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)