### PR TITLE
fix(spreadsheetbench): let the agent verify its answer — stop ending the episode on first write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ All notable changes to cap-evolve are documented here. The format follows
 
 ## [Unreleased]
 ### Fixed
+- **The agent could not check its own answer: the loop ended the instant a file appeared.**
+  Measured on run 30740145597, the agent used **2.2 of 30 available turns** (seed: 1.9) because
+  the CodeAct loop did `if case1_path.exists(): break`. Every behaviour that has to happen
+  *after* writing was therefore unreachable — and not hypothetically: that run's champion had
+  itself rewritten the job description to add *"3. Verification code: re-open output_path …
+  You are done only once that verification looks correct"*, and turn usage moved 1.9 → 2.2. The
+  optimizer wrote the right skill and the harness refused to run it. It also explains the
+  dominant failure mode, 40% of tasks producing a file whose values were wrong while **0%**
+  failed to produce a file at all. The loop now continues after the first write, ending when the
+  agent replies without code (its way of saying it is finished), when `VERIFY_TURNS` idle rounds
+  have passed (default 3), or at `MAX_TURNS`. Two traps came with it, both covered by tests:
+  cases 2 and 3 are scored by **replaying** the agent's code, so replay now uses the code that
+  actually *wrote* the answer (tracked by an mtime/size stamp) rather than whatever ran last —
+  replaying a trailing verification snippet writes nothing and would have scored 0 on two of
+  three test cases, turning the fix into a large regression; and the post-answer phase is
+  **bounded**, because each round is an LLM call and an unbounded 30-turn loop is ~15× the token
+  cost per rollout. The seed job description was updated to match, since it still told the agent
+  the old rule.
 - **The editable job description was inert: the optimizer was never told it existed.** #282
   made `task_template.md` optimizable, and pilot 30736646559 showed the optimizer ignoring it
   entirely — its `PROCESS.md` reported *"Changes made this iteration (all in `prompt.md` — the

