### PR TITLE
feat(spreadsheetbench): make the agent's job description optimizable, not frozen in code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ All notable changes to cap-evolve are documented here. The format follows
 
 ## [Unreleased]
 ### Added
+- **The agent's job description is optimizable capability text now, not frozen code.** On run
+  30714307266 the SpreadsheetBench agent read 359 words before starting a task: 144 in
+  `prompt.md` (optimizable) and **215 frozen in `adapter.py`** — so 60% of its instruction
+  surface could not be optimized. That frozen text is not boilerplate: it defines what
+  `instruction_type` means (Cell-Level = exact cells, Sheet-Level = the *maximum* range you may
+  modify), it defines the interaction contract, and it tells the agent **"once that file
+  exists, you are done"** — which is the precise behaviour behind that run's dominant failure
+  mode (40 of 91 val tasks produced an output file whose values were wrong). The one accepted
+  candidate added a *"verify before you save"* checklist to `prompt.md`, i.e. it was arguing
+  with a sentence it was not allowed to delete. Comparable published work optimizes a single
+  skill document which, in a Claude Code / Codex harness, covers this same ground, so freezing
+  it made our editable surface strictly smaller than what we were comparing against. A
+  capability may now ship `task_template.md`; absent, the built-in is used, so existing
+  capabilities are unchanged. Because a bad edit here would tell every rollout to write its
+  answer to a path it was never given, `live()` validates the placeholder contract **once per
+  evaluation** and rejects the candidate before any task runs — missing required placeholders,
+  invented ones (a `KeyError` on every task), and unbalanced braces are all fatal, while the
+  cosmetic `{max_turns}` may be dropped. The optimizer-facing contract is documented in an
+  HTML comment inside the file, which is stripped before the agent sees it.
 - **Two knobs for comparing SpreadsheetBench against published skill-optimization results**,
   both defaulting to existing behaviour so no current run changes.
   `BENCH_SB_SCORING=hard` optimizes and reports the benchmark's **hard** score (all three

