### PR TITLE
fix(spreadsheetbench): a broken task template must cost one candidate, not the whole run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to cap-evolve are documented here. The format follows
 [Semantic Versioning](https://semver.org/) (currently `0.x` — anything may change).
 
 ## [Unreleased]
+### Fixed
+- **A broken `task_template.md` would have aborted the whole run instead of costing one
+  candidate.** #282's guard raised from `live()`, and `harness.run_step` wraps the *optimizer*
+  call in `try/except` — with a comment saying a bad proposal "must not abort a long run" —
+  but leaves the `evaluate_candidate` call directly below it unprotected. So one bad text edit
+  would have propagated out and killed a multi-hour run, destroying the sealed evaluation it
+  existed to produce. The validation now RETURNS the reason instead of raising: `live()` logs
+  it once, loudly, and `run_target` returns it as each rollout's error before any LLM call,
+  container or turn loop — so the candidate scores 0, the gate rejects it, the run continues,
+  and the optimizer reads the reason in its next trajectories and learns the contract. Tests
+  now assert `live()` cannot raise, including through the real `harness._live()` path, and that
+  the check precedes `import litellm`/`_get_sandbox()` so a rejected candidate costs nothing.
+
 ### Added
 - **The agent's job description is optimizable capability text now, not frozen code.** On run
   30714307266 the SpreadsheetBench agent read 359 words before starting a task: 144 in

--- a/core/tests/test_spreadsheetbench_task_template.py
+++ b/core/tests/test_spreadsheetbench_task_template.py
@@ -97,35 +97,69 @@ def _write(tmp_path, body: str) -> Path:
     return tmp_path
 
 
-def test_a_dropped_placeholder_is_rejected_before_any_task_runs(tmp_path):
-    """Without this, every rollout is told to write its answer to a path it never got."""
+def test_a_dropped_placeholder_is_reported_not_raised(tmp_path):
+    """Reporting rather than raising is the whole point: harness.run_step does NOT wrap
+    evaluate_candidate in try/except, so anything raised from live() aborts the entire run —
+    losing a multi-hour sealed evaluation over one bad text edit."""
     mod = _adapter()
     ctx = _write(tmp_path, "Do {instruction} on {spreadsheet_path}. {spreadsheet_content} "
                            "{instruction_type} {answer_position}\n")   # no {output_path}
-    with pytest.raises(RuntimeError) as e:
-        mod._validate_task_template(ctx)
-    msg = str(e.value)
-    assert "{output_path}" in msg and "missing required placeholder" in msg
-    assert "no task was run" in msg
+    msg = mod._task_template_error(ctx)
+    assert msg and "{output_path}" in msg and "missing required placeholder" in msg
+    assert "every" in msg and "scores 0" in msg, "the message must say what the consequence is"
 
 
-def test_an_unknown_placeholder_is_rejected(tmp_path):
+def test_an_unknown_placeholder_is_reported(tmp_path):
     """An invented field raises KeyError inside str.format on every single task."""
     mod = _adapter()
     body = "{instruction} {spreadsheet_path} {spreadsheet_content} {instruction_type} " \
            "{answer_position} {output_path} {sheet_name}\n"
-    with pytest.raises(RuntimeError) as e:
-        mod._validate_task_template(_write(tmp_path, body))
-    assert "unknown placeholder" in str(e.value) and "{sheet_name}" in str(e.value)
+    msg = mod._task_template_error(_write(tmp_path, body))
+    assert msg and "unknown placeholder" in msg and "{sheet_name}" in msg
 
 
-def test_unbalanced_braces_are_rejected_with_the_doubling_rule(tmp_path):
+def test_unbalanced_braces_are_reported_with_the_doubling_rule(tmp_path):
     mod = _adapter()
     body = "{instruction} {spreadsheet_path} {spreadsheet_content} {instruction_type} " \
            "{answer_position} {output_path} then write {\n"
-    with pytest.raises(RuntimeError) as e:
-        mod._validate_task_template(_write(tmp_path, body))
-    assert "not a valid format string" in str(e.value)
+    msg = mod._task_template_error(_write(tmp_path, body))
+    assert msg and "not a valid format string" in msg
+
+
+def test_a_good_template_reports_no_error(tmp_path):
+    mod = _adapter()
+    assert mod._task_template_error(SEED) is None
+    assert mod._task_template_error(tmp_path) is None       # no file at all
+
+
+def test_live_never_raises_so_a_bad_edit_cannot_abort_the_run(tmp_path):
+    """The bug this fixes: live() raising propagates through evaluate_candidate, which
+    run_step leaves unprotected, and kills the run."""
+    mod = _adapter()
+    ad = object.__new__(mod.Adapter)
+    ctx = _write(tmp_path, "only {instruction}\n")          # badly broken
+    with ad.live(ctx) as yielded:                            # must NOT raise
+        assert yielded == ctx
+
+
+def test_the_harness_path_also_survives_a_broken_template(tmp_path):
+    """Exercised through harness._live, which is what the eval actually calls."""
+    mod = _adapter()
+    sys.path.insert(0, str(REPO / "core"))
+    from cap_evolve import harness
+    ad = object.__new__(mod.Adapter)
+    ctx = _write(tmp_path, "only {instruction}\n")
+    with harness._live(ad, ctx) as yielded:
+        assert yielded == ctx
+
+
+def test_run_target_refuses_before_spending_anything(tmp_path):
+    """The candidate must cost ~nothing: no LLM call, no container, no 30-turn loop."""
+    src = (ADAPTER_DIR / "adapter.py").read_text(encoding="utf-8")
+    body = src.split("def run_target(", 1)[1].split("def score(", 1)[0]
+    check = body.index("_task_template_error(ctx)")
+    for later in ("import litellm", "_get_sandbox()", "_entries_by_id()"):
+        assert check < body.index(later), f"the template check must precede {later}"
 
 
 def test_dropping_the_cosmetic_turn_budget_is_allowed(tmp_path):
@@ -135,7 +169,7 @@ def test_dropping_the_cosmetic_turn_budget_is_allowed(tmp_path):
     body = "{instruction} {spreadsheet_path} {spreadsheet_content} {instruction_type} " \
            "{answer_position} {output_path}\n"
     ctx = _write(tmp_path, body)
-    mod._validate_task_template(ctx)                      # must not raise
+    assert mod._task_template_error(ctx) is None           # accepted
     assert mod._read_task_template(ctx).format(**_FIELDS)  # and still renders
 
 
@@ -147,7 +181,7 @@ def test_a_rewritten_template_is_accepted_which_is_the_whole_point(tmp_path):
             "Write to: {output_path}\nVERIFY your values before saving. Do NOT stop merely "
             "because a file exists.\n")
     ctx = _write(tmp_path, body)
