### PR TITLE
feat(spreadsheetbench): localize scoring failures so the optimizer can learn WHERE it went wrong

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to cap-evolve are documented here. The format follows
 [Semantic Versioning](https://semver.org/) (currently `0.x` — anything may change).
 
 ## [Unreleased]
+### Added
+- **Scoring now localizes a failure instead of only saying "values did not match".** On run
+  30762167950, **197 of 639 sealed tasks failed all three test cases**, and the entire signal
+  the optimizer got for each was one bit — *wrong* — plus the range name. So it could learn
+  generic discipline ("do not hardcode", "verify your work") but had no way to discover that
+  **locating and covering** the target range was the failing sub-step: our champion learned six
+  of the nine rules comparable published work reports and missed exactly the two about full
+  range coverage and cross-sheet location. Task `19-7` is the archetype — `answer_position` of
+  `MINUS'!B2:E11,'PLUS'!B2:E5200`, two sheets and ~5,200 rows, and the agent spent two turns
+  (write, then "Done.") from a five-row preview. A miss now reports **coverage** (cells written
+  vs the span of the range it was given), **unchanged sheets** (parts of `answer_position`
+  byte-identical to the input), and **type mismatches** (*"text where a date was expected"*).
+  Gold safety: coverage and unchanged-sheet notes never open the gold file at all — they use
+  the agent's own input and the range it was handed, both already known to it — and a test
+  proves that by deleting the gold file. The type note discloses a value's *type*, never a
+  value; that narrow disclosure is a deliberate judgment, being the most actionable diagnostic
+  for this benchmark. Runs only on a miss, only on one test case, and is wrapped so a
+  diagnostic can never cost a score.
+
 ### Fixed
 - **The agent could not check its own answer: the loop ended the instant a file appeared.**
   Measured on run 30740145597, the agent used **2.2 of 30 available turns** (seed: 1.9) because

--- a/core/tests/test_spreadsheetbench_failure_localization.py
+++ b/core/tests/test_spreadsheetbench_failure_localization.py
@@ -1,0 +1,176 @@
+"""A failure that says only "values did not match" teaches the optimizer nothing.
+
+MEASURED on run 30762167950: **197 of 639 sealed tasks failed all three test cases**, and the
+entire signal the optimizer received for each was:
+
+    "0/3 test cases passed (Sheet-Level Manipulation, checked range:
+     MINUS'!B2:E11,'PLUS'!B2:E5200). Test case(s) [1, 2, 3] produced an output file but its
+     values did not match the expected result."
+
+One bit: wrong. It never said whether the range was left empty, whether a whole sheet was
+untouched, whether only 10 of 5,199 cells were filled, or whether the values were right but
+stored as text. So the optimizer could only learn generic discipline ("do not hardcode",
+"verify your work") — and indeed our champion learned six of the nine rules comparable
+published work reports, while missing exactly the two about LOCATING and COVERING the target
+range. It had no evidence those were the failing sub-step.
+
+Task 19-7 is the archetype: two sheets, ~5,200 rows, and the agent spent two turns — write,
+then "Done." — from a five-row preview.
+
+GOLD SAFETY. Coverage and untouched-sheet notes never open the gold file: they compare the
+agent's output against its own INPUT and against the range it was handed, both already known
+to it. The type note reports a value's TYPE, not a value — metadata, judged worth that narrow
+disclosure because it is the most actionable diagnostic here. No cell value is ever emitted.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+ADAPTER_DIR = REPO / "templates" / "adapters" / "spreadsheetbench"
+openpyxl = pytest.importorskip("openpyxl")
+
+
+def _adapter():
+    for p in (REPO / "core", ADAPTER_DIR, ADAPTER_DIR.parent):
+        if str(p) not in sys.path:
+            sys.path.insert(0, str(p))
+    spec = importlib.util.spec_from_file_location("_sb_loc", ADAPTER_DIR / "adapter.py")
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _book(path, sheets):
+    """sheets: {name: {(row, col): value}}"""
+    wb = openpyxl.Workbook()
+    wb.remove(wb.active)
+    for name, cells in sheets.items():
+        ws = wb.create_sheet(name)
+        for (r, c), v in cells.items():
+            ws.cell(r, c).value = v
+    wb.save(path)
+    return path
+
+
+# --- range parsing -----------------------------------------------------------------------
+
+
+def test_multi_sheet_multi_range_answer_position_is_parsed():
+    """The real notation from task 19-7 — two sheets in one answer_position."""
+    mod = _adapter()
+    got = list(mod._range_cells("MINUS'!B2:E11,'PLUS'!B2:E5200"))
+    assert got == [("MINUS", 2, 2, 5, 11), ("PLUS", 2, 2, 5, 5200)]
+
+
+def test_single_cell_and_sheetless_forms_are_parsed():
+    mod = _adapter()
+    assert list(mod._range_cells("C20:C29")) == [(None, 3, 20, 3, 29)]
+    assert list(mod._range_cells("'Test'!B7")) == [("Test", 2, 7, 2, 7)]
+
+
+def test_unparseable_parts_are_skipped_not_fatal():
+    mod = _adapter()
+    assert list(mod._range_cells("garbage,,C1:C2")) == [(None, 3, 1, 3, 2)]
+
+
+# --- the diagnostics ---------------------------------------------------------------------
+
+
+def test_an_empty_target_range_is_named_as_such(tmp_path):
+    """The most common total failure: a file was written, the answer was not."""
+    mod = _adapter()
+    src = _book(tmp_path / "in.xlsx", {"S": {(1, 1): "hdr"}})
+    out = _book(tmp_path / "out.xlsx", {"S": {(1, 1): "hdr"}})
+    gold = _book(tmp_path / "gold.xlsx", {"S": {(1, 1): "hdr", (2, 3): 5, (3, 3): 6}})
+    notes = mod._localize_failure({"answer_position": "'S'!C2:C3"}, out, src, gold)
+    joined = " ".join(notes)
+    assert "COVERAGE" in joined and "spans 2 cell(s)" in joined and "value in 0" in joined
+    assert "EMPTY in your output" in joined
+
+
+def test_partial_coverage_of_a_large_range_is_flagged(tmp_path):
+    """Task 19-7's shape: a 5,200-row range with a handful of cells filled."""
+    mod = _adapter()
+    src = _book(tmp_path / "in.xlsx", {"P": {}})
+    out = _book(tmp_path / "out.xlsx", {"P": {(r, 2): r for r in range(2, 12)}})
+    gold = _book(tmp_path / "gold.xlsx", {"P": {(r, 2): r for r in range(2, 5201)}})
+    notes = mod._localize_failure({"answer_position": "'P'!B2:B5200"}, out, src, gold)
+    joined = " ".join(notes)
+    assert "spans 5199 cell(s)" in joined and "value in 10 of them" in joined
+    assert "Most of the target range was left unfilled" in joined
+
+
+def test_a_sheet_never_modified_is_named(tmp_path):
+    """The other half of 19-7: one range handled, the second sheet ignored entirely."""
+    mod = _adapter()
+    cells = {(r, 2): "x" for r in range(2, 6)}
+    src = _book(tmp_path / "in.xlsx", {"MINUS": dict(cells), "PLUS": dict(cells)})
+    out = _book(tmp_path / "out.xlsx", {"MINUS": {(r, 2): "done" for r in range(2, 6)},
+                                        "PLUS": dict(cells)})
+    gold = _book(tmp_path / "gold.xlsx", {"MINUS": {(r, 2): "done" for r in range(2, 6)},
+                                          "PLUS": {(r, 2): "done" for r in range(2, 6)}})
+    notes = mod._localize_failure({"answer_position": "'MINUS'!B2:B5,'PLUS'!B2:B5"}, out, src, gold)
+    joined = " ".join(notes)
+    assert "UNCHANGED" in joined and "PLUS" in joined
+    assert "MINUS" not in joined.split("UNCHANGED")[1][:60], "the sheet that WAS edited must not be listed"
+
+
+def test_a_type_mismatch_reports_the_type_and_never_the_value(tmp_path):
+    """The date-as-text class. The expected TYPE is disclosed; the value is not."""
+    import datetime
+    mod = _adapter()
+    src = _book(tmp_path / "in.xlsx", {"S": {}})
+    out = _book(tmp_path / "out.xlsx", {"S": {(2, 1): "2026-01-02", (3, 1): "2026-01-03"}})
+    gold = _book(tmp_path / "gold.xlsx", {"S": {(2, 1): datetime.datetime(2026, 1, 2),
+                                                (3, 1): datetime.datetime(2026, 1, 3)}})
+    notes = mod._localize_failure({"answer_position": "'S'!A2:A3"}, out, src, gold)
+    joined = " ".join(notes)
+    assert "TYPE:" in joined and "str where datetime was expected" in joined
+    for leaked in ("2026-01-02", "2026-01-03"):
+        assert leaked not in joined, "a gold VALUE must never appear in feedback"
+
+
+def test_coverage_and_untouched_notes_do_not_consult_the_gold_file(tmp_path):
+    """Proven by deleting it: the two structural signals must still be produced."""
+    mod = _adapter()
+    src = _book(tmp_path / "in.xlsx", {"S": {(2, 1): "a"}})
+    out = _book(tmp_path / "out.xlsx", {"S": {(2, 1): "a"}})
+    notes = mod._localize_failure({"answer_position": "'S'!A2:A3"}, out, src,
+                                  tmp_path / "does-not-exist.xlsx")
+    joined = " ".join(notes)
+    assert "COVERAGE" in joined and "UNCHANGED" in joined
+    assert "TYPE:" not in joined
+
+
+def test_a_broken_produced_file_degrades_quietly(tmp_path):
+    """A diagnostic must never cost a score."""
+    mod = _adapter()
+    bad = tmp_path / "corrupt.xlsx"
+    bad.write_bytes(b"not a workbook")
+    assert mod._localize_failure({"answer_position": "A1:A2"}, bad, bad, bad) == []
+
+
+# --- wiring ------------------------------------------------------------------------------
+
+
+def test_the_notes_reach_the_feedback_the_optimizer_reads():
+    mod = _adapter()
+    fb = mod._build_feedback({"instruction_type": "Cell-Level Manipulation",
+                              "answer_position": "C2:C3"},
+                             [0, 0, 0], [], [1, 2, 3], True, None,
+                             ["COVERAGE: the target range spans 2 cell(s); your output has a value in 0 of them."])
+    assert "COVERAGE" in fb and "did not match" in fb
+
+
+def test_localization_runs_only_on_a_miss_and_only_once():
+    """Scoring opens workbooks; doing this for every passing task would be wasted work."""
+    src = (ADAPTER_DIR / "adapter.py").read_text(encoding="utf-8")
+    seg = src.split("localized: list[str] = []", 1)[1].split("feedback = _build_feedback", 1)[0]
+    assert "if mismatched:" in seg
+    assert "idx = mismatched[0]" in seg, "one case is enough; the diagnosis generalizes"
+    assert "except Exception" in seg, "must never cost a score"

--- a/templates/adapters/spreadsheetbench/adapter.py
+++ b/templates/adapters/spreadsheetbench/adapter.py
@@ -1338,8 +1338,26 @@ class Adapter(CapabilityAdapter):
 
         soft = sum(test_results) / len(test_results)
         hard = 1.0 if all(test_results) else 0.0
+
+        # Localize the failure while the produced workbook is still on disk. Only for a MISS,
+        # and only on test case 1 — the diagnosis generalizes across the three cases and this
+        # keeps scoring cheap. Best-effort: a diagnostic that cannot be computed must never
+        # cost a score.
+        localized: list[str] = []
+        if mismatched:
+            try:
+                idx = mismatched[0]
+                localized = _localize_failure(
+                    entry,
+                    data_dir / "outputs" / run_tag / f"{idx}_{sid}_output.xlsx",
+                    _resolve_case_file(data_dir / "spreadsheet" / sid, idx, sid, "input"),
+                    _resolve_case_file(data_dir / "spreadsheet" / sid, idx, sid, "answer"),
+                )
+            except Exception:  # noqa: BLE001
+                localized = []
+
         feedback = _build_feedback(entry, test_results, missing, mismatched, bool(libre),
-                                   recalc_failed)
+                                   recalc_failed, localized)
 
         # Scoring has consumed every output; drop the per-rollout dir.
         _cleanup_output_dir(rollout)
