### PR TITLE
site: add a mobile nav hamburger (#123)

### DIFF
--- a/site/adapter-templates.html
+++ b/site/adapter-templates.html
@@ -24,14 +24,17 @@
   <!-- dark-first: default dark, honor an explicit saved choice. Applied pre-paint (no FOUC) + enables JS-gated reveal -->
   <script>(function(){try{document.documentElement.setAttribute('data-theme',localStorage.getItem('capevolve-theme')||'dark');}catch(e){document.documentElement.setAttribute('data-theme','dark');}document.documentElement.classList.add('js');})();</script>
   <!-- bump the ?v=... string on every style.css edit so browsers ignore their cached copy -->
-  <link rel="stylesheet" href="style.css?v=20260724b">
+  <link rel="stylesheet" href="style.css?v=20260822">
 </head>
 <body>
 
 <nav class="nav">
   <div class="nav-inner">
     <a class="nav-brand" href="./"><img src="assets/logo-300.png" alt="" class="nav-brand-logo" aria-hidden="true"><span class="wordmark">cap<span class="wordmark-dot">·</span>evolve</span></a>
-    <div class="nav-links">
+    <button class="nav-toggle" type="button" aria-label="Menu" aria-expanded="false" aria-controls="nav-links">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18"></path></svg>
+    </button>
+    <div class="nav-links" id="nav-links">
       <a href="getting-started.html">Get started</a>
       <a href="run-end-to-end.html">Run end-to-end</a>
       <a href="results.html">Results</a>
@@ -173,6 +176,6 @@ OPENAI_API_KEY=sk-…</code></pre>
   </div>
 </footer>
 
-<script src="js/site.js?v=20260724" defer></script>
+<script src="js/site.js?v=20260822" defer></script>
 </body>
 </html>

--- a/site/agent-orchestration.html
+++ b/site/agent-orchestration.html
@@ -24,20 +24,23 @@
   <!-- dark-first: default dark, honor an explicit saved choice. Applied pre-paint (no FOUC) + enables JS-gated reveal -->
   <script>(function(){try{document.documentElement.setAttribute('data-theme',localStorage.getItem('capevolve-theme')||'dark');}catch(e){document.documentElement.setAttribute('data-theme','dark');}document.documentElement.classList.add('js');})();</script>
   <!-- bump the ?v=... string on every style.css edit so browsers ignore their cached copy -->
-  <link rel="stylesheet" href="style.css?v=20260724b">
+  <link rel="stylesheet" href="style.css?v=20260822">
 </head>
 <body>
 
 <nav class="nav">
   <div class="nav-inner">
     <a class="nav-brand" href="./"><img src="assets/logo-300.png" alt="" class="nav-brand-logo" aria-hidden="true"><span class="wordmark">cap<span class="wordmark-dot">·</span>evolve</span></a>
-    <div class="nav-links">
+    <button class="nav-toggle" type="button" aria-label="Menu" aria-expanded="false" aria-controls="nav-links">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18"></path></svg>
+    </button>
+    <div class="nav-links" id="nav-links">
       <a href="getting-started.html">Get started</a>
       <a href="run-end-to-end.html">Run end-to-end</a>
       <a href="results.html">Results</a>
       <a href="benchmarks.html">Benchmarks</a>
       <a href="architecture.html">Architecture</a>
-      <a href="agent-orchestration.html" class="active">Agent mode</a>
+      <a href="agent-orchestration.html" class="active" aria-current="page">Agent mode</a>
       <a href="harbor.html">Harbor</a>
       <a class="gh" href="https://github.com/skillberry-ai/cap-evolve">GitHub</a>
       <button class="theme-toggle" type="button" aria-label="Switch theme">
@@ -188,6 +191,6 @@ stop_condition:     "stop when the FULL val mean reward &gt;= 0.78; keep eval + 
   </div>
 </footer>
 
-<script src="js/site.js?v=20260724" defer></script>
+<script src="js/site.js?v=20260822" defer></script>
 </body>
 </html>

--- a/site/architecture.html
+++ b/site/architecture.html
@@ -24,19 +24,22 @@
   <!-- dark-first: default dark, honor an explicit saved choice. Applied pre-paint (no FOUC) + enables JS-gated reveal -->
   <script>(function(){try{document.documentElement.setAttribute('data-theme',localStorage.getItem('capevolve-theme')||'dark');}catch(e){document.documentElement.setAttribute('data-theme','dark');}document.documentElement.classList.add('js');})();</script>
   <!-- bump the ?v=... string on every style.css edit so browsers ignore their cached copy -->
-  <link rel="stylesheet" href="style.css?v=20260724b">
+  <link rel="stylesheet" href="style.css?v=20260822">
 </head>
 <body>
 
 <nav class="nav">
   <div class="nav-inner">
     <a class="nav-brand" href="./"><img src="assets/logo-300.png" alt="" class="nav-brand-logo" aria-hidden="true"><span class="wordmark">cap<span class="wordmark-dot">·</span>evolve</span></a>
-    <div class="nav-links">
+    <button class="nav-toggle" type="button" aria-label="Menu" aria-expanded="false" aria-controls="nav-links">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18"></path></svg>
+    </button>
+    <div class="nav-links" id="nav-links">
       <a href="getting-started.html">Get started</a>
       <a href="run-end-to-end.html">Run end-to-end</a>
       <a href="results.html">Results</a>
       <a href="benchmarks.html">Benchmarks</a>
-      <a href="architecture.html" class="active">Architecture</a>
+      <a href="architecture.html" class="active" aria-current="page">Architecture</a>
       <a href="agent-orchestration.html">Agent mode</a>
       <a href="harbor.html">Harbor</a>
       <a class="gh" href="https://github.com/skillberry-ai/cap-evolve">GitHub</a>
@@ -352,6 +355,6 @@
   </div>
 </footer>
 
-<script src="js/site.js?v=20260724" defer></script>
+<script src="js/site.js?v=20260822" defer></script>
 </body>
 </html>

--- a/site/benchmarks.html
+++ b/site/benchmarks.html
@@ -24,18 +24,21 @@
   <!-- dark-first: default dark, honor an explicit saved choice. Applied pre-paint (no FOUC) + enables JS-gated reveal -->
   <script>(function(){try{document.documentElement.setAttribute('data-theme',localStorage.getItem('capevolve-theme')||'dark');}catch(e){document.documentElement.setAttribute('data-theme','dark');}document.documentElement.classList.add('js');})();</script>
   <!-- bump the ?v=... string on every style.css edit so browsers ignore their cached copy -->
-  <link rel="stylesheet" href="style.css?v=20260729c">
+  <link rel="stylesheet" href="style.css?v=20260822">
 </head>
 <body>
 
 <nav class="nav">
   <div class="nav-inner">
     <a class="nav-brand" href="./"><img src="assets/logo-300.png" alt="" class="nav-brand-logo" aria-hidden="true"><span class="wordmark">cap<span class="wordmark-dot">·</span>evolve</span></a>
-    <div class="nav-links">
+    <button class="nav-toggle" type="button" aria-label="Menu" aria-expanded="false" aria-controls="nav-links">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18"></path></svg>
+    </button>
+    <div class="nav-links" id="nav-links">
       <a href="getting-started.html">Get started</a>
       <a href="run-end-to-end.html">Run end-to-end</a>
       <a href="results.html">Results</a>
-      <a href="benchmarks.html" class="active">Benchmarks</a>
+      <a href="benchmarks.html" class="active" aria-current="page">Benchmarks</a>
       <a href="architecture.html">Architecture</a>
       <a href="agent-orchestration.html">Agent mode</a>
       <a href="harbor.html">Harbor</a>
@@ -150,6 +153,6 @@
 </footer>
 
 <script src="benchmarks.js?v=20260730d"></script>
-<script src="js/site.js?v=20260724" defer></script>
+<script src="js/site.js?v=20260822" defer></script>
 </body>
 </html>

--- a/site/getting-started.html
+++ b/site/getting-started.html
@@ -24,15 +24,18 @@
   <!-- dark-first: default dark, honor an explicit saved choice. Applied pre-paint (no FOUC) + enables JS-gated reveal -->
   <script>(function(){try{document.documentElement.setAttribute('data-theme',localStorage.getItem('capevolve-theme')||'dark');}catch(e){document.documentElement.setAttribute('data-theme','dark');}document.documentElement.classList.add('js');})();</script>
   <!-- bump the ?v=... string on every style.css edit so browsers ignore their cached copy -->
-  <link rel="stylesheet" href="style.css?v=20260724b">
+  <link rel="stylesheet" href="style.css?v=20260822">
 </head>
 <body>
 
 <nav class="nav">
   <div class="nav-inner">
     <a class="nav-brand" href="./"><img src="assets/logo-300.png" alt="" class="nav-brand-logo" aria-hidden="true"><span class="wordmark">cap<span class="wordmark-dot">·</span>evolve</span></a>
-    <div class="nav-links">
-      <a href="getting-started.html" class="active">Get started</a>
+    <button class="nav-toggle" type="button" aria-label="Menu" aria-expanded="false" aria-controls="nav-links">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18"></path></svg>
+    </button>
+    <div class="nav-links" id="nav-links">
+      <a href="getting-started.html" class="active" aria-current="page">Get started</a>
       <a href="run-end-to-end.html">Run end-to-end</a>
       <a href="results.html">Results</a>
       <a href="benchmarks.html">Benchmarks</a>
@@ -146,6 +149,6 @@ cap-evolve version          # verify</code></pre>
   </div>
 </footer>
 
-<script src="js/site.js?v=20260724" defer></script>
+<script src="js/site.js?v=20260822" defer></script>
 </body>
 </html>

--- a/site/harbor-openshift.html
+++ b/site/harbor-openshift.html
@@ -20,14 +20,17 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600&family=Fira+Sans:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <script>(function(){try{document.documentElement.setAttribute('data-theme',localStorage.getItem('capevolve-theme')||'dark');}catch(e){document.documentElement.setAttribute('data-theme','dark');}document.documentElement.classList.add('js');})();</script>
-  <link rel="stylesheet" href="style.css?v=20260724b">
+  <link rel="stylesheet" href="style.css?v=20260822">
 </head>
 <body>
 
 <nav class="nav">
   <div class="nav-inner">
     <a class="nav-brand" href="./"><img src="assets/logo-300.png" alt="" class="nav-brand-logo" aria-hidden="true"><span class="wordmark">cap<span class="wordmark-dot">·</span>evolve</span></a>
-    <div class="nav-links">
+    <button class="nav-toggle" type="button" aria-label="Menu" aria-expanded="false" aria-controls="nav-links">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18"></path></svg>
+    </button>
+    <div class="nav-links" id="nav-links">
       <a href="getting-started.html">Get started</a>
       <a href="run-end-to-end.html">Run end-to-end</a>
       <a href="results.html">Results</a>
@@ -166,6 +169,6 @@ curl -s http://vllm-svc:8000/v1/models</code></pre>
   </div>
 </footer>
 
-<script src="js/site.js?v=20260724" defer></script>
+<script src="js/site.js?v=20260822" defer></script>
 </body>
 </html>

--- a/site/harbor.html
+++ b/site/harbor.html
@@ -20,21 +20,24 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600&family=Fira+Sans:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <script>(function(){try{document.documentElement.setAttribute('data-theme',localStorage.getItem('capevolve-theme')||'dark');}catch(e){document.documentElement.setAttribute('data-theme','dark');}document.documentElement.classList.add('js');})();</script>
-  <link rel="stylesheet" href="style.css?v=20260724b">
+  <link rel="stylesheet" href="style.css?v=20260822">
 </head>
 <body>
 
 <nav class="nav">
   <div class="nav-inner">
     <a class="nav-brand" href="./"><img src="assets/logo-300.png" alt="" class="nav-brand-logo" aria-hidden="true"><span class="wordmark">cap<span class="wordmark-dot">·</span>evolve</span></a>
-    <div class="nav-links">
+    <button class="nav-toggle" type="button" aria-label="Menu" aria-expanded="false" aria-controls="nav-links">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18"></path></svg>
+    </button>
+    <div class="nav-links" id="nav-links">
       <a href="getting-started.html">Get started</a>
       <a href="run-end-to-end.html">Run end-to-end</a>
       <a href="results.html">Results</a>
       <a href="benchmarks.html">Benchmarks</a>
       <a href="architecture.html">Architecture</a>
       <a href="agent-orchestration.html">Agent mode</a>
-      <a href="harbor.html" class="active">Harbor</a>
+      <a href="harbor.html" class="active" aria-current="page">Harbor</a>
       <a class="gh" href="https://github.com/skillberry-ai/cap-evolve">GitHub</a>
       <button class="theme-toggle" type="button" aria-label="Switch theme">
         <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
@@ -207,6 +210,6 @@ podman push quay.io/&lt;your-org&gt;/cap-evolve-harbor-runner:latest</code></pre
   </div>
 </footer>
 
-<script src="js/site.js?v=20260724" defer></script>
+<script src="js/site.js?v=20260822" defer></script>
 </body>
 </html>

--- a/site/index.html
+++ b/site/index.html
@@ -24,14 +24,17 @@
   <!-- dark-first: default dark, honor an explicit saved choice. Applied pre-paint (no FOUC) + enables JS-gated reveal -->
   <script>(function(){try{document.documentElement.setAttribute('data-theme',localStorage.getItem('capevolve-theme')||'dark');}catch(e){document.documentElement.setAttribute('data-theme','dark');}document.documentElement.classList.add('js');})();</script>
   <!-- bump the ?v=... string on every style.css edit so browsers ignore their cached copy -->
-  <link rel="stylesheet" href="style.css?v=20260724b">
+  <link rel="stylesheet" href="style.css?v=20260822">
 </head>
 <body>
 
 <nav class="nav">
   <div class="nav-inner">
     <a class="nav-brand" href="./"><img src="assets/logo-300.png" alt="" class="nav-brand-logo" aria-hidden="true"><span class="wordmark">cap<span class="wordmark-dot">·</span>evolve</span></a>
-    <div class="nav-links">
+    <button class="nav-toggle" type="button" aria-label="Menu" aria-expanded="false" aria-controls="nav-links">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18"></path></svg>
+    </button>
+    <div class="nav-links" id="nav-links">
       <a href="getting-started.html">Get started</a>
       <a href="run-end-to-end.html">Run end-to-end</a>
       <a href="results.html">Results</a>
@@ -359,6 +362,6 @@ bash examples/toy_calc/run.sh</code></pre>
   </div>
 </footer>
 
-<script src="js/site.js?v=20260724" defer></script>
+<script src="js/site.js?v=20260822" defer></script>
 </body>
 </html>

--- a/site/js/site.js
+++ b/site/js/site.js
@@ -48,6 +48,29 @@
     pre.appendChild(btn);
   });
 
