### PR TITLE
fix(spreadsheetbench): name both editable artifacts, or the unlocked surface stays inert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to cap-evolve are documented here. The format follows
 
 ## [Unreleased]
 ### Fixed
+- **The editable job description was inert: the optimizer was never told it existed.** #282
+  made `task_template.md` optimizable, and pilot 30736646559 showed the optimizer ignoring it
+  entirely — its `PROCESS.md` reported *"Changes made this iteration (all in `prompt.md` — the
+  system prompt)"*. Both files were in its workdir; the rendered instructions mentioned
+  **neither filename**, and the shared prompt-only template speaks of "the prompt" in the
+  singular, so editing only the obvious artifact was the reasonable reading. The
+  spreadsheetbench arm now appends a section naming both files, stating what share of the
+  agent's words each accounts for (~40% / ~60%), inviting deletion of unhelpful guidance
+  (pointing at the "you are done once the file exists" line specifically), and spelling out the
+  placeholder contract so the optimizer learns it from instructions rather than from a rejected
+  candidate. Appended to the per-benchmark copy, so the shared template stays benchmark-neutral
+  — a test asserts that.
 - **A broken `task_template.md` would have aborted the whole run instead of costing one
   candidate.** #282's guard raised from `live()`, and `harness.run_step` wraps the *optimizer*
   call in `try/except` — with a comment saying a bad proposal "must not abort a long run" —

--- a/ci/benchmarks/lib/run_suite.sh
+++ b/ci/benchmarks/lib/run_suite.sh
@@ -156,6 +156,38 @@ ENV
     mkdir -p "$PROJ/optimizer"
     cp "$REPO/templates/project/optimizer/INSTRUCTIONS.prompt-only.md" \
        "$PROJ/optimizer/INSTRUCTIONS.md"
+    # NAME THE ARTIFACTS. The shared template speaks of "the prompt" in the singular and the
+    # rendered instructions mention no filename at all, so an optimizer handed TWO editable
+    # files reasonably edits only the obvious one: in pilot 30736646559 it reported "all in
+    # prompt.md — the system prompt" and never touched task_template.md, leaving the unlocked
+    # surface inert. Both files are in its workdir; it just had no reason to know the second
+    # one was fair game. This appendix is benchmark-specific, which is why it lives here
+    # rather than in the shared template.
+    cat >> "$PROJ/optimizer/INSTRUCTIONS.md" <<'OPTNOTE'
+
+## The TWO files you may edit (this benchmark)
+Your capability is BOTH of these, and an iteration that only touches the first is leaving
+most of the agent's instruction surface untouched:
+
+1. **`prompt.md`** — the agent's SYSTEM message: who it is, how it should work, what to
+   check. ~40% of the words the agent reads.
+
+2. **`task_template.md`** — the agent's FIRST USER message: how the job is framed, what each
+   field means, and the interaction contract. ~60% of the words the agent reads. It is
+   ordinary prose and you may reword, restructure, add to, or DELETE from it — including
+   guidance that is actively unhelpful. (Read it critically: a line telling the agent it is
+   finished as soon as an output file exists will discourage it from verifying values, which
+   is the most common way tasks fail here.)
+
+   The `{placeholders}` in it are filled in per task and are LOAD-BEARING. Keep every one of
+   `{instruction}` `{spreadsheet_path}` `{spreadsheet_content}` `{instruction_type}`
+   `{answer_position}` `{output_path}`; `{max_turns}` is optional; invent no others; write a
+   literal brace as `{{` or `}}`. Break that and EVERY task scores 0 — the agent is never
+   told where to write its answer — so the candidate is rejected outright.
+
+Decide per cluster which file is the right place to fix it, and say which you chose in
+PROCESS.md.
+OPTNOTE
     OPT_INSTRUCTIONS="$PROJ/optimizer/INSTRUCTIONS.md"
     SB_CACHE="${CAPEVOLVE_CI_CACHE:-$HOME/.cache/capevolve-ci}/spreadsheetbench-data"
     SB_DEFAULT="$SB_CACHE/sample_data_200"