--- a/core/tests/test_spreadsheetbench_verify_turns.py
+++ b/core/tests/test_spreadsheetbench_verify_turns.py
@@ -1,0 +1,165 @@
+"""The agent must be allowed to check its own answer before the episode ends.
+
+MEASURED on run 30740145597: the agent used **2.2 of 30 available turns** (seed: 1.9). The
+cause was one line in the CodeAct loop:
+
+    exec_results.append(exec_result)
+    messages.append({"role": "user", "content": exec_result})
+    if case1_path.exists():
+        break          # ← episode over the instant ANY output file appeared
+
+So every behaviour that has to happen *after* writing was unreachable. That is not a
+hypothetical: `cand_0003` of that run had itself rewritten the job description to say
+
+    "3. Verification code: re-open output_path, print the values in answer_position …
+     You are done only once that verification looks correct."
+
+and turn usage moved 1.9 → 2.2. The optimizer wrote the right skill and the harness refused to
+execute it. It also matches the dominant failure mode — 40% of tasks produced a file whose
+values were wrong, and 0% failed to produce a file at all.
+
+Comparable published work reports its skill learning exactly these post-write behaviours
+("reopening the saved file to verify boundary rows", "inspect the real workbook rather than
+trusting previews"), which our loop made impossible to perform.
+
+Two traps that a literal one-line deletion walks straight into, both covered below:
+
+1. **Cases 2 and 3 are scored by REPLAYING the agent's code.** Replay must use the code that
+   WROTE the answer, not whatever ran last — a trailing verification snippet writes nothing, so
+   replaying it scores 0 on two of three test cases and turns the fix into a big regression.
+2. **Cost.** Each round is an LLM call. Unbounded, MAX_TURNS=30 is ~15x the token cost of the
+   old behaviour, so the post-answer phase is bounded by VERIFY_TURNS.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+ADAPTER_DIR = REPO / "templates" / "adapters" / "spreadsheetbench"
+
+
+def _adapter():
+    for p in (REPO / "core", ADAPTER_DIR, ADAPTER_DIR.parent):
+        if str(p) not in sys.path:
+            sys.path.insert(0, str(p))
+    spec = importlib.util.spec_from_file_location("_sb_verify", ADAPTER_DIR / "adapter.py")
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+SRC = (ADAPTER_DIR / "adapter.py").read_text(encoding="utf-8")
+
+
+# --- the break is gone -------------------------------------------------------------------
+
+
+def test_the_loop_no_longer_ends_on_first_file_write():
+    loop = SRC.split("for _round in range(MAX_TURNS):", 1)[1].split("if not case1_path.exists()", 1)[0]
+    assert "if case1_path.exists():\n                    break" not in loop, \
+        "the episode must not end merely because an output file exists"
+
+
+def test_the_post_answer_phase_is_bounded_so_cost_cannot_explode():
+    """Unbounded, 30 turns is ~15x the old token cost per rollout."""
+    mod = _adapter()
+    assert mod.VERIFY_TURNS == 3, "default should allow inspect+fix without paying for 30 rounds"
+    loop = SRC.split("for _round in range(MAX_TURNS):", 1)[1].split("if not case1_path.exists()", 1)[0]
+    assert "verify_left -= 1" in loop and "if verify_left <= 0" in loop
+
+
+def test_a_no_code_reply_after_an_answer_exists_ends_the_episode():
+    """That is the agent saying it is finished; nagging it costs a round for nothing."""
+    loop = SRC.split("for _round in range(MAX_TURNS):", 1)[1].split("if not case1_path.exists()", 1)[0]
+    seg = loop.split("if code is None or not code.strip():", 1)[1].split("last_code = code", 1)[0]
+    assert "if solution_code:" in seg and "break" in seg
+
+
+def test_an_agent_that_never_writes_code_is_cut_off():
+    loop = SRC.split("for _round in range(MAX_TURNS):", 1)[1].split("if not case1_path.exists()", 1)[0]
+    assert "no_code_replies >= 3" in loop
+
+
+# --- trap 1: the replay must use the code that WROTE the answer ---------------------------
+
+
+def test_replay_uses_the_writing_code_not_the_last_code():
+    replay = SRC.split("for idx in (2, 3):", 1)[1].split("return Rollout", 1)[0]
+    assert "solution_code.replace(input_file.name" in replay, \
+        "replaying a verification snippet would score 0 on cases 2 and 3"
+    assert "last_code.replace(input_file.name" not in replay
+
+
+def test_the_recorded_solution_is_the_writing_code():
+    assert "output=solution_code or last_code" in SRC
+
+
+def test_artifact_stamp_detects_a_rewrite_but_not_a_read(tmp_path):
+    """The stamp is how the loop tells 'wrote the answer' from 'looked at the answer'."""
+    mod = _adapter()
+    f = tmp_path / "1_x_output.xlsx"
+    assert mod._artifact_stamp(f) is None            # absent
+    f.write_bytes(b"PK\x03\x04one")
+    s1 = mod._artifact_stamp(f)
+    assert s1 is not None
+    assert mod._artifact_stamp(f) == s1              # merely reading changes nothing
+    f.write_bytes(b"PK\x03\x04two-different-size")
+    assert mod._artifact_stamp(f) != s1              # a rewrite does
+
+
+# --- the loop's decision logic, simulated ------------------------------------------------
+
+
+def _simulate(mod, rounds, tmp_path):
+    """Replay the loop's post-exec decisions over a scripted sequence of rounds.
+
+    Each round is (code, writes_answer). Mirrors the adapter's ordering exactly; kept here
+    because the real loop needs an LLM, a container and a dataset to run.
+    """
+    case1 = tmp_path / "1_x_output.xlsx"
+    solution_code, artifact, verify_left, executed = "", None, mod.VERIFY_TURNS, 0
+    for code, writes in rounds:
+        executed += 1
+        if writes:
+            case1.write_bytes(b"PK" + str(executed).encode() * 4)
+        stamp = mod._artifact_stamp(case1)
+        if stamp is not None and stamp != artifact:
+            artifact, solution_code = stamp, code
+        elif solution_code:
+            verify_left -= 1
+            if verify_left <= 0:
+                break
+    return solution_code, executed
+
+
+def test_verification_rounds_do_not_steal_the_solution(tmp_path):
+    """The exact regression: write, then verify. Replay must still use the writing code."""
+    mod = _adapter()
+    sol, n = _simulate(mod, [("SOLVE", True), ("PRINT_CHECK", False)], tmp_path)
+    assert sol == "SOLVE" and n == 2
+
+
+def test_a_correction_supersedes_the_earlier_answer(tmp_path):
+    """Inspect, write, verify, fix — the FIX is what cases 2 and 3 must replay."""
+    mod = _adapter()
+    sol, _ = _simulate(mod, [("LOOK", False), ("SOLVE_V1", True),
+                             ("PRINT_CHECK", False), ("SOLVE_V2", True)], tmp_path)
+    assert sol == "SOLVE_V2"
+
+
+def test_endless_verification_is_cut_off_at_the_budget(tmp_path):
+    mod = _adapter()
+    rounds = [("SOLVE", True)] + [("CHECK%d" % i, False) for i in range(10)]
+    sol, n = _simulate(mod, rounds, tmp_path)
+    assert sol == "SOLVE"
+    assert n == 1 + mod.VERIFY_TURNS, f"should stop after {mod.VERIFY_TURNS} idle rounds, ran {n}"
+
+
+def test_rounds_before_any_answer_are_never_charged_to_the_verify_budget(tmp_path):
+    """Inspection BEFORE writing is the behaviour we want most; it must be free."""
+    mod = _adapter()
+    rounds = [("LOOK%d" % i, False) for i in range(8)] + [("SOLVE", True)]
+    sol, n = _simulate(mod, rounds, tmp_path)
+    assert sol == "SOLVE" and n == 9

--- a/templates/adapters/spreadsheetbench/adapter.py
+++ b/templates/adapters/spreadsheetbench/adapter.py
@@ -130,6 +130,12 @@ EXEC_TIMEOUT = int(os.environ.get("SPREADSHEETBENCH_EXEC_TIMEOUT", "180"))
 # Container teardown is bookkeeping, not work: keep it short so a hung server delays a
 # finished rollout by seconds, never by the exec timeout.
 RELEASE_TIMEOUT = int(os.environ.get("SPREADSHEETBENCH_RELEASE_TIMEOUT", "30"))
+# How many further rounds the agent gets AFTER it has first written a graded output file, to
+# re-open it, check the values and correct them. Was effectively 0: the loop broke the instant
+# the file appeared, so "verify your work" was unreachable no matter what the skill said, and
+# agents used ~2 of 30 available turns. Bounded rather than unbounded because each round is a
+# real LLM call: at MAX_TURNS=30 an unbounded loop is ~15x the token cost of the old behaviour.
+VERIFY_TURNS = int(os.environ.get("SPREADSHEETBENCH_VERIFY_TURNS", "3"))
 LIBREOFFICE_BIN = os.environ.get("SPREADSHEETBENCH_LIBREOFFICE_BIN", "")
 
 # Which of SpreadsheetBench's two OJ-style metrics becomes the optimization target.
@@ -839,6 +845,22 @@ _TEMPLATE_REQUIRED = frozenset({
 _TEMPLATE_OPTIONAL = frozenset({"max_turns"})
 
 
+def _artifact_stamp(path: Path):
+    """A change-detecting stamp for the graded output file, or None when it does not exist.
+
+    Used to tell "the code that WROTE the answer" apart from "the code that merely inspected
+    it". That distinction only started to matter once the agent was allowed to keep working
+    after its first write: cases 2 and 3 are scored by REPLAYING the agent's code, so replaying
+    a verification snippet (which writes nothing) would produce no output for them and score 0
+    on two of three test cases — turning a fix into a large regression.
+    """
+    try:
+        st = path.stat()
+    except OSError:
+        return None
+    return (st.st_mtime_ns, st.st_size)
+
+
 def _read_task_template(ctx) -> str:
     """The agent's first user message, as editable capability text.
 
