### PR TITLE
docs(runs): migrate per-run markdowns from main to benchmark-history

### DIFF
--- a/docs/runs/local-20260729-skillsbench-baseline-gptoss120b.md
+++ b/docs/runs/local-20260729-skillsbench-baseline-gptoss120b.md
@@ -1,0 +1,63 @@
+<!-- Local benchmark run detail page. Linked from https://skillberry-ai.github.io/cap-evolve/benchmarks.html -->
+
+> **Local benchmark run** (recorded on the benchmark-history branch).
+> Ran outside the CI workflow (source: `bcarmeli`); artifacts on the recording host.
+> Benchmark: SkillsBench (all 87 tasks, fit metric — train==val==test); agent under test: aws/gpt-oss-120b.
+
+# Run summary — `run_baseline_gptoss`
+
+- **Benchmark:** `skillsbench`
+- **Agent under test:** `aws/gpt-oss-120b`
+- **Optimizer:** `none`
+- **Tasks / trials:** 87 tasks · 1 trials
+- **Iterations (actual / cap):** 0 / 3
+- **Split discipline:** fit-metric (train==val==test, no holdout)
+- **Best candidate:** `seed`
+
+## Headline
+
+|  | value |
+|---|---|
+| val_reward (mean) | **0.0396 ± 0.0191** (4.0%) |
+| pass_at_1 (fully passing) | **2/87** (2.3%) |
+| test_reward | **0.0396** |
+| test_delta (best - baseline) | 0.0 |
+| val wall-clock | 76m 53s |
+| test wall-clock | 41m 4s |
+| total wall-clock | 118m 5s |
+
+## Rollout breakdown (n = 87)
+
+- Passed (r = 1.0): **2**
+- Partial (0 < r < 1): **4**
+- Errored (infra): **11**
+- Failed (r = 0): **70**
+
+## Passing tasks
+
+- ✓ `3d-scan-calc`
+- ✓ `pddl-tpp-planning`
+
+## Partial credit
+
+| task | reward |
+|---|---|
+| `dialogue-parser` | 0.833 |
+| `lab-unit-harmonization` | 0.312 |
+| `debug-trl-grpo` | 0.250 |
+| `tictoc-unnecessary-abort-detection` | 0.050 |
+
+## Errored tasks (infra, not skill defect)
+
+- ⚠ `earthquake-phase-association`
+- ⚠ `fix-build-agentops`
+- ⚠ `fix-build-google-auto`
+- ⚠ `fix-druid-loophole-cve`
+- ⚠ `flink-query`
+- ⚠ `manufacturing-equipment-maintenance`
+- ⚠ `multilingual-video-dubbing`
+- ⚠ `python-scala-translation`
+- ⚠ `react-performance-debugging`
+- ⚠ `seismic-phase-picking`
+- ⚠ `spring-boot-jakarta-migration`
+

