### PR TITLE
fix(ci): record the real conclusion in runmeta, and stop interpolating head_ref into a shell

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -303,16 +303,53 @@ jobs:
             echo "no run dir at $run_dir (job likely failed/cancelled before producing one) — skipping UI export"
           fi
 
+      # Completion gate. Without this the suite is green whenever `cap-evolve run` exits
+      # non-zero: run_suite.sh only emits an annotation, so a run that crashed
+      # mid-optimization and never produced a sealed test number still reports "success".
+      # Regression is NOT asserted here (see --allow-regression in assert_run.py) — real
+      # model rewards are noisy; this checks the run COMPLETED.
+      #
+      # Ordered BEFORE the publishing steps, not last. `job.status` is evaluated when a step
+      # runs, so a gate placed after "Write run metadata" leaves runmeta.json recording
+      # "conclusion": "success" for a run that then fails the gate — and the aggregate job
+      # publishes that to benchmark-history, where a crashed run reads as a clean success
+      # (runs 30553822478 and 30608405812 are both recorded that way). Everything downstream
+      # is `if: always()`, so metrics/UI/artifacts/PR-comment are still published on failure;
+      # only the recorded conclusion changes.
+      - name: Assert the suite run completed
+        if: always()
+        run: |
+          tasks="ci/benchmarks/${{ matrix.bench }}/${{ matrix.tier }}/tasks.json"
+          if [ ! -f "$tasks" ]; then
+            echo "no tasks.json for ${{ matrix.tier }}/${{ matrix.bench }} — nothing to assert"
+            exit 0
+          fi
+          run_dir="$GITHUB_WORKSPACE/ci/benchmarks/.work/suite_${{ matrix.tier }}_${{ matrix.bench }}_proj/.capevolve/run_suite"
+          "${CAPEVOLVE_PY:-python3}" ci/benchmarks/lib/assert_run.py "$run_dir" \
+            --min-iterations 1 --allow-regression
+
       - name: Write run metadata
         if: always()
+        env:
+          # A PR branch name is attacker-controlled and this job runs on a SELF-HOSTED
+          # runner, so interpolating it straight into the shell is a command-injection
+          # vector (actionlint [expression]). Pass it through the environment, where the
+          # shell treats it as data instead of source text.
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
         run: |
           out="$GITHUB_WORKSPACE/ci/benchmarks/.work/suite_${{ matrix.tier }}_${{ matrix.bench }}"
           mkdir -p "$out"
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            source="PR #${{ github.event.pull_request.number }}"; pr="${{ github.event.pull_request.number }}"
+            SOURCE_TEXT="PR #${{ github.event.pull_request.number }}"; pr="${{ github.event.pull_request.number }}"
           else
-            source="manual (${{ github.ref_name }})"; pr="null"
+            SOURCE_TEXT="manual ($BRANCH_NAME)"; pr="null"
           fi
+          export SOURCE_TEXT
+          # Emit both free-form fields as JSON *string literals*. Shell quoting alone is not
+          # enough: a branch name containing a double quote would close the string early and
+          # produce a runmeta.json the aggregate job cannot parse (verified locally).
+          branch_json=$("${CAPEVOLVE_PY:-python3}" -c 'import json,os;print(json.dumps(os.environ["BRANCH_NAME"]))')
+          source_json=$("${CAPEVOLVE_PY:-python3}" -c 'import json,os;print(json.dumps(os.environ["SOURCE_TEXT"]))')
           cat > "$out/runmeta.json" <<JSON
           {
             "run_id": ${{ github.run_id }},
@@ -320,9 +357,9 @@ jobs:
             "bench": "${{ matrix.bench }}",
             "tier": "${{ matrix.tier }}",
             "event": "${{ github.event_name }}",
-            "source": "$source",
+            "source": $source_json,
             "pr": $pr,
-            "branch": "${{ github.head_ref || github.ref_name }}",
+            "branch": $branch_json,
             "sha": "${{ github.event.pull_request.head.sha || github.sha }}",
             "date": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
             "iterations": ${ITERATIONS:-3},
@@ -361,24 +398,6 @@ jobs:
             } else {
               await github.rest.issues.createComment({owner, repo, issue_number, body});
             }
