### PR TITLE
fix(harbor): an unscored trial is missing data, not a reward of 0.0

### DIFF
--- a/capevolve_harbor/results.py
+++ b/capevolve_harbor/results.py
@@ -86,12 +86,20 @@ def _extract_task_id(trial_dir: Path) -> str:
 
 
 def _parse_trial(trial_dir: Path, task_id: str) -> TrialResult:
-    """Parse a single trial directory into a TrialResult."""
+    """Parse a single trial directory into a TrialResult.
+
+    ``error`` is set when the trial never produced a score — Harbor raised before
+    or during the verifier (image build failure, agent-setup timeout, agent
+    timeout). That distinction matters: an unscored trial is *missing data*, not a
+    reward of 0.0, and only ``error`` tells the harness to exclude it from the
+    mean instead of feeding the optimizer a phantom regression.
+    """
     tr = TrialResult(task_id=task_id)
 
+    scored = False
     verifier_dir = trial_dir / "verifier"
     if verifier_dir.is_dir():
-        tr.reward, tr.reward_json = _read_reward(verifier_dir)
+        tr.reward, tr.reward_json, scored = _read_reward(verifier_dir)
         tr.verifier_stdout = _read_text(verifier_dir / "test-stdout.txt")
         tr.verifier_stderr = _read_text(verifier_dir / "test-stderr.txt")
 
@@ -103,15 +111,67 @@ def _parse_trial(trial_dir: Path, task_id: str) -> TrialResult:
     if result_path.exists():
         tr.cost_usd, tr.tokens = _extract_cost_tokens(result_path)
 
+    # A reward file is the authoritative "this trial was measured" signal. If one
+    # exists, honour it even alongside an exception (a crash in teardown must not
+    # discard a genuine measurement). Only when nothing scored do we look for the
+    # cause and mark the trial errored.
+    if not scored:
+        tr.error = _read_error(trial_dir)
+
     return tr
 
 
-def _read_reward(verifier_dir: Path) -> tuple[float, dict]:
+def _read_error(trial_dir: Path) -> str:
+    """Why this trial produced no score, as a bounded single-line string.
+
+    Prefers ``result.json``'s structured ``exception_info`` (Harbor's own record)
+    and falls back to the ``exception.txt`` traceback. Returns a generic reason
+    when neither exists, because "no reward and no explanation" is still not a
+    measurement.
+    """
+    info = {}
+    result_path = trial_dir / "result.json"
+    if result_path.exists():
+        try:
+            data = json.loads(result_path.read_text(encoding="utf-8"))
+            info = data.get("exception_info") or {}
+        except (json.JSONDecodeError, ValueError, AttributeError, OSError):
+            info = {}
+
+    if isinstance(info, dict) and (info.get("exception_type") or info.get("exception_message")):
+        etype = str(info.get("exception_type") or "Error")
+        msg = " ".join(str(info.get("exception_message") or "").split())
+        return _clip(f"{etype}: {msg}" if msg else etype)
+
+    text = _read_text(trial_dir / "exception.txt", max_chars=8000)
+    if text.strip():
+        # The last traceback line is the exception itself ("RuntimeError: ...");
+        # everything above it is frames the reader does not need here.
+        lines = [ln for ln in text.splitlines() if ln.strip()]
+        for ln in reversed(lines):
+            if not ln.startswith(" ") and ":" in ln:
+                return _clip(" ".join(ln.split()))
+        return _clip(" ".join(lines[-1].split()))
+
+    return "Trial produced no reward and no verifier output (no result recorded)"
+
+
+def _clip(text: str, limit: int = 2000) -> str:
+    """Bound an error string — it flows into feedback, event logs and rollout JSON."""
+    return text if len(text) <= limit else text[: limit - 1] + "…"
+
+
+def _read_reward(verifier_dir: Path) -> tuple[float, dict, bool]:
     """Read reward from verifier output.
 
     Tries reward.json first (``"reward"`` key). Falls back to reward.txt
     only when reward.json is absent or unparseable — a legitimate 0.0 in
     reward.json is honoured as-is.
+
+    Returns ``(reward, reward_json, scored)``. ``scored`` is False when no reward
+    could be read at all, which is the difference between "the verifier scored
+    this 0.0" and "this trial was never scored". Callers must not conflate them:
+    the second is missing data and belongs out of the mean entirely.
     """
     reward_json: dict = {}
 
@@ -120,18 +180,18 @@ def _read_reward(verifier_dir: Path) -> tuple[float, dict]:
         try:
             reward_json = json.loads(rj_path.read_text(encoding="utf-8"))
             if "reward" in reward_json:
-                return float(reward_json["reward"]), reward_json
+                return float(reward_json["reward"]), reward_json, True
         except (json.JSONDecodeError, ValueError):
             pass
 
     rt_path = verifier_dir / "reward.txt"
     if rt_path.exists():
         try:
-            return float(rt_path.read_text(encoding="utf-8").strip()), reward_json
+            return float(rt_path.read_text(encoding="utf-8").strip()), reward_json, True
         except ValueError:
             pass
 
-    return 0.0, reward_json
+    return 0.0, reward_json, False
 
 
 def _read_trajectory(agent_dir: Path) -> Any:

--- a/capevolve_harbor/tests/test_results.py
+++ b/capevolve_harbor/tests/test_results.py
@@ -93,42 +93,48 @@ def test_parse_job_dir_nonexistent(tmp_path):
 
 def test_read_reward_from_json_key(tmp_path):
     (tmp_path / "reward.json").write_text(json.dumps({"reward": 0.9}))
-    reward, rj = _read_reward(tmp_path)
+    reward, _, scored = _read_reward(tmp_path)
     assert reward == 0.9
+    assert scored is True
 
 
 def test_read_reward_zero_is_honoured(tmp_path):
     """A legitimate 0.0 in reward.json must NOT trigger reward.txt fallback."""
     (tmp_path / "reward.json").write_text(json.dumps({"reward": 0.0}))
     (tmp_path / "reward.txt").write_text("0.99")
-    reward, _ = _read_reward(tmp_path)
+    reward, _, scored = _read_reward(tmp_path)
     assert reward == 0.0
+    assert scored is True
 
 
 def test_read_reward_falls_back_to_txt_when_json_absent(tmp_path):
     (tmp_path / "reward.txt").write_text("0.42")
-    reward, _ = _read_reward(tmp_path)
+    reward, _, scored = _read_reward(tmp_path)
     assert reward == 0.42
+    assert scored is True
 
 
 def test_read_reward_falls_back_to_txt_when_json_has_no_reward_key(tmp_path):
     (tmp_path / "reward.json").write_text(json.dumps({"accuracy": 0.8}))
     (tmp_path / "reward.txt").write_text("0.33")
-    reward, _ = _read_reward(tmp_path)
+    reward, _, scored = _read_reward(tmp_path)
     assert reward == 0.33
+    assert scored is True
 
 
 def test_read_reward_falls_back_to_txt_when_json_malformed(tmp_path):
     (tmp_path / "reward.json").write_text("not json at all")
     (tmp_path / "reward.txt").write_text("0.5")
-    reward, _ = _read_reward(tmp_path)
+    reward, _, scored = _read_reward(tmp_path)
     assert reward == 0.5
+    assert scored is True
 
 
 def test_read_reward_returns_zero_when_nothing_exists(tmp_path):
-    reward, rj = _read_reward(tmp_path)
+    reward, rj, scored = _read_reward(tmp_path)
     assert reward == 0.0
     assert rj == {}
+    assert scored is False, "an absent reward file is missing data, not a 0.0"
 
 
 # --- build_feedback tests ---
