### PR TITLE
fix(ci): plan job must check out the repo — the tier filter selected ZERO legs

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -172,6 +172,14 @@ jobs:
       # off this instead of trying to introspect the JSON.
       has_legs: ${{ steps.plan.outputs.has_legs }}
     steps:
+      # REQUIRED: the planner reads ci/benchmarks/<bench>/<tier>/tasks.json to decide which
+      # tiers a benchmark has populated. Without a checkout every path lookup misses and the
+      # planner selects ZERO legs — which is exactly what happened in run 30682558719, where
+      # a dispatch produced "skip pilot/spreadsheetbench: no tasks.json" and a skipped matrix.
+      # If you remove this step, remove the filesystem filter below with it.
+      - name: Run actions/checkout@v4
+        uses: actions/checkout@v4
+
       - name: Select tier x bench legs
         id: plan
         env:
@@ -200,6 +208,12 @@ jobs:
           # that names the tier deliberately.
           EXPLICIT_ONLY_TIERS = {"pilot"}
 
+          # Is the repository actually checked out here? See the fail-open note below.
+          tree_present = os.path.isdir("ci/benchmarks")
+          if not tree_present:
+              print("WARNING: no ci/benchmarks tree — tier-population filter disabled",
+                    file=sys.stderr, flush=True)
+
           event = os.environ["EVENT"]
           tier_sel = os.environ.get("TIER_SEL") or "smoke"
           bench_sel = os.environ.get("BENCH_SEL") or "all"
@@ -221,7 +235,12 @@ jobs:
                   # the waste this planner was introduced to remove. Filtering here keeps a
                   # partially-populated tier (e.g. only one benchmark ships `pilot/`) free for
                   # everyone else. No-op for smoke/full, which every benchmark populates.
-                  if run and not os.path.isfile(f"ci/benchmarks/{bench}/{tier}/tasks.json"):
+                  # FAIL OPEN if the working tree is not here at all: filtering on a missing
+                  # checkout would silently select ZERO legs for every benchmark, turning a
+                  # dispatch into a no-op that still reports success. Only trust the filter
+                  # when there is a tree to look at.
+                  if run and tree_present and not os.path.isfile(
+                          f"ci/benchmarks/{bench}/{tier}/tasks.json"):
                       print(f"skip {tier}/{bench}: no tasks.json for that tier",
                             file=sys.stderr, flush=True)
                       run = False

--- a/core/tests/test_benchmarks_plan_legs.py
+++ b/core/tests/test_benchmarks_plan_legs.py
@@ -118,3 +118,38 @@ def test_only_spreadsheetbench_ships_a_pilot_tier():
     shipped = sorted(p.parent.parent.name
                      for p in (REPO / "ci" / "benchmarks").glob("*/pilot/tasks.json"))
     assert shipped == ["spreadsheetbench"], shipped
+
+
+# ---- the missing-checkout regression (run 30682558719) -----------------------
+
+def _run_plan_in(cwd, *, event, tier_sel=None, bench_sel=None, labels=None):
+    env = dict(os.environ, EVENT=event, LABELS=json.dumps(labels or []))
+    if tier_sel is not None:
+        env["TIER_SEL"] = tier_sel
+    if bench_sel is not None:
+        env["BENCH_SEL"] = bench_sel
+    proc = subprocess.run([sys.executable, "-c", _plan_script()], capture_output=True,
+                          text=True, cwd=str(cwd), env=env)
+    assert proc.returncode == 0, proc.stderr
+    legs = json.loads(re.search(r"^matrix=(.*)$", proc.stdout, re.M).group(1))
+    return [(l["tier"], l["bench"]) for l in legs], proc.stderr
+
+
+def test_planner_fails_open_without_a_checked_out_tree(tmp_path):
+    """The bug: the plan job had no checkout, so the tasks.json filter matched NOTHING and a
+    dispatch selected zero legs while still reporting success. Filtering must only apply when
+    there is a tree to inspect."""
+    legs, err = _run_plan_in(tmp_path, event="workflow_dispatch", tier_sel="smoke", bench_sel="all")
+    assert sorted(legs) == sorted(("smoke", b) for b in ALL_BENCHES), (
+        f"planner selected {legs} with no checkout — it must fall back to unfiltered selection"
+    )
+    assert "filter disabled" in err
+
+
+def test_plan_job_checks_out_the_repo():
+    """The filter is only meaningful with a tree, so the job must provide one."""
+    src = WORKFLOW.read_text(encoding="utf-8")
+    plan = src[src.index("\n  plan:"):src.index("\n  bench:")]
+    assert "actions/checkout" in plan, (
+        "plan job reads ci/benchmarks/**/tasks.json but does not check out the repository"
+    )


### PR DESCRIPTION
**Regression I introduced in #267. Benchmark CI has been a silent no-op since it merged.**

#267 added a filter so the planner only emits a leg when `ci/benchmarks/<bench>/<tier>/tasks.json` exists. The `plan` job has **no checkout step**, so every path lookup missed and the planner selected **nothing — for every benchmark and every tier**, not just pilot.

[Run 30682558719](https://github.com/skillberry-ai/cap-evolve/actions/runs/30682558719) dispatched `pilot/spreadsheetbench` and produced:

```
skip pilot/spreadsheetbench: no tasks.json for that tier
selected 0 leg(s): []
```

…a skipped matrix job, and a run that still reported **success**. Worst kind of failure: a dispatch that does nothing and looks fine.

## Why my tests missed it

They invoke the planner with `cwd=REPO`, so a tree was always present. CI was the one environment where it wasn't. Testing the script in isolation validated the logic but not its *environment* — the assumption I never made explicit.

## Fix — two layers

1. **`actions/checkout` on the plan job**, so the filter has the tree it needs.
2. **Fail open when `ci/benchmarks` is absent** — a future refactor that drops the checkout now degrades to unfiltered selection (previous behaviour) instead of silently selecting nothing. Filtering against a missing tree can only ever be wrong.

## Verification

Negative-controlled against main's planner under the exact CI condition:

```
BROKEN planner (main) with no tree -> 0 legs   <- the bug
fixed planner with no tree        -> all 4 benchmarks selected
```

New regression tests: run the planner from a directory with **no tree** and assert all four benchmarks are still selected; assert the plan job contains a checkout while the planner reads the filesystem. `256 passed`, actionlint clean.

Merging this promptly restores benchmark CI — no dispatch works until it lands.