### PR TITLE
fix(spreadsheetbench): stop pandas 3.x PyArrow strings from segfaulting the rollout pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to cap-evolve are documented here. The format follows
 
 ## [Unreleased]
 ### Fixed
+- **SpreadsheetBench rollouts could segfault the whole run (pandas 3.x + PyArrow strings).**
+  `_spreadsheet_preview` builds its preview with `pd.read_excel`; pandas 3.x makes `str`
+  columns `ArrowStringArray`, so construction goes through pyarrow's C++ layer. Called
+  concurrently from the rollout thread pool that crashed with SIGSEGV in
+  `ArrowStringArray._from_sequence` — uncatchable, so one bad preview killed the algorithm
+  process and every completed iteration with it (run 30634898569 lost 68 minutes and ~$6
+  after an accepted baseline). The adapter now pins `mode.string_storage = "python"` once per
+  process, so the crashing frame is never reached; verified on pandas 3.0.5 / pyarrow 25.0.0
+  that the preview text is byte-identical to the default, so the agent's prompt — and result
+  comparability — are unchanged. Set once at import rather than per call, because
+  `pd.option_context` restores a process-global option on exit and would race the other
+  rollout threads. Guarded by both runtime tests and dependency-free AST checks, since
+  `core[dev]` has no pandas and a skipped guard is no guard.
 - **A failed benchmark run was recorded as `"conclusion": "success"`.** The completion gate
   (`Assert the suite run completed`) ran *after* `Write run metadata`, and `job.status` is
   evaluated when a step runs — so a run that crashed mid-optimization and failed the gate still