-    mod._validate_task_template(ctx)
+    assert mod._task_template_error(ctx) is None
     out = mod._read_task_template(ctx).format(**_FIELDS)
     assert "Do NOT stop merely because a file exists" in out
     assert "once that file exists, you are done" not in out
@@ -156,16 +190,17 @@ def test_a_rewritten_template_is_accepted_which_is_the_whole_point(tmp_path):
 # --- wiring --------------------------------------------------------------------------------
 
 
-def test_live_validates_and_run_target_uses_the_capability_template():
+def test_live_reports_and_run_target_uses_the_capability_template():
     src = (ADAPTER_DIR / "adapter.py").read_text(encoding="utf-8")
-    assert "_validate_task_template(candidate_dir)" in src, "live() must validate"
+    assert "_task_template_error(candidate_dir)" in src, "live() must report the reason once"
     assert "def live(self, candidate_dir)" in src
+    assert "raise RuntimeError" not in src.split("def live(", 1)[1].split("def run_target", 1)[0]
     assert "user_msg = _read_task_template(ctx).format(" in src, "run_target must use it"
     assert "_TASK_TEMPLATE.format(" not in src, "the frozen template must no longer be used directly"
 
 
-def test_live_validates_once_per_evaluation_not_once_per_task():
-    """91 (or 639) identical failures is not a useful way to learn the template is broken."""
+def test_live_logs_the_reason_once_per_evaluation():
+    """One loud line per eval, not 639 — while run_target still fails each rollout cheaply."""
     src = (ADAPTER_DIR / "adapter.py").read_text(encoding="utf-8")
