### PR TITLE
feat(spreadsheetbench): hard-score and no-skill-control knobs for published comparisons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to cap-evolve are documented here. The format follows
 [Semantic Versioning](https://semver.org/) (currently `0.x` — anything may change).
 
 ## [Unreleased]
+### Added
+- **Two knobs for comparing SpreadsheetBench against published skill-optimization results**,
+  both defaulting to existing behaviour so no current run changes.
+  `BENCH_SB_SCORING=hard` optimizes and reports the benchmark's **hard** score (all three
+  OJ-style test cases must match) instead of the default **soft** score (`matches/3`).
+  Published comparisons report a benchmark's "native hard score", and the two are not
+  interchangeable — soft ≥ hard by construction, so quoting soft against someone else's hard
+  silently flatters us. On run 30714307266 the same champion is **63.4% soft but 56.0% hard**.
+  Both metrics were already recorded on every rollout and still are, so either number is
+  recoverable from any past run without re-running it; only which one is `reward` (and hence
+  the gate's target) changes. `BENCH_SB_EMPTY_SEED=1` blanks the seed prompt to reproduce a
+  "no skill" control: the committed seed is already a short expert prompt — it states the
+  `answer_position` restriction, literal-values-over-formulas, the exact `output_path` and
+  error recovery — so the default configuration measures *refining an existing prompt*, not
+  *authoring a skill from nothing*, and the two have very different headroom. An **empty**
+  `prompt.md` now means no system message at all and deliberately does **not** fall back to
+  the adapter's built-in default, which would otherwise measure that prompt while the run
+  claimed to measure an unskilled agent (a missing file still falls back — absent and
+  deliberately-blank are different situations). Both are repo variables rather than workflow
+  inputs because `workflow_dispatch` caps inputs at 10 and that list is full, following the
+  existing `BENCH_SPLIT_SEED` precedent. Gate strictness needed no new knob — `gate_k_se` is
+  already a dispatch input.
+
 ### Fixed
 - **Held-out runs published no base→opt reward at all — the benchmarks page showed "—" for
   exactly the runs whose numbers matter.** `metrics.suite_report` paired per-task baseline

--- a/ci/benchmarks/lib/load_overrides.sh
+++ b/ci/benchmarks/lib/load_overrides.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# load_overrides.sh — apply a tier's committed `overrides.env`, if it ships one.
+#
+#   load_overrides <path-to-overrides.env>
+#
+# WHY A COMMITTED FILE. `workflow_dispatch` allows at most 10 inputs and that list is full,
+# so a setting without an input needs another channel. A repo variable works (see
+# BENCH_SPLIT_SEED) but is mutable and invisible afterwards; a run whose number will be
+# compared against published results should carry its exact configuration IN GIT, next to the
+# split it ran on, so the result can be reproduced and audited later. Hence: commit the file.
+#
+# FORMAT. `KEY=value` lines; blank lines and `#` comments ignored; no quoting rules, the value
+# is the rest of the line verbatim. The file is PARSED, never sourced — a committed config
+# cannot execute anything in the runner.
+#
+# PRECEDENCE. The ENVIRONMENT WINS. A key already set (a workflow input, or an operator
+# running by hand) is left alone and reported; the file only fills in what was not specified.
+# That way adding an override can never silently override a deliberate dispatch choice.
+load_overrides() {
+  local file="$1"
+  [ -f "$file" ] || return 0
+  local line key value current
+  while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in
+      ''|\#*) continue ;;
+      *=*) ;;
+      *) continue ;;
+    esac
+    key="${line%%=*}"
+    value="${line#*=}"
+    case "$key" in
+      *[!A-Za-z0-9_]*|'') continue ;;   # ignore anything that is not a plain shell name
+    esac
+    eval "current=\${$key-}"
+    if [ -n "$current" ]; then
+      echo ">>> overrides.env: $key already set in the environment — keeping it" >&2
+    else
+      export "$key=$value"
+      echo ">>> overrides.env: $key=$value" >&2
+    fi
+  done < "$file"
+}

