### PR TITLE
fix(spreadsheetbench): unusable 912 mount (0700 archive root) + prompt-only optimizer instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,44 @@ All notable changes to cap-evolve are documented here. The format follows
 
 ## [Unreleased]
 ### Fixed
+- **The 912-task dataset's own top-level directory locked the sandbox out of everything.**
+  The upstream `spreadsheetbench_912_v0.1.tar.gz` stores its top-level dir as `drwx------`
+  (the 200-task sample stores `0755`), and `tar` preserves stored modes. The adapter
+  bind-mounts exactly that dir at `/mnt/data` in a container running as uid 1000, so a
+  non-traversable root makes every path under the mount unreachable — **reads too, not just
+  writes**: `open()` on an input workbook and even `Path.exists()` raise `EACCES`, because a
+  missing search bit is not a missing file. Only the `full`/`pilot` tiers were affected;
+  `smoke` uses the 200-task sample. Pilot run 30691123806 spent **$77.49 and ~3h** to
+  discover this, scored 0.000 across 50 tasks with an EACCES traceback in all 50 rollouts,
+  and blamed "the output dir is not writable" — a diagnosis that costs hours, because the
+  output dir was fine and so were `spreadsheet/` and the workbooks (0755/0644). Fixed at
+  three levels: `fetch_data.sh` normalizes modes on extract (`chmod -R a+rX` — traverse and
+  read only; the dataset is read-only INPUT) and re-normalizes the root for trees cached by
+  an older revision; the adapter widens the root it can own and then **verifies the mount
+  before the first LLM call** (`_preflight_mount`), so an unusable mount aborts in seconds at
+  ~$0 instead of burning a full eval; and the denial classifier now recognizes denied
+  *reads* anywhere under the mount and reports the traverse fault distinctly from the
+  output-dir fault, since the two need different fixes.
+- **The optimizer was told to edit `tools.py` on a benchmark that has no tools.** The shared
+  `templates/project/optimizer/INSTRUCTIONS.md` is written for a capability that includes
+  tool CODE: it instructs "prefer code", names `tools.py` and tau2's `get_*_details`, and its
+  self-check demands "edits across BOTH policy.md AND tools.py". SpreadsheetBench's
+  capability is `[system-prompt]` — a single `prompt.md` — so that guidance contradicts the
+  correctly-rendered "what you are editing" block and sends the optimizer hunting for code.
+  In run 30691123806 it found some: `cand_0002` scored 0.567 by patching **`adapter.py`** to
+  chmod the data root while leaving `prompt.md` byte-identical to the seed, so that run's
+  apparent 0.000 → 0.567 gain was infrastructure repair, not capability. A prompt-only
+  instructions template (`INSTRUCTIONS.prompt-only.md`) now ships alongside the default:
+  prompt-appropriate levers (output contract, ordered/unavoidable step, worked method,
+  narrowing predicate, consolidation), an explicit boundary that the adapter/harness/scorer
+  are not editable, and a rule that an ENVIRONMENT fault is to be *diagnosed and handed
+  back*, not worked around. `run_suite.sh` selects it for the spreadsheetbench arm at the
+  path `cli.py` already defaults to, and additionally pins it by ABSOLUTE path — a relative
+  `optimizer_instructions_file` resolves against different cwds in check vs run and can
+  silently fall back to the generic template (#252), which would erase this fix with no
+  error. That spec line is empty (a verified no-op in both the PyYAML and the fallback
+  parser) for every other benchmark, so no `core/` change was needed and tau2's
+  code-bearing guidance is untouched.
 - **A running `pilot` leg was invisible on the benchmarks page.** `site/benchmarks.js`'s
   `JOB_RE` hardcoded `smoke|full`, so it never matched the `pilot / spreadsheetbench` job name:
   no "Running now" entry and no way to open the run's UI while it executed. Nothing errored —

--- a/ci/benchmarks/lib/run_suite.sh
+++ b/ci/benchmarks/lib/run_suite.sh
@@ -122,6 +122,20 @@ ENV
   spreadsheetbench)
     cp "$TPL/spreadsheetbench/adapter.py" "$PROJ/adapters/"
     cp -R "$TPL/spreadsheetbench/seed_capability" "$PROJ/seed_capability"
+    # Prompt-only optimizer instructions. The default template shipped in
+    # templates/project/optimizer/INSTRUCTIONS.md is written for a capability that
+    # includes TOOL CODE: it tells the optimizer to prefer in-body guards, names
+    # `tools.py` and tau2's `get_*_details`, and its self-check demands "edits across BOTH
+    # policy.md AND tools.py". This capability is `[system-prompt]` — one prompt.md, no
+    # tools — so that guidance sends the optimizer hunting for code to change (in run
+    # 30691123806 it went and edited adapter.py). The harness picks up
+    # $PROJ/optimizer/INSTRUCTIONS.md automatically, and OPT_INSTRUCTIONS pins it by
+    # absolute path so it cannot silently fall back to the generic template (#252). No
+    # core change is needed either way.
+    mkdir -p "$PROJ/optimizer"
+    cp "$REPO/templates/project/optimizer/INSTRUCTIONS.prompt-only.md" \
+       "$PROJ/optimizer/INSTRUCTIONS.md"
+    OPT_INSTRUCTIONS="$PROJ/optimizer/INSTRUCTIONS.md"
     SB_CACHE="${CAPEVOLVE_CI_CACHE:-$HOME/.cache/capevolve-ci}/spreadsheetbench-data"
     SB_DEFAULT="$SB_CACHE/sample_data_200"
     # pilot draws its tasks from full's train split, so it needs the 912-task dataset too.
@@ -215,6 +229,12 @@ optimizer_model:    $OPTIMIZER_MODEL
 target_model:       $AGENT_MODEL
 optimizer_max_turns:    ${OPTIMIZER_MAX_TURNS:-80}
 optimizer_usd_per_iter: ${OPTIMIZER_USD_PER_ITER:-0}
+# Set (to an ABSOLUTE path) only by an arm that ships its own optimizer instructions;
+# empty is falsy in core, which then uses its default optimizer/INSTRUCTIONS.md lookup —
+# so this line is a no-op for every other benchmark. Absolute on purpose: a RELATIVE value
+# resolves against different cwds in check vs run and can silently fall back to the generic
+# template (issue #252), which would erase an arm's instructions with no error.
+optimizer_instructions_file: "${OPT_INSTRUCTIONS:-}"
 algorithm_skill:    hill-climb
 algorithm_focus:    $ALGORITHM_FOCUS
 dataset_source:     adapter

--- a/ci/benchmarks/spreadsheetbench/fetch_data.sh
+++ b/ci/benchmarks/spreadsheetbench/fetch_data.sh
@@ -36,6 +36,9 @@ esac
 OUT="$DEST/$INNER"
 
 if [ -f "$OUT/dataset.json" ]; then
+  # A tree cached by an older revision of this script may still carry the archive's
+  # restrictive root mode, and the root is the one that matters (see below). O(1).
+  chmod a+rX "$OUT" 2>/dev/null || true
   echo "$OUT"
   exit 0
 fi
@@ -50,6 +53,15 @@ tar -xzf "$tmp/$INNER.tar.gz" -C "$tmp"
 [ -f "$tmp/$INNER/dataset.json" ] || { echo "::error:: $INNER.tar.gz did not contain dataset.json" >&2; exit 1; }
 rm -rf "$OUT"
 mv "$tmp/$INNER" "$OUT"
+
+# Normalize modes for the sandbox container. `tar` preserves the modes STORED in the
+# archive, and the upstream 912 archive stores its top-level dir as `drwx------` (the
+# 200-task sample stores 0755). The adapter bind-mounts that top-level dir AT /mnt/data
+# inside a container running as uid 1000, so a non-traversable root makes every path under
+# the mount unreachable — reads included — and a whole run scores 0.000 with 50 EACCES
+# tracebacks (run 30691123806: $77 and ~3h). a+rX adds traverse/read only, never write:
+# this tree is read-only INPUT.
+chmod -R a+rX "$OUT"
 echo "::endgroup::" >&2
 
 echo "$OUT"

