### PR TITLE
chore: run the dashboard backend suite in CI, and fix CITATION.cff dates (#207, #186)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,9 @@
 #
 # PURPOSE:
 # Runs parallel jobs on every push to main and every pull request:
-#   1. test-python     — installs cap-evolve-core[dev] and runs pytest on core/tests/
-#   2. build-dashboard — installs dashboard/frontend dependencies and runs npm build
+#   1. test-python     — installs cap-evolve-core[dev] and capevolve-dashboard[dev], then
+#                        runs pytest on core/tests/ and dashboard/backend/tests/
+#   2. build-dashboard — installs dashboard/frontend dependencies, runs npm build + vitest
 #   3. toy-example     — runs the zero-API toy_calc example and asserts test_reward 1.0
 #   4. docs-links      — checks relative links/images in Markdown resolve (offline)
 #   5. spellcheck      — codespell over README + docs
@@ -23,7 +24,7 @@ on:
 
 jobs:
   test-python:
-    name: Test Python (core)
+    name: Test Python (core + dashboard backend)
     runs-on: ubuntu-latest
 
     steps:
@@ -40,6 +41,12 @@ jobs:
 
       - name: Run pytest
         run: python -m pytest core/tests -q
+
+      - name: Install dashboard backend with dev extras
+        run: pip install -e "./dashboard/backend[dev]"
+
+      - name: Run pytest (dashboard backend)
+        run: python -m pytest dashboard/backend/tests -q
 
   build-dashboard:
     name: Build Dashboard (frontend)

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,5 +5,7 @@ authors:
   - name: "cap-evolve contributors"
 version: 0.1.0
 license: Apache-2.0
-date-released: 2026-06-14
+# Convention: date-released is the GitHub release's publishedAt (same date as the
+# `## [x.y.z]` heading in CHANGELOG.md), not the tag-commit date.
+date-released: 2026-07-27
 repository-code: "https://github.com/skillberry-ai/cap-evolve"


### PR DESCRIPTION
Two unrelated fixes, shipped together because each is a few lines in one file and both are pure hygiene — no runtime code touched, zero dependency change, nothing in `core/cap_evolve/`, `skills/`, or `dashboard/` source.

---

## Fix 1 — #207: the dashboard backend suite ran in no workflow

Scoped down from the issue's headline, which is **already fixed on main**: `.github/workflows/ci.yml` runs `npm test` in `build-dashboard` (added by #187, the same PR the issue's Provenance names). That suite is green and has *grown* since the issue was filed — **15 files / 124 tests**, not the 13 the issue counted. No doc or README in the repo cites 13, so there was nothing to correct there.

The one real residual is the issue's third acceptance bullet: `dashboard/backend/tests/` — 8 files / 38 tests — was invoked by **nothing**. `test-python` ran only `python -m pytest core/tests -q`, and no other workflow referenced the suite (`benchmarks.yml`'s only `dashboard/backend` mention is a `PYTHONPATH` for `export_static`). Live coverage sitting dark.

Wired into the **existing** `test-python` job rather than adding a runner — it already does `setup-python@v5` and `pip install -e "./core[dev]"`, and `cap-evolve-core` is a backend dependency, so the editable install resolves against what is already there:

```yaml
      - name: Run pytest
        run: python -m pytest core/tests -q

+      - name: Install dashboard backend with dev extras
+        run: pip install -e "./dashboard/backend[dev]"
+
+      - name: Run pytest (dashboard backend)
+        run: python -m pytest dashboard/backend/tests -q
```

`dashboard/backend/pyproject.toml` already declares everything needed (`dev = ["pytest>=7", "httpx>=0.27"]`, `testpaths = ["tests"]`) — no packaging change. The job's `name:` and the file's header comment were updated to stop claiming the job is core-only. Nothing deleted: both suites are live coverage of a surface epic #127 actively changes.

<details><summary>Evidence — backend suite passes (38 tests)</summary>