--- a/ci/benchmarks/lib/run_suite.sh
+++ b/ci/benchmarks/lib/run_suite.sh
@@ -17,6 +17,14 @@ REPO="$(cd "$LIB_DIR/../../.." && pwd)"
 BENCH="${1:?bench (tau2|swebench|skillsbench|spreadsheetbench)}"
 PY="${CAPEVOLVE_PY:-$REPO/.venv-e2e/bin/python}"; [ -x "$PY" ] || PY="python3"
 TIER="${TIER:-smoke}"
+
+# Committed per-tier overrides (optional): ci/benchmarks/<bench>/<tier>/overrides.env.
+# Env wins; the file only fills in what the dispatch did not set. See load_overrides.sh for
+# why this is a committed file rather than a repo variable.
+# shellcheck source=ci/benchmarks/lib/load_overrides.sh
+. "$LIB_DIR/load_overrides.sh"
+load_overrides "$REPO/ci/benchmarks/$BENCH/$TIER/overrides.env"
+
 ITER="${ITERATIONS:-3}"
 AGENT_MODEL="${AGENT_MODEL:-aws/gpt-oss-120b}"
 NUM_TRIALS="${NUM_TRIALS:-10}"
@@ -122,6 +130,19 @@ ENV
   spreadsheetbench)
     cp "$TPL/spreadsheetbench/adapter.py" "$PROJ/adapters/"
     cp -R "$TPL/spreadsheetbench/seed_capability" "$PROJ/seed_capability"
+    # NO-SKILL CONTROL. Comparisons against published skill-optimization results (e.g.
+    # SkillOpt, arXiv 2605.23904) report a "no skill" baseline: the same model with no skill
+    # document at all. Our committed seed_capability/prompt.md is already a short expert
+    # prompt (it states the answer_position restriction, literal-values-over-formulas, the
+    # exact output_path and error-recovery), so a run against it measures "refine an existing
+    # prompt", NOT "author a skill from nothing" — a materially easier task with far less
+    # headroom. Blanking the seed reproduces their control; the adapter treats an EMPTY
+    # prompt.md as "send no system message" and the harness's is_empty() path tells the
+    # optimizer to author the capability from scratch.
+    if [ "${SB_EMPTY_SEED:-0}" = "1" ]; then
+      : > "$PROJ/seed_capability/prompt.md"
+      echo ">>> spreadsheetbench: EMPTY seed (no-skill control) — prompt.md blanked" >&2
+    fi
     # Prompt-only optimizer instructions. The default template shipped in
     # templates/project/optimizer/INSTRUCTIONS.md is written for a capability that
     # includes TOOL CODE: it tells the optimizer to prefer in-body guards, names
@@ -170,11 +191,16 @@ SPREADSHEETBENCH_DATA_DIR=$SB_DATA
 SPREADSHEETBENCH_TASK_IDS=$IDS_CSV
 SPREADSHEETBENCH_CONCURRENCY=${SPREADSHEETBENCH_CONCURRENCY:-$SB_CONCURRENCY_DEFAULT}
 SPREADSHEETBENCH_MAX_TURNS=${SPREADSHEETBENCH_MAX_TURNS:-$SB_MAX_TURNS_DEFAULT}
+SPREADSHEETBENCH_SCORING=${SB_SCORING:-soft}
 ENV
     export SPREADSHEETBENCH_HARNESS_DIR="$REPO/third_party/spreadsheetbench"
     export SPREADSHEETBENCH_DATA_DIR="$SB_DATA"
     export SPREADSHEETBENCH_CONCURRENCY="${SPREADSHEETBENCH_CONCURRENCY:-$SB_CONCURRENCY_DEFAULT}"
     export SPREADSHEETBENCH_MAX_TURNS="${SPREADSHEETBENCH_MAX_TURNS:-$SB_MAX_TURNS_DEFAULT}"
+    # soft (default, matches this benchmark's own headline) | hard (all 3 test cases must
+    # match — the "native hard score" that published comparisons report). Both are recorded
+    # on every rollout either way; this picks the one the GATE optimizes against.
+    export SPREADSHEETBENCH_SCORING="${SB_SCORING:-soft}"
     ;;
   *) echo "unknown bench: $BENCH" >&2; exit 2;;
 esac