--- a/core/tests/test_spreadsheetbench_pandas_backend.py
+++ b/core/tests/test_spreadsheetbench_pandas_backend.py
@@ -1,0 +1,131 @@
+"""The spreadsheet preview must not build PyArrow-backed string columns.
+
+Run 30634898569 died with SIGSEGV inside pyarrow, reached from the rollout thread pool:
+
+    Current thread (most recent call first):
+      File ".../pandas/core/arrays/string_arrow.py", line 241 in _from_sequence
+      ...
+      File ".../pandas/io/excel/_base.py", line 1780 in parse
+      File ".../adapter.py", line ... in _spreadsheet_preview
+      File ".../cap_evolve/trials.py", line 49 in _one          <- ThreadPoolExecutor worker
+
+pandas 3.x makes `str` columns ArrowStringArray by default, so `read_excel` goes through
+pyarrow's C++ layer. A segfault is uncatchable, so one bad preview kills the whole algorithm
+process and every completed iteration with it (68 minutes and ~$6 in that run).
+
+These tests pin the invariant that keeps the crashing frame out of the call stack, and that
+the preview text is unchanged so benchmark results stay comparable.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+ADAPTER_DIR = REPO / "templates" / "adapters" / "spreadsheetbench"
+
+pd = pytest.importorskip("pandas", reason="pandas not installed in this environment")
+pytest.importorskip("openpyxl", reason="openpyxl not installed in this environment")
+
+
+def _load_adapter_module():
+    import importlib.util
+    for p in (REPO / "core", ADAPTER_DIR, ADAPTER_DIR.parent):
+        if str(p) not in sys.path:
+            sys.path.insert(0, str(p))
+    spec = importlib.util.spec_from_file_location("_sb_adapter_pandas", ADAPTER_DIR / "adapter.py")
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _workbook(tmp_path: Path) -> Path:
+    """A workbook with the shapes that exercise string construction: text, numbers, gaps."""
+    import openpyxl
+    wb = openpyxl.Workbook()
+    for s in range(3):
+        ws = wb.create_sheet(f"S{s}") if s else wb.active
+        for r in range(1, 40):
+            ws.cell(r, 1, f"lbl-{r}")
+            ws.cell(r, 2, r * 1.5 if r % 3 else None)
+            ws.cell(r, 3, None if r % 5 == 0 else f"text {r}")
+            ws.cell(r, 4, r)
+    p = tmp_path / "m.xlsx"
+    wb.save(p)
+    return p
+
+
+def test_preview_does_not_produce_arrow_string_columns(tmp_path):
+    """The crashing frame is ArrowStringArray._from_sequence — it must not be reachable."""
+    mod = _load_adapter_module()
+    book = _workbook(tmp_path)
+    mod._spreadsheet_preview(book, 5)          # configures pandas as a side effect
+
+    frame = mod._pandas().read_excel(book)
+    backends = {type(frame[c].array).__name__ for c in frame.columns}
+    assert "ArrowStringArray" not in backends, (
+        f"pyarrow-backed strings are back — the SIGSEGV path is reachable again: {backends}"
+    )
+
+
+def test_pandas_string_storage_is_python(tmp_path):
+    mod = _load_adapter_module()
+    mod._spreadsheet_preview(_workbook(tmp_path), 5)
+    assert mod._pandas().options.mode.string_storage == "python"
+
+
+def test_preview_text_is_unchanged_by_the_backend_switch(tmp_path):
+    """Results must stay comparable: the agent's prompt may not change."""
+    mod = _load_adapter_module()
+    book = _workbook(tmp_path)
+    ours = mod._spreadsheet_preview(book, 5)
+
+    # Recompute the same preview under pandas' DEFAULT backend for comparison.
+    with pd.option_context("mode.string_storage", "pyarrow"):
+        xf = pd.ExcelFile(book)
+        chunks = []
+        for name in xf.sheet_names:
+            df = xf.parse(name)
+            n = 5 if df.shape[0] > 5 else df.shape[0]
+            chunks.append(f"Sheet Name: {name}\n{df.head(n).to_string()}\n" + "-" * 50)
+        default = "\n".join(chunks)
+
+    assert ours == default, "preview text changed — the agent would see a different prompt"
+
+
+def test_preview_is_configured_once_not_per_call(tmp_path):
+    """Per-call pd.option_context would race in the rollout thread pool; assert we don't.
+
+    Checked by AST so prose *about* option_context (the helper's docstring explains why it is
+    avoided) does not trip the assertion — only a real call does.
+    """
+    import ast
+    tree = ast.parse((ADAPTER_DIR / "adapter.py").read_text(encoding="utf-8"))
+    calls = [
+        n for n in ast.walk(tree)
+        if isinstance(n, ast.Call)
+        and ((isinstance(n.func, ast.Attribute) and n.func.attr == "option_context")
+             or (isinstance(n.func, ast.Name) and n.func.id == "option_context"))
+    ]
+    assert not calls, (
+        "option_context mutates a process-global option and restores it on exit; in a thread "
+        f"pool one thread can restore the Arrow backend while another is mid-read "
+        f"(found call at line {calls[0].lineno if calls else '?'})"
+    )
+    mod = _load_adapter_module()
+    mod._spreadsheet_preview(_workbook(tmp_path), 5)
+    assert mod._pandas_configured is True
+
+
+def test_concurrent_previews_all_succeed(tmp_path):
+    """The real shape: the same workbook previewed from several threads at once."""
+    from concurrent.futures import ThreadPoolExecutor
+    mod = _load_adapter_module()
+    book = _workbook(tmp_path)
+    with ThreadPoolExecutor(max_workers=4) as ex:
+        out = list(ex.map(lambda _: mod._spreadsheet_preview(book, 5), range(24)))
+    assert len(out) == 24
+    assert all(o == out[0] for o in out), "previews of one workbook must be deterministic"
+    assert "Sheet Name: S1" in out[0]

