### PR TITLE
fix(swebench): sample the pilot across each repo's id range, not its head

### DIFF
--- a/ci/benchmarks/swebench/pilot/tasks.json
+++ b/ci/benchmarks/swebench/pilot/tasks.json
@@ -5,7 +5,7 @@
     "agent": "Azure/gpt-5-mini-2025-08-07"
   },
   {
-    "id": "astropy__astropy-13236",
+    "id": "astropy__astropy-8707",
     "tag": "pilot",
     "agent": "Azure/gpt-5-mini-2025-08-07"
   },
@@ -15,62 +15,7 @@
     "agent": "Azure/gpt-5-mini-2025-08-07"
   },
   {
-    "id": "django__django-10880",
-    "tag": "pilot",
-    "agent": "Azure/gpt-5-mini-2025-08-07"
-  },
-  {
-    "id": "django__django-10973",
-    "tag": "pilot",
-    "agent": "Azure/gpt-5-mini-2025-08-07"
-  },
-  {
-    "id": "django__django-11095",
-    "tag": "pilot",
-    "agent": "Azure/gpt-5-mini-2025-08-07"
-  },
-  {
-    "id": "django__django-11133",
-    "tag": "pilot",
-    "agent": "Azure/gpt-5-mini-2025-08-07"
-  },
-  {
-    "id": "django__django-11211",
-    "tag": "pilot",
-    "agent": "Azure/gpt-5-mini-2025-08-07"
-  },
-  {
     "id": "django__django-11292",
-    "tag": "pilot",
-    "agent": "Azure/gpt-5-mini-2025-08-07"
-  },
-  {
-    "id": "django__django-11299",
-    "tag": "pilot",
-    "agent": "Azure/gpt-5-mini-2025-08-07"
-  },
-  {
-    "id": "django__django-11333",
-    "tag": "pilot",
-    "agent": "Azure/gpt-5-mini-2025-08-07"
-  },
-  {
-    "id": "django__django-11477",
-    "tag": "pilot",
-    "agent": "Azure/gpt-5-mini-2025-08-07"
-  },
-  {
-    "id": "django__django-11490",
-    "tag": "pilot",
-    "agent": "Azure/gpt-5-mini-2025-08-07"
-  },
-  {
-    "id": "django__django-11551",
-    "tag": "pilot",
-    "agent": "Azure/gpt-5-mini-2025-08-07"
-  },
-  {
-    "id": "django__django-11555",
     "tag": "pilot",
     "agent": "Azure/gpt-5-mini-2025-08-07"
   },
@@ -80,27 +25,82 @@
     "agent": "Azure/gpt-5-mini-2025-08-07"
   },
   {
-    "id": "django__django-11728",
+    "id": "django__django-11999",
     "tag": "pilot",
     "agent": "Azure/gpt-5-mini-2025-08-07"
   },
   {
-    "id": "django__django-11740",
+    "id": "django__django-12308",
     "tag": "pilot",
     "agent": "Azure/gpt-5-mini-2025-08-07"
   },
   {
-    "id": "django__django-11790",
+    "id": "django__django-12713",
     "tag": "pilot",
     "agent": "Azure/gpt-5-mini-2025-08-07"
   },
   {
-    "id": "django__django-11815",
+    "id": "django__django-13279",
     "tag": "pilot",
     "agent": "Azure/gpt-5-mini-2025-08-07"
   },
   {
-    "id": "django__django-11880",
+    "id": "django__django-13569",
+    "tag": "pilot",
+    "agent": "Azure/gpt-5-mini-2025-08-07"
+  },
+  {
+    "id": "django__django-13933",
+    "tag": "pilot",
+    "agent": "Azure/gpt-5-mini-2025-08-07"
+  },
+  {
+    "id": "django__django-14349",
+    "tag": "pilot",
+    "agent": "Azure/gpt-5-mini-2025-08-07"
+  },
+  {
+    "id": "django__django-14539",
+    "tag": "pilot",
+    "agent": "Azure/gpt-5-mini-2025-08-07"
+  },
+  {
+    "id": "django__django-14855",
+    "tag": "pilot",
+    "agent": "Azure/gpt-5-mini-2025-08-07"
+  },
+  {
+    "id": "django__django-15268",
+    "tag": "pilot",
+    "agent": "Azure/gpt-5-mini-2025-08-07"
+  },
+  {
+    "id": "django__django-15467",
+    "tag": "pilot",
+    "agent": "Azure/gpt-5-mini-2025-08-07"
+  },
+  {
+    "id": "django__django-15731",
+    "tag": "pilot",
+    "agent": "Azure/gpt-5-mini-2025-08-07"
+  },
+  {
+    "id": "django__django-15987",
+    "tag": "pilot",
+    "agent": "Azure/gpt-5-mini-2025-08-07"
+  },
+  {
+    "id": "django__django-16502",
+    "tag": "pilot",
+    "agent": "Azure/gpt-5-mini-2025-08-07"
+  },
+  {
+    "id": "django__django-16819",
+    "tag": "pilot",
+    "agent": "Azure/gpt-5-mini-2025-08-07"
+  },
+  {
+    "id": "django__django-9296",
     "tag": "pilot",
     "agent": "Azure/gpt-5-mini-2025-08-07"
   },
