### PR TITLE
ci: fix aggregate history failure when no benchmark artifacts exist

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -478,6 +478,9 @@ jobs:
         with:
           path: _artifacts
           pattern: benchmarks-*
+          # Don't fail when no benchmarks ran (e.g. PR has no benchmark label
+          # so all bench matrix jobs were skipped). Build-records handles empty.
+          if-no-files-found: ignore
 
       - name: Check for UI snapshots
         id: uicheck


### PR DESCRIPTION
## Problem

When a PR has no `benchmark-smoke` or `benchmark-full` label, all `bench` matrix jobs are skipped (the job-level `if` is false). The `aggregate history` job still runs because of `if: always()`, but `actions/download-artifact@v4` exits non-zero when `pattern: benchmarks-*` matches **zero** artifacts — causing it to fail with no actual benchmark work having been done.

## Fix

One line: add `if-no-files-found: ignore` to the **Download all benchmark artifacts** step. The **Build records** step already handles an empty `_artifacts/` directory gracefully (`have=0`, loop never executes, no `exit 1`).