@@ -1360,9 +1378,117 @@ class Adapter(CapabilityAdapter):
         )
 
 
+def _range_cells(answer_position: str):
+    """Yield (sheet, min_col, min_row, max_col, max_row) for each part of answer_position.
+
+    answer_position is SpreadsheetBench's own notation and may name several ranges across
+    several sheets, e.g. "MINUS'!B2:E11,'PLUS'!B2:E5200". Parsed here only to describe the
+    agent's own output against the range it was GIVEN — no gold data is consulted.
+    """
+    for part in str(answer_position).split(","):
+        part = part.strip()
+        sheet = None
+        if "!" in part:
+            sheet, _, part = part.rpartition("!")
+            sheet = sheet.strip().strip("'")
+        m = re.fullmatch(r"\$?([A-Za-z]+)\$?(\d+)(?::\$?([A-Za-z]+)\$?(\d+))?", part.strip())
+        if not m:
+            continue
+        c1, r1, c2, r2 = m.group(1), int(m.group(2)), m.group(3) or m.group(1), int(m.group(4) or m.group(2))
+        col = lambda t: sum((ord(ch.upper()) - 64) * 26 ** i for i, ch in enumerate(reversed(t)))
+        yield sheet, col(c1), r1, col(c2), r2
+
+
+def _localize_failure(entry: dict, produced: Path, source: Path, gold: Path) -> list[str]:
+    """WHY a produced workbook missed, in terms the optimizer can act on.
+
+    The previous feedback said only "values did not match", which is one bit. The optimizer
+    could therefore learn generic discipline rules ("do not hardcode", "verify your work") but
+    had no way to discover that LOCATING and COVERING the target range was the failing
+    sub-step — which is exactly the pair of rules comparable published work reports learning
+    and ours never did. On run 30762167950, 197 of 639 sealed tasks failed ALL THREE test
+    cases, and nothing in the logs said why.
+
+    GOLD SAFETY. Three of the four signals never open the gold file at all — they compare the
+    agent's output against its own INPUT and against the range it was handed, both of which it
+    already knows. The fourth reports a value's TYPE (e.g. "text where a date was expected"),
+    which is metadata rather than an answer; it is the single most actionable diagnostic for
+    this benchmark and is judged worth that narrow disclosure. No cell VALUE is ever emitted.
+    """
+    notes: list[str] = []
+    try:
+        import openpyxl
+        pw = openpyxl.load_workbook(produced, data_only=True)
+        sw = openpyxl.load_workbook(source, data_only=True)
+    except Exception:  # noqa: BLE001
+        return notes
+
+    total = written = 0
+    untouched_sheets: list[str] = []
+    for sheet, c1, r1, c2, r2 in _range_cells(entry.get("answer_position", "")):
+        name = sheet if sheet in pw.sheetnames else pw.sheetnames[0]
+        ws = pw[name]
+        src = sw[name] if name in sw.sheetnames else None
+        span = (c2 - c1 + 1) * (r2 - r1 + 1)
+        filled = same_as_input = 0
+        for row in range(r1, r2 + 1):
+            for cc in range(c1, c2 + 1):
+                v = ws.cell(row, cc).value
+                if v is not None and str(v) != "":
+                    filled += 1
+                if src is not None and v == src.cell(row, cc).value:
+                    same_as_input += 1
+        total += span
+        written += filled
+        if span and same_as_input == span:
+            untouched_sheets.append(name)
+
+    if total:
+        notes.append(
+            f"COVERAGE: the target range spans {total} cell(s); your output has a value in "
+            f"{written} of them."
+        )
+        if written == 0:
+            notes.append("The target range is EMPTY in your output — nothing was written there.")
+        elif written * 4 < total:
+            notes.append(
+                "Most of the target range was left unfilled — check where the data actually "
+                "ends rather than assuming the extent from the preview."
+            )
+    if untouched_sheets:
+        notes.append(
+            f"UNCHANGED: sheet(s) {sorted(set(untouched_sheets))} are byte-identical to the "
+            f"input across the target range — that part of answer_position was never modified."
+        )
+
+    # TYPE mismatch (reports the expected TYPE, never a value).
+    try:
+        gw = openpyxl.load_workbook(gold, data_only=True)
+        bad: dict[str, int] = {}
+        for sheet, c1, r1, c2, r2 in _range_cells(entry.get("answer_position", "")):
+            name = sheet if sheet in pw.sheetnames else pw.sheetnames[0]
+            gname = sheet if sheet in gw.sheetnames else gw.sheetnames[0]
+            ws, gs = pw[name], gw[gname]
+            for row in range(r1, min(r2, r1 + 200) + 1):
+                for cc in range(c1, c2 + 1):
+                    a, b = ws.cell(row, cc).value, gs.cell(row, cc).value
+                    if a is None or b is None or type(a) is type(b):
+                        continue
+                    bad[f"{type(a).__name__} where {type(b).__name__} was expected"] = \
+                        bad.get(f"{type(a).__name__} where {type(b).__name__} was expected", 0) + 1
+        if bad:
+            worst = sorted(bad.items(), key=lambda kv: -kv[1])[:2]
+            notes.append("TYPE: " + "; ".join(f"{n} cell(s) hold {k}" for k, n in worst)
+                         + " — write real numbers/dates, not their text form.")
+    except Exception:  # noqa: BLE001
+        pass
+    return notes
+
+
 def _build_feedback(
     entry: dict, test_results: list[int], missing: list[int], mismatched: list[int],
     had_libreoffice: bool, recalc_failed: list[int] | None = None,
+    localized: list[str] | None = None,
 ) -> str:
     """Gold-SAFE feedback: which test cases passed/failed and why, never gold cell values."""
     n_pass = sum(test_results)
