### PR TITLE
fix(ci): held-out runs published no base→opt reward — the page showed "—" for the runs that matter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ All notable changes to cap-evolve are documented here. The format follows
 
 ## [Unreleased]
 ### Fixed
+- **Held-out runs published no base→opt reward at all — the benchmarks page showed "—" for
+  exactly the runs whose numbers matter.** `metrics.suite_report` paired per-task baseline
+  from `baseline.json` (the **val** split) against optimized from `final.json` (the **test**
+  split). That was correct while every tier was no-holdout, which its docstring stated
+  outright — but #266 gave `full`/`pilot` genuinely disjoint splits, after which no task id
+  could ever match. Every `reward_opt` came back `null`, `record.rollup` then returned `None`
+  for the whole suite (it requires both sides), and `benchmarks.js` renders `—` when
+  `suite` is null. Verified on the published record for run 30708908659: 50/50 tasks with
+  `reward_baseline`, **0/50** with `reward_opt`, `suite: null`. The honest pairing was
+  available all along: `final.json` carries `test_baseline` (the seed) and `test` (the best
+  candidate) over the **same sealed tasks**, which is the comparison a held-out run exists to
+  produce, so that is what a held-out run now reports — and the report stops claiming
+  `train==val==test` on runs where it is false. Conditioned on the val and test splits being
+  genuinely disjoint, so no-holdout `smoke` keeps byte-identical behaviour (a test pins
+  this; an earlier draft of the fix would have quietly shifted smoke's numbers).
+- **`ci/benchmarks/utils/rebuild_record.py`** repairs records that were already published,
+  reconstructing the per-task rows and suite rollup from the run's artifact (which retains
+  `final.json`) using the aggregate job's own `rollup`. Needed because the aggregate job
+  checks out at the dispatch SHA, so a run already in flight when this merges still publishes
+  a stale record. It refuses to touch any record whose rows already carry an opt reward, so it
+  is safe to point at the whole directory, and it is idempotent.
 - **tau2 runs reported $0.0000 of eval spend despite real rollouts, so they could not be
   costed at all.** `sim.agent_cost`/`sim.user_cost` come from tau2's `get_cost`, which is
   **all-or-nothing**: it returns `None` the moment any non-tool message lacks a per-message

--- a/ci/benchmarks/lib/metrics.py
+++ b/ci/benchmarks/lib/metrics.py
@@ -126,12 +126,22 @@ def iteration_rows(run_dir: str, best_id: str | None = None) -> list[dict]:
 
 def suite_report(run_dir: str, bench: str, tier: str, agent: str, iters, jsonl_path: str = "",
                   steps_jsonl_path: str = "", optimizer_model: str = "claude-opus-4-8") -> str:
-    """Render the per-task + per-iteration + suite-rollup report for ONE run_suite.sh
-    run (all of a tier's tasks optimized together, no-holdout FIT: train==val==test).
+    """Render the per-task + per-iteration + suite-rollup report for ONE run_suite.sh run.
 
