### PR TITLE
fix(spreadsheetbench): stop miseducating the optimizer, stop forgetting between runs, warn when the gate is too strict

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -395,6 +395,12 @@ jobs:
             SOURCE_TEXT="manual ($BRANCH_NAME)"; pr="null"
           fi
           export SOURCE_TEXT
+          # SB_* flags live in the tier's committed overrides.env, which only run_suite.sh
+          # sources — so resolve them here too, or the disclosure field below would always read
+          # as "not warm" even on a warm-started run. An env var still wins over the file.
+          ov="$GITHUB_WORKSPACE/ci/benchmarks/${{ matrix.bench }}/${{ matrix.tier }}/overrides.env"
+          warm_file=$(sed -n 's/^[[:space:]]*SB_WARM_SEED=\([01]\).*/\1/p' "$ov" 2>/dev/null | tail -1)
+          if [ "${SB_WARM_SEED:-${warm_file:-0}}" = "1" ]; then warm_json=true; else warm_json=false; fi
           # Emit both free-form fields as JSON *string literals*. Shell quoting alone is not
           # enough: a branch name containing a double quote would close the string early and
           # produce a runmeta.json the aggregate job cannot parse (verified locally).
@@ -416,6 +422,8 @@ jobs:
             "trials": ${NUM_TRIALS:-10},
             "agent_model": "${AGENT_MODEL:-aws/gpt-oss-120b}",
             "optimizer_model": "${OPTIMIZER_MODEL:-claude-opus-4-8}",
