### PR TITLE
fix(site): match any tier in the live panel — a running pilot leg was invisible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to cap-evolve are documented here. The format follows
 
 ## [Unreleased]
 ### Fixed
+- **A running `pilot` leg was invisible on the benchmarks page.** `site/benchmarks.js`'s
+  `JOB_RE` hardcoded `smoke|full`, so it never matched the `pilot / spreadsheetbench` job name:
+  no "Running now" entry and no way to open the run's UI while it executed. Nothing errored —
+  the run simply could not be seen. The tier is now matched generically (the bench allowlist
+  stays explicit so "plan legs"/"aggregate history" still never match), and the history table's
+  tier filter offers `pilot`. A test ties the site's matcher to the workflow's `TIERS` list so
+  adding a tier cannot silently hide it again.
+
+### Fixed
 - **gpt-5.x rejected our temperature override, failing every rollout at $0.00 spend.** The
   gateway answers `400 Unsupported value: 'temperature' does not support 0.0 with this model.
   Only the default (1) value is supported.` — so run 30682720920 lost an entire pilot: all 60

--- a/core/tests/test_site_live_panel_tiers.py
+++ b/core/tests/test_site_live_panel_tiers.py
@@ -1,0 +1,75 @@
+"""The benchmarks page must recognise every tier the workflow can run.
+
+`site/benchmarks.js` matches CI job names ("<tier> / <bench>") to build the "Running now"
+panel and its "Open UI" links. That regex hardcoded `smoke|full`, so when the `pilot` tier
+landed a live pilot run was **invisible on the page while it executed** — no panel entry, no
+way to open its UI. Nothing failed; the run simply could not be seen.
+
+This is cross-file drift: the tier list lives in .github/workflows/benchmarks.yml and the
+matcher lives in the site. These tests tie them together so adding a tier cannot silently
+hide it again.
+"""
+
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO / ".github" / "workflows" / "benchmarks.yml"
+JS = REPO / "site" / "benchmarks.js"
+HTML = REPO / "site" / "benchmarks.html"
+
+BENCHES = ["tau2", "swebench", "skillsbench", "spreadsheetbench"]
+
+
+def _workflow_tiers() -> list[str]:
+    """The planner's TIERS list — the single source of truth for what CI can run."""
+    src = WORKFLOW.read_text(encoding="utf-8")
+    m = re.search(r"^\s*TIERS\s*=\s*\[([^\]]*)\]", src, re.M)
+    assert m, "TIERS not found in benchmarks.yml"
+    tiers = re.findall(r'"([^"]+)"', m.group(1))
+    assert tiers, m.group(1)
+    return tiers
+
+
+def _job_regex() -> re.Pattern:
+    """Translate the JS JOB_RE into an equivalent Python pattern."""
+    src = JS.read_text(encoding="utf-8")
+    m = re.search(r"JOB_RE\s*=\s*/(.+?)/[gimsuy]*\s*;", src)
+    assert m, "JOB_RE not found in site/benchmarks.js"
+    pattern = m.group(1).replace("\\/", "/")
+    return re.compile(pattern)
+
+
+def test_live_panel_matches_every_tier_the_workflow_can_run():
+    rx = _job_regex()
+    missing = [f"{t} / {b}" for t in _workflow_tiers() for b in BENCHES
+               if not rx.match(f"{t} / {b}")]
+    assert not missing, (
+        "site/benchmarks.js JOB_RE does not match these CI job names, so those runs would be "
+        f"invisible in the live panel: {missing}"
+    )
+
+
+def test_live_panel_captures_tier_and_bench_groups():
+    rx = _job_regex()
+    m = rx.match("pilot / spreadsheetbench")
+    assert m and m.group(1) == "pilot" and m.group(2) == "spreadsheetbench", (
+        "the panel reads tier from group 1 and bench from group 2 to build its UI links"
+    )
+
+
+def test_live_panel_ignores_non_leg_jobs():
+    """The other jobs in the workflow must never appear as benchmark legs."""
+    rx = _job_regex()
+    for name in ("plan legs", "aggregate history", "collect-pr-context", "Test Python (core)"):
+        assert not rx.match(name), f"JOB_RE should not match the {name!r} job"
+
+
+def test_tier_filter_offers_every_tier():
+    """The history table filters on tier; a tier missing from the dropdown is unselectable."""
+    html = HTML.read_text(encoding="utf-8")
+    sel = re.search(r'<select id="f-tier">(.*?)</select>', html, re.S)
+    assert sel, "f-tier select not found"
+    options = set(re.findall(r"<option[^>]*>([^<]+)</option>", sel.group(1)))
+    missing = [t for t in _workflow_tiers() if t not in options]
+    assert not missing, f"tier filter is missing {missing} (offers {sorted(options)})"

