### PR TITLE
ci(spreadsheetbench): optimize and report the HARD score on the pilot and full tiers

### DIFF
--- a/ci/benchmarks/spreadsheetbench/full/overrides.env
+++ b/ci/benchmarks/spreadsheetbench/full/overrides.env
@@ -1,0 +1,16 @@
+# SpreadsheetBench — committed run configuration (see ci/benchmarks/lib/load_overrides.sh).
+#
+# Optimize and report the benchmark's HARD score: a task counts only when ALL THREE of its
+# OJ-style test cases match. The default is `soft` (matches/3, partial credit), which is the
+# benchmark's own headline but is NOT comparable to published work that reports a "native hard
+# score" — soft >= hard by construction. On run 30714307266 the same champion measured 63.4%
+# soft and 56.0% hard on val, 60.3% / 52.0% on the sealed split.
+#
+# Optimizing hard directly also aligns the gate with the number we report: it pays for
+# converting a 2-of-3 task to 3-of-3, and pays nothing for nudging 0-of-3 to 1-of-3.
+#
+# NB hard scoring makes per-task reward Bernoulli, so the gate's SE is WIDER than under soft.
+# Pair it with a lower `gate_k_se` dispatch input (0.2) or almost nothing will be accepted —
+# gate_k_se cannot live in this file, because the workflow always sets GATE_K_SE and the
+# environment deliberately wins over committed overrides.
+SB_SCORING=hard

--- a/ci/benchmarks/spreadsheetbench/pilot/overrides.env
+++ b/ci/benchmarks/spreadsheetbench/pilot/overrides.env
@@ -1,0 +1,16 @@
+# SpreadsheetBench — committed run configuration (see ci/benchmarks/lib/load_overrides.sh).
+#
+# Optimize and report the benchmark's HARD score: a task counts only when ALL THREE of its
+# OJ-style test cases match. The default is `soft` (matches/3, partial credit), which is the
+# benchmark's own headline but is NOT comparable to published work that reports a "native hard
+# score" — soft >= hard by construction. On run 30714307266 the same champion measured 63.4%
+# soft and 56.0% hard on val, 60.3% / 52.0% on the sealed split.
+#
+# Optimizing hard directly also aligns the gate with the number we report: it pays for
+# converting a 2-of-3 task to 3-of-3, and pays nothing for nudging 0-of-3 to 1-of-3.
+#
+# NB hard scoring makes per-task reward Bernoulli, so the gate's SE is WIDER than under soft.
+# Pair it with a lower `gate_k_se` dispatch input (0.2) or almost nothing will be accepted —
+# gate_k_se cannot live in this file, because the workflow always sets GATE_K_SE and the
+# environment deliberately wins over committed overrides.
+SB_SCORING=hard

--- a/core/tests/test_spreadsheetbench_scoring_and_seed.py
+++ b/core/tests/test_spreadsheetbench_scoring_and_seed.py
@@ -185,7 +185,33 @@ def test_a_missing_overrides_file_is_a_no_op(tmp_path):
     assert out.returncode == 0 and "ok=0" in out.stdout
 
 
-def test_no_tier_ships_overrides_yet_so_every_run_is_unchanged():
-    """Adding the mechanism must not change any existing run. When a comparison run does ship
-    one, this test is the reminder to state which tier and why."""
-    assert not sorted((REPO / "ci" / "benchmarks").glob("*/*/overrides.env"))
+def test_exactly_the_expected_tiers_ship_overrides_and_only_with_known_keys():
+    """Every committed override is a deliberate deviation from the default, so each one is
+    pinned here: a tier acquiring a config silently is how a run's numbers stop meaning what
+    the reader thinks they mean.
+
+    spreadsheetbench pilot+full optimize the HARD score, to be comparable with published work
+    that reports a benchmark's native hard score (soft >= hard by construction).
+    """
+    shipped = {
+        str(p.relative_to(REPO)): dict(
+            line.split("=", 1) for line in p.read_text(encoding="utf-8").splitlines()
+            if line.strip() and not line.startswith("#")
+        )
+        for p in sorted((REPO / "ci" / "benchmarks").glob("*/*/overrides.env"))
+    }
+    assert shipped == {
+        "ci/benchmarks/spreadsheetbench/full/overrides.env": {"SB_SCORING": "hard"},
+        "ci/benchmarks/spreadsheetbench/pilot/overrides.env": {"SB_SCORING": "hard"},
+    }, "a tier gained or changed a committed override — say which and why in the PR"
+
+
+def test_the_shipped_overrides_do_not_pretend_to_set_workflow_owned_vars():
+    """The workflow always sets GATE_K_SE/NUM_TRIALS/ITERATIONS/AGENT_MODEL, and the loader
+    lets the environment win — so putting them here would look configured but do nothing."""
+    workflow_owned = {"GATE_K_SE", "NUM_TRIALS", "ITERATIONS", "AGENT_MODEL",
+                      "OPTIMIZER_MODEL", "SPLIT_SEED", "TIER", "ALGORITHM_FOCUS"}
+    for p in sorted((REPO / "ci" / "benchmarks").glob("*/*/overrides.env")):
+        keys = {l.split("=", 1)[0] for l in p.read_text(encoding="utf-8").splitlines()
+                if l.strip() and not l.startswith("#")}
+        assert not (keys & workflow_owned), f"{p.name} sets workflow-owned {keys & workflow_owned}"


### PR DESCRIPTION
Commits `SB_SCORING=hard` for both tiers through the `overrides.env` mechanism from #281, so the configuration of a run whose number will be compared against published work lives **in git, next to the split it ran on**.

## Why hard

Published skill-optimization results report a benchmark's **"native hard score"** — a task counts only when all three of its OJ-style test cases match. Our default is soft (`matches/3`, partial credit): SpreadsheetBench's own headline, but not comparable, since soft ≥ hard by construction.

| run 30714307266, same champion | soft | hard |
|---|---:|---:|
| val (91) | 63.4% | 56.0% |
| sealed test (639) | 60.3% | **52.0%** |

A 7–8 point gap that would silently flatter us in any comparison table.

Optimizing hard also **aligns the gate with the reported number**: it pays for converting a 2-of-3 task to 3-of-3 and pays nothing for nudging 0-of-3 to 1-of-3 — which matches where the headroom actually is (102 of 639 sealed tasks sit on partial credit).

## The caveat, recorded in the files themselves

Hard scoring makes per-task reward Bernoulli, so the gate's SE is **wider** than under soft. This must be paired with a lower `gate_k_se` (0.2) at dispatch or almost nothing will be accepted. `gate_k_se` deliberately *cannot* live in these files: the workflow always sets `GATE_K_SE`, and the loader lets the environment win — so a value here would look configured and do nothing.

## The tripwire worked

#281 shipped a test asserting *no tier ships an overrides.env yet*, with a comment saying it was the reminder to state which tier and why when one did. It failed on this change, as designed. It's replaced by two stronger tests:

- **exactly which tiers ship which keys** is pinned — a tier cannot silently acquire a config that changes what its numbers mean;
- **no overrides file may set a workflow-owned variable** (`GATE_K_SE`, `NUM_TRIALS`, `ITERATIONS`, `AGENT_MODEL`, …), which would be configuration theatre.

Suite: **361 passed, 1 skipped**.

Signed-off-by: Eran Raichstein <eranra@il.ibm.com>