### PR TITLE
docs(readme): render the demo as a linked poster and cut three redundant paragraphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,17 +23,17 @@ diagnose the failures → propose an edit → keep it only if it beats a held-ou
 significant margin → commit — and reports one honest number. It optimizes what your agent
 *reads*, not its weights.
 
-<!-- src is the Pages URL, not raw.githubusercontent: raw serves the file as
-     application/octet-stream, which stricter browsers refuse to play inline. Pages serves
-     it as video/mp4 (verified). The repo copy stays the fallback download below. -->
+<!-- A linked poster, not a <video> tag: GitHub's README sanitizer only honors <video> for
+     its own attachment hosts, so an external src renders as an empty gap. The thumbnail
+     opens GitHub's own player. The site embeds the real <video> — Pages serves it as
+     video/mp4, which raw.githubusercontent does not. -->
 <p align="center">
-  <video
-    src="https://skillberry-ai.github.io/cap-evolve/assets/demo/cap-evolve-demo.mp4"
-    poster="https://raw.githubusercontent.com/skillberry-ai/cap-evolve/main/site/assets/demo-poster.jpg"
-    width="900" controls muted playsinline></video>
+  <a href="https://github.com/skillberry-ai/cap-evolve/blob/main/docs/assets/demo/cap-evolve-demo.mp4">
+    <img src="site/assets/demo-poster.jpg" alt="Play the 85-second cap-evolve demo — the CLI, four real dashboard tabs, and both benchmark results" width="900"/>
+  </a>
   <br/>
-  <sub>Player not loading? <a href="docs/assets/demo/cap-evolve-demo.mp4">Watch the 85-second
-  demo</a> · <a href="https://skillberry-ai.github.io/cap-evolve/#demo-video">open it on the site</a></sub>
+  <sub>▶︎ <a href="https://github.com/skillberry-ai/cap-evolve/blob/main/docs/assets/demo/cap-evolve-demo.mp4">Watch
+  the 85-second demo</a> · <a href="https://skillberry-ai.github.io/cap-evolve/#demo-video">plays inline on the site</a></sub>
 </p>
 
 <p align="center">
@@ -131,22 +131,6 @@ cap-evolve watch --diff            # …and show what each accepted candidate ch
   <em>not&nbsp;evaluated</em> distinctly from <em>failed</em>, and spend split into
   runner / optimizer / intake.</sub>
 </p>
-
-Nothing there is a fabricated number: a value the run didn't record renders as `—`, an
-un-evaluated task gets its own glyph rather than a zero, and **indecisive** is a first-class
-outcome — it means *the measurement could not decide*, which is not the same as losing.
-
-▶️ **[Watch the 85-second demo](docs/assets/demo/cap-evolve-demo.mp4)** — 1920×1080, narrated.
-Nothing in it is a mockup. The dashboard segment crossfades four real tabs — Overview,
-Candidates, **Gate**, Tasks — captured from the committed
-[`run_full`](examples/tau2_airline/run_full/): baseline **53.6% → 71.2%**, 5 accepted and 5
-rejected, sealed test **69.4%**. The Gate tab is the one worth pausing on: it shows every
-candidate's Δ, standard error, n, and the bar it had to clear.
-
-`watch` and `replay` render the same projection the dashboard does (`events.jsonl` →
-`reduce_run`), so the terminal and the browser can never disagree about what happened.
-Piped or non-TTY output falls back to a plain line log, and `run --tui` leaves stdout
-byte-identical so scripts can still parse it as JSON.
 
 ## The dashboard
 


### PR DESCRIPTION
## The bug

The `<video>` tag added in #318 rendered as an **empty gap** on the README. Only the
fallback `<sub>` line survived, which is exactly what the page showed:

> cap-evolve improves an AI agent's prompts, tools, and skills…
>
> Player not loading? Watch the 85-second demo · open it on the site

**Cause:** GitHub's README HTML sanitizer only honors `<video>` for its own attachment
hosts. An external `src` — Pages, raw, anywhere — is stripped before render, so no
attribute tuning would have fixed it. This is not the same pipeline that renders `<video>`
in issue and PR comments, which is where the tag usually works.

**Fix:** a linked poster image, the shape every repo uses. `site/assets/demo-poster.jpg`
wrapped in a link to the mp4 blob, which opens GitHub's own player rather than downloading.
`site/index.html` keeps the real inline `<video>` — untouched here — because Pages serves
the file as `video/mp4` (verified), which `raw.githubusercontent` does not.

## Also removed, as requested

Three paragraphs under the live-view screenshot:

| Paragraph | Why it goes |
|---|---|
| "Nothing there is a fabricated number: a value the run didn't record renders as `—`…" | The screenshot caption immediately above already says *marks not evaluated distinctly from failed* and names **indecisive** — this restated it in prose |
| "▶️ Watch the 85-second demo — 1920×1080, narrated…" | The demo is now the poster at the top of the page |
| "`watch` and `replay` render the same projection the dashboard does…" | The dashboard section two paragraphs later says the same thing about the same projection |

No measured figure was removed. `run_full`'s numbers (53.6% → 71.2%, sealed test 69.4%)
remain in **Results** and in `docs/RESULTS.md`, and the honesty guarantees remain in
`docs/HONEST_EVAL.md`.

## Verification

| Check | Result |
|---|---|
| `lychee --offline --include-fragments` (CI's exact args) | 267 total, **0 errors**, 214 OK |
| `codespell` (CI's exact word list) | clean |
| Poster asset on disk | `site/assets/demo-poster.jpg`, 99,751 B |

**One thing I could not verify locally:** GitHub's sanitizer runs server-side, so the only
proof this renders is looking at the README on this PR's branch. Worth one glance at the
Files tab before merging — an `<img>` inside an `<a>` is squarely inside the allowlist, but
that was true of `<video>` too, by my reading, and it was wrong.

Diff is 9 insertions / 25 deletions in `README.md` alone.