### PR TITLE
Revise project naming and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,6 @@
 **cap-evolve improves an AI agent's prompts, tools, and skills by learning from failed
 evaluation traces.**
 
-> **Note on naming.** This project was previously called *Acapo*. The current name is
-> **cap-evolve** everywhere — templates, scaffolds, and hooks. New projects use the
-> `.capevolve` run directory (no hyphen); the legacy `.agentcapo` directory is still
-> honored as a fallback.
-
 You bring the agent and the eval you already have. cap-evolve runs the loop — evaluate →
 diagnose the failures → propose an edit → keep it only if it beats a held-out split by a
 significant margin → commit — and reports one honest number. It optimizes what your agent


### PR DESCRIPTION
Updated project name from 'Acapo' to 'cap-evolve' and clarified naming conventions.

## What & why
<!-- What does this change and why? Link any issue. -->

## Checklist
- [ ] `python -m pytest core/tests -q` passes
- [ ] `python skills/_registry/build_manifest.py skills` is clean (no errors)
- [ ] Any new/changed skill's `scripts/check.py` is green
- [ ] Honesty invariants untouched (gate on val, test sealed) — or explained
- [ ] Docs updated (README/skill SKILL.md) if behavior changed
