### PR TITLE
fix(ci): rebuild_record must accept the run's real final.json, not only an artifact

### DIFF
--- a/ci/benchmarks/utils/rebuild_record.py
+++ b/ci/benchmarks/utils/rebuild_record.py
@@ -12,9 +12,14 @@ WHY THIS EXISTS
     fix merged will also publish a stale record. This repairs those too.
 
 USAGE
-    # 1. get the run's artifact (contains ui/data/runs_*_file_path_final_json.json)
+    # From the run dir directly — PREFERRED whenever the workspace still exists, because the
+    # artifact's UI snapshot is size-capped and truncates on a large test split (the 639-task
+    # full tier does not fit, so the artifact route simply cannot rebuild it).
+    scp runner:.../run_suite/final.json /tmp/final.json
+    python3 ci/benchmarks/utils/rebuild_record.py /tmp/final.json records/<run_id>__<tier>-<bench>.json
+
+    # Or from a downloaded artifact, for a run whose workspace is long gone:
     gh run download <run_id> --repo <owner>/<repo> --dir /tmp/art
-    # 2. rewrite the record in place
     python3 ci/benchmarks/utils/rebuild_record.py /tmp/art records/<run_id>__<tier>-<bench>.json
     # 3. inspect, then commit the record to the benchmark-history branch
 
@@ -31,7 +36,19 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "lib"))
 from record import rollup  # noqa: E402  (the SAME rollup the aggregate job uses)
 
 
-def _find_final_json(artifact_dir: Path) -> dict:
+def _load_final(source: Path) -> dict:
+    """`final.json` itself, or the copy inside a downloaded artifact's UI snapshot.
+
+    Prefer the real file: the UI snapshot is size-capped and silently truncates, which a
+    639-task test split exceeds — so for a full-tier run the artifact route cannot work at all
+    and would otherwise look like a mysterious failure.
+    """
+    if source.is_file():
+        return json.loads(source.read_text(encoding="utf-8"))
+    return _find_final_json_in_artifact(source)
+
+
+def _find_final_json_in_artifact(artifact_dir: Path) -> dict:
     """Pull `final.json`'s contents out of a downloaded artifact's UI snapshot."""
     hits = sorted(artifact_dir.rglob("*file_path_final_json.json"))
     if not hits:
@@ -40,7 +57,11 @@ def _find_final_json(artifact_dir: Path) -> dict:
     wrapper = json.loads(hits[0].read_text(encoding="utf-8"))
     text = wrapper.get("text")
     if wrapper.get("truncated"):
-        raise SystemExit(f"{hits[0]} is truncated — cannot rebuild from it")
+        raise SystemExit(
+            f"{hits[0]} is truncated (the UI snapshot is size-capped, and a large test split "
+            f"does not fit) — pass the run's real final.json instead: "
+            f"scp runner:.../run_suite/final.json /tmp/final.json"
+        )
     if not text:
         raise SystemExit(f"{hits[0]} carries no text payload")
     return json.loads(text)
@@ -88,13 +109,14 @@ def rebuild_tasks(record: dict, final: dict) -> list[dict]:
 
 def main() -> int:
     ap = argparse.ArgumentParser()
-    ap.add_argument("artifact_dir", type=Path)
+    ap.add_argument("source", type=Path,
+                    help="the run's final.json, or a downloaded artifact directory")
     ap.add_argument("record", type=Path)
     ap.add_argument("--dry-run", action="store_true")
     args = ap.parse_args()
 
     record = json.loads(args.record.read_text(encoding="utf-8"))
-    final = _find_final_json(args.artifact_dir)
+    final = _load_final(args.source)
 
     before_opt = sum(1 for t in (record.get("tasks") or []) if t.get("reward_opt") is not None)
     tasks = rebuild_tasks(record, final)

--- a/core/tests/test_benchmarks_holdout_base_opt.py
+++ b/core/tests/test_benchmarks_holdout_base_opt.py
@@ -18,6 +18,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 REPO = Path(__file__).resolve().parents[2]
 LIB = REPO / "ci" / "benchmarks" / "lib"
 UTILS = REPO / "ci" / "benchmarks" / "utils"
@@ -200,6 +202,30 @@ def test_rebuild_record_skips_when_sides_cover_different_tasks(tmp_path):
     final = {"test": {"per_task": [_pt("t1", 1.0)]},
              "test_baseline": {"per_task": [_pt("OTHER", 0.5)]}}
     assert rb.rebuild_tasks(stale, final) == original
+
+
+def test_rebuild_accepts_the_runs_real_final_json(tmp_path):
+    """The artifact's UI snapshot is size-capped and truncates on a large test split — the
+    639-task full tier does not fit — so the run's own final.json must be a valid source."""
+    rb = _load("_rebuild_record", UTILS / "rebuild_record.py")
+    fj = tmp_path / "final.json"
+    fj.write_text(json.dumps({
+        "test": {"reward": 0.75, "per_task": [_pt("t1", 1.0), _pt("t2", 0.5)]},
+        "test_baseline": {"reward": 0.25, "per_task": [_pt("t1", 0.5), _pt("t2", 0.0)]},
+    }), encoding="utf-8")
+    assert rb._load_final(fj)["test"]["reward"] == 0.75
+
+
+def test_a_truncated_artifact_snapshot_says_what_to_do_instead(tmp_path):
+    """Failing with 'is truncated' and no remedy is how this wasted a cycle the first time."""
+    rb = _load("_rebuild_record", UTILS / "rebuild_record.py")
+    art = tmp_path / "art" / "ui" / "data"
+    art.mkdir(parents=True)
+    (art / "runs_run_suite_file_path_final_json.json").write_text(
+        json.dumps({"truncated": True, "text": "{}"}), encoding="utf-8")
+    with pytest.raises(SystemExit) as e:
+        rb._load_final(tmp_path / "art")
+    assert "final.json" in str(e.value) and "truncated" in str(e.value)
 
 
 def test_rebuild_is_idempotent(tmp_path):


### PR DESCRIPTION
Follow-up to #280, found by using it on the full tier.

Rebuilding run 30714307266's record failed:

```
runs_run_suite_file_path_final_json.json is truncated — cannot rebuild from it
```

The artifact's UI snapshot is **size-capped**, and a 639-task sealed split does not fit (that `final.json` is ~978 KB with 639×2 per-task entries). So the artifact route cannot rebuild precisely the runs whose numbers matter most — the full tier with a large sealed split.

The utility now accepts **either** the run's real `final.json` (preferred whenever the workspace still exists — it's the authoritative copy) **or** an artifact directory as before. The truncation error now names the remedy instead of being a dead end.

Used to publish the sealed comparison that was missing from the benchmarks page:

```
reward 0.5743 → 0.6030 (n=639) · eval $151.55 · optimizer $50.17 · 11.2h
```

Paired over those same 639 tasks the gain is **+0.0287 soft (2.2× SE)** and **+0.0282 hard (2.0× SE)** — 63 improved, 37 regressed, 539 unchanged.

Tests: 2 new — `final.json` accepted as a source, and the truncated-artifact path failing with actionable guidance. Suite: **363 passed, 1 skipped**.

Signed-off-by: Eran Raichstein <eranra@il.ibm.com>