```
$ cd dashboard/backend && python -m pytest tests -q
......................................                                   [100%]
38 passed in 2.34s

$ python -m pytest dashboard/backend/tests -q     # the exact CI invocation, from repo root
......................................                                   [100%]
38 passed in 2.13s
```
</details>

<details><summary>Evidence — the joined job already exists; workflow still parses</summary>

```
$ ruby -ryaml -e '...'
YAML OK jobs=test-python,build-dashboard,toy-example,docs-links,spellcheck
Checkout repository | Set up Python 3.11 | Install cap-evolve-core with dev extras | Run pytest | Install dashboard backend with dev extras | Run pytest (dashboard backend)
```
</details>

---

## Fix 2 — #186: `CITATION.cff` `date-released` contradicted the v0.1.0 tag

| Source | Before | After |
|---|---|---|
| `CITATION.cff` `date-released` | **2026-06-14** ❌ | **2026-07-27** ✅ |
| `v0.1.0` tag commit (`git log -1 --format=%ai v0.1.0`) | 2026-07-26 19:05:21 +0300 | unchanged |
| GitHub release `v0.1.0` `publishedAt` | 2026-07-27T10:51:37Z | unchanged |
| `CHANGELOG.md:693` `## [0.1.0]` | 2026-07-27 | unchanged |

The citation metadata claimed a release ~6 weeks before the tag existed.

**`2026-07-27` is authoritative** — it is the GitHub release's `publishedAt`. CFF defines `date-released` as the date the version was *released*, not the date the commit was authored, and `CHANGELOG.md` has already made and documented this exact choice in prose ("the GitHub release's `publishedAt` … not the tag-commit date … because Keep a Changelog dates the *release*"). Picking the tag date `2026-07-26` would fix the 6-week error but open a fresh 1-day disagreement with CHANGELOG.md, so it is strictly worse. This way the repo has one release-date convention, not two.

Added a two-line comment above the field so the convention travels with it — that is the cheapest recurrence guard the issue asks for. Skipped a CI job that cross-checks CITATION.cff / CHANGELOG.md / the tag: with one release so far, a comment is proportionate; add the job when releases are frequent enough for drift to recur.

### Version consistency check — no adjacent drift found

Checked as asked; every surface already agrees on `0.1.0`, so **nothing to fix here**:

| Surface | Value |
|---|---|
| `CITATION.cff` `version` | 0.1.0 |
| `core/pyproject.toml:7` | 0.1.0 |
| `core/cap_evolve/__init__.py:46` `__version__` | 0.1.0 |
| `dashboard/backend/pyproject.toml:7` | 0.1.0 |
| git tag | v0.1.0 |

---


## `core/tests` untouched and green

`git diff main -- core/` is empty (0 lines); the diff is `.github/workflows/ci.yml` + `CITATION.cff` only. No Python changes at all.

```
$ python -m pytest core/tests -q
789 passed, 12 skipped in 112.92s (0:01:52)
```

Note for contributors — a real footgun worth knowing: this suite only passes when **one** copy of `cap_evolve` is importable. Many files in `core/tests` do `sys.path.insert(0, CORE)`, and `sys.path` takes precedence over the editable install's finder. So if you run the suite from a **git worktree** against a venv whose `pip install -e ./core` points at a *different* checkout, one pytest process ends up holding two distinct `cap_evolve` trees, and two tests in `test_eventstream.py` fail as a result: an identity assertion (`stream.read_new_events is eventstream.read_new_events`), and a `monkeypatch.setattr(eventstream, "render_line", ...)` that patches one copy while `_spawn_follower` calls the other copy's, so the follower thread never dies. Both are artifacts of the duplicate tree, not real defects — pinning imports to a single tree (`PYTHONPATH=$PWD/core:$PWD/dashboard/backend`) restores the clean `789 passed, 12 skipped`.

Closes #207
Closes #186