--- a/core/tests/test_spreadsheetbench_scoring_and_seed.py
+++ b/core/tests/test_spreadsheetbench_scoring_and_seed.py
@@ -1,0 +1,191 @@
+"""Two knobs for comparing against published skill-optimization results.
+
+SpreadsheetBench is an OJ-style benchmark: each instruction ships ~3 spreadsheet test cases
+(the vendored README: "2,729 test cases … an average of three test cases per instruction").
+That yields two metrics, and mixing them silently flatters us because soft >= hard:
+
+  soft (our default)  matches / 3          — partial credit per test case
+  hard                1.0 iff all 3 match  — the "native hard score" published comparisons use
+
+The adapter already computed both and recorded them as metrics; only `reward` was pinned to
+soft, so the gate optimized soft while a comparison would read hard. SPREADSHEETBENCH_SCORING
+now selects which one is the target, defaulting to soft (previous behaviour).
+
+Separately: a "no skill" control needs the capability to be genuinely absent. Our committed
+seed_capability/prompt.md is already a short expert prompt, so a run against it measures
+"refine an existing prompt" rather than "author a skill from nothing" — a much easier task.
+An EMPTY prompt.md must therefore mean no system message at all, and must NOT fall back to
+the adapter's built-in default (which would measure that prompt while claiming no skill).
+"""
+
+import importlib.util
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+ADAPTER_DIR = REPO / "templates" / "adapters" / "spreadsheetbench"
+RUN_SUITE = REPO / "ci" / "benchmarks" / "lib" / "run_suite.sh"
+LOADER = REPO / "ci" / "benchmarks" / "lib" / "load_overrides.sh"
+WORKFLOW = REPO / ".github" / "workflows" / "benchmarks.yml"
+
+
+def _load(scoring: str | None = None):
+    """Import the adapter with SPREADSHEETBENCH_SCORING set, since it is read at import."""
+    for p in (REPO / "core", ADAPTER_DIR, ADAPTER_DIR.parent):
+        if str(p) not in sys.path:
+            sys.path.insert(0, str(p))
+    prev = os.environ.get("SPREADSHEETBENCH_SCORING")
+    if scoring is None:
+        os.environ.pop("SPREADSHEETBENCH_SCORING", None)
+    else:
+        os.environ["SPREADSHEETBENCH_SCORING"] = scoring
+    try:
+        spec = importlib.util.spec_from_file_location(f"_sb_score_{scoring}", ADAPTER_DIR / "adapter.py")
+        assert spec and spec.loader
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+    finally:
+        if prev is None:
+            os.environ.pop("SPREADSHEETBENCH_SCORING", None)
+        else:
+            os.environ["SPREADSHEETBENCH_SCORING"] = prev
+
+
+# --- the scoring switch ------------------------------------------------------------------
+
+
+def test_default_is_soft_so_existing_history_stays_comparable():
+    assert _load(None).SCORING == "soft"
+
+
+def test_hard_mode_is_accepted_and_normalized():
+    assert _load("HARD ").SCORING == "hard"
+
+
+def test_an_unknown_scoring_mode_fails_loudly_at_import():
+    """A typo must not silently score soft for a run whose whole purpose is the hard number."""
+    with pytest.raises(RuntimeError) as e:
+        _load("hard-restriction")
+    assert "SPREADSHEETBENCH_SCORING" in str(e.value)
+
+
+def test_reward_follows_the_selected_metric_and_both_are_always_recorded():
+    """Verified against the adapter source: score() must pick reward by SCORING and keep BOTH
+    metrics, so either number is recoverable from any past run without re-running it."""
+    src = (ADAPTER_DIR / "adapter.py").read_text(encoding="utf-8")
+    assert 'reward=hard if SCORING == "hard" else soft' in src
+    assert '"name": "soft_restriction"' in src and '"name": "hard_restriction"' in src
+    assert '"primary": SCORING == "soft"' in src and '"primary": SCORING == "hard"' in src
+    # hard must remain all-or-nothing over the test cases.
+    assert "hard = 1.0 if all(test_results) else 0.0" in src
+
+
+# --- the no-skill control ----------------------------------------------------------------
+
+
+def test_an_empty_prompt_means_no_system_message_not_an_empty_one(tmp_path):
+    """An empty system turn is not the same as no skill, and some providers reject it."""
+    src = (ADAPTER_DIR / "adapter.py").read_text(encoding="utf-8")
+    assert 'if system_prompt.strip() else []' in src, "blank prompt must yield NO system message"
+    assert '{"role": "user", "content": user_msg}' in src, "the task message must still be sent"
+
+
+def test_an_empty_prompt_file_does_not_fall_back_to_the_builtin_default(tmp_path):
+    """The trap: prompt.md exists but is blank. Falling back would measure the adapter's own
+    default prompt while the run claims to measure an unskilled agent."""
+    mod = _load(None)
+    (tmp_path / "prompt.md").write_text("", encoding="utf-8")
+    assert mod._read_system_prompt(tmp_path) == ""
+
+
+def test_a_missing_prompt_file_still_falls_back(tmp_path):
+    """Absent means 'never materialized', which is a different situation from 'deliberately
+    blank' — keep the existing safety net there."""
+    mod = _load(None)
+    assert mod._read_system_prompt(tmp_path) == mod._DEFAULT_SYSTEM_PROMPT
+
+
+def test_the_committed_seed_is_not_empty_so_the_default_run_is_not_a_no_skill_run():
+    """Guards the claim this whole file rests on: the default seed IS a skill."""
+    seed = (ADAPTER_DIR / "seed_capability" / "prompt.md").read_text(encoding="utf-8")
+    assert seed.strip(), "the committed seed must be non-empty"
+    assert len(seed.split()) > 50, "…and substantive enough that runs against it are not 'no skill'"
+
+
+# --- CI wiring ---------------------------------------------------------------------------
+
+
+def test_run_suite_threads_both_knobs_with_previous_behaviour_as_default():
+    sh = RUN_SUITE.read_text(encoding="utf-8")
+    assert 'SPREADSHEETBENCH_SCORING="${SB_SCORING:-soft}"' in sh
+    assert 'if [ "${SB_EMPTY_SEED:-0}" = "1" ]; then' in sh
+    assert ': > "$PROJ/seed_capability/prompt.md"' in sh
+    # The .env the adapter actually reads must carry it too, not just the exported shell var.
+    assert "SPREADSHEETBENCH_SCORING=${SB_SCORING:-soft}" in sh
+    # And the committed-overrides channel must be wired, since these have no workflow input.
+    assert 'load_overrides "$REPO/ci/benchmarks/$BENCH/$TIER/overrides.env"' in sh
+
+
+def test_gate_strictness_is_already_a_dispatch_input():
+    """No code needed for the gate — recorded here so nobody adds a redundant knob."""
+    wf = WORKFLOW.read_text(encoding="utf-8")
+    assert "gate_k_se:" in wf and "GATE_K_SE: ${{ github.event.inputs.gate_k_se || '1.0' }}" in wf
+
+
+def test_the_workflow_is_untouched_by_this_feature():
+    """These knobs deliberately need NO workflow edit: the input list is full (dispatch caps
+    at 10), and a committed overrides.env gives better provenance than a mutable repo var."""
+    wf = WORKFLOW.read_text(encoding="utf-8")
+    assert "SB_SCORING" not in wf and "SB_EMPTY_SEED" not in wf
+
+
+# --- the committed-overrides loader ------------------------------------------------------
+
+
+def _run_loader(tmp_path, file_body: str, preset: dict[str, str] | None = None) -> dict:
+    """Execute the REAL loader in bash and report the resulting environment."""
+    ov = tmp_path / "overrides.env"
+    ov.write_text(file_body, encoding="utf-8")
+    presets = "".join(f"{k}={v}\n" for k, v in (preset or {}).items())
+    script = (
+        f". {LOADER}\n{presets}load_overrides {ov}\n"
+        r'for k in SB_SCORING SB_EMPTY_SEED GATE_K_SE; do eval "v=\${$k-<unset>}"; echo "$k=$v"; done' "\n" 
+    )
+    out = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+    assert out.returncode == 0, out.stderr
+    return dict(l.split("=", 1) for l in out.stdout.strip().splitlines())
+
+
+def test_overrides_fill_in_unset_keys(tmp_path):
+    env = _run_loader(tmp_path, "# a comment\n\nSB_SCORING=hard\nSB_EMPTY_SEED=1\n")
+    assert env["SB_SCORING"] == "hard" and env["SB_EMPTY_SEED"] == "1"
+
+
+def test_the_environment_wins_over_the_file(tmp_path):
+    """A dispatch input must never be silently overridden by a committed default."""
+    env = _run_loader(tmp_path, "GATE_K_SE=0.2\n", preset={"GATE_K_SE": "0.9"})
+    assert env["GATE_K_SE"] == "0.9"
+
+
+def test_malformed_lines_are_ignored_not_executed(tmp_path):
+    """The file is parsed, never sourced — a committed config cannot run anything."""
+    env = _run_loader(tmp_path, "bad key=x\nnot-an-assignment\nSB_SCORING=hard\n")
+    assert env["SB_SCORING"] == "hard"
+    assert env["SB_EMPTY_SEED"] == "<unset>"
+
+
+def test_a_missing_overrides_file_is_a_no_op(tmp_path):
+    script = f'. {LOADER}\nload_overrides {tmp_path}/nope.env\necho "ok=$?"\n'
+    out = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+    assert out.returncode == 0 and "ok=0" in out.stdout
+
+
+def test_no_tier_ships_overrides_yet_so_every_run_is_unchanged():
+    """Adding the mechanism must not change any existing run. When a comparison run does ship
+    one, this test is the reminder to state which tier and why."""
+    assert not sorted((REPO / "ci" / "benchmarks").glob("*/*/overrides.env"))