-    run_target = src.split("def run_target(", 1)[1]
-    assert "_validate_task_template" not in run_target.split("def score(", 1)[0]
+    live = src.split("def live(", 1)[1].split("def run_target", 1)[0]
+    assert "file=sys.stderr" in live

--- a/templates/adapters/spreadsheetbench/adapter.py
+++ b/templates/adapters/spreadsheetbench/adapter.py
@@ -54,7 +54,7 @@ WHAT THIS OPTIMIZES — ALL the text the agent reads, in two files:
   instruction surface un-optimizable, including the line "once that file exists, you are
   done" — which encourages exactly the dominant failure (a wrong-but-present output file).
   Per-task VALUES (instruction, paths, preview, answer_position) are still supplied by the
-  adapter through placeholders that live() validates; see _validate_task_template.
+  adapter through placeholders that live() validates; see _task_template_error.
 
 HOW IT WORKS:
   - tasks()       → loads all SpreadsheetBench instances from the fetched dataset.json.
@@ -859,25 +859,31 @@ def _read_task_template(ctx) -> str:
     return _TEMPLATE_COMMENT_RE.sub("", path.read_text(encoding="utf-8"), count=1).strip() + "\n"
 
 
-def _validate_task_template(ctx) -> None:
-    """Reject a candidate whose template broke the placeholder contract, BEFORE any task runs.
+def _task_template_error(ctx) -> str | None:
+    """Why this candidate's template is unusable, or None if it is fine.
 
-    Called from live(), so this costs one check per evaluation instead of discovering the
-    breakage as N failed rollouts. Both directions are fatal: a MISSING required placeholder
-    means the agent is never told (say) where to write its answer, and an UNKNOWN one raises
-    KeyError inside str.format on every single task.
+    Returns a message rather than raising, because the CALLER decides the consequence and the
+    consequence must never be "abort the run". harness.run_step wraps the optimizer call in
+    try/except precisely so a bad proposal costs one iteration rather than the whole run — but
+    the evaluate_candidate call right below it is NOT wrapped, so anything this raised from
+    live() would propagate and kill a multi-hour run, destroying the sealed evaluation over one
+    bad text edit. Instead every rollout returns this as its error: the candidate scores 0, the
+    gate rejects it, the run continues, and the optimizer READS the reason in its next
+    trajectories and learns not to break the contract.
+
+    Both directions are unusable: a MISSING required placeholder means the agent is never told
+    (say) where to write its answer, and an UNKNOWN one raises KeyError inside str.format on
+    every single task.
     """
     path = Path(ctx) / "task_template.md"
     if not path.exists():
-        return
+        return None
     text = _read_task_template(ctx)
     try:
         found = {f for _, f, _, _ in string.Formatter().parse(text) if f}
     except ValueError as e:  # unbalanced braces — a literal brace must be doubled
-        raise RuntimeError(
-            f"task_template.md is not a valid format string ({e}). A literal brace must be "
-            f"written as {{{{ or }}}}."
-        ) from e
+        return (f"task_template.md is not a valid format string ({e}). A literal brace must "
+                f"be written as {{{{ or }}}}.")
     missing = sorted(_TEMPLATE_REQUIRED - found)
     unknown = sorted(found - _TEMPLATE_REQUIRED - _TEMPLATE_OPTIONAL)
     if missing or unknown:
@@ -886,12 +892,14 @@ def _validate_task_template(ctx) -> None:
             problems.append(f"missing required placeholder(s): {', '.join('{%s}' % m for m in missing)}")
         if unknown:
             problems.append(f"unknown placeholder(s): {', '.join('{%s}' % u for u in unknown)}")
-        raise RuntimeError(
+        return (
             "task_template.md broke the placeholder contract — " + "; ".join(problems)
             + f". Required: {', '.join('{%s}' % r for r in sorted(_TEMPLATE_REQUIRED))}"
             + f" · optional: {', '.join('{%s}' % o for o in sorted(_TEMPLATE_OPTIONAL))}."
-            + " The edit is rejected; no task was run against it."
+            + " Restore the placeholder and this candidate can be scored; as it stands every"
+            + " task scores 0 because the agent is not told where to write its answer."
         )
+    return None
 
 
 def _read_system_prompt(ctx) -> str:
@@ -1021,13 +1029,16 @@ class Adapter(CapabilityAdapter):
 
     @contextmanager
     def live(self, candidate_dir):
-        """Validate the candidate's editable job description ONCE, then run against it.
+        """Report a broken job description ONCE per evaluation, loudly — but do not raise.
 
-        live() is entered once per evaluation, so a template that broke the placeholder
-        contract fails here — loudly, with the reason — instead of surfacing as N rollouts
-        that were each told to write their answer to a path they were never given.
+        Raising here would propagate through harness.evaluate_candidate, which run_step does
+        NOT wrap in try/except, and abort the whole run. So this only logs; run_target turns
+        the same message into a per-rollout error, which costs the candidate its score and
+        nothing else.
         """