@@ -1108,7 +1130,11 @@ class Adapter(CapabilityAdapter):
 
             cost = 0.0
             tokens = 0
-            last_code = ""  # last code actually EXECUTED (what cases 2/3 replay)
+            last_code = ""      # last code executed at all (diagnostics)
+            solution_code = ""  # last code that actually WROTE case 1's output — what 2/3 replay
+            artifact = None     # stamp of case 1's output, to detect which code wrote it
+            verify_left = VERIFY_TURNS
+            no_code_replies = 0
             exec_results: list[str] = []
             case1_path = host_out_dir / f"1_{sid}_output.xlsx"
 
@@ -1137,8 +1163,15 @@ class Adapter(CapabilityAdapter):
 
                 code = _extract_python(vendor, assistant_text)
                 if code is None or not code.strip():
-                    # Nothing runnable in the reply — re-state the contract rather than
-                    # feeding prose to the kernel for a guaranteed SyntaxError.
+                    # Nothing runnable in the reply. Once an answer exists this is the agent
+                    # saying it is FINISHED — honour that instead of nagging it into burning a
+                    # round. Before that, re-state the contract rather than feeding prose to
+                    # the kernel for a guaranteed SyntaxError.
+                    if solution_code:
+                        break
+                    no_code_replies += 1
+                    if no_code_replies >= 3:
+                        break  # it is not going to produce code; stop paying for rounds
                     messages.append({"role": "user", "content": _NO_CODE_REMINDER})
                     continue
                 last_code = code
@@ -1157,8 +1190,19 @@ class Adapter(CapabilityAdapter):
 
                 exec_results.append(exec_result)
                 messages.append({"role": "user", "content": exec_result})
-                if case1_path.exists():
-                    break
+
+                stamp = _artifact_stamp(case1_path)
+                if stamp is not None and stamp != artifact:
+                    # This round produced or changed the graded file, so THIS is the solution
+                    # to replay onto cases 2 and 3 — and a later correction supersedes it.
+                    artifact, solution_code = stamp, code
+                elif solution_code:
+                    # A round that did not touch the answer is inspection/verification. Give a
+                    # bounded number of them, then stop: the benchmark grades the file, not the
+                    # commentary, and every extra round is another LLM call.
+                    verify_left -= 1
+                    if verify_left <= 0:
+                        break
 
             if not case1_path.exists():
                 blocked = _sandbox_access_denied(exec_results, container_out_dir)