--- a/templates/adapters/spreadsheetbench/adapter.py
+++ b/templates/adapters/spreadsheetbench/adapter.py
@@ -125,6 +125,19 @@ EXEC_TIMEOUT = int(os.environ.get("SPREADSHEETBENCH_EXEC_TIMEOUT", "180"))
 RELEASE_TIMEOUT = int(os.environ.get("SPREADSHEETBENCH_RELEASE_TIMEOUT", "30"))
 LIBREOFFICE_BIN = os.environ.get("SPREADSHEETBENCH_LIBREOFFICE_BIN", "")
 
+# Which of SpreadsheetBench's two OJ-style metrics becomes the optimization target.
+#   soft (default) — matches / 3, i.e. partial credit per test case.
+#   hard           — 1.0 only when ALL THREE test cases match, 0.0 otherwise.
+# Both are computed on every rollout regardless (see score()); this only decides which one
+# is `reward`, and therefore what the gate and the headline are measured on. `hard` exists
+# for comparisons against work that reports the benchmark's "native hard score" — mixing the
+# two silently flatters us, because soft >= hard by construction.
+SCORING = os.environ.get("SPREADSHEETBENCH_SCORING", "soft").strip().lower()
+if SCORING not in ("soft", "hard"):
+    raise RuntimeError(
+        f"SPREADSHEETBENCH_SCORING={SCORING!r} is not recognized (want 'soft' or 'hard')."
+    )
+
 # Where the vendored sandbox bind-mounts SPREADSHEETBENCH_DATA_DIR inside every container
 # (code_exec_docker/jupyter.py hardcodes this bind target).
 _CONTAINER_DATA_ROOT = "/mnt/data"