--- a/core/tests/test_spreadsheetbench_task_template.py
+++ b/core/tests/test_spreadsheetbench_task_template.py
@@ -190,6 +190,26 @@ def test_a_rewritten_template_is_accepted_which_is_the_whole_point(tmp_path):
 # --- wiring --------------------------------------------------------------------------------
 
 
+def test_the_optimizer_is_told_both_files_are_editable():
+    """The unlock is inert unless the instructions NAME the second artifact. Pilot
+    30736646559 proved it: both files were in the optimizer's workdir, the rendered
+    instructions mentioned neither by name, and it reported "all in prompt.md"."""
+    sh = (REPO / "ci" / "benchmarks" / "lib" / "run_suite.sh").read_text(encoding="utf-8")
+    arm = sh.split("  spreadsheetbench)", 1)[1].split("\n  *)", 1)[0]
+    assert "## The TWO files you may edit" in arm
+    for f in ("prompt.md", "task_template.md"):
+        assert f"`{f}`" in arm, f"{f} must be named explicitly"
+    # It must also carry the contract, so the optimizer does not learn it via a rejection.
+    for ph in ("{instruction}", "{output_path}", "{answer_position}"):
+        assert ph in arm
+    assert "EVERY task scores 0" in arm, "state the consequence of breaking a placeholder"
+    assert "appended" not in arm.lower() or True
+    # …and it must be APPENDED to the copied file, not to the shared template in templates/.
+    assert '>> "$PROJ/optimizer/INSTRUCTIONS.md"' in arm
+    shared = (REPO / "templates" / "project" / "optimizer" / "INSTRUCTIONS.prompt-only.md").read_text(encoding="utf-8")
+    assert "task_template.md" not in shared, "the shared template must stay benchmark-neutral"
+
+
 def test_live_reports_and_run_target_uses_the_capability_template():
     src = (ADAPTER_DIR / "adapter.py").read_text(encoding="utf-8")
     assert "_task_template_error(candidate_dir)" in src, "live() must report the reason once"


### PR DESCRIPTION
#282 made the agent's job description (`task_template.md`) optimizable. Pilot [30736646559](https://github.com/skillberry-ai/cap-evolve/actions/runs/30736646559) shows the optimizer never touching it:

> `## Changes made this iteration (all in prompt.md — the system prompt)`

Both files **were** in its workdir, so it could have. The cause:

```
rendered INSTRUCTIONS mentions "task_template.md": 0
rendered INSTRUCTIONS mentions "prompt.md":        0
```

…and the shared prompt-only template speaks of *"the prompt"* in the singular. Handed two files and told about one artifact in the abstract, editing the obvious one is the reasonable reading. **This is an instructions bug, not an optimizer failure** — and it made the whole #282 unlock inert.

## The fix

The spreadsheetbench arm appends a section that:

- **names both files**, with what share of the agent's words each carries (~40% / ~60%);
- states the job description is ordinary prose it may reword, restructure or **delete from** — pointing explicitly at *"once that file exists, you are done"* as an example worth removing, since it discourages verifying values, which is how most tasks here fail;
- **spells out the placeholder contract and the consequence** of breaking it, so the optimizer learns it from instructions rather than by burning an iteration on a rejected candidate;
- asks it to state per cluster which file it chose, so the decision is visible in `PROCESS.md`.

It's appended to the per-benchmark **copy**. The shared template stays benchmark-neutral, and a test asserts `task_template.md` never appears in `templates/project/optimizer/INSTRUCTIONS.prompt-only.md`.

Suite: **368 passed, 1 skipped**.

## Note on the pilot

I'm cancelling 30736646559 and re-running rather than letting it finish: its remaining two iterations would test hard scoring and the gate (which its baseline already validated — `0.480` hard, binary rewards, both metrics recorded, 0 errors) while leaving the actual hypothesis untested. One pilot exercising the final configuration is a cleaner experiment than two that each cover half of it. I'll delete the resulting cancelled record from `benchmark-history` so it doesn't reintroduce a `—` row.

Signed-off-by: Eran Raichstein <eranra@il.ibm.com>