--- a/core/tests/test_spreadsheetbench_task_template.py
+++ b/core/tests/test_spreadsheetbench_task_template.py
@@ -1,0 +1,171 @@
+"""The agent's job description is capability text now, not frozen code.
+
+Measured on run 30714307266, the agent read 359 words before starting a task: 144 in
+`prompt.md` (optimizable) and 215 frozen in `adapter.py` — so **60% of its instruction
+surface could not be optimized**. That frozen text is not boilerplate. It defines what
+`instruction_type` means (Cell-Level = exact cells, Sheet-Level = the MAXIMUM range you may
+modify), it defines the interaction contract, and it says:
+
+    "once that file exists, you are done."
+
+which tells the agent to stop as soon as it has written *any* output — the exact behaviour
+behind the run's dominant failure mode (40 of 91 val tasks produced an output file whose
+values were wrong). The one accepted candidate added a "verify before you save" checklist to
+prompt.md, i.e. it was arguing with a sentence it was not allowed to delete.
+
+Comparable published work (SkillOpt, arXiv 2605.23904) optimizes a single skill document
+which, in a Claude Code / Codex harness, covers this same ground — so freezing it made our
+editable surface strictly smaller than the thing we were comparing against.
+
+`task_template.md` is therefore capability text. The risk it introduces is that an edit can
+break the per-task placeholders, which would tell every rollout to write its answer to a path
+it was never given — so live() validates once per evaluation and rejects the candidate before
+any task runs.
+"""
+
+import importlib.util
+import string
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+ADAPTER_DIR = REPO / "templates" / "adapters" / "spreadsheetbench"
+SEED = ADAPTER_DIR / "seed_capability"
+
+
+def _adapter():
+    for p in (REPO / "core", ADAPTER_DIR, ADAPTER_DIR.parent):
+        if str(p) not in sys.path:
+            sys.path.insert(0, str(p))
+    spec = importlib.util.spec_from_file_location("_sb_tmpl", ADAPTER_DIR / "adapter.py")
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_FIELDS = dict(instruction="do a thing", spreadsheet_path="/mnt/data/x.xlsx",
+               spreadsheet_content="A1: 1", instruction_type="Cell-Level Manipulation",
+               answer_position="'S'!C2", output_path="/mnt/data/outputs/t/1_x_output.xlsx",
+               max_turns=30)
+
+
+# --- the seed ships an editable template -------------------------------------------------
+
+
+def test_the_seed_capability_ships_the_job_description_as_editable_text():
+    assert (SEED / "task_template.md").is_file()
+    assert (SEED / "prompt.md").is_file(), "the system prompt stays a separate artifact"
+
+
+def test_the_shipped_template_carries_every_required_placeholder():
+    mod = _adapter()
+    text = (SEED / "task_template.md").read_text(encoding="utf-8")
+    found = {f for _, f, _, _ in string.Formatter().parse(text) if f}
+    assert mod._TEMPLATE_REQUIRED <= found
+
+
+def test_the_shipped_template_still_renders_a_real_task():
+    mod = _adapter()
+    out = mod._read_task_template(SEED).format(**_FIELDS)
+    for v in ("/mnt/data/outputs/t/1_x_output.xlsx", "'S'!C2", "do a thing"):
+        assert v in out
+
+
+def test_the_optimizer_facing_comment_never_reaches_the_agent():
+    """The placeholder contract is documented inside the file; the agent must not see it."""
+    mod = _adapter()
+    raw = (SEED / "task_template.md").read_text(encoding="utf-8")
+    assert "LOAD-BEARING PLACEHOLDERS" in raw, "the contract must be stated where it is edited"
+    rendered = mod._read_task_template(SEED)
+    assert "LOAD-BEARING" not in rendered and "<!--" not in rendered
+
+
+def test_a_capability_without_a_template_falls_back_to_the_builtin(tmp_path):
+    """Older capabilities, and any other adapter user, must be unaffected."""
+    mod = _adapter()
+    assert mod._read_task_template(tmp_path) == mod._TASK_TEMPLATE
+
+
+# --- the guard: what a bad edit would otherwise do ---------------------------------------
+
+
+def _write(tmp_path, body: str) -> Path:
+    (tmp_path / "task_template.md").write_text(body, encoding="utf-8")
+    return tmp_path
+
+
+def test_a_dropped_placeholder_is_rejected_before_any_task_runs(tmp_path):
+    """Without this, every rollout is told to write its answer to a path it never got."""
+    mod = _adapter()
+    ctx = _write(tmp_path, "Do {instruction} on {spreadsheet_path}. {spreadsheet_content} "
+                           "{instruction_type} {answer_position}\n")   # no {output_path}
+    with pytest.raises(RuntimeError) as e:
+        mod._validate_task_template(ctx)
+    msg = str(e.value)
+    assert "{output_path}" in msg and "missing required placeholder" in msg
+    assert "no task was run" in msg
+
+
+def test_an_unknown_placeholder_is_rejected(tmp_path):
+    """An invented field raises KeyError inside str.format on every single task."""
+    mod = _adapter()
+    body = "{instruction} {spreadsheet_path} {spreadsheet_content} {instruction_type} " \
+           "{answer_position} {output_path} {sheet_name}\n"
+    with pytest.raises(RuntimeError) as e:
+        mod._validate_task_template(_write(tmp_path, body))
+    assert "unknown placeholder" in str(e.value) and "{sheet_name}" in str(e.value)
+
+
+def test_unbalanced_braces_are_rejected_with_the_doubling_rule(tmp_path):
+    mod = _adapter()
+    body = "{instruction} {spreadsheet_path} {spreadsheet_content} {instruction_type} " \
+           "{answer_position} {output_path} then write {\n"
+    with pytest.raises(RuntimeError) as e:
+        mod._validate_task_template(_write(tmp_path, body))
+    assert "not a valid format string" in str(e.value)
+
+
+def test_dropping_the_cosmetic_turn_budget_is_allowed(tmp_path):
+    """{max_turns} only tells the agent its round budget — the optimizer may restructure it
+    away without breaking anything, so the guard must not be gratuitously strict."""
+    mod = _adapter()
+    body = "{instruction} {spreadsheet_path} {spreadsheet_content} {instruction_type} " \
+           "{answer_position} {output_path}\n"
+    ctx = _write(tmp_path, body)
+    mod._validate_task_template(ctx)                      # must not raise
+    assert mod._read_task_template(ctx).format(**_FIELDS)  # and still renders
+
+
+def test_a_rewritten_template_is_accepted_which_is_the_whole_point(tmp_path):
+    """The optimizer must be free to delete 'once that file exists, you are done'."""
+    mod = _adapter()
+    body = ("Task: {instruction}\nFile: {spreadsheet_path}\nPreview: {spreadsheet_content}\n"
+            "Kind: {instruction_type}\nCells you may touch: {answer_position}\n"
+            "Write to: {output_path}\nVERIFY your values before saving. Do NOT stop merely "
+            "because a file exists.\n")
+    ctx = _write(tmp_path, body)
+    mod._validate_task_template(ctx)
+    out = mod._read_task_template(ctx).format(**_FIELDS)
+    assert "Do NOT stop merely because a file exists" in out
+    assert "once that file exists, you are done" not in out
+
+
+# --- wiring --------------------------------------------------------------------------------
+
+
+def test_live_validates_and_run_target_uses_the_capability_template():
+    src = (ADAPTER_DIR / "adapter.py").read_text(encoding="utf-8")
+    assert "_validate_task_template(candidate_dir)" in src, "live() must validate"
+    assert "def live(self, candidate_dir)" in src
+    assert "user_msg = _read_task_template(ctx).format(" in src, "run_target must use it"
+    assert "_TASK_TEMPLATE.format(" not in src, "the frozen template must no longer be used directly"
+
+
+def test_live_validates_once_per_evaluation_not_once_per_task():
+    """91 (or 639) identical failures is not a useful way to learn the template is broken."""
+    src = (ADAPTER_DIR / "adapter.py").read_text(encoding="utf-8")
+    run_target = src.split("def run_target(", 1)[1]
+    assert "_validate_task_template" not in run_target.split("def score(", 1)[0]