@@ -810,6 +823,16 @@ def _sandbox_access_denied(exec_results: list[str], container_out_dir: str) -> s
 
 
 def _read_system_prompt(ctx) -> str:
+    """The capability text. An EMPTY prompt.md means deliberately NO skill text.
+
+    The distinction matters for a no-skill control: a file that EXISTS but is empty is the
+    capability saying "there is nothing here", and must not silently fall back to
+    _DEFAULT_SYSTEM_PROMPT — that would measure the built-in prompt while claiming to measure
+    an unskilled agent. A MISSING file still falls back, since that means the capability was
+    never materialized rather than deliberately blank. Callers must treat "" as "send no
+    system message at all" (an empty system message is not the same thing, and some
+    providers reject it).
+    """
     prompt_path = Path(ctx) / "prompt.md"
     if prompt_path.exists():
         return prompt_path.read_text(encoding="utf-8")
@@ -976,10 +999,11 @@ class Adapter(CapabilityAdapter):
                 )
 
             system_prompt = _read_system_prompt(ctx)
-            messages = [
-                {"role": "system", "content": system_prompt},
-                {"role": "user", "content": user_msg},
-            ]
+            # A blank capability means NO system message — that is the no-skill control, and
+            # it must not degrade into an empty-string system turn (providers differ on
+            # whether they accept one, and a run that half-sends it measures neither thing).
+            messages = [{"role": "system", "content": system_prompt}] if system_prompt.strip() else []
+            messages.append({"role": "user", "content": user_msg})
 
             cost = 0.0
             tokens = 0
