### PR TITLE
fix(tau2): report token usage and stop reporting unpriced runs as $0.00

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ All notable changes to cap-evolve are documented here. The format follows
 
 ## [Unreleased]
 ### Fixed
+- **tau2 runs reported $0.0000 of eval spend despite real rollouts, so they could not be
+  costed at all.** `sim.agent_cost`/`sim.user_cost` come from tau2's `get_cost`, which is
+  **all-or-nothing**: it returns `None` the moment any non-tool message lacks a per-message
+  `cost`. The adapter's `sim.agent_cost or 0.0` collapsed that `None` into `0.0`, so "the
+  provider did not price this" and "this was free" produced the identical number — and
+  `litellm_proxy/...` gateway aliases, which is what every CI benchmark uses, are exactly the
+  unpriced case. Run 30684845463 spent real money across 10 tasks × 3 iterations and reported
+  eval $0.00, with only the $25.90 optimizer cost visible. The adapter now (a) recovers
+  **tokens**, which tau2 exposes per message and which the adapter was discarding with a
+  hardcoded `tokens=0` — the honest fallback unit, since spend can be derived from them
+  out-of-band; (b) salvages a **partial** cost from whatever the provider did price, instead
+  of dropping the whole run's cost over one unpriced message; and (c) records `cost_source`
+  (`tau2` / `partial_messages` / `unpriced`) plus the missing-cost and missing-usage counts in
+  the rollout metadata, so a `0.0` can be read as *unpriced* rather than *free*. It
+  deliberately does **not** price tokens from a public rate table — the gateway's real rates
+  are not knowable client-side, and a fabricated dollar figure sitting next to measured ones
+  is worse than an absent one; a test enforces that. `Rollout.cost_usd` is a non-optional
+  float that coerces `None` to `0.0`, so representing "unknown" in the field itself would
+  need a `core/` change and is left alone.
 - **Sandbox containers were never released, and the leftovers ran forever.** The vendored
   server reclaims a container only on a hardcoded 10-minute idle timeout
   (`api.py`'s `KERNEL_TIMEOUT`) or on a force-cleanup at SIGINT, and nothing released a

--- a/core/tests/test_tau2_eval_cost.py
+++ b/core/tests/test_tau2_eval_cost.py
@@ -1,0 +1,166 @@
+"""tau2 runs reported $0.0000 of eval spend despite real rollouts, so they could not be costed.
+
+`sim.agent_cost` / `sim.user_cost` come from tau2's `get_cost`, which is ALL-OR-NOTHING: it
+returns None the moment ANY non-tool message lacks a per-message `cost`. The adapter's
+`sim.agent_cost or 0.0` collapsed that None into 0.0, so "the provider did not price this"
+and "this was free" produced the identical number — and `litellm_proxy/...` gateway aliases,
+which is what every CI benchmark uses, are exactly the unpriced case. Run 30684845463 spent
+real money on 10 tasks × 3 iterations and reported eval $0.00 (only the $25.90 optimizer
+cost was visible).
+
+The adapter now recovers tokens (which tau2 exposes per-message and the adapter was throwing
+away with a hardcoded `tokens=0`), salvages a partial cost from whatever the provider DID
+price, and records `cost_source` so a 0.0 can be read as "unpriced" rather than "free". It
+deliberately does not price tokens from a public rate table: the gateway's real rates are
+not knowable here, and a fabricated dollar figure sitting next to measured ones is worse
+than an absent one.
+"""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+ADAPTER = REPO / "templates" / "adapters" / "tau2_bench" / "adapter.py"
+
+
+def _load_adapter_module():
+    """Import the tau2 adapter with `cap_evolve`/`model_config` real and `tau2` stubbed.
+
+    tau2-bench is a heavy external install that CI does not have; the cost helper only
+    touches `tau2.utils.llm_utils.get_token_usage`, so that one function is stubbed.
+    """
+    for p in (REPO / "core", ADAPTER.parent, ADAPTER.parent.parent):
+        if str(p) not in sys.path:
+            sys.path.insert(0, str(p))
+
+    llm_utils = types.ModuleType("tau2.utils.llm_utils")
+
+    def get_token_usage(messages):
+        usage = {"completion_tokens": 0, "prompt_tokens": 0}
+        for m in messages:
+            u = getattr(m, "usage", None)
+            if u is None:
+                continue
+            usage["completion_tokens"] += u["completion_tokens"]
+            usage["prompt_tokens"] += u["prompt_tokens"]
+        return usage
+
+    llm_utils.get_token_usage = get_token_usage
+    for name, mod in (
+        ("tau2", types.ModuleType("tau2")),
+        ("tau2.utils", types.ModuleType("tau2.utils")),
+        ("tau2.utils.llm_utils", llm_utils),
+    ):
+        sys.modules.setdefault(name, mod)
+
+    spec = importlib.util.spec_from_file_location("_tau2_adapter_cost", ADAPTER)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class _Msg:
+    def __init__(self, cost=None, usage=None):
+        self.cost = cost
+        self.usage = usage
+
+
+class _Sim:
+    def __init__(self, agent_cost, user_cost, messages):
+        self.agent_cost = agent_cost
+        self.user_cost = user_cost
+        self._messages = messages
+
+    def get_messages(self):
+        return self._messages
+
+
+_USAGE = {"prompt_tokens": 100, "completion_tokens": 20}
+
+
+def test_priced_run_is_reported_as_before():
+    mod = _load_adapter_module()
+    sim = _Sim(1.25, 0.75, [_Msg(cost=1.0, usage=_USAGE), _Msg(cost=1.0, usage=_USAGE)])
+    cost, tokens, meta = mod._cost_and_tokens(sim)
+    assert cost == 2.0, "tau2's own total wins when it has one"
+    assert meta["cost_source"] == "tau2"
+    assert tokens == 240, "tokens must be recovered, not hardcoded to 0"
+
+
+def test_unpriced_run_reports_tokens_and_says_it_is_unpriced():
+    """The bug: this used to be indistinguishable from a genuinely free run."""
+    mod = _load_adapter_module()
+    sim = _Sim(None, None, [_Msg(cost=None, usage=_USAGE), _Msg(cost=None, usage=_USAGE)])
+    cost, tokens, meta = mod._cost_and_tokens(sim)
+    assert cost == 0.0
+    assert meta["cost_source"] == "unpriced", "0.0 must be readable as unknown, not free"
+    assert meta["messages_missing_cost"] == 2
+    assert tokens == 240, "tokens are the honest fallback unit and must survive"
+
+
+def test_partially_priced_run_salvages_what_the_provider_gave():
+    """tau2 discards the whole run's cost over ONE unpriced message; partial beats zero."""
+    mod = _load_adapter_module()
+    sim = _Sim(None, None, [
+        _Msg(cost=0.4, usage=_USAGE),
+        _Msg(cost=None, usage=_USAGE),
+        _Msg(cost=0.1, usage=_USAGE),
+    ])
+    cost, tokens, meta = mod._cost_and_tokens(sim)
+    assert abs(cost - 0.5) < 1e-9
+    assert meta["cost_source"] == "partial_messages"
+    assert meta["messages_missing_cost"] == 1
+    assert tokens == 360
+
+
+def test_no_cost_is_ever_invented_from_a_rate_table():
+    """A fabricated dollar figure next to measured ones is worse than an absent one."""
+    mod = _load_adapter_module()
+    sim = _Sim(None, None, [_Msg(cost=None, usage={"prompt_tokens": 10**6,
+                                                   "completion_tokens": 10**6})])
+    cost, tokens, meta = mod._cost_and_tokens(sim)
+    assert cost == 0.0, "two million tokens must not become a guessed dollar amount"
+    assert tokens == 2_000_000
+    src = ADAPTER.read_text(encoding="utf-8")
+    for banned in ("completion_cost", "cost_per_token", "model_cost", "litellm.model_prices"):
+        assert banned not in src, f"{banned} would synthesize a price"
+
+
+def test_missing_usage_is_counted_not_silently_dropped():
+    mod = _load_adapter_module()
+    sim = _Sim(None, None, [_Msg(cost=None, usage=None), _Msg(cost=None, usage=_USAGE)])
+    cost, tokens, meta = mod._cost_and_tokens(sim)
+    assert tokens == 120, "usage-bearing messages still count"
+    assert meta["messages_missing_usage"] == 1
+
+
+def test_a_sim_whose_messages_explode_still_yields_a_rollout():
+    """Cost accounting must never be able to fail a rollout that otherwise succeeded."""
+    mod = _load_adapter_module()
+
+    class _Bad(_Sim):
+        def get_messages(self):
+            raise RuntimeError("tau2 internals changed")
+
+    cost, tokens, meta = mod._cost_and_tokens(_Bad(None, None, []))
+    assert (cost, tokens) == (0.0, 0)
+    assert meta["cost_source"] == "unpriced"
+
+
+def test_cost_metadata_reaches_the_rollout():
+    """The flags are only useful if they are actually attached to the record."""
+    src = ADAPTER.read_text(encoding="utf-8")
+    assert "cost_usd=cost_usd" in src and "tokens=tokens" in src
+    assert "**cost_meta," in src, "cost_source must land in Rollout.metadata"
+    assert "tokens=0," not in src, "the hardcoded zero must be gone"
+
+
+def test_the_all_or_nothing_upstream_behavior_is_documented():
+    """If a tau2 upgrade makes get_cost partial, this fallback can be simplified — the
+    reason it exists must be findable in the code, not just in a PR."""
+    src = ADAPTER.read_text(encoding="utf-8")
+    assert "ALL-OR-NOTHING" in src
+    assert "get_cost" in src

--- a/templates/adapters/tau2_bench/adapter.py
+++ b/templates/adapters/tau2_bench/adapter.py
@@ -109,6 +109,84 @@ def _read_candidate_policy(candidate_dir: Path) -> str:
     return Path(AIRLINE_POLICY_PATH).read_text(encoding="utf-8")
 
 
+_cost_unpriced_warned = False
+
+
+def _cost_and_tokens(sim) -> tuple[float, int, dict]:
+    """Cost and token usage for one simulation, plus metadata saying how solid the cost is.
+
+    `sim.agent_cost`/`sim.user_cost` come from tau2's ``get_cost``, which is ALL-OR-NOTHING:
+    it returns None the moment ANY non-tool message lacks a per-message ``cost``. The
+    previous ``sim.agent_cost or 0.0`` therefore collapsed "the provider did not price this"
+    into "$0.00", and every tau2 run has reported **$0.0000 of eval spend** despite real
+    rollouts — so tau2 runs could not be costed at all, and a genuinely free run was
+    indistinguishable from an unpriced one. `litellm_proxy/...` gateway aliases are exactly
+    the case that goes unpriced, and that is what CI uses for every benchmark.
+
+    What this does about it:
+      * TOKENS are always recovered. tau2 exposes ``get_token_usage``, which SKIPS messages
+        without usage instead of nulling the whole run, and the adapter was hardcoding
+        ``tokens=0`` and discarding it. Tokens are the honest fallback unit: they are what
+        the provider actually reports, and spend can be derived from them out-of-band.
+      * COST falls back to summing the per-message ``cost`` values that ARE present, which
+        beats zero when only a few messages are unpriced.
+      * It deliberately does NOT price tokens from a public rate table. The gateway's real
+        rates are not knowable here, and a fabricated dollar figure presented next to
+        measured ones is worse than an absent one.
+      * ``cost_source`` and ``messages_missing_cost`` record which of those happened, so a
+        0.0 can be read as "unpriced" rather than "free". (``Rollout.cost_usd`` is a
+        non-optional float that coerces None to 0.0, so "unknown" cannot be expressed in the
+        field itself without a core change.)
+    """
+    global _cost_unpriced_warned
+
+    agent_cost, user_cost = sim.agent_cost, sim.user_cost
+    try:
+        messages = list(sim.get_messages())
+    except Exception:  # noqa: BLE001
+        messages = []
+
+    tokens, missing_usage = 0, 0
+    try:
+        from tau2.utils.llm_utils import get_token_usage
+
+        usage = get_token_usage(messages) or {}
+        tokens = int(usage.get("prompt_tokens", 0)) + int(usage.get("completion_tokens", 0))
+    except Exception:  # noqa: BLE001
+        tokens = 0
+    missing_usage = sum(1 for m in messages if getattr(m, "usage", None) is None)
+
+    if agent_cost is not None or user_cost is not None:
+        return (
+            float(agent_cost or 0.0) + float(user_cost or 0.0),
+            tokens,
+            {"cost_source": "tau2", "messages_missing_cost": 0, "messages_missing_usage": missing_usage},
+        )
+
+    # tau2 gave up on the whole run: salvage whatever the provider did price.
+    priced = [m for m in messages if getattr(m, "cost", None) is not None]
+    missing = len(messages) - len(priced)
+    partial = float(sum(m.cost for m in priced))
+    if priced:
+        source = "partial_messages"
+    else:
+        source = "unpriced"
+        if not _cost_unpriced_warned:
+            _cost_unpriced_warned = True
+            print(
+                f"tau2: the provider returned no per-message cost (model "
+                f"{model_config.MODEL!r}), so eval spend cannot be measured for this run; "
+                f"reporting tokens instead. Rollout cost_usd will read 0.0 with "
+                f"metadata cost_source='unpriced'.",
+                file=sys.stderr,
+            )
+    return partial, tokens, {
+        "cost_source": source,
+        "messages_missing_cost": missing,
+        "messages_missing_usage": missing_usage,
+    }
+
+
 # ---------------------------------------------------------------------------
 # Adapter
 # ---------------------------------------------------------------------------
@@ -204,7 +282,10 @@ class Adapter(CapabilityAdapter):
 
     @staticmethod
     def _sim_to_rollout(sim) -> Rollout:
-        """Map one tau2 SimulationRun to a cap-evolve Rollout."""
+        """Map one tau2 SimulationRun to a cap-evolve Rollout.
+
+        See _cost_and_tokens for why cost needs more care than ``sim.agent_cost or 0.0``.
+        """
         from tau2.data_model.simulation import TerminationReason
 
         infra_reasons = {
@@ -219,8 +300,7 @@ class Adapter(CapabilityAdapter):
             if reward_info is not None and reward_info.reward is not None
             else 0.0
         )
-        agent_cost = sim.agent_cost or 0.0
-        user_cost = sim.user_cost or 0.0
+        cost_usd, tokens, cost_meta = _cost_and_tokens(sim)
         term = sim.termination_reason
         error = None
         if term in infra_reasons:
@@ -239,14 +319,15 @@ class Adapter(CapabilityAdapter):
             task_id=task_id,
             output=messages,
             trace=messages,
-            cost_usd=float(agent_cost) + float(user_cost),
-            tokens=0,
+            cost_usd=cost_usd,
+            tokens=tokens,
             error=error,
             metadata={
                 "domain": DOMAIN,
                 "tau2_reward": reward,
                 "tau2_reward_info": reward_info_dump,
                 "termination_reason": str(term),
+                **cost_meta,
             },
         )
 