@@ -157,3 +163,103 @@ def test_feedback_includes_metrics():
 def test_feedback_includes_error():
     tr = TrialResult(task_id="t1", reward=0.0, error="timeout")
     assert "timeout" in build_feedback(tr)
+
+
+# --- infra-error detection tests -------------------------------------------
+#
+# A trial that crashed before the verifier ran has no reward file at all. Left
+# undetected it reads as a legitimate "reward 0.0", which is how a Docker Hub
+# 429 storm silently became a val score of 0.000 for two whole iterations.
+
+_DOCKER_429 = (
+    "Docker compose command failed for environment django__django-10554. "
+    "Return code: 1. Stdout: #3 ERROR: unexpected status from HEAD request to "
+    "https://registry-1.docker.io/v2/swebench/sweb.eval.x86_64.django_1776_"
+    "django-10554/manifests/latest: 429 Too Many Requests"
+)
+
+
+def _errored_trial(root: Path, name: str, task: str, *, structured=True, text=True):
+    """A trial dir shaped like harbor leaves one behind when _prepare() raises."""
+    t = root / name
+    (t / "verifier").mkdir(parents=True)   # created but EMPTY — no reward file
+    (t / "agent").mkdir()
+    (t / "config.json").write_text(json.dumps({"task": {"name": task}}))
+    result: dict = {"task_name": task, "agent_result": None, "verifier_result": None}
+    if structured:
+        result["exception_info"] = {
+            "exception_type": "RuntimeError",
+            "exception_message": _DOCKER_429,
+            "exception_traceback": "Traceback (most recent call last):\n  ...\n",
+            "occurred_at": "2026-08-05T21:42:30.793278",
+        }
+    (t / "result.json").write_text(json.dumps(result))
+    if text:
+        (t / "exception.txt").write_text(
+            "Traceback (most recent call last):\n"
+            '  File ".../trial.py", line 351, in run\n'
+            f"RuntimeError: {_DOCKER_429}\n"
+        )
+    return t
+
+
+def test_errored_trial_sets_error(tmp_path):
+    _errored_trial(tmp_path, "trial-err", "task-err")
+    tr = parse_job_dir(tmp_path)["task-err"][0]
+    assert tr.error is not None
+    assert "RuntimeError" in tr.error
+
+
+def test_errored_trial_surfaces_the_actual_cause(tmp_path):
+    """The error text must name the real cause so a human can grep for it."""
+    _errored_trial(tmp_path, "trial-err", "task-err")
+    tr = parse_job_dir(tmp_path)["task-err"][0]
+    assert tr.error is not None
+    assert "429" in tr.error
+
+
+def test_errored_trial_falls_back_to_exception_txt(tmp_path):
+    """result.json may be absent/partial; exception.txt alone is enough."""
+    _errored_trial(tmp_path, "trial-err", "task-err", structured=False)
+    tr = parse_job_dir(tmp_path)["task-err"][0]
+    assert tr.error is not None
+    assert "RuntimeError" in tr.error
+
+
+def test_errored_trial_error_is_bounded(tmp_path):
+    """Errors land in feedback and event logs — they must not be unbounded."""
+    t = _errored_trial(tmp_path, "trial-err", "task-err")
+    (t / "exception.txt").write_text("RuntimeError: " + "x" * 100_000)
+    tr = parse_job_dir(tmp_path)["task-err"][0]
+    assert tr.error is not None
+    assert len(tr.error) <= 2000
+
+
+def test_healthy_trial_has_no_error(job_dir):
+    """Regression guard: a real 0.0 from the verifier is NOT an infra error."""
+    results = parse_job_dir(job_dir)
+    assert results["task-001"][0].error is None
+    assert results["task-002"][0].error is None
+    assert results["task-002"][0].reward == 0.0
+
+
+def test_verifier_reward_wins_over_exception(tmp_path):
+    """An exception AFTER the verifier scored is a hiccup, not a lost trial.
+
+    The reward file is the authoritative signal that the trial produced a real
+    score, so honour it rather than discarding a genuine measurement.
+    """
+    t = _errored_trial(tmp_path, "trial-late", "task-late")
+    (t / "verifier" / "reward.json").write_text(json.dumps({"reward": 1.0}))
+    tr = parse_job_dir(tmp_path)["task-late"][0]
+    assert tr.reward == 1.0
+    assert tr.error is None
+
+
+def test_missing_verifier_dir_without_exception_is_an_error(tmp_path):
+    """No reward AND no verifier output is not a measurement either."""
+    t = tmp_path / "trial-bare"
+    t.mkdir()
+    (t / "config.json").write_text(json.dumps({"task": {"name": "task-bare"}}))
+    tr = parse_job_dir(tmp_path)["task-bare"][0]
+    assert tr.error is not None

--- a/core/cap_evolve/gate.py
+++ b/core/cap_evolve/gate.py
@@ -18,6 +18,10 @@ class GateDecision:
     reason: str
     delta: float
     threshold: float = 0.0
+    #: True when the gate declined to judge at all (not "the edit was bad"). The
+    #: caller must not treat this as a content rejection: it should not count
+    #: toward the stall counter and it says nothing about the candidate's quality.
+    indecisive: bool = False
 
     def to_dict(self) -> dict:
         return {
@@ -25,6 +29,7 @@ class GateDecision:
             "reason": self.reason,
             "delta": self.delta,
             "threshold": self.threshold,
+            "indecisive": self.indecisive,
         }
 
 
@@ -55,6 +60,27 @@ def _warn_se_zero(run_dir, mode: str, context: str) -> None:
             context=context)
 
 