--- a/core/tests/test_spreadsheetbench_pandas_backend_static.py
+++ b/core/tests/test_spreadsheetbench_pandas_backend_static.py
@@ -1,0 +1,101 @@
+"""Dependency-free guard on the pandas/pyarrow SIGSEGV fix.
+
+`test_spreadsheetbench_pandas_backend.py` proves the fix *behaves* correctly, but it needs
+pandas and openpyxl — and `core[dev]` installs only pytest, so in CI it skips entirely. A
+guard that never runs where changes land is not a guard. These checks are pure AST/source
+inspection: they run everywhere and fail if someone removes the fix or reintroduces the
+crashing pattern.
+
+Background: run 30634898569 died with SIGSEGV in `ArrowStringArray._from_sequence`, reached
+from `_spreadsheet_preview` inside the rollout thread pool. pandas 3.x makes `str` columns
+pyarrow-backed by default; the fix pins `mode.string_storage = "python"` once per process.
+"""
+
+import ast
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+ADAPTER = REPO / "templates" / "adapters" / "spreadsheetbench" / "adapter.py"
+
+
+def _tree():
+    return ast.parse(ADAPTER.read_text(encoding="utf-8"))
+
+
+def _func(tree, name):
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
+            return node
+    raise AssertionError(f"{name}() not found in {ADAPTER}")
+
+
+def test_adapter_pins_the_python_string_backend():
+    """The one line that keeps pyarrow out of the read_excel path."""
+    assigns = [
+        n for n in ast.walk(_tree())
+        if isinstance(n, ast.Assign)
+        and any(isinstance(t, ast.Attribute) and t.attr == "string_storage" for t in n.targets)
+    ]
+    assert assigns, (
+        "no `...string_storage = ...` assignment: pandas 3.x will build ArrowStringArray "
+        "columns again and the rollout pool can segfault (run 30634898569)"
+    )
+    values = {n.value.value for n in assigns if isinstance(n.value, ast.Constant)}
+    assert values == {"python"}, f'expected string_storage set to "python", found {values}'
+
+
+def test_preview_gets_pandas_through_the_configuring_helper():
+    """A bare `import pandas as pd` inside the preview bypasses the fix — that is the regression."""
+    preview = _func(_tree(), "_spreadsheet_preview")
+    imports = [n for n in ast.walk(preview) if isinstance(n, (ast.Import, ast.ImportFrom))]
+    imported = []
+    for node in imports:
+        if isinstance(node, ast.Import):
+            imported += [a.name for a in node.names]
+        elif node.module:
+            imported.append(node.module)
+    assert not any(m and m.split(".")[0] == "pandas" for m in imported), (
+        "_spreadsheet_preview imports pandas directly, bypassing the helper that pins the "
+        "non-Arrow string backend"
+    )
+    calls = [n.func.id for n in ast.walk(preview)
+             if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)]
+    assert "_pandas" in calls, "_spreadsheet_preview must obtain pandas via _pandas()"
+
+
+def test_no_per_call_option_context():
+    """option_context restores on exit; in a thread pool that races the other workers."""
+    calls = [
+        n for n in ast.walk(_tree())
+        if isinstance(n, ast.Call)
+        and ((isinstance(n.func, ast.Attribute) and n.func.attr == "option_context")
+             or (isinstance(n.func, ast.Name) and n.func.id == "option_context"))
+    ]
+    assert not calls, (
+        f"pd.option_context called at line {calls[0].lineno if calls else '?'}: it mutates a "
+        "process-global option and restores it on exit, so one thread can restore the Arrow "
+        "backend while another is mid-read"
+    )
+
+
+def test_every_pandas_entry_point_goes_through_the_helper():
+    """Any future pandas user in this adapter must route through _pandas(), not import it."""
+    tree = _tree()
+    offenders = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if node.name == "_pandas":
+            continue  # the helper itself is the single sanctioned import site
+        for inner in ast.walk(node):
+            if isinstance(inner, ast.Import) and any(
+                a.name.split(".")[0] == "pandas" for a in inner.names
+            ):
+                offenders.append(f"{node.name}:{inner.lineno}")
+            elif isinstance(inner, ast.ImportFrom) and inner.module and \
+                    inner.module.split(".")[0] == "pandas":
+                offenders.append(f"{node.name}:{inner.lineno}")
+    assert not offenders, (
+        f"pandas imported outside _pandas() at {offenders} — those call sites skip the "
+        "string-backend fix"
+    )

--- a/templates/adapters/spreadsheetbench/adapter.py
+++ b/templates/adapters/spreadsheetbench/adapter.py
@@ -475,8 +475,51 @@ def _read_system_prompt(ctx) -> str:
     return _DEFAULT_SYSTEM_PROMPT
 
 
-def _spreadsheet_preview(path: Path, rows: int) -> str:
+_pandas_configured = False
+
+
+def _pandas():
+    """Import pandas with the PyArrow-backed string dtype turned OFF, once per process.
+
+    pandas 3.x makes `str` columns `ArrowStringArray` by default, so `read_excel` constructs
+    them through pyarrow's C++ layer. Called concurrently from the rollout thread pool that
+    is exactly where a run died:
+
+        Current thread (most recent call first):
+          File ".../pandas/core/arrays/string_arrow.py", line 241 in _from_sequence
+          File ".../pandas/core/construction.py", line 616 in sanitize_array
+          ...
+          File ".../pandas/io/excel/_base.py", line 1780 in parse
+          File ".../adapter.py", line ... in _spreadsheet_preview
+          File ".../cap_evolve/trials.py", line 49 in _one      <- ThreadPoolExecutor worker
+
+    SIGSEGV, so nothing catches it: one bad preview takes down the whole algorithm process
+    and every completed iteration with it (run 30634898569 lost 68 minutes and ~$6 that way).
+
+    `mode.string_storage = "python"` keeps the `str` dtype but backs it with Python objects,
+    so `ArrowStringArray._from_sequence` — the frame that crashed — is never called. Verified
+    locally on pandas 3.0.5 / pyarrow 25.0.0 that the resulting preview text is BYTE-IDENTICAL
+    to the default, so the agent's prompt does not change and results stay comparable.
+
+    Set once at import rather than per call via `pd.option_context`: that context manager
+    mutates a process-global option and restores it on exit, which in a thread pool lets one
+    thread restore the Arrow backend while another is still reading — the same class of race
+    `run_trials_pool` documents for `redirect_stdout`.
+    """
+    global _pandas_configured
     import pandas as pd