### PR DESCRIPTION
Closes #277.

## Summary

tau2 runs have always reported **$0.0000 of eval spend despite real rollouts**, so tau2 could not be costed at all — [run 30684845463](https://github.com/skillberry-ai/cap-evolve/actions/runs/30684845463) spent real money on 10 tasks × 3 iterations and showed eval $0.00, with only the $25.90 optimizer cost visible.

The cost comes from `sim.agent_cost`/`sim.user_cost`, which tau2 fills from `get_cost` — and that function is **all-or-nothing**: it returns `None` the moment *any* non-tool message lacks a per-message `cost`. The adapter's `sim.agent_cost or 0.0` collapsed that `None` into `0.0`, so *"the provider did not price this"* and *"this was free"* produced the identical number with nothing in the record to tell them apart. `litellm_proxy/...` gateway aliases are exactly the unpriced case, and that is what every CI benchmark uses.

Three changes, all in the adapter:

| | |
|---|---|
| **Recover tokens** | tau2 exposes them per message via `get_token_usage`, which *skips* unmetered messages instead of nulling the whole run — and the adapter was hardcoding `tokens=0`. Tokens are the honest fallback unit: they're what the provider actually reports, and spend can be derived from them out-of-band. |
| **Salvage a partial cost** | Sum the per-message costs that *are* present, rather than losing a whole run's cost to one unpriced message. |
| **Say which happened** | `cost_source` (`tau2` / `partial_messages` / `unpriced`) plus missing-cost and missing-usage counts land in the rollout metadata, so a `0.0` reads as *unpriced* rather than *free*. One stderr warning per process names the model. |

## Design decisions

- **No price synthesis.** I deliberately did not price tokens from litellm's public rate table. The gateway's real rates aren't knowable client-side, and a fabricated dollar figure sitting next to measured ones is worse than an absent one — that's how a `0.00` became misleading in the first place. A test asserts no pricing API (`completion_cost`, `cost_per_token`, `model_cost`, …) is reachable from this file.
- **`core/` untouched.** The honest representation would be `cost_usd = None` → reports render "—" instead of "$0.0000". But `Rollout.cost_usd` is a non-optional `float` whose `from_dict` coerces `None → 0.0`, so that needs a schema + aggregation + report change. Left alone; the metadata carries the distinction instead. Worth doing properly if you want unknown-vs-zero visible in the published tables.
- **Cost accounting can never fail a rollout.** Everything is inside `try`/`except`, including `get_messages()` — a rollout that did its work must not be lost to bookkeeping.
- **An upstream tripwire.** The docstring and a test record *why* the fallback exists (`get_cost` being all-or-nothing), so a future tau2 upgrade that makes it partial can retire this rather than inheriting it as folklore.

## Testing

8 new tests in `core/tests/test_tau2_eval_cost.py` — priced / unpriced / partially-priced paths, tokens surviving all three, a two-million-token unpriced run still reporting `$0.00` rather than a guess, missing usage counted rather than silently dropped, a `get_messages()` that raises not failing the rollout, and the metadata actually reaching the `Rollout`. tau2-bench isn't installed in CI, so the one function the helper touches is stubbed.

Suite: **322 passed, 1 skipped**.

## Verification note

This is not yet confirmed against a live tau2 run — the last tau2 workspace was wiped by subsequent runs, and the published artifact carries no per-rollout traces, so I could not read real `message.cost` values. The logic is exercised against tau2's actual `get_cost`/`get_token_usage` semantics as vendored on the runner (quoted in #277), and the next tau2 dispatch will show either a real cost or `cost_source: "unpriced"` with non-zero tokens. Happy to run a tau2 smoke leg to confirm before merge if you'd rather — it contends with the SpreadsheetBench pilot for the single self-hosted runner, which is why I didn't queue one.

Signed-off-by: Eran Raichstein <eranra@il.ibm.com>