--- a/docs/runs/local-20260729-skillsbench-baseline-opus46.md
+++ b/docs/runs/local-20260729-skillsbench-baseline-opus46.md
@@ -1,0 +1,80 @@
+<!-- Local benchmark run detail page. Linked from https://skillberry-ai.github.io/cap-evolve/benchmarks.html -->
+
+> **Local benchmark run** (recorded on the benchmark-history branch).
+> Ran outside the CI workflow (source: `bcarmeli`); artifacts on the recording host.
+> Benchmark: SkillsBench (all 87 tasks, fit metric — train==val==test); agent under test: claude-opus-4-6.
+
+# Run summary — `run_baseline_opus`
+
+- **Benchmark:** `skillsbench`
+- **Agent under test:** `claude-opus-4-6`
+- **Optimizer:** `none`
+- **Tasks / trials:** 87 tasks · 1 trials
+- **Iterations (actual / cap):** 0 / 3
+- **Split discipline:** fit-metric (train==val==test, no holdout)
+- **Best candidate:** `seed`
+
+## Headline
+
+|  | value |
+|---|---|
+| val_reward (mean) | **0.2809 ± 0.0475** (28.1%) |
+| pass_at_1 (fully passing) | **23/87** (26.4%) |
+| test_reward | **0.2809** |
+| test_delta (best - baseline) | 0.0 |
+| val wall-clock | 106m 59s |
+| test wall-clock | 41m 38s |
+| total wall-clock | 148m 42s |
+
+## Rollout breakdown (n = 87)
+
+- Passed (r = 1.0): **23**
+- Partial (0 < r < 1): **3**
+- Errored (infra): **8**
+- Failed (r = 0): **53**
+
+## Passing tasks
+
+- ✓ `3d-scan-calc`
+- ✓ `adaptive-cruise-control`
+- ✓ `citation-check`
+- ✓ `court-form-filling`
+- ✓ `crystallographic-wyckoff-position-analysis`
+- ✓ `econ-detrending-correlation`
+- ✓ `exam-block-sequencing`
+- ✓ `fix-erlang-ssh-cve`
+- ✓ `glm-lake-mendota`
+- ✓ `gravitational-wave-detection`
+- ✓ `hvac-control`
+- ✓ `lean4-proof`
+- ✓ `mars-clouds-clustering`
+- ✓ `offer-letter-generator`
+- ✓ `parallel-tfidf-search`
+- ✓ `pddl-tpp-planning`
+- ✓ `pdf-excel-diff`
+- ✓ `powerlifting-coef-calc`
+- ✓ `pptx-reference-formatting`
+- ✓ `protein-expression-analysis`
+- ✓ `spring-boot-jakarta-migration`
+- ✓ `threejs-to-obj`
+- ✓ `tictoc-unnecessary-abort-detection`
+
+## Partial credit
+
+| task | reward |
+|---|---|
+| `dialogue-parser` | 0.667 |
+| `lab-unit-harmonization` | 0.521 |
+| `debug-trl-grpo` | 0.250 |
+
+## Errored tasks (infra, not skill defect)
+
+- ⚠ `earthquake-phase-association`
+- ⚠ `energy-ac-optimal-power-flow`
+- ⚠ `fix-druid-loophole-cve`
+- ⚠ `fix-visual-stability`
+- ⚠ `multilingual-video-dubbing`
+- ⚠ `python-scala-translation`
+- ⚠ `quantum-numerical-simulation`
+- ⚠ `seismic-phase-picking`
+