+
+    if not _pandas_configured:
+        try:
+            pd.options.mode.string_storage = "python"
+        except Exception:  # noqa: BLE001 — older pandas without the option; nothing to disable
+            pass
+        _pandas_configured = True
+    return pd
+
+
+def _spreadsheet_preview(path: Path, rows: int) -> str:
+    pd = _pandas()
 
     excel_file = pd.ExcelFile(path)
     chunks = []


### PR DESCRIPTION
Closes #257. **Root cause found** — using exactly the native traceback that #263's `faulthandler` change was added to produce.

## The traceback

```
Current thread (most recent call first):
  File ".../pandas/core/arrays/string_arrow.py", line 241 in _from_sequence
  File ".../pandas/core/construction.py", line 616 in sanitize_array
  ...
  File ".../pandas/io/excel/_base.py", line 1780 in parse
  File ".../adapter.py", line 484 in _spreadsheet_preview
  File ".../adapter.py", line 570 in run_target
  File ".../core/cap_evolve/trials.py", line 49 in _one      <- ThreadPoolExecutor worker
```

pandas 3.x — note `pandas._libs._cyutility` in the loaded extension list — makes `str` columns `ArrowStringArray`, so `read_excel` constructs them through pyarrow's C++ layer. Four rollout threads doing that at once crashed. A SIGSEGV can't be caught, so one bad preview took down the algorithm process **and every completed iteration with it**: 68 minutes and ~$6, after baseline (0.507) and iteration 1 had already finished.

## Fix

Pin `mode.string_storage = "python"` once per process. `str` columns become Python-backed, so `ArrowStringArray._from_sequence` — the frame that crashed — is never called.

- **Byte-identical output.** Verified on pandas 3.0.5 / pyarrow 25.0.0 that the preview text matches the default exactly, so the agent's prompt doesn't change and results stay comparable across runs.
- **Set once at import, not per call.** `pd.option_context` mutates a process-global option and restores it on exit, which in a thread pool lets one worker restore the Arrow backend while another is mid-read — the same race `run_trials_pool` already documents for `redirect_stdout`.

## Honest limit

**I could not reproduce the segfault locally** — 72 concurrent previews on the same pandas/pyarrow stack completed cleanly. So this is not an empirically-reproduced fix; it is a *by-construction* one: the function that crashed is no longer on the call path. If a SIGSEGV recurs elsewhere in a rollout, the follow-up is crash isolation (run rollouts in subprocesses, so a signal costs one rollout instead of the whole run).

## Tests

Two layers, both negative-controlled (removing the fix makes them fail):
- **Runtime** (real pandas): no `ArrowStringArray` after configuration, preview text identical to default, concurrent previews deterministic.
- **Static AST** (no deps): the `string_storage` pin exists, `_spreadsheet_preview` goes through `_pandas()` rather than importing pandas directly, no `option_context` call, and no pandas import anywhere outside the helper.

The static layer exists because `core[dev]` installs only pytest, so the runtime file **skips entirely in CI** — a guard that never runs where changes land is not a guard.

`203 passed` without pandas, `208 passed` with it, plus the adapter's self-checks.

## Also verified in run 30634898569 — #256 and #255 are confirmed fixed in reality

| check | before | in this run |
|---|---|---|
| `Error processing …: [Errno 13]` recalc failures | pervasive | **0** |
| `INFRASTRUCTURE: formula recalculation FAILED` | n/a | **0** (reclaim succeeded on the real foreign-uid case) |
| `JSONDecodeError` on phase stdout | killed the run | **0** |
| baseline reward | 0.293 → 0.393 | **0.507** |

The baseline trend is consistent with recalculation finally running, though with n=1 and ±0.1 LLM variance it is suggestive rather than conclusive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)