### PR TITLE
feat(spreadsheetbench): state the target size and the other graded copies, instead of asking the agent to go find them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,40 @@ All notable changes to cap-evolve are documented here. The format follows
 
 ## [Unreleased]
 ### Added
+- **The agent is now told where the other two graded copies are, and how big its target is.**
+  PR #289 fixed the *signal* — the optimizer duly named coverage as failure cluster rank 2 and
+  added a "count non-empty cells versus range size" rule. It changed no behaviour: over pilot
+  30799393875 turn usage went **3.52 → 3.32 against a cap of 30**, and −0.21 on the very tasks
+  where reconnaissance was the prescribed fix. Prose cannot buy reconnaissance, so these facts
+  are now stated rather than requested. Of the champion's 22 failures on 50 val tasks, **8
+  passed only 1/3 or 2/3** — right for copy 1, wrong for the two other graded copies. The agent
+  is told 201 times across 150 rollouts that its code is "replayed on two other copies" and
+  referenced them **zero** times: nothing ever said where they are, and it never enumerated the
+  directory, though they sit beside its input in the mount. `spreadsheet_content` now carries
+  (a) `TARGET SIZE`, computed with `_range_cells` — the same helper the scorer grades with, so
+  the agent sees exactly the denominator `COVERAGE` will hold it to; (b) the paths of copies 2
+  and 3; and (c) each sheet's real data extent, from the already-parsed frame's shape and
+  explicitly **not** `openpyxl`'s `max_row`, which counts formatted-but-empty cells and would
+  teach overfilling. Task `110-2` is the archetype: it wrote 9 of 39 target cells, exactly
+  `3 rows × 3 cols`, from a five-row preview; it is now told *39 cells* and *rows 1-13*.
+  Deliberately **factual, not prescriptive** — nothing instructs the agent to self-test on the
+  copies, so if that strategy emerges the gain belongs to the optimizer rather than to us
+  (cf. #276). One hazard closed: cases 2 and 3 are produced by replaying the agent's *final*
+  code block with filenames substituted, so a final block looping over copies would have those
+  names rewritten and corrupt the graded outputs — the injected text states that the final
+  block must read exactly one input. The added facts are computed after the preview and inside
+  a `try`, because this call site was previously unwrapped and a pandas/PyArrow `SIGSEGV` here
+  once cost a whole algorithm process (run 30634898569, ~68 min and ~$6).
+
+### Fixed
+- **`openpyxl`/`pandas` are now dev extras, so the spreadsheetbench tests actually run.** They
+  were declared nowhere, so every test that builds or reads a real `.xlsx` hit
+  `pytest.importorskip` and vanished — including the whole of PR #289's
+  `test_spreadsheetbench_failure_localization.py`, in CI as well as locally. Enabling them
+  surfaced a stale test: `test_preview_text_is_unchanged_by_the_backend_switch` re-implemented
+  the preview's format string inline and compared against that, so it tested the format rather
+  than the python-vs-pyarrow invariant the file exists to pin. It now compares
+  `_spreadsheet_preview` against itself under both backends, and skips when `pyarrow` is absent.
 - **Scoring now localizes a failure instead of only saying "values did not match".** On run
   30762167950, **197 of 639 sealed tasks failed all three test cases**, and the entire signal
   the optimizer got for each was one bit — *wrong* — plus the range name. So it could learn

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -15,7 +15,11 @@ dependencies = []
 [project.optional-dependencies]
 judge = []        # llm-judge evaluator extras (filled when that evaluator lands)
 dashboard = []    # static-HTML / Flask dashboard extras
-dev = ["pytest>=7"]
+# openpyxl/pandas are the spreadsheetbench adapter's workbook stack. They are TEST deps, not
+# runtime deps of cap-evolve itself — but without them every test that builds or reads a real
+# .xlsx `importorskip`s, which silently skipped the whole of PR #289's
+# test_spreadsheetbench_failure_localization.py in CI as well as locally.
+dev = ["pytest>=7", "openpyxl>=3.1", "pandas>=2.0"]
 
 [project.scripts]
 cap-evolve = "cap_evolve.cli:main"

--- a/core/tests/test_spreadsheetbench_pandas_backend.py
+++ b/core/tests/test_spreadsheetbench_pandas_backend.py
@@ -77,20 +77,20 @@ def test_pandas_string_storage_is_python(tmp_path):
 
 
 def test_preview_text_is_unchanged_by_the_backend_switch(tmp_path):
-    """Results must stay comparable: the agent's prompt may not change."""
+    """Results must stay comparable: the agent's prompt may not change with the backend.
+
+    Compares `_spreadsheet_preview` against ITSELF under the pyarrow backend. The previous
+    version re-implemented the preview's format string inline and compared against that, so it
+    broke whenever the preview legitimately changed — which is a test of the format, not of the
+    backend-independence invariant this file exists to pin.
+    """
+    pytest.importorskip("pyarrow", reason="the python-vs-pyarrow comparison needs pyarrow")
     mod = _load_adapter_module()
     book = _workbook(tmp_path)
     ours = mod._spreadsheet_preview(book, 5)
 
-    # Recompute the same preview under pandas' DEFAULT backend for comparison.
     with pd.option_context("mode.string_storage", "pyarrow"):
-        xf = pd.ExcelFile(book)
-        chunks = []
-        for name in xf.sheet_names:
-            df = xf.parse(name)
-            n = 5 if df.shape[0] > 5 else df.shape[0]
-            chunks.append(f"Sheet Name: {name}\n{df.head(n).to_string()}\n" + "-" * 50)
-        default = "\n".join(chunks)
+        default = mod._spreadsheet_preview(book, 5)
 
     assert ours == default, "preview text changed — the agent would see a different prompt"
 

--- a/core/tests/test_spreadsheetbench_workbook_context.py
+++ b/core/tests/test_spreadsheetbench_workbook_context.py
@@ -1,0 +1,205 @@
+"""The agent is handed facts it was previously expected to go and discover.
+
+Measured on pilot run 30799393875 (50 val tasks, champion `cand_0001`), two failure modes
+survived PR #289's richer scoring feedback:
+
+  * **8 tasks passed 1/3 or 2/3** — the solution was right for copy 1 and wrong for the two
+    other graded copies. The agent is told 201 times across 150 rollouts that "the grader
+    replays your SAME final code on two other copies", and it referenced those copies
+    **zero** times — because nothing ever told it WHERE they are. They sit in the same
+    mounted directory it reads its input from.
+  * **4 tasks filled far too few cells** — e.g. task `110-2` wrote 9 of 39 target cells,
+    exactly `3 rows x 3 cols`, because the five-row preview was the only extent signal it had.
+
+Turn usage over the same run went 3.52 -> 3.32 against a cap of 30, so asking the agent to go
+look is demonstrably not what changes its behaviour. These helpers therefore STATE the facts:
+the target range's size, each sheet's real data extent, and the existence and location of the
+other graded copies.
+
+Deliberately FACTUAL, not prescriptive. Nothing here tells the agent to self-test on the other
+copies — that strategy is left to the optimizer to discover, so any resulting gain is credited
+to the optimizer rather than hand-supplied by us (cf. issue #276).
+
+One hazard this closes: the replay substitutes filenames into the agent's FINAL code block
+(`adapter.py`, "replay the SAME code onto cases 2 and 3"). If the agent left a three-copy loop
+in that final block, the substitution would corrupt cases 2 and 3 — so the injected text
+states that the final block must read exactly one input.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+ADAPTER_DIR = REPO / "templates" / "adapters" / "spreadsheetbench"
+SEED = ADAPTER_DIR / "seed_capability"
+
+
+def _adapter():
+    for p in (REPO / "core", ADAPTER_DIR, ADAPTER_DIR.parent):
+        if str(p) not in sys.path:
+            sys.path.insert(0, str(p))
+    spec = importlib.util.spec_from_file_location("_sb_ctx", ADAPTER_DIR / "adapter.py")
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# --- target size: pure arithmetic on a string the agent already has ----------------------
+
+
+def test_a_single_range_reports_its_exact_cell_count():
+    # 'Sheet1'!A1:C13 is task 110-2's real answer_position; the scorer graded it as 39 cells.
+    out = _adapter()._target_facts("'Sheet1'!A1:C13")
+    assert "39" in out
+    assert "Sheet1" in out
+
+
+def test_the_count_matches_what_the_scorer_will_grade_against():
+    """_target_facts and the COVERAGE diagnostic must not disagree about the denominator."""
+    mod = _adapter()
+    pos = "'Sheet1'!A1:C13"
+    span = sum((c2 - c1 + 1) * (r2 - r1 + 1) for _, c1, r1, c2, r2 in mod._range_cells(pos))
+    assert str(span) in mod._target_facts(pos)
+
+
+def test_multi_range_multi_sheet_targets_are_summed_and_both_sheets_named():
+    # Task 19-7's real answer_position: 40 + 20,796 = 20,836 cells over two sheets.
+    out = _adapter()._target_facts("'MINUS'!B2:E11,'PLUS'!B2:E5200")
+    assert "20836" in out.replace(",", "")
+    assert "MINUS" in out and "PLUS" in out
+
+
+def test_absolute_and_single_cell_notation_are_understood():
+    mod = _adapter()
+    assert "40" in mod._target_facts("'S'!$B$2:$E$11")
+    assert "1" in mod._target_facts("'S'!B2")
+
+
+def test_an_unparseable_answer_position_degrades_quietly():
+    """_range_cells skips parts it cannot match, so this must not raise."""
+    assert _adapter()._target_facts("not a range at all") == ""
+
+
+def test_target_facts_states_size_without_prescribing_strategy():
+    """Integrity: the facts must not smuggle in the rule we want the optimizer to learn."""
+    out = _adapter()._target_facts("'Sheet1'!A1:C13").lower()
+    for prescription in ("you should", "make sure", "verify", "test your", "always"):
+        assert prescription not in out
+
+
+# --- the other graded copies -------------------------------------------------------------
+
+
+def _make_book(path: Path, data_rows: int, cols: int = 3, pad_to: int | None = None):
+    openpyxl = pytest.importorskip("openpyxl")
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.append([f"Col{i + 1}" for i in range(cols)])
+    for r in range(data_rows):
+        ws.append([r * 10 + c for c in range(cols)])
+    if pad_to:  # formatted-but-EMPTY trailing cell: inflates max_row, not the real extent
+        ws.cell(pad_to, 1).number_format = "0.00"
+    wb.save(path)
+    return path
+
+
+def test_existing_sibling_copies_are_named_with_their_container_paths(tmp_path):
+    for idx in (1, 2, 3):
+        _make_book(tmp_path / f"{idx}_42_input.xlsx", 5)
+    out = _adapter()._sibling_inputs(tmp_path, "42", "/mnt/data/spreadsheet/42")
+    assert "/mnt/data/spreadsheet/42/2_42_input.xlsx" in out
+    assert "/mnt/data/spreadsheet/42/3_42_input.xlsx" in out
+
+
+def test_missing_sibling_copies_are_not_advertised(tmp_path):
+    _make_book(tmp_path / "1_42_input.xlsx", 5)
+    _make_book(tmp_path / "2_42_input.xlsx", 5)
+    out = _adapter()._sibling_inputs(tmp_path, "42", "/mnt/data/spreadsheet/42")
+    assert "2_42_input.xlsx" in out
+    assert "3_42_input.xlsx" not in out
+
+
+def test_no_siblings_yields_no_text(tmp_path):
+    _make_book(tmp_path / "1_42_input.xlsx", 5)
+    assert _adapter()._sibling_inputs(tmp_path, "42", "/mnt/data/spreadsheet/42") == ""
+
+
+def test_the_replay_constraint_is_stated_so_a_self_test_cannot_corrupt_cases_2_and_3(tmp_path):
+    """The final block is replayed with filenames substituted; it must read ONE input."""
+    for idx in (1, 2, 3):
+        _make_book(tmp_path / f"{idx}_42_input.xlsx", 5)
+    out = _adapter()._sibling_inputs(tmp_path, "42", "/mnt/data/spreadsheet/42").lower()
+    assert "final" in out
+    assert "one input" in out or "exactly one" in out
+
+
+# --- per-sheet data extent ---------------------------------------------------------------
+
+
+def test_the_preview_reports_the_real_data_extent(tmp_path):
+    book = _make_book(tmp_path / "1_42_input.xlsx", data_rows=12, cols=9)
+    out = _adapter()._spreadsheet_preview(book, 5)
+    assert "12" in out and "9" in out, "must state rows x cols"
+    assert "extent" in out.lower()
+
+
+def test_the_extent_uses_the_parsed_shape_not_openpyxls_inflated_max_row(tmp_path):
+    """max_row counts formatted-but-empty cells; trusting it would teach overfilling."""
+    openpyxl = pytest.importorskip("openpyxl")
+    book = _make_book(tmp_path / "1_42_input.xlsx", data_rows=12, cols=3, pad_to=200)
+    assert openpyxl.load_workbook(book).active.max_row >= 200, "fixture must inflate max_row"
+    out = _adapter()._spreadsheet_preview(book, 5)
+    assert "200" not in out, "the inflated max_row must not reach the agent"
+    assert "12" in out
+
+
+def test_the_five_data_rows_are_still_shown(tmp_path):
+    book = _make_book(tmp_path / "1_42_input.xlsx", data_rows=12, cols=3)
+    out = _adapter()._spreadsheet_preview(book, 5)
+    assert "Col1" in out, "column headers survive"
+    assert out.count("\n") > 5, "data rows are still rendered"
+
+
+# --- composition and failure containment -------------------------------------------------
+
+
+def test_the_context_block_carries_all_three_kinds_of_fact(tmp_path):
+    for idx in (1, 2, 3):
+        _make_book(tmp_path / f"{idx}_42_input.xlsx", 12)
+    mod = _adapter()
+    out = mod._workbook_context(tmp_path / "1_42_input.xlsx", tmp_path, "42",
+                                "/mnt/data/spreadsheet/42", "'Sheet'!A1:C13", 5)
+    assert "39" in out                          # target size
+    assert "2_42_input.xlsx" in out             # sibling copies
+    assert "extent" in out.lower()              # data extent
+    assert "Col1" in out                        # the original preview
+
+
+def test_a_broken_structure_computation_degrades_to_the_plain_preview(tmp_path, monkeypatch):
+    """_spreadsheet_preview at the call site was previously unwrapped, and this file has a
+    documented history of a pandas/PyArrow SIGSEGV in that path killing a whole run."""
+    book = _make_book(tmp_path / "1_42_input.xlsx", 12)
+    mod = _adapter()
+
+    def boom(*a, **k):
+        raise RuntimeError("structure computation failed")
+
+    monkeypatch.setattr(mod, "_target_facts", boom)
+    out = mod._workbook_context(book, tmp_path, "42", "/mnt/data/spreadsheet/42",
+                                "'Sheet'!A1:C13", 5)
+    assert "Col1" in out, "the agent still gets its preview"
+    assert "39" not in out
+
+
+# --- the seed template advertises what it now receives -----------------------------------
+
+
+def test_the_seed_template_describes_the_enriched_content_field():
+    text = (SEED / "task_template.md").read_text(encoding="utf-8").lower()
+    assert "extent" in text or "target size" in text, (
+        "the template's spreadsheet_content bullet should describe the facts now injected"
+    )

--- a/docs/superpowers/specs/2026-08-04-spreadsheetbench-structural-preview-design.md
+++ b/docs/superpowers/specs/2026-08-04-spreadsheetbench-structural-preview-design.md
@@ -1,0 +1,209 @@
+# SpreadsheetBench: structural facts in the prompt
+
+**Date:** 2026-08-04
+**Status:** IMPLEMENTED — two changes, `A1` (name the graded copies) + `B` (structural preview).
+**Scope:** `templates/adapters/spreadsheetbench/adapter.py`, its seed `task_template.md`, and
+`core/pyproject.toml` dev extras. No `core/` runtime changes.
+
+## The two changes
+
+**A1 — name the other graded copies.** Each task is scored on three copies of the workbook
+whose data differs, and copies 2 and 3 sit in the same mounted directory as the input. The
+agent was told 201 times across 150 rollouts that its code is "replayed on two other copies"
+and referenced them **zero** times, because nothing said where they are and it never
+enumerated the directory. `_sibling_inputs()` now states their paths.
+
+Kept deliberately **factual, not prescriptive** — it does not tell the agent to self-test.
+That strategy is left for the optimizer to discover, so any gain is credited to the optimizer
+rather than hand-supplied by us (issue #276). Targets the 8 partial-pass tasks; under hard
+scoring each is worth full credit, so the ceiling is +0.16 val.
+
+One hazard it must close: cases 2 and 3 are produced by replaying the agent's **final** code
+block with filenames substituted. A final block that itself looped over copies would have
+those names rewritten too, corrupting the graded outputs. The injected text therefore states
+that the final block must read exactly one input.
+
+**B — structural preview.** `TARGET SIZE` (from `_range_cells`, the same helper the scorer
+grades with) plus each sheet's real data extent. Targets the 4 severe coverage shortfalls.
+
+> **Correction that reshaped this spec (2026-08-04).** Its first draft claimed ~19–24 coverage-short
+> tasks, derived by counting the `COVERAGE:` string in scorer feedback. That was wrong:
+> `_localize_failure` emits `COVERAGE:` for *every* failure with a parseable range, so the
+> count was tracking failures, not shortfalls. Corrected numbers on the seed's 25 failures
+> over 50 val tasks (pilot 30799393875):
+>
+> | failure mode | seed | champion `cand_0001` | fixable by this spec? |
+> |---|---|---|---|
+> | filled == span, **values wrong** | **15** | 14 | No |
+> | filled < span (real shortfall) | 9 | 6 | Yes |
+> | ⤷ severe (<70% filled) | 4 | 4 | Yes — the real targets |
+> | no COVERAGE number | 1 | — | — |
+>
+> Shortfall fill ratios at seed: `0.05, 0.23, 0.55, 0.62, 0.71, 0.84, 0.90, 0.99, 0.99`
+> (the `0.99`s are off-by-one boundary cases, not "assumed the data ended early").
+>
+> So extent is **not** the main bottleneck. This fix's ceiling is ~9 tasks (+0.18 val) if
+> every shortfall converted perfectly, realistically ~4–5 (+0.08–0.10). The dominant
+> failure — 60% of failures — is **correct coverage, wrong values**, matching the
+> optimizer's own `PROCESS.md` cluster rank 4 ("genuine logic / ambiguous-spec misreads",
+> 15 tasks), which it marked not prose-fixable.
+>
+> Unchanged and still the important finding: the agent does one-shot reasoning in 3.3 of 30
+> turns and prose provably cannot change that. What was wrong is *which* failure that costs
+> us — mostly wrong-values, not wrong-extent.
+>
+> That diagnosis was then done at $0 from the artifacts, and produced `A1` above. Two further
+> hypotheses were tested and **refuted** — do not re-run them: (1) the replay's naive
+> `str.replace` silently breaking solutions that build paths dynamically — no, all 50 tasks
+> emit both literal filenames, and upstream `inference_multiple.py:121-124` does the identical
+> substitution; (2) gold being read by the agent — no, 0 gold filename references and 0
+> `load_workbook` calls on an answer path across 150 trajectories, though gold IS reachable in
+> the mount and that exposure is worth hardening with #276.
+
+## Problem
+
+The agent fills a fraction of its target range because it infers the input's extent from a
+five-row preview, and it will not spend turns discovering the real extent.
+
+Measured on pilot run 30799393875 (sha `83e1296b`, PR #289) over 50 paired val tasks:
+
+| | mean turns (cap 30) | median | val reward | coverage-short |
+|---|---|---|---|---|
+| seed | 3.52 | 3.0 | 0.500 | 24/50 |
+| champion `cand_0001` | **3.32** | 3.0 | 0.560 | 20/50 |
+
+PR #289 successfully fixed the *signal*: its localized `COVERAGE` diagnostic reached the
+optimizer, which named coverage as failure cluster rank 2 in `PROCESS.md` and added a
+"count non-empty cells versus range size" rule to `task_template.md`. But turn usage went
+**down** (−0.20 overall, −0.21 on the 24 coverage-short tasks specifically), and only 5 of
+those 24 converted to a pass.
+
+**Conclusion: prose cannot buy reconnaissance.** The optimizer wrote the inspection rules
+and the agent ignored them. So the next lever must *remove the need* for reconnaissance
+rather than request it.
+
+### Worked example — task `110-2` (real, from the run's own trajectory)
+
+The agent was given `answer_position = 'Sheet1'!A1:C13` (39 cells) and this preview:
+
+```
+Sheet Name: Sheet1
+   Column 1  Column 2  Column 3  Unnamed: 3 ... Column 1.1  Column 2.1  Column 3.1
+0         1        11       101         NaN            1.0        11.0       101.0
+1         2        12       102         NaN            2.0        12.0       102.0
+2         3        13       103         NaN            NaN         NaN         NaN
+3         4        14       101         NaN            NaN         NaN         NaN
+4         5        15       102         NaN            NaN         NaN         NaN
+```
+
+It produced 9 filled cells — exactly `3 rows × 3 cols`. The target needs `13 rows × 3 cols`.
+The preview showed it Excel rows 2–6 only; rows 7–13 were never visible, and nothing in the
+prompt stated that the target spans 13 rows.
+
+## Design
+
+### 1. What gets injected
+
+Prepended into the existing `{spreadsheet_content}` placeholder:
+
+```
+TARGET: 'Sheet1'!A1:C13 — 39 cells across 1 sheet ('Sheet1').
+The range above is what you must FILL. The data extents below are what the input
+CONTAINS — do not assume the data ends where the sample rows end.
+
+Sheet Name: Sheet1  [data extent: rows 1-13, cols A-I  (12 data rows x 9 cols)]
+   <existing five-row pandas preview, unchanged>
+(showing first 5 of 12 data rows)
+--------------------------------------------------
+```
+
+Multi-range, multi-sheet targets are summed and listed, e.g. for task `19-7`
+(`'MINUS'!B2:E11,'PLUS'!B2:E5200`): `20,836 cells across 2 sheets ('MINUS', 'PLUS')`
+— 40 + 20,796.
+
+Cost: roughly 30–60 tokens per prompt.
+
+### 2. Data sources, and why this is gold-safe
+
+| fact | source | added I/O | leaks gold? |
+|---|---|---|---|
+| target cell count, sheets named | `_range_cells(answer_position)` — the same helper the scorer grades with | none | No — arithmetic on a string the agent already has |
+| per-sheet data extent | the `DataFrame` `_spreadsheet_preview` already parses | none | No — it is the input file the agent is given |
+
+Two deliberate choices:
+
+- **Reuse `_range_cells`.** The count the agent sees is then *the same number* the
+  `COVERAGE` diagnostic later grades it against. Any other parse risks teaching a number
+  that disagrees with the grade.
+- **Use `df.shape`, never `openpyxl`'s `ws.max_row`/`max_column`.** `max_row` counts
+  formatted-but-empty cells, so it overstates extent. That would teach the agent to
+  overfill and could regress currently-passing tasks — a real risk, since 28 of 50 val
+  tasks already pass.
+
+### 3. Structure
+
+All in `templates/adapters/spreadsheetbench/adapter.py`:
+
+- **`_target_facts(answer_position) -> str`** — new. Pure function, zero I/O, no
+  dependencies beyond `_range_cells`. Independently unit-testable.
+- **`_spreadsheet_preview(path, rows)`** — extended to append the per-sheet extent
+  annotation, derived from the frame it already parses. Still one pandas pass; no doubled
+  I/O.
+- Composed at the call site (`adapter.py:1104`).
+
+`answer_position` is already available at the call site (`entry["answer_position"]`, passed
+to `.format()` on the next line), so no plumbing is needed to reach it.
+
+### 4. Error handling
+
+`_spreadsheet_preview` at `:1104` is currently **not** wrapped, and this file has a
+documented history of a pandas/PyArrow `SIGSEGV` in exactly this call path taking down a
+whole algorithm process (run 30634898569 lost 68 minutes and ~$6). The new composition gets
+a `try/except` that degrades to today's plain preview text, so a structure-computation
+failure can never cost a rollout. A malformed `answer_position` that `_range_cells` cannot
+parse yields no `TARGET:` line rather than an error — matching `_range_cells`'s existing
+`continue`-on-no-match behaviour.
+
+### 5. Testing
+
+Follows the existing `core/tests/test_spreadsheetbench_*.py` pattern:
+
+- `_target_facts` on the real notation forms: single range; multi-range multi-sheet
+  (`'MINUS'!B2:E11,'PLUS'!B2:E5200` → 20,836 / 2 sheets); `$`-absolute (`$B$2:$E$11`);
+  single cell (`'S'!B2`); malformed input → degrades to empty, no raise.
+- The extent annotation reports pandas' `shape`, asserted *not* to equal an
+  `openpyxl.max_row` value on a fixture with trailing formatted-but-empty rows.
+- The composed block still contains every load-bearing placeholder's content and the
+  five data rows.
+- A failure injected into the structure path falls back to the plain preview.
+
+### 6. Validation
+
+This fix is measurable **before any optimization**: the next pilot's *seed baseline*
+prices it with the optimizer uninvolved. If the facts help, seed val rises above the
+measured 0.500 immediately.
+
+Pass criteria for the follow-up pilot (~$45, ~2h) before committing to a full run:
+
+| signal | current | pass |
+|---|---|---|
+| coverage-short tasks | 19/50 | ≤ 10 |
+| mean turns | 3.32 | ~flat — **flat is the point** |
+| val reward | 0.500 seed | any increase |
+
+Flat turn usage is the intended outcome, not a disappointment: it demonstrates the fix
+removed the need for reconnaissance rather than begging for it. A turn *increase* would
+suggest the facts prompted more exploration, which is fine but is a different mechanism.
+
+This deliberately changes the prompt, so the new seed is **not** comparable to prior runs'
+seed. That is by design, and the seed-vs-seed delta (0.500 → new) is itself a measurement.
+
+## Out of scope
+
+- The 182 train tasks never being evaluated (hill-climb with `focus=all` consumes train
+  nowhere, so the optimizer's evidence and the acceptance gate are the same 91 val tasks).
+  Tracked separately; likely the next lever after this.
+- `skillopt_loop` (meta-skill / slow-update / protected regions) — the faithful path to the
+  paper's 80–85%, and a substantially larger piece of work.
+- The capability text itself. Writing rules is the optimizer's job; this change only makes
+  the facts available.

--- a/templates/adapters/spreadsheetbench/adapter.py
+++ b/templates/adapters/spreadsheetbench/adapter.py
@@ -984,7 +984,28 @@ def _pandas():
     return pd
 
 
+def _col_letter(n: int) -> str:
+    """1 -> A, 26 -> Z, 27 -> AA. Local so the pandas path needs no openpyxl import."""
+    s = ""
+    while n > 0:
+        n, r = divmod(n - 1, 26)
+        s = chr(65 + r) + s
+    return s
+
+
 def _spreadsheet_preview(path: Path, rows: int) -> str:
+    """The first `rows` rows of every sheet, each annotated with its REAL data extent.
+
+    The extent comes from the shape of the frame we already parse, NOT from openpyxl's
+    `ws.max_row`/`max_column`: those count formatted-but-empty cells, so they overstate the
+    extent, and an overstated extent would teach the agent to write cells that should stay
+    empty — a regression risk against the 28 of 50 val tasks that already pass.
+
+    Why state it at all: on pilot 30799393875 task `110-2` filled 9 of its 39 target cells,
+    exactly `3 rows x 3 cols`, because five preview rows were the only extent signal it had.
+    Asking the agent to go and measure does not work — turn usage over that run FELL from
+    3.52 to 3.32 against a cap of 30.
+    """
     pd = _pandas()
 
     excel_file = pd.ExcelFile(path)
@@ -992,8 +1013,96 @@ def _spreadsheet_preview(path: Path, rows: int) -> str:
     for sheet_name in excel_file.sheet_names:
         df = excel_file.parse(sheet_name)
         n = rows if df.shape[0] > rows else df.shape[0]
-        chunks.append(f"Sheet Name: {sheet_name}\n{df.head(n).to_string()}\n" + "-" * 50)
+        nrows, ncols = df.shape
+        # +1: pandas consumed row 1 as the header, and Excel addressing is 1-based.
+        extent = (
+            f"  [data extent: rows 1-{nrows + 1}, cols A-{_col_letter(ncols)}"
+            f"  ({nrows} data row(s) x {ncols} column(s))]"
+            if ncols else ""
+        )
+        shown = f"\n(showing the first {n} of {nrows} data row(s))" if nrows > n else ""
+        chunks.append(
+            f"Sheet Name: {sheet_name}{extent}\n{df.head(n).to_string()}{shown}\n" + "-" * 50
+        )
     return "\n".join(chunks)
+
+
+def _target_facts(answer_position: str) -> str:
+    """How big the target range is — derived from the string the agent was already given.
+
+    Reuses `_range_cells`, the same helper `_localize_failure` grades with, so the number the
+    agent is shown is exactly the denominator the COVERAGE diagnostic will hold it to. No file
+    is opened and no gold is consulted: this is arithmetic on `answer_position`.
+
+    Deliberately FACTUAL. It states the size and stops; it does not tell the agent to cover the
+    range, verify it, or self-test. Those are the rules we want the OPTIMIZER to discover, so
+    that a gain is credited to the optimizer instead of hand-supplied here (cf. issue #276).
+    """
+    total = 0
+    sheets: list[str] = []
+    for sheet, c1, r1, c2, r2 in _range_cells(answer_position):
+        total += (c2 - c1 + 1) * (r2 - r1 + 1)
+        if sheet and sheet not in sheets:
+            sheets.append(sheet)
+    if not total:
+        return ""
+    where = f", across {len(sheets)} sheet(s): {', '.join(sheets)}" if sheets else ""
+    return f"TARGET SIZE: answer_position covers {total} cell(s){where}."
+
+
+def _sibling_inputs(local_dir: Path, sid: str, container_dir: str) -> str:
+    """Name the other two graded copies, and the constraint the replay imposes.
+
+    This task is scored on three copies of the workbook whose data differs, and the other two
+    are already on disk beside the input. On pilot 30799393875 the agent was told 201 times
+    across 150 rollouts that its code would be "replayed on two other copies" and referenced
+    them ZERO times — it was never told where they are, and never enumerated the directory.
+    8 of 50 val tasks failed only on those copies.
+
+    The final paragraph is load-bearing, not advice. Cases 2 and 3 are produced by replaying
+    the agent's FINAL code block with the input/output filenames substituted (see run_target).
+    A final block that itself loops over several copies would have those names rewritten too,
+    corrupting the very outputs being graded — so the one-input constraint must be stated.
+    """
+    others = [
+        f"{container_dir}/{p.name}"
+        for p in (_resolve_case_file(local_dir, idx, sid, "input") for idx in (2, 3))
+        if p.exists()
+    ]
+    if not others:
+        return ""
+    listing = "\n  ".join(others)
+    return (
+        "OTHER GRADED COPIES: this task is scored on three copies of this workbook whose data "
+        "differs (row counts and values change). The other two are already on disk at:\n  "
+        f"{listing}\n"
+        "Your FINAL code block is replayed verbatim on each of them with the input and output "
+        "filenames substituted, so that final block must read exactly ONE input — the "
+        "spreadsheet_path given above. Anything you run across several copies belongs in an "
+        "EARLIER turn."
+    )
+
+
+def _workbook_context(
+    input_file: Path, local_dir: Path, sid: str, container_dir: str,
+    answer_position: str, rows: int,
+) -> str:
+    """The full `spreadsheet_content` block: target size, sibling copies, then the preview.
+
+    The preview is computed first and returned alone if anything about the added facts fails.
+    That ordering is deliberate: this call site used to be unwrapped, and a pandas/PyArrow
+    SIGSEGV in exactly this path once took down a whole algorithm process (run 30634898569,
+    ~68 minutes and ~$6). New facts must never be able to cost a rollout.
+    """
+    preview = _spreadsheet_preview(input_file, rows)
+    try:
+        blocks = [
+            b for b in (_target_facts(answer_position),
+                        _sibling_inputs(local_dir, sid, container_dir)) if b
+        ]
+    except Exception:  # noqa: BLE001 — facts are a bonus; the preview is the contract
+        return preview
+    return "\n\n".join([*blocks, preview]) if blocks else preview
 
 
 def _resolve_case_file(dir_path: Path, idx: int, sid: str, kind: str) -> Path:
@@ -1101,7 +1210,10 @@ class Adapter(CapabilityAdapter):
             _make_container_writable(host_out_dir)
 
             input_file = _resolve_case_file(local_dir, 1, sid, "input")
-            preview = _spreadsheet_preview(input_file, PREVIEW_ROWS)
+            preview = _workbook_context(
+                input_file, local_dir, sid, container_dir,
+                entry["answer_position"], PREVIEW_ROWS,
+            )
             user_msg = _read_task_template(ctx).format(
                 instruction=entry["instruction"],
                 spreadsheet_path=f"{container_dir}/{input_file.name}",

--- a/templates/adapters/spreadsheetbench/seed_capability/task_template.md
+++ b/templates/adapters/spreadsheetbench/seed_capability/task_template.md
@@ -17,7 +17,8 @@
 You need to solve the following spreadsheet manipulation question. It contains six pieces of information:
 - instruction: the question about spreadsheet manipulation.
 - spreadsheet_path: the path of the spreadsheet file you need to manipulate.
-- spreadsheet_content: the first few rows of the content of the spreadsheet file.
+- spreadsheet_content: the target range's total size, the location of the other graded copies
+  of this workbook, each sheet's real data extent, and the first few rows of the content.
 - instruction_type: Cell-Level Manipulation (answer_position is exact cell(s)) or Sheet-Level Manipulation (answer_position is the maximum range you may modify).
 - answer_position: the cell(s)/range you must modify or fill in.
 - output_path: write the modified spreadsheet file to this exact path.


### PR DESCRIPTION
## Why

PR #289 fixed the **signal** and changed no **behaviour**. The optimizer duly named coverage as failure cluster rank 2 in `PROCESS.md` and added a "count non-empty cells versus range size" rule — yet over pilot [30799393875](https://github.com/skillberry-ai/cap-evolve/actions/runs/30799393875) turn usage went **3.52 → 3.32 against a cap of 30**, and −0.21 on the very tasks where reconnaissance was the prescribed fix.

**Prose cannot buy reconnaissance.** So state the facts instead of requesting them.

Census of the champion's 22 failures on 50 val tasks (hard scoring — only 3/3 earns reward):

| outcome | tasks | nature |
|---|---|---|
| ✅ 3/3 | 28 | — |
| ❌ 0/3 | 14 | logic / spec comprehension — untouched by this PR |
| ⚠️ 1/3 or 2/3 | **8** | right for copy 1, wrong for the other graded copies |
| ⚠️ coverage short | 6 (4 severe) | misjudged where data ends |

The agent is told **201 times** across 150 rollouts that its code is "replayed on two other copies" and references them **zero** times — nothing said where they are, and it never enumerated the directory, though they sit beside its input in the mount.

## What changed

`spreadsheet_content` now carries three facts before the existing five preview rows:

1. **`TARGET SIZE`** — via `_range_cells`, the same helper `_localize_failure` grades with, so the agent sees exactly the denominator `COVERAGE` will hold it to. No file opened, no gold read.
2. **The container paths of graded copies 2 and 3.**
3. **Each sheet's real data extent** — from the already-parsed frame's shape, explicitly **not** `openpyxl`'s `max_row`, which counts formatted-but-empty cells and would teach overfilling (a regression risk against the 28 tasks that already pass).

Task `110-2` is the archetype: it wrote 9 of 39 target cells, exactly `3 rows × 3 cols`, from a five-row preview. It is now told *39 cell(s)* and *rows 1-13*.

```
TARGET SIZE: answer_position covers 39 cell(s), across 1 sheet(s): Sheet1.

OTHER GRADED COPIES: this task is scored on three copies of this workbook whose data
differs (row counts and values change). The other two are already on disk at:
  /mnt/data/spreadsheet/110-2/2_110-2_input.xlsx
  /mnt/data/spreadsheet/110-2/3_110-2_input.xlsx
Your FINAL code block is replayed verbatim on each of them with the input and output
filenames substituted, so that final block must read exactly ONE input — the
spreadsheet_path given above. Anything you run across several copies belongs in an
EARLIER turn.

Sheet Name: Sheet1  [data extent: rows 1-13, cols A-C  (12 data row(s) x 3 column(s))]
   Column 1  Column 2  Column 3
0         1        11       101
...
(showing the first 5 of 12 data row(s))
```

## Integrity

Deliberately **factual, not prescriptive**: nothing instructs the agent to self-test on the copies. That strategy is left for the optimizer to discover, so if it emerges the gain belongs to the optimizer rather than being hand-supplied here (cf. #276). A test asserts the target-facts text contains no prescriptive phrasing.

Note upstream gives its agent only copy 1 too (`inference_multiple.py:52-53`), so this is an **environment/adapter change** and should be disclosed as such rather than folded into an optimizer win when comparing against published numbers.

## Hazard closed

Cases 2 and 3 are produced by replaying the agent's **final** code block with filenames substituted. A final block that itself looped over copies would have those names rewritten and corrupt the graded outputs — so the injected text states the final block must read exactly one input.

The added facts are computed *after* the preview and inside a `try`: this call site was previously unwrapped, and a pandas/PyArrow `SIGSEGV` in exactly this path once took down a whole algorithm process (run 30634898569, ~68 min and ~$6). New facts must never cost a rollout.

## Tests

`openpyxl`/`pandas` were declared nowhere, so every test touching a real `.xlsx` hit `importorskip` and vanished — **including all of PR #289's `test_spreadsheetbench_failure_localization.py`, in CI as well as locally.** Adding them as dev extras made 10 dead tests live and surfaced a stale one: `test_preview_text_is_unchanged_by_the_backend_switch` re-implemented the preview format inline, so it tested the format rather than the python-vs-pyarrow invariant. It now compares `_spreadsheet_preview` against itself under both backends.

16 new tests; **410 passed, 1 skipped** (the `pyarrow` guard) on the full core suite.

## Two hypotheses tested and REFUTED

Recorded so nobody re-runs them:

1. *The replay's naive `str.replace` silently breaks solutions that build paths dynamically.* **No** — all 50 tasks emit both literal filenames, and upstream `inference_multiple.py:121-124` does the identical substitution. The adapter is faithful; the partials are real generalization failures.
2. *The agent reads gold.* **No** — 0 gold filename references and 0 `load_workbook` calls on an answer path across 150 trajectories (39 apparent `_answer` hits were the agent's own variable names, `inside_answer`, `first_answer_row`). Gold **is** reachable in the mount, which is worth hardening alongside #276.

## Expected effect

Ceiling is +0.16 val if all 8 partials convert, +0.08 for the 4 severe shortfalls; realistically about half. This does **not** address the 14 logic failures, which is where the gap to the paper's 80–85% lives.

Next step is a pilot re-run, where the mechanism check is unambiguous: the agent references the alternate copies **zero** times today, so any non-zero means it engaged.

Signed-off-by: Eran Raichstein <eranra@il.ibm.com>