--- a/core/tests/test_spreadsheetbench_mount_perms.py
+++ b/core/tests/test_spreadsheetbench_mount_perms.py
@@ -1,0 +1,312 @@
+"""The bind mount must be USABLE before a run is allowed to spend money.
+
+SPREADSHEETBENCH_DATA_DIR is bind-mounted at /mnt/data inside a container running as uid
+1000, so if that ONE directory is not traversable by other uids then every path under the
+mount is unreachable — `open()` on an input workbook and even `Path.exists()` raise EACCES
+(a missing search bit, not a missing file). The upstream 912-task archive ships its
+top-level dir as `drwx------` while everything below it is 0755 (the 200-task sample ships
+0755), and `tar` preserves stored modes — so the extracted tree passes every casual
+inspection while locking the sandbox out completely.
+
+That is not hypothetical: pilot run 30691123806 burned $77.49 and ~3h of wall time, scored
+0.000 on 50 tasks with an EACCES traceback in all 50 rollouts, and reported the cause as
+"the output dir is not writable" — which sent the diagnosis after SELinux and output-dir
+modes for hours. Then the optimizer, told to prefer code edits, "fixed" it by patching
+adapter.py, so the run's apparent 0.000 → 0.567 gain was pure infrastructure repair with
+the prompt under optimization left byte-identical.
+
+So: heal what we own, verify before the first LLM call, fail loudly, and describe the
+fault correctly when it happens anyway.
+"""
+
+import importlib.util
+import os
+import stat
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+ADAPTER_DIR = REPO / "templates" / "adapters" / "spreadsheetbench"
+FETCH_SH = REPO / "ci" / "benchmarks" / "spreadsheetbench" / "fetch_data.sh"
+RUN_SUITE = REPO / "ci" / "benchmarks" / "lib" / "run_suite.sh"
+TPL_DIR = REPO / "templates" / "project" / "optimizer"
+
+
+def _load_adapter_module():
+    """Import the adapter template for its pure helpers (see test_spreadsheetbench_recalc_perms)."""
+    for p in (REPO / "core", ADAPTER_DIR, ADAPTER_DIR.parent):
+        if str(p) not in sys.path:
+            sys.path.insert(0, str(p))
+    spec = importlib.util.spec_from_file_location("_sb_adapter_mount", ADAPTER_DIR / "adapter.py")
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _dataset_tree(root: Path, *, root_mode: int) -> Path:
+    """A minimal dataset tree whose top-level dir carries `root_mode`, as tar would leave it."""
+    tree = root / "all_data_912_v0.1"
+    task = tree / "spreadsheet" / "110-2"
+    task.mkdir(parents=True)
+    (task / "1_110-2_input.xlsx").write_bytes(b"PK\x03\x04")
+    (task / "1_110-2_answer.xlsx").write_bytes(b"PK\x03\x04")
+    (tree / "dataset.json").write_text("[]", encoding="utf-8")
+    os.chmod(tree, root_mode)
+    return tree
+
+
+# --- the mount preflight ----------------------------------------------------------------
+
+
+def test_preflight_heals_the_0700_root_the_912_archive_ships():
+    mod = _load_adapter_module()
+    with tempfile.TemporaryDirectory() as td:
+        tree = _dataset_tree(Path(td), root_mode=0o700)
+        mod._preflight_mount(tree)                       # must widen, not raise
+        mode = os.stat(tree).st_mode
+        assert mode & stat.S_IROTH and mode & stat.S_IXOTH, "root must be o+rX for the container"
+        assert mode & stat.S_IRGRP and mode & stat.S_IXGRP, "and g+rX — group class matches first"
+        # a+w is NOT granted: the dataset tree is read-only INPUT.
+        assert not mode & stat.S_IWOTH and not mode & stat.S_IWGRP
+
+
+def test_preflight_creates_a_container_writable_outputs_root():
+    mod = _load_adapter_module()
+    with tempfile.TemporaryDirectory() as td:
+        tree = _dataset_tree(Path(td), root_mode=0o755)
+        mod._preflight_mount(tree)
+        outputs = tree / "outputs"
+        assert outputs.is_dir()
+        assert os.stat(outputs).st_mode & stat.S_IWOTH, "container's uid must be able to write"
+        assert os.stat(outputs).st_mode & stat.S_ISVTX, "sticky: one rollout must not delete another's"
+
+
+def test_preflight_is_idempotent_on_a_healthy_tree():
+    mod = _load_adapter_module()
+    with tempfile.TemporaryDirectory() as td:
+        tree = _dataset_tree(Path(td), root_mode=0o755)
+        mod._preflight_mount(tree)
+        before = os.stat(tree).st_mode, os.stat(tree / "outputs").st_mode
+        mod._preflight_mount(tree)
+        assert (os.stat(tree).st_mode, os.stat(tree / "outputs").st_mode) == before
+
+
+def test_preflight_heals_workbooks_the_extracting_umask_left_unreadable():
+    """`tar` ANDs stored modes with the extracting shell's umask, so the workbooks
+    themselves can land 0640/0600 — fixing only the root would still deny the read."""
+    mod = _load_adapter_module()
+    with tempfile.TemporaryDirectory() as td:
+        tree = _dataset_tree(Path(td), root_mode=0o750)
+        wb = tree / "spreadsheet" / "110-2" / "1_110-2_input.xlsx"
+        os.chmod(wb, 0o600)
+        os.chmod(wb.parent, 0o750)
+        mod._preflight_mount(tree)                       # heals the tree we own
+        mode = os.stat(wb).st_mode
+        # BOTH classes: the container's gid usually matches the tree's group, and POSIX
+        # stops at the first matching class — `-rw----r--` is still EACCES for it.
+        assert mode & stat.S_IROTH and mode & stat.S_IRGRP, "workbook must be container-readable"
+        dmode = os.stat(wb.parent).st_mode
+        assert dmode & stat.S_IXOTH and dmode & stat.S_IXGRP, "and its dir traversable"
+        assert not mode & stat.S_IWOTH, "read-only input stays read-only"
+
+
+def test_preflight_aborts_when_the_inputs_cannot_be_widened():
+    """A tree we do NOT own must stop the run, not produce 50 rollouts of EACCES."""
+    mod = _load_adapter_module()
+    with tempfile.TemporaryDirectory() as td:
+        tree = _dataset_tree(Path(td), root_mode=0o755)
+        wb = tree / "spreadsheet" / "110-2" / "1_110-2_input.xlsx"
+        os.chmod(wb, 0o600)
+        real_chmod = os.chmod
+
+        def _refuse(path, mode, *a, **k):
+            if Path(path) == wb:
+                raise PermissionError(13, "Operation not permitted")
+            return real_chmod(path, mode, *a, **k)
+
+        os.chmod = _refuse
+        try:
+            with pytest.raises(RuntimeError) as e:
+                mod._preflight_mount(tree)
+        finally:
+            os.chmod = real_chmod
+        msg = str(e.value)
+        assert "not readable by the container's uid" in msg
+        assert "chmod -R a+rX" in msg, "the message must state the fix"
+
+
+def test_preflight_error_names_the_mode_and_the_fix(monkeypatch):
+    """The 0700-root message is the one a future reader will act on — keep it specific."""
+    mod = _load_adapter_module()
+    with tempfile.TemporaryDirectory() as td:
+        tree = _dataset_tree(Path(td), root_mode=0o700)
+
+        # Simulate a root we do NOT own (a shared cache): the chmod cannot land, so
+        # preflight has nothing to heal and must refuse to start the run.
+        real_chmod = os.chmod
+
+        def _refuse(path, mode, *a, **k):
+            if Path(path) == tree:
+                raise PermissionError(13, "Operation not permitted")
+            return real_chmod(path, mode, *a, **k)
+
+        monkeypatch.setattr(os, "chmod", _refuse)
+        with pytest.raises(RuntimeError) as e:
+            mod._preflight_mount(tree)
+        msg = str(e.value)
+        assert "0o700" in msg, "state the mode we actually found"
+        assert "cannot traverse" in msg
+        assert "read AND write" in msg, "reads fail too — that is the whole misdiagnosis"
+        assert "912" in msg, "point at the known-bad archive"
+
+
+def test_preflight_runs_before_the_sandbox_is_started():
+    """Ordering is the saving: run_target calls _get_sandbox() before its first LLM call,
+    so a bad mount costs ~$0 per rollout instead of a full 30-turn eval."""
+    src = (ADAPTER_DIR / "adapter.py").read_text(encoding="utf-8")
+    body = src.split("def _get_sandbox()", 1)[1].split("\ndef ", 1)[0]
+    assert "_preflight_mount(_data_dir())" in body
+    assert body.index("_preflight_mount") < body.index("_Sandbox()")
+
+
+# --- classifying the denial --------------------------------------------------------------
+
+
+_OUT = "/mnt/data/outputs/110-2_0_fb4ec95f"
+
+
+def _traceback(path: str) -> str:
+    return (
+        "PermissionError                        Traceback (most recent call last)\n"
+        "Cell In[1], line 3\n"
+        "----> 3 wb = openpyxl.load_workbook(path)\n"
+        f"PermissionError: [Errno 13] Permission denied: '{path}'"
+    )
+
+
+def test_denied_input_read_is_infrastructure_not_a_zero_reward_miss():
+    """The 912 fault denies READS. Classified as a capability miss, it would teach the
+    optimizer that 50 tasks are simply unsolvable."""
+    mod = _load_adapter_module()
+    hit = mod._sandbox_access_denied([_traceback("/mnt/data/spreadsheet/110-2/1_110-2_input.xlsx")], _OUT)
+    assert hit is not None and "1_110-2_input.xlsx" in hit
+
+
+def test_denied_output_write_still_classifies():
+    mod = _load_adapter_module()
+    assert mod._sandbox_access_denied([_traceback(f"{_OUT}/1_110-2_output.xlsx")], _OUT) is not None
+
+
+def test_another_rollouts_output_dir_is_not_our_fault():
+    """50 rollouts share the outputs root; a denial in someone else's dir is not ours."""
+    mod = _load_adapter_module()
+    assert mod._sandbox_access_denied([_traceback("/mnt/data/outputs/other_tag/1_x_output.xlsx")], _OUT) is None
+
+
+def test_ordinary_code_errors_are_left_to_the_optimizer():
+    mod = _load_adapter_module()
+    assert mod._sandbox_access_denied(["NameError: name 'wb' is not defined"], _OUT) is None
+    assert mod._sandbox_access_denied([], _OUT) is None
+
+
+def test_read_and_write_denials_get_different_diagnoses():
+    """Same classifier, two causes, two fixes — the run must say which one it hit."""
+    src = (ADAPTER_DIR / "adapter.py").read_text(encoding="utf-8")
+    assert "sandbox denied writes to the bind-mounted output dir" in src
+    assert "sandbox denied access through the bind mount" in src
+    assert "traverse/read SPREADSHEETBENCH_DATA_DIR" in src
+
+
+# --- fetch-time normalization -------------------------------------------------------------
+
+
+def test_fetch_data_normalizes_modes_after_extract():
+    sh = FETCH_SH.read_text(encoding="utf-8")
+    assert "chmod -R a+rX" in sh, "tar preserves the archive's 0700 root — normalize it"
+    assert "chmod -R a+rw" not in sh and "chmod -R 777" not in sh, "input data stays read-only"
+    # The cached-tree early exit must normalize too, or a tree fetched by an older
+    # revision of this script keeps its bad root forever.
+    cached_branch = sh.split('if [ -f "$OUT/dataset.json" ]; then', 1)[1].split("fi", 1)[0]
+    assert "chmod a+rX" in cached_branch
+
+
+def test_fetch_data_is_valid_bash():
+    assert subprocess.run(["bash", "-n", str(FETCH_SH)]).returncode == 0
+
+
+# --- Fix 2: prompt-only optimizer instructions --------------------------------------------
+
+
+def test_prompt_only_template_has_no_tools_guidance():
+    """spreadsheetbench's capability is `[system-prompt]` — one prompt.md, no tools. The
+    default template names tau2's artifacts, so the optimizer goes looking for code."""
+    txt = (TPL_DIR / "INSTRUCTIONS.prompt-only.md").read_text(encoding="utf-8")
+    for leak in ("tools.py", "get_*_details", "policy.md", "docstring"):
+        assert leak not in txt, f"prompt-only instructions must not mention {leak}"
+
+
+def test_prompt_only_template_keeps_the_placeholders_the_harness_substitutes():
+    """A template without {{FOCUS_SUMMARY}} is silently discarded for a minimal built-in
+    prompt (harness._focus_instructions), which would drop this fix without a trace."""
+    txt = (TPL_DIR / "INSTRUCTIONS.prompt-only.md").read_text(encoding="utf-8")
+    for ph in ("{{FOCUS_SUMMARY}}", "{{FAILURES}}", "{{PASSING}}", "{{CAP_BRIEF}}",
+               "{{ALGO_BRIEF}}", "{{BENCH_REPO}}", "{{PARALLEL_NOTE}}", "{{EMPTY_SEED}}",
+               "{{TARGET_READER}}"):
+        assert ph in txt, f"missing {ph}"
+
+
+def test_prompt_only_template_forbids_editing_the_harness():
+    """cand_0002 of run 30691123806 scored 0.567 by patching adapter.py while leaving
+    prompt.md byte-identical. Nothing in the instructions told it not to."""
+    txt = (TPL_DIR / "INSTRUCTIONS.prompt-only.md").read_text(encoding="utf-8")
+    assert "may NOT edit the adapter" in txt
+    assert "ENVIRONMENT fault" in txt, "and it must say what to do INSTEAD: hand the fault back"
+
+
+def test_default_template_is_untouched_for_code_bearing_capabilities():
+    """tau2 ([system-prompt, tools]) must keep the prefer-code guidance — this PR is
+    additive, not a rewrite of the shared default."""
+    txt = (TPL_DIR / "INSTRUCTIONS.md").read_text(encoding="utf-8")
+    assert "tools.py" in txt
+
+
+def test_run_suite_uses_the_prompt_only_template_for_spreadsheetbench_only():
+    sh = RUN_SUITE.read_text(encoding="utf-8")
+    arm = sh.split("  spreadsheetbench)", 1)[1].split("\n  *)", 1)[0]
+    assert "INSTRUCTIONS.prompt-only.md" in arm
+    assert '"$PROJ/optimizer/INSTRUCTIONS.md"' in arm, "must land at the path cli.py defaults to"
+    assert sh.count("INSTRUCTIONS.prompt-only.md") == 1, "other benchmarks keep the default"
+
+
+def test_run_suite_pins_the_instructions_file_absolutely():
+    """A RELATIVE optimizer_instructions_file resolves against different cwds in check vs
+    run and can silently fall back to the generic template (#252) — which would erase this
+    fix with no error. Pin it, and keep the spec line a no-op for every other arm."""
+    sh = RUN_SUITE.read_text(encoding="utf-8")
+    assert 'optimizer_instructions_file: "${OPT_INSTRUCTIONS:-}"' in sh
+    arm = sh.split("  spreadsheetbench)", 1)[1].split("\n  *)", 1)[0]
+    assert 'OPT_INSTRUCTIONS="$PROJ/optimizer/INSTRUCTIONS.md"' in arm
+    assert sh.count("OPT_INSTRUCTIONS=") == 1, "only the spreadsheetbench arm sets it"
+    # $PROJ is absolute (built from $REPO), so the pinned value is absolute.
+    assert 'PROJ="$WORK/.capevolve/project"' in sh and 'WORK="$REPO/ci/benchmarks/' in sh
+
+
+def test_an_empty_instructions_spec_value_is_falsy_in_both_yaml_parsers():
+    """core reads `spec.get(...) or <default>`, so the no-op depends on "" being falsy —
+    in PyYAML AND in the hand-rolled fallback parser used when PyYAML is absent."""
+    sys.path.insert(0, str(REPO / "core"))
+    from cap_evolve import specfile
+
+    sample = 'capabilities: [system-prompt]\noptimizer_instructions_file: ""\nalgorithm_skill: x\n'
+    parsed = specfile.read_yaml(sample)
+    assert not parsed.get("optimizer_instructions_file")
+    assert parsed.get("algorithm_skill") == "x", "the empty value must not swallow later keys"
+
+
+def test_run_suite_is_valid_bash():
+    assert subprocess.run(["bash", "-n", str(RUN_SUITE)]).returncode == 0