+            "gate_k_se": ${GATE_K_SE:-1.0},
+            "warm_seed": $warm_json,
             "conclusion": "${{ job.status }}"
           }
           JSON

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,41 @@ All notable changes to cap-evolve are documented here. The format follows
 [Semantic Versioning](https://semver.org/) (currently `0.x` — anything may change).
 
 ## [Unreleased]
+### Fixed
+- **The TYPE diagnostic's advice was unconditionally backwards half the time.** PR #289 appended
+  one static clause to every type mismatch — *"write real numbers/dates, not their text form"* —
+  regardless of direction. On pilot 30890657732 it fired on 6 tasks and was **wrong on two**:
+  `57232` held `float where str was expected` and `50630` held `datetime where str was expected`,
+  and both were told to write real numbers. Pilot 30799393875's own `PROCESS.md` had already
+  root-caused `50630` correctly — *"GT keeps the fragment as the original text string"* — so the
+  optimizer was reading its correct diagnosis and our contradictory advice at once. Feedback that
+  points the wrong way is worse than none: the optimizer writes capability rules from it, and a
+  rule pushing the wrong direction can regress a passing task. Advice is now direction-aware, and
+  a mismatch between two non-textual types (`int` vs `float`) gets no directional claim at all.
+
 ### Added
+- **Learning now carries across runs (opt-in warm start).** Every run began from the pristine
+  seed, so each explored a different subset of rules and forgot the rest. Measured across the two
+  pilots' champions: 30799393875 learned "spill/volatile functions do not survive LibreOffice
+  recalculation — write the literal" (`_xlfn`×4, `TEXTJOIN`×3) and fixed tasks `47741` and
+  `51958`; 30890657732 carried **zero** of it and both regressed. That is 2 tasks (0.04 val) lost
+  to forgetting, which also means part of the apparent run-to-run noise was lost knowledge rather
+  than variance. `SB_WARM_SEED=1` now starts from `seed_capability_warm/` — a **verbatim optimizer
+  artifact, never hand-edited** (see its `PROVENANCE.md`), because hand-authoring rules there
+  would make the next measured "optimizer gain" partly ours (#276). A warm-started run's
+  `base→opt` delta is **not** comparable to a pristine run's — absolute score higher, measured
+  gain smaller — so it is opt-in, mutually exclusive with the `SB_EMPTY_SEED` no-skill control,
+  disclosed in the log, and recorded as `"warm_seed"` in `runmeta.json`. Enabled for `pilot`;
+  `full` deliberately stays pristine so the headline stays a from-scratch measurement, pinned by
+  a test.
+- **A loud warning when the acceptance gate is too strict for hard scoring.** The committed
+  overrides already documented that hard scoring makes per-task reward Bernoulli, widening the
+  gate's SE, and that it must be paired with `gate_k_se=0.2` — but `GATE_K_SE` is always set by
+  the workflow, so `overrides.env` cannot enforce it and nothing warned. Both pilots consequently
+  ran `k_se=1.0` against hard scoring, and 30890657732's `cand_0003` scored **0.600 — above its
+  accepted champion's 0.580 — and was rejected** on a delta of 0.020. `run_suite.sh` now emits a
+  `::warning::` whenever `SB_SCORING=hard` meets `gate_k_se >= 0.5`. `runmeta.json` also records
+  `gate_k_se`, so a run's strictness travels with its number.
 - **The agent is now told where the other two graded copies are, and how big its target is.**
   PR #289 fixed the *signal* — the optimizer duly named coverage as failure cluster rank 2 and
   added a "count non-empty cells versus range size" rule. It changed no behaviour: over pilot

--- a/ci/benchmarks/lib/run_suite.sh
+++ b/ci/benchmarks/lib/run_suite.sh
@@ -139,9 +139,48 @@ ENV
     # headroom. Blanking the seed reproduces their control; the adapter treats an EMPTY
     # prompt.md as "send no system message" and the harness's is_empty() path tells the
     # optimizer to author the capability from scratch.
+    if [ "${SB_EMPTY_SEED:-0}" = "1" ] && [ "${SB_WARM_SEED:-0}" = "1" ]; then
+      echo "::error:: SB_EMPTY_SEED and SB_WARM_SEED are mutually exclusive — 'no skill at all'" \
+           "and 'start from an already-optimized skill' cannot both be the baseline." >&2
+      exit 1
+    fi
     if [ "${SB_EMPTY_SEED:-0}" = "1" ]; then
       : > "$PROJ/seed_capability/prompt.md"
       echo ">>> spreadsheetbench: EMPTY seed (no-skill control) — prompt.md blanked" >&2
+    fi
+    # WARM START. Learning was not cumulative: every run began from the pristine seed, so each
+    # explored a different subset of rules and forgot the rest. Across the two pilots' champions,
+    # 30799393875 learned "spill/volatile functions do not survive LibreOffice recalc — write the
+    # literal" (_xlfn x4, TEXTJOIN x3) and fixed tasks 47741 and 51958; 30890657732 carried NONE
+    # of it and both regressed. That is 2 tasks lost to forgetting, not to variance.
+    #
+    # seed_capability_warm/ is a verbatim optimizer artifact, never hand-edited — see its
+    # PROVENANCE.md. A warm-started run's base->opt delta is NOT comparable to a pristine run's:
+    # the baseline is already optimized, so the absolute score is higher and the measured gain
+    # smaller. Hence opt-in only, and disclosed in runmeta.json as "warm_seed".
+    if [ "${SB_WARM_SEED:-0}" = "1" ]; then
+      WARM="$TPL/spreadsheetbench/seed_capability_warm"
+      if [ ! -f "$WARM/prompt.md" ] || [ ! -f "$WARM/task_template.md" ]; then
+        echo "::error:: SB_WARM_SEED=1 but $WARM is missing prompt.md/task_template.md" >&2
+        exit 1
+      fi
+      cp "$WARM/prompt.md" "$WARM/task_template.md" "$PROJ/seed_capability/"
+      echo ">>> spreadsheetbench: WARM seed — baseline is the champion of run 30890657732" \
+           "(cand_0002, val 0.580). base->opt is NOT comparable to a pristine-seed run." >&2
+    fi
+    # Gate strictness vs scoring mode. Hard scoring makes per-task reward Bernoulli, which widens
+    # the gate's SE, so the k_se that is sane under soft scoring rejects almost everything under
+    # hard. This bit us twice and silently: pilots 30799393875 and 30890657732 both ran the
+    # default k_se=1.0 against SB_SCORING=hard, and 30890657732's cand_0003 scored 0.600 — ABOVE
+    # its accepted champion's 0.580 — and was rejected on a delta of 0.020. GATE_K_SE is always
+    # set by the workflow so it cannot be corrected from overrides.env; warn loudly instead.
+    if [ "${SB_SCORING:-soft}" = "hard" ]; then
+      if awk "BEGIN{exit !(${GATE_K_SE:-1.0} >= 0.5)}"; then
+        echo "::warning:: SB_SCORING=hard with gate_k_se=${GATE_K_SE:-1.0}. Bernoulli per-task" \
+             "reward widens the gate's SE, so real gains are likely to be REJECTED (run" \
+             "30890657732 rejected a 0.600 candidate in favour of 0.580). Dispatch with" \
+             "gate_k_se=0.2 for hard scoring." >&2
+      fi
     fi
     # Prompt-only optimizer instructions. The default template shipped in
     # templates/project/optimizer/INSTRUCTIONS.md is written for a capability that

--- a/ci/benchmarks/spreadsheetbench/pilot/overrides.env
+++ b/ci/benchmarks/spreadsheetbench/pilot/overrides.env
@@ -14,3 +14,15 @@
 # gate_k_se cannot live in this file, because the workflow always sets GATE_K_SE and the
 # environment deliberately wins over committed overrides.
 SB_SCORING=hard
+
+# WARM START (pilot only). Learning was not cumulative: every run began from the pristine seed,
+# so pilot 30799393875 learned "spill/volatile functions do not survive LibreOffice recalc —
+# write the literal" (_xlfn x4, TEXTJOIN x3) and fixed tasks 47741 and 51958, while pilot
+# 30890657732 carried none of it and both regressed. 2 tasks lost to forgetting, not variance.
+#
+# The baseline is therefore an ALREADY-OPTIMIZED capability (a verbatim optimizer artifact — see
+# templates/adapters/spreadsheetbench/seed_capability_warm/PROVENANCE.md, never hand-edited), so
+# this tier's base->opt delta is NOT comparable to a pristine-seed run's: absolute score higher,
+# measured optimizer gain smaller. runmeta.json records "warm_seed": true so it cannot be
+# misquoted as a from-scratch result. The `full` tier deliberately stays pristine.
+SB_WARM_SEED=1

--- a/core/tests/test_spreadsheetbench_scoring_and_seed.py
+++ b/core/tests/test_spreadsheetbench_scoring_and_seed.py
@@ -192,6 +192,17 @@ def test_exactly_the_expected_tiers_ship_overrides_and_only_with_known_keys():
 
     spreadsheetbench pilot+full optimize the HARD score, to be comparable with published work
     that reports a benchmark's native hard score (soft >= hard by construction).
+
+    The pilot ALSO sets `SB_WARM_SEED=1`, and that is exactly the kind of deviation this test
+    exists to make loud. Learning was not cumulative across runs: pilot 30799393875 learned
+    "spill/volatile functions do not survive LibreOffice recalculation — write the literal" and
+    fixed tasks 47741 and 51958, while pilot 30890657732 carried none of it and both regressed —
+    2 tasks lost to forgetting rather than variance. The pilot therefore starts from the previous
+    champion (a verbatim optimizer artifact; see seed_capability_warm/PROVENANCE.md). Its
+    base->opt delta is consequently NOT comparable to a pristine-seed run's: absolute score
+    higher, measured optimizer gain smaller. runmeta.json records "warm_seed": true so the
+    difference travels with the number. The `full` tier deliberately stays pristine, so the
+    headline result remains a from-scratch measurement.
     """
     shipped = {
         str(p.relative_to(REPO)): dict(
@@ -202,8 +213,17 @@ def test_exactly_the_expected_tiers_ship_overrides_and_only_with_known_keys():
     }
     assert shipped == {
         "ci/benchmarks/spreadsheetbench/full/overrides.env": {"SB_SCORING": "hard"},
-        "ci/benchmarks/spreadsheetbench/pilot/overrides.env": {"SB_SCORING": "hard"},
+        "ci/benchmarks/spreadsheetbench/pilot/overrides.env": {
+            "SB_SCORING": "hard", "SB_WARM_SEED": "1",
+        },
     }, "a tier gained or changed a committed override — say which and why in the PR"
+
+
+def test_the_full_tier_stays_pristine_so_the_headline_is_from_scratch():
+    """A warm-started `full` run would publish a sealed number whose baseline was already
+    optimized — the one number that must stay a from-scratch measurement."""
+    full = (REPO / "ci" / "benchmarks" / "spreadsheetbench" / "full" / "overrides.env")
+    assert "SB_WARM_SEED" not in full.read_text(encoding="utf-8")
 
 
 def test_the_shipped_overrides_do_not_pretend_to_set_workflow_owned_vars():

--- a/core/tests/test_spreadsheetbench_type_advice.py
+++ b/core/tests/test_spreadsheetbench_type_advice.py
@@ -1,0 +1,122 @@
+"""Feedback that points the wrong way is worse than no feedback.
+
+PR #289 appended one UNCONDITIONAL clause to every TYPE mismatch it reported:
+
+    " — write real numbers/dates, not their text form."
+
+Measured on pilot 30890657732 that clause fired on 6 tasks and was **backwards on two of them**:
+`57232` held `float where str was expected` and `50630` held `datetime where str was expected`, and
+both were told to write real numbers. Worse, pilot 30799393875's own `PROCESS.md` had already
+root-caused `50630` correctly — *"GT keeps the fragment as the original text string"* — so the
+optimizer was simultaneously reading its own correct diagnosis and our contradictory advice.
+
+This matters more than a cosmetic wording bug: the optimizer writes capability rules from this
+feedback, and a rule pushing the wrong direction can regress a task that currently passes.
+
+Also pins the warm-start seed as a *valid capability*, because a broken template there would
+reject every candidate before any task runs.
+"""
+
+import importlib.util
+import string
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+ADAPTER_DIR = REPO / "templates" / "adapters" / "spreadsheetbench"
+WARM = ADAPTER_DIR / "seed_capability_warm"
+
+
+def _adapter():
+    for p in (REPO / "core", ADAPTER_DIR, ADAPTER_DIR.parent):
+        if str(p) not in sys.path:
+            sys.path.insert(0, str(p))
+    spec = importlib.util.spec_from_file_location("_sb_adv", ADAPTER_DIR / "adapter.py")
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# --- direction awareness -----------------------------------------------------------------
+
+
+def test_text_where_a_number_was_expected_says_write_the_real_value():
+    out = _adapter()._type_advice([("str", "int")]).lower()
+    assert "real typed value" in out or "real value" in out
+    assert "keep the original text" not in out
+
+
+def test_a_number_where_text_was_expected_says_KEEP_the_text():
+    """The exact case (`57232`) the old static clause got backwards."""
+    out = _adapter()._type_advice([("float", "str")]).lower()
+    assert "keep the original text" in out
+    assert "write the real typed value" not in out
+
+
+def test_a_datetime_where_text_was_expected_says_do_not_parse():
+    """Task `50630`: the agent parsed a split-out date fragment; gold keeps it as text."""
+    out = _adapter()._type_advice([("datetime", "str")]).lower()
+    assert "do not parse" in out
+    assert "keep the original text" in out
+
+
+def test_a_mixed_pair_gets_both_directions_and_contradicts_neither():
+    out = _adapter()._type_advice([("str", "int"), ("float", "str")]).lower()
+    assert "real typed value" in out and "keep the original text" in out
+
+
+def test_two_non_textual_types_get_no_directional_advice():
+    """int vs float: neither side is text, so neither tip applies."""
+    out = _adapter()._type_advice([("int", "float")]).lower()
+    assert "match the expected type exactly" in out
+    assert "text form" not in out
+
+
+def test_the_old_unconditional_wording_is_gone_for_the_to_text_direction():
+    """Regression pin: the exact string that miseducated the optimizer must not reappear."""
+    for pairs in ([("float", "str")], [("datetime", "str")]):
+        assert "not their text form" not in _adapter()._type_advice(pairs)
+
+
+def test_advice_never_returns_empty_so_the_note_is_always_well_formed():
+    for pairs in ([("str", "int")], [("float", "str")], [("int", "float")], []):
+        out = _adapter()._type_advice(pairs)
+        assert out.startswith(" — ") and out.rstrip().endswith(".")
+
+
+# --- the warm-start seed must be a usable capability -------------------------------------
+
+
+def test_the_warm_seed_ships_both_editable_artifacts():
+    assert (WARM / "prompt.md").is_file()
+    assert (WARM / "task_template.md").is_file()
+    assert (WARM / "PROVENANCE.md").is_file(), "a warm seed without provenance is unciteable"
+
+
+def test_the_warm_seed_template_carries_every_required_placeholder():
+    """A missing placeholder here would reject every candidate before any task runs."""
+    mod = _adapter()
+    found = {
+        f for _, f, _, _ in
+        string.Formatter().parse((WARM / "task_template.md").read_text(encoding="utf-8")) if f
+    }
+    assert mod._TEMPLATE_REQUIRED <= found
+
+
+def test_the_warm_seed_template_renders_a_real_task():
+    fields = dict(instruction="do a thing", spreadsheet_path="/mnt/data/x.xlsx",
+                  spreadsheet_content="A1: 1", instruction_type="Cell-Level Manipulation",
+                  answer_position="'S'!C2", output_path="/mnt/data/outputs/t/1_x_output.xlsx",
+                  max_turns=30)
+    # Go through _read_task_template, which strips the optimizer-facing HTML comment block —
+    # that block documents the contract and itself contains a literal "{braces}", so formatting
+    # the raw file would raise KeyError on documentation rather than on a real defect.
+    out = _adapter()._read_task_template(WARM).format(**fields)
+    for v in ("/mnt/data/outputs/t/1_x_output.xlsx", "'S'!C2", "do a thing"):
+        assert v in out
+
+
+def test_the_warm_seed_prompt_is_not_empty():
+    """An empty prompt.md is the no-skill CONTROL; a warm seed must not silently become it."""
+    assert (WARM / "prompt.md").read_text(encoding="utf-8").strip()

--- a/templates/adapters/spreadsheetbench/adapter.py
+++ b/templates/adapters/spreadsheetbench/adapter.py
@@ -1511,6 +1511,42 @@ def _range_cells(answer_position: str):
         yield sheet, col(c1), r1, col(c2), r2
 
 
+_TEXTUAL = {"str"}
+
+
+def _type_advice(pairs: list[tuple[str, str]]) -> str:
+    """Advice that matches the DIRECTION of each type mismatch.
+
+    This clause used to be the unconditional string "— write real numbers/dates, not their text
+    form", appended whichever way the mismatch went. Measured on pilot 30890657732 it was
+    therefore backwards for a third of the tasks it fired on: task `57232` held `float where str
+    was expected` and `50630` held `datetime where str was expected`, and both were told to write
+    real numbers. Worse, pilot 30799393875's own PROCESS.md had already root-caused `50630`
+    correctly — "GT keeps the fragment as the original text string" — so the optimizer was
+    reading our advice and its own correct diagnosis in direct contradiction.
+
+    Feedback that points the wrong way is worse than no feedback: the optimizer writes rules from
+    it, and a rule pushing the wrong direction can regress a task that currently passes.
+    """
+    to_text = [(g, w) for g, w in pairs if w in _TEXTUAL and g not in _TEXTUAL]
+    from_text = [(g, w) for g, w in pairs if g in _TEXTUAL and w not in _TEXTUAL]
+    tips: list[str] = []
+    if from_text:
+        tips.append(
+            "where a number or date is expected, write the real typed value rather than its "
+            "text form"
+        )
+    if to_text:
+        tips.append(
+            "where a str is expected, KEEP the original text — do not parse or convert it into "
+            "a number or date"
+        )
+    if not tips:
+        # e.g. int vs float: neither side is textual, so no directional advice applies.
+        return " — match the expected type exactly."
+    return " — " + "; ".join(tips) + "."
+
+
 def _localize_failure(entry: dict, produced: Path, source: Path, gold: Path) -> list[str]:
     """WHY a produced workbook missed, in terms the optimizer can act on.
 
@@ -1576,7 +1612,7 @@ def _localize_failure(entry: dict, produced: Path, source: Path, gold: Path) -> 
     # TYPE mismatch (reports the expected TYPE, never a value).
     try:
         gw = openpyxl.load_workbook(gold, data_only=True)
-        bad: dict[str, int] = {}
+        bad: dict[tuple[str, str], int] = {}
         for sheet, c1, r1, c2, r2 in _range_cells(entry.get("answer_position", "")):
             name = sheet if sheet in pw.sheetnames else pw.sheetnames[0]
             gname = sheet if sheet in gw.sheetnames else gw.sheetnames[0]
@@ -1586,12 +1622,16 @@ def _localize_failure(entry: dict, produced: Path, source: Path, gold: Path) -> 
                     a, b = ws.cell(row, cc).value, gs.cell(row, cc).value
                     if a is None or b is None or type(a) is type(b):
                         continue
-                    bad[f"{type(a).__name__} where {type(b).__name__} was expected"] = \
-                        bad.get(f"{type(a).__name__} where {type(b).__name__} was expected", 0) + 1
+                    key = (type(a).__name__, type(b).__name__)
+                    bad[key] = bad.get(key, 0) + 1
         if bad:
             worst = sorted(bad.items(), key=lambda kv: -kv[1])[:2]
-            notes.append("TYPE: " + "; ".join(f"{n} cell(s) hold {k}" for k, n in worst)
-                         + " — write real numbers/dates, not their text form.")
+            notes.append(
+                "TYPE: "
+                + "; ".join(f"{n} cell(s) hold {got} where {want} was expected"
+                            for (got, want), n in worst)
+                + _type_advice([pair for pair, _ in worst])
+            )
     except Exception:  # noqa: BLE001
         pass
     return notes

--- a/templates/adapters/spreadsheetbench/seed_capability_warm/PROVENANCE.md
+++ b/templates/adapters/spreadsheetbench/seed_capability_warm/PROVENANCE.md
@@ -1,0 +1,49 @@
+# Warm-start seed — provenance
+
+**This is NOT a hand-authored capability.** Every word of `prompt.md` and `task_template.md` in
+this directory was written by the optimizer during a real run. Nothing here was added by a human,
+which is what makes using it a *warm start* rather than hand-supplying the answer.
+
+| field | value |
+|---|---|
+| source run | [30890657732](https://github.com/skillberry-ai/cap-evolve/actions/runs/30890657732) (`pilot`, spreadsheetbench) |
+| candidate | `cand_0002` — the accepted champion |
+| val reward (hard, 50 tasks) | **0.580** (seed that run scored 0.520) |
+| adapter sha | `7e3b7f9d` (PR #291 — target size, graded copies, data extent) |
+| agent / optimizer | `azure/gpt-5.5` / Claude Code `claude-opus-4-8` |
+
+## Why this exists
+
+Learning was **not cumulative across runs**. Every run started from the pristine
+`seed_capability/`, so each one explored a different subset of rules and forgot the rest.
+Measured across the two pilots' champions:
+
+| rule token | 30799393875 `cand_0001` | 30890657732 `cand_0002` |
+|---|---|---|
+| `_xlfn` | 4 | **0** |
+| `TEXTJOIN` | 3 | **0** |
+| `volatile` | 3 | **0** |
+
+Pilot 1 learned "spill/volatile functions do not survive LibreOffice recalculation — write the
+literal value" and fixed tasks `47741` and `51958` with it. Pilot 2 never rediscovered it and
+both regressed to failing. That is 2 tasks (0.04 val) lost purely to forgetting, and it means
+some of what looked like run-to-run noise was lost knowledge rather than variance.
+
+## Honesty rules for using this
+
+**A warm-started run's `base→opt` delta is NOT comparable to a pristine-seed run's.** The
+baseline is already optimized, so the measured optimizer gain is *smaller* while the absolute
+score is *higher*. Both numbers are real; they answer different questions.
+
+- Opt in explicitly with `SB_WARM_SEED=1`. The default stays the pristine seed.
+- `run_suite.sh` prints a loud disclosure and `runmeta.json` records `"warm_seed": true`, so a
+  warm-started run cannot be quoted later as a from-scratch result by accident.
+- Mutually exclusive with `SB_EMPTY_SEED=1` (the no-skill control) — combining "no skill at all"
+  with "start from an optimized skill" is incoherent, and `run_suite.sh` refuses it.
+- When comparing against published from-scratch numbers, report the pristine-seed run.
+
+## Refreshing this
+
+Replace both files with a later champion's `optimized/optimized_capability/` and update the table
+above. Do not edit the text by hand — hand edits would make the next measured "optimizer gain"
+partly ours, which is the failure mode issue #276 describes.

--- a/templates/adapters/spreadsheetbench/seed_capability_warm/prompt.md
+++ b/templates/adapters/spreadsheetbench/seed_capability_warm/prompt.md
@@ -1,0 +1,11 @@
+You are a spreadsheet expert who can manipulate spreadsheets through Python code.
+
+Solve the given spreadsheet manipulation question precisely:
+- Read the instruction, spreadsheet content preview, instruction type, and answer position carefully before writing any code.
+- For Cell-Level Manipulation questions, modify or fill in values ONLY within the exact cell(s) given in answer_position.
+- For Sheet-Level Manipulation questions, modify or fill in values ONLY within the cell range given in answer_position — never touch cells outside that range.
+- Prefer computing and writing LITERAL values (e.g. with pandas/openpyxl) over live spreadsheet formulas, so the result is unambiguous when the file is re-opened for grading.
+- Your final code is re-run unchanged on other copies of this workbook whose data differs, so compute every answer from the data present at run time — detect the real data extent, group/segment boundaries, and any thresholds from the data itself, and never hardcode a row count, cell position, boundary value, or year you saw only in the preview.
+- A copy may show a manually worked example or summary of the answer (a pre-filled totals/counts table, one filled-in example row, or a spilled UNIQUE/FILTER/SORT list); these reflect only the previewed copy and change on the other copies, so use them to learn the required format but recompute every answer value yourself from the raw source columns rather than copying them or letting them constrain your result.
+- Always save your result to the exact output_path given, creating any missing parent directories first.
+- If code execution returns an error, read the traceback carefully and fix the code — do not repeat a failing approach unchanged.

--- a/templates/adapters/spreadsheetbench/seed_capability_warm/task_template.md
+++ b/templates/adapters/spreadsheetbench/seed_capability_warm/task_template.md
@@ -1,0 +1,79 @@
+<!--
+  THE AGENT'S JOB DESCRIPTION — editable capability text, same as prompt.md.
+
+  Everything below is sent to the agent as its first user message, so it is part of the
+  skill you are optimizing: reword it, restructure it, add or remove guidance, change the
+  interaction contract. This comment block is STRIPPED before the agent sees it.
+
+  LOAD-BEARING PLACEHOLDERS — these are filled in per task and must SURVIVE any edit:
+    {instruction} {spreadsheet_path} {spreadsheet_content} {instruction_type}
+    {answer_position} {output_path}
+  Optional: {max_turns}. No other {braces} are allowed.
+
+  If a required placeholder goes missing, or an unknown one appears, the candidate is
+  REJECTED before any task runs — the agent would otherwise be told to write its answer to
+  a path it was never given. A literal brace must be doubled: {{ or }}.
+-->
+You need to solve the following spreadsheet manipulation question. It contains six pieces of information:
+- instruction: the question about spreadsheet manipulation.
+- spreadsheet_path: the path of the spreadsheet file you need to manipulate.
+- spreadsheet_content: the target range's total size, the location of the other graded copies
+  of this workbook, each sheet's real data extent, and the first few rows of the content.
+- instruction_type: Cell-Level Manipulation (answer_position is exact cell(s)) or Sheet-Level Manipulation (answer_position is the maximum range you may modify).
+- answer_position: the cell(s)/range you must modify or fill in.
+- output_path: write the modified spreadsheet file to this exact path.
+
+### instruction
+{instruction}
+
+### spreadsheet_path
+{spreadsheet_path}
+
+### spreadsheet_content
+{spreadsheet_content}
+
+### instruction_type
+{instruction_type}
+
+### answer_position
+{answer_position}
+
+### output_path
+{output_path}
+
+### how your answer is graded (read before writing code)
+Your FINAL code block is re-run UNCHANGED on three copies of this workbook whose data
+differs; each output is graded cell-by-cell against a reference answer, comparing BOTH the
+value AND the type. Only copy 1 is previewed above; the other two copies are already on disk
+(paths in spreadsheet_content). Read and write using the exact spreadsheet_path and
+output_path strings given above — the re-run substitutes the filenames — so never glob for
+files or build paths from a copy number. In an EARLY turn you may open all three input copies
+to confirm your logic generalizes; the final block itself must read only the one
+spreadsheet_path.
+
+Match the expected TYPE and format of each answer cell:
+- If the target range already contains a worked-example cell, replicate its exact per-column
+  type and formatting — text stays text, a real date stays a date, a number stays a number —
+  and preserve any leading/trailing spaces the source keeps (do not strip them).
+- If the instruction names the form a result may take (e.g. "the result may be #N/A" or the
+  "output result may be '-'"), write that exact literal for those cases, not a numeric
+  placeholder such as 0.
+- Rich-text and conditional-formatting cells are themselves the graded answer — preserve the
+  CellRichText / cell formatting, and never flatten them to a plain string.
+
+Fill exactly what is asked and nothing more:
+- Fill every cell the instruction requires; add no extra labels, totals, headers, or summary
+  rows it didn't request.
+- For formatting or conditional-formatting tasks, keep the existing cell values and formulas
+  unchanged and modify only the formatting.
+
+You have up to {max_turns} rounds of interaction. In each round, reply with exactly ONE python code block:
+1. Information-gathering code (e.g. inspecting the file, or all three input copies) — the execution result is returned to you.
+2. Solution code that writes the modified file to output_path.
+3. Verification code: re-open output_path and print, for each cell in answer_position, its
+   value and its python type. Confirm every cell the task requires is filled with the intended
+   value in a matching type (a rich-text or formatting answer keeps its special type, not a
+   plain string), and that no cell you meant to fill is unexpectedly None. If anything is
+   wrong, fix your code and write again.
+Reply without a code block when you are satisfied the saved file is correct.
+If your code raises an error, the traceback will be returned to you; fix the code and try again.


### PR DESCRIPTION
Three defects in the optimization **process**, found by cross-analysing pilots [30799393875](https://github.com/skillberry-ai/cap-evolve/actions/runs/30799393875) and [30890657732](https://github.com/skillberry-ai/cap-evolve/actions/runs/30890657732) — which between them give **four capability states scored on the same 50 val tasks**.

That 2×2 sets the context for everything below:

| category | tasks |
|---|---|
| **Always** pass (all 4 states) | 22 |
| **Never** pass (all 4 states) | **18** |
| Volatile | **10** |

Per-state 3/3 counts: **25, 28, 26, 29**. The entire observed range across four very different capability texts is **4 tasks out of 50**.

## 1. The TYPE diagnostic's advice was backwards half the time

PR #289 appended one **static** clause to every mismatch, whichever way it went:

```
 — write real numbers/dates, not their text form.
```

It fired on 6 tasks and was wrong on two:

| task | mismatch | old advice |
|---|---|---|
| 59259, 55931, 56427, 51958 | `str` where number/date expected | ✅ correct |
| **57232** | `float` where **`str`** expected | ❌ backwards |
| **50630** | `datetime` where **`str`** expected | ❌ backwards |

Pilot 30799393875's own `PROCESS.md` had already root-caused `50630` correctly — *"GT keeps the fragment as the original text string"* — so the optimizer was reading its correct diagnosis and our contradictory advice at the same time.

Feedback that points the wrong way is worse than none: the optimizer writes capability rules from it, and a rule pushing the wrong direction can **regress a task that currently passes**. Advice is now direction-aware, and two non-textual types (`int` vs `float`) get no directional claim at all.

## 2. Learning was not cumulative across runs

Every run started from the pristine seed, so each explored a different subset of rules and forgot the rest:

| token | run 1 `cand_0001` | run 2 `cand_0002` |
|---|---|---|
| `_xlfn` | 4 | **0** |
| `TEXTJOIN` | 3 | **0** |
| `volatile` | 3 | **0** |

Run 1 learned *"spill/volatile functions do not survive LibreOffice recalculation — write the literal"* and fixed `47741` and `51958`. Run 2 never rediscovered it and **both regressed** — the `0,3,0,0` pattern in the volatility matrix. So 2 tasks (0.04 val) were lost to *forgetting*, and part of what looked like run-to-run noise was lost knowledge rather than variance.

`SB_WARM_SEED=1` now starts from `seed_capability_warm/` — a **verbatim optimizer artifact, never hand-edited** (see its `PROVENANCE.md`). Hand-authoring rules there would make the next measured "optimizer gain" partly ours, which is exactly #276.

**Honesty controls**, because a warm-started `base→opt` delta is *not* comparable to a pristine run's (absolute higher, measured gain smaller):

- opt-in only; default stays pristine
- mutually exclusive with `SB_EMPTY_SEED` (the no-skill control) — `run_suite.sh` refuses both
- loud log disclosure, and `runmeta.json` records `"warm_seed"` so it travels with the number
- enabled for `pilot`; **`full` stays pristine, pinned by a test**, so the headline stays from-scratch

## 3. The gate has been too strict for hard scoring — silently, in every pilot

The committed overrides already said this:

> *"hard scoring makes per-task reward Bernoulli, so the gate's SE is WIDER than under soft. Pair it with a lower `gate_k_se` dispatch input (0.2) or almost nothing will be accepted"*

…but the workflow **always** sets `GATE_K_SE`, so `overrides.env` cannot enforce it and nothing warned. Both pilots ran `k_se=1.0` against `SB_SCORING=hard`, and run 30890657732's `cand_0003` scored **0.600 — above its accepted champion's 0.580 — and was rejected** on a delta of 0.020.

`run_suite.sh` now emits a `::warning::` when `SB_SCORING=hard` meets `gate_k_se >= 0.5`, and `runmeta.json` records `gate_k_se`.

## Also recorded, for scope realism

- **Coverage is essentially solved.** In the champion's 21 failures nearly all have `span == filled` (1/1, 50/50, 96/96, 146/146, 190/190); only `56427`, `30709` and `325_44` still short-fill. Further coverage work is not worth it.
- **LibreOffice recalc is not broadly failing** — only `73_45` mentions it — so that understatement risk isn't currently biting.
- **18 tasks have never passed under any condition**, several asking for VBA macros openpyxl can't write. Even a perfect prompt caps around ~0.64 on this val set.

## Tests

`422 passed, 1 skipped`. `actionlint` clean on `benchmarks.yml`. An existing guard on committed overrides caught the new key and was updated deliberately with its reason, as its own assert message asks.

Signed-off-by: Eran Raichstein <eranra@il.ibm.com>