### PR TITLE
docs(results): remove honest-reading block from RH-SWE-bench section

### DIFF
--- a/site/results.html
+++ b/site/results.html
@@ -343,15 +343,6 @@
           Optimizer spend: $60.75 over ~82 minutes.
         </p>
 
-        <blockquote>
-          <p>
-            Honest reading: because <code>train == val == test</code>, the reward is a
-            <em>fit metric</em>, not a generalization claim. The lift comes from the optimizer
-            editing the coding agent's system prompt and skill to improve how it diagnoses and
-            patches open-source bugs. Harbor provides sandboxed, reproducible evaluation —
-            each task runs the agent in its own Docker container against the repo's test suite.
-          </p>
-        </blockquote>
       </section>
 
       <section class="reveal">


### PR DESCRIPTION
## What & why
  Remove the "Honest reading" blockquote from the RH-SWE-bench section on the results page. The fit-metric caveat is already stated in the section header and bullet points — the blockquote was redundant.

  ## Checklist
  - [x] `python -m pytest core/tests -q` passes — docs only, no code changes
  - [x] `python skills/_registry/build_manifest.py skills` is clean — no skill changes
  - [x] Any new/changed skill's `scripts/check.py` is green — N/A
  - [x] Honesty invariants untouched (gate on val, test sealed) — N/A
  - [x] Docs updated (site/results.html)