@@ -110,12 +110,12 @@
     "agent": "Azure/gpt-5-mini-2025-08-07"
   },
   {
-    "id": "matplotlib__matplotlib-14623",
+    "id": "matplotlib__matplotlib-24637",
     "tag": "pilot",
     "agent": "Azure/gpt-5-mini-2025-08-07"
   },
   {
-    "id": "matplotlib__matplotlib-21568",
+    "id": "matplotlib__matplotlib-26342",
     "tag": "pilot",
     "agent": "Azure/gpt-5-mini-2025-08-07"
   },
@@ -135,7 +135,7 @@
     "agent": "Azure/gpt-5-mini-2025-08-07"
   },
   {
-    "id": "psf__requests-1921",
+    "id": "psf__requests-2931",
     "tag": "pilot",
     "agent": "Azure/gpt-5-mini-2025-08-07"
   },
@@ -145,12 +145,12 @@
     "agent": "Azure/gpt-5-mini-2025-08-07"
   },
   {
-    "id": "pydata__xarray-3095",
+    "id": "pydata__xarray-6461",
     "tag": "pilot",
     "agent": "Azure/gpt-5-mini-2025-08-07"
   },
   {
-    "id": "pydata__xarray-3677",
+    "id": "pydata__xarray-7393",
     "tag": "pilot",
     "agent": "Azure/gpt-5-mini-2025-08-07"
   },
@@ -160,7 +160,7 @@
     "agent": "Azure/gpt-5-mini-2025-08-07"
   },
   {
-    "id": "pylint-dev__pylint-4661",
+    "id": "pylint-dev__pylint-7080",
     "tag": "pilot",
     "agent": "Azure/gpt-5-mini-2025-08-07"
   },
@@ -170,7 +170,7 @@
     "agent": "Azure/gpt-5-mini-2025-08-07"
   },
   {
-    "id": "pytest-dev__pytest-10356",
+    "id": "pytest-dev__pytest-7490",
     "tag": "pilot",
     "agent": "Azure/gpt-5-mini-2025-08-07"
   },
@@ -180,17 +180,17 @@
     "agent": "Azure/gpt-5-mini-2025-08-07"
   },
   {
-    "id": "scikit-learn__scikit-learn-10908",
+    "id": "scikit-learn__scikit-learn-13135",
     "tag": "pilot",
     "agent": "Azure/gpt-5-mini-2025-08-07"
   },
   {
-    "id": "scikit-learn__scikit-learn-11578",
+    "id": "scikit-learn__scikit-learn-14894",
     "tag": "pilot",
     "agent": "Azure/gpt-5-mini-2025-08-07"
   },
   {
-    "id": "scikit-learn__scikit-learn-12682",
+    "id": "scikit-learn__scikit-learn-26194",
     "tag": "pilot",
     "agent": "Azure/gpt-5-mini-2025-08-07"
   },