-        _validate_task_template(candidate_dir)
+        err = _task_template_error(candidate_dir)
+        if err:
+            print(f"spreadsheetbench: candidate rejected — {err}", file=sys.stderr)
         yield candidate_dir
 
     def run_target(self, task: Task, ctx, *, seed: int = 0) -> Rollout:
@@ -1037,6 +1048,13 @@ class Adapter(CapabilityAdapter):
         sandbox: _Sandbox | None = None
         conv_id = ""
         try:
+            # Before ANY work: a candidate whose job description lost a required placeholder
+            # cannot be scored, and must fail cheaply rather than either aborting the run or
+            # burning 30 turns per task on a prompt with no output path in it.
+            tmpl_error = _task_template_error(ctx)
+            if tmpl_error:
+                return Rollout(task_id=task.id, error=tmpl_error)
+
             entry = _entries_by_id().get(task.id)
             if entry is None:
                 return Rollout(task_id=task.id, error=f"task id {task.id} not found in dataset")


### PR DESCRIPTION
Fixes a bug I introduced in #282 and described incorrectly there.

## What was wrong

#282's placeholder guard **raised** from `live()`. I documented that as "the candidate is rejected; no task was run against it". It isn't. `harness.run_step` protects the optimizer call:

```python
except Exception as e:
    # A failed proposal (e.g. a transient optimizer/API error) must not abort a
    # long run — leave the workdir as the parent copy so the candidate == parent
    # and the gate simply rejects it (a wasted iteration, not a crash).
```

…but the `evaluate_candidate(adapter, workdir, …)` call **immediately below it is not wrapped**. So anything raised from `live()` propagates out of `run_step` and aborts the run.

On the full tier that means: one bad text edit at iteration 4 destroys a 10-hour run *and* the sealed 639-task evaluation it exists to produce. It would have stayed invisible until the first time the optimizer broke a placeholder.

## The fix

Validation returns the reason instead of raising:

- `live()` logs it **once per evaluation**, loudly, to stderr;
- `run_target` returns it as **each rollout's error, before** the LLM call, the sandbox, and the turn loop — so a rejected candidate costs ~nothing;
- the candidate scores 0, the paired gate rejects it, **the run continues**;
- and the optimizer **reads the reason in its next trajectories**, so it learns the contract instead of repeating the mistake.

The message now states the real consequence — *"every task scores 0 because the agent is not told where to write its answer"* — rather than the now-false "no task was run against it".

## Testing

- `live()` cannot raise, asserted directly **and** through the real `harness._live()` path.
- The template check **precedes** `import litellm`, `_get_sandbox()` and `_entries_by_id()`, so rejection is free.
- `live()` still logs exactly once per evaluation rather than 639 times.

Suite: **367 passed, 1 skipped**.

## Worth noting separately

The underlying gap is in `core`: an adapter's `live()` is a documented hook, and *any* exception from it kills a run for every benchmark, not just this one. Wrapping `evaluate_candidate` the way the optimizer call is already wrapped would fix that class generally. Deliberately out of scope here — this PR keeps to the adapter so it can land immediately before a run — but it's the more complete fix and I'd suggest an issue for it.

Signed-off-by: Eran Raichstein <eranra@il.ibm.com>