+def _warn_low_coverage(run_dir, *, coverage: float, min_coverage: float) -> None:
+    """Log a ``gate_warning`` when too little of the split actually ran.
+
+    Loud and auditable on purpose: a run that keeps producing indecisive steps is
+    burning budget on an infrastructure fault, and the event stream is where an
+    operator (or the CI assert) can see that rather than reading a plausible-looking
+    val score that happens to be meaningless.
+    """
+    if run_dir is None:
+        return
+    log = getattr(run_dir, "log_event", None)
+    if callable(log):
+        log("gate_warning",
+            mode="coverage",
+            reason=("too few val tasks produced a valid score — the gate is "
+                    "declining to judge this candidate. This is an infrastructure "
+                    "failure (runner/environment), not a bad edit: fix the runner "
+                    "before spending more budget."),
+            context=f"coverage={coverage:.3f} < min_coverage={min_coverage:.3f}")
+
+
 def decide(
     current_val: float,
     candidate_val: float,
@@ -68,6 +94,8 @@ def decide(
     candidate_size: int | None = None,
     current_size: int | None = None,
     paired_deltas: list | None = None,
+    coverage: float | None = None,
+    min_coverage: float = 0.6,
     run_dir=None,
 ) -> GateDecision:
     """Decide whether to accept the candidate.
@@ -87,6 +115,14 @@ def decide(
       - ``simplicity_tiebreak``: like strict, but on a (near-)tie prefer the
         smaller candidate (``candidate_size`` < ``current_size``).
 
+    ``coverage`` is the fraction of val tasks that produced a real measurement
+    (``SplitResult.coverage``). Below ``min_coverage`` the gate REFUSES TO JUDGE and
+    returns an ``indecisive`` decision rather than a rejection: when most of the
+    split never ran, the val number describes the infrastructure, not the edit, and
+    calling that a regression both discards a possibly-good candidate and tells the
+    optimizer to go fix content that was never evaluated. Pass ``min_coverage=0.0``
+    to disable the guard.
+
     ``run_dir`` (optional) is used only to log a ``gate_warning`` event when an SE
     collapses to 0 (so the silent degeneration to strict is auditable).
     """
@@ -97,6 +133,17 @@ def decide(
         )
 
     delta = candidate_val - current_val
+
+    if coverage is not None and min_coverage > 0.0 and coverage < min_coverage:
+        pct, bar = coverage * 100.0, min_coverage * 100.0
+        reason = (
+            f"INDECISIVE: only {pct:.0f}% of val tasks produced a valid score "
+            f"(< {bar:.0f}% required). The evaluation measured the infrastructure, "
+            "not the edit — not counted as a rejection."
+        )
+        _warn_low_coverage(run_dir, coverage=coverage, min_coverage=min_coverage)
+        return GateDecision(accept=False, reason=reason, delta=delta,
+                            threshold=0.0, indecisive=True)
 
     if mode == "paired":
         deltas = list(paired_deltas or [])

--- a/core/cap_evolve/gepa.py
+++ b/core/cap_evolve/gepa.py
@@ -61,7 +61,7 @@ from .harness import (
     evaluate_candidate,
     split_result_from_rollouts,
 )
-from .loop import SplitResult, aggregate_scores
+from .loop import SplitResult, aggregate_scores, has_valid_trials
 from .rundir import RunDir
 from .types import Rollout, Score
 
@@ -704,14 +704,19 @@ def _full_val_gate(
     decision = gate_mod.decide(
         parent_result.reward, cand_val.reward, split="val",
         candidate_stderr=cand_val.stderr, current_stderr=parent_result.stderr,
-        paired_deltas=paired, run_dir=run_dir, **gk,
+        paired_deltas=paired, coverage=cand_val.coverage, run_dir=run_dir, **gk,
     )
     accepted = decision.accept
     if accepted and no_regression:
         eps = 1e-9
-        pr = {pt["task_id"]: pt.get("reward", 0.0) for pt in parent_result.per_task}
-        cr = {pt["task_id"]: pt.get("reward", 0.0) for pt in cand_val.per_task}
-        regressions = sorted(t for t, v in pr.items() if cr.get(t, 0.0) < v - eps)
+        # Compare only tasks BOTH sides actually measured: an unscored candidate
+        # task is missing data, and reading its 0.0 as "broke a task the parent
+        # passed" would let one image-pull failure veto a genuinely better edit.
+        pr = {pt["task_id"]: pt.get("reward", 0.0) for pt in parent_result.per_task
+              if has_valid_trials(pt)}
+        cr = {pt["task_id"]: pt.get("reward", 0.0) for pt in cand_val.per_task
+              if has_valid_trials(pt)}
+        regressions = sorted(t for t, v in pr.items() if t in cr and cr[t] < v - eps)
         if regressions:
             accepted = False
             decision.reason += f"; REJECTED by no-regression gate (broke {regressions})"

--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from typing import Callable
 
 from . import gate as gate_mod
-from .loop import SplitResult, aggregate_scores
+from .loop import SplitResult, aggregate_scores, has_valid_trials
 from .rundir import RunDir, _atomic_write
 from .splits import Splits, make_splits
 from .types import Rollout, Score, Task
@@ -238,7 +238,8 @@ def evaluate_candidate(
             # `filled` already turned that into a failed rollout above. Do NOT serially
             # re-run it here, which would add a slow tail to every batch evaluation.
             rollout = filled[tid]
-            if getattr(rollout, "error", None):
+            errored = bool(getattr(rollout, "error", None))
+            if errored:
                 per_task_errored[tid] = True
                 per_task_errored_trials[tid] += 1
             run_acc["cost"] += float(getattr(rollout, "cost_usd", 0.0) or 0.0)
@@ -246,9 +247,16 @@ def evaluate_candidate(
             sc = scores_by_id.get(tid)
             if sc is None:  # not in has_score_batch mode, or the batch omitted this id
                 sc = adapter.score(task, rollout)
-            per_task_trials[tid].append(sc.reward)
+            # An errored trial never ran the target, so its reward is not a
+            # measurement — it is missing data. Averaging its 0.0 in would state
+            # that the capability failed a task it was never given, which is how a
+            # Docker Hub 429 storm became a val score of 0.000 and taught the
+            # optimizer to "fix" content that was never at fault. Keep the rollout
+            # file (written below) for forensics, but leave the number out.
+            if not errored:
+                per_task_trials[tid].append(sc.reward)
+                per_task_metrics[tid].append(sc.metrics)
             per_task_feedback[tid] = sc.feedback or per_task_feedback[tid]
-            per_task_metrics[tid].append(sc.metrics)
             (out_dir / f"{tid}__{tag}__t{k}.json").write_text(
                 json.dumps({"input": task.input, "rollout": rollout.to_dict(),
                             "score": sc.to_dict()}, default=str),
@@ -302,15 +310,19 @@ def evaluate_candidate(
 
     scores: list[Score] = []
     for tid in task_by_id:
-        tr = per_task_trials[tid]
+        tr = per_task_trials[tid]   # VALID (non-errored) trial rewards only
         # ``raw.errored`` carries the structured infra signal (rollout.error was set
         # on some trial) into the per-task record, so the focus builder can classify
         # uncontrollable failures without substring-matching feedback prose.
+        # ``raw.valid_trials`` is what downstream honesty depends on: 0 means this
+        # task produced no measurement at all and must be excluded from the split
+        # mean and from paired deltas rather than counted as a 0.0.
         scores.append(Score(
             task_id=tid, reward=mean(tr), feedback=per_task_feedback[tid],
             n=n_trials, stderr=stderr(tr), trial_rewards=tr,
             raw={"errored": per_task_errored[tid],
                  "errored_trials": per_task_errored_trials[tid],
+                 "valid_trials": len(tr),
                  "n_trials": n_trials},
             metrics=_aggregate_metrics(per_task_metrics[tid], mean(tr)),
         ))
@@ -343,18 +355,34 @@ def split_result_from_rollouts(run_dir: RunDir, tag: str, split: str = "val", ks
             rec = _json.loads(f.read_text(encoding="utf-8"))
             sc = rec.get("score", {})
             tid = sc.get("task_id") or f.name.split("__")[0]
-            by_task.setdefault(tid, []).append(float(sc.get("reward", 0.0)))
             feedback[tid] = sc.get("feedback", feedback.get(tid, ""))
-            metrics_by_task.setdefault(tid, []).append(sc.get("metrics") or [])
             # carry the structured infra flag + trial counts forward across resume.
             # Each rollout file is one trial, so count an errored trial here and tally
             # the total trials seen — letting _is_infra_ignore reconstruct the
             # majority-errored condition from disk.
+            #
+            # The authoritative per-trial signal is the persisted ``rollout.error``:
+            # ``score.raw`` is whatever the ADAPTER returned for a single trial, and
+            # adapters (harbor's included) legitimately leave it empty — the errored
+            # flag is synthesised later during per-task aggregation. Reading only
+            # ``score.raw`` therefore reconstructed every infra failure as a real
+            # 0.0 on resume, silently re-introducing the bug this path exists to
+            # carry across.
+            errored = bool((rec.get("rollout") or {}).get("error")
+                           or (sc.get("raw") or {}).get("errored"))
             r0 = raw.setdefault(tid, {})
             r0["n_trials"] = int(r0.get("n_trials", 0)) + 1
-            if (sc.get("raw") or {}).get("errored"):
+            by_task.setdefault(tid, [])
+            if errored:
                 r0["errored"] = True
                 r0["errored_trials"] = int(r0.get("errored_trials", 0)) + 1
+            else:
+                # Valid trials only — mirrors evaluate_candidate so a resumed score
+                # equals the score the run originally computed.
+                by_task[tid].append(float(sc.get("reward", 0.0)))
+                metrics_by_task.setdefault(tid, []).append(sc.get("metrics") or [])
+    for tid, r0 in raw.items():
+        r0["valid_trials"] = len(by_task.get(tid, []))
     scores = [Score(task_id=t, reward=mean(r), feedback=feedback.get(t, ""),
                     n=len(r), stderr=stderr(r), trial_rewards=r, raw=raw.get(t, {}),
                     metrics=_aggregate_metrics(metrics_by_task.get(t, []), mean(r)))
@@ -387,7 +415,22 @@ def baseline(adapter, seed_dir: Path, *, run_dir: RunDir, n_trials: int = 1, ks=
                                split="val", n_trials=n_trials, ks=ks, tag="seed")
     (run_dir.root / "baseline.json").write_text(
         json.dumps({"val": result.to_dict(), "best_id": "seed"}, indent=2), encoding="utf-8")
-    run_dir.log_event("baseline", val=result.reward, stderr=result.stderr)
+    run_dir.log_event("baseline", val=result.reward, stderr=result.stderr,
+                      n_scored=result.n_scored, n_tasks=result.n_tasks)
+    # The baseline is the number every later delta is measured against, so a
+    # partially-evaluated one poisons the whole run rather than a single iteration.
+    # Nothing downstream can detect this after the fact — baseline.json looks like a
+    # perfectly ordinary score — so say it loudly, here, once.
+    if result.n_tasks and result.coverage < 1.0:
+        run_dir.log_event(
+            "baseline_incomplete",
+            n_scored=result.n_scored, n_tasks=result.n_tasks,
+            coverage=round(result.coverage, 4), val=result.reward,
+            reason=("the baseline was measured on only part of the val split "
+                    f"({result.n_scored}/{result.n_tasks} tasks produced a score) — "
+                    "the remaining tasks failed with runner/infrastructure errors. "
+                    "Every Δ in this run is measured against this partial number; "
+                    "fix the runner and re-baseline before trusting the result."))
     return result
 
 
@@ -511,13 +554,24 @@ def _paired_deltas(current_val: SplitResult, cand_val: SplitResult) -> list | No
     Returns ``None`` if either side lacks per-task data or they share no task ids
     (so the caller falls back to the unpaired significance test). Tasks present in
     only one side are dropped — a paired test needs both halves of the pair.
+
+    A task is also dropped when EITHER side failed to produce a valid trial. This
+    matters more here than anywhere else: pairing is per-task, so an unscored task
+    on the candidate side that the parent happened to pass contributes a full
+    -1.0 delta — the gate reads an infrastructure outage as the single largest
+    regression the candidate could possibly have caused. That is exactly how a
+    Docker Hub 429 storm produced ``paired Δ̄=-0.6400`` and rejected candidates
+    whose content was never evaluated.
     """
-    cur = {pt.get("task_id"): pt.get("reward", 0.0) for pt in (current_val.per_task or [])}
-    cand = {pt.get("task_id"): pt.get("reward", 0.0) for pt in (cand_val.per_task or [])}
-    shared = [t for t in cand if t in cur]
+    cur = {pt.get("task_id"): pt for pt in (current_val.per_task or [])}
+    cand = {pt.get("task_id"): pt for pt in (cand_val.per_task or [])}
+    shared = [t for t in cand
+              if t in cur and has_valid_trials(cand[t]) and has_valid_trials(cur[t])]
     if not shared:
         return None
-    return [float(cand[t]) - float(cur[t]) for t in sorted(shared)]
+    return [float(cand[t].get("reward", 0.0) or 0.0)
+            - float(cur[t].get("reward", 0.0) or 0.0)
+            for t in sorted(shared)]
 
 
 
@@ -1309,7 +1363,7 @@ def run_step(
     decision = gate_mod.decide(
         current_val.reward, cand_val.reward, split="val",
         candidate_stderr=cand_val.stderr, current_stderr=current_val.stderr,
-        paired_deltas=paired_deltas, run_dir=run_dir,
+        paired_deltas=paired_deltas, coverage=cand_val.coverage, run_dir=run_dir,
         **gate_kwargs,
     )
 
@@ -1317,12 +1371,17 @@ def run_step(
     regressions = []
     if accepted and no_regression:
         # A regression is ANY task whose reward strictly dropped (works for graded
-        # rewards too, not just binary pass/fail).
+        # rewards too, not just binary pass/fail). Restricted to tasks BOTH sides
+        # actually measured — an unscored task is missing data, and treating its
+        # 0.0 as "broke a task the parent passed" would let a single image-pull
+        # failure veto a genuinely better candidate.
         eps = 1e-9
-        parent_reward = {pt["task_id"]: pt.get("reward", 0.0) for pt in current_val.per_task}
-        cand_reward = {pt["task_id"]: pt.get("reward", 0.0) for pt in cand_val.per_task}
+        parent_reward = {pt["task_id"]: pt.get("reward", 0.0) for pt in current_val.per_task
+                         if has_valid_trials(pt)}
+        cand_reward = {pt["task_id"]: pt.get("reward", 0.0) for pt in cand_val.per_task
+                       if has_valid_trials(pt)}
         regressions = sorted(t for t, pr in parent_reward.items()
-                             if cand_reward.get(t, 0.0) < pr - eps)
+                             if t in cand_reward and cand_reward[t] < pr - eps)
         if regressions:
             accepted = False
             decision.reason += f"; REJECTED by no-regression gate (broke {regressions})"
@@ -1334,7 +1393,11 @@ def run_step(
     run_dir.snapshot(cid, workdir, ignore=_SNAPSHOT_IGNORE)
     if accepted:
         run_dir.set_best(cid)
-    run_dir.update_spent(iterations=1, accepted=accepted)
+    # ``accepted=None`` leaves the stall counter untouched. An indecisive step is not
+    # evidence that the optimizer has run out of ideas — the candidate was never
+    # judged — so it must not push the run toward an early "stalled" stop.
+    run_dir.update_spent(iterations=1,
+                         accepted=None if decision.indecisive else accepted)
     _step_extra = {}
     if isinstance(opt_report, dict):
         _step_extra["optimizer_report"] = opt_report
@@ -1368,6 +1431,14 @@ def run_step(
     if accepted:
         if history is not None:
             history.add(cid, summary, cand_val.reward, note=note, impact=impact)
+    elif decision.indecisive:
+        # Do NOT record an indecisive step as a rejection. The rejected list is fed
+        # back to the optimizer as "these edits did not work" guidance, and an
+        # infrastructure outage says nothing about the edit — filing it there teaches
+        # the optimizer to avoid a change that was never actually evaluated.
+        run_dir.log_event("step_indecisive", candidate=cid, reason=decision.reason,
+                          val=cand_val.reward, n_scored=cand_val.n_scored,
+                          n_tasks=cand_val.n_tasks)
     else:
         if rejected is not None:
             rejected.add(cid, summary, decision.reason, cand_val.reward, note=note, impact=impact)

--- a/core/cap_evolve/loop.py
+++ b/core/cap_evolve/loop.py
@@ -31,6 +31,30 @@ def _as_k_dict(v) -> dict:
     return {}
 
 
+def has_valid_trials(pt) -> bool:
+    """Did this task produce at least one real measurement?
+
+    ``raw.valid_trials`` is written by the harness as the count of trials whose
+    rollout carried NO ``error``. A task at 0 was never actually run (image build
+    failure, agent-setup timeout, runner crash), so its reward is missing data
+    rather than evidence of failure, and it must stay out of the split mean and
+    out of paired deltas.
+
+    Tolerant of shapes that predate the field: older run dirs and hand-built
+    Scores have no ``valid_trials``, and for those we fall back to "at least one
+    trial did not error", finally defaulting to True so absent metadata can never
+    silently erase a task from a mean.
+    """
+    raw = (pt.get("raw") if isinstance(pt, dict) else getattr(pt, "raw", None)) or {}
+    if "valid_trials" in raw:
+        return int(raw.get("valid_trials") or 0) > 0
+    n = raw.get("n_trials")
+    errored = raw.get("errored_trials")
+    if n is not None and errored is not None:
+        return int(errored) < int(n)
+    return True
+
+
 @dataclass
 class SplitResult:
     """Aggregate evaluation of one candidate on one split."""
@@ -45,6 +69,19 @@ class SplitResult:
     cost_usd: float = 0.0
     tokens: int = 0
     seconds: float = 0.0
+    # Honest denominator: how many of the split's tasks actually produced a
+    # measurement. ``reward`` is the mean over ``n_scored`` tasks, NOT over
+    # ``n_tasks`` — so a caller can tell "scored 0.08" from "0.08 because two
+    # thirds of the split never ran".
+    n_tasks: int = 0
+    n_scored: int = 0
+
+    @property
+    def coverage(self) -> float:
+        """Fraction of the split that produced a measurement (1.0 if unknown)."""
+        if not self.n_tasks:
+            return 1.0
+        return self.n_scored / self.n_tasks
 
     def to_dict(self) -> dict:
         return {
@@ -57,6 +94,8 @@ class SplitResult:
             "cost_usd": self.cost_usd,
             "tokens": self.tokens,
             "seconds": self.seconds,
+            "n_tasks": self.n_tasks,
+            "n_scored": self.n_scored,
         }
 
     @classmethod
@@ -71,13 +110,24 @@ class SplitResult:
             cost_usd=float(d.get("cost_usd") or 0.0),
             tokens=int(d.get("tokens") or 0),
             seconds=float(d.get("seconds") or 0.0),
+            n_tasks=int(d.get("n_tasks") or 0),
+            n_scored=int(d.get("n_scored") or 0),
         )
 
 
 def aggregate_scores(split: str, scores: Sequence[Score], ks: Sequence[int] = (1, 2)) -> SplitResult:
-    """Turn per-task ``Score`` objects into a ``SplitResult`` with honest stats."""
-    means = [s.reward for s in scores]
-    ses = [s.stderr for s in scores]
+    """Turn per-task ``Score`` objects into a ``SplitResult`` with honest stats.
+
+    Tasks that produced NO valid trial are excluded from every statistic. They
+    are still reported in ``per_task`` (nothing is hidden), but counting their
+    0.0 would understate the capability and — worse — hand the optimizer a
+    phantom regression to chase. ``n_tasks``/``n_scored`` expose the real
+    denominator so callers can refuse to gate on a decimated split.
+    """
+    scored = [s for s in scores if has_valid_trials(s)]
+
+    means = [s.reward for s in scored]
+    ses = [s.stderr for s in scored]
     overall = stats.aggregate(means)
     overall_se = stats.combined_stderr(means, ses)
 
@@ -87,7 +137,7 @@ def aggregate_scores(split: str, scores: Sequence[Score], ks: Sequence[int] = (1
     # when the truth is "not enough trials". So we OMIT any k > min trials — a
     # missing key is the N/A representation (JSON: absent/null; human surfaces
     # render "N/A"/"—"). k < 1 is undefined too.
-    trials_per_task = [len(s.trial_rewards or [s.reward]) for s in scores]
+    trials_per_task = [len(s.trial_rewards or [s.reward]) for s in scored]
     max_usable_k = min(trials_per_task) if trials_per_task else 0
 
     pk: dict = {}
@@ -95,8 +145,8 @@ def aggregate_scores(split: str, scores: Sequence[Score], ks: Sequence[int] = (1
     for k in ks:
         if k < 1 or k > max_usable_k:
             continue
-        rel = [stats.pass_k(s.trial_rewards or [s.reward], k) for s in scores]
-        cap = [stats.pass_at_k(s.trial_rewards or [s.reward], k) for s in scores]
+        rel = [stats.pass_k(s.trial_rewards or [s.reward], k) for s in scored]
+        cap = [stats.pass_at_k(s.trial_rewards or [s.reward], k) for s in scored]
         if rel:
             pk[str(k)] = stats.mean(rel)      # pass^k: reliability (all k pass)
         if cap:
@@ -107,7 +157,9 @@ def aggregate_scores(split: str, scores: Sequence[Score], ks: Sequence[int] = (1
         stderr=overall_se,
         pass_k=pk,
         pass_at_k=pak,
-        per_task=[s.to_dict() for s in scores],
+        per_task=[s.to_dict() for s in scores],   # ALL tasks, including unscored
+        n_tasks=len(scores),
+        n_scored=len(scored),
     )
 
 

--- a/core/tests/test_infra_errors_not_zeros.py
+++ b/core/tests/test_infra_errors_not_zeros.py
@@ -1,0 +1,415 @@
+"""An unscored trial is missing data, not a reward of 0.0.
+
+From benchmarks run 31040448986 (`full / swebench` on skillberry-1). Docker Hub
+rate-limits unauthenticated pulls to 100 manifest requests/hour per source IP,
+and the runner had no `docker.io` credential, so `docker compose build` failed
+with HTTP 429 before the agent ever started:
+
+    RuntimeError: Docker compose command failed for environment django__django-10554
+    #3 ERROR: unexpected status from HEAD request to registry-1.docker.io/...: 429
+
+Harbor recorded that faithfully (`n_errored_trials: 50`, `n_trials: 0`), but
+`capevolve_harbor.results` never read `exception_info`, so every crashed trial
+arrived as a legitimate "Task not solved (reward 0.0)". Consequences, all of
+which these tests pin down:
+
+  * cand_0001 and cand_0002 scored val **0.000** with 50/50 trials never run.
+  * The baseline itself was measured with 33/50 tasks unscored (val 0.08 where
+    the tasks that ran gave ~0.27), so every delta was against a fiction.
+  * The `paired` gate reads per-task, so an unscored candidate task the parent
+    had passed contributed a full -1.0: cand_0007 was rejected at
+    `paired Δ̄=-0.6400` without a single task being evaluated.
+  * cand_0006 scored 0.69 on the tasks that ran — better than the accepted
+    cand_0003 — but was rejected as Δ=-0.16 because 9 of its tasks 429'd.
+  * The optimizer burned an iteration proving to itself that "iters 1–2 were
+    infra flakes, not content regressions".
+"""
+
+import json
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+CORE = REPO / "core"
+sys.path.insert(0, str(CORE))
+
+
+# ---- has_valid_trials: the single predicate everything else keys off --------
+
+def test_valid_trials_zero_means_unscored():
+    from cap_evolve.loop import has_valid_trials
+    assert has_valid_trials({"raw": {"valid_trials": 0, "n_trials": 1}}) is False
+    assert has_valid_trials({"raw": {"valid_trials": 2, "n_trials": 3}}) is True
+
+
+def test_falls_back_to_errored_trial_counts_for_older_run_dirs():
+    from cap_evolve.loop import has_valid_trials
+    assert has_valid_trials({"raw": {"errored_trials": 3, "n_trials": 3}}) is False
+    assert has_valid_trials({"raw": {"errored_trials": 1, "n_trials": 3}}) is True
+
+
+def test_absent_metadata_defaults_to_scored():
+    """Missing metadata must never silently erase a task from a mean."""
+    from cap_evolve.loop import has_valid_trials
+    assert has_valid_trials({}) is True
+    assert has_valid_trials({"raw": {}}) is True
+
+
+# ---- aggregate_scores: unscored tasks leave the statistics ------------------
+
+def _score(tid, reward, *, valid=1, n=1):
+    from cap_evolve import Score
+    return Score(task_id=tid, reward=reward, trial_rewards=[reward] * valid,
+                 n=n, raw={"valid_trials": valid, "n_trials": n,
+                           "errored_trials": n - valid, "errored": valid < n})
+
+
+def test_unscored_tasks_are_excluded_from_the_mean():
+    from cap_evolve.loop import aggregate_scores
+    # 1 pass, 1 real fail, 2 never ran. Honest answer is 1/2, not 1/4.
+    res = aggregate_scores("val", [
+        _score("pass", 1.0),
+        _score("fail", 0.0),
+        _score("infra1", 0.0, valid=0),
+        _score("infra2", 0.0, valid=0),
+    ])
+    assert res.reward == 0.5, "unscored tasks must not dilute the mean"
+    assert res.n_tasks == 4
+    assert res.n_scored == 2
+    assert res.coverage == 0.5
+
+
+def test_unscored_tasks_are_still_reported():
+    """Excluded from the statistics, but never hidden from the record."""
+    from cap_evolve.loop import aggregate_scores
+    res = aggregate_scores("val", [_score("pass", 1.0), _score("infra", 0.0, valid=0)])
+    assert {pt["task_id"] for pt in res.per_task} == {"pass", "infra"}
+
+
+def test_coverage_is_one_when_nothing_errored():
+    from cap_evolve.loop import aggregate_scores
+    res = aggregate_scores("val", [_score("a", 1.0), _score("b", 0.0)])
+    assert res.coverage == 1.0
+    assert res.reward == 0.5
+
+
+def test_coverage_defaults_to_one_for_legacy_split_results():
+    """A SplitResult read back from an old run dir must not look decimated."""
+    from cap_evolve.loop import SplitResult
+    old = SplitResult.from_dict({"split": "val", "reward": 0.5, "stderr": 0.1})
+    assert old.coverage == 1.0
+
+
+def test_split_result_roundtrips_coverage():
+    from cap_evolve.loop import SplitResult
+    r = SplitResult(split="val", reward=0.5, stderr=0.1, n_tasks=10, n_scored=4)
+    assert SplitResult.from_dict(r.to_dict()).coverage == 0.4
+
+
+# ---- _paired_deltas: the -0.64 that never happened -------------------------
+
+def test_paired_deltas_drop_unscored_candidate_tasks():
+    """The cand_0007 failure: infra outage read as the largest possible regression."""
+    from cap_evolve.harness import _paired_deltas
+    from cap_evolve.loop import aggregate_scores
+
+    parent = aggregate_scores("val", [_score(f"t{i}", 1.0) for i in range(4)])
+    # Candidate: one real regression, three tasks that never ran.
+    cand = aggregate_scores("val", [
+        _score("t0", 0.0),
+        _score("t1", 0.0, valid=0),
+        _score("t2", 0.0, valid=0),
+        _score("t3", 0.0, valid=0),
+    ])
+    deltas = _paired_deltas(parent, cand)
+    assert deltas == [-1.0], "only the one measured task may contribute a delta"
+
+
+def test_paired_deltas_drop_unscored_parent_tasks():
+    from cap_evolve.harness import _paired_deltas
+    from cap_evolve.loop import aggregate_scores
+    parent = aggregate_scores("val", [_score("t0", 1.0), _score("t1", 0.0, valid=0)])
+    cand = aggregate_scores("val", [_score("t0", 1.0), _score("t1", 1.0)])
+    assert _paired_deltas(parent, cand) == [0.0]
+
+
+def test_paired_deltas_none_when_nothing_is_comparable():
+    """No shared measured task -> fall back to the unpaired test, not a fake 0."""
+    from cap_evolve.harness import _paired_deltas
+    from cap_evolve.loop import aggregate_scores
+    parent = aggregate_scores("val", [_score("t0", 1.0)])
+    cand = aggregate_scores("val", [_score("t0", 0.0, valid=0)])
+    assert _paired_deltas(parent, cand) is None
+
+
+# ---- the gate refuses to judge a decimated split ---------------------------
+
+def test_gate_is_indecisive_below_min_coverage():
+    from cap_evolve import gate
+    d = gate.decide(0.08, 0.0, coverage=0.02, min_coverage=0.6,
+                    paired_deltas=[-1.0] * 50)
+    assert d.accept is False
+    assert d.indecisive is True
+    assert "INDECISIVE" in d.reason
+
+
+def test_gate_judges_normally_at_acceptable_coverage():
+    from cap_evolve import gate
+    d = gate.decide(0.0, 1.0, coverage=0.9, min_coverage=0.6, mode="strict")
+    assert d.accept is True
+    assert d.indecisive is False
+
+
+def test_min_coverage_zero_disables_the_guard():
+    from cap_evolve import gate
+    d = gate.decide(0.0, 1.0, coverage=0.01, min_coverage=0.0, mode="strict")
+    assert d.indecisive is False
+    assert d.accept is True
+
+
+def test_coverage_none_disables_the_guard():
+    """Callers that don't know their coverage keep the old behaviour."""
+    from cap_evolve import gate
+    d = gate.decide(0.0, 1.0, coverage=None, mode="strict")
+    assert d.indecisive is False
+    assert d.accept is True
+
+
+def test_indecisive_decision_is_serialised():
+    from cap_evolve import gate
+    d = gate.decide(0.5, 0.0, coverage=0.1, min_coverage=0.6, mode="strict")
+    assert d.to_dict()["indecisive"] is True
+
+
+# ---- end to end through evaluate_candidate --------------------------------
+
+class _FlakyAdapter:
+    """A/B score for real; C/D always fail to start (the 429 case)."""
+
+    ERRORED = ("C", "D")
+
+    def tasks(self, split):
+        from cap_evolve import Task
+        return [Task(id=t) for t in ("A", "B", "C", "D")]
+
+    def run_target(self, task, ctx, *, seed=0):
+        from cap_evolve import Rollout
+        if task.id in self.ERRORED:
+            return Rollout(task_id=task.id,
+                           error="RuntimeError: Docker compose command failed ... "
+                                 "429 Too Many Requests")
+        return Rollout(task_id=task.id, output="pass" if task.id == "A" else "fail")
+
+    def score(self, task, rollout):
+        from cap_evolve import Score
+        # Deliberately returns 0.0 for the errored rollouts, exactly as the harbor
+        # adapter does. The harness must not let that 0.0 into the mean.
+        ok = rollout.output == "pass"
+        return Score(task_id=task.id, reward=1.0 if ok else 0.0)
+
+    def apply(self, candidate_dir, edits=None):
+        return None
+
+
+def _run_dir(tmp_path, ts, ids=("A", "B", "C", "D")):
+    from cap_evolve import RunDir
+    from cap_evolve.splits import Splits
+    rd = RunDir.create(tmp_path / ".capevolve", ts=ts)
+    rd.write_splits(Splits(train=[], val=list(ids), test=[], seed=0))
+    seed = tmp_path / "seed"
+    seed.mkdir(exist_ok=True)
+    (seed / "cap.md").write_text("x")
+    rd.snapshot("seed", seed)
+    rd.set_best("seed")
+    return rd
+
+
+def test_evaluate_candidate_excludes_errored_trials(tmp_path):
+    from cap_evolve import harness
+    rd = _run_dir(tmp_path, "ee")
+    res = harness.evaluate_candidate(_FlakyAdapter(), rd.candidate_dir("seed"),
+                                     run_dir=rd, split="val", tag="seed")
+    # A=1.0, B=0.0 measured; C,D never ran. 0.5, not 0.25.
+    assert res.reward == 0.5
+    assert res.n_scored == 2
+    assert res.n_tasks == 4
+    assert res.coverage == 0.5
+
+
+def test_errored_tasks_are_marked_in_per_task_records(tmp_path):
+    from cap_evolve import harness
+    rd = _run_dir(tmp_path, "mark")
+    res = harness.evaluate_candidate(_FlakyAdapter(), rd.candidate_dir("seed"),
+                                     run_dir=rd, split="val", tag="seed")
+    by_id = {pt["task_id"]: pt for pt in res.per_task}
+    assert by_id["C"]["raw"]["valid_trials"] == 0
+    assert by_id["C"]["raw"]["errored"] is True
+    assert by_id["A"]["raw"]["valid_trials"] == 1
+    assert by_id["A"]["raw"]["errored"] is False
+
+
+def test_rollout_files_still_record_the_error(tmp_path):
+    """Excluded from the mean, but the forensic trail must survive."""
+    from cap_evolve import harness
+    rd = _run_dir(tmp_path, "forensics")
+    harness.evaluate_candidate(_FlakyAdapter(), rd.candidate_dir("seed"),
+                               run_dir=rd, split="val", tag="seed")
+    rec = json.loads((rd.rollouts / "val" / "C__seed__t0.json").read_text())
+    assert "429" in rec["rollout"]["error"]
+
+
+def test_resume_reproduces_the_same_score(tmp_path):
+    """A resumed val score must equal the score the run computed live.
+
+    The resume path reads persisted rollouts, and it used to look only at
+    `score.raw.errored` — which adapters legitimately leave empty, so every infra
+    failure came back from disk as a real 0.0 and the bug reappeared on resume.
+    """
+    from cap_evolve import harness
+    rd = _run_dir(tmp_path, "resume")
+    live = harness.evaluate_candidate(_FlakyAdapter(), rd.candidate_dir("seed"),
+                                      run_dir=rd, split="val", tag="seed")
+    back = harness.split_result_from_rollouts(rd, "seed", split="val")
+    assert back.reward == live.reward == 0.5
+    assert back.coverage == live.coverage == 0.5
+
+
+class _TotalOutageAdapter(_FlakyAdapter):
+    """Every task fails to start — cand_0001/cand_0002's actual situation."""
+    ERRORED = ("A", "B", "C", "D")
+
+
+def test_total_outage_does_not_count_as_a_stall(tmp_path):
+    """A candidate that was never evaluated must not push the run toward 'stalled'."""
+    from cap_evolve import harness
+    rd = _run_dir(tmp_path, "outage")
+    base = harness.evaluate_candidate(_FlakyAdapter(), rd.candidate_dir("seed"),
+                                      run_dir=rd, split="val", tag="seed")
+    stall_before = rd.spent.stall
+
+    noop = harness.optimizer_from_command(["python3", "-c", "pass"])
+    step = harness.run_step(_TotalOutageAdapter(), run_dir=rd,
+                            parent_dir=rd.candidate_dir("seed"), optimizer=noop,
+                            instructions="x", current_val=base)
+
+    assert step["accepted"] is False
+    assert step["decision"]["indecisive"] is True
+    assert rd.spent.stall == stall_before, (
+        "an unevaluated candidate is not evidence the optimizer has run out of ideas"
+    )
+
+
+def test_indecisive_step_is_not_filed_as_a_rejected_edit(tmp_path):
+    """The rejected list is optimizer guidance — an outage must not enter it.
+
+    Otherwise the next iteration is told "this edit did not work" about a change
+    whose content was never evaluated, which is how cand_0003 ended up spending an
+    iteration proving iters 1-2 were infra flakes rather than real regressions.
+    """
+    from cap_evolve import harness
+
+    class _Rejected:
+        def __init__(self):
+            self.entries = []
+
+        def add(self, *a, **kw):
+            self.entries.append((a, kw))
+
+    rd = _run_dir(tmp_path, "noguide")
+    base = harness.evaluate_candidate(_FlakyAdapter(), rd.candidate_dir("seed"),
+                                      run_dir=rd, split="val", tag="seed")
+    rejected = _Rejected()
+    noop = harness.optimizer_from_command(["python3", "-c", "pass"])
+    harness.run_step(_TotalOutageAdapter(), run_dir=rd,
+                     parent_dir=rd.candidate_dir("seed"), optimizer=noop,
+                     instructions="x", current_val=base, rejected=rejected)
+    assert rejected.entries == []
+
+
+def test_total_outage_reward_is_not_reported_as_a_measurement(tmp_path):
+    from cap_evolve import harness
+    rd = _run_dir(tmp_path, "outage2")
+    res = harness.evaluate_candidate(_TotalOutageAdapter(), rd.candidate_dir("seed"),
+                                     run_dir=rd, split="val", tag="seed")
+    assert res.n_scored == 0
+    assert res.coverage == 0.0
+
+
+# ---- the baseline poisons every later delta, so it warns loudly -------------
+
+def _events(rd):
+    p = rd.root / "events.jsonl"
+    return [json.loads(ln) for ln in p.read_text().splitlines() if ln.strip()] \
+        if p.exists() else []
+
+
+def test_partial_baseline_is_flagged(tmp_path):
+    """The real run established val 0.08 with 34/50 tasks never scored.
+
+    baseline.json looks like an ordinary number, so nothing downstream can notice.
+    """
+    from cap_evolve import harness
+    rd = _run_dir(tmp_path, "basewarn")
+    seed = tmp_path / "seed"
+    res = harness.baseline(_FlakyAdapter(), seed, run_dir=rd)
+    assert res.coverage == 0.5
+    kinds = [e.get("kind") for e in _events(rd)]
+    assert "baseline_incomplete" in kinds
+
+
+def test_complete_baseline_is_not_flagged(tmp_path):
+    from cap_evolve import harness
+
+    class _Clean(_FlakyAdapter):
+        ERRORED = ()
+
+    rd = _run_dir(tmp_path, "baseok")
+    seed = tmp_path / "seed"
+    res = harness.baseline(_Clean(), seed, run_dir=rd)
+    assert res.coverage == 1.0
+    kinds = [e.get("kind") for e in _events(rd)]
+    assert "baseline_incomplete" not in kinds
+
+
+# ---- the CI safety net was correct; it was starved of the signal ------------
+
+def _assert_run_module():
+    import importlib.util
+    path = REPO / "ci" / "benchmarks" / "lib" / "assert_run.py"
+    spec = importlib.util.spec_from_file_location("_assert_run_test", path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_infra_tasks_now_trip_the_ci_assertion(tmp_path):
+    """`assert_run.py --max-infra-frac` keys off `raw.errored`.
+
+    That guard has existed since run 30682720920 and would have failed this run at
+    the assert step — but `raw.errored` was never set for harbor, so it saw a clean
+    baseline and passed. Setting the flag is what re-arms it.
+    """
+    from cap_evolve import harness
+    ar = _assert_run_module()
+
+    rd = _run_dir(tmp_path, "assertwire")
+    res = harness.evaluate_candidate(_FlakyAdapter(), rd.candidate_dir("seed"),
+                                     run_dir=rd, split="val", tag="seed")
+    infra = [pt for pt in res.per_task if ar._infra_task(pt)]
+    assert {pt["task_id"] for pt in infra} == {"C", "D"}
+    # 2/4 tasks infra-errored, i.e. exactly at the default 0.5 ceiling.
+    assert len(infra) / len(res.per_task) == 0.5
+
+
+def test_healthy_tasks_do_not_trip_the_ci_assertion(tmp_path):
+    from cap_evolve import harness
+    ar = _assert_run_module()
+
+    class _Clean(_FlakyAdapter):
+        ERRORED = ()
+
+    rd = _run_dir(tmp_path, "assertclean")
+    res = harness.evaluate_candidate(_Clean(), rd.candidate_dir("seed"),
+                                     run_dir=rd, split="val", tag="seed")
+    assert [pt for pt in res.per_task if ar._infra_task(pt)] == []


### PR DESCRIPTION
Closes #306.

## Summary

An unscored trial is **missing data**, not a reward of 0.0. Run [31040448986](https://github.com/skillberry-ai/cap-evolve/actions/runs/31040448986/job/92423271498) (`full / swebench`) spent 18 hours optimizing against noise because the harbor result parser could not tell the difference.

Docker Hub rate-limits unauthenticated pulls to 100 manifest requests/hour per source IP. The runner had no `docker.io` credential, so `docker compose build` failed with HTTP 429 before the agent ever started. Harbor recorded that faithfully (`n_errored_trials: 50`, `n_trials: 0`, structured `exception_info`), but `_parse_trial` never read `exception_info` and `_read_reward` returned `0.0` for an absent reward file — so each crashed trial arrived as a legitimate `"Task not solved (reward 0.0)."` with `raw.errored == false`.

Replaying the run's real job dirs through this branch:

| candidate | reported val | scored | errored | honest val | coverage | new verdict |
|---|---|---|---|---|---|---|
| seed (baseline) | 0.08 | 16 | 34 | 0.250 | 0.32 | flagged `baseline_incomplete` |
| cand_0001 | **0.00** | 0 | 50 | n/a | 0.00 | indecisive |
| cand_0002 | **0.00** | 0 | 50 | n/a | 0.00 | indecisive |
| cand_0003 (accepted) | 0.64 | 49 | 1 | 0.653 | 0.98 | judged |
| cand_0004 | 0.38 | 33 | 17 | 0.576 | 0.66 | judged |
| cand_0005 | **0.02** | 1 | 49 | n/a | 0.02 | indecisive |
| cand_0006 | 0.48 | 36 | 14 | **0.667** | 0.72 | judged |
| cand_0007 | **0.00** | 1 | 49 | 0.000 | 0.02 | indecisive |

Three consequences, all now closed:

1. The baseline was measured with 34/50 tasks unscored, so **every delta in the run was against a fiction** (true seed ~0.25, not 0.08).
2. cand_0006 scored **0.667** on the tasks that ran — above the accepted cand_0003 (0.653) — but was rejected as `delta=-0.16` purely because 9 of its tasks 429'd.
3. The `paired` gate is per-task, so an unscored task the parent had passed contributes a full -1.0. cand_0007 was rejected at `paired mean-delta=-0.6400` **without a single task being evaluated**, and that rejection was then fed back to the optimizer as "this edit did not work" guidance. cand_0003's journal note reads *"PROVE iters 1-2 were infra flakes, not content regressions"* — an iteration spent reverse-engineering a harness bug.

## Design decisions

**The safety nets were already correct; they were starved of the signal.** `per_task_errored` in `harness.py`, gepa's `## Ignore — failed with run/infra errors` bucket, `metrics.py`'s `_infra_task`, and `assert_run.py`'s `--max-infra-frac` guard (added after run 30682720920 for this exact class of bug) all key off `rollout.error`. The harbor path never set it, so they saw a clean run and passed it. The primary change is therefore small and surgical — feed the signal — plus closing the remaining paths that still turned an unscored trial into a zero.

- **A reward file is the authoritative "this was measured" signal.** If one exists it wins even alongside an exception, so a crash in teardown never discards a genuine measurement.
- **Unscored tasks are excluded from statistics but never hidden.** They stay in `per_task` with `raw.valid_trials == 0`; only reward/stderr/pass^k skip them. `coverage` exposes the real denominator, so `0.08` is distinguishable from `0.08 because two thirds of the split never ran`.
- **Indecisive is not rejection.** Below `min_coverage` (default 0.6) the gate declines to judge: no stall increment (`accepted=None` already supported this in `rundir`), and no entry in the rejected list — because that list is optimizer guidance, and filing an outage there teaches the optimizer to avoid a change that was never evaluated.
- **`min_coverage=0.6` is a default, not a policy.** Pass `0.0` to disable; `coverage=None` preserves the old behaviour exactly for any caller that doesn't know its coverage.
- **The baseline gets its own warning** because it poisons every later delta and nothing downstream can detect it after the fact — `baseline.json` looks like an ordinary score.

### Backward compatibility

- `has_valid_trials` falls back to `errored_trials`/`n_trials` for older run dirs, and defaults to **scored** when metadata is absent — missing fields can never silently erase a task from a mean.
- `SplitResult.coverage` is `1.0` when `n_tasks` is unknown, so a legacy run dir never looks decimated.
- A fully-errored task still reports `reward == 0.0` (`mean([]) == 0.0`), preserving `metrics.py`'s low-mean infra condition.
- New JSON keys (`n_tasks`, `n_scored`, `valid_trials`, `indecisive`) are purely additive.

### Reviewer notes

- `_read_reward` now returns a 3-tuple `(reward, reward_json, scored)` — a signature change on a private helper; its six existing tests are updated and now assert the flag.
- The resume path (`split_result_from_rollouts`) previously read `score.raw.errored`, which **adapters legitimately leave empty** (harbor's `score()` returns a bare `Score`). It now reads the persisted `rollout.error`. Without this, every infra failure was rebuilt as a real 0.0 on resume, silently re-introducing the bug this path exists to carry across.

## Testing

- **572 tests pass** (`core/tests` + `capevolve_harbor/tests`), up from 568 — 27 new tests across `core/tests/test_infra_errors_not_zeros.py` and `capevolve_harbor/tests/test_results.py`.
- Verified against the **real job dirs on skillberry-1**, not just synthetic fixtures: the patched parser detects 34/50, 50/50, 49/50 and 14/50 infra failures in the runs that reported 0.08, 0.000, 0.02 and 0.48, and captures the actual cause (`RuntimeError: Docker compose ... 429 Too Many Requests`) rather than merely the fact of failure.
- Regression guards included: a real `0.0` from the verifier is still a real `0.0`; a reward alongside an exception is honoured; absent metadata defaults to scored; legacy `SplitResult`s report coverage 1.0.
- A test asserts that `assert_run.py`'s pre-existing `--max-infra-frac` guard now fires on this data, i.e. the CI net is re-armed.
- Unrelated local failures: `test_otel_observer.py` (no `opentelemetry` installed) and `dashboard/backend/tests` (no `fastapi` installed) cannot run in this environment; this branch touches neither.

## Not in this PR (operational)

The 429s themselves are fixed on the runner, no code change: authenticated to Docker Hub (200/hr keyed to the account rather than 100/hr keyed to the shared NAT IP) and pre-pulled all 50 val base images. BuildKit resolves `FROM` from the local image store without a registry round trip when the image is present — measured 0.1s cached vs 0.8s uncached, with no rate-limit token spent. A `docker login` step in `benchmarks.yml` would cover a fresh runner; happy to add it here or separately.

Signed-off-by: Eran Raichstein <eranra@il.ibm.com>
