### PR TITLE
fix(spreadsheetbench): stop scolding correct answers, and say WHICH cells are wrong

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ All notable changes to cap-evolve are documented here. The format follows
 
 ## [Unreleased]
 ### Fixed
+- **The COVERAGE diagnostic measured the agent against the wrong denominator, and so scolded
+  correct answers.** It compared how many cells the agent filled against the SIZE of
+  `answer_position`, and complained when the ratio was low. But measured across all 912 tasks,
+  the expected output fills **under a quarter of that range on 90 of them (10.1%)** and under 60%
+  on 203 (22.8%) — so on a tenth of the benchmark a *perfect* answer was told *"Most of the target
+  range was left unfilled — check where the data actually ends"*. Task `56427` in pilot
+  30906175891 got exactly that: it filled 15 cells, the expected output fills 20, the span is 324.
+  It was scolded for ~300 cells it was never meant to write while its real defects (14 numbers
+  written as text, 5 cells left empty) went unnamed. Conversely `50051` filled 32 of 32 and was
+  told nothing at all, when the expected output fills **3** — its whole bug was writing 29 cells
+  that should stay empty. COVERAGE now states the expected fill alongside the span, and the
+  "mostly unfilled" warning is measured against that expected fill. When the gold cannot be read
+  no fill claim is made at all, rather than guessed — guessing is what made this wrong. Same
+  defect class as the TYPE-direction bug below, and 10× the blast radius.
+- **`answer_position` strings the parser could not read made a task silently invisible.** 23 of
+  the 912 tasks (2.5%) quote their range in ways the strict pattern rejected, in seven families:
+  `'Vendor!'A1:D101` (the `!` quoted with the sheet, 16 tasks), `'Data'!'A2:C150` (quote before
+  the range), `'T_Data!A1:AB700'` (quotes wrapping sheet and range together),
+  `'Received'!'Received!A1:G16'` (sheet named twice), `'Sheet1'!BD2:308` (end *column* omitted,
+  not the row), and `G12：J15` (a full-width U+FF1A colon). Every localization signal AND the
+  agent-facing `TARGET SIZE` line route through `_range_cells`, so those tasks received the
+  one-sentence feedback PR #289 existed to eliminate — and their prompts carried no target size
+  at all. Verified on the real dataset: **23 unparseable → 1**, the remaining case being bare
+  `A:G`, which names no rows and is deliberately left skipped rather than given an invented bound.
+  Task `450-9` goes from zero diagnostics to a full localization (212 of 447 cells differing, 38
+  empty, 32 written past the end).
 - **`pass^k` / `pass@k` report as N/A, never a fake `0.0`, when `k > num_trials` (#112).**
   The default `num_trials: 1` run used to print `pass^2 = 0.0`, which reads as "0%
   reliable" when the statistic is simply undefined — and `pass_at_k` was worse, since
@@ -34,6 +60,22 @@ All notable changes to cap-evolve are documented here. The format follows
   a mismatch between two non-textual types (`int` vs `float`) gets no directional claim at all.
 
 ### Added
+- **A `MISMATCH` diagnostic: how many cells differ, and in which named class.** Replaying each of
+  pilot 30906175891's champion failures against the gold shows that **11 of its 17 failures
+  received the line "the target range spans N cell(s); your output has a value in N of them" and
+  nothing else** — full coverage, matching types, so every existing signal was silent. What that
+  silence hid: task `56637` differed in **1 cell of 146**, `5192` in 1 of 3, `53367` in 1 of 1,
+  `11842` in 2 of 96. "1 of 146 cells differs" and "wrong" are different instructions to an
+  optimizer. Each differing cell is now assigned exactly one class, so the counts cannot
+  double-count: the correct value stored as text (`325-44` ×15, `56427` ×14), an Excel error text
+  the agent wrote out (`55931` ×8 `#N/A`), a cell whose expected value *is* an error marker while
+  the agent computed a number (`57232` ×15), values written where the expected output has none
+  (`50051` ×29), text that is a prefix of the expected text (`5192`), and numeric direction when
+  every difference agrees (`11842`, `59743` low; `57090` high). A separate subset count names the
+  cells CHANGED although the expected value equals the cell's own input — which is the entire bug
+  in `56637`. Cheap because it reuses the pass the other signals already make; capped at 50,000
+  cells (4 tasks of 912 span more), and the cap is disclosed in the note rather than silently
+  truncating.
 - **Learning now carries across runs (opt-in warm start).** Every run began from the pristine
   seed, so each explored a different subset of rules and forgot the rest. Measured across the two
   pilots' champions: 30799393875 learned "spill/volatile functions do not survive LibreOffice

--- a/core/tests/test_spreadsheetbench_failure_localization.py
+++ b/core/tests/test_spreadsheetbench_failure_localization.py
@@ -17,10 +17,18 @@ range. It had no evidence those were the failing sub-step.
 Task 19-7 is the archetype: two sheets, ~5,200 rows, and the agent spent two turns — write,
 then "Done." — from a five-row preview.
 
-GOLD SAFETY. Coverage and untouched-sheet notes never open the gold file: they compare the
-agent's output against its own INPUT and against the range it was handed, both already known
-to it. The type note reports a value's TYPE, not a value — metadata, judged worth that narrow
-disclosure because it is the most actionable diagnostic here. No cell value is ever emitted.
+Sparse feedback was only half the problem. Feedback measured against the WRONG REFERENCE is the
+other half, and it is worse: on 90 of the 912 tasks (10.1%) the expected output fills under a
+quarter of answer_position, so comparing the agent's fill to the SPAN told a perfect answer that
+it had "left most of the target range unfilled". Task 56427 was scolded that way while its real
+defects went unnamed. This is the same defect class as the TYPE advice that used to point the
+wrong way — and fixing that one is what finally moved the val ceiling past 0.580.
+
+GOLD SAFETY. Coverage of the agent's own output and the untouched-sheet note still never open
+the gold. Three signals do: a value's TYPE, the expected FILL COUNT (one integer per range), and
+the MISMATCH classes (how many cells differ, in which category). All three are metadata ABOUT
+the answer — a count, a type, a category — never the answer. No cell value is ever emitted;
+test_no_gold_value_leaks_through_the_mismatch_note asserts it.
 """
 
 import importlib.util
@@ -78,6 +86,65 @@ def test_unparseable_parts_are_skipped_not_fatal():
     assert list(mod._range_cells("garbage,,C1:C2")) == [(None, 3, 1, 3, 2)]
 
 
+# --- the dataset's own quoting quirks ----------------------------------------------------
+#
+# MEASURED on all 912 tasks: 23 (2.5%) of answer_position strings do not match the strict
+# notation, in seven families. Every localization signal AND the agent-facing TARGET SIZE line
+# route through _range_cells, so a part it cannot read makes the task silently invisible: on
+# pilot 30906175891, task 450-9 got the one-sentence feedback #289 existed to eliminate, and
+# its prompt carried no TARGET SIZE line at all while every well-formed task's did.
+
+
+def test_a_stray_quote_before_the_range_is_tolerated():
+    """Task 450-9's real notation — the apostrophe lands before the range, not after the sheet."""
+    mod = _adapter()
+    assert list(mod._range_cells("'Data'!'A2:C150")) == [("Data", 1, 2, 3, 150)]
+    assert list(mod._range_cells("'Sheet2'!'B7:C22")) == [("Sheet2", 2, 7, 3, 22)]
+
+
+def test_a_bang_inside_the_sheet_quotes_is_tolerated():
+    """The largest family (16 of the 23): the ! is quoted along with the sheet name."""
+    mod = _adapter()
+    assert list(mod._range_cells("'Vendor!'A1:D101,'NotPaid!'A1:D7")) == [
+        ("Vendor", 1, 1, 4, 101), ("NotPaid", 1, 1, 4, 7)]
+
+
+def test_a_whole_part_wrapped_in_quotes_is_tolerated():
+    """Task 172-10: the quotes wrap sheet AND range together."""
+    mod = _adapter()
+    assert list(mod._range_cells("'T_Data!A1:AB700','NY_Data!A1:AB30'")) == [
+        ("T_Data", 1, 1, 28, 700), ("NY_Data", 1, 1, 28, 30)]
+
+
+def test_a_sheet_named_twice_keeps_the_range():
+    """Task 532-3: "'Received'!'Received!A1:G16'" names the sheet on both sides of the bang."""
+    mod = _adapter()
+    assert list(mod._range_cells("'Received'!'Received!A1:G16'")) == [("Received", 1, 1, 7, 16)]
+
+
+def test_a_missing_end_column_repeats_the_start_column():
+    """Task 73-45: "BD2:308" means BD2:BD308 — a column, not a truncated range."""
+    mod = _adapter()
+    assert list(mod._range_cells("'Sheet1'!BD2:308")) == [("Sheet1", 56, 2, 56, 308)]
+
+
+def test_a_full_width_colon_is_tolerated():
+    """Task 37456 was authored with U+FF1A rather than ASCII colon."""
+    mod = _adapter()
+    assert list(mod._range_cells("G12：J15")) == [(None, 7, 12, 10, 15)]
+
+
+def test_a_column_only_range_is_still_skipped_deliberately():
+    """"A:G" names no rows, and _range_cells has no workbook to ask for the extent.
+
+    One task (of 912) is affected. Inventing a bound would corrupt the COVERAGE denominator
+    for it, which is the exact class of defect this PR removes elsewhere — so it stays
+    skipped, and stays documented.
+    """
+    mod = _adapter()
+    assert list(mod._range_cells("Sheet3'!A:G,'Sheet4'!A:G")) == []
+
+
 # --- the diagnostics ---------------------------------------------------------------------
 
 
@@ -94,7 +161,7 @@ def test_an_empty_target_range_is_named_as_such(tmp_path):
 
 
 def test_partial_coverage_of_a_large_range_is_flagged(tmp_path):
-    """Task 19-7's shape: a 5,200-row range with a handful of cells filled."""
+    """Task 19-7's shape: a 5,200-row range whose answer really does fill it, 10 cells written."""
     mod = _adapter()
     src = _book(tmp_path / "in.xlsx", {"P": {}})
     out = _book(tmp_path / "out.xlsx", {"P": {(r, 2): r for r in range(2, 12)}})
@@ -102,7 +169,7 @@ def test_partial_coverage_of_a_large_range_is_flagged(tmp_path):
     notes = mod._localize_failure({"answer_position": "'P'!B2:B5200"}, out, src, gold)
     joined = " ".join(notes)
     assert "spans 5199 cell(s)" in joined and "value in 10 of them" in joined
-    assert "Most of the target range was left unfilled" in joined
+    assert "Most of the expected answer is missing" in joined
 
 
 def test_a_sheet_never_modified_is_named(tmp_path):
@@ -145,6 +212,174 @@ def test_coverage_and_untouched_notes_do_not_consult_the_gold_file(tmp_path):
     joined = " ".join(notes)
     assert "COVERAGE" in joined and "UNCHANGED" in joined
     assert "TYPE:" not in joined
+
+
+# --- COVERAGE must be measured against the expected output, not the span -----------------
+#
+# MEASURED across all 912 tasks: on 90 of them (10.1%) the expected output fills less than a
+# QUARTER of answer_position, and on 203 (22.8%) less than 60%. The old note compared the
+# agent's fill to the span, so on those tasks a PERFECT answer was told "Most of the target
+# range was left unfilled". Task 56427 in pilot 30906175891 got exactly that: it filled 15
+# cells, the expected output fills 20, the span is 324 — scolded for ~300 cells it was never
+# supposed to write, while its real defects (14 numbers written as text, 5 cells left empty)
+# went unnamed.
+
+
+def test_coverage_states_the_expected_fill_and_withholds_the_false_scold(tmp_path):
+    """Task 56427's measured shape: span 324, expected fill 20, agent fill 15."""
+    mod = _adapter()
+    src = _book(tmp_path / "in.xlsx", {"S": {}})
+    out = _book(tmp_path / "out.xlsx", {"S": {(r, 1): r for r in range(2, 17)}})
+    gold = _book(tmp_path / "gold.xlsx", {"S": {(r, 1): r for r in range(2, 22)}})
+    notes = mod._localize_failure({"answer_position": "'S'!A1:A324"}, out, src, gold)
+    joined = " ".join(notes)
+    assert "spans 324 cell(s)" in joined
+    assert "expected output has a value in 20" in joined, "the real denominator must be stated"
+    assert "Most of the target range was left unfilled" not in joined, \
+        "15 of an expected 20 is not an unfilled range"
+
+
+# The scold's surviving case — a range whose answer really does fill it — is covered by
+# test_partial_coverage_of_a_large_range_is_flagged above, now measured against the expected fill.
+
+
+def test_coverage_makes_no_fill_claim_when_the_gold_cannot_be_read(tmp_path):
+    """Without the expected fill there is no honest claim to make, so none is made."""
+    mod = _adapter()
+    src = _book(tmp_path / "in.xlsx", {"S": {}})
+    out = _book(tmp_path / "out.xlsx", {"S": {(2, 1): 1}})
+    notes = mod._localize_failure({"answer_position": "'S'!A1:A400"}, out, src,
+                                  tmp_path / "does-not-exist.xlsx")
+    joined = " ".join(notes)
+    assert "spans 400 cell(s)" in joined
+    assert "expected output has a value in" not in joined
+    assert "Most of the target range was left unfilled" not in joined
+
+
+# --- MISMATCH: how many cells differ, and in which named class ---------------------------
+#
+# MEASURED on pilot 30906175891: 11 of the champion's 17 failures received the line "the target
+# range spans N cell(s); your output has a value in N of them" and NOTHING else — the range was
+# fully covered and the types matched, so every existing signal was silent. Replaying each
+# candidate's own final code against the gold shows what that silence hid: task 56637 differed
+# in 1 cell of 146, 5192 in 1 of 3, 11842 in 2 of 96. "1 of 146 cells differs" and "wrong" are
+# different instructions to an optimizer.
+
+
+def test_mismatch_states_how_many_cells_differ(tmp_path):
+    """Task 56637's measured shape: 146 cells covered, exactly one wrong."""
+    mod = _adapter()
+    cells = {(r, 2): "2nd Shift" for r in range(12, 158)}
+    src = _book(tmp_path / "in.xlsx", {"S": dict(cells)})
+    gold = _book(tmp_path / "gold.xlsx", {"S": dict(cells)})
+    wrong = dict(cells); wrong[(33, 2)] = "1st Shift"
+    out = _book(tmp_path / "out.xlsx", {"S": wrong})
+    notes = mod._localize_failure({"answer_position": "'S'!B12:B157"}, out, src, gold)
+    joined = " ".join(notes)
+    assert "MISMATCH: 1 of 146 cell(s) differ" in joined
+    assert "original input" in joined, "the cell was changed although the input was already right"
+
+
+def test_the_correct_value_stored_as_text_is_named(tmp_path):
+    """Tasks 325-44 (15 cells) and 56427 (14): the value is RIGHT, the storage type is not."""
+    mod = _adapter()
+    src = _book(tmp_path / "in.xlsx", {"S": {}})
+    out = _book(tmp_path / "out.xlsx", {"S": {(1, 1): "98", (2, 1): "66"}})
+    gold = _book(tmp_path / "gold.xlsx", {"S": {(1, 1): 98, (2, 1): 66}})
+    notes = mod._localize_failure({"answer_position": "'S'!A1:A2"}, out, src, gold)
+    joined = " ".join(notes)
+    assert "2 cell(s) hold the CORRECT value stored as text" in joined
+
+
+def test_an_excel_error_text_the_agent_wrote_is_named(tmp_path):
+    """Task 55931: 8 cells hold the literal string "#N/A" while its own helpers could do the sum.
+
+    The value quoted here is the AGENT's, not the gold's — naming it is what turns "str where
+    int was expected" into a rule the optimizer can write.
+    """
+    mod = _adapter()
+    src = _book(tmp_path / "in.xlsx", {"S": {}})
+    out = _book(tmp_path / "out.xlsx", {"S": {(1, 1): "#N/A", (2, 1): "#N/A"}})
+    gold = _book(tmp_path / "gold.xlsx", {"S": {(1, 1): 4, (2, 1): 6}})
+    notes = mod._localize_failure({"answer_position": "'S'!A1:A2"}, out, src, gold)
+    joined = " ".join(notes)
+    assert "#N/A" in joined and "Excel error text" in joined
+    for leaked in ("4", "6"):
+        assert f" {leaked} " not in joined.replace("A1:A2", ""), "no gold value"
+
+
+def test_a_cell_expected_to_stay_unresolved_is_named(tmp_path):
+    """Task 57232's inverse case: the expected value IS #N/A and the agent computed a number.
+
+    Today's TYPE advice tells it to "KEEP the original text" — impossible, the input cell is
+    empty. Naming the class is the only way that rule can be learned.
+    """
+    mod = _adapter()
+    src = _book(tmp_path / "in.xlsx", {"S": {}})
+    out = _book(tmp_path / "out.xlsx", {"S": {(1, 1): 0.25, (2, 1): 1.75}})
+    gold = _book(tmp_path / "gold.xlsx", {"S": {(1, 1): "#N/A", (2, 1): "#N/A"}})
+    notes = mod._localize_failure({"answer_position": "'S'!A1:A2"}, out, src, gold)
+    joined = " ".join(notes)
+    assert "2 cell(s) expect an Excel error text" in joined
+
+
+def test_values_written_past_the_end_of_the_answer_are_named(tmp_path):
+    """Task 50051: 29 of 32 cells hold a value the expected output leaves empty — and the old
+    COVERAGE line called that "32 of 32", which reads like success."""
+    mod = _adapter()
+    src = _book(tmp_path / "in.xlsx", {"S": {}})
+    out = _book(tmp_path / "out.xlsx", {"S": {(r, 1): r for r in range(2, 34)}})
+    gold = _book(tmp_path / "gold.xlsx", {"S": {(r, 1): r for r in range(2, 5)}})
+    notes = mod._localize_failure({"answer_position": "'S'!A2:A33"}, out, src, gold)
+    joined = " ".join(notes)
+    assert "29 cell(s) hold a value where the expected output has none" in joined
+
+
+def test_a_truncated_string_is_named_as_a_prefix(tmp_path):
+    """Task 5192: wrote '1456CH02' where '1456CH02A' was expected — its own slice cut one char."""
+    mod = _adapter()
+    src = _book(tmp_path / "in.xlsx", {"S": {}})
+    out = _book(tmp_path / "out.xlsx", {"S": {(2, 2): "1456CH02"}})
+    gold = _book(tmp_path / "gold.xlsx", {"S": {(2, 2): "1456CH02A"}})
+    notes = mod._localize_failure({"answer_position": "'S'!B2"}, out, src, gold)
+    assert "PREFIX of the expected text" in " ".join(notes)
+
+
+def test_numeric_direction_is_reported_only_when_every_difference_agrees(tmp_path):
+    """Task 11842: 2 of 96 cells wrong, both LOW — a pointer at undercounting."""
+    mod = _adapter()
+    src = _book(tmp_path / "in.xlsx", {"S": {}})
+    out = _book(tmp_path / "out.xlsx", {"S": {(1, 1): 2, (2, 1): 1}})
+    gold = _book(tmp_path / "gold.xlsx", {"S": {(1, 1): 4, (2, 1): 2}})
+    low = " ".join(mod._localize_failure({"answer_position": "'S'!A1:A2"}, out, src, gold))
+    assert "LOWER than expected" in low
+
+    mixed_out = _book(tmp_path / "out2.xlsx", {"S": {(1, 1): 2, (2, 1): 9}})
+    mixed = " ".join(mod._localize_failure({"answer_position": "'S'!A1:A2"}, mixed_out, src, gold))
+    assert "LOWER than expected" not in mixed, "a direction claim needs every cell to agree"
+
+
+def test_no_gold_value_leaks_through_the_mismatch_note(tmp_path):
+    """The invariant that keeps this diagnostic honest: classes and counts, never answers."""
+    mod = _adapter()
+    src = _book(tmp_path / "in.xlsx", {"S": {}})
+    out = _book(tmp_path / "out.xlsx", {"S": {(1, 1): 1, (2, 1): "x", (3, 1): None}})
+    gold = _book(tmp_path / "gold.xlsx", {"S": {(1, 1): 987654,
+                                                (2, 1): "SECRETSTRING", (3, 1): 424242}})
+    joined = " ".join(mod._localize_failure({"answer_position": "'S'!A1:A3"}, out, src, gold))
+    for leaked in ("987654", "SECRETSTRING", "424242"):
+        assert leaked not in joined
+
+
+def test_a_scan_cap_is_disclosed_rather_than_silent(tmp_path):
+    """Four tasks of 912 span more than 50,000 cells. A cap is fine; a silent cap is not."""
+    mod = _adapter()
+    setattr(mod, "_CELL_SCAN_CAP", 4)
+    src = _book(tmp_path / "in.xlsx", {"S": {}})
+    out = _book(tmp_path / "out.xlsx", {"S": {(r, 1): 1 for r in range(1, 11)}})
+    gold = _book(tmp_path / "gold.xlsx", {"S": {(r, 1): 2 for r in range(1, 11)}})
+    joined = " ".join(mod._localize_failure({"answer_position": "'S'!A1:A10"}, out, src, gold))
+    assert "first 4" in joined and "inspected" in joined
 
 
 def test_a_broken_produced_file_degrades_quietly(tmp_path):

--- a/docs/superpowers/specs/2026-08-05-spreadsheetbench-feedback-fidelity-design.md
+++ b/docs/superpowers/specs/2026-08-05-spreadsheetbench-feedback-fidelity-design.md
@@ -1,0 +1,118 @@
+# SpreadsheetBench: feedback fidelity before the loop
+
+**Date:** 2026-08-05
+**Status:** IMPLEMENTED — three changes, all in `_range_cells` / `_localize_failure`.
+**Scope:** `templates/adapters/spreadsheetbench/adapter.py` and its two test modules. **No seed
+capability edits** — the rules stay the optimizer's to write (#276), and no `core/` runtime change.
+
+## How this was measured
+
+Pilot [30906175891](https://github.com/skillberry-ai/cap-evolve/actions/runs/30906175891) reached
+val 0.660 (33/50) with 17 failures. For each failure, its own final code block was **replayed**
+against the gold file for the case the scorer localized on, then diffed cell by cell. The replay
+agrees with the recorded per-case results everywhere they overlap (`39046`/`51359` pass case 1 with
+0 diffs; `11842` fails case 1 with 2). Two dataset-wide scans (all 912 tasks) sized the rest.
+
+The finding that reordered the work: **the feedback was not merely sparse, it was wrong on a
+measurable slice** — and the precedent for what fixing that buys is #293, where correcting the
+TYPE advice's direction is what finally moved the ceiling past 0.580.
+
+## What the 17 failures were actually told
+
+| feedback the optimizer received | tasks |
+|---|---|
+| only `COVERAGE: spans N; your output has a value in N` — no actionable content | **11** |
+| that line plus a `TYPE` note | 5 |
+| nothing at all (`answer_position` unparseable) | 1 |
+
+And what the replay says those 11 were wrong by:
+
+| task | cells differing | the real defect |
+|---|---|---|
+| `56637` | **1 of 146** | changed one cell whose expected value equals the input |
+| `5192` | 1 of 3 | its own `prefix[:4]` cut one character off the string |
+| `53367` | 1 of 1 | wrote the boolean `True` where a number belongs |
+| `11842` | 2 of 96 | both numbers low |
+| `50051` | 29 of 32 | wrote values into cells the expected output leaves empty |
+| `39046` / `51359` | 1 of 5 / 1 of 4 | one number off, on a different graded copy |
+| `3911`,`56996`,`57090`,`59743` | 12/63, 3/5, 3/5, 2/3 | genuinely wrong arithmetic |
+
+## Change 1 — COVERAGE against the expected fill, not the span
+
+Measured over all 912: the expected output fills **under 25% of `answer_position` on 90 tasks
+(10.1%)** and under 60% on 203 (22.8%). The old branch `written * 4 < total` therefore fired on a
+tenth of the benchmark *for correct answers*. `56427` filled 15 where the expected output fills 20
+in a 324-cell span — scolded for ~300 cells it was never meant to write. `50051` filled 32 of 32
+against an expected 3 and was told nothing.
+
+COVERAGE now appends the expected fill and measures the warning against it. If the gold cannot be
+read, no fill claim is made — withholding beats guessing, since guessing is the defect.
+
+## Change 2 — the MISMATCH note
+
+One class per differing cell, most specific first, so counts sum to the difference count and
+cannot double-count. Classes were chosen from the shapes actually present, not invented:
+
+| class | measured in |
+|---|---|
+| correct value stored as text | `325-44` ×15, `56427` ×14 |
+| an Excel error text the agent wrote out | `55931` ×8 (`#N/A`) |
+| expected value *is* an error marker, agent computed one | `57232` ×15 |
+| value written where the expected output has none | `50051` ×29 |
+| empty where a value is expected | `56427` ×5 |
+| text is a prefix of the expected text | `5192` |
+| numeric direction, only when every difference agrees | `11842`, `59743` low; `57090` high |
+| (subset) CHANGED although the expected value equals the input | `56637` ×1, `56427` ×10, `325-44` ×9 |
+
+The subset count is reported separately and marked "of these", because "the expected value is the
+cell's own input" overlaps every other class while being the most actionable of them.
+
+## Change 3 — range-parser robustness
+
+23 of 912 `answer_position` strings (2.5%) were unreadable, in seven families. Six are now handled;
+verified against the real dataset, **23 → 1**. The survivor is bare `A:G`, which names no rows:
+`_range_cells` has no workbook in scope, and inventing a bound would corrupt the COVERAGE
+denominator — the exact defect Change 1 removes. It stays skipped, and stays tested.
+
+This matters to the agent too, not only the optimizer: `_target_size` shares the helper, so
+`450-9`'s prompt carried no `TARGET SIZE` line while every well-formed task's did.
+
+## Expected effect, stated honestly
+
+A better signal is not a better score. What the evidence supports:
+
+- **Plausible conversions** — `56637`, `5192`, `55931`, `325-44`, `56427`. All mechanical or
+  convention defects, the class prose has reliably fixed before (the `_xlfn`→literal rule, the
+  split/extract rule). `50051` too, though it is anti-correlated with `47741` across three
+  candidates. `57232` partially: the 15 sentinel cells, not its 9 wrong numbers.
+- **Not expected to convert** — `3911`, `56996`, `57090`, `59743`, `39046`, `53367`. Reasoning
+  failures; they now learn "2 cells off and low", which is honest but may not be enough.
+- **Blocked regardless** — `30709`, whose fix conflicts with `50630` (extract-a-date wants a real
+  datetime, split-a-sentence wants text kept). No single global rule satisfies both.
+
+A second reason to expect the named classes to land: **12 of the 17 failures already ran a
+read-back verification block and still failed**, because reading back your own file shows what you
+wrote, never whether it is right. The classes above are precisely the ones a self-check *can* catch.
+
+## What was retired by this analysis
+
+- **`trials=3`.** Justified as "make single-task wins detectable", but the gate made the correct
+  call on all four rejections and the deltas came from real task flips, not noise. 3× eval cost.
+- **Surfacing rejected candidates' per-task deltas.** Already built: `LEDGER.md` recorded
+  `fixed={11842, 30709} broke={38332, 50630, 73-45}` verbatim and the optimizer ignored it twice.
+- **"The graded copies differ in size, so the agent hardcodes extents."** False. All 17 failures
+  have identical `(rows, cols)` across the three copies, as do 846 of 905 tasks (93%). The copies
+  differ in data, not shape.
+
+## Deliberate decisions
+
+- **Gold-safety policy widened, narrowly.** Three signals now read the gold: a value's TYPE (as
+  before), the expected fill count (one integer per range), and the MISMATCH classes. All are
+  metadata about the answer — a count, a type, a category — never the answer.
+  `test_no_gold_value_leaks_through_the_mismatch_note` asserts the invariant. The one value that
+  appears, `#N/A` in the error-text class, is the agent's own.
+- **The warm seed stays pinned to `cand_0002`.** Refreshing it to the 0.660 champion would raise
+  the absolute score and make the next pilot unattributable — we could not tell better feedback
+  from a better starting point.
+- **No prompt or seed-capability edits.** The optimizer writes the rules; we only fix what it is
+  told about its own failures.

--- a/templates/adapters/spreadsheetbench/adapter.py
+++ b/templates/adapters/spreadsheetbench/adapter.py
@@ -1496,17 +1496,43 @@ def _range_cells(answer_position: str):
     answer_position is SpreadsheetBench's own notation and may name several ranges across
     several sheets, e.g. "MINUS'!B2:E11,'PLUS'!B2:E5200". Parsed here only to describe the
     agent's own output against the range it was GIVEN — no gold data is consulted.
+
+    The dataset's quoting is INCONSISTENT, and a part this function cannot read costs the task
+    every localization signal AND its agent-facing TARGET SIZE line (both route through here).
+    Measured across all 912 tasks, 23 (2.5%) are affected in seven families; six are handled:
+
+        'Vendor!'A1:D101          the ! is quoted with the sheet name        (16 tasks)
+        'Data'!'A2:C150           the quote lands before the range          (450-9, 374-9, 488-14)
+        'T_Data!A1:AB700'         quotes wrap sheet AND range together      (172-10, 188-47, 156-14)
+        'Received'!'Received!A1:G16'   the sheet is named on both sides     (532-3)
+        'Sheet1'!BD2:308          the end COLUMN is omitted, not the row    (73-45)
+        G12：J15                  authored with a full-width colon U+FF1A   (37456)
+
+    The seventh — bare "A:G" with no row numbers (1 task) — is deliberately still skipped: no
+    workbook is in scope to resolve the extent, and inventing a bound would corrupt the
+    COVERAGE denominator, which is the class of defect this module works to remove.
     """
     for part in str(answer_position).split(","):
-        part = part.strip()
+        part = part.strip().replace("：", ":")
+        # Quotes here are noise, not structure: strip a symmetric pair wrapping the whole part
+        # so that "'T_Data!A1:AB700'" reduces to the ordinary "sheet!range" form.
+        if len(part) > 1 and part[0] == "'" and part[-1] == "'":
+            part = part[1:-1]
         sheet = None
         if "!" in part:
             sheet, _, part = part.rpartition("!")
-            sheet = sheet.strip().strip("'")
-        m = re.fullmatch(r"\$?([A-Za-z]+)\$?(\d+)(?::\$?([A-Za-z]+)\$?(\d+))?", part.strip())
+            # Whatever survives on the left may still hold quotes, a stray bang, or the sheet
+            # name twice ("'Received'!'Received"). The last non-empty token is the sheet.
+            tokens = [t for t in re.split(r"['!]", sheet) if t.strip()]
+            sheet = tokens[-1].strip() if tokens else None
+        part = part.strip().strip("'").strip()
+        m = re.fullmatch(r"\$?([A-Za-z]+)\$?(\d+)(?::\$?([A-Za-z]*)\$?(\d+))?", part)
         if not m:
             continue
-        c1, r1, c2, r2 = m.group(1), int(m.group(2)), m.group(3) or m.group(1), int(m.group(4) or m.group(2))
+        c1, r1 = m.group(1), int(m.group(2))
+        # An empty end column is the "BD2:308" form — one column, many rows — not a truncation.
+        c2 = m.group(3) or c1
+        r2 = int(m.group(4) or m.group(2))
         col = lambda t: sum((ord(ch.upper()) - 64) * 26 ** i for i, ch in enumerate(reversed(t)))
         yield sheet, col(c1), r1, col(c2), r2
 
@@ -1547,6 +1573,95 @@ def _type_advice(pairs: list[tuple[str, str]]) -> str:
     return " — " + "; ".join(tips) + "."
 
 
+_CELL_SCAN_CAP = 50_000
+
+_EXCEL_ERROR = re.compile(r"^#(N/A|VALUE!|REF!|DIV/0!|NAME\?|NUM!|NULL!|SPILL!|CALC!|GETTING_DATA)$")
+
+
+def _is_number(v) -> bool:
+    return isinstance(v, (int, float)) and not isinstance(v, bool)
+
+
+def _mismatch_classes(diffs: list[tuple]) -> list[str]:
+    """Name WHY the differing cells differ, as counted classes — never as values.
+
+    Each differing cell is assigned exactly ONE class, most specific first, so the counts sum to
+    the number of differences and cannot double-count. `kept` is reported separately and is
+    explicitly a SUBSET ("of these"), because "the expected value is the cell's original input"
+    overlaps every other class and is the single most actionable of them.
+
+    Every class below was measured on pilot 30906175891's own failures; see the module tests for
+    the task each shape came from.
+    """
+    if not diffs:
+        return []
+    buckets: dict[str, int] = {}
+    kept = 0
+    prefix_short = 0
+    for got, want, inp in diffs:
+        if want == inp and got != inp:
+            kept += 1
+        if want is None and got is not None:
+            key = "extra"
+        elif got is None and want is not None:
+            key = "missing"
+        elif str(got) == str(want):
+            key = "textform"
+        elif isinstance(got, str) and _EXCEL_ERROR.match(got.strip()):
+            key = "sent_written"
+        elif isinstance(want, str) and _EXCEL_ERROR.match(want.strip()):
+            key = "sent_expected"
+        elif isinstance(got, str) and isinstance(want, str) and \
+                got.strip().casefold() == want.strip().casefold():
+            key = "ws_case"
+        elif isinstance(got, str) and isinstance(want, str) and \
+                (want.startswith(got) or got.startswith(want)):
+            key = "prefix"
+            if want.startswith(got):
+                prefix_short += 1
+        elif _is_number(got) and _is_number(want):
+            key = "num_low" if got < want else "num_high"
+        elif type(got) is not type(want):
+            key = "type_other"
+        else:
+            key = "value"
+        buckets[key] = buckets.get(key, 0) + 1
+
+    def phrase(key: str, c: int) -> str:
+        n = f"{c} cell(s)"
+        return {
+            "extra": f"{n} hold a value where the expected output has none — written past where "
+                     f"the answer ends",
+            "missing": f"{n} are empty in your output where a value is expected",
+            "textform": f"{n} hold the CORRECT value stored as text instead of as a number/date",
+            "sent_written": f"{n} hold an Excel error text (e.g. #N/A) — an unresolved "
+                            f"formula/lookup was written out as its error string",
+            "sent_expected": f"{n} expect an Excel error text and you wrote a computed value — "
+                             f"an unmatched lookup is meant to stay unresolved",
+            "ws_case": f"{n} differ only in surrounding whitespace or letter case",
+            "prefix": (f"{n} hold text that is a PREFIX of the expected text (cut short)"
+                       if prefix_short else
+                       f"{n} hold text that EXTENDS the expected text (too long)"),
+            "num_low": f"{n} hold a number LOWER than expected",
+            "num_high": f"{n} hold a number HIGHER than expected",
+            "type_other": f"{n} hold a value of the wrong type",
+            "value": f"{n} hold a different value of the right type",
+        }[key]
+
+    # A direction claim is only worth making when EVERY numeric difference agrees; a mixed bag
+    # ("some low, some high") points at nothing and would read as a pattern that is not there.
+    if buckets.get("num_low") and buckets.get("num_high"):
+        buckets["value"] = buckets.pop("num_low") + buckets.pop("num_high") + buckets.get("value", 0)
+
+    ranked = sorted(buckets.items(), key=lambda kv: -kv[1])[:3]
+    out = "; ".join(phrase(k, c) for k, c in ranked)
+    if kept:
+        out += (f". Of these, {kept} cell(s) were CHANGED although the expected value is the "
+                f"cell's own original input — leave untouched what the instruction does not "
+                f"ask for")
+    return [out]
+
+
 def _localize_failure(entry: dict, produced: Path, source: Path, gold: Path) -> list[str]:
     """WHY a produced workbook missed, in terms the optimizer can act on.
 
@@ -1557,11 +1672,19 @@ def _localize_failure(entry: dict, produced: Path, source: Path, gold: Path) -> 
     and ours never did. On run 30762167950, 197 of 639 sealed tasks failed ALL THREE test
     cases, and nothing in the logs said why.
 
-    GOLD SAFETY. Three of the four signals never open the gold file at all — they compare the
-    agent's output against its own INPUT and against the range it was handed, both of which it
-    already knows. The fourth reports a value's TYPE (e.g. "text where a date was expected"),
-    which is metadata rather than an answer; it is the single most actionable diagnostic for
-    this benchmark and is judged worth that narrow disclosure. No cell VALUE is ever emitted.
+    COVERAGE is measured against the EXPECTED OUTPUT's own fill, not against the span. Across
+    all 912 tasks the expected output fills under a quarter of answer_position on 90 of them
+    (10.1%) and under 60% on 203 (22.8%) — so comparing to the span told a perfect answer it had
+    left the range unfilled. Task 56427 in pilot 30906175891 was scolded for ~300 cells it was
+    never meant to write, while its actual defects went unnamed.
+
+    GOLD SAFETY. Coverage and untouched-sheet notes still never open the gold. Three signals now
+    do: the TYPE note (a value's type), the expected FILL COUNT (one integer per range), and the
+    MISMATCH classes (how many cells differ and in which category, including whether the expected
+    value is an Excel error marker). All three are metadata ABOUT the answer rather than the
+    answer: a count, a type, a category. No cell VALUE is ever emitted — asserted by
+    test_no_gold_value_leaks_through_the_mismatch_note. The one value that does appear, "#N/A" in
+    the sent_written class, is the AGENT's own text, not the gold's.
     """
     notes: list[str] = []
     try:
@@ -1571,12 +1694,24 @@ def _localize_failure(entry: dict, produced: Path, source: Path, gold: Path) -> 
     except Exception:  # noqa: BLE001
         return notes
 
-    total = written = 0
+    # The gold is opened ONCE and shared by three signals below. It may be unreadable (a
+    # diagnostic must never cost a score), in which case every gold-derived claim is withheld
+    # rather than guessed — guessing is what made the old coverage scold wrong.
+    try:
+        gw = openpyxl.load_workbook(gold, data_only=True)
+    except Exception:  # noqa: BLE001
+        gw = None
+
+    total = written = expected = 0
+    scanned = capped = 0
     untouched_sheets: list[str] = []
+    diffs: list[tuple] = []
+    bad: dict[tuple[str, str], int] = {}
     for sheet, c1, r1, c2, r2 in _range_cells(entry.get("answer_position", "")):
         name = sheet if sheet in pw.sheetnames else pw.sheetnames[0]
         ws = pw[name]
         src = sw[name] if name in sw.sheetnames else None
+        gs = gw[sheet if gw and sheet in gw.sheetnames else gw.sheetnames[0]] if gw else None
         span = (c2 - c1 + 1) * (r2 - r1 + 1)
         filled = same_as_input = 0
         for row in range(r1, r2 + 1):
@@ -1584,23 +1719,43 @@ def _localize_failure(entry: dict, produced: Path, source: Path, gold: Path) -> 
                 v = ws.cell(row, cc).value
                 if v is not None and str(v) != "":
                     filled += 1
-                if src is not None and v == src.cell(row, cc).value:
+                inp = src.cell(row, cc).value if src is not None else None
+                if src is not None and v == inp:
                     same_as_input += 1
+                if gs is None:
+                    continue
+                if scanned >= _CELL_SCAN_CAP:
+                    capped = 1
+                    continue
+                scanned += 1
+                want = gs.cell(row, cc).value
+                if want is not None:
+                    expected += 1
+                if v == want:
+                    continue
+                diffs.append((v, want, inp))
+                if v is not None and want is not None and type(v) is not type(want):
+                    key = (type(v).__name__, type(want).__name__)
+                    bad[key] = bad.get(key, 0) + 1
         total += span
         written += filled
         if span and same_as_input == span:
             untouched_sheets.append(name)
 
     if total:
-        notes.append(
-            f"COVERAGE: the target range spans {total} cell(s); your output has a value in "
-            f"{written} of them."
-        )
+        # The span is stated because it is what the agent was handed (and what TARGET SIZE tells
+        # it); the expected fill is stated because it is the only honest denominator for "did you
+        # cover the answer".
+        line = (f"COVERAGE: the target range spans {total} cell(s); your output has a value in "
+                f"{written} of them")
+        if gw is not None and not capped:
+            line += f"; the expected output has a value in {expected}"
+        notes.append(line + ".")
         if written == 0:
             notes.append("The target range is EMPTY in your output — nothing was written there.")
-        elif written * 4 < total:
+        elif expected and not capped and written * 4 < expected:
             notes.append(
-                "Most of the target range was left unfilled — check where the data actually "
+                "Most of the expected answer is missing — check where the data actually "
                 "ends rather than assuming the extent from the preview."
             )
     if untouched_sheets:
@@ -1609,31 +1764,24 @@ def _localize_failure(entry: dict, produced: Path, source: Path, gold: Path) -> 
             f"input across the target range — that part of answer_position was never modified."
         )
 
+    # MISMATCH: how many cells differ, and in which named class. This is the signal that was
+    # missing entirely: on pilot 30906175891, 11 of the champion's 17 failures had full coverage
+    # and matching types, so every other note was silent while 1-of-146 cells was wrong.
+    if diffs:
+        head = f"MISMATCH: {len(diffs)} of {scanned} cell(s) differ from the expected output"
+        if capped:
+            head += f" (first {_CELL_SCAN_CAP} of {total} cells inspected)"
+        notes.append(head + ": " + "; ".join(_mismatch_classes(diffs)) + ".")
+
     # TYPE mismatch (reports the expected TYPE, never a value).
-    try:
-        gw = openpyxl.load_workbook(gold, data_only=True)
-        bad: dict[tuple[str, str], int] = {}
-        for sheet, c1, r1, c2, r2 in _range_cells(entry.get("answer_position", "")):
-            name = sheet if sheet in pw.sheetnames else pw.sheetnames[0]
-            gname = sheet if sheet in gw.sheetnames else gw.sheetnames[0]
-            ws, gs = pw[name], gw[gname]
-            for row in range(r1, min(r2, r1 + 200) + 1):
-                for cc in range(c1, c2 + 1):
-                    a, b = ws.cell(row, cc).value, gs.cell(row, cc).value
-                    if a is None or b is None or type(a) is type(b):
-                        continue
-                    key = (type(a).__name__, type(b).__name__)
-                    bad[key] = bad.get(key, 0) + 1
-        if bad:
-            worst = sorted(bad.items(), key=lambda kv: -kv[1])[:2]
-            notes.append(
-                "TYPE: "
-                + "; ".join(f"{n} cell(s) hold {got} where {want} was expected"
-                            for (got, want), n in worst)
-                + _type_advice([pair for pair, _ in worst])
-            )
-    except Exception:  # noqa: BLE001
-        pass
+    if bad:
+        worst = sorted(bad.items(), key=lambda kv: -kv[1])[:2]
+        notes.append(
+            "TYPE: "
+            + "; ".join(f"{n} cell(s) hold {got} where {want} was expected"
+                        for (got, want), n in worst)
+            + _type_advice([pair for pair, _ in worst])
+        )
     return notes
 
 


### PR DESCRIPTION
Closes #301.

## Summary

Three defects in the learning signal the optimizer reads. All were found by **replaying pilot [30906175891](https://github.com/skillberry-ai/cap-evolve/actions/runs/30906175891)'s own failing code against the gold files** and by two scans over all 912 tasks. The replay agrees with the recorded per-case results everywhere they overlap (`39046`/`51359` pass case 1 with 0 diffs; `11842` fails case 1 with 2).

**1. COVERAGE measured the agent against the span, not the expected answer.** The expected output fills under a quarter of `answer_position` on **90 of 912 tasks (10.1%)** and under 60% on 203 (22.8%), so on a tenth of the benchmark a *perfect* answer was told "Most of the target range was left unfilled". `56427` filled 15 where 20 was expected in a 324-cell span — scolded for ~300 cells it was never meant to write, while its real defects went unnamed. `50051` filled 32 of 32 against an expected **3** and was told nothing at all. The denominator is now the expected output's own fill; when the gold cannot be read, no fill claim is made rather than guessed.

**2. A new MISMATCH note.** 11 of the champion's 17 failures received `spans N; your output has a value in N` and nothing else — full coverage, matching types, every signal silent. That silence hid: `56637` differing in **1 cell of 146**, `5192` in 1 of 3, `53367` in 1 of 1, `11842` in 2 of 96. Each differing cell now gets exactly one class (so counts cannot double-count): correct value stored as text, an Excel error text written out, a cell expected to *stay* unresolved, values written past the end of the answer, a truncated prefix, and numeric direction when every difference agrees — plus a subset count for cells CHANGED although the expected value equals their own input, which is the entire bug in `56637`.

**3. Range-parser robustness.** 23 of 912 `answer_position` strings (2.5%) were unparseable across seven quoting families, silently costing those tasks every localization signal **and** their agent-facing `TARGET SIZE` line. Six families are handled; verified on the real dataset, **23 unparseable → 1**. The survivor is bare `A:G`, which names no rows — left skipped rather than given an invented bound, since a fabricated extent would corrupt the very denominator item 1 fixes.

## Design decisions

- **Gold-safety policy widened, narrowly.** Three signals now read the gold: a value's TYPE (as before), the expected fill count (one integer per range), and the MISMATCH classes. All are metadata *about* the answer — a count, a type, a category — never the answer. `test_no_gold_value_leaks_through_the_mismatch_note` asserts the invariant; the only value that appears (`#N/A`) is the agent's own.
- **No seed-capability or prompt edits.** The rules stay the optimizer's to write (#276). Item 3 improves the agent's prompt for free, because `_target_size` shares the parser.
- **The warm seed stays pinned to `cand_0002`.** Refreshing it to the 0.660 champion would raise the absolute number but make the next pilot unattributable — better feedback and a better starting point would be indistinguishable.
- **The scan cap is disclosed, not silent.** 4 tasks of 912 span more than 50,000 cells; the note says how many cells were inspected rather than quietly truncating.

## Expected effect, stated honestly

A better signal is not a better score.

- **Plausible conversions:** `56637`, `5192`, `55931`, `325-44`, `56427` — mechanical/convention defects, the class prose has reliably fixed before. `50051` too, though it is anti-correlated with `47741` across three candidates. `57232` partially (its 15 sentinel cells, not its 9 wrong numbers).
- **Not expected to convert:** `3911`, `56996`, `57090`, `59743`, `39046`, `53367` — reasoning failures, which now learn "2 cells off and low".
- **Blocked regardless:** `30709`, whose fix conflicts with `50630` under any single global rule.

Also retired by this analysis: `trials=3` (the gate made the correct call on all four rejections — the deltas were real task flips, not noise), re-surfacing rejected candidates' per-task deltas (already built in `LEDGER.md`, and ignored twice), and the theory that partial passes come from copies of differing size (all 17 failures have identical extents across the three copies, as do 846 of 905 tasks).

## Testing

- `python -m pytest core/tests -q` → **455 passed, 1 skipped**. 21 new tests, each fixture taken from a real measured shape.
- The **shipped** `_localize_failure` was run over **59 real failures from three capability states**: 0 exceptions, 0 silent no-note cases, 58 producing a MISMATCH note.
- The **shipped** `_range_cells` was run over all 912 real `answer_position` strings: 23 unparseable → 1, with previously-working spans unchanged (`110-2` = 39, `19-7` = 20,836).
- Sample of what `56637` now receives, where it previously got one useless line:
  > `MISMATCH: 1 of 146 cell(s) differ from the expected output: 1 cell(s) hold a different value of the right type. Of these, 1 cell(s) were CHANGED although the expected value is the cell's own original input — leave untouched what the instruction does not ask for.`

Design notes: `docs/superpowers/specs/2026-08-05-spreadsheetbench-feedback-fidelity-design.md`.

Signed-off-by: Eran Raichstein <eranra@il.ibm.com>