+  /* ── mobile nav disclosure ── */
+  var navToggle = document.querySelector(".nav-toggle");
+  var navLinks = document.getElementById("nav-links");
+  if (navToggle && navLinks) {
+    var setNav = function (open) {
+      navLinks.classList.toggle("open", open);
+      navToggle.setAttribute("aria-expanded", open ? "true" : "false");
+    };
+    var navOpen = function () { return navToggle.getAttribute("aria-expanded") === "true"; };
+    navToggle.addEventListener("click", function () { setNav(!navOpen()); });
+    document.addEventListener("keydown", function (e) {
+      if (e.key === "Escape" && navOpen()) { setNav(false); navToggle.focus(); }
+    });
+    document.addEventListener("click", function (e) {
+      if (navOpen() && !navToggle.contains(e.target) && !navLinks.contains(e.target)) setNav(false);
+    });
+    /* matchMedia, not resize: iOS fires resize when it collapses its URL bar mid-scroll,
+       with no real width change, which would slam the menu shut under the user's thumb. */
+    window.matchMedia("(min-width: 861px)").addEventListener("change", function (e) {
+      if (e.matches) setNav(false);
+    });
+  }
+
   /* ── TOC scrollspy ── */
   var tocLinks = Array.prototype.slice.call(document.querySelectorAll(".toc a[href^='#']"));
   if (tocLinks.length && "IntersectionObserver" in window) {

--- a/site/optimize-your-own.html
+++ b/site/optimize-your-own.html
@@ -24,14 +24,17 @@
   <!-- dark-first: default dark, honor an explicit saved choice. Applied pre-paint (no FOUC) + enables JS-gated reveal -->
   <script>(function(){try{document.documentElement.setAttribute('data-theme',localStorage.getItem('capevolve-theme')||'dark');}catch(e){document.documentElement.setAttribute('data-theme','dark');}document.documentElement.classList.add('js');})();</script>
   <!-- bump the ?v=... string on every style.css edit so browsers ignore their cached copy -->
-  <link rel="stylesheet" href="style.css?v=20260724b">
+  <link rel="stylesheet" href="style.css?v=20260822">
 </head>
 <body>
 
 <nav class="nav">
   <div class="nav-inner">
     <a class="nav-brand" href="./"><img src="assets/logo-300.png" alt="" class="nav-brand-logo" aria-hidden="true"><span class="wordmark">cap<span class="wordmark-dot">·</span>evolve</span></a>
-    <div class="nav-links">
+    <button class="nav-toggle" type="button" aria-label="Menu" aria-expanded="false" aria-controls="nav-links">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18"></path></svg>
+    </button>
+    <div class="nav-links" id="nav-links">
       <a href="getting-started.html">Get started</a>
       <a href="run-end-to-end.html">Run end-to-end</a>
       <a href="results.html">Results</a>
@@ -302,6 +305,6 @@ open .capevolve/run_*/dashboard.html</code></pre>
   </div>
 </footer>
 
-<script src="js/site.js?v=20260724" defer></script>
+<script src="js/site.js?v=20260822" defer></script>
 </body>
 </html>

--- a/site/results.html
+++ b/site/results.html
@@ -24,17 +24,20 @@
   <!-- dark-first: default dark, honor an explicit saved choice. Applied pre-paint (no FOUC) + enables JS-gated reveal -->
   <script>(function(){try{document.documentElement.setAttribute('data-theme',localStorage.getItem('capevolve-theme')||'dark');}catch(e){document.documentElement.setAttribute('data-theme','dark');}document.documentElement.classList.add('js');})();</script>
   <!-- bump the ?v=... string on every style.css edit so browsers ignore their cached copy -->
-  <link rel="stylesheet" href="style.css?v=20260724b">
+  <link rel="stylesheet" href="style.css?v=20260822">
 </head>
 <body>
 
 <nav class="nav">
   <div class="nav-inner">
     <a class="nav-brand" href="./"><img src="assets/logo-300.png" alt="" class="nav-brand-logo" aria-hidden="true"><span class="wordmark">cap<span class="wordmark-dot">·</span>evolve</span></a>
-    <div class="nav-links">
+    <button class="nav-toggle" type="button" aria-label="Menu" aria-expanded="false" aria-controls="nav-links">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18"></path></svg>
+    </button>
+    <div class="nav-links" id="nav-links">
       <a href="getting-started.html">Get started</a>
       <a href="run-end-to-end.html">Run end-to-end</a>
-      <a href="results.html" class="active">Results</a>
+      <a href="results.html" class="active" aria-current="page">Results</a>
       <a href="benchmarks.html">Benchmarks</a>
       <a href="architecture.html">Architecture</a>
       <a href="agent-orchestration.html">Agent mode</a>
@@ -583,6 +586,6 @@
   </div>
 </footer>
 
-<script src="js/site.js?v=20260724" defer></script>
+<script src="js/site.js?v=20260822" defer></script>
 </body>
 </html>

--- a/site/run-end-to-end.html
+++ b/site/run-end-to-end.html
@@ -24,16 +24,19 @@
   <!-- dark-first: default dark, honor an explicit saved choice. Applied pre-paint (no FOUC) + enables JS-gated reveal -->
   <script>(function(){try{document.documentElement.setAttribute('data-theme',localStorage.getItem('capevolve-theme')||'dark');}catch(e){document.documentElement.setAttribute('data-theme','dark');}document.documentElement.classList.add('js');})();</script>
   <!-- bump the ?v=... string on every style.css edit so browsers ignore their cached copy -->
-  <link rel="stylesheet" href="style.css?v=20260724b">
+  <link rel="stylesheet" href="style.css?v=20260822">
 </head>
 <body>
 
 <nav class="nav">
   <div class="nav-inner">
     <a class="nav-brand" href="./"><img src="assets/logo-300.png" alt="" class="nav-brand-logo" aria-hidden="true"><span class="wordmark">cap<span class="wordmark-dot">·</span>evolve</span></a>
-    <div class="nav-links">
+    <button class="nav-toggle" type="button" aria-label="Menu" aria-expanded="false" aria-controls="nav-links">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18"></path></svg>
+    </button>
+    <div class="nav-links" id="nav-links">
       <a href="getting-started.html">Get started</a>
-      <a href="run-end-to-end.html" class="active">Run end-to-end</a>
+      <a href="run-end-to-end.html" class="active" aria-current="page">Run end-to-end</a>
       <a href="results.html">Results</a>
       <a href="benchmarks.html">Benchmarks</a>
       <a href="architecture.html">Architecture</a>
@@ -332,6 +335,6 @@ cat "$RD/rejected.jsonl"        # what the honest gate rejected = optimizer memo
   </div>
 </footer>
 
-<script src="js/site.js?v=20260724" defer></script>
+<script src="js/site.js?v=20260822" defer></script>
 </body>
 </html>

--- a/site/style.css
+++ b/site/style.css
@@ -192,6 +192,28 @@ body::before {
 :root[data-theme="light"] .theme-toggle .icon-sun { display: block; }
 :root[data-theme="light"] .theme-toggle .icon-moon { display: none; }
 
+/* hamburger — hidden at desktop, revealed under 860px by the responsive block below */
+.nav-toggle {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 34px; height: 34px;
+  margin-left: auto;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-soft);
+  color: var(--muted);
+  cursor: pointer;
+  transition: color 0.14s ease, border-color 0.14s ease;
+}
+.nav-toggle:hover { color: var(--ink); border-color: var(--accent); }
+.nav-toggle svg { width: 18px; height: 18px; display: block; }
+
+/* keyboard focus has to stay visible on every nav control */
+.nav-links a:focus-visible,
+.theme-toggle:focus-visible,
+.nav-toggle:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
 /* ─────────────────────── page containers ─────────────────────── */
 
 .page { max-width: var(--maxw); margin: 0 auto; padding: 3.5rem 1.5rem 5rem; }
@@ -622,7 +644,21 @@ table.detail { width: 100%; font-size: 0.85rem; }
 
 @media (max-width: 860px) {
   .nav-inner { flex-wrap: wrap; gap: 0.75rem 1rem; padding: 0.7rem 1rem; }
-  .nav-links { gap: 0.9rem; font-size: 0.84rem; margin-left: auto; overflow-x: auto; }
+  /* stacked menu instead of the old horizontal scroll strip, which had no affordance */
+  .nav-links {
+    flex-direction: column;
+    align-items: flex-start;
+    width: 100%;
+    margin-left: 0;
+    gap: 0.9rem;
+    padding: 0.6rem 0 0.3rem;
+    border-top: 1px solid var(--border);
+  }
+  /* gated on html.js: with JS off the links stay visible and the toggle never appears,
+     so there is no dead control. With JS on the list becomes a disclosure. */
+  html.js .nav-toggle { display: inline-flex; }
+  html.js .nav-links { display: none; }
+  html.js .nav-links.open { display: flex; }
 }
 @media (max-width: 640px) {
   .page, .page-narrow { padding: 2.2rem 1.1rem 3.5rem; }


### PR DESCRIPTION
Closes #123 (mobile-nav half only — see "Dropped" below).

Below 860px the marketing site's nav is a horizontally-scrollable strip with **no
affordance**: `site/style.css` shipped `.nav-links { overflow-x: auto }` and nothing else, so
at 390px you get 9 controls (7 links + GitHub + theme toggle) in a scroll region with no hint
that more exists. This adds a real hamburger disclosure.

## Pages changed (13 files, +133/-41)

The toggle markup was hand-added to all **11** chrome-bearing pages:

`index.html`, `getting-started.html`, `run-end-to-end.html`, `results.html`,
`benchmarks.html`, `architecture.html`, `agent-orchestration.html`, `harbor.html`,
`harbor-openshift.html`, `optimize-your-own.html`, `adapter-templates.html`

(`googleec4f88b9dc3ed9b7.html` is a Google-verification stub with no nav — untouched.)

Plus `site/style.css` (+38/-1) and `site/js/site.js` (+23).

**The repeated block is byte-identical on all 11 pages.** Verified mechanically — hashing each
`<nav class="nav">…</nav>` block with `class="active"` / `aria-current="page"` normalised away
yields **one** hash across all 11 files, both before and after this change. So whenever someone
does consolidate this chrome (#136 or otherwise), it is a mechanical find-and-replace, not a
merge of 11 divergent variants. That repetition is the deliberate trade here — see "Dropped".

`core/`, `skills/`, and `dashboard/` are untouched.

## Toggle mechanism, and why it needs no dependency

A `<button>` toggles one class; CSS does the rest.

```js
var setNav = function (open) {
  navLinks.classList.toggle("open", open);
  navToggle.setAttribute("aria-expanded", open ? "true" : "false");
};
```

23 lines of vanilla JS appended to the `site/js/site.js` that already ships on every page
(theme toggle, scroll-reveal, copy buttons, TOC scrollspy). No new file, no framework, no build
step, no CSS library — consistent with this repo's zero-dependency posture.

The four things beyond the bare toggle, each earning its line:

- **Esc closes and returns focus to the button.** Otherwise a keyboard user who opens the menu
  and changes their mind is stranded mid-list.
- **Click outside closes.** Standard disclosure behaviour; without it the menu covers the page.
- **`matchMedia("(min-width: 861px)")` reset**, deliberately *not* a `resize` listener: iOS
  fires `resize` when it collapses its URL bar mid-scroll, with no real width change, which
  would slam the menu shut under the user's thumb. `matchMedia` only fires on an actual
  breakpoint crossing.
- **`html.js` gating.** The `.nav-toggle { display: none }` → `inline-flex` flip and the
  `.nav-links` hide both live behind `html.js`, which the existing pre-paint `<head>` script
  sets. With JS off the toggle never appears and the links stay visible — no dead control.

Not a focus trap, and not `role="menu"`: this is a disclosure widget, not a modal or an
application menu, so native focus order (button → links, in DOM order) is correct.

I did *not* use the checkbox/`:target` CSS-only pattern. `<input type="checkbox">` exposes the
`checkbox` role and a checked state to a screen reader instead of a button with
`aria-expanded`, and `:target` writes history entries on every open/close. 23 lines of JS buys
the correct semantics; the CSS-only versions do not.

## Accessibility verification

Verified in real headless Chrome over CDP against `python3 -m http.server 8765`, not by
inspection. Scripts: `/tmp/capreview/shoot.mjs`, `/tmp/capreview/a11y.mjs`. Raw output:
`/tmp/capreview/shots-196/verification.json`, `/tmp/capreview/shots-196/a11y.json`.

**Computed accessible name/role/state, read from Chrome's own accessibility tree**
(`Accessibility.getPartialAXTree` — not from the attributes I wrote):

| | closed | after activation |
|---|---|---|
| `role` | `button` | `button` |
| `name` | `Menu` | `Menu` |
| `expanded` | `false` | `true` |
| `focusable` | `true` | `true` |

**Keyboard operability, driven with real `Input.dispatchKeyEvent` key events — no synthetic
`.click()`:**

- `Tab` from the brand link lands on the toggle → `document.activeElement` is
  `nav-toggle|BUTTON`.
- `Enter` on it opens the menu → `aria-expanded="true"`, computed `display: flex`,
  `.open` class present. (`opened_by: "Enter"` in the JSON; a Space fallback was coded and not
  needed.)
- Focus then moves into the menu → first focusable is `Get started`.
- `Escape` closes it → `aria-expanded="false"` and
  `document.activeElement === document.querySelector('.nav-toggle')`, i.e. focus really is
  returned, not dropped to `<body>`.
- `:focus-visible` rings added for `.nav-links a`, `.theme-toggle`, and `.nav-toggle` — the ring
  is visible on the toggle in the OPEN screenshot below, because that screenshot was taken
  after a keyboard activation.

**`aria-current="page"`** added next to the visual-only `.active` marker on the 7 pages that
have one, so the current page is announced and not merely coloured.

**JS disabled** (`Emulation.setScriptExecutionDisabled`): `html` has no `js` class, the toggle
stays `display: none`, and all 11 links render as a visible stacked list. Screenshot below.

**All 11 pages, not just index:** each was loaded at 390px and the toggle open/close cycle
asserted — 11/11 `OK`, 0 `MISSING`, 0 `BROKEN`.

One honest caveat: with the menu closed, Chrome's AX tree reports the `aria-controls` relation
as absent, because the referenced element is `display: none`. It appears once the menu opens.
That is Chrome's handling of relations to hidden nodes, not a missing attribute — `aria-controls="nav-links"`
is in the markup unconditionally.

## Screenshots

Real captures from headless Chrome 2x DPI at `http://127.0.0.1:8765/index.html`. GitHub PR
bodies can't take file attachments from `gh`, so the paths are listed; each is described so the
description can be checked against the file.

| file | what it shows |
|---|---|
| `/tmp/capreview/shots-196/mobile-390-closed.png` | **390px, CLOSED.** Brand at left, hamburger at far right, nothing else in the bar. No horizontal scroll strip. `aria-expanded="false"`, `#nav-links` computed `display: none`. |
| `/tmp/capreview/shots-196/mobile-390-open.png` | **390px, OPEN** (opened by `Enter`, so the accent `:focus-visible` ring is drawn around the hamburger). All 8 links stacked below a `border-top` divider — Get started, Run end-to-end, Results, Benchmarks, Architecture, Agent mode, Harbor, GitHub — with the theme toggle last. Page content pushed down; nothing overlaps. |
| `/tmp/capreview/shots-196/desktop-1280.png` | **1280px, unchanged.** All 7 links + GitHub pill + theme toggle in one row at the right, no hamburger. Asserted, not eyeballed: `.nav-toggle` computed `display: none`, `#nav-links` `display: flex` / `flex-direction: row`, 8 links. |
| `/tmp/capreview/shots-196/mobile-390-js-disabled.png` | **390px, JS off.** No hamburger; links stacked and reachable. Proves the `html.js` gate leaves no dead control. |

## Dropped: the shared-chrome generator

PR #196 also contained ~500 lines of build machinery — `scripts/sync-site-chrome.py` (+357),
`core/tests/test_site_chrome_guard.py` (+146), a new `site-chrome` CI job, `CONTRIBUTING.md`
and `site/README.md` rewrites, and regenerated chrome across every HTML file. **None of that
is in this PR, because:**

1. **It is ~500 lines to prevent cosmetic drift on a 12-page docs site.** What it actually
   guards is a stale cache *key* (worst case: a returning visitor sees cached CSS) and
   `og:`/`twitter:description` blurbs differing from `<meta description>` — which is a
   defensible authoring choice, not self-evidently a bug. Principle 5 of this repo's design
   rules is that deletion beats addition.
2. **#196's own body concedes the exit path** — "if #136 adopts a docs framework, this script is
   the thing it deletes." Building 500 lines you already expect to delete is code that
   shouldn't be written.
3. **The guard test was in the wrong place.** `core/tests` owns the honesty invariants (split
   seal, val-only gate, tamper guard). A marketing-site HTML linter there means
   `pytest core/tests` fails on a site edit.
4. **It could not merge anyway.** `PAGES` registered 9 pages; `site/` now has 12, and the
   script *errors* on unregistered pages — the new CI job would fail immediately on
   `harbor.html`, `harbor-openshift.html`, and `googleec4f88b9dc3ed9b7.html`, and `NAV_LINKS`
   predates the Harbor link main already ships. That is a re-author, not a rebase.

The cost of dropping it is the repeated toggle block on 11 pages. That is 11 one-line edits
against 500 lines of generator plus a CI gate plus a new contributor ritual, and the blocks are
byte-identical (hash-verified above), so consolidation stays cheap whenever someone wants it.

Also **not** included, as unrequested scope: the Google Fonts → system-stack swap and the
`Fira Sans`/`Fira Code` → `--font-sans`/`--font-mono` change (that is #120, and it changes the
site's typographic identity site-wide), and the `sitemap.xml` churn.

One small thing I *did* fold in, because this PR requires it: `style.css` and `js/site.js`
cache keys are bumped to `?v=20260822` on all 11 pages, since both files changed and
`site/index.html` instructs exactly that. This incidentally collapses the two coexisting
`style.css` keys (`?v=20260724b`, `?v=20260729c`) into one. The remaining `?v=` drift and the 5
drifted `og`/`twitter` descriptions are untouched — a ~15-line hand fix for whoever wants it.