@@ -200,17 +200,17 @@
     "agent": "Azure/gpt-5-mini-2025-08-07"
   },
   {
-    "id": "sphinx-doc__sphinx-11510",
+    "id": "sphinx-doc__sphinx-8056",
     "tag": "pilot",
     "agent": "Azure/gpt-5-mini-2025-08-07"
   },
   {
-    "id": "sphinx-doc__sphinx-7440",
+    "id": "sphinx-doc__sphinx-8621",
     "tag": "pilot",
     "agent": "Azure/gpt-5-mini-2025-08-07"
   },
   {
-    "id": "sphinx-doc__sphinx-7454",
+    "id": "sphinx-doc__sphinx-9711",
     "tag": "pilot",
     "agent": "Azure/gpt-5-mini-2025-08-07"
   },
@@ -220,32 +220,32 @@
     "agent": "Azure/gpt-5-mini-2025-08-07"
   },
   {
-    "id": "sympy__sympy-12096",
+    "id": "sympy__sympy-13798",
     "tag": "pilot",
     "agent": "Azure/gpt-5-mini-2025-08-07"
   },
   {
-    "id": "sympy__sympy-12419",
+    "id": "sympy__sympy-15875",
     "tag": "pilot",
     "agent": "Azure/gpt-5-mini-2025-08-07"
   },
   {
-    "id": "sympy__sympy-12481",
+    "id": "sympy__sympy-18211",
     "tag": "pilot",
     "agent": "Azure/gpt-5-mini-2025-08-07"
   },
   {
-    "id": "sympy__sympy-13480",
+    "id": "sympy__sympy-20428",
     "tag": "pilot",
     "agent": "Azure/gpt-5-mini-2025-08-07"
   },
   {
-    "id": "sympy__sympy-13551",
+    "id": "sympy__sympy-22456",
     "tag": "pilot",
     "agent": "Azure/gpt-5-mini-2025-08-07"
   },
   {
-    "id": "sympy__sympy-13647",
+    "id": "sympy__sympy-24443",
     "tag": "pilot",
     "agent": "Azure/gpt-5-mini-2025-08-07"
   }