--- a/docs/runs/local-20260730-skillsbench-opus46-optimize.md
+++ b/docs/runs/local-20260730-skillsbench-opus46-optimize.md
@@ -1,0 +1,103 @@
+<!-- Local benchmark run detail page. Linked from https://skillberry-ai.github.io/cap-evolve/benchmarks.html -->
+
+> **Local optimization run** (recorded on the benchmark-history branch).
+> Ran outside the CI workflow (source: `bcarmeli`); optimizer proposed 3 candidates over the shared office-document skills (docx/pptx/xlsx/pdf), 1 accepted by paired gate.
+> Benchmark: SkillsBench (all 87 tasks, fit metric — train==val==test); agent + optimizer: `claude-opus-4-6`.
+
+> **Splice note:** the finalize steps baseline-test re-evaluation was broken by an overnight VPN drop; `test_baseline_reward` here is spliced from a properly-scored prior baseline run (fit-metric: test == val by construction). See PATCH_NOTE.md in the run dir for details.
+
+
+# Run summary — `run_opus_optimize3`
+
+- **Benchmark:** `skillsbench`
+- **Agent under test:** `claude-opus-4-6`
+- **Optimizer:** `claude-opus-4-6`
+- **Tasks / trials:** 87 tasks · 1 trials
+- **Iterations (actual / cap):** 3 / 3  ·  1 accepted
+- **Split discipline:** fit-metric (train==val==test, no holdout)
+- **Best candidate:** `cand_0001`
+
+## Headline
+
+| | baseline (seed) | best (`cand_0001`) |
+|---|---|---|
+| val_reward (mean) | 0.2809 ± 0.0475 | **0.3574 ± 0.0502** (35.7%) |
+| pass_at_1 (fully passing) | — | **28/87** (—) |
+| test_reward | 0.2809 | **0.3574** |
+| test_delta (best − baseline) |  | **0.0765** |
+| val wall-clock |  | 188m 52s |
+| test wall-clock |  | 301m 5s |
+| total wall-clock |  | 1272m 2s |
+
+## Iterations
+
+| iter | candidate | parent | val | Δ vs parent | accepted? |
+|---|---|---|---|---|---|
+| 1 | `cand_0001` | `seed` | 0.3574 | +0.0765 | ✓ |
+| 2 | `cand_0002` | `cand_0001` | 0.3247 | -0.0327 | ✗ |
+| 3 | `cand_0003` | `cand_0001` | 0.1703 | -0.1871 | ✗ |
+
+## Passing tasks
+
+- ✓ `3d-scan-calc`
+- ✓ `adaptive-cruise-control`
+- ✓ `bike-rebalance`
+- ✓ `court-form-filling`
+- ✓ `econ-detrending-correlation`
+- ✓ `energy-ac-optimal-power-flow`
+- ✓ `energy-market-pricing`
+- ✓ `exam-block-sequencing`
+- ✓ `exceltable-in-ppt`
+- ✓ `fix-erlang-ssh-cve`
+- ✓ `glm-lake-mendota`
+- ✓ `gravitational-wave-detection`
+- ✓ `grid-dispatch-operator`
+- ✓ `hvac-control`
+- ✓ `lean4-proof`
+- ✓ `mars-clouds-clustering`
+- ✓ `offer-letter-generator`
+- ✓ `paper-anonymizer`
+- ✓ `parallel-tfidf-search`
+- ✓ `paratransit-routing`
+- ✓ `pddl-tpp-planning`
+- ✓ `pdf-excel-diff`
+- ✓ `powerlifting-coef-calc`
+- ✓ `protein-expression-analysis`
+- ✓ `spring-boot-jakarta-migration`
+- ✓ `threejs-to-obj`
+- ✓ `tictoc-unnecessary-abort-detection`
+- ✓ `weighted-gdp-calc`
+
+## Partial credit
+
+| task | reward |
+|---|---|
+| `dialogue-parser` | 0.833 |
+| `lab-unit-harmonization` | 0.646 |
+| `debug-trl-grpo` | 0.600 |
+| `drone-planning-control` | 0.567 |
+| `crystallographic-wyckoff-position-analysis` | 0.450 |
+
+## Errored tasks (infra, not skill defect)
+
+- ⚠ `earthquake-phase-association`
+- ⚠ `fix-build-google-auto`
+- ⚠ `fix-druid-loophole-cve`
+- ⚠ `multilingual-video-dubbing`
+- ⚠ `python-scala-translation`
+- ⚠ `quantum-numerical-simulation`
+- ⚠ `seismic-phase-picking`
+- ⚠ `shock-analysis-demand`
+
+## Artifacts
+
+Local run — artifacts live on the recording host under `.capevolve/run_opus_optimize3/`
+(gitignored, per-run):
+
+- `baseline.json` — full per-task rewards
+- `final.json` — headline numbers
+- `events.jsonl` — event timeline (including manual splice records)
+- `PATCH_NOTE.md` — human-readable splice documentation
+- `rollouts/val/*.json` — 348 per-rollout JSONs across the 4 candidates (agent transcript + CTRF)
+- `rollouts/test/*.json` — 174 per-rollout JSONs for the finalize step
+- `dashboard.html` — static snapshot of the run's dashboard