-
-      # Completion gate — LAST, so metrics/UI/artifacts/PR-comment are all published
-      # before the job is allowed to go red. Without this the suite is green whenever
-      # `cap-evolve run` exits non-zero: run_suite.sh only emits an annotation, so a run
-      # that crashed mid-optimization and never produced a sealed test number still
-      # reports "success". Regression is NOT asserted here (see --allow-regression in
-      # assert_run.py) — real model rewards are noisy; this checks the run COMPLETED.
-      - name: Assert the suite run completed
-        if: always()
-        run: |
-          tasks="ci/benchmarks/${{ matrix.bench }}/${{ matrix.tier }}/tasks.json"
-          if [ ! -f "$tasks" ]; then
-            echo "no tasks.json for ${{ matrix.tier }}/${{ matrix.bench }} — nothing to assert"
-            exit 0
-          fi
-          run_dir="$GITHUB_WORKSPACE/ci/benchmarks/.work/suite_${{ matrix.tier }}_${{ matrix.bench }}_proj/.capevolve/run_suite"
-          "${CAPEVOLVE_PY:-python3}" ci/benchmarks/lib/assert_run.py "$run_dir" \
-            --min-iterations 1 --allow-regression
 
   # Collect each run's per-(run x bench) record onto the benchmark-history branch (single
   # writer → no push races) and regenerate benchmarks.json for the Pages history page.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ All notable changes to cap-evolve are documented here. The format follows
 
 ## [Unreleased]
 ### Fixed
+- **A failed benchmark run was recorded as `"conclusion": "success"`.** The completion gate
+  (`Assert the suite run completed`) ran *after* `Write run metadata`, and `job.status` is
+  evaluated when a step runs — so a run that crashed mid-optimization and failed the gate still
+  wrote `success` into `runmeta.json`, which the aggregate job then published to
+  `benchmark-history`. Runs 30553822478 and 30608405812 are both recorded as successes on the
+  history page despite failing. The gate now runs before the publishing steps; everything
+  downstream is `if: always()`, so metrics/UI/artifacts/PR-comment are still published on
+  failure — only the recorded conclusion changes.
+- **Command-injection vector in the benchmark job's metadata step.** `github.head_ref` (an
+  attacker-controlled PR branch name) was interpolated straight into an inline script on a
+  **self-hosted** runner. It now travels via the environment, and both free-form fields
+  (`branch`, `source`) are emitted as JSON string literals — shell quoting alone let a branch
+  name containing a double quote produce an unparseable `runmeta.json`. Verified against 24
+  combinations of hostile branch name x event x job status. `benchmarks.yml` is now
+  actionlint-clean.
+
 - **SpreadsheetBench formula recalculation was silently never running (#256).** #240 widened the
   *directories* the adapter creates so the uid-1000 container could write its output; the output
   *file* it writes is still owned by uid 1000 at ~0644, so the host-side scorer could not rewrite


### PR DESCRIPTION
Two faults in the benchmark job's metadata step, both surfaced while verifying the spreadsheetbench work. **Not required for #255/#263** — filed separately so those stayed scoped.

## 1. A failed run is published to the history page as a success

`Assert the suite run completed` ran **after** `Write run metadata`, and `job.status` is evaluated when a step runs. So a run that crashed mid-optimization and then failed the gate still wrote:

```json
"conclusion": "success"
```

…and the `aggregate history` job pushed that to `benchmark-history`. **Runs [30553822478](https://github.com/skillberry-ai/cap-evolve/actions/runs/30553822478) and [30608405812](https://github.com/skillberry-ai/cap-evolve/actions/runs/30608405812) both sit on the benchmarks page as successes despite failing** — one produced only a baseline, the other died of SIGSEGV in iteration 2.

The gate now runs before the publishing steps. Everything downstream is `if: always()`, so metrics / UI snapshot / artifacts / PR comment are still published on failure — only the recorded conclusion changes.

## 2. Command injection vector on a self-hosted runner

`github.head_ref` — an attacker-controlled PR branch name — was interpolated straight into an inline `run:` script. actionlint flags it (`[expression]`); it was **pre-existing on main**, but since this change routes `head_ref` through the same `source` string it's fixed here rather than carried forward. It now travels via the environment.

Fixing that exposed a second-order bug I would otherwise have shipped: `"source": "$source"` and the `branch` field relied on *shell* quoting for *JSON* correctness. A branch name containing a double quote closes the string early and yields a `runmeta.json` the aggregate job can't parse:

```
{"source": "manual (quote"inject)"}   ->  JSONDecodeError
```

Both free-form fields are now emitted as JSON string literals via `json.dumps`.

## Verification

- The metadata step, extracted verbatim, produces **valid and correct** JSON across **24 combinations** of hostile branch name (`evil$(touch …)`, `quote"inject`, `` back`tick` ``, whitespace) x event x job status — branch, source, pr and conclusion all round-trip, and no shell injection fires.
- `benchmarks.yml` is **actionlint-clean**. The three remaining repo-wide findings are the same class of issue in unrelated bob/label workflows and are left alone.

Note: this does not retroactively correct the two already-published history records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)