### PR TITLE
feat(site): default to successful runs, derive filter lists, show local time

### DIFF
--- a/site/benchmarks.html
+++ b/site/benchmarks.html
@@ -89,16 +89,16 @@
       <input id="f-to" type="datetime-local">
     </label>
     <label>Benchmark
-      <select id="f-bench"><option value="">all</option><option>tau2</option><option>swebench</option><option>skillsbench</option></select>
+      <select id="f-bench"><option value="">all</option></select>
     </label>
     <label>Type
-      <select id="f-tier"><option value="">all</option><option>smoke</option><option>pilot</option><option>full</option></select>
+      <select id="f-tier"><option value="">all</option></select>
     </label>
     <label>Source
       <select id="f-source"><option value="">all</option><option value="pr">PR</option><option value="manual">manual</option></select>
     </label>
     <label>Result
-      <select id="f-conc"><option value="">all</option><option>success</option><option>failure</option><option>cancelled</option></select>
+      <select id="f-conc"><option value="">all</option><option selected>success</option><option>failure</option><option>cancelled</option></select>
     </label>
     <label>Search
       <input id="f-q" type="search" placeholder="branch or task…">
@@ -107,7 +107,7 @@
 
   <table id="runs">
     <thead><tr>
-      <th data-k="date">Date</th>
+      <th data-k="date">Date<span id="date-zone" class="muted"></span></th>
       <th data-k="source">Source</th>
       <th data-k="bench">Bench</th>
       <th data-k="tier">Type</th>

--- a/site/benchmarks.js
+++ b/site/benchmarks.js
@@ -9,6 +9,39 @@ let RECORDS = [], sortKey = "date", sortDir = -1;
 
 const $ = (s) => document.querySelector(s);
 const fmt = (v, d = 3) => (typeof v === "number" ? v.toFixed(d) : "—");
+// Records carry ISO-8601 UTC timestamps ("2026-08-09T14:11:02Z"). The old renderer just
+// stripped the "T" and the "Z", which DISPLAYED UTC while looking like local time — the worst
+// of both, since a reader in UTC+3 saw a run they started at 17:11 labelled 14:11 with nothing
+// to signal the offset. Parse and format in the browser's own zone instead.
+const fmtLocal = (iso) => {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  if (isNaN(d)) return String(iso);          // unparseable: show it raw rather than "Invalid Date"
+  return d.toLocaleString(undefined, {
+    year: "numeric", month: "2-digit", day: "2-digit",
+    hour: "2-digit", minute: "2-digit", second: "2-digit",
+  });
+};
+// The viewer's zone, shown once in the table header so the timestamps are unambiguous.
+const localZone = () => {
+  try { return Intl.DateTimeFormat().resolvedOptions().timeZone || "local"; }
+  catch { return "local"; }
+};
+
+// Populate a <select> from the values actually present in the data, preserving the current
+// selection. Hardcoded option lists silently hide whole benchmarks: `spreadsheetbench` and
+// `rh-swebench` records existed in benchmark-history but were unreachable in the UI because the
+// markup only listed tau2/swebench/skillsbench.
+function hydrateFilter(sel, values, fallbackLabel) {
+  const el = $(sel);
+  if (!el) return;
+  const prev = el.value;
+  const opts = [...new Set(values.filter(Boolean))].sort((a, b) => a.localeCompare(b));
+  el.innerHTML = `<option value="">${fallbackLabel}</option>` +
+    opts.map((v) => `<option${v === prev ? " selected" : ""}>${esc(v)}</option>`).join("");
+  el.value = opts.includes(prev) ? prev : "";
+}
+
 // Wall-time seconds as minutes+seconds (e.g. 14m48s), matching metrics.py's _fmt_duration.
 const fmtDuration = (v) => {
   if (typeof v !== "number") return "—";
@@ -102,6 +135,12 @@ async function load() {
       fetch(`${RAW}/meta.json?t=${Date.now()}`).then((r) => r.json()).catch(() => null),
     ]);
     RECORDS = Array.isArray(recs) ? recs : [];
+    // Derive the Benchmark and Tier choices from the records themselves, so a new benchmark or
+    // tier appears the moment it publishes a run — no markup change required.
+    hydrateFilter("#f-bench", RECORDS.map((r) => r.bench), "all");
+    hydrateFilter("#f-tier", RECORDS.map((r) => r.tier || "smoke"), "all");
+    const zh = $("#date-zone");
+    if (zh) zh.textContent = ` (${localZone()})`;
     if (meta && meta.updated) {
       $("#updated").textContent = `· last updated ${new Date(meta.updated).toLocaleString()}`;
     }
@@ -190,7 +229,7 @@ function render() {
         ? `<a href="${esc(r.summary_url)}" target="_blank" rel="noopener">${esc(r.source || "—")}</a>`
         : esc(r.source || "—");
     const badge = `<span class="badge ${esc(r.conclusion)}">${esc(r.conclusion)}</span>`;
-    const date = esc((r.date || "").replace("T", " ").replace("Z", ""));
+    const date = esc(fmtLocal(r.date));
     const tier = esc(r.tier || "smoke");
     tr.innerHTML = `<td><a href="${esc(r.run_url)}">${date}</a></td>
       <td>${src}</td><td>${esc(r.bench)}</td><td>${tier}</td><td>${r.iterations ?? "—"}</td>


### PR DESCRIPTION
Three fixes to [benchmarks.html](https://skillberry-ai.github.io/cap-evolve/benchmarks.html).

### 1. Result filter defaults to `success`
15 of 59 published records are failures/cancellations, and they were the first thing a visitor saw.

### 2. Benchmark + Type filters derived from the data, not hardcoded
The markup listed only `tau2`/`swebench`/`skillsbench`, so **two whole benchmarks were unreachable** despite having published runs:

```
derived : rh-swebench, skillsbench, spreadsheetbench, swebench, tau2
hidden  : rh-swebench, spreadsheetbench
```

The **Type** filter had the identical defect — it listed `smoke/pilot/full` and would have hidden `runnable-subset-43`, which is also in the data. Fixed the same way, since the reasoning applies equally.

A new benchmark or tier now appears the moment it publishes a run. The inline `all` option remains only as a pre-hydration fallback so the control is never empty if the fetch fails; the current selection survives re-hydration.

### 3. Local timezone
The old code did `.replace("T"," ").replace("Z","")` — which **displayed UTC while looking like local time**, the worst of both. A reader in UTC+3 saw a run they started at 16:50 labelled `13:50` with nothing signalling the offset.

Now `toLocaleString` in the browser's own zone, with the resolved zone shown once in the Date header so values are unambiguous. Unparseable dates fall back to the raw string rather than `Invalid Date`.

| | before | after (Asia/Jerusalem) |
|---|---|---|
| `2026-07-24T13:50:51Z` | `2026-07-24 13:50:51` | `07/24/2026, 04:50:51 PM` |

### Deliberately unchanged
- The **live "Running now" panel** needed nothing: it renders elapsed *duration*, not an absolute clock.
- **`JOB_RE`'s bench allowlist stays explicit.** It parses workflow job names to detect in-flight runs and must not match `plan legs` or `aggregate history`. `rh-swebench` arrived as a manual import, never a CI job, so it cannot appear there.

### Verification
`node --check` passes; derivation run against the real published `benchmarks.json` (59 records) and the committed fixture; date change checked in a UTC+3 zone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)