-    Per-task base→opt come from the run's per_task arrays: baseline from ``baseline.json``
-    (val) and optimized from ``final.json`` (test), which — because the split is no-holdout —
-    are the same task set scored before/after. This is a TRAIN-FIT metric, labelled as such.
+    Per-task base→opt must compare the SAME tasks scored before and after, and where that
+    pairing comes from depends on whether the run held anything out:
+
+    * HELD-OUT run (``full``/``pilot`` since #266) — take both sides from ``final.json``:
+      ``test_baseline`` (the seed) and ``test`` (the best candidate), evaluated on the SAME
+      sealed split. This is the honest headline comparison the run exists to produce.
+    * NO-HOLDOUT run (``smoke``: train==val==test) — fall back to ``baseline.json`` (val)
+      vs ``final.json`` (test), which is the same task set either way. A TRAIN-FIT metric.
+
+    Pairing val against test unconditionally — as this did — silently produced
+    ``reward_opt: null`` for EVERY task on held-out runs, because the two splits are
+    disjoint by construction, so no task id could ever match. ``record.rollup`` then
+    returned None for the whole suite (it needs both sides), and the benchmarks page
+    rendered "—" in the reward column for exactly the runs whose numbers matter most.
     """
     rd = Path(run_dir)
     baseline = _load(rd / "baseline.json")
@@ -142,9 +152,20 @@ def suite_report(run_dir: str, bench: str, tier: str, agent: str, iters, jsonl_p
 
     bval = baseline.get("val") or {}
     ftest = final.get("test") or {}
-    base_pt = {p["task_id"]: p for p in (bval.get("per_task") or [])}
     opt_pt = {p["task_id"]: p for p in (ftest.get("per_task") or [])}
-    task_ids = list(base_pt) or list(opt_pt)
+    sealed_pt = {p["task_id"]: p for p in ((final.get("test_baseline") or {}).get("per_task") or [])}
+    val_pt = {p["task_id"]: p for p in (bval.get("per_task") or [])}
+    # "Held out" means the val and test SPLITS are genuinely disjoint — not merely that
+    # final.json happens to carry both sides. On a no-holdout tier test_baseline/test also
+    # share a task set, and switching that pairing would silently shift smoke's published
+    # numbers; smoke is not broken, so it keeps exactly the behaviour it had.
+    held_out = bool(val_pt and opt_pt and set(val_pt).isdisjoint(opt_pt))
+    if held_out and sealed_pt and set(sealed_pt) == set(opt_pt):
+        base_pt, task_ids = sealed_pt, list(opt_pt)
+    else:
+        held_out = False
+        base_pt = val_pt
+        task_ids = list(base_pt) or list(opt_pt)
 
     rows = []
     for tid in task_ids:
@@ -171,10 +192,17 @@ def suite_report(run_dir: str, bench: str, tier: str, agent: str, iters, jsonl_p
                 f.write(json.dumps(s) + "\n")
 
     # ---- render: per-task reward table ----
-    out = [f"## {tier.capitalize()} suite — {bench}  (train-fit, no holdout)", ""]
-    out.append(f"Agent `{agent}` · optimizer Claude Code `{optimizer_model}` · {iters} iteration(s) · "
-               f"**all {len(task_ids)} tasks optimized together** · `train==val==test` (FIT metric, "
-               "not a generalization/held-out claim).")
+    kind = "held-out test split" if held_out else "train-fit, no holdout"
+    out = [f"## {tier.capitalize()} suite — {bench}  ({kind})", ""]
+    if held_out:
+        out.append(f"Agent `{agent}` · optimizer Claude Code `{optimizer_model}` · {iters} iteration(s) · "
+                   f"base→opt is the seed vs the best candidate on the **same {len(task_ids)} "
+                   "SEALED test tasks**, which the optimizer never saw (selection happened on a "
+                   "disjoint val split). This is a held-out generalization number.")
+    else:
+        out.append(f"Agent `{agent}` · optimizer Claude Code `{optimizer_model}` · {iters} iteration(s) · "
+                   f"**all {len(task_ids)} tasks optimized together** · `train==val==test` (FIT metric, "
+                   "not a generalization/held-out claim).")
     out.append("")
     out.append("| bench | task | reward (base→opt) | Δ | note |")
     out.append("|---|---|---|---|:--:|")
@@ -191,13 +219,18 @@ def suite_report(run_dir: str, bench: str, tier: str, agent: str, iters, jsonl_p
         note = "↓" if isinstance(d, (int, float)) and d < 0 else ""
         out.append(f"| {bench} | `{r['task']}` | {_fmt(r['reward_baseline'])} → {_fmt(r['reward_opt'])} | {dtxt} | {note} |")
 
-    # Suite headline = the run's aggregate reward (baseline val → optimized test).
-    agg_b, agg_o = bval.get("reward"), ftest.get("reward")
+    # Suite headline. Held-out: seed vs best on the SAME sealed test split (both from
+    # final.json). No-holdout: baseline val → optimized test, which is the same task set.
+    if held_out:
+        agg_b = (final.get("test_baseline") or {}).get("reward")
+    else:
+        agg_b = bval.get("reward")
+    agg_o = ftest.get("reward")
     accepted = "seed (no candidate beat baseline)" if best_id in ("seed", "", None) else f"`{best_id}`"
     out.append("")
     if isinstance(agg_b, (int, float)) and isinstance(agg_o, (int, float)):
         rel = f" ({(agg_o-agg_b)/agg_b*100:+.0f}% rel)" if agg_b else ""
-        out.append(f"**Suite (train-fit):** mean reward {agg_b:.3f} → {agg_o:.3f} "
+        out.append(f"**Suite ({'held-out' if held_out else 'train-fit'}):** mean reward {agg_b:.3f} → {agg_o:.3f} "
                    f"(Δ {agg_o-agg_b:+.3f}{rel}) · best = {accepted} · "
                    f"optimizer ${spent.get('optimizer_usd',0) or 0:.2f} over {spent.get('iterations','?')} iter(s)"
                    + (f" · {infra_n} task(s) infra-errored" if infra_n else ""))

--- a/ci/benchmarks/utils/rebuild_record.py
+++ b/ci/benchmarks/utils/rebuild_record.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Rebuild a published history record's per-task rows + suite rollup from a run's artifact.
+
+WHY THIS EXISTS
+    Held-out runs published before the fix in `metrics.suite_report` carry
+    `reward_opt: null` on every task and `suite: null`, so the benchmarks page shows "—" in
+    the reward column (see that function's docstring for the pairing bug). The numbers were
+    never lost — they are in the run's `final.json`, which the run's artifact retains — so a
+    record can be repaired without re-running anything.
+
+    The aggregate job checks out at the DISPATCH sha, so a run already in flight when the
+    fix merged will also publish a stale record. This repairs those too.
+
+USAGE
+    # 1. get the run's artifact (contains ui/data/runs_*_file_path_final_json.json)
+    gh run download <run_id> --repo <owner>/<repo> --dir /tmp/art
+    # 2. rewrite the record in place
+    python3 ci/benchmarks/utils/rebuild_record.py /tmp/art records/<run_id>__<tier>-<bench>.json
+    # 3. inspect, then commit the record to the benchmark-history branch
+
+Idempotent: re-running on an already-correct record produces identical output.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "lib"))
+from record import rollup  # noqa: E402  (the SAME rollup the aggregate job uses)
+
+
+def _find_final_json(artifact_dir: Path) -> dict:
+    """Pull `final.json`'s contents out of a downloaded artifact's UI snapshot."""
+    hits = sorted(artifact_dir.rglob("*file_path_final_json.json"))
+    if not hits:
+        raise SystemExit(f"no final.json snapshot under {artifact_dir} — artifact expired or "
+                         "predates the UI export step")
+    wrapper = json.loads(hits[0].read_text(encoding="utf-8"))
+    text = wrapper.get("text")
+    if wrapper.get("truncated"):
+        raise SystemExit(f"{hits[0]} is truncated — cannot rebuild from it")
+    if not text:
+        raise SystemExit(f"{hits[0]} carries no text payload")
+    return json.loads(text)
+
+
+def rebuild_tasks(record: dict, final: dict) -> list[dict]:
+    """Per-task rows paired the way `metrics.suite_report` now pairs them.
+
+    Held-out: seed (`test_baseline`) vs best (`test`) on the SAME sealed tasks. If the two
+    task sets differ the run was not held out and its existing rows are already correct.
+    """
+    existing = list(record.get("tasks") or [])
+    # Only repair records that actually show the bug. A record whose rows already carry an
+    # opt reward (any no-holdout run) is correct as published — leave it exactly as it is, so
+    # this is safe to point at every record in the directory.
+    if any(t.get("reward_opt") is not None for t in existing):
+        return existing
+
+    opt = {p["task_id"]: p for p in ((final.get("test") or {}).get("per_task") or [])}
+    base = {p["task_id"]: p for p in ((final.get("test_baseline") or {}).get("per_task") or [])}
+    if not opt or set(opt) != set(base):
+        return existing
+
+    template = (record.get("tasks") or [{}])[0]
+    rows = []
+    for tid, o in opt.items():
+        b = base[tid]
+        rb, ro = b.get("reward"), o.get("reward")
+        # An infra-errored side has no meaningful delta — match metrics.py's treatment.
+        infra = bool((o.get("raw") or {}).get("errored")) or bool((b.get("raw") or {}).get("errored"))
+        rows.append({
+            "bench": record.get("bench") or template.get("bench"),
+            "tier": record.get("tier") or template.get("tier"),
+            "task": tid,
+            "reward_baseline": rb,
+            "reward_opt": ro,
+            "reward_delta": (round(ro - rb, 6)
+                             if isinstance(rb, (int, float)) and isinstance(ro, (int, float))
+                             and not infra else None),
+            "opt_infra": infra,
+            "run_dir": template.get("run_dir", ""),
+        })
+    return rows
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("artifact_dir", type=Path)
+    ap.add_argument("record", type=Path)
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+
+    record = json.loads(args.record.read_text(encoding="utf-8"))
+    final = _find_final_json(args.artifact_dir)
+
+    before_opt = sum(1 for t in (record.get("tasks") or []) if t.get("reward_opt") is not None)
+    tasks = rebuild_tasks(record, final)
+    after_opt = sum(1 for t in tasks if t.get("reward_opt") is not None)
+
+    record["tasks"] = tasks
+    # rollup() returns None unless BOTH sides are present, which is exactly why suite was
+    # null before; recompute it from the repaired rows using the aggregate job's own code.
+    record["suite"] = (rollup(tasks, record.get("steps") or [])
+                       if record.get("conclusion") == "success" else None)
+    record["rebuilt_from_artifact"] = True
+
+    s = record["suite"]
+    print(f"{args.record.name}: tasks {len(tasks)} | reward_opt present {before_opt} -> {after_opt}")
+    print("  suite: " + (f"{s['reward_base']:.4f} -> {s['reward_opt']:.4f} (n={s['n']})"
+                         if s else "None (no valid pairing / run not successful)"))
+    if args.dry_run:
+        print("  (dry run — not written)")
+        return 0
+    args.record.write_text(json.dumps(record, indent=2) + "\n", encoding="utf-8")
+    print(f"  written: {args.record}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/core/tests/test_benchmarks_holdout_base_opt.py
+++ b/core/tests/test_benchmarks_holdout_base_opt.py
@@ -1,0 +1,212 @@
+"""Held-out runs published `reward_opt: null` for every task, so the page showed "—".
+
+`metrics.suite_report` paired per-task baseline from `baseline.json` (the VAL split) against
+optimized from `final.json` (the TEST split). That was correct while every tier was
+no-holdout (train==val==test), which its docstring said out loud. #266 gave `full`/`pilot`
+genuinely disjoint splits, after which no task id could match — so every `reward_opt` came
+back null, `record.rollup` returned None for the whole suite (it requires both sides), and
+the benchmarks page rendered "—" in the reward column for precisely the runs whose numbers
+matter most. Confirmed on record `30708908659__pilot-spreadsheetbench.json`: 50/50 tasks
+with `reward_baseline`, 0/50 with `reward_opt`, `suite: null`.
+
+`final.json` always carries BOTH sides over the same sealed tasks (`test_baseline` = seed,
+`test` = best), so the honest pairing was available all along.
+"""
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+LIB = REPO / "ci" / "benchmarks" / "lib"
+UTILS = REPO / "ci" / "benchmarks" / "utils"
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _metrics():
+    if str(LIB) not in sys.path:
+        sys.path.insert(0, str(LIB))
+    return _load("_bench_metrics", LIB / "metrics.py")
+
+
+def _pt(task_id, reward, errored=False):
+    return {"task_id": task_id, "reward": reward, "raw": {"errored": errored}}
+
+
+def _run_dir(tmp: Path, *, held_out: bool, best="cand_0001") -> Path:
+    """A run dir shaped like a real one. held_out=True gives disjoint val/test ids."""
+    rd = tmp / "run_suite"
+    rd.mkdir(parents=True)
+    # held_out: val and test are DISJOINT (as since #266). else: train==val==test.
+    val_ids = ["v1", "v2", "v3"] if held_out else ["t1", "t2"]
+    (rd / "baseline.json").write_text(json.dumps({
+        "val": {"split": "val", "reward": 0.4, "stderr": 0.1,
+                "per_task": [_pt(i, 0.4) for i in val_ids]},
+        "best_id": "seed",
+    }))
+    (rd / "final.json").write_text(json.dumps({
+        "test": {"split": "test", "reward": 0.75, "stderr": 0.1,
+                 "per_task": [_pt("t1", 1.0), _pt("t2", 0.5)]},
+        "best_id": best,
+        "test_baseline": {"split": "test", "reward": 0.25, "stderr": 0.1,
+                          "per_task": [_pt("t1", 0.5), _pt("t2", 0.0)]},
+        "baseline_id": "seed",
+        "test_delta": 0.5,
+    }))
+    (rd / "state.json").write_text(json.dumps({"best_id": best, "spent": {"iterations": 2}}))
+    (rd / "events.jsonl").write_text("")
+    return rd
+
+
+# --- the fix -----------------------------------------------------------------------------
+
+
+def test_held_out_run_pairs_seed_vs_best_on_the_same_sealed_tasks(tmp_path):
+    m = _metrics()
+    rd = _run_dir(tmp_path, held_out=True)
+    jsonl = tmp_path / "metrics.jsonl"
+    m.suite_report(str(rd), "spreadsheetbench", "full", "azure/gpt-5.5", 2, jsonl_path=str(jsonl))
+    rows = [json.loads(l) for l in jsonl.read_text().splitlines()]
+
+    assert {r["task"] for r in rows} == {"t1", "t2"}, "rows must be the SEALED test tasks"
+    assert all(r["reward_opt"] is not None for r in rows), "this is the bug: opt was null"
+    by = {r["task"]: r for r in rows}
+    assert by["t1"]["reward_baseline"] == 0.5 and by["t1"]["reward_opt"] == 1.0
+    assert by["t1"]["reward_delta"] == 0.5
+    assert by["t2"]["reward_baseline"] == 0.0 and by["t2"]["reward_opt"] == 0.5
+
+
+def test_the_suite_rollup_is_no_longer_none_for_a_held_out_run(tmp_path):
+    """rollup() needs both sides; null opt made it return None, which is what blanked the page."""
+    m = _metrics()
+    if str(LIB) not in sys.path:
+        sys.path.insert(0, str(LIB))
+    rec = _load("_bench_record", LIB / "record.py")
+
+    rd = _run_dir(tmp_path, held_out=True)
+    jsonl = tmp_path / "metrics.jsonl"
+    m.suite_report(str(rd), "spreadsheetbench", "full", "azure/gpt-5.5", 2, jsonl_path=str(jsonl))
+    rows = [json.loads(l) for l in jsonl.read_text().splitlines()]
+
+    suite = rec.rollup(rows, [])
+    assert suite is not None, "the page renders '—' when this is None"
+    assert suite["reward_base"] == 0.25 and suite["reward_opt"] == 0.75
+    assert suite["n"] == 2
+
+
+def test_no_holdout_run_keeps_its_train_fit_pairing(tmp_path):
+    """smoke has train==val==test; its behaviour must not change."""
+    m = _metrics()
+    rd = _run_dir(tmp_path, held_out=False)
+    jsonl = tmp_path / "metrics.jsonl"
+    md = m.suite_report(str(rd), "spreadsheetbench", "smoke", "aws/gpt-oss-120b", 3,
+                        jsonl_path=str(jsonl))
+    rows = [json.loads(l) for l in jsonl.read_text().splitlines()]
+    assert all(r["reward_opt"] is not None for r in rows)
+    assert "train-fit" in md and "train==val==test" in md
+
+
+def test_report_stops_claiming_no_holdout_on_a_held_out_run(tmp_path):
+    """The old header asserted `train==val==test` unconditionally — false, and the exact
+    claim a reader would rely on when judging whether a number generalizes."""
+    m = _metrics()
+    md = m.suite_report(str(_run_dir(tmp_path, held_out=True)), "spreadsheetbench", "full",
+                        "azure/gpt-5.5", 2)
+    assert "train==val==test" not in md
+    assert "SEALED test tasks" in md and "held-out" in md
+    # The headline must compare seed-on-test vs best-on-test, not val vs test.
+    assert "0.250 → 0.750" in md
+
+
+def test_best_equals_seed_yields_a_zero_delta_not_trial_noise(tmp_path):
+    """When nothing was accepted, final.json's test_baseline IS the test result, so base==opt.
+    The old val-vs-test pairing reported a spurious non-zero delta from re-scoring noise."""
+    m = _metrics()
+    rd = _run_dir(tmp_path, held_out=True, best="seed")
+    same = {"split": "test", "reward": 0.75, "stderr": 0.1,
+            "per_task": [_pt("t1", 1.0), _pt("t2", 0.5)]}
+    f = json.loads((rd / "final.json").read_text())
+    f["test_baseline"], f["baseline_id"], f["test_delta"] = same, "seed", 0.0
+    (rd / "final.json").write_text(json.dumps(f))
+
+    jsonl = tmp_path / "metrics.jsonl"
+    m.suite_report(str(rd), "spreadsheetbench", "full", "azure/gpt-5.5", 2, jsonl_path=str(jsonl))
+    rows = [json.loads(l) for l in jsonl.read_text().splitlines()]
+    assert all(r["reward_delta"] == 0.0 for r in rows)
+
+
+def test_infra_errored_side_still_suppresses_the_delta(tmp_path):
+    m = _metrics()
+    rd = _run_dir(tmp_path, held_out=True)
+    f = json.loads((rd / "final.json").read_text())
+    f["test"]["per_task"] = [_pt("t1", 0.0, errored=True), _pt("t2", 0.5)]
+    (rd / "final.json").write_text(json.dumps(f))
+    jsonl = tmp_path / "metrics.jsonl"
+    m.suite_report(str(rd), "spreadsheetbench", "full", "azure/gpt-5.5", 2, jsonl_path=str(jsonl))
+    rows = {json.loads(l)["task"]: json.loads(l) for l in jsonl.read_text().splitlines()}
+    assert rows["t1"]["opt_infra"] is True and rows["t1"]["reward_delta"] is None
+    assert rows["t2"]["reward_delta"] == 0.5
+
+
+# --- the backfill utility ----------------------------------------------------------------
+
+
+def test_rebuild_record_repairs_a_stale_record(tmp_path):
+    """Records already published cannot be re-run; they are repaired from the artifact."""
+    rb = _load("_rebuild_record", UTILS / "rebuild_record.py")
+    stale = {
+        "bench": "spreadsheetbench", "tier": "full", "conclusion": "success",
+        "steps": [{"eval_usd": 1.0, "optimizer_usd": 2.0, "eval_seconds": 10, "optimizer_seconds": 20}],
+        "tasks": [{"bench": "spreadsheetbench", "tier": "full", "task": "v1",
+                   "reward_baseline": 0.4, "reward_opt": None, "reward_delta": None,
+                   "opt_infra": False, "run_dir": "/x"}],
+        "suite": None,
+    }
+    final = {
+        "test": {"reward": 0.75, "per_task": [_pt("t1", 1.0), _pt("t2", 0.5)]},
+        "test_baseline": {"reward": 0.25, "per_task": [_pt("t1", 0.5), _pt("t2", 0.0)]},
+    }
+    tasks = rb.rebuild_tasks(stale, final)
+    assert [t["task"] for t in tasks] == ["t1", "t2"]
+    assert all(t["reward_opt"] is not None for t in tasks)
+    assert tasks[0]["reward_delta"] == 0.5
+    assert all(t["tier"] == "full" and t["bench"] == "spreadsheetbench" for t in tasks)
+
+
+def test_rebuild_record_leaves_an_already_correct_record_alone(tmp_path):
+    """A record whose rows already carry an opt reward is not broken — never rewrite it, so
+    the utility is safe to point at every record in the directory."""
+    rb = _load("_rebuild_record", UTILS / "rebuild_record.py")
+    original = [{"task": "t1", "reward_baseline": 0.4, "reward_opt": 0.6}]
+    stale = {"bench": "b", "tier": "smoke", "tasks": original, "suite": None}
+    final = {"test": {"per_task": [_pt("t1", 1.0)]},
+             "test_baseline": {"per_task": [_pt("t1", 0.5)]}}
+    assert rb.rebuild_tasks(stale, final) == original
+
+
+def test_rebuild_record_skips_when_sides_cover_different_tasks(tmp_path):
+    rb = _load("_rebuild_record", UTILS / "rebuild_record.py")
+    original = [{"task": "v1", "reward_baseline": 0.4, "reward_opt": None}]
+    stale = {"bench": "b", "tier": "full", "tasks": original, "suite": None}
+    final = {"test": {"per_task": [_pt("t1", 1.0)]},
+             "test_baseline": {"per_task": [_pt("OTHER", 0.5)]}}
+    assert rb.rebuild_tasks(stale, final) == original
+
+
+def test_rebuild_is_idempotent(tmp_path):
+    rb = _load("_rebuild_record", UTILS / "rebuild_record.py")
+    stale = {"bench": "b", "tier": "full", "tasks": [{"run_dir": "/x"}], "suite": None}
+    final = {"test": {"per_task": [_pt("t1", 1.0)]},
+             "test_baseline": {"per_task": [_pt("t1", 0.5)]}}
+    once = rb.rebuild_tasks(stale, final)
+    twice = rb.rebuild_tasks({**stale, "tasks": once}, final)
+    assert once == twice


### PR DESCRIPTION
Closes #279.

## Summary

`metrics.suite_report` paired per-task baseline from `baseline.json` (**val**) against optimized from `final.json` (**test**). Correct while every tier was no-holdout — its docstring said so outright — but #266 gave `full`/`pilot` disjoint splits, after which no task id could match:

```
reward_opt = null for every task  →  record.rollup() returns None  →  benchmarks.js renders "—"
```

Verified on the published record for run 30708908659: **50/50** tasks carry `reward_baseline`, **0/50** carry `reward_opt`, `suite: null`. (The per-phase rewards survive in `steps`, which is why the steps table still shows numbers and only the reward column is blank.)

**The honest pairing was already in the data.** `final.json` carries `test_baseline` (the seed) and `test` (the best candidate) over the **same sealed tasks** — precisely the comparison a held-out run exists to produce. A held-out run now reports that, and the report stops claiming `train==val==test` on runs where it's false.

## Design decisions

- **Scoped to genuinely disjoint splits.** On a no-holdout tier `test_baseline`/`test` *also* share a task set, so my first draft would have quietly changed `smoke`'s published numbers and relabelled its report. A test caught it. `smoke` is not broken, so it keeps byte-identical behaviour, and the condition is now "val and test are disjoint" rather than "a same-set pairing happens to exist".
- **Better even where it overlaps.** When `best == seed`, `test_baseline` *is* the test result, so deltas are correctly `0` — the old pairing reported a spurious non-zero delta from re-scoring the seed on a second split.
- **The label matters as much as the number.** `## … (train-fit, no holdout)` and `train==val==test` are exactly what a reader uses to judge whether a number generalizes. On a held-out run the header now says so and names the sealed task count.
- **Repair, don't re-run.** `ci/benchmarks/utils/rebuild_record.py` rebuilds a published record's rows + rollup from the run's artifact using the aggregate job's own `rollup()`, so no re-run is needed. It refuses to touch a record whose rows already carry an opt reward (safe to point at the whole directory) and is idempotent. This is also how the **full run currently in flight** gets a correct record, since the aggregate job checks out at the dispatch SHA.

## Testing

- **10 new tests**: the sealed pairing, `rollup` no longer None, `smoke` untouched (byte-identical wording), the header no longer asserting no-holdout, `best == seed` giving a zero delta, infra-error suppression, and the utility's repair / skip / idempotence paths.
- **Validated against the real broken record** with its real artifact:
  ```
  30708908659__pilot-spreadsheetbench.json: tasks 5 | reward_opt present 0 -> 5
    suite: 0.6000 -> 0.4000 (n=5)
  ```
- Suite: **332 passed, 1 skipped**.

## Note on backfilling the pilots

Both pilot records are repairable, but their sealed split is only **5 tasks** (SE ≈ 0.24), and the two pilots disagree in *sign* on the same 5 tasks (+0.2 and −0.2) purely from noise. So once backfilled the page will show two contradictory pilot rows. That is a faithful rendering of what those runs measured — the tier's own description says its rewards are not comparable — but it should not be read as a capability signal. The `full` tier's 639-task split is the one to read.

Signed-off-by: Eran Raichstein <eranra@il.ibm.com>