@@ -1194,7 +1238,7 @@ class Adapter(CapabilityAdapter):
                 # Case 1 solved — replay the SAME code onto cases 2 and 3 (no new LLM calls).
                 for idx in (2, 3):
                     case_input = _resolve_case_file(local_dir, idx, sid, "input")
-                    solution = last_code.replace(input_file.name, case_input.name)
+                    solution = solution_code.replace(input_file.name, case_input.name)
                     solution = solution.replace(f"1_{sid}_output.xlsx", f"{idx}_{sid}_output.xlsx")
                     try:
                         vendor["exec_code"](client, solution)
@@ -1203,7 +1247,7 @@ class Adapter(CapabilityAdapter):
 
             return Rollout(
                 task_id=task.id,
-                output=last_code,
+                output=solution_code or last_code,
                 trace=messages,
                 cost_usd=cost,
                 tokens=tokens,

--- a/templates/adapters/spreadsheetbench/seed_capability/task_template.md
+++ b/templates/adapters/spreadsheetbench/seed_capability/task_template.md
@@ -42,5 +42,8 @@ You need to solve the following spreadsheet manipulation question. It contains s
 
 You have up to {max_turns} rounds of interaction. In each round, reply with exactly ONE python code block:
 1. Information-gathering code (e.g. inspecting the file) — the execution result is returned to you.
-2. Final solution code that writes the modified file to output_path — once that file exists, you are done.
+2. Solution code that writes the modified file to output_path.
+3. Verification code: re-open output_path and print the values you wrote in answer_position,
+   to confirm they are correct before finishing. If they are wrong, fix your code and write again.
+Reply without a code block when you are satisfied the saved file is correct.
 If your code raises an error, the traceback will be returned to you; fix the code and try again.


### PR DESCRIPTION
## The finding

Measured on run 30740145597, the agent used **2.2 of 30 available turns** (seed: 1.9). One line:

```python
exec_results.append(exec_result)
messages.append({"role": "user", "content": exec_result})
if case1_path.exists():
    break          # ← episode over the instant ANY output file appeared
```

Every behaviour that has to happen *after* writing was unreachable. And this isn't hypothetical: that run's champion had **itself** rewritten the job description to add

> *"3. Verification code: re-open output_path, print the values in answer_position … You are done only once that verification looks correct."*

…and turn usage moved 1.9 → 2.2. **The optimizer produced the right skill and the harness refused to execute it.**

It also explains the dominant failure mode far better than any prompt deficiency: **40% of tasks produced a file whose values were wrong, while 0% failed to produce a file at all.** Published work on this benchmark reports its skill learning exactly these post-write behaviours ("reopening the saved file to verify boundary rows", "inspect the real workbook rather than trusting previews") — things our loop made impossible.

## The change

The loop continues past the first write and ends when the agent **replies with no code** (its way of saying it's finished), after `VERIFY_TURNS` idle rounds (default 3), after three no-code replies with no answer yet, or at `MAX_TURNS`.

## Two traps a literal one-line deletion walks into

**1. Cases 2 and 3 are scored by REPLAYING the agent's code.** Replay must use the code that *wrote* the answer, not whatever ran last — a trailing verification snippet writes nothing, so replaying it scores 0 on two of three test cases and would have turned this fix into a **large regression**. The loop now stamps the graded file `(mtime_ns, size)` after each round and records the code that changed it, so a later correction supersedes an earlier answer.

**2. Cost.** Each round is an LLM call. Unbounded at `MAX_TURNS=30` that's ~**15×** the token cost per rollout, which on the full tier is the difference between ~$190 and thousands. Hence the bounded post-answer budget.

The seed job description is updated too, since it still told the agent the old rule.

## Testing

12 new tests, including a **simulation of the loop's post-exec decisions** over scripted round sequences, because the real loop needs an LLM, a container and a dataset:

| scenario | asserted |
|---|---|
| write → verify | replay still uses the *writing* code |
| inspect → write → verify → fix | the **fix** is what replays |
| write → 10 verification rounds | cut off at the budget |
| 8 inspection rounds → write | inspection *before* writing is never charged to the budget |

Two of these caught a patch of mine that had **silently not applied** (the no-code branch has a different condition than I'd targeted). Suite: **379 passed, 1 skipped**.

## Expected effect on cost and runtime

Turns per rollout should rise from ~2 to ~4–5, so eval cost roughly doubles: expect ~**$300–400** for a full run rather than ~$190, and a longer wall-clock. That's the price of letting the agent check its work, and it's bounded by design rather than open-ended.

Signed-off-by: Eran Raichstein <eranra@il.ibm.com>