--- a/ci/benchmarks/swebench/utils/make_pilot.py
+++ b/ci/benchmarks/swebench/utils/make_pilot.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Generate the swebench pilot tier as a representative subset of the full tier.
+
+  make_pilot.py [--size 50] [--write]
+
+The pilot exists so the per-trial cost and runtime of a 250-task full run can be measured on
+a tenth of the tasks first — every task is independent, so cost and throughput extrapolate
+linearly, which a 5-task smoke cannot do.
+
+ALLOCATION: floor of 1 per repo, then the remainder proportionally by largest remainder. The
+floor means no repo's build/test toolchain can hide from the pilot; the proportional remainder
+keeps the mix close enough to full that timings still predict it. django lands at ~38% against
+full's ~46% — that tilt is the price of the floor and is deliberate.
+
+SELECTION WITHIN A REPO — the bit that was wrong. The first version took `ids[:n]`, the HEAD of
+each repo's slice. The full tier is sorted by instance id, and SWE-bench ids track upstream PR
+numbers, so that drew almost exclusively from the oldest issues: measured mean relative position
+0.08 on a 0=first / 1=last scale, with django spanning 10554-11880 out of 9296-17084. A
+systematic age skew, not a sample. Now the picks are spread evenly across each repo's ordering,
+which keeps the whole id range represented.
+
+Deterministic by construction — no RNG — so the output is reproducible and reviewable in a diff.
+"""
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+FULL = HERE.parent / "full" / "tasks.json"
+PILOT = HERE.parent / "pilot" / "tasks.json"
+
+
+def allocate(counts: dict[str, int], target: int) -> dict[str, int]:
+    """Floor of 1 per repo, remainder by largest fractional share."""
+    alloc = {r: 1 for r in counts}
+    left = target - len(alloc)
+    if left < 0:
+        raise SystemExit(f"target {target} < {len(counts)} repos; cannot give each a floor of 1")
+    pool = sum(counts.values()) - len(alloc)
+    share = {r: (counts[r] - 1) / pool * left if pool else 0 for r in counts}
+    for r in counts:
+        alloc[r] += int(share[r])
+    rem = target - sum(alloc.values())
+    for r in sorted(counts, key=lambda r: (-(share[r] - int(share[r])), r)):
+        if rem <= 0:
+            break
+        if alloc[r] < counts[r]:
+            alloc[r] += 1
+            rem -= 1
+    return alloc
+
+
+def spread(ids: list[str], n: int) -> list[str]:
+    """n ids spread evenly across `ids`, always including the first and last.
+
+    Even spacing rather than `ids[:n]` is the whole point: it samples the full id range instead
+    of clustering on the oldest instances.
+    """
+    if n >= len(ids):
+        return list(ids)
+    if n == 1:
+        return [ids[len(ids) // 2]]
+    step = (len(ids) - 1) / (n - 1)
+    return [ids[round(i * step)] for i in range(n)]
+
+
+def build(size: int) -> list[dict]:
+    full = json.loads(FULL.read_text(encoding="utf-8"))
+    by_repo: dict[str, list[dict]] = collections.defaultdict(list)
+    for t in full:
+        by_repo[t["id"].split("__")[0]].append(t)
+    counts = {r: len(v) for r, v in by_repo.items()}
+    alloc = allocate(counts, size)
+    out: list[dict] = []
+    for repo in sorted(by_repo):
+        chosen = spread([t["id"] for t in by_repo[repo]], alloc[repo])
+        by_id = {t["id"]: t for t in by_repo[repo]}
+        out += [{"id": i, "tag": "pilot", "agent": by_id[i]["agent"]} for i in chosen]
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--size", type=int, default=50)
+    ap.add_argument("--write", action="store_true")
+    a = ap.parse_args()
+
+    rows = build(a.size)
+    full_ids = [t["id"] for t in json.loads(FULL.read_text(encoding="utf-8"))]
+    assert len(rows) == a.size, f"got {len(rows)} not {a.size}"
+    assert len({r['id'] for r in rows}) == a.size, "duplicate ids"
+    assert {r["id"] for r in rows} <= set(full_ids), "pilot id not present in full"
+
+    if a.write:
+        PILOT.write_text(json.dumps(rows, indent=2) + "\n", encoding="utf-8")
+        print(f"wrote {PILOT} ({len(rows)} tasks)")
+    c = collections.Counter(r["id"].split("__")[0] for r in rows)
+    for repo in sorted(c, key=lambda r: -c[r]):
+        print(f"  {repo:<13}{c[repo]:>3}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
The pilot's purpose is to predict a 250-task full run from 50 tasks. The first version couldn't: it allocated per repo correctly, then took `ids[:n]` — the **head** of each repo's slice. The full tier is sorted by instance id, and SWE-bench ids track upstream PR numbers, so it drew almost entirely from the **oldest** issues.

Measured on a 0=first / 1=last scale, the picks' mean relative position was **0.08**:

| repo | full id-range | pilot BEFORE | pilot AFTER |
|---|---|---|---|
| django | 9296–17084 | 10554–11880 | 9296–16819 |
| sympy | 11618–24443 | 11618–13647 | 11618–24443 |
| scikit-learn | 10844–26194 | 10844–12682 | 10844–26194 |
| matplotlib | 13989–26342 | 13989–21568 | 13989–26342 |

**mean relative position 0.08 → 0.50**

I had called that selection "stratified" without qualifying it, which overstated it — proportional across repos, but systematically age-skewed within them.

Picks are now spread evenly across each repo's ordering. Still fully deterministic (no RNG), so the file stays reproducible and reviewable in a diff.

### Also
Promotes the generator from a throwaway to `ci/benchmarks/swebench/utils/make_pilot.py`, beside the existing `select_candidates.py`. It asserts its own invariants: exact size, unique ids, every id present in the full tier.

### Deliberately unchanged
The floor of 1 per repo, which tilts django to ~38% against full's ~46%. That's the price of guaranteeing no repo's build/test toolchain can hide from the pilot.

### Scope of the fix
This fixes representativeness of the **sample**, not of the **statistic**. At n=50, p≈0.8 the 95% interval is ~±0.11 versus ~±0.05 at n=250. The pilot predicts **cost and runtime** well — tasks are independent, so both scale linearly — but gives only a ballpark for reward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)