--- a/templates/adapters/spreadsheetbench/adapter.py
+++ b/templates/adapters/spreadsheetbench/adapter.py
@@ -45,11 +45,16 @@ SETUP:
 
   8. Run: cap-evolve check && cap-evolve run
 
-WHAT THIS OPTIMIZES:
-  - The spreadsheet agent's system prompt (prompt.md in the seed capability).
-  - The prompt guides HOW the agent reads instructions, respects answer_position, and
-    writes results — the task-specific scaffold (instruction/paths/preview/rounds
-    protocol) is fixed, not optimizable.
+WHAT THIS OPTIMIZES — ALL the text the agent reads, in two files:
+  - prompt.md         the system prompt: who the agent is, how it should work.
+  - task_template.md  the per-task user message: how the job is framed, what the fields
+                      mean, and the interaction contract. Optional — no file falls back to
+                      the built-in _TASK_TEMPLATE, so older capabilities are unaffected.
+  Keeping the job description frozen in this file used to leave ~60% of the agent's
+  instruction surface un-optimizable, including the line "once that file exists, you are
+  done" — which encourages exactly the dominant failure (a wrong-but-present output file).
+  Per-task VALUES (instruction, paths, preview, answer_position) are still supplied by the
+  adapter through placeholders that live() validates; see _validate_task_template.
 
 HOW IT WORKS:
   - tasks()       → loads all SpreadsheetBench instances from the fetched dataset.json.
@@ -95,6 +100,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import string
 import shutil
 import signal
 import socket
@@ -104,6 +110,7 @@ import tempfile
 import threading
 import time
 import uuid
+from contextlib import contextmanager
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -822,6 +829,71 @@ def _sandbox_access_denied(exec_results: list[str], container_out_dir: str) -> s
 # ---------------------------------------------------------------------------
 
 