@@ -1377,6 +1503,8 @@ def _build_feedback(
             f"Test case(s) {mismatched} produced an output file but its values in "
             f"{entry['answer_position']} did not match the expected result."
         )
+    for note in (localized or []):
+        lines.append(note)
     if not had_libreoffice and (missing or mismatched):
         lines.append(
             "Note: LibreOffice was unavailable, so formula-only cells (never assigned a "


### PR DESCRIPTION
## The finding this fixes

On run 30762167950, **197 of 639 sealed tasks failed all three test cases** — the dominant failure mode. The entire signal the optimizer received for each:

> *"0/3 test cases passed (Sheet-Level Manipulation, checked range: MINUS'!B2:E11,'PLUS'!B2:E5200). Test case(s) [1, 2, 3] produced an output file but its values did not match the expected result."*

**One bit: wrong.** Nothing about whether the range was left empty, whether a whole sheet was untouched, whether 10 of 5,199 cells were filled, or whether the values were right but stored as text.

That explains a pattern I couldn't otherwise account for. Checked against the nine rules comparable published work reports its skill learning, our champion had **six** — and was missing exactly the two about **locating** and **covering** the target range. It learned the rules it could see evidence for, and had none for those.

Task `19-7` is the archetype: `answer_position` = `MINUS'!B2:E11,'PLUS'!B2:E5200` — two sheets, ~5,200 rows — and the agent spent **two turns** (write, then `"Done."`) working from a five-row preview.

## What a miss now reports

| | |
|---|---|
| **COVERAGE** | cells written vs the span of the range it was given — *"spans 5199 cell(s); your output has a value in 10 of them"* |
| **UNCHANGED** | sheets in `answer_position` byte-identical to the input — *"sheet 'PLUS' was never modified"* |
| **TYPE** | *"str where datetime was expected"*, capped at the worst two classes |

## Gold safety, which is the part I want reviewed

Coverage and unchanged-sheet notes **never open the gold file**. They compare the agent's output against its own **input** and against the **range it was handed** — both already known to it. A test proves this by deleting the gold file and asserting both notes are still produced.

The type note discloses a value's **type**, never a value. That is a deliberate judgment: it's the single most actionable diagnostic for this benchmark (the date-as-text class), and type is metadata rather than an answer. A test asserts no gold value ever appears in feedback. If you'd rather not disclose even that, dropping the type note leaves the other two intact.

Cost/safety: runs **only on a miss**, only on the first mismatched case (the diagnosis generalizes across the three), and is wrapped so a diagnostic can never cost a score.

## Testing

11 new tests against **real xlsx files**: the actual 19-7 multi-sheet notation, empty range, partial coverage of a 5,199-cell range, an untouched sheet named while the edited one isn't, a date-as-text mismatch with a no-leak assertion, gold-free operation with the gold file deleted, and quiet degradation on a corrupt workbook.

They need `openpyxl`, which isn't in CI or my local env, so they **skip there**. I ran all 11 on the self-hosted runner, which has it:

```
11 passed in 0.62s
```

Flagging that explicitly rather than letting a green CI imply coverage it doesn't have. Suite otherwise: 379 passed, 2 skipped.

## What this is for

It's the precondition for the next experiment, not a score change by itself. The hypothesis is that with a legible failure signal the optimizer starts writing location/coverage rules — the two it's been missing. That's observable on the 50-task pilot in 3 iterations (~$30) by reading its `PROCESS.md`, without needing a full run to move a number.

Signed-off-by: Eran Raichstein <eranra@il.ibm.com>