--- a/site/benchmarks.html
+++ b/site/benchmarks.html
@@ -92,7 +92,7 @@
       <select id="f-bench"><option value="">all</option><option>tau2</option><option>swebench</option><option>skillsbench</option></select>
     </label>
     <label>Type
-      <select id="f-tier"><option value="">all</option><option>smoke</option><option>full</option></select>
+      <select id="f-tier"><option value="">all</option><option>smoke</option><option>pilot</option><option>full</option></select>
     </label>
     <label>Source
       <select id="f-source"><option value="">all</option><option value="pr">PR</option><option value="manual">manual</option></select>

--- a/site/benchmarks.js
+++ b/site/benchmarks.js
@@ -1,6 +1,10 @@
 const RAW = "https://raw.githubusercontent.com/skillberry-ai/cap-evolve/benchmark-history";
 const GH_API = "https://api.github.com/repos/skillberry-ai/cap-evolve";
-const JOB_RE = /^(smoke|full) \/ (tau2|swebench|skillsbench|spreadsheetbench)$/;
+// Tier is matched GENERICALLY: the workflow's TIERS list grows (smoke, pilot, full, …) and
+// hardcoding it here silently hides new tiers from the live panel — a `pilot` run was
+// invisible while it was executing. The bench allowlist stays explicit so unrelated jobs
+// ("plan legs", "aggregate history") never match.
+const JOB_RE = /^([a-z][a-z0-9-]*) \/ (tau2|swebench|skillsbench|spreadsheetbench)$/;
 let RECORDS = [], sortKey = "date", sortDir = -1;
 
 const $ = (s) => document.querySelector(s);


### PR DESCRIPTION
Reported while [run 30691123806](https://github.com/skillberry-ai/cap-evolve/actions/runs/30691123806) was executing: no "Running now" entry on the benchmarks page and no way to open the pilot's UI.

## Cause — mine, from the pilot-tier PR

```js
const JOB_RE = /^(smoke|full) \/ (tau2|swebench|skillsbench|spreadsheetbench)$/;
```

`pilot / spreadsheetbench` never matched. **Nothing errored** — the run was executing normally on the runner, it just couldn't be seen from the page. I added a tier without updating the site.

## Fix

- Tier matched **generically** (`[a-z][a-z0-9-]*`), which is what the workflow's `TIERS` list actually is. The bench allowlist stays explicit so `plan legs` / `aggregate history` still never match as legs.
- The tier filter dropdown now offers `pilot` — otherwise pilot rows in the history table were unselectable.
- The history table itself already handled tiers generically (it reads `r.tier`), so nothing else needed changing.

Verified against real job names:

```
MATCH  tier=smoke bench=tau2                <- "smoke / tau2"
MATCH  tier=pilot bench=spreadsheetbench    <- "pilot / spreadsheetbench"
MATCH  tier=full  bench=swebench            <- "full / swebench"
no match                                    <- "plan legs"
no match                                    <- "aggregate history"
```

## The real root cause: cross-file drift

The tier list lives in `.github/workflows/benchmarks.yml`; the matcher lives in the site; nothing tied them together. The new test **parses `TIERS` out of the workflow** and asserts `JOB_RE` matches every `tier × bench` job name, and that the filter offers every tier — so the next tier can't silently disappear.

Negative-controlled: restoring the old regex fails two of the four tests.

This is the third time in this session that a workflow-adjacent change was the risky part rather than the code — the pattern being that shared config has consumers no single test covered.