--- a/templates/adapters/spreadsheetbench/adapter.py
+++ b/templates/adapters/spreadsheetbench/adapter.py
@@ -74,6 +74,15 @@ NOTE ON SCORING:
   _make_container_writable); if a write is still denied, the rollout is reported as an
   infrastructure error rather than as a zero-reward miss, so the optimizer is not sent
   chasing a mount problem it cannot fix from the prompt.
+
+  The SAME uid mismatch also applies to the dataset root itself, which is what gets
+  bind-mounted AT /mnt/data — and there it is worse, because a root the container cannot
+  TRAVERSE makes every path under the mount unreachable, reads included. The upstream
+  912-task archive ships its top-level dir as 0700 (the 200-task sample ships 0755), and
+  `tar` preserves stored modes, so extracting it yields a mount no container can enter.
+  _preflight_mount widens the root and then VERIFIES the mount before any LLM call, so
+  this fails in seconds with a precise message instead of burning a full eval (it cost
+  $77 and ~3h of wall time once — run 30691123806).
 """
 
 from __future__ import annotations
@@ -107,6 +116,10 @@ PREVIEW_ROWS = int(os.environ.get("SPREADSHEETBENCH_ROWS", "5"))
 CONCURRENCY = int(os.environ.get("SPREADSHEETBENCH_CONCURRENCY", "4"))
 EXEC_TIMEOUT = int(os.environ.get("SPREADSHEETBENCH_EXEC_TIMEOUT", "180"))
 LIBREOFFICE_BIN = os.environ.get("SPREADSHEETBENCH_LIBREOFFICE_BIN", "")
+
+# Where the vendored sandbox bind-mounts SPREADSHEETBENCH_DATA_DIR inside every container
+# (code_exec_docker/jupyter.py hardcodes this bind target).
+_CONTAINER_DATA_ROOT = "/mnt/data"
 LIBRE_TIMEOUT = int(os.environ.get("SPREADSHEETBENCH_LIBREOFFICE_TIMEOUT", "120"))
 
 _TASK_TEMPLATE = """You need to solve the following spreadsheet manipulation question. It contains six pieces of information:
@@ -332,6 +345,11 @@ def _get_sandbox() -> _Sandbox:
     global _sandbox
     with _sandbox_lock:
         if _sandbox is None:
+            # Check the mount BEFORE the first container exists. run_target calls us
+            # before its first LLM call, so an unusable mount costs ~$0 per rollout and
+            # every rollout carries the same precise reason — which the report renders as
+            # an infra error and assert_run.py's >50% gate turns into a failed job.
+            _preflight_mount(_data_dir())
             _sandbox = _Sandbox()
             import atexit
 
@@ -366,6 +384,123 @@ def _make_container_writable(p: Path, *, sticky: bool = False) -> None:
         os.chmod(p, 0o1777 if sticky else 0o777)
     except OSError:
         pass
+
+
+# a+rX, minus the owner bits already present: enough for the container to enter a dir and
+# read what is inside, and deliberately NOT a+w — the dataset tree is INPUT, nothing in the
+# sandbox may rewrite it.
+#
+# BOTH the group and other classes must be granted, not just other. POSIX checks the
+# classes in order and the FIRST match decides: the executor image runs as uid 1000 gid
+# 100(users) and the dataset is typically owned by <runner>:users, so the container matches
+# the GROUP class and never falls through to other. A file at 0o604 (`-rw----r--`) is
+# therefore still EACCES for it — verified against the real image, which is why this is
+# 0o055/0o044 rather than 0o005/0o004.
+_TRAVERSE_BITS = 0o055   # dirs: g+rx, o+rx
+_READ_BITS = 0o044       # files: g+r, o+r
+
+
+def _make_container_readable(p: Path) -> int:
+    """OR o+rX onto `p` so the container's uid can traverse/read it. Returns the mode.
+
+    Unlike _make_container_writable this widens as LITTLE as possible, because it is
+    applied to the dataset tree rather than to a scratch dir we own. Best-effort: a
+    foreign-owned dir cannot be chmod'ed, and _preflight_mount then reports the real
+    mode instead of this failing silently.
+    """
+    try:
+        mode = os.stat(p).st_mode & 0o7777
+    except OSError:
+        return 0
+    if mode & _TRAVERSE_BITS != _TRAVERSE_BITS:
+        try:
+            os.chmod(p, mode | _TRAVERSE_BITS)
+            mode = os.stat(p).st_mode & 0o7777
+        except OSError:
+            pass
+    return mode
+
+
+def _widen_tree_for_container(root: Path) -> None:
+    """OR o+rX across the dataset tree, the `chmod -R a+rX` fetch_data.sh applies on extract.
+
+    Needed for a tree extracted by an older revision of the fetcher, or fetched by hand: the
+    modes `tar` writes come from the archive AND the extracting shell's umask, so the input
+    workbooks themselves can land 0640. Best-effort per entry (a foreign-owned file simply
+    stays as it is and the caller then reports it), and O(files) with no stat churn beyond
+    the walk — a few thousand entries, well under a second, once per process.
+    """
+    for dirpath, dirnames, filenames in os.walk(root):
+        for name in (*dirnames, *filenames):
+            p = Path(dirpath) / name
+            try:
+                mode = os.stat(p).st_mode & 0o7777
+                want = mode | (_TRAVERSE_BITS if p.is_dir() else _READ_BITS)
+                if want != mode:
+                    os.chmod(p, want)
+            except OSError:
+                continue
+
+
+def _preflight_mount(data_dir: Path) -> None:
+    """Verify the container can actually USE the bind mount, before any LLM call.
+
+    The dataset root is bind-mounted at /mnt/data, so if the container's uid cannot
+    traverse it then EVERY path under the mount is unreachable — `open()` on an input
+    workbook and even `Path.exists()` raise EACCES (a missing search bit, not a missing
+    file). The upstream 912-task archive ships its top-level dir as 0700, and `tar`
+    preserves that, so the extracted tree looks perfect on inspection (`spreadsheet/` and
+    the workbooks are 0755/0644) while the ONE dir at the top locks everyone out.
+
+    We widen what we can and then check, rather than assuming the chmod worked: the data
+    dir may be owned by another uid (a shared cache), in which case the run must stop
+    here. Raising is the whole point — a silent mount fault reads as a capability score
+    of 0.000, and the optimizer then "fixes" it by editing infrastructure. Run
+    30691123806 spent $77.49 and ~3h before this became visible.
+
+    Host-side and O(1): no container is started, so it is safe to call per process.
+    """
+    mode = _make_container_readable(data_dir)
+    if mode & _TRAVERSE_BITS != _TRAVERSE_BITS:
+        raise RuntimeError(
+            f"spreadsheetbench mount is unusable: SPREADSHEETBENCH_DATA_DIR={data_dir} is "
+            f"mode 0o{mode & 0o777:03o}, so the sandbox container's uid cannot traverse it "
+            f"— every read AND write under /mnt/data would fail with EACCES. The upstream "
+            f"912-task archive ships this dir as 0700; fix with "
+            f"`chmod -R a+rX {data_dir}` (fetch_data.sh does this on extract)."
+        )
+
+    # The inputs themselves must be readable through the mount, not just the root. Which
+    # modes `tar` leaves depends on the extracting shell's umask (the runner's 077 yields a
+    # 0700 root, an interactive 027 yields 0750 dirs and 0640 workbooks), so check a real
+    # file rather than trusting the root's mode alone.
+    probe = next((data_dir / "spreadsheet").glob("*/*_input.xls*"), None)
+
+    def _readable(p: Path) -> bool:
+        # Both classes, for the group-precedence reason documented at _READ_BITS.
+        return os.stat(p).st_mode & _READ_BITS == _READ_BITS
+
+    if probe is not None and not _readable(probe):
+        _widen_tree_for_container(data_dir)  # we own it → heal it, same as fetch_data.sh
+    if probe is not None and not _readable(probe):
+        raise RuntimeError(
+            f"spreadsheetbench mount is unusable: input workbook {probe} is mode "
+            f"0o{os.stat(probe).st_mode & 0o777:03o} — not readable by the container's uid, "
+            f"and we do not own it so it cannot be widened here. "
+            f"Fix with `chmod -R a+rX {data_dir}`."
+        )
+
+    # And the outputs root must be writable by the container, or nothing can be scored.
+    outputs_root = data_dir / "outputs"
+    outputs_root.mkdir(parents=True, exist_ok=True)
+    _make_container_writable(outputs_root, sticky=True)
+    if os.stat(outputs_root).st_mode & 0o022 != 0o022:  # both classes, as above
+        raise RuntimeError(
+            f"spreadsheetbench mount is unusable: {outputs_root} is mode "
+            f"0o{os.stat(outputs_root).st_mode & 0o777:03o} — the container's uid cannot "
+            f"create its output file there. It must be world-writable (see "
+            f"_make_container_writable); a foreign-owned outputs dir cannot be widened by us."
+        )
 
 
 def _reclaim_container_file(p: Path) -> bool:
@@ -500,20 +635,33 @@ def _cleanup_output_dir(rollout) -> None:
         pass  # _data_dir() unset — nothing was created, nothing to clean
 
 
-def _output_write_blocked(exec_results: list[str], container_out_dir: str) -> str | None:
-    """Return the offending line if the sandbox was denied writes to the output dir.
+def _sandbox_access_denied(exec_results: list[str], container_out_dir: str) -> str | None:
+    """Return the offending line if the sandbox was denied access through the bind mount.
 
-    A PermissionError/OSError on output_path is an INFRASTRUCTURE fault (the bind mount
-    is not writable by the container's uid — see _make_container_writable), not a defect
-    in the prompt under optimization. Reporting it as a plain zero-reward miss sends the
-    optimizer chasing an unfixable wall; surfacing it as a rollout error routes it
+    A PermissionError/OSError on a path under the mount is an INFRASTRUCTURE fault, not a
+    defect in the prompt under optimization. Reporting it as a plain zero-reward miss sends
+    the optimizer chasing an unfixable wall; surfacing it as a rollout error routes it
     through score()'s "do not optimize against it" path instead.
+
+    Two distinct faults land here, and telling them apart is what makes the report
+    actionable — the earlier write-only version of this function reported BOTH as "the
+    output dir is not writable", which cost hours of hunting the wrong thing:
+      - a denial under `container_out_dir` → the OUTPUT dir is not writable (the classic
+        uid mismatch on a dir we created; see _make_container_writable).
+      - a denial anywhere else under _CONTAINER_DATA_ROOT — typically on an INPUT workbook
+        — → the mount ROOT is not traversable, so nothing under it is reachable at all
+        (see _preflight_mount). Another rollout's output dir is NOT ours: ignore it.
     """
+    other_out_dirs = f"{_CONTAINER_DATA_ROOT}/outputs/"
     for res in reversed(exec_results):
         if "PermissionError" not in res and "OSError" not in res:
             continue
         for line in res.splitlines():
-            if ("PermissionError" in line or "OSError" in line) and container_out_dir in line:
+            if "PermissionError" not in line and "OSError" not in line:
+                continue
+            if container_out_dir in line:
+                return line.strip()
+            if _CONTAINER_DATA_ROOT in line and other_out_dirs not in line:
                 return line.strip()
     return None
 
@@ -652,8 +800,8 @@ class Adapter(CapabilityAdapter):
             conv_id = _sanitize_conv_id(f"capevolve-{run_tag}")
 
             local_dir = data_dir / "spreadsheet" / sid
-            container_dir = f"/mnt/data/spreadsheet/{sid}"
-            container_out_dir = f"/mnt/data/outputs/{run_tag}"
+            container_dir = f"{_CONTAINER_DATA_ROOT}/spreadsheet/{sid}"
+            container_out_dir = f"{_CONTAINER_DATA_ROOT}/outputs/{run_tag}"
             outputs_root = data_dir / "outputs"
             host_out_dir = outputs_root / run_tag
             # Both levels must be writable by the container's uid, not just the leaf:
@@ -746,19 +894,33 @@ class Adapter(CapabilityAdapter):
                     break
 
             if not case1_path.exists():
-                blocked = _output_write_blocked(exec_results, container_out_dir)
+                blocked = _sandbox_access_denied(exec_results, container_out_dir)
                 if blocked:
+                    # Name the fault precisely: a denial on the OUTPUT dir is the uid
+                    # mismatch on a dir we created, while a denial anywhere else under the
+                    # mount means the container cannot traverse the dataset root at all —
+                    # a different fix, and _preflight_mount should have caught it.
+                    if container_out_dir in blocked:
+                        why = (
+                            f"sandbox denied writes to the bind-mounted output dir "
+                            f"{container_out_dir} ({blocked}) — the host dir is not "
+                            f"writable by the container's uid; see _make_container_writable"
+                        )
+                    else:
+                        why = (
+                            f"sandbox denied access through the bind mount "
+                            f"{_CONTAINER_DATA_ROOT} ({blocked}) — the container's uid cannot "
+                            f"traverse/read SPREADSHEETBENCH_DATA_DIR, so no path under the "
+                            f"mount is reachable; run `chmod -R a+rX` on it (see "
+                            f"_preflight_mount)"
+                        )
                     return Rollout(
                         task_id=task.id,
                         output=last_code,
                         trace=messages,
                         cost_usd=cost,
                         tokens=tokens,
-                        error=(
-                            f"sandbox denied writes to the bind-mounted output dir "
-                            f"{container_out_dir} ({blocked}) — the host dir is not "
-                            f"writable by the container's uid; see _make_container_writable"
-                        ),
+                        error=why,
                         metadata={"run_tag": run_tag, "id": sid, "model": model_config.MODEL, "seed": seed},
                     )
             else:
@@ -961,12 +1123,46 @@ if __name__ == "__main__":
         "---> 76 wb.save(output_path)\n"
         f"PermissionError: [Errno 13] Permission denied: '{_out}/1_160-6_output.xlsx'"
     )
-    assert _output_write_blocked([_perm], _out) is not None
-    assert _output_write_blocked(["ok", _perm], _out) is not None
-    assert _output_write_blocked([_perm], "/mnt/data/outputs/other_tag") is None  # different rollout's dir
-    assert _output_write_blocked(["NameError: name 'wb' is not defined"], _out) is None
-    assert _output_write_blocked([], _out) is None
-    print("spreadsheetbench output-write-blocked self-check: OK")
+    assert _sandbox_access_denied([_perm], _out) is not None
+    assert _sandbox_access_denied(["ok", _perm], _out) is not None
+    assert _sandbox_access_denied([_perm], "/mnt/data/outputs/other_tag") is None  # different rollout's dir
+    assert _sandbox_access_denied(["NameError: name 'wb' is not defined"], _out) is None
+    assert _sandbox_access_denied([], _out) is None
+
+    # A non-traversable mount ROOT denies the INPUT read — the 912-archive fault. It must
+    # classify as infra too, or 50 rollouts get reported as plain zero-reward misses.
+    _read_denied = (
+        "PermissionError                        Traceback (most recent call last)\n"
+        "Cell In[1], line 3\n"
+        "----> 3 wb = openpyxl.load_workbook(path)\n"
+        "PermissionError: [Errno 13] Permission denied: "
+        "'/mnt/data/spreadsheet/110-2/1_110-2_input.xlsx'"
+    )
+    _hit = _sandbox_access_denied([_read_denied], _out)
+    assert _hit is not None and "1_110-2_input.xlsx" in _hit
+    print("spreadsheetbench sandbox-access-denied self-check: OK")
+
+    # The mount preflight: heal a 0700 dataset root, and refuse to run when we cannot.
+    with _tempfile.TemporaryDirectory() as _td:
+        _root = Path(_td) / "all_data_912_v0.1"
+        (_root / "spreadsheet" / "110-2").mkdir(parents=True)
+        (_root / "spreadsheet" / "110-2" / "1_110-2_input.xlsx").write_bytes(b"PK\x03\x04")
+        os.chmod(_root, 0o700)                      # exactly what the 912 tarball ships
+        _preflight_mount(_root)                     # must widen, not raise
+        assert (_root.stat().st_mode & 0o055) == 0o055
+        assert (_root / "outputs").is_dir() and (_root / "outputs").stat().st_mode & 0o002
+        _preflight_mount(_root)                     # idempotent on a healthy tree
+
+        # tar ANDs stored modes with the extracting umask, so the workbooks can land 0640
+        # too — a root-only fix would still deny the read. We own this tree, so heal it.
+        _wb = _root / "spreadsheet" / "110-2" / "1_110-2_input.xlsx"
+        os.chmod(_wb, 0o600)
+        _preflight_mount(_root)
+        # BOTH classes — the container's gid matches the tree's group and POSIX stops at
+        # the first matching class, so 0o604 (`-rw----r--`) is still EACCES for it.
+        assert _wb.stat().st_mode & 0o044 == 0o044, "workbook must be container-readable"
+        assert not _wb.stat().st_mode & 0o022, "read-only input stays read-only"
+    print("spreadsheetbench mount-preflight self-check: OK")
 
     with _tempfile.TemporaryDirectory() as _td:
         _p = Path(_td) / "outputs"

--- a/templates/project/optimizer/INSTRUCTIONS.prompt-only.md
+++ b/templates/project/optimizer/INSTRUCTIONS.prompt-only.md
@@ -1,0 +1,230 @@
+# Optimize the capability — ship several REAL, SAFE, VERIFIED prompt fixes this iteration
+
+{{TARGET_READER}}
+
+{{FOCUS_SUMMARY}}
+
+{{EMPTY_SEED}}
+
+GOAL: raise the eval score as much as you can THIS iteration, then STOP (the harness
+re-scores you — don't run evaluation yourself). The capability under optimization is
+PROSE: the agent's prompt / skill text. There are no tool implementations to edit here.
+
+Make **AS MANY real fixes as you can this iteration — solve many issues across many
+trajectories, not just the biggest one.** A timid one- or two-edit iteration is an
+under-used iteration: diagnose EVERY failure cluster in `./trajectories/` and ship a fix
+for each one that passes the three tests below. Breadth is the goal — the more distinct
+failing clusters you fix in this ONE candidate, the larger the gain.
+
+The ONLY brake on breadth is regression: every edit must pass all three tests, because a
+single speculative edit that breaks a passing task can sink an iteration of good work (it
+did in prior runs). So the discipline is "many fixes, each one real and safe" — NOT "few
+fixes". Do not stop at the first cluster; work through them all.
+
+## WHAT YOU MAY EDIT — and the two ways iterations get wasted here
+Edit ONLY the capability files listed in `{{CAP_BRIEF}}` below (the prompt / skill text in
+this working directory). Everything else you can see is READ-ONLY CONTEXT.
+
+**You may NOT edit the adapter, the harness, the scorer, the benchmark, or the
+environment** — not to make a task pass, not to fix a broken mount or a missing binary,
+not "just to unblock the run". Those files are how your score is MEASURED; changing them
+does not improve the capability, and a gain obtained that way is not a result. An
+iteration that edits infrastructure has produced NOTHING measurable, however green the
+number looks. **If the traces show an ENVIRONMENT fault** (permission denied, missing
+binary, gateway/network error, timeout, container failure — the same error on nearly every
+task, unrelated to the task's content), then the correct and complete action is:
+1. do NOT edit the prompt to work around it (a prose workaround for a broken environment
+   is a speculative edit that fails the REAL test — the prompt is not the defect), and
+2. state the diagnosis in `PROCESS.md` and `JOURNAL.md` precisely — the exact error, how
+   many tasks it hit, and what a human must fix — then STOP. Handing back an accurate
+   "the environment is broken, here is the evidence" is a SUCCESSFUL iteration.
+
+**The other way iterations get wasted: another prose rule for a behavior the agent already
+knows.** When the agent has the rule and skips it anyway, adding a second sentence saying
+the same thing changes nothing — you must change the STRUCTURE that makes it skippable
+(see the levers below): make the step unavoidable and ordered, make the contract explicit,
+or give a worked example it can pattern-match. Prose is for genuine KNOWLEDGE gaps (a
+fact / format / criterion the agent cannot derive) and for STRUCTURE that changes what the
+agent does — not for repetition or emphasis.
+
+## The THREE TESTS every change must pass (this is the whole game)
+Before you keep any edit, confirm all three. Drop any edit that fails even one.
+1. **REAL** — it targets a cluster that is FAILING in THIS iteration's `./trajectories/`
+   (reward 0, partial-credit, or communication/omission). Never edit for a hypothetical
+   problem, and never edit on account of a task whose failure is an environment fault.
+2. **SAFE (bounded blast radius)** — the real regression question is *behavioral*:
+   **would this edit change what the agent DOES on ANY currently-passing task?** Two
+   blast-radius classes:
+   - **BOUNDED** — an ADDITIVE rule that applies only under a stated condition present in
+     the failing cases, or a clarification of an output contract the passing tasks already
+     satisfy. This is the SAFE default — prefer it.
+   - **UNBOUNDED** — any edit to a GLOBAL decision/permission/refusal rule, or a rewrite /
+     reordering / deletion that changes the instruction the agent follows on every task. It
+     changes behavior across the ENTIRE class, including tasks where the original behavior
+     was the gold answer. Allowed ONLY if the new behavior is correct for EVERY task in
+     that class AND you have read the currently-passing tasks in the class and confirmed
+     none relied on the old wording.
+   Name the passing tasks in each edit's blast-radius class and state which class it is.
+   A regression wastes the whole candidate (the gate rejects a net-zero), not one task.
+3. **VERIFIED** — you have shown it actually fixes its target (see VERIFY-THE-FIX). An
+   edit you cannot verify is a guess — drop it.
+
+Quality AND breadth: ship every fix that passes the three tests — the more clusters you
+cover safely, the bigger the gain. The only edits to leave out are the speculative ones
+(an edit that fails a test), not real fixes you ran out of patience for. Don't re-add
+anything `LEDGER.md` / `JOURNAL.md` show was already tried and rejected.
+
+## Read these first (everything is in this working directory)
+- **`./guidance/<cap>/SKILL.md` for EACH selected capability — READ IT IN FULL before you
+  edit; it is the MENU of improvement TYPES available to you.** For a prompt capability it
+  lists the concrete kinds of change you can make (role/contract, decision-rule narrowing,
+  missing-rule, worked example, ordered procedure, consolidation of conflicting text). Do
+  not invent change types from memory — take them from the skill, and deliberately apply
+  MULTIPLE DIFFERENT types this iteration, matching each cluster to the strongest type the
+  skill describes for it.
+- `./guidance/diagnose/SKILL.md` — the failure-clustering method. Use it.
+- `./trajectories/` — the FULL traces of the current best candidate (the step you build
+  on). The `{{FAILURES}}` block below summarizes them with argument-level feedback — read
+  the actual traces for the clusters you'll fix, don't rely on the summary alone.
+- `./LEDGER.md` — FACTS (read-only): every prior iteration's outcome + the exact tasks it
+  broke/fixed. Your SAFE test starts here — never re-introduce a change that broke a task.
+- `./JOURNAL.md` — the accumulating handover. Each entry is the optimizer's INTENT, and
+  directly below it the framework stamps a **RESULT** line (objective: ACCEPTED/REJECTED ·
+  Δ · the exact tasks fixed/broke). The RESULT lines — not the intent — are the truth of
+  what worked: read them all before proposing. If the most recent RESULT is **REJECTED**,
+  its batch was reverted; read that entry's `./prior_iterations/<id>/diff.patch`, keep the
+  edits that did NOT appear in its `broke={...}`, and DROP or REDESIGN the ones that did —
+  do NOT resubmit the whole rejected batch, and do NOT abandon the cluster. APPEND your new
+  entry (intent only) below the marker; never edit earlier entries or re-try a refuted idea.
+- `./RUNMAP.md` + `./prior_iterations/<id>/` — EVERY prior iteration's (accepted AND
+  rejected) PROCESS.md + diff.patch. Read the one(s) that touched a cluster you're about to
+  work on, so you build on what worked and avoid repeating what regressed.
+- `./PROCESS.md` — your REQUIRED explainability file for THIS iteration (template inside).
+- `./guidance/optimizer/<name>.md` — your agent's subagent/parallelism features (optional).
+{{BENCH_REPO}}
+
+## Process (do this, then STOP)
+**Parallelism:** {{PARALLEL_NOTE}}
+1. Read your capability SKILL(s) + the diagnose method + the cross-iteration files
+   (LEDGER facts, JOURNAL handover, RUNMAP for clusters you'll touch).
+2. Diagnose THIS iteration's `./trajectories/` ONLY (not stale signatures). Cluster ALL
+   failures by shared root cause — total, partial-credit, AND communication/omission.
+   **First separate ENVIRONMENT faults from capability failures** (see above): a cluster
+   whose every trace dies on the same infrastructure error is not yours to fix.
+   RANK the remaining clusters by LEVERAGE = (# failing tasks × trials × score
+   recoverable), biggest first — but plan to fix ALL of them this iteration.
+3. For EACH cluster, pick the strongest improvement TYPE from the capability SKILL(s)
+   (cross-check the FAILURE TYPE section next) and draft the edit. Across the iteration
+   use MULTIPLE different types from the skills, not the same one repeatedly. Run each
+   edit through the THREE TESTS; keep it only if it passes all three.
+4. Ship every passing edit together in this ONE candidate — cover as many clusters as you
+   can SAFELY (that is the win), and never include an edit that fails a test.
+5. Fill `PROCESS.md` and APPEND your entry to `JOURNAL.md`. STOP.
+
+## Choose the lever by FAILURE TYPE
+Pick the strongest lever your capability's edit space offers (see `./guidance/<cap>/`).
+Every lever below is a PROSE edit — the point is that they are not all the same edit.
+
+- **OUTPUT-CONTRACT / FORMAT MISS** — the work is right but the graded artifact is wrong
+  (written to the wrong place, wrong shape, wrong precision, formula instead of value,
+  extra cells/keys touched). **Default strong lever: state the contract exactly, once, in
+  imperative form, at the point of use** — the precise path/shape/type, what must NOT be
+  touched, and the one-line check the agent can run before finishing. This is the
+  highest-yield, lowest-regression prompt edit; reach for it first.
+- **SKIPPED / OUT-OF-ORDER STEP (behavioral)** — the agent knows the rule and skips it, or
+  acts before verifying. Do NOT restate the rule. **Make it structurally unavoidable:** an
+  ORDERED, numbered procedure with the step as a precondition of the next one, or a
+  short pre-finish checklist the agent must satisfy — phrased as work to perform, not as
+  advice to remember.
+- **CAPABILITY GAP / ACTION STALL** — the agent has no reliable way to do the thing, or it
+  narrates a multi-step action then never executes it. Prose CANNOT invent a missing
+  capability: what it can do is supply the concrete METHOD — a worked, copyable procedure
+  (the exact sequence, API/idiom, and end-to-end example) that the agent can execute
+  directly. If no wording could make the task achievable, say so in PROCESS.md rather than
+  shipping a hopeful paragraph; a hard zero does not move on emphasis.
+- **KNOWLEDGE GAP** — a format/criterion/fact the agent genuinely cannot derive → state it
+  precisely, and only it. Don't restate a rule the agent already has; that's a skipped
+  step (use structure), not a knowledge gap.
+- **DECISION / PERMISSION (ACT vs REFUSE)** — the agent made the wrong call on a decision
+  the prompt governs. **This is the most dangerous cluster to fix wrong.** NEVER loosen,
+  broaden, or alter a GLOBAL decision/permission/refusal rule — a global change (e.g.
+  "restricted records MAY now be modified") flips behavior for the WHOLE class and
+  regresses every currently-passing task where the stricter behavior was the gold answer
+  (this exact mistake sank a prior run). Instead add an ADDITIVE rule that NARROWS: state
+  the exact discriminating CONDITION that separates the qualifying cases, so only those
+  change.
+- **CONFLICT / BLOAT** — two instructions disagree, or the rule that matters is buried in
+  prose the agent skims. CONSOLIDATE: resolve the contradiction and hoist the decisive
+  rule to where it is read. Deleting is allowed here — but only text you have shown to be
+  redundant or contradicted, never a rule a passing task depends on.
+
+Also fix **recovery guidance** — what the agent should do when its own attempt errors —
+when a recoverable error stranded it mid-task. High leverage, low risk.
+
+## VERIFY-THE-FIX (do this for EACH kept edit — it satisfies the VERIFIED + SAFE tests)
+A prompt edit cannot be unit-tested, so verify it against the TRACES, concretely:
+- **Point at the evidence:** quote the line(s) from the failing trace that the edit
+  addresses, and state what the agent would have done differently had the edit been
+  present. "It would have been clearer" is not verification.
+- **Contract / format edit:** confirm the value you now state matches what the SCORER
+  compares (read the answer/expected artifact in the trace or the benchmark source) — not
+  merely what the old prompt said. A confidently-stated wrong contract is worse than none.
+- **Structural edit (ordered procedure / checklist):** confirm the skipped step is now a
+  precondition of a step the agent must take, not just mentioned earlier.
+- **Decision / permission edit:** the SAFE check is BEHAVIORAL. Enumerate the
+  currently-passing tasks in the SAME decision class and confirm the edit would NOT flip
+  the agent's action on any of them — in particular that it does not make the agent newly
+  ACT where a passing task's gold answer was to refuse. If you cannot enumerate and check
+  that class, the edit is UNBOUNDED and unverified — rescope it to the qualifying cases.
+- **Deletion / consolidation:** name the tasks whose traces show the removed text was
+  unused or contradicted, and confirm no passing trace relies on it.
+
+Record one line per edit in PROCESS.md, e.g.
+`trace <task>: wrote formula not value → contract line "write literal values"; passing <ids> already write literals`.
+An edit with no verification line is unverified — verify it or drop it.
+
+## NON-OVERFITTING (every edit must GENERALIZE)
+Every edit encodes a GENERAL rule that holds across the whole class of inputs — NEVER a
+literal that special-cases one task (its id, target, name, or expected answer), and never
+the answer itself. ALLOWED: constants the domain defines (a fixed threshold, a required
+path shape, a domain enum). Use per-task specifics and any ground-truth in the traces ONLY
+to understand the failure CLASS, then write the general fix.
+
+## Handover (REQUIRED before you STOP)
+- **PROCESS.md** (this iteration): the ranked cluster list (with leverage + CONTRACT/
+  STRUCTURE/KNOWLEDGE/DECISION tag), every kept edit + its lever, the VERIFY-THE-FIX +
+  blast-radius line per edit, any ENVIRONMENT fault you diagnosed and handed back, what you
+  deliberately skipped and why, and (if you used subagents) that you did.
+- **JOURNAL.md** (append ONE entry below the marker; never edit earlier entries). Write
+  INTENT only — you cannot know your gate result; the framework stamps the RESULT below
+  your entry: the changes I made (1 line/edit, naming the section + cluster) · the
+  EXPECTED effect + why each is safe · which prior RESULTS I built on and which regressing
+  edits I did NOT re-try (cite ids) · refuted hypotheses (a prior RESULT disproved — never
+  re-test) · high-value clusters not yet cracked + designs already tried · plateau signal +
+  which lever to switch to · focus next iteration.
+
+{{FAILURES}}
+{{PASSING}}
+{{CAP_BRIEF}}
+{{ALGO_BRIEF}}
+
+## Self-check before STOP
+- Every kept edit passes the THREE TESTS (REAL, SAFE, VERIFIED) and has its
+  verify + blast-radius line in PROCESS.md. Drop any that doesn't.
+- You edited ONLY the capability files in `{{CAP_BRIEF}}` — no adapter, harness, scorer,
+  benchmark or environment file, and no shell command that mutates the environment.
+- You read each selected capability's `./guidance/<cap>/SKILL.md` and applied MULTIPLE
+  DIFFERENT improvement types it describes (not the same lever repeated).
+- You addressed EVERY failing capability cluster you found this iteration (not just the
+  top few), and separated out any ENVIRONMENT-fault cluster with its diagnosis handed back.
+- No edit is a restatement of a rule the agent already has: every behavioral cluster is
+  fixed by STRUCTURE (ordered/unavoidable step, explicit contract, worked example), not by
+  another sentence of emphasis.
+- For DECISION / PERMISSION clusters you did NOT loosen or alter a global decision/
+  permission/refusal rule; you added the discriminating CONDITION and confirmed it does
+  not flip the action on any passing task in the class.
+- Every edit is ADDITIVE knowledge or structure the agent lacked — never a change to a
+  decision the agent currently gets right — and any deletion is text you showed is unused.
+- No edit hardcodes a task-specific id/value/date/answer, or the expected answer itself.
+- PROCESS.md + JOURNAL.md are filled. Keep narration minimal; don't restate these
+  instructions or explore unrelated files.


### PR DESCRIPTION
Closes #272.

## Summary

Two fixes for defects that [pilot run 30691123806](https://github.com/skillberry-ai/cap-evolve/actions/runs/30691123806) paid **$77.49 and ~3h** to expose. No `core/` changes — everything lands in the adapter and the CI scripts.

### 1. The 912 dataset's top-level dir is `drwx------`, so the sandbox cannot use the mount at all

`spreadsheetbench_912_v0.1.tar.gz` stores its top-level dir as `0700` (the 200-task sample stores `0755`), `tar` preserves stored modes, and the adapter bind-mounts exactly that dir at `/mnt/data` in a container running as uid 1000. A non-traversable root makes every path under the mount unreachable — **reads too, not just writes**: even `Path.exists()` raises EACCES, because a missing search bit is not a missing file. All 50 baseline rollouts contained a denial. `smoke` uses the 200-task sample, which is why only `full`/`pilot` broke.

Fixed at three levels:

| where | what |
|---|---|
| `fetch_data.sh` | `chmod -R a+rX` on extract (traverse+read only — the dataset is read-only INPUT), plus an O(1) root re-normalize for a tree cached by an older revision |
| `adapter.py` | heals the tree it owns, then **verifies the mount before the first LLM call** (`_preflight_mount`) — an unusable mount aborts in seconds at ~$0 instead of burning a full eval |
| `adapter.py` | the denial classifier now catches denied **reads** anywhere under the mount and reports the traverse fault distinctly from the output-dir fault |

The old message asserted *"the host dir is not writable by the container's uid"* for both faults, which sent the last diagnosis after SELinux and output-dir modes for hours while the real fault was one directory at the top (`spreadsheet/` and the workbooks were 0755/0644 all along; SELinux was Permissive with zero AVCs).

### 2. The optimizer was told to edit `tools.py` on a benchmark that has no tools

The shared `templates/project/optimizer/INSTRUCTIONS.md` is written for a capability containing tool CODE — it instructs "prefer code", names `tools.py` and tau2's `get_*_details`, and its self-check demands *"edits across BOTH policy.md AND tools.py"*. SpreadsheetBench declares `[system-prompt]`: one `prompt.md`. That guidance contradicts the correctly-rendered `{{CAP_BRIEF}}`, and the static prose wins.

In this run the optimizer found code to change — `cand_0002` scored 0.567 by patching **`adapter.py`** to chmod the data root while leaving `prompt.md` byte-identical to the seed. **That run's 0.000 → 0.567 was infrastructure repair, not capability.**

`INSTRUCTIONS.prompt-only.md` now ships alongside the default with prompt-appropriate levers (output contract, ordered/unavoidable step, worked method, narrowing predicate, consolidation), an explicit boundary that the adapter/harness/scorer are **not** editable, and a rule that an ENVIRONMENT fault is to be *diagnosed and handed back* rather than worked around — which is what should have happened here.

## Design decisions

- **No `core/` change.** `cli.py` already resolves `optimizer_instructions_file`, defaulting to `optimizer/INSTRUCTIONS.md` inside the project, so `run_suite.sh` only has to drop the file there. tau2's code-bearing guidance is untouched, and a test asserts the default template still contains `tools.py`.
- **Pinned by absolute path.** A relative `optimizer_instructions_file` resolves against different cwds in check vs run and can silently fall back to the generic template (#252) — which would erase this fix with no error. The new spec line is `""` for every other benchmark; that empty value is verified falsy in **both** the PyYAML path and the hand-rolled fallback parser, and verified not to swallow the following keys.
- **`a+rX`, never `a+w`.** The dataset tree is read-only input. Both the group and other classes are granted, because the container runs as gid 100(`users`) and POSIX stops at the first matching class — `0o604` (`-rw----r--`) is still EACCES for it. I found this the hard way: my first version widened `o+r` only and the container still could not read. See the constant's comment.
- **Preflight is host-side and O(1)-ish** (a `stat` and one probe glob; the recursive heal only runs when the probe is unreadable). No container is started, so it is safe once per process, and it runs *before* `_Sandbox()` in `_get_sandbox()` — which is what makes a bad mount cost ~$0 per rollout rather than 30 turns.
- **Fail loud, but heal what we own.** A tree we own is repaired; a foreign-owned tree raises with the mode we actually found and the exact `chmod` to run. Either way the rollout errors are INFRASTRUCTURE, so #269's >50% gate turns the job red instead of publishing a 0.000.

## Testing

**Verified in the real executor image against the real archive**, not just in unit tests. With the mode the failing run actually had (`0700` root, `0600` workbooks):

```
BEFORE — the failing run reproduced:
    read  input workbook: DENIED -> PermissionError [Errno 13] '/mnt/data/spreadsheet'
    write output workbook: DENIED -> PermissionError [Errno 13] '/mnt/data/outputs/312-46_0_probe'

_preflight_mount: mount verified usable

AFTER — same probe, only the preflight ran (root now drwxr-xr-x):
    read  input workbook: OK
    write output workbook: OK
```

The fetch-time layer was verified independently the same way (`chmod -R a+rX` alone → container read OK, write OK).

- **24 new tests** in `core/tests/test_spreadsheetbench_mount_perms.py`: preflight heal / abort / idempotence, that it runs before the sandbox is created, read-vs-write classification (including that another rollout's output dir is not our fault), fetch-time normalization on both the fresh and cached paths, and the template/wiring invariants.
- Adapter inline self-checks extended (`python3 adapter.py` → all OK).
- Full suite: **304 passed, 1 skipped**. `bash -n` clean on both scripts; no workflow touched.

## Not in this PR

- **Containment.** The optimizer edited `adapter.py`, outside its declared capability, and the harness scored it as a gain. `_CAP_DIFF_SKIP` only hides such files from diffs — nothing prevents or flags them. Fix 2 addresses it by instruction; a real guard belongs in `core/` and is deliberately out of scope here.
- **Leaked containers.** 176 `codeact-executor` containers were still running on the runner (all "unhealthy", load 14): `remove=True` only fires on stop and `cleanup_kernels` only on timeout, so they accumulate one per rollout. Consistent with the `ConnectionRefusedError` entries in the sandbox log and with baseline taking 116 minutes. Cleaned up manually; the leak is filed in #272.

Signed-off-by: Eran Raichstein <eranra@il.ibm.com>