### PR TITLE
fix(ci): gpt-5.x temperature override + fail runs that measured nothing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to cap-evolve are documented here. The format follows
 [Semantic Versioning](https://semver.org/) (currently `0.x` — anything may change).
 
 ## [Unreleased]
+### Fixed
+- **gpt-5.x rejected our temperature override, failing every rollout at $0.00 spend.** The
+  gateway answers `400 Unsupported value: 'temperature' does not support 0.0 with this model.
+  Only the default (1) value is supported.` — so run 30682720920 lost an entire pilot: all 60
+  tasks errored on their first LLM call, the run finished in 9 minutes having billed nothing,
+  and reported **success** with a clean-looking 0.000. `model_config` (shared by five adapters)
+  now sends no `temperature` for model families that pin it, making the effective temperature
+  the model's own default — 1 for gpt-5.x, the only value they accept. Safer than sending the
+  value the error names, since a deployment may reject the parameter outright. A blank or
+  `default`/`model`/`none` TEMPERATURE now also means "use the model default"; every other
+  model still gets 0.0, so this is a no-op for tau2/swebench/skillsbench.
+- **An infra-dominated run reported success.** Completion is not sufficient: a run whose every
+  rollout died on infrastructure still writes `baseline.json`/`final.json`, records iterations,
+  passes the gate, and publishes 0.000 to `benchmark-history` as though it measured something.
+  `assert_run.py` now FAILS when more than `--max-infra-frac` (default 0.5) of baseline tasks
+  are infrastructure errors, reusing `metrics.py`'s existing `_infra_task` rule — which already
+  rendered those tasks as `⚠️ infra-error` in the report while the job went green. Verified by
+  replaying run 30682720920's real `baseline.json`: the old gate exits 0, the new one exits 1.
+  A genuine all-zero run with no infra errors still passes.
+
 ### Added
 - **`pilot` tier — a cost/runtime measurement rig for SpreadsheetBench.** Answers the three
   things a ~$450 full run depends on and nobody has measured: cost and wall-clock per rollout at

--- a/ci/benchmarks/lib/assert_run.py
+++ b/ci/benchmarks/lib/assert_run.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
 """Assert a cap-evolve run dir completed and did not regress on the sealed test.
 
-  assert_run.py <run_dir> [--min-iterations N] [--allow-regression]
+  assert_run.py <run_dir> [--min-iterations N] [--allow-regression] [--max-infra-frac F]
 
 - completed: baseline.json + final.json present
 - iteration_ran: state.json spent.iterations >= N (default 1)
+- measured: not infra-dominated — at most F of the baseline's tasks failed with an
+  INFRASTRUCTURE error (default 0.5)
 - no_regression: final test reward >= baseline val reward
 Exit 0 on pass, 1 on failure (prints why).
 
@@ -13,10 +15,35 @@ where the reward is a real, noisy model measurement (the benchmarks suite): ther
 re-scoring the winner on the sealed test can land a hair under baseline through trial
 noise alone, and failing CI for that would be a false alarm. The completion checks are
 the ones that catch a genuinely broken run — a crashed step leaves no final.json.
+
+The `measured` check exists because completion is NOT sufficient. A run whose every rollout
+died on an infrastructure fault still writes baseline.json and final.json, still records
+iterations, and still reports `success` — while measuring nothing. That is what
+run 30682720920 did: `azure/gpt-5.5` rejected `temperature=0.0`, so all 60 tasks errored,
+eval spend was $0.00, and the job went green with a clean-looking 0.000. An all-zero run
+caused by a broken gateway, a missing binary or a bad model id must be LOUD, because the
+alternative is publishing it as a real capability measurement.
 """
 from __future__ import annotations
 import json, sys
 from pathlib import Path
+
+
+def _infra_task(pt: dict) -> bool:
+    """True if this task's reward≈0 is an infrastructure error, not a capability result.
+
+    Same rule as ci/benchmarks/lib/metrics.py's `_infra_task`, which already renders these
+    as `⚠️ infra-error` in the report — this wires that existing signal to the exit code.
+    """
+    raw = pt.get("raw") or {}
+    if not raw.get("errored"):
+        return False
+    if float(pt.get("reward", 0) or 0) > 1e-9:
+        return False
+    et, nt = raw.get("errored_trials"), (raw.get("n_trials") or pt.get("n"))
+    if et is not None and nt:
+        return int(et) * 2 > int(nt)
+    return True
 
 
 def main(argv: list[str]) -> int:
@@ -27,18 +54,32 @@ def main(argv: list[str]) -> int:
     if "--min-iterations" in argv:
         min_it = int(argv[argv.index("--min-iterations") + 1])
     allow_regression = "--allow-regression" in argv
+    max_infra_frac = 0.5
+    if "--max-infra-frac" in argv:
+        max_infra_frac = float(argv[argv.index("--max-infra-frac") + 1])
 
     for f in ("baseline.json", "final.json", "state.json"):
         if not (rd / f).exists():
             print(f"FAIL: missing {f} — the run did not complete (a step crashed or was killed)")
             return 1
 
-    base = json.loads((rd / "baseline.json").read_text())["val"]["reward"]
+    baseline = json.loads((rd / "baseline.json").read_text())["val"]
+    base = baseline["reward"]
     fin = json.loads((rd / "final.json").read_text())["test"]["reward"]
     it = json.loads((rd / "state.json").read_text()).get("spent", {}).get("iterations", 0)
 
     if it < min_it:
         print(f"FAIL: only {it} optimizer iteration(s), need >= {min_it}"); return 1
+
+    per_task = baseline.get("per_task") or []
+    infra = [pt for pt in per_task if _infra_task(pt)]
+    if per_task and len(infra) > max_infra_frac * len(per_task):
+        ids = ", ".join(str(pt.get("task_id")) for pt in infra[:5])
+        print(f"FAIL: {len(infra)}/{len(per_task)} baseline tasks failed with an "
+              f"INFRASTRUCTURE error (> {max_infra_frac:.0%}) — this run measured nothing, "
+              f"its 0.000 is not a capability result. First: {ids}. "
+              f"Check the gateway/model id/binaries, not the capability.")
+        return 1
     if fin + 1e-9 < base and not allow_regression:
         print(f"FAIL: regression — test {fin} < baseline {base}"); return 1
     note = ""

--- a/core/tests/test_temperature_and_infra_gate.py
+++ b/core/tests/test_temperature_and_infra_gate.py
@@ -1,0 +1,173 @@
+"""Two silent-failure fixes from the lost pilot run (30682720920).
+
+`azure/gpt-5.5` rejects a `temperature` override with HTTP 400, so every one of the 60 tasks
+errored on its first LLM call. Eval spend was $0.00, the run finished in 9 minutes, wrote
+baseline.json and final.json, passed the completion gate, and reported **success** with a
+clean-looking 0.000 — indistinguishable from a real capability measurement.
+
+Layer 1: `model_config` must not send an override to a model that pins temperature.
+Layer 2: `assert_run.py` must FAIL a run whose rollouts were infra errors, so this can never
+         be published as a result again.
+"""
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+MODEL_CONFIG = REPO / "templates" / "adapters" / "model_config.py"
+ASSERT_RUN = REPO / "ci" / "benchmarks" / "lib" / "assert_run.py"
+
+
+def _model_config(monkeypatch, model, temperature=None):
+    """Import model_config fresh with MODEL/TEMPERATURE set (MODEL is read at import)."""
+    monkeypatch.setenv("MODEL", model)
+    if temperature is None:
+        monkeypatch.delenv("TEMPERATURE", raising=False)
+    else:
+        monkeypatch.setenv("TEMPERATURE", temperature)
+    spec = importlib.util.spec_from_file_location("_mc_test", MODEL_CONFIG)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ---- layer 1: temperature ---------------------------------------------------
+
+@pytest.mark.parametrize("model", [
+    "azure/gpt-5.5",
+    "litellm_proxy/azure/gpt-5.5",       # the form CI actually uses
+    "azure/gpt-5.6-luna",
+    "azure/gpt-5.3-codex",
+    "Azure/gpt-5-2025-08-07",
+])
+def test_no_temperature_override_for_models_that_pin_it(monkeypatch, model):
+    """Effective temperature becomes the model default — 1 for gpt-5.x — which is the only
+    value these accept. Sending anything (even 1) risks the 400 that killed the pilot."""
+    mc = _model_config(monkeypatch, model, "0.0")
+    assert "temperature" not in mc.llm_kwargs(), f"{model} must get no temperature override"
+
+
+@pytest.mark.parametrize("model", [
+    "aws/gpt-oss-120b",
+    "litellm_proxy/aws/claude-sonnet-4-5",
+    "azure/gpt-4o",                      # gpt-4 family is unaffected
+    "gcp/gemini-2.5-pro",
+])
+def test_temperature_still_sent_for_every_other_model(monkeypatch, model):
+    """model_config is shared by five adapters — this change must be a no-op elsewhere."""
+    mc = _model_config(monkeypatch, model, "0.0")
+    assert mc.llm_kwargs()["temperature"] == 0.0
+
+
+def test_blank_temperature_means_use_the_model_default(monkeypatch):
+    mc = _model_config(monkeypatch, "aws/gpt-oss-120b", "")
+    assert "temperature" not in mc.llm_kwargs()
+
+
+@pytest.mark.parametrize("word", ["default", "model", "none", "DEFAULT"])
+def test_sentinel_words_mean_use_the_model_default(monkeypatch, word):
+    mc = _model_config(monkeypatch, "aws/gpt-oss-120b", word)
+    assert "temperature" not in mc.llm_kwargs()
+
+
+def test_explicit_nonzero_temperature_is_honoured(monkeypatch):
+    mc = _model_config(monkeypatch, "aws/gpt-oss-120b", "0.7")
+    assert mc.llm_kwargs()["temperature"] == 0.7
+
+
+def test_default_when_unset_is_still_zero(monkeypatch):
+    """Unset TEMPERATURE must keep meaning 0.0, not "model default"."""
+    mc = _model_config(monkeypatch, "aws/gpt-oss-120b", None)
+    assert mc.llm_kwargs()["temperature"] == 0.0
+
+
+# ---- layer 2: the infra gate ------------------------------------------------
+
+def _run_dir(tmp_path, per_task, *, iterations=2):
+    rd = tmp_path / "run"
+    rd.mkdir()
+    (rd / "baseline.json").write_text(json.dumps(
+        {"val": {"reward": 0.0 if all(p["reward"] == 0 for p in per_task) else 0.5,
+                 "per_task": per_task}}))
+    (rd / "final.json").write_text(json.dumps({"test": {"reward": 0.0}}))
+    (rd / "state.json").write_text(json.dumps({"spent": {"iterations": iterations}}))
+    return rd
+
+
+def _assert_run(rd, *extra):
+    return subprocess.run([sys.executable, str(ASSERT_RUN), str(rd),
+                           "--min-iterations", "1", "--allow-regression", *extra],
+                          capture_output=True, text=True)
+
+
+def _errored(tid):
+    return {"task_id": tid, "reward": 0.0, "n": 1,
+            "raw": {"errored": True, "errored_trials": 1, "n_trials": 1}}
+
+
+def _scored(tid, reward):
+    return {"task_id": tid, "reward": reward, "n": 1,
+            "raw": {"errored": False, "errored_trials": 0, "n_trials": 1}}
+
+
+def test_all_infra_error_run_now_fails(tmp_path):
+    """The pilot's exact shape: every task errored, 0.000, previously reported success."""
+    rd = _run_dir(tmp_path, [_errored(f"t{i}") for i in range(60)])
+    out = _assert_run(rd)
+    assert out.returncode == 1, out.stdout
+    assert "measured nothing" in out.stdout
+    assert "60/60" in out.stdout
+
+
+def test_a_genuine_all_zero_run_still_passes(tmp_path):
+    """A model that simply fails every task — no infra error — is a real 0.000 result."""
+    rd = _run_dir(tmp_path, [_scored(f"t{i}", 0.0) for i in range(10)])
+    out = _assert_run(rd)
+    assert out.returncode == 0, out.stdout
+
+
+def test_a_minority_of_infra_errors_still_passes(tmp_path):
+    """Flaky infra must not fail the suite — metrics.py already excludes those tasks."""
+    per_task = [_errored("a"), _errored("b")] + [_scored(f"t{i}", 0.6) for i in range(8)]
+    out = _assert_run(_run_dir(tmp_path, per_task))
+    assert out.returncode == 0, out.stdout
+
+
+def test_threshold_is_configurable(tmp_path):
+    per_task = [_errored("a"), _errored("b")] + [_scored(f"t{i}", 0.6) for i in range(8)]
+    out = _assert_run(_run_dir(tmp_path, per_task), "--max-infra-frac", "0.1")
+    assert out.returncode == 1, out.stdout
+
+
+def test_healthy_run_message_unchanged(tmp_path):
+    rd = _run_dir(tmp_path, [_scored(f"t{i}", 0.6) for i in range(10)])
+    out = _assert_run(rd)
+    assert out.returncode == 0 and out.stdout.startswith("OK:")
+
+
+def test_gate_matches_metrics_infra_classifier():
+    """Both must use the same rule, or the report and the exit code can disagree."""
+    import ast
+    a = ast.parse(ASSERT_RUN.read_text(encoding="utf-8"))
+    m = ast.parse((REPO / "ci" / "benchmarks" / "lib" / "metrics.py").read_text(encoding="utf-8"))
+    def logic(tree):
+        """The function body with its docstring stripped — the docstrings differ by design."""
+        for n in ast.walk(tree):
+            if isinstance(n, ast.FunctionDef) and n.name == "_infra_task":
+                body = list(n.body)
+                if (body and isinstance(body[0], ast.Expr)
+                        and isinstance(body[0].value, ast.Constant)
+                        and isinstance(body[0].value.value, str)):
+                    body = body[1:]
+                return ast.dump(ast.Module(body=body, type_ignores=[]))
+        raise AssertionError("_infra_task not found")
+    assert logic(a) == logic(m), (
+        "assert_run and metrics disagree on what an infra error is — the report would render "
+        "tasks as infra-error while the exit code judged them differently (or vice versa)"
+    )

--- a/templates/adapters/model_config.py
+++ b/templates/adapters/model_config.py
@@ -80,6 +80,40 @@ MODEL: str = _env("MODEL", "gpt-4.1-mini")
 """The litellm model string — set via the ``MODEL`` env var."""
 
 
+# Model families that PIN temperature to their own default and reject any override — even
+# the value they claim to support. The gateway answers HTTP 400:
+#
+#   Unsupported value: 'temperature' does not support 0.0 with this model.
+#   Only the default (1) value is supported.
+#
+# That fails EVERY rollout of a run, at $0.00 spend and in a few minutes, which reads exactly
+# like a capability of 0.000 rather than a misconfiguration (run 30682720920 lost a whole
+# pilot to it). Sending no override at all is safer than sending the value the error names,
+# because a deployment may reject the parameter outright; the effective temperature is then
+# the model's default, which for gpt-5.x IS 1.
+#
+# Matched against the last path segment of the resolved model id, so `azure/gpt-5.5`,
+# `litellm_proxy/azure/gpt-5.6-luna` and `azure/gpt-5.3-codex` are all covered.
+_TEMPERATURE_PINNED = ("gpt-5",)
+
+
+def _temperature() -> float | None:
+    """Resolve TEMPERATURE, or None meaning "send no override, use the model's default".
+
+    A blank/`default`/`model` value is the explicit way to ask for the model's own default,
+    which some models are the only way to call successfully.
+    """
+    raw = os.environ.get("TEMPERATURE", "0.0").strip()
+    if raw == "" or raw.lower() in ("default", "model", "none"):
+        return None
+    return float(raw)
+
+
+def _pins_temperature(model: str) -> bool:
+    name = model.lower().rsplit("/", 1)[-1]
+    return any(p in name for p in _TEMPERATURE_PINNED)
+
+
 def llm_kwargs() -> dict[str, Any]:
     """Return provider-appropriate kwargs for ``litellm.completion(**llm_kwargs())``.
 
@@ -113,7 +147,9 @@ def llm_kwargs() -> dict[str, Any]:
     if api_key:
         kwargs["api_key"] = api_key
 
-    kwargs["temperature"] = float(os.environ.get("TEMPERATURE", "0.0"))
+    temperature = _temperature()
+    if temperature is not None and not _pins_temperature(MODEL):
+        kwargs["temperature"] = temperature
     # Optional output cap. Set high for reasoning models (they spend tokens on a
     # hidden reasoning pass before the visible answer), or for long outputs (patches).
     max_tokens = os.environ.get("MAX_TOKENS")


### PR DESCRIPTION
Both faults come from one lost pilot ([run 30682720920](https://github.com/skillberry-ai/cap-evolve/actions/runs/30682720920)), where `azure/gpt-5.5` failed **every** rollout and CI called it a success.

## 1. The temperature override

```
400 Unsupported value: 'temperature' does not support 0.0 with this model.
    Only the default (1) value is supported.   [Model Group=azure/gpt-5.5]
```

All 60 tasks errored on their first LLM call. **Eval spend $0.00**, run over in 9 minutes, `baseline.json` and `final.json` written, `conclusion=success`, reward 0.000 — indistinguishable from a real capability measurement. This would have burned the full run.

`model_config` (shared by **five** adapters) now omits `temperature` for model families that pin it, so the effective temperature is the model's own default — **1** for gpt-5.x, the only value they accept. Omitting beats sending the value the error names, since a deployment may reject the parameter outright. Matching is on the last path segment of the resolved id, so `litellm_proxy/azure/gpt-5.5` is covered.

A blank or `default`/`model`/`none` `TEMPERATURE` now also means "use the model default" — a generic capability every adapter gains.

**No-op for everything else**, asserted for `aws/gpt-oss-120b`, `claude-sonnet-4-5`, `azure/gpt-4o` and `gemini-2.5-pro`: they all still get `0.0`. tau2/swebench/skillsbench are unaffected.

## 2. The gate that let it through

Completion was not sufficient. `assert_run.py` checked only that files and iterations existed — so a run where **not one rollout succeeded** passed, went green, and was published to `benchmark-history` as a 0.000 result.

`metrics.py` already classified those tasks and rendered them `⚠️ infra-error` in the report. **The signal existed; it just wasn't wired to the exit code.** Now it fails above `--max-infra-frac` (default 0.5), using the same `_infra_task` rule, with a test asserting the two implementations can't drift apart.

### Verified against the real run's data

```
main (old gate)      exit=0  OK: baseline=0.0 test=0.0 iterations=2
this PR (new gate)   exit=1  FAIL: 50/50 baseline tasks failed with an
                             INFRASTRUCTURE error — this run measured nothing
```

A genuine all-zero run with **no** infra errors still passes (a model that simply fails every task is a real result), and a flaky minority still passes.

## Note on the experiment, for the record

gpt-5.5's effective temperature is now **1**, not 0 — its only option. Combined with `trials=1` that means noisier per-task rewards than the 10-task ±0.1 we measured at temperature 0. The paper reports no trial count, so `trials=1` was always an assumption; if the pilot's variance looks high, raising trials for the full run is the lever.

`278 passed`, `core/cap_evolve` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)