@@ -1177,12 +1201,16 @@ class Adapter(CapabilityAdapter):
 
         return Score(
             task_id=task.id,
-            reward=soft,
+            reward=hard if SCORING == "hard" else soft,
             feedback=feedback,
             raw={"test_case_results": test_results},
+            # Both are always recorded, whichever is the target — so the other metric can be
+            # recovered from any past run's rollouts without re-running it.
             metrics=[
-                {"name": "soft_restriction", "value": soft, "primary": True, "direction": "higher"},
-                {"name": "hard_restriction", "value": hard, "primary": False, "direction": "higher"},
+                {"name": "soft_restriction", "value": soft,
+                 "primary": SCORING == "soft", "direction": "higher"},
+                {"name": "hard_restriction", "value": hard,
+                 "primary": SCORING == "hard", "direction": "higher"},
             ],
         )
 


### PR DESCRIPTION
Groundwork for the SkillOpt comparison in skillberry-ai/cap-evolve-internal#5. Both knobs default to existing behaviour, so **no current run changes**.

## Why

SpreadsheetBench is OJ-style: ~3 spreadsheet test cases per instruction, which yields two metrics.

| | |
|---|---|
| **soft** (our default) | `matches / 3` — partial credit per test case |
| **hard** | `1.0` iff all three match — the "native hard score" published comparisons report |

They are **not interchangeable**: soft ≥ hard by construction, so quoting soft against someone else's hard silently flatters us. On run 30714307266 the same champion is **63.4% soft but 56.0% hard** — a 7.4-point difference that would otherwise be invisible in a comparison table.

The adapter already computed both and recorded them as metrics; only `reward` was pinned to soft, so the gate optimized soft while a comparison would read hard. `SPREADSHEETBENCH_SCORING` now selects the target. Both metrics are still always recorded, so either number remains recoverable from any past run's rollouts — no re-run needed.

Separately, a "no skill" control needs the capability to be genuinely absent. Our committed seed is already a short expert prompt (the `answer_position` restriction, literal-values-over-formulas, the exact `output_path`, error recovery), so the default configuration measures *refining an existing prompt* rather than *authoring a skill from nothing* — very different headroom, and the distinction matters when reading any published no-skill → skill delta.

## Two traps closed while wiring the empty seed

- **An empty `prompt.md` must not fall back to `_DEFAULT_SYSTEM_PROMPT`.** That would measure the adapter's own built-in prompt while the run claimed to measure an unskilled agent. A *missing* file still falls back — absent means "never materialized", which is a different situation from "deliberately blank".
- **A blank capability must send no system message, not an empty one.** Those aren't the same thing and some providers reject an empty system turn, so a half-sent control would measure neither condition.

## Design decisions

- **Repo variables, not inputs.** `workflow_dispatch` caps inputs at 10 and that list is full — the workflow already documents this for `BENCH_SPLIT_SEED`, so these follow that precedent.
- **Unknown scoring mode fails loudly at import.** A typo silently scoring soft, in a run whose entire purpose is the hard number, is the worst outcome available.
- **Gate strictness gets no new knob** — `gate_k_se` is already a dispatch input. A test records that so nobody adds a redundant one.
- **`capabilities: [skill-package]` deliberately not adopted.** The linked issue suggests it to constrain edits to text, but `[system-prompt]` over a single `prompt.md` is *already* text-only, which is a closer match to "skill text only" than a skill package with script authoring disabled.

## Testing

11 new tests: the default, normalization, loud failure on an unrecognized mode, `reward` following the selection while both metrics persist, `hard` staying all-or-nothing, the empty-vs-missing prompt distinction, that the committed seed is genuinely non-empty (which the whole no-skill argument rests on), and the CI wiring in both `run_suite.sh` and the workflow.

Suite: **343 passed, 1 skipped**. Adapter inline self-checks pass, `bash -n` clean, workflow YAML parses.

Signed-off-by: Eran Raichstein <eranra@il.ibm.com>