--- a/records/20260729001__local-20260729-skillsbench-baseline-gptoss120b.json
+++ b/records/20260729001__local-20260729-skillsbench-baseline-gptoss120b.json
@@ -1,6 +1,6 @@
 {
   "run_id": 20260729001,
-  "run_url": "https://github.com/skillberry-ai/cap-evolve/blob/main/docs/runs/local-20260729-skillsbench-baseline-gptoss120b.md",
+  "run_url": "https://github.com/skillberry-ai/cap-evolve/blob/benchmark-history/docs/runs/local-20260729-skillsbench-baseline-gptoss120b.md",
   "bench": "skillsbench",
   "tier": "full",
   "event": "local",
@@ -15,7 +15,7 @@
   "optimizer_model": "none",
   "conclusion": "success",
   "schema": 1,
-  "summary_url": "https://github.com/skillberry-ai/cap-evolve/blob/main/docs/runs/local-20260729-skillsbench-baseline-gptoss120b.md",
+  "summary_url": "https://github.com/skillberry-ai/cap-evolve/blob/benchmark-history/docs/runs/local-20260729-skillsbench-baseline-gptoss120b.md",
   "tasks": [],
   "steps": [],
   "suite": {

--- a/records/20260729002__local-20260729-skillsbench-baseline-opus46.json
+++ b/records/20260729002__local-20260729-skillsbench-baseline-opus46.json
@@ -1,6 +1,6 @@
 {
   "run_id": 20260729002,
-  "run_url": "https://github.com/skillberry-ai/cap-evolve/blob/main/docs/runs/local-20260729-skillsbench-baseline-opus46.md",
+  "run_url": "https://github.com/skillberry-ai/cap-evolve/blob/benchmark-history/docs/runs/local-20260729-skillsbench-baseline-opus46.md",
   "bench": "skillsbench",
   "tier": "full",
   "event": "local",
@@ -15,7 +15,7 @@
   "optimizer_model": "none",
   "conclusion": "success",
   "schema": 1,
-  "summary_url": "https://github.com/skillberry-ai/cap-evolve/blob/main/docs/runs/local-20260729-skillsbench-baseline-opus46.md",
+  "summary_url": "https://github.com/skillberry-ai/cap-evolve/blob/benchmark-history/docs/runs/local-20260729-skillsbench-baseline-opus46.md",
   "tasks": [],
   "steps": [],
   "suite": {

--- a/records/20260730001__local-20260730-skillsbench-opus46-optimize.json
+++ b/records/20260730001__local-20260730-skillsbench-opus46-optimize.json
@@ -1,6 +1,6 @@
 {
   "run_id": 20260730001,
-  "run_url": "https://github.com/skillberry-ai/cap-evolve/blob/main/docs/runs/local-20260730-skillsbench-opus46-optimize.md",
+  "run_url": "https://github.com/skillberry-ai/cap-evolve/blob/benchmark-history/docs/runs/local-20260730-skillsbench-opus46-optimize.md",
   "bench": "skillsbench",
   "tier": "full",
   "event": "local",
@@ -15,7 +15,7 @@
   "optimizer_model": "claude-opus-4-6",
   "conclusion": "success",
   "schema": 1,
-  "summary_url": "https://github.com/skillberry-ai/cap-evolve/blob/main/docs/runs/local-20260730-skillsbench-opus46-optimize.md",
+  "summary_url": "https://github.com/skillberry-ai/cap-evolve/blob/benchmark-history/docs/runs/local-20260730-skillsbench-opus46-optimize.md",
   "tasks": [],
   "steps": [
     {


### PR DESCRIPTION
Companion to the corresponding PR against main (removes the same files from docs/runs/). Rationale: keep per-run artifacts co-located with their JSON records under benchmark-history; main stays clean of run-history churn.

- Copy 3 existing docs/runs/*.md from main to benchmark-history
- Update the 3 corresponding records' `run_url` and `summary_url` to point at blob/benchmark-history/... (previously blob/main/...)

Merge order: this PR first (adds new location + updates records to point there). Then the main-side removal PR (deletes from main).

## What & why
<!-- What does this change and why? Link any issue. -->

## Checklist
- [ ] `python -m pytest core/tests -q` passes
- [ ] `python skills/_registry/build_manifest.py skills` is clean (no errors)
- [ ] Any new/changed skill's `scripts/check.py` is green
- [ ] Honesty invariants untouched (gate on val, test sealed) — or explained
- [ ] Docs updated (README/skill SKILL.md) if behavior changed
