### PR TITLE
fix(spreadsheetbench): unblock the recalc rewrite (#256) + make a native crash visible (#257)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ All notable changes to cap-evolve are documented here. The format follows
 
 ## [Unreleased]
 ### Fixed
+- **SpreadsheetBench formula recalculation was silently never running (#256).** #240 widened the
+  *directories* the adapter creates so the uid-1000 container could write its output; the output
+  *file* it writes is still owned by uid 1000 at ~0644, so the host-side scorer could not rewrite
+  it. `just_open_libreoffice` recalculates into a `/tmp` tempdir and moves the result back —
+  cross-filesystem, so `shutil.move` falls back to `copy2`, which opens the container-owned file
+  for writing and dies with `[Errno 13] Permission denied: <n>_<id>_output.xlsx`. The adapter
+  swallowed that with `except Exception: pass`, so comparisons ran on **stale cached values** and
+  formula-only cells read as empty — every score a floor, and the noise looked like model variance
+  (baseline 0.293 vs 0.393 on two runs of the same 10 tasks). `chmod` cannot fix this (you may not
+  chmod a file you do not own), so `_reclaim_container_file` replaces the file with a byte-identical
+  copy we own — the create and rename need write+execute on the *directory*, which is already
+  `0o777` and deliberately non-sticky for per-rollout dirs. A recalc that still fails is now
+  reported as an `INFRASTRUCTURE:` line in the task feedback instead of being swallowed, so the
+  optimizer is told not to spend budget on it.
+- **A native crash in a phase process left no evidence (#257).** Run 30608405812's algorithm step
+  died with `{"returncode": -11, "signal": "SIGSEGV"}` and nothing usable: a segfault has no Python
+  traceback, and `_step_failure` captured only `stderr[-8000:]` — a window filled entirely with
+  routine per-rollout scoring chatter emitted long after the crash-relevant output. Now:
+  `cap_evolve` enables `faulthandler` on import (stderr only, so the stdout JSON contract is
+  untouched; opt out with `CAPEVOLVE_NO_FAULTHANDLER=1`), the captured stderr keeps a head *and* a
+  tail with an explicit omission marker, and the signal hint is signal-specific — SIGSEGV no longer
+  misdirects the reader to the OOM killer and `dmesg`.
 - **A printing scorer no longer destroys a completed run (`cap-evolve run` stdout contract).**
   `harness.evaluate_candidate` now wraps the whole run+score body in
   `redirect_stdout(sys.stderr)`, not just the rollout pool. Only the RUN phase was guarded

--- a/core/cap_evolve/__init__.py
+++ b/core/cap_evolve/__init__.py
@@ -12,6 +12,24 @@ cap_evolve <command>`` and parse the JSON it prints.
 
 from __future__ import annotations
 
+import faulthandler as _faulthandler
+import os as _os
+
+# Dump a native traceback to stderr if this process dies on a fatal signal.
+#
+# A phase/algorithm process that segfaults leaves NO Python-level evidence: the CLI records
+# `{"returncode": -11, "signal": "SIGSEGV"}` and nothing else, so there is nothing to debug
+# from CI logs alone (see run 30608405812, killed mid-iteration with the cause unrecoverable).
+# faulthandler costs nothing until a fatal signal arrives, and adapters here routinely pull in
+# C extensions (numpy/pandas via scorers, LibreOffice/Docker clients) where a hard crash is
+# possible. Writes to stderr, never stdout, so the JSON-on-stdout contract is untouched.
+# Opt out with CAPEVOLVE_NO_FAULTHANDLER=1 if a host needs the default signal disposition.
+if not _os.environ.get("CAPEVOLVE_NO_FAULTHANDLER"):
+    try:
+        _faulthandler.enable()
+    except Exception:  # noqa: BLE001 — e.g. stderr replaced by a non-file object
+        pass
+
 from .adapter import CapabilityAdapter, stub_methods
 from .cache import EvalCache, hash_candidate_dir
 from .gate import GateDecision, TrainGateError, decide

--- a/core/cap_evolve/cli.py
+++ b/core/cap_evolve/cli.py
@@ -108,18 +108,45 @@ def _step_failure(step: str, proc) -> dict:
     """
     rec: dict = {"step": step, "returncode": proc.returncode}
     if proc.returncode < 0:
+        sig = -proc.returncode
         try:
-            rec["signal"] = signal.Signals(-proc.returncode).name
+            name = signal.Signals(sig).name
         except ValueError:
-            rec["signal"] = f"signal {-proc.returncode}"
-        rec["hint"] = (
-            f"{step} was killed by a signal, not a Python exception — there is no "
-            "traceback to find. SIGKILL is usually the OOM killer; check dmesg/journalctl -k."
-        )
-    rec["error"] = proc.stderr[-8000:] if proc.stderr else ""
+            name = f"signal {sig}"
+        rec["signal"] = name
+        # Signal-specific, because the remedy differs and a wrong hint sends the reader
+        # to the wrong place: SIGKILL is usually the OOM killer, but SIGSEGV is a native
+        # crash in a C extension and dmesg will say nothing useful about it.
+        if name == "SIGSEGV":
+            rec["hint"] = (
+                f"{step} died in NATIVE code (SIGSEGV), not a Python exception — most likely a "
+                "C extension the adapter pulls in (numpy/pandas in a scorer, a client library). "
+                "cap_evolve enables faulthandler, so look for a 'Fatal Python error' block with "
+                "a native traceback in this record's error field."
+            )
+        else:
+            rec["hint"] = (
+                f"{step} was killed by {name}, not a Python exception — there is no Python "
+                "traceback to find. SIGKILL is usually the OOM killer; check dmesg/journalctl -k."
+            )
+    # Head AND tail. A tail alone loses the crash: a chatty scoring phase can emit tens of
+    # kilobytes AFTER the interesting output, so the window shows routine per-rollout noise
+    # and the record reads as if nothing went wrong (exactly what masked run 30608405812's
+    # SIGSEGV). faulthandler's native traceback lands at the very end, so keep more tail
+    # than head.
+    rec["error"] = _clip(proc.stderr, head=4000, tail=12000)
     if proc.stdout:
         rec["stdout_tail"] = proc.stdout[-2000:]
     return rec
+
+
+def _clip(text: str | None, *, head: int, tail: int) -> str:
+    """Keep the first ``head`` and last ``tail`` characters, marking what was dropped."""
+    text = text or ""
+    if len(text) <= head + tail:
+        return text
+    dropped = len(text) - head - tail
+    return f"{text[:head]}\n\n... [{dropped} chars omitted] ...\n\n{text[-tail:]}"
 
 
 def _json_payload(text: str) -> dict:

--- a/core/tests/test_crash_visibility.py
+++ b/core/tests/test_crash_visibility.py
@@ -1,0 +1,86 @@
+"""A native crash in a phase process must leave evidence.
+
+Run 30608405812's algorithm step died with `{"returncode": -11, "signal": "SIGSEGV"}` and
+nothing else: no Python traceback (there isn't one for a segfault) and a stderr window that
+held only the tail — tens of kilobytes of routine per-rollout scoring chatter emitted long
+after the interesting output. The crash was undiagnosable from CI alone. These tests pin the
+three things that make it diagnosable next time.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+CORE = REPO / "core"
+sys.path.insert(0, str(CORE))
+
+
+class _Proc:
+    def __init__(self, returncode, stderr="", stdout=""):
+        self.returncode = returncode
+        self.stderr = stderr
+        self.stdout = stdout
+
+
+# ---- stderr window keeps the head, not just the tail ----------------------
+
+def test_clip_keeps_head_and_tail():
+    from cap_evolve.cli import _clip
+    text = "HEAD" + ("x" * 50_000) + "TAIL"
+    out = _clip(text, head=100, tail=200)
+    assert out.startswith("HEAD")
+    assert out.endswith("TAIL")
+    assert "chars omitted" in out
+
+
+def test_clip_passes_short_text_through():
+    from cap_evolve.cli import _clip
+    assert _clip("short", head=100, tail=200) == "short"
+    assert _clip(None, head=10, tail=10) == ""
+
+
+def test_crash_context_survives_a_chatty_scoring_tail():
+    """The failure record must still show the crash even when scoring logged 40 KB after it."""
+    from cap_evolve.cli import _step_failure
+    stderr = ("Fatal Python error: Segmentation fault\n  File \"scorer.py\", line 1 in compare\n"
+              + "Cell values in the specified range are identical.\n" * 1000)
+    rec = _step_failure("algorithm", _Proc(-11, stderr=stderr))
+    assert "Fatal Python error" in rec["error"]
+
+
+# ---- the hint must not misdirect ------------------------------------------
+
+def test_sigsegv_hint_does_not_blame_the_oom_killer():
+    from cap_evolve.cli import _step_failure
+    rec = _step_failure("algorithm", _Proc(-11, stderr="boom"))
+    assert rec["signal"] == "SIGSEGV"
+    assert "OOM" not in rec["hint"] and "dmesg" not in rec["hint"]
+    assert "faulthandler" in rec["hint"]
+
+
+def test_sigkill_hint_still_points_at_the_oom_killer():
+    from cap_evolve.cli import _step_failure
+    rec = _step_failure("algorithm", _Proc(-9, stderr="boom"))
+    assert rec["signal"] == "SIGKILL"
+    assert "OOM" in rec["hint"]
+
+
+# ---- faulthandler is armed by importing cap_evolve -----------------------
+
+def test_importing_cap_evolve_arms_faulthandler():
+    """A real segfault in a child that imported cap_evolve must print a native traceback."""
+    code = "import cap_evolve, faulthandler; faulthandler._sigsegv()"
+    proc = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True,
+                          env={"PYTHONPATH": str(CORE), "PATH": "/usr/bin:/bin"})
+    assert proc.returncode != 0
+    assert "Fatal Python error" in proc.stderr, f"no native traceback: {proc.stderr!r}"
+    assert proc.stdout == "", "faulthandler must never write to the JSON stdout contract"
+
+
+def test_faulthandler_can_be_disabled_for_a_host_that_needs_default_signals():
+    code = "import cap_evolve, faulthandler; print(faulthandler.is_enabled())"
+    proc = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True,
+                          env={"PYTHONPATH": str(CORE), "PATH": "/usr/bin:/bin",
+                               "CAPEVOLVE_NO_FAULTHANDLER": "1"})
+    assert proc.stdout.strip() == "False", proc.stdout

--- a/core/tests/test_spreadsheetbench_recalc_perms.py
+++ b/core/tests/test_spreadsheetbench_recalc_perms.py
@@ -1,0 +1,143 @@
+"""Scoring must be able to rewrite the container-created output file.
+
+The sandbox container runs as uid 1000 and creates `<n>_<id>_output.xlsx` at its umask, so
+the file is NOT writable by the (different-uid) runner user. Scoring then needs to rewrite it:
+`just_open_libreoffice` recalculates cached formula values into a /tmp tempdir and moves the
+result back — cross-filesystem, so `shutil.move` falls back to `copy2`, which opens the
+existing file for WRITING and fails with `[Errno 13] Permission denied`. The adapter swallowed
+that, so recalculation silently never ran and every score was a floor (issue #256).
+
+`chmod` cannot fix it — you may not chmod a file you do not own — hence the replace-with-a-copy
+approach exercised here.
+
+Note on fidelity: creating a file owned by a *different uid* needs root, so these tests use an
+unwritable-mode file, which reproduces the same `EACCES`-on-open-for-write that the foreign-uid
+case produces. The directory-level permissions the fix depends on (write+execute, non-sticky)
+are asserted directly instead.
+"""
+
+import os
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+ADAPTER_DIR = REPO / "templates" / "adapters" / "spreadsheetbench"
+
+
+def _load_adapter_module():
+    """Import the adapter template for its pure helpers.
+
+    ``model_config.py`` sits in ``templates/adapters/`` and is copied *alongside* the adapter
+    by ``run_suite.sh``, so that dir goes on the path too. litellm/pandas are imported lazily
+    inside functions, so they are not needed here.
+    """
+    import importlib.util
+    for p in (REPO / "core", ADAPTER_DIR, ADAPTER_DIR.parent):
+        if str(p) not in sys.path:
+            sys.path.insert(0, str(p))
+    spec = importlib.util.spec_from_file_location("_sb_adapter", ADAPTER_DIR / "adapter.py")
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _unwritable_file(d: Path) -> Path:
+    """A readable-but-not-writable file, standing in for a container-owned output."""
+    p = d / "1_42_output.xlsx"
+    p.write_bytes(b"PK\x03\x04original-workbook-bytes")
+    os.chmod(p, 0o444)
+    return p
+
+
+def test_shutil_move_over_an_unwritable_file_fails_without_the_fix():
+    """Pins the underlying failure the fix exists for — the cross-filesystem copy2 path."""
+    d = Path(tempfile.mkdtemp())
+    os.chmod(d, 0o777)
+    dest = _unwritable_file(d)
+    src = Path(tempfile.mkdtemp()) / "recalculated.xlsx"
+    src.write_bytes(b"PK\x03\x04recalculated-bytes")
+    try:
+        # copy2 is what shutil.move falls back to across filesystems.
+        shutil.copy2(src, dest)
+    except PermissionError as e:
+        assert e.errno == 13
+        return
+    raise AssertionError("expected PermissionError writing over an unwritable dest")
+
+
+def test_reclaim_makes_the_file_writable_and_preserves_bytes():
+    mod = _load_adapter_module()
+    d = Path(tempfile.mkdtemp())
+    os.chmod(d, 0o777)
+    p = _unwritable_file(d)
+    original = p.read_bytes()
+
+    assert not os.access(p, os.W_OK)          # precondition: the failure state
+    assert mod._reclaim_container_file(p) is True
+    assert os.access(p, os.W_OK)              # now rewritable by us
+    assert p.read_bytes() == original         # byte-identical: scoring reads the same workbook
+    assert not list(d.glob("*.hostcopy"))     # no temp litter left behind
+
+
+def test_reclaim_then_move_succeeds():
+    """The end-to-end shape scoring needs: reclaim, then the recalc move-back works."""
+    mod = _load_adapter_module()
+    d = Path(tempfile.mkdtemp())
+    os.chmod(d, 0o777)
+    dest = _unwritable_file(d)
+    src = Path(tempfile.mkdtemp()) / "recalculated.xlsx"
+    src.write_bytes(b"PK\x03\x04recalculated-bytes")
+
+    assert mod._reclaim_container_file(dest) is True
+    shutil.copy2(src, dest)                   # what previously raised EACCES
+    assert dest.read_bytes() == b"PK\x03\x04recalculated-bytes"
+
+
+def test_reclaim_is_a_noop_when_already_writable():
+    mod = _load_adapter_module()
+    d = Path(tempfile.mkdtemp())
+    p = d / "out.xlsx"
+    p.write_bytes(b"mine")
+    inode = p.stat().st_ino
+    assert mod._reclaim_container_file(p) is True
+    assert p.stat().st_ino == inode, "must not needlessly replace a file we already own"
+
+
+def test_per_rollout_dir_is_writable_and_not_sticky():
+    """The fix relies on directory permissions: replace needs w+x, and sticky would block it
+    (with sticky set, only the file's owner may rename/unlink it — which is the whole problem)."""
+    mod = _load_adapter_module()
+    d = Path(tempfile.mkdtemp())
+    per_rollout = d / "42_0_abc"
+    per_rollout.mkdir()
+    mod._make_container_writable(per_rollout)
+    mode = per_rollout.stat().st_mode
+    assert mode & 0o300 == 0o300, "need write+execute to replace files inside"
+    assert not mode & 0o1000, "per-rollout dirs must NOT be sticky, or the replace is blocked"
+
+    # The shared root IS sticky by design (concurrent rollouts must not delete each other's).
+    shared = d / "outputs"
+    shared.mkdir()
+    mod._make_container_writable(shared, sticky=True)
+    assert shared.stat().st_mode & 0o1000, "shared outputs root should stay sticky"
+
+
+# ---- the failure is reported, not swallowed ------------------------------
+
+def test_feedback_flags_a_failed_recalc_as_infrastructure():
+    mod = _load_adapter_module()
+    entry = {"instruction_type": "Cell-Level Manipulation", "answer_position": "H3:H5"}
+    fb = mod._build_feedback(entry, [0, 0, 0], [], [1, 2, 3], True, recalc_failed=[1, 2, 3])
+    assert "INFRASTRUCTURE" in fb
+    assert "do not optimize against it" in fb
+
+
+def test_feedback_unchanged_when_recalc_worked():
+    mod = _load_adapter_module()
+    entry = {"instruction_type": "Cell-Level Manipulation", "answer_position": "H3:H5"}
+    fb = mod._build_feedback(entry, [1, 1, 1], [], [], True, recalc_failed=[])
+    assert "INFRASTRUCTURE" not in fb
+    assert "All checks passed" in fb

--- a/templates/adapters/spreadsheetbench/adapter.py
+++ b/templates/adapters/spreadsheetbench/adapter.py
@@ -364,6 +364,45 @@ def _make_container_writable(p: Path, *, sticky: bool = False) -> None:
         pass
 
 
+def _reclaim_container_file(p: Path) -> bool:
+    """Make a container-created output file writable by US. Returns True if it now is.
+
+    ``_make_container_writable`` widens the DIRS we create so the uid-1000 container can
+    create its output file — but that file is then owned by uid 1000 at its umask (~0644),
+    so WE cannot write it. Scoring needs to: ``just_open_libreoffice`` recalculates cached
+    formula values by converting into a ``/tmp`` tempdir and moving the result back over the
+    original. ``/tmp`` and the data dir are different filesystems, so that move falls back
+    to ``copy2``, which opens the existing container-owned file for WRITING and dies with
+    ``[Errno 13] Permission denied: <n>_<id>_output.xlsx``.
+
+    ``chmod`` cannot fix this — you may not chmod a file you do not own. Replacing the file
+    with a byte-identical copy we DO own can: the file stays readable (0644), and both the
+    create and the rename need write+execute on the *directory*, which is already 0o777 and
+    deliberately NOT sticky for these per-rollout dirs. ``os.replace`` is atomic, so a
+    concurrent reader never observes a partial file.
+
+    Best-effort: on failure the caller reports the recalc as failed rather than silently
+    comparing stale cached values, which is how this hid for so long.
+    """
+    if os.access(p, os.W_OK):
+        return True
+    try:
+        data = p.read_bytes()
+    except OSError:
+        return False
+    tmp = p.with_name(p.name + ".hostcopy")
+    try:
+        tmp.write_bytes(data)
+        os.replace(tmp, p)
+        return True
+    except OSError:
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+        return False
+
+
 _FENCE_RE = re.compile(r"```[a-zA-Z0-9_+-]*[ \t]*\r?\n(.*?)```", re.DOTALL)
 
 _NO_CODE_REMINDER = (
@@ -681,6 +720,7 @@ class Adapter(CapabilityAdapter):
         test_results: list[int] = []
         missing: list[int] = []
         mismatched: list[int] = []
+        recalc_failed: list[int] = []   # cases whose formula recalc could not run
         for idx in (1, 2, 3):
             gt_path = _resolve_case_file(data_dir / "spreadsheet" / sid, idx, sid, "answer")
             proc_path = data_dir / "outputs" / run_tag / f"{idx}_{sid}_output.xlsx"
@@ -693,11 +733,22 @@ class Adapter(CapabilityAdapter):
                 # Recalculate cached formula values before comparing. Serialized: concurrent
                 # headless LibreOffice invocations against the same profile conflict. Only the
                 # rollout-owned proc file is mutated — the shared gt/answer file never is.
-                with _libre_lock:
-                    try:
-                        vendor["just_open_libreoffice"](str(proc_path), libre)
-                    except Exception:
-                        pass  # best-effort; comparison below still runs on whatever is cached
+                #
+                # Take ownership first: the file was created by the uid-1000 container and is
+                # not writable by us, which makes the helper's move-back fail with EACCES (see
+                # _reclaim_container_file). Still best-effort — the comparison below runs on
+                # whatever is cached either way — but a failure is now RECORDED rather than
+                # swallowed, because silently comparing un-recalculated formula cells
+                # understates every score and looks like a prompt defect.
+                if not _reclaim_container_file(proc_path):
+                    recalc_failed.append(idx)
+                else:
+                    with _libre_lock:
+                        try:
+                            if vendor["just_open_libreoffice"](str(proc_path), libre) is False:
+                                recalc_failed.append(idx)
+                        except Exception:
+                            recalc_failed.append(idx)
 
             try:
                 ok, _ = vendor["compare_workbooks"](
@@ -712,7 +763,8 @@ class Adapter(CapabilityAdapter):
 
         soft = sum(test_results) / len(test_results)
         hard = 1.0 if all(test_results) else 0.0
-        feedback = _build_feedback(entry, test_results, missing, mismatched, bool(libre))
+        feedback = _build_feedback(entry, test_results, missing, mismatched, bool(libre),
+                                   recalc_failed)
 
         # Scoring has consumed every output; drop the per-rollout dir.
         _cleanup_output_dir(rollout)
@@ -730,7 +782,8 @@ class Adapter(CapabilityAdapter):
 
 
 def _build_feedback(
-    entry: dict, test_results: list[int], missing: list[int], mismatched: list[int], had_libreoffice: bool
+    entry: dict, test_results: list[int], missing: list[int], mismatched: list[int],
+    had_libreoffice: bool, recalc_failed: list[int] | None = None,
 ) -> str:
     """Gold-SAFE feedback: which test cases passed/failed and why, never gold cell values."""
     n_pass = sum(test_results)
@@ -749,6 +802,15 @@ def _build_feedback(
         lines.append(
             "Note: LibreOffice was unavailable, so formula-only cells (never assigned a "
             "literal value) could not be recalculated before comparison."
+        )
+    if recalc_failed:
+        # An INFRASTRUCTURE fault, not a prompt defect: the comparison ran on stale cached
+        # values, so this score is a floor. Say so, or the optimizer spends budget rewriting
+        # a prompt against a broken mount (exactly what happened in run 30520700500).
+        lines.append(
+            f"INFRASTRUCTURE: formula recalculation FAILED for test case(s) {recalc_failed}, "
+            "so comparison used stale cached values and this score may understate the real "
+            "result. Not a prompt defect — do not optimize against it."
         )
     if n_pass == len(test_results):
         lines.append("All checks passed.")
@@ -823,6 +885,20 @@ if __name__ == "__main__":
         assert (_leaf.stat().st_mode & 0o777) == 0o777
         _make_container_writable(Path(_td) / "does-not-exist")  # best-effort, must not raise
     print("spreadsheetbench container-writable self-check: OK")
+
+    with _tempfile.TemporaryDirectory() as _td:
+        # A container-created output is readable but not writable by us; scoring's recalc
+        # rewrite needs it writable, and chmod cannot deliver that on a foreign-owned file.
+        _f = Path(_td) / "1_42_output.xlsx"
+        _f.write_bytes(b"workbook")
+        os.chmod(_f, 0o444)
+        assert not os.access(_f, os.W_OK)
+        assert _reclaim_container_file(_f) is True
+        assert os.access(_f, os.W_OK)
+        assert _f.read_bytes() == b"workbook"      # bytes preserved
+        assert not list(Path(_td).glob("*.hostcopy"))
+        assert _reclaim_container_file(_f) is True  # idempotent once ours
+    print("spreadsheetbench reclaim-container-file self-check: OK")
 
     class _FakeRollout:
         def __init__(self, metadata):


### PR DESCRIPTION
Closes #256. Makes #257 diagnosable (does **not** fix it).

Both found in [run 30608405812](https://github.com/skillberry-ai/cap-evolve/actions/runs/30608405812), which got past the stdout-contract crash (#255) but still didn't complete.

## #256 — formula recalculation has been silently failing on every run

**This is not #240 regressing.** #240 is working; the two faults have mutually exclusive symptom strings, and the run shows exactly one of them:

| symptom string | source | in run 30608405812 |
|---|---|---|
| `produced NO output file` | `adapter.py` (#240's fault: container can't *create* output) | **absent** — every task "produced an output file" |
| `Error processing …: [Errno 13]` | `open_spreadsheet.py:102` (host can't *rewrite* output) | **present throughout** |

#240 widened the *directories* the adapter creates so the uid-1000 container could create its output. That file is then owned by uid 1000 at ~0644 — so **we** can't rewrite it, and scoring must: `just_open_libreoffice` recalculates cached formula values into a `/tmp` tempdir and moves the result back. `/tmp` and the data dir are different filesystems, so `shutil.move` falls back to `copy2`, which opens the container-owned file for **writing** → `EACCES`.

The adapter wrapped it in `except Exception: pass`, so it never surfaced.

**Impact:** comparisons ran on **stale cached values**. With `data_only=True`, formula-only cells read as `None`, so tasks the agent genuinely solved compared unequal. **Every spreadsheetbench number so far is a floor, not a measurement** — and the resulting variance read as model noise (baseline 0.293 vs 0.393 across two runs of the same 10 tasks). It's also the failure class #240's own writeup warns about: it presents as a prompt defect, so the optimizer spends budget on something unreachable from a prompt.

**Fix:** `chmod` can't do it — you may not chmod a file you don't own. `_reclaim_container_file` replaces the file with a byte-identical copy we own; both the create and the `os.replace` need write+execute on the *directory*, which is already `0o777` and deliberately **non-sticky** for per-rollout dirs (sticky would block exactly this — that's why only the shared outputs root gets it). A recalc that still fails is now an `INFRASTRUCTURE:` line in the feedback instead of silence.

## #257 — a segfault left nothing to debug

The algorithm died with `{"returncode": -11, "signal": "SIGSEGV"}` and no usable evidence: segfaults have no Python traceback, and `_step_failure` captured only `stderr[-8000:]` — a window holding nothing but per-rollout scoring chatter emitted after the crash-relevant output.

- `cap_evolve` enables `faulthandler` on import — stderr only, so the stdout JSON contract is untouched; `CAPEVOLVE_NO_FAULTHANDLER=1` opts out.
- Captured stderr keeps a **head and** tail with an explicit omission marker.
- The hint is signal-specific: SIGSEGV no longer misdirects to the OOM killer and `dmesg`, which say nothing about a native crash.

**This does not fix the segfault.** Its cause is still unknown and needs runner-side diagnostics I can't reach. This makes the next occurrence diagnosable.

## Verification

`199 passed` (185 + 14 new), plus the adapter's six self-checks including a new `reclaim-container-file` one.

**Honest limit on test fidelity:** creating a file owned by a *different uid* requires root, so the perms tests use an unwritable-mode file — same `EACCES`-on-open-for-write, not the same ownership. The directory preconditions the fix depends on (write+execute, non-sticky) are asserted directly instead. One test pins the underlying `copy2` failure so the regression can't come back silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)