+_TEMPLATE_COMMENT_RE = re.compile(r"<!--.*?-->\s*", re.DOTALL)
+# Filled in per task, so they must survive any edit the optimizer makes. {max_turns} is
+# cosmetic (it only tells the agent its round budget) and may be dropped.
+_TEMPLATE_REQUIRED = frozenset({
+    "instruction", "spreadsheet_path", "spreadsheet_content",
+    "instruction_type", "answer_position", "output_path",
+})
+_TEMPLATE_OPTIONAL = frozenset({"max_turns"})
+
+
+def _read_task_template(ctx) -> str:
+    """The agent's first user message, as editable capability text.
+
+    Previously this lived only in _TASK_TEMPLATE, i.e. frozen in the adapter — so ~60% of the
+    text the agent reads (the field semantics, the interaction contract, and the line "once
+    that file exists, you are done") could not be optimized, while the thing it most needs to
+    fix — writing a wrong-but-present output file — is exactly what that line encourages.
+    Comparable published work optimizes a single skill document that covers this same ground,
+    so keeping it frozen made our editable surface strictly smaller than theirs.
+
+    A capability that ships `task_template.md` overrides the built-in; the leading HTML
+    comment (which documents the placeholder contract for the optimizer) is stripped so the
+    agent never sees it. No file ⇒ the built-in, so older capabilities are unaffected.
+    """
+    path = Path(ctx) / "task_template.md"
+    if not path.exists():
+        return _TASK_TEMPLATE
+    return _TEMPLATE_COMMENT_RE.sub("", path.read_text(encoding="utf-8"), count=1).strip() + "\n"
+
+
+def _validate_task_template(ctx) -> None:
+    """Reject a candidate whose template broke the placeholder contract, BEFORE any task runs.
+
+    Called from live(), so this costs one check per evaluation instead of discovering the
+    breakage as N failed rollouts. Both directions are fatal: a MISSING required placeholder
+    means the agent is never told (say) where to write its answer, and an UNKNOWN one raises
+    KeyError inside str.format on every single task.
+    """
+    path = Path(ctx) / "task_template.md"
+    if not path.exists():
+        return
+    text = _read_task_template(ctx)
+    try:
+        found = {f for _, f, _, _ in string.Formatter().parse(text) if f}
+    except ValueError as e:  # unbalanced braces — a literal brace must be doubled
+        raise RuntimeError(
+            f"task_template.md is not a valid format string ({e}). A literal brace must be "
+            f"written as {{{{ or }}}}."
+        ) from e
+    missing = sorted(_TEMPLATE_REQUIRED - found)
+    unknown = sorted(found - _TEMPLATE_REQUIRED - _TEMPLATE_OPTIONAL)
+    if missing or unknown:
+        problems = []
+        if missing:
+            problems.append(f"missing required placeholder(s): {', '.join('{%s}' % m for m in missing)}")
+        if unknown:
+            problems.append(f"unknown placeholder(s): {', '.join('{%s}' % u for u in unknown)}")
+        raise RuntimeError(
+            "task_template.md broke the placeholder contract — " + "; ".join(problems)
+            + f". Required: {', '.join('{%s}' % r for r in sorted(_TEMPLATE_REQUIRED))}"
+            + f" · optional: {', '.join('{%s}' % o for o in sorted(_TEMPLATE_OPTIONAL))}."
+            + " The edit is rejected; no task was run against it."
+        )
+
+
 def _read_system_prompt(ctx) -> str:
     """The capability text. An EMPTY prompt.md means deliberately NO skill text.
 
@@ -947,6 +1019,17 @@ class Adapter(CapabilityAdapter):
             tasks, n_trials=n_trials, base_seed=base_seed, max_workers=CONCURRENCY,
         )
 
+    @contextmanager
+    def live(self, candidate_dir):
+        """Validate the candidate's editable job description ONCE, then run against it.
+
+        live() is entered once per evaluation, so a template that broke the placeholder
+        contract fails here — loudly, with the reason — instead of surfacing as N rollouts
+        that were each told to write their answer to a path they were never given.
+        """
+        _validate_task_template(candidate_dir)
+        yield candidate_dir
+
     def run_target(self, task: Task, ctx, *, seed: int = 0) -> Rollout:
         """Multi-round CodeAct loop for one task, then replay onto test cases 2 and 3."""
         # Bound before the try so the finally can release the container on EVERY exit path —
@@ -979,7 +1062,7 @@ class Adapter(CapabilityAdapter):
 
             input_file = _resolve_case_file(local_dir, 1, sid, "input")
             preview = _spreadsheet_preview(input_file, PREVIEW_ROWS)
-            user_msg = _TASK_TEMPLATE.format(
+            user_msg = _read_task_template(ctx).format(
                 instruction=entry["instruction"],
                 spreadsheet_path=f"{container_dir}/{input_file.name}",
                 spreadsheet_content=preview,

--- a/templates/adapters/spreadsheetbench/seed_capability/task_template.md
+++ b/templates/adapters/spreadsheetbench/seed_capability/task_template.md
@@ -1,0 +1,46 @@
+<!--
+  THE AGENT'S JOB DESCRIPTION — editable capability text, same as prompt.md.
+
+  Everything below is sent to the agent as its first user message, so it is part of the
+  skill you are optimizing: reword it, restructure it, add or remove guidance, change the
+  interaction contract. This comment block is STRIPPED before the agent sees it.
+
+  LOAD-BEARING PLACEHOLDERS — these are filled in per task and must SURVIVE any edit:
+    {instruction} {spreadsheet_path} {spreadsheet_content} {instruction_type}
+    {answer_position} {output_path}
+  Optional: {max_turns}. No other {braces} are allowed.
+
+  If a required placeholder goes missing, or an unknown one appears, the candidate is
+  REJECTED before any task runs — the agent would otherwise be told to write its answer to
+  a path it was never given. A literal brace must be doubled: {{ or }}.
+-->
+You need to solve the following spreadsheet manipulation question. It contains six pieces of information:
+- instruction: the question about spreadsheet manipulation.
+- spreadsheet_path: the path of the spreadsheet file you need to manipulate.
+- spreadsheet_content: the first few rows of the content of the spreadsheet file.
+- instruction_type: Cell-Level Manipulation (answer_position is exact cell(s)) or Sheet-Level Manipulation (answer_position is the maximum range you may modify).
+- answer_position: the cell(s)/range you must modify or fill in.
+- output_path: write the modified spreadsheet file to this exact path.
+
+### instruction
+{instruction}
+
+### spreadsheet_path
+{spreadsheet_path}
+
+### spreadsheet_content
+{spreadsheet_content}
+
+### instruction_type
+{instruction_type}
+
+### answer_position
+{answer_position}
+
+### output_path
+{output_path}
+
+You have up to {max_turns} rounds of interaction. In each round, reply with exactly ONE python code block:
+1. Information-gathering code (e.g. inspecting the file) — the execution result is returned to you.
+2. Final solution code that writes the modified file to output_path — once that file exists, you are done.
+If your code raises an error, the traceback will be returned to you; fix the code and try again.


### PR DESCRIPTION
## The finding

Measured on run 30714307266, the agent read **359 words** before starting a task:

```
prompt.md          144 words   OPTIMIZABLE
_TASK_TEMPLATE     176 words   frozen in adapter.py
_NO_CODE_REMINDER   39 words   frozen in adapter.py
                   ─────────
frozen             215 words   60%
```

So **60% of the agent's instruction surface could not be optimized** — and it isn't boilerplate. It defines what `instruction_type` means (Cell-Level = exact cells, Sheet-Level = the *maximum* range you may modify), it defines the interaction contract, and it says:

> **"once that file exists, you are done."**

That tells the agent to stop the moment it has written *any* output file, which is precisely that run's dominant failure mode: **40 of 91 val tasks produced an output file whose values were wrong**, and **0** failed to produce a file. The single accepted candidate added a *"verify before you save"* checklist to `prompt.md` — it was arguing with a sentence it had no permission to delete.

It also made the comparison unfair to us: SkillOpt optimizes one natural-language skill document which, in a Claude Code / Codex harness, is *all* the text above the raw task. It could rewrite the equivalent of both files; we could rewrite one.

## The change

A capability may now ship `task_template.md` next to `prompt.md`. Absent ⇒ the built-in is used, so existing capabilities and any other adapter user are unaffected.

## The risk, and the guard

A bad edit here fails in the worst possible way: drop `{output_path}` and every rollout is told to write its answer to a path it was never given — which looks like a capability regression, not a broken template. So `live()` — entered once per evaluation, **before any rollout** — validates the contract and rejects the candidate with the reason.

| | |
|---|---|
| missing required placeholder | **fatal** |
| invented placeholder (`KeyError` on every task) | **fatal** |
| unbalanced braces | **fatal**, with the doubling rule in the message |
| dropping cosmetic `{max_turns}` | allowed |
| any rewording / restructuring | allowed — the whole point |

The contract is documented in an HTML comment *inside the file*, stripped before the agent sees it, so the optimizer reads it exactly where it's editing.

## Testing

12 new tests, plus an integration check that the guard fires through the real `harness._live()` path rather than only when called directly:

```
harness._live rejected it: task_template.md broke the placeholder contract —
  missing required placeholder(s): {answer_position}, {instruction_type}, …
```

Covered: the shipped template renders a real task; the optimizer-facing comment never reaches the agent; fallback when the file is absent; each rejection mode; `{max_turns}` may be dropped; a rewritten template that *deletes the stop-early line* is accepted; and validation happens per-evaluation, not per-task (639 identical failures is not a useful way to learn a template is broken).

Suite: **360 passed, 1 skipped**.

## What this is and isn't

It is still **text only** — no tools, no scoring access, no harness internals. It widens what the optimizer may improve *and* what it may damage, which is what the guard is for.

It **changes the harness**, so results are not comparable to run 30714307266 or to our earlier history. Runs using it should be labelled a new configuration rather than a continuation. It is a hypothesis about our ceiling, not a promise of a specific number: our sealed hard score is 52.0% and the partial-credit pool is worth at most +16 points, so this alone does not close a 28-point gap to published figures.

Signed-off-by: Eran Raichstein <eranra@il.ibm.com>