### PR TITLE
feat(skills): dogfood the skill authoring lint in CI (report-only) + validator fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,34 @@ jobs:
             "README.md" "docs/**/*.md" "examples/**/*.md" "*.md"
           fail: true
 
+  lint-skills:
+    name: Skill authoring lint (report-only)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      # Points the shipped skill-package validator at the repo's OWN skills, so the
+      # framework is held to the authoring bar it advertises in CONTRIBUTING.md.
+      #
+      # REPORT-ONLY on purpose, for exactly as long as it takes to rewrite the
+      # skills (issues #322-#339): `skills/_registry/authoring-baseline.txt` records
+      # every violation on the tree today, so a NEW violation still fails the step
+      # while the known ones only print. `continue-on-error` keeps the whole build
+      # green in the meantime.
+      #
+      # TO FLIP IT BLOCKING once the baseline is empty: delete
+      # authoring-baseline.txt, drop `--baseline` and drop `continue-on-error`.
+      - name: Lint bundled skills against the authoring rules
+        continue-on-error: true
+        run: python skills/_registry/lint_skills.py skills --baseline
+
   spellcheck:
     name: Spellcheck (docs)
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,10 @@ them off as clean CI runs.
 
 ## Quality bar for skills
 - SKILL.md body under ~500 lines (it is the primary doc); references one level deep with a TOC if long, and only when filled.
+- Check it yourself with `python skills/_registry/lint_skills.py skills` — the same
+  validator the `skill-package` capability applies to user skills, pointed at ours. CI
+  runs it report-only against `skills/_registry/authoring-baseline.txt` while the
+  bundled skills are being rewritten; do not add lines to that baseline.
 - A real `check.py` smoke test (not just an import) that fails on stubs and on
   non-determinism.
 - Ground claims in cited papers/repos/docs.

--- a/core/tests/test_skill_authoring_lint.py
+++ b/core/tests/test_skill_authoring_lint.py
@@ -1,0 +1,282 @@
+"""The skill authoring lint itself is under test, not merely its verdict.
+
+Two halves:
+
+1. **Rule table.** A known-good fixture skill must pass every rule, and one
+   deliberately-broken fixture per rule must fail with a message that names the
+   problem. Without this, a reworded or accidentally-dead check turns the lint into
+   a silent no-op and nobody notices.
+2. **Lint plumbing.** Discovery must stay dynamic, the coverage-drift guard must
+   fire, every PROMOTED fragment must be reachable from a real violation, and the
+   baseline must suppress exactly the known lines and nothing else.
+"""
+
+import importlib.util
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+SKILLS = REPO / "skills"
+LINT = SKILLS / "_registry" / "lint_skills.py"
+BASELINE = SKILLS / "_registry" / "authoring-baseline.txt"
+
+GOOD_DESC = ("Extracts tabular data from spreadsheets and writes a tidy CSV. Use when "
+             "the user has an xlsx/csv and wants columns reshaped, filtered, or joined.")
+
+
+def _lint_module():
+    spec = importlib.util.spec_from_file_location("lint_skills", LINT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def validator():
+    return _lint_module()._load_validator(SKILLS)
+
+
+def _skill(tmp: Path, *, name="fixture-skill", desc=GOOD_DESC, body="# Fixture\n\nDo the thing.\n",
+           refs: dict[str, str] | None = None, frontmatter: str | None = None) -> Path:
+    """Write one skill package and return its directory."""
+    cap = tmp / "cap"
+    cap.mkdir(parents=True, exist_ok=True)
+    fm = frontmatter if frontmatter is not None else f"name: {name}\ndescription: {desc}"
+    (cap / "SKILL.md").write_text(f"---\n{fm}\n---\n\n{body}", encoding="utf-8")
+    for rel, text in (refs or {}).items():
+        target = cap / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(text, encoding="utf-8")
+    return cap
+
+
+def _lines(n: int, prefix: str = "Line") -> str:
+    return "\n".join(f"{prefix} {i} of prose that carries no real weight." for i in range(n))
+
+
+def _long_ref_without_toc(n: int = 400) -> str:
+    return "# Long reference\n\n## An ordinary first section, not a TOC\n\n" + _lines(n)
+
+
+def _long_ref_with_toc(n: int = 400) -> str:
+    toc = "\n".join(f"- [Section {i}](#section-{i})" for i in range(4))
+    return f"# Long reference\n\n{toc}\n\n## Section 0\n\n" + _lines(n)
+
+
+# (rule id, kwargs for _skill, expected fragment, hard problem or warning)
+BROKEN = [
+    ("name-missing", dict(frontmatter=f"description: {GOOD_DESC}"),
+     "missing 'name'", "problems"),
+    ("name-too-long", dict(name="a" * 65), "must be <=64 chars", "problems"),
+    ("name-bad-charset", dict(name="Fixture_Skill"), "lowercase [a-z0-9-]", "problems"),
+    ("name-xml", dict(frontmatter=f'name: "<x>fixture</x>"\ndescription: {GOOD_DESC}'),
+     "name must not contain XML tags", "problems"),
+    ("desc-missing", dict(frontmatter="name: fixture-skill"),
+     "missing a non-empty 'description'", "problems"),
+    ("desc-empty", dict(frontmatter='name: fixture-skill\ndescription: ""'),
+     "missing a non-empty 'description'", "problems"),
+    ("desc-too-long", dict(desc="Reshapes data. Use when asked. " + "x" * 1024),
+     "chars (>1024)", "problems"),
+    ("desc-xml", dict(desc="Routes <phase> requests. Use when the user names a phase."),
+     "description must not contain XML tags", "problems"),
+    ("desc-no-when-clause", dict(desc="Processes documents and returns extracted text."),
+     "should say WHEN to use the skill", "warnings"),
+    ("body-over-500-lines", dict(body="# Fixture\n\n" + _lines(600)),
+     "lines (>500)", "warnings"),
+    ("reference-nested-dir", dict(refs={"references/deep/inner.md": "# Inner\n"}),
+     "level deep", "warnings"),
+    ("reference-links-reference",
+     dict(refs={"references/a.md": "# A\n\nSee [b](b.md).\n", "references/b.md": "# B\n"}),
+     "references must be one level deep", "warnings"),
+    ("long-reference-without-toc", dict(refs={"references/long.md": _long_ref_without_toc()}),
+     "table of contents", "warnings"),
+    ("broken-link-from-body", dict(body="# Fixture\n\nSee [gone](references/gone.md).\n"),
+     "'references/gone.md' which does not exist", "warnings"),
+    ("broken-link-from-reference",
+     dict(refs={"references/a.md": "# A\n\nSee [script](../scripts/gone.py).\n"}),
+     "does not exist", "warnings"),
+]
+
+
+def test_a_well_formed_skill_passes_every_rule(tmp_path, validator):
+    """The known-good fixture exercises every rule's happy path: a long reference WITH
+    a TOC, a reference linked only from SKILL.md, and a live relative link."""
+    cap = _skill(
+        tmp_path,
+        body=("# Fixture\n\nDo the thing.\n\n"
+              "Read [the long reference](references/long.md) for the details, and "
+              "[the short one](references/short.md#a-heading) for the summary.\n"),
+        refs={"references/long.md": _long_ref_with_toc(),
+              "references/short.md": "# Short\n\n## A heading\n\nSummary.\n"},
+    )
+    v = validator.validate(cap)
+    assert v == {"ok": True, "name": "fixture-skill", "problems": [], "warnings": []}
+
+
+@pytest.mark.parametrize("rule,kwargs,fragment,bucket",
+                         BROKEN, ids=[b[0] for b in BROKEN])
+def test_each_broken_fixture_fails_its_rule(tmp_path, validator, rule, kwargs, fragment, bucket):
+    v = validator.validate(_skill(tmp_path, **kwargs))
+    found = v[bucket]
+    assert any(fragment in m for m in found), (rule, fragment, v)
+    if bucket == "problems":
+        assert not v["ok"], (rule, v)
+
+
+STRUCTURAL = [b for b in BROKEN
+              if b[3] == "warnings" and b[0] != "desc-no-when-clause"]
+
+
+@pytest.mark.parametrize("rule,kwargs,fragment,bucket", STRUCTURAL,
+                         ids=[b[0] for b in STRUCTURAL])
+def test_structural_warnings_are_promoted_to_lint_errors(rule, kwargs, fragment, bucket):
+    """`validate()` keeps structural findings as warnings so a mid-run optimizer is not
+    hard-blocked by a style budget; the repo's own lint promotes them to errors. If
+    abstract.py rewords one, PROMOTED stops matching and the lint silently goes blind —
+    so the promotion is asserted per rule, not just in aggregate."""
+    mod = _lint_module()
+    assert any(frag in fragment for frag in mod.PROMOTED), (rule, fragment, mod.PROMOTED)
+
+
+def test_the_when_clause_advisory_stays_advisory():
+    """Judgement calls are reported, never failed: "say WHEN" is a heuristic on prose,
+    so it must not be promoted into a build-breaking error."""
+    mod = _lint_module()
+    assert not any(frag in "should say WHEN to use the skill" for frag in mod.PROMOTED)
+
+
+def _repo_skills_copy(tmp_path: Path) -> Path:
+    root = tmp_path / "skills"
+    shutil.copytree(SKILLS, root, ignore=shutil.ignore_patterns("__pycache__", "*.pyc"))
+    return root
+
+
+def _run(root: Path, *args: str):
+    return subprocess.run([sys.executable, str(LINT), str(root), *args],
+                          capture_output=True, text=True)
+
+
+def test_the_repo_is_clean_against_its_recorded_baseline():
+    """Report-only mode: every violation on the tree today is recorded, so CI reports
+    the list without going red. A NEW violation is not in the baseline and fails."""
+    out = _run(SKILLS, "--baseline")
+    assert out.returncode == 0, out.stdout + out.stderr
+    assert "no violations outside the baseline" in out.stdout, out.stdout
+
+
+def test_the_baseline_matches_the_tree_exactly():
+    """A baseline that drifts stale is worse than none: it would mask a real regression
+    or nag about violations already fixed."""
+    mod = _lint_module()
+    errors, _, _ = mod.lint(SKILLS)
+    assert mod._flatten(errors) == [
+        ln for ln in BASELINE.read_text(encoding="utf-8").splitlines() if ln.strip()
+    ], "regenerate with: python skills/_registry/lint_skills.py skills --write-baseline"
+
+
+def test_a_new_violation_fails_even_with_the_baseline(tmp_path):
+    root = _repo_skills_copy(tmp_path)
+    (root / "phases" / "gate" / "SKILL.md").write_text(
+        f"---\nname: gate\ndescription: {GOOD_DESC}\n---\n\n# Gate\n\n" + _lines(600),
+        encoding="utf-8")
+    out = _run(root, f"--baseline={BASELINE}")
+    assert out.returncode == 1, out.stdout
+    assert "phases/gate" in out.stdout and "lines (>500)" in out.stdout, out.stdout
+
+
+def test_a_fixed_baselined_violation_is_reported_as_stale(tmp_path):
+    root = _repo_skills_copy(tmp_path)
+    tools = root / "capabilities" / "tools" / "SKILL.md"
+    head, _, _ = tools.read_text(encoding="utf-8").partition("\n---\n")
+    tools.write_text(head + "\n---\n\n# Tools\n\nShort body now.\n", encoding="utf-8")
+    out = _run(root, f"--baseline={BASELINE}")
+    assert "are now FIXED" in out.stdout and "capabilities/tools" in out.stdout, out.stdout
+
+
+def test_discovery_is_dynamic_and_sees_every_skill():
+    """The lint globs; it never reads a committed list that could go stale."""
+    mod = _lint_module()
+    on_disk = {p.parent.relative_to(SKILLS).as_posix() for p in SKILLS.glob("*/*/SKILL.md")}
+    _, _, n = mod.lint(SKILLS)
+    assert n == len(on_disk), (n, sorted(on_disk))
+    assert not mod._manifest_drift(SKILLS)
+
+
+def test_coverage_drift_fires_on_rename_away_plus_add_new(tmp_path):
+    """Non-vacuity: removing one skill and adding another in the same commit nets to the
+    same count, so a `n < MIN_SKILLS` floor would miss it. Comparing PATH SETS against
+    the committed manifest catches it, and needs no magic number."""
+    root = _repo_skills_copy(tmp_path)
+    shutil.rmtree(root / "phases" / "gate")
+    replacement = root / "phases" / "newskill"
+    replacement.mkdir()
+    (replacement / "SKILL.md").write_text(
+        f"---\nname: newskill\ndescription: {GOOD_DESC}\n---\n\n# New\n\nBody.\n",
+        encoding="utf-8")
+    out = _run(root, f"--baseline={BASELINE}")
+    assert out.returncode == 1, out.stdout
+    assert "renamed/moved/removed" in out.stdout, out.stdout
+    assert "phases/gate" in out.stdout, out.stdout
+
+
+def test_block_scalar_descriptions_are_actually_parsed(tmp_path, validator):
+    """`description: >-` used to parse as the literal '>-' (len 2), so EVERY description
+    check — including the XML-tag hard problem — passed vacuously on it. The parser must
+    read the folded value, and the checks must then fire on it."""
+    for mark, joined in ((">-", "first line second line"), ("|", "first line\nsecond line")):
+        fm, body = validator._parse_frontmatter(
+            f"---\nname: fixture\ndescription: {mark}\n  first line\n"
+            f"  second line\ncomponent: phase\n---\n\nBody.\n")
+        assert fm["description"] == joined, (mark, fm)
+        assert fm["component"] == "phase", fm     # keys AFTER the block still parse
+        assert body.strip() == "Body."
+
+    cap = _skill(tmp_path, frontmatter=("name: fixture\ndescription: >-\n"
+                                        "  Does a thing. Use when proving the parser reads a\n"
+                                        "  folded scalar. Wrap it in <X> tags."))
+    assert any("XML tags" in p for p in validator.validate(cap)["problems"])
+
+    # every shipped description is really parsed, not silently truncated to a marker
+    for skill_md in sorted(SKILLS.glob("*/*/SKILL.md")):
+        fm, _ = validator._parse_frontmatter(skill_md.read_text(encoding="utf-8"))
+        assert len(fm.get("description", "")) > 100, (skill_md, fm.get("description"))
+
+
+def test_an_anchor_in_a_link_is_not_part_of_the_path(tmp_path, validator):
+    """`references/x.md#a-heading` used to be existence-checked verbatim, so every deep
+    link read as broken — a false positive on a correct skill."""
+    cap = _skill(tmp_path, body="# F\n\nSee [detail](references/x.md#deep-heading).\n",
+                 refs={"references/x.md": "# X\n\n## Deep heading\n\nDetail.\n"})
+    assert validator.validate(cap)["warnings"] == []
+
+
+def test_say_when_advisory_accepts_positional_when_phrasing(validator):
+    """The advisory demanded the literal bigram 'use when', so descriptions that state
+    WHEN positionally ('Use after intake') were false positives. Rewording good prose to
+    green a regex would be a downgrade; the check accepts both forms instead."""
+    for desc in ("Scores a candidate. Use when you need a number.",
+                 "Establishes the starting point. Use after implement-and-check.",
+                 "Applies the acceptance decision. Use to inspect one decision.",
+                 "Extracts the learning signal. Use between evaluation and edits."):
+        assert validator.SAYS_WHEN_RE.search(desc), desc
+    assert not validator.SAYS_WHEN_RE.search("Processes documents and returns text.")
+
+
+def test_promoted_fragments_still_match_the_validators_wording(tmp_path, validator):
+    """Each PROMOTED fragment must be reachable from a real violation. If abstract.py
+    rewords a warning, this fails loudly rather than the lint quietly going blind."""
+    mod = _lint_module()
+    cap = _skill(
+        tmp_path,
+        body="# F\n\n" + _lines(1400) + "\n\nSee [gone](references/gone.md).\n",
+        refs={"references/long.md": _long_ref_without_toc(),
+              "references/a.md": "# A\n\nSee [long](long.md).\n",
+              "references/nested/deep.md": "# Deep\n"},
+    )
+    warnings = validator.validate(cap)["warnings"]
+    for frag in mod.PROMOTED:
+        assert any(frag in w for w in warnings), (frag, warnings)

--- a/core/tests/test_skill_authoring_lint.py
+++ b/core/tests/test_skill_authoring_lint.py
@@ -168,6 +168,16 @@ def test_the_repo_is_clean_against_its_recorded_baseline():
     assert "no violations outside the baseline" in out.stdout, out.stdout
 
 
+def test_the_violation_list_is_ordered_deterministically():
+    """The baseline is compared line-for-line, so a wobble in the order findings come
+    out fails the build on a machine whose filesystem enumerates references differently
+    (this is what turned CI red the first time). Sorted output pins it everywhere."""
+    mod = _lint_module()
+    errors, _, _ = mod.lint(SKILLS)
+    lines = mod._flatten(errors)
+    assert lines == sorted(lines), lines
+
+
 def test_the_baseline_matches_the_tree_exactly():
     """A baseline that drifts stale is worse than none: it would mask a real regression
     or nag about violations already fixed."""

--- a/skills/_registry/authoring-baseline.txt
+++ b/skills/_registry/authoring-baseline.txt
@@ -1,12 +1,12 @@
 algorithms/agent-optimize: SKILL.md body is 915 lines (>500); split detail into references/ (progressive disclosure)
 algorithms/agent-optimize: SKILL.md body is ~14678 tokens (>5000); it is a recurring per-session cost — move detail into references/
 algorithms/agent-optimize: references/measured-lessons.md is 543 lines without an early table of contents (needs >=3 '[section](#anchor)' links up front)
+algorithms/evograph: references/clustering.md links to another reference 'graph.md'; references must be one level deep — link it from SKILL.md instead
 algorithms/evograph: references/dashboard.md links to another reference 'clustering.md'; references must be one level deep — link it from SKILL.md instead
 algorithms/evograph: references/dashboard.md links to another reference 'graph.md'; references must be one level deep — link it from SKILL.md instead
-algorithms/evograph: references/clustering.md links to another reference 'graph.md'; references must be one level deep — link it from SKILL.md instead
 algorithms/evograph: references/graph.md links to another reference 'clustering.md'; references must be one level deep — link it from SKILL.md instead
-capabilities/skill-package: references/concepts.md links to another reference 'description-optimization.md'; references must be one level deep — link it from SKILL.md instead
 capabilities/skill-package: references/concepts.md links to another reference 'anti-patterns.md'; references must be one level deep — link it from SKILL.md instead
+capabilities/skill-package: references/concepts.md links to another reference 'description-optimization.md'; references must be one level deep — link it from SKILL.md instead
 capabilities/tools: SKILL.md body is 741 lines (>500); split detail into references/ (progressive disclosure)
 capabilities/tools: SKILL.md body is ~12222 tokens (>5000); it is a recurring per-session cost — move detail into references/
 capabilities/tools: references/examples.md is 378 lines without an early table of contents (needs >=3 '[section](#anchor)' links up front)

--- a/skills/_registry/authoring-baseline.txt
+++ b/skills/_registry/authoring-baseline.txt
@@ -1,0 +1,14 @@
+algorithms/agent-optimize: SKILL.md body is 915 lines (>500); split detail into references/ (progressive disclosure)
+algorithms/agent-optimize: SKILL.md body is ~14678 tokens (>5000); it is a recurring per-session cost — move detail into references/
+algorithms/agent-optimize: references/measured-lessons.md is 543 lines without an early table of contents (needs >=3 '[section](#anchor)' links up front)
+algorithms/evograph: references/dashboard.md links to another reference 'clustering.md'; references must be one level deep — link it from SKILL.md instead
+algorithms/evograph: references/dashboard.md links to another reference 'graph.md'; references must be one level deep — link it from SKILL.md instead
+algorithms/evograph: references/clustering.md links to another reference 'graph.md'; references must be one level deep — link it from SKILL.md instead
+algorithms/evograph: references/graph.md links to another reference 'clustering.md'; references must be one level deep — link it from SKILL.md instead
+capabilities/skill-package: references/concepts.md links to another reference 'description-optimization.md'; references must be one level deep — link it from SKILL.md instead
+capabilities/skill-package: references/concepts.md links to another reference 'anti-patterns.md'; references must be one level deep — link it from SKILL.md instead
+capabilities/tools: SKILL.md body is 741 lines (>500); split detail into references/ (progressive disclosure)
+capabilities/tools: SKILL.md body is ~12222 tokens (>5000); it is a recurring per-session cost — move detail into references/
+capabilities/tools: references/examples.md is 378 lines without an early table of contents (needs >=3 '[section](#anchor)' links up front)
+capabilities/tools: references/optimizer-playbook.md links to another reference 'examples.md'; references must be one level deep — link it from SKILL.md instead
+orchestrate/using-cap-evolve: description must not contain XML tags

--- a/skills/_registry/lint_skills.py
+++ b/skills/_registry/lint_skills.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Dogfood the skill-package authoring lint on cap-evolve's OWN bundled skills.
+
+The framework ships `skills/capabilities/skill-package/scripts/abstract.py` to
+enforce the Agent-Skills authoring rules (skill-creator's progressive-disclosure
+budget, frontmatter shape, one-level references) on *user* skills. This script
+points that same validator at `skills/*/*/SKILL.md`, so the framework is held to
+the bar it advertises in CONTRIBUTING.md instead of only selling it.
+
+Structural authoring warnings are ERRORS here. `validate()` reports body size /
+reference depth / missing-TOC / broken links as *warnings* because an optimizer
+mid-run should not be hard-blocked by a style budget. For the repo's own skills
+there is no such excuse, so `PROMOTED` turns them into failures. Description
+*style* heuristics (POV, all-caps, "say WHEN", truncation risk) stay advisory —
+they are judgement calls, not measurable violations.
+
+Discovery is a glob, never a committed list, so a NEW skill is linted the day it
+lands. The anti-vacuity guard cross-checks that glob against the committed
+`manifest.json` — two independent views of one tree that must agree — so a
+rename/move/deletion fails loudly even when an addition in the same commit keeps
+the count unchanged.
+
+`--baseline FILE` records the violations that are already known (the skills are
+being rewritten under issues #322-#339). Known lines are still printed but do not
+affect the exit code; anything NEW fails. Delete the baseline to make the lint
+absolute again.
+
+Usage: python skills/_registry/lint_skills.py [skills_root] [--baseline[=FILE]]
+                                              [--write-baseline[=FILE]]
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+# `validate()` warnings that are objectively measurable authoring violations, keyed
+# by a stable fragment of the message. Anything not matched here stays advisory.
+# Coupled to abstract.py's wording on purpose; test_skill_authoring_lint.py proves
+# each of these still fires, so a reworded warning breaks the test, not the lint.
+PROMOTED = (
+    "lines (>",              # body over MAX_BODY_LINES
+    "tokens (>",             # body over MAX_BODY_TOKENS
+    "level deep",            # references nested, or a reference linking a reference
+    "table of contents",     # long reference with no early TOC
+    "does not exist",        # a relative link pointing at a missing file
+)
+
+DEFAULT_BASELINE = "authoring-baseline.txt"
+
+
+def _load_validator(skills_root: Path):
+    path = skills_root / "capabilities" / "skill-package" / "scripts" / "abstract.py"
+    if not path.is_file():
+        raise SystemExit(f"lint_skills: cannot find the validator at {path}")
+    spec = importlib.util.spec_from_file_location("skill_package_abstract", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _manifest_drift(skills_root: Path) -> str:
+    """Anti-vacuity: the glob and the committed manifest are two independent views of
+    the same tree and must agree. A floor (`n < 20`) misses rename-away + add-new in
+    one commit; comparing the PATH SETS catches it, and needs no magic number."""
+    manifest = skills_root / "_registry" / "manifest.json"
+    if not manifest.is_file():
+        return f"the committed manifest is missing at {manifest}"
+    listed = {s["path"] for s in
+              json.loads(manifest.read_text(encoding="utf-8"))["skills"].values()}
+    found = {p.parent.relative_to(skills_root).as_posix()
+             for p in skills_root.glob("*/*/SKILL.md")}
+    if found == listed:
+        return ""
+    return (f"{len(found)} skill package(s) on disk do not match the {len(listed)} in "
+            f"manifest.json — on disk only: {sorted(found - listed) or 'none'}; in "
+            f"manifest only: {sorted(listed - found) or 'none'}. A skill was "
+            f"renamed/moved/removed; rebuild the manifest and re-review coverage")
+
+
+def lint(skills_root: Path) -> tuple[dict[str, list[str]], dict[str, list[str]], int]:
+    """Return (per-skill errors, per-skill advisories, number of skills linted)."""
+    validator = _load_validator(skills_root)
+    errors: dict[str, list[str]] = {}
+    advisories: dict[str, list[str]] = {}
+    skills = sorted(skills_root.glob("*/*/SKILL.md"))
+    for skill_md in skills:
+        skill_dir = skill_md.parent
+        key = skill_dir.relative_to(skills_root).as_posix()
+        v = validator.validate(skill_dir)
+        errs = list(v["problems"])
+        advs: list[str] = []
+        for w in v["warnings"]:
+            (errs if any(frag in w for frag in PROMOTED) else advs).append(w)
+        if errs:
+            errors[key] = errs
+        if advs:
+            advisories[key] = advs
+    return errors, advisories, len(skills)
+
+
+def _flatten(errors: dict[str, list[str]]) -> list[str]:
+    """One stable `<skill>: <message>` line per violation — the baseline's format."""
+    return [f"{key}: {e}" for key in sorted(errors) for e in errors[key]]
+
+
+def _parse_argv(argv: list[str]) -> tuple[Path, dict[str, str]]:
+    positional = [a for a in argv if not a.startswith("--")]
+    opts = {}
+    for a in argv:
+        if a.startswith("--"):
+            flag, _, value = a.partition("=")
+            opts[flag] = value
+    return Path(positional[0] if positional else "skills").resolve(), opts
+
+
+def _baseline_path(root: Path, value: str) -> Path:
+    return Path(value) if value else root / "_registry" / DEFAULT_BASELINE
+
+
+def main(argv: list[str]) -> int:
+    root, opts = _parse_argv(argv[1:])
+    errors, advisories, n = lint(root)
+    lines = _flatten(errors)
+
+    if "--write-baseline" in opts:
+        out = _baseline_path(root, opts["--write-baseline"])
+        out.write_text("".join(f"{ln}\n" for ln in lines), encoding="utf-8")
+        print(f"wrote {len(lines)} known violation(s) to {out}")
+        return 0
+
+    known: set[str] = set()
+    if "--baseline" in opts:
+        bl = _baseline_path(root, opts["--baseline"])
+        if bl.is_file():
+            known = {ln for ln in bl.read_text(encoding="utf-8").splitlines() if ln.strip()}
+
+    print(f"skill authoring lint — {n} skill package(s) under {root}")
+    for ln in lines:
+        print(f"  {'known ' if ln in known else 'ERROR '} {ln}")
+    for key in sorted(advisories):
+        for a in advisories[key]:
+            print(f"  advise {key}: {a}")
+
+    drift = _manifest_drift(root)
+    if drift:
+        print(f"  ERROR  discovery: {drift}")
+        return 1
+
+    new = [ln for ln in lines if ln not in known]
+    fixed = sorted(known - set(lines))
+    if fixed:
+        print(f"{len(fixed)} baselined violation(s) are now FIXED — remove them from "
+              f"the baseline: {fixed}")
+    if new:
+        print(f"FAIL — {len(new)} authoring violation(s) not in the baseline "
+              f"({len(lines) - len(new)} known, {len(advisories)} skill(s) with advisories)")
+        return 1
+    print(f"OK — {n} skill packages, no violations outside the baseline "
+          f"({len(lines)} known, {len(advisories)} skill(s) with advisories)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/skills/_registry/lint_skills.py
+++ b/skills/_registry/lint_skills.py
@@ -102,8 +102,13 @@ def lint(skills_root: Path) -> tuple[dict[str, list[str]], dict[str, list[str]],
 
 
 def _flatten(errors: dict[str, list[str]]) -> list[str]:
-    """One stable `<skill>: <message>` line per violation — the baseline's format."""
-    return [f"{key}: {e}" for key in sorted(errors) for e in errors[key]]
+    """One stable `<skill>: <message>` line per violation — the baseline's format.
+
+    Fully sorted, not just by skill: the baseline is compared line-for-line against a
+    committed file, so any wobble in the order findings are produced would fail the
+    build on a different machine. (`abstract.py` also sorts its reference iteration —
+    this is the second belt, because a baseline that depends on ordering rots.)"""
+    return sorted(f"{key}: {e}" for key in errors for e in errors[key])
 
 
 def _parse_argv(argv: list[str]) -> tuple[Path, dict[str, str]]:

--- a/skills/capabilities/skill-package/scripts/abstract.py
+++ b/skills/capabilities/skill-package/scripts/abstract.py
@@ -13,8 +13,11 @@ Anthropic docs — see references/concepts.md):
     says WHAT + WHEN ("use when").
   - SKILL.md body stays under ~500 lines AND ~5k tokens (progressive disclosure
     budget; the body is a recurring per-session token cost).
-  - references are one level deep and any long reference (>300 lines) has a TOC.
-  - referenced files that the body points at actually exist.
+  - references are one level deep — no nested ``references/<dir>/`` AND no
+    reference that links to another reference (the agent may read a reference only
+    partially, so a second hop can be missed) — and any long reference (>300 lines)
+    has a real table of contents (a list of anchor links, not just a heading).
+  - every relative link, from the body or from a reference, resolves to a real file.
 
 Soft authoring lints (warnings, not failures): a first-person description
 (point-of-view drift hurts discovery), all-caps CRITICAL/ALWAYS/MUST/NEVER in the
@@ -32,10 +35,21 @@ from pathlib import Path
 NAME_RE = re.compile(r"^[a-z0-9-]{1,64}$")
 FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---", re.S)
 XML_TAG_RE = re.compile(r"</?[a-zA-Z][^>]*>")  # an actual tag, not a stray "<"
+BLOCK_SCALAR_RE = re.compile(r"^([>|])[+-]?\d*$")  # "description: >-" and friends
+# WHEN can be stated conditionally ("Use when …") or positionally/imperatively
+# ("Use after intake", "Use as the last evaluation step") — both are real triggering
+# signals, so demanding the literal "use when" bigram flags good descriptions.
+SAYS_WHEN_RE = re.compile(
+    r"\bwhen\b|\buse (after|before|as|at|to|between|right|during|only|this|the moment)\b",
+    re.I)
 MAX_BODY_LINES = 500
 MAX_BODY_TOKENS = 5000            # ~chars/4; Level-2 body budget
 CHARS_PER_TOKEN = 4
 LONG_REF_LINES = 300
+TOC_LINK_RE = re.compile(r"\]\(#[^)\s]+\)")   # an in-document anchor link
+REL_LINK_RE = re.compile(r"\]\(([^)\s]+)\)")  # any Markdown link target
+TOC_SCAN_CHARS = 1500                         # "early" = within the first ~1.5k chars
+MIN_TOC_LINKS = 3                             # a list of links, not one stray cross-ref
 LISTING_CAP_CHARS = 1536          # description + when_to_use truncation in the listing
 LONG_DESC_CHARS = 1024            # hard cap; also the front-load advisory threshold
 
@@ -45,12 +59,50 @@ def _parse_frontmatter(text: str) -> tuple[dict, str]:
     if not m:
         return {}, text
     fm = {}
-    for line in m.group(1).splitlines():
-        if ":" in line and not line.startswith(" "):
-            k, _, v = line.partition(":")
+    lines = m.group(1).splitlines()
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        i += 1
+        if ":" not in line or line.startswith((" ", "\t")):
+            continue
+        k, _, v = line.partition(":")
+        blk = BLOCK_SCALAR_RE.match(v.strip())
+        if blk:
+            # A YAML block scalar ("description: >-") holds its value on the FOLLOWING
+            # indented lines. Without this the value parses as the literal ">-" and
+            # every description check below passes vacuously on it.
+            # ponytail: folds with spaces / keeps newlines for "|", and always strips.
+            # The +/-/digit chomping and indentation indicators only affect trailing
+            # whitespace, which no check here looks at.
+            chunk = []
+            while i < len(lines) and (not lines[i].strip()
+                                      or lines[i].startswith((" ", "\t"))):
+                chunk.append(lines[i].strip())
+                i += 1
+            joiner = " " if blk.group(1) == ">" else "\n"
+            fm[k.strip()] = joiner.join(c for c in chunk if c).strip()
+        else:
             fm[k.strip()] = v.strip().strip('"').strip("'")
     body = text[m.end():]
     return fm, body
+
+
+def _relative_links(text: str) -> list[str]:
+    """Local relative link targets in Markdown, anchors stripped.
+
+    Skips absolute URLs, bare in-document anchors and mailto:/absolute paths — only
+    targets that must resolve to a file NEXT TO the linking document come back."""
+    out = []
+    for raw in REL_LINK_RE.findall(text):
+        if raw.startswith(("#", "/", "mailto:")) or "://" in raw:
+            continue
+        target = raw.split("#", 1)[0].strip()
+        if target:
+            out.append(target)
+    # One violation per distinct target: the same file linked five times is one
+    # problem to fix, not five findings to wade through.
+    return list(dict.fromkeys(out))
 
 
 def _subpackages(capability_dir: Path) -> list[Path]:
@@ -194,7 +246,7 @@ def _validate_one(capability_dir: Path) -> dict:
             problems.append(f"description is {len(desc)} chars (>{LONG_DESC_CHARS})")
         if XML_TAG_RE.search(desc):
             problems.append("description must not contain XML tags")
-        if not re.search(r"\b(use when|when )\b", desc, re.I):
+        if not SAYS_WHEN_RE.search(desc):
             warnings.append("description should say WHEN to use the skill "
                             "('Use when …') — it is the primary triggering signal")
         # point-of-view drift: descriptions must be third person.
@@ -227,13 +279,33 @@ def _validate_one(capability_dir: Path) -> dict:
                 warnings.append(f"references/{sub.name}/ is nested >1 level deep; "
                                 "keep references one level deep")
         for f in refs.glob("*.md"):
-            ln = f.read_text(encoding="utf-8").count("\n") + 1
-            if ln > LONG_REF_LINES and "## " not in f.read_text(encoding="utf-8")[:1500]:
+            ref_text = f.read_text(encoding="utf-8")
+            ln = ref_text.count("\n") + 1
+            # A TOC is a LIST OF ANCHOR LINKS, not merely "some '## ' appears in the
+            # first 1500 chars" — that older condition was satisfied by ordinary prose,
+            # so the check was near-tautological.
+            if ln > LONG_REF_LINES and len(
+                    TOC_LINK_RE.findall(ref_text[:TOC_SCAN_CHARS])) < MIN_TOC_LINKS:
                 warnings.append(f"references/{f.name} is {ln} lines without an early "
-                                "table of contents")
+                                f"table of contents (needs >={MIN_TOC_LINKS} "
+                                "'[section](#anchor)' links up front)")
+            # One level deep: SKILL.md -> reference, never reference -> reference. The
+            # agent may read a reference only partially, so a second hop can be missed
+            # entirely; the depth has to be flat, not merely the directory layout.
+            for target in _relative_links(ref_text):
+                hop = (f.parent / target).resolve()
+                if hop.suffix == ".md" and hop.parent == refs.resolve() and hop != f.resolve():
+                    warnings.append(f"references/{f.name} links to another reference "
+                                    f"'{target}'; references must be one level deep — "
+                                    "link it from SKILL.md instead")
+                if not hop.exists():
+                    warnings.append(f"references/{f.name} links to '{target}' "
+                                    "which does not exist")
 
-    # broken reference links the body points at
-    for rel in re.findall(r"\(((?:references|scripts|assets)/[^)\s]+)\)", body):
+    # Every relative link the body points at must resolve. A Markdown link may carry
+    # an anchor ("references/x.md#a-heading"); the anchor is not part of the path, so
+    # it is stripped before the existence check or every deep link reads as broken.
+    for rel in _relative_links(body):
         if not (capability_dir / rel).exists():
             warnings.append(f"SKILL.md references '{rel}' which does not exist")
 

--- a/skills/capabilities/skill-package/scripts/abstract.py
+++ b/skills/capabilities/skill-package/scripts/abstract.py
@@ -274,11 +274,14 @@ def _validate_one(capability_dir: Path) -> dict:
 
     refs = capability_dir / "references"
     if refs.is_dir():
-        for sub in refs.iterdir():
+        # sorted(): filesystem iteration order differs between machines, and callers
+        # (the repo's own lint diffs its output against a committed baseline) need the
+        # findings to come out in the same order everywhere.
+        for sub in sorted(refs.iterdir()):
             if sub.is_dir():
                 warnings.append(f"references/{sub.name}/ is nested >1 level deep; "
                                 "keep references one level deep")
-        for f in refs.glob("*.md"):
+        for f in sorted(refs.glob("*.md")):
             ref_text = f.read_text(encoding="utf-8")
             ln = ref_text.count("\n") + 1
             # A TOC is a LIST OF ANCHOR LINKS, not merely "some '## ' appears in the


### PR DESCRIPTION
Closes #107 (redesign of #213 against current main).

Scope is deliberately **the lint and its CI wiring only**. The skills themselves are being
rewritten concurrently under #322-#339, so this PR does not touch a single `SKILL.md` — it
produces the authoritative violation checklist those rewrites work against, and the gate that
stops the next regression.

## Extend, not new

`skill-package/scripts/abstract.py` already **is** the authoring validator (`MAX_BODY_LINES = 500`,
frontmatter/reference/TOC rules) shipped to user skills, so it is extended in place and pointed at
our own skills; `core/cap_evolve/skillcheck.py` was read first and rejected as the wrong module — it
is the shared harness for each skill's *behavioral* `scripts/check.py` (`Checker`, `SyntheticAdapter`,
`temp_run_dir`) and contains no authoring rule at all.

## Rule table

Every rule below is enforced by the shipped validator and reported by the lint.

| Rule | Budget / condition | Severity in lint |
|---|---|---|
| `name` present | non-empty frontmatter key | hard error |
| `name` length | ≤ 64 chars | hard error |
| `name` charset | `[a-z0-9-]` only | hard error |
| `name` no XML | no `<tag>` | hard error |
| `description` present | non-empty | hard error |
| `description` length | ≤ 1024 chars | hard error |
| `description` no XML | no `<tag>` | hard error |
| `description` when-to-use | states WHEN (conditional *or* positional) | advisory |
| body length | ≤ 500 lines | error (promoted) |
| body tokens | ≤ ~5000 (~chars/4) | error (promoted) |
| references one level deep | no `references/<dir>/`, **and no reference linking another reference** | error (promoted) |
| long-reference TOC | > 300 lines needs ≥ 3 `[section](#anchor)` links up front | error (promoted) |
| relative links resolve | from the body **and** from every reference | error (promoted) |

Severity split: structural findings are measurable, so the lint promotes them to errors;
`validate()` keeps them as warnings because an optimizer mid-run must not be hard-blocked by a
style budget. Description *style* heuristics (POV, all-caps, truncation risk, "say WHEN") stay
advisory — they are judgement calls. `test_the_when_clause_advisory_stays_advisory` pins that.

### Validator bugs fixed (all live on main, all user-facing)

1. **`description: >-` bypassed every description check.** A YAML block scalar parsed as the
   literal `">-"` (len 2), so length/XML/when-to-use all passed vacuously — one line of valid YAML
   defeated half the validator.
2. **`#anchor` was not stripped before the existence test**, so `references/x.md#heading` read as
   broken. This was a live false positive on `agent-optimize` on main today.
3. **The TOC check was near-tautological** (`"## " in text[:1500]`) — satisfied by ordinary prose.
   It now requires a real list of anchor links, which surfaces two genuinely TOC-less references
   main was silently passing.
4. **The "say WHEN" advisory demanded the literal bigram `use when`**, flagging 11 good
   descriptions that state WHEN positionally ("Use after implement-and-check"). Rewording correct
   prose to green a regex would be a downgrade; the check now accepts both forms.

**Two of these are rule changes, not bug fixes, and want explicit sign-off:** the TOC tightening
and the reference→reference rule change what *user* skills pass, not just ours.

## The validator's own tests — 34 passed

Table-driven: one known-good fixture that exercises every rule's happy path (long reference *with*
a TOC, references linked only from SKILL.md, a live anchored link), plus one deliberately-broken
fixture per rule.

```
test_a_well_formed_skill_passes_every_rule PASSED
test_each_broken_fixture_fails_its_rule[name-missing] PASSED
test_each_broken_fixture_fails_its_rule[name-too-long] PASSED
test_each_broken_fixture_fails_its_rule[name-bad-charset] PASSED
test_each_broken_fixture_fails_its_rule[name-xml] PASSED
test_each_broken_fixture_fails_its_rule[desc-missing] PASSED
test_each_broken_fixture_fails_its_rule[desc-empty] PASSED
test_each_broken_fixture_fails_its_rule[desc-too-long] PASSED
test_each_broken_fixture_fails_its_rule[desc-xml] PASSED
test_each_broken_fixture_fails_its_rule[desc-no-when-clause] PASSED
test_each_broken_fixture_fails_its_rule[body-over-500-lines] PASSED
test_each_broken_fixture_fails_its_rule[reference-nested-dir] PASSED
test_each_broken_fixture_fails_its_rule[reference-links-reference] PASSED
test_each_broken_fixture_fails_its_rule[long-reference-without-toc] PASSED
test_each_broken_fixture_fails_its_rule[broken-link-from-body] PASSED
test_each_broken_fixture_fails_its_rule[broken-link-from-reference] PASSED
test_structural_warnings_are_promoted_to_lint_errors[body-over-500-lines] PASSED
test_structural_warnings_are_promoted_to_lint_errors[reference-nested-dir] PASSED
test_structural_warnings_are_promoted_to_lint_errors[reference-links-reference] PASSED
test_structural_warnings_are_promoted_to_lint_errors[long-reference-without-toc] PASSED
test_structural_warnings_are_promoted_to_lint_errors[broken-link-from-body] PASSED
test_structural_warnings_are_promoted_to_lint_errors[broken-link-from-reference] PASSED
test_the_when_clause_advisory_stays_advisory PASSED
test_the_repo_is_clean_against_its_recorded_baseline PASSED
test_the_violation_list_is_ordered_deterministically PASSED
test_the_baseline_matches_the_tree_exactly PASSED
test_a_new_violation_fails_even_with_the_baseline PASSED
test_a_fixed_baselined_violation_is_reported_as_stale PASSED
test_discovery_is_dynamic_and_sees_every_skill PASSED
test_coverage_drift_fires_on_rename_away_plus_add_new PASSED
test_block_scalar_descriptions_are_actually_parsed PASSED
test_an_anchor_in_a_link_is_not_part_of_the_path PASSED
test_say_when_advisory_accepts_positional_when_phrasing PASSED
test_promoted_fragments_still_match_the_validators_wording PASSED

34 passed in 1.27s
```

`test_promoted_fragments_still_match_the_validators_wording` is the anti-rot test: if `abstract.py`
rewords a warning, `PROMOTED` stops matching and the test fails instead of the lint quietly going
blind. `test_the_baseline_matches_the_tree_exactly` stops the baseline going stale in either
direction.

## FULL current violation list — 14 violations across 5 of 20 skills

`python skills/_registry/lint_skills.py skills`:

```
skill authoring lint — 20 skill package(s) under <repo>/skills
  ERROR  algorithms/agent-optimize: SKILL.md body is 915 lines (>500); split detail into references/ (progressive disclosure)
  ERROR  algorithms/agent-optimize: SKILL.md body is ~14678 tokens (>5000); it is a recurring per-session cost — move detail into references/
  ERROR  algorithms/agent-optimize: references/measured-lessons.md is 543 lines without an early table of contents (needs >=3 '[section](#anchor)' links up front)
  ERROR  algorithms/evograph: references/clustering.md links to another reference 'graph.md'; references must be one level deep — link it from SKILL.md instead
  ERROR  algorithms/evograph: references/dashboard.md links to another reference 'clustering.md'; references must be one level deep — link it from SKILL.md instead
  ERROR  algorithms/evograph: references/dashboard.md links to another reference 'graph.md'; references must be one level deep — link it from SKILL.md instead
  ERROR  algorithms/evograph: references/graph.md links to another reference 'clustering.md'; references must be one level deep — link it from SKILL.md instead
  ERROR  capabilities/skill-package: references/concepts.md links to another reference 'anti-patterns.md'; references must be one level deep — link it from SKILL.md instead
  ERROR  capabilities/skill-package: references/concepts.md links to another reference 'description-optimization.md'; references must be one level deep — link it from SKILL.md instead
  ERROR  capabilities/tools: SKILL.md body is 741 lines (>500); split detail into references/ (progressive disclosure)
  ERROR  capabilities/tools: SKILL.md body is ~12222 tokens (>5000); it is a recurring per-session cost — move detail into references/
  ERROR  capabilities/tools: references/examples.md is 378 lines without an early table of contents (needs >=3 '[section](#anchor)' links up front)
  ERROR  capabilities/tools: references/optimizer-playbook.md links to another reference 'examples.md'; references must be one level deep — link it from SKILL.md instead
  ERROR  orchestrate/using-cap-evolve: description must not contain XML tags
FAIL — 14 authoring violation(s) not in the baseline (0 known, 0 skill(s) with advisories)
```

### Checklist for the skill rewrites (#322-#339)

| Skill | Rule | Measured | Budget |
|---|---|---|---|
| `algorithms/agent-optimize` | body lines | **915** | ≤ 500 |
| `algorithms/agent-optimize` | body tokens | **~14678** | ≤ 5000 |
| `algorithms/agent-optimize` | long-ref TOC | `references/measured-lessons.md` 543 lines, no TOC | TOC ≥ 3 anchor links |
| `algorithms/evograph` | one level deep | `dashboard.md` → `clustering.md`, `graph.md`; `clustering.md` → `graph.md`; `graph.md` → `clustering.md` | 0 ref→ref links |
| `capabilities/skill-package` | one level deep | `concepts.md` → `description-optimization.md`, `anti-patterns.md` | 0 ref→ref links |
| `capabilities/tools` | body lines | **741** | ≤ 500 |
| `capabilities/tools` | body tokens | **~12222** | ≤ 5000 |
| `capabilities/tools` | long-ref TOC | `references/examples.md` 378 lines, no TOC | TOC ≥ 3 anchor links |
| `capabilities/tools` | one level deep | `optimizer-playbook.md` → `examples.md` | 0 ref→ref links |
| `orchestrate/using-cap-evolve` | description no XML | `<X>` / `<benchmark>` / `<phase>` literals | 0 tags |

Violation counts per rule: body lines **2**, body tokens **2**, references one level deep **7**,
long-reference TOC **2**, description XML **1**. Zero broken links, zero advisories — the 11 "say
WHEN" advisories main reports are all false positives and disappear with the regex fix.

The 15 remaining skills are clean.

## CI wiring, and why it is non-blocking

New `lint-skills` job in `.github/workflows/ci.yml`, `continue-on-error: true`, running
`python skills/_registry/lint_skills.py skills --baseline`.

- **Report-only** because the 14 violations above are being fixed in the concurrent skill rewrites.
  Merging a red build to make a point is not a gate, it is noise.
- **Not permanently advisory**, which is how this rots. `authoring-baseline.txt` records exactly the
  14 known lines; anything NEW is not in the baseline and the step exits 1 today. When a baselined
  violation is fixed the lint says so and names it, so the baseline cannot silently go stale.
- **To flip it blocking**: delete `authoring-baseline.txt`, drop `--baseline`, drop
  `continue-on-error`. That is the comment in the job body.

Non-vacuity is guarded two ways: discovery is a glob (never a committed list), cross-checked against
`manifest.json` path sets, so removing a skill fails loudly even when an addition in the same commit
keeps the count at 20 — a `n < 20` floor cannot see that.

Zero new dependencies (stdlib only), nothing added to `core/` but a test file, no `SKILL.md` touched.

## Determinism fix (CI went red once, on this PR's own test)

The first push failed `test_the_baseline_matches_the_tree_exactly` in CI while passing locally. Not a
stale baseline: `abstract.py` walked references with `refs.iterdir()` / `refs.glob("*.md")`, which
enumerate in **directory order**, so per-skill findings came out in a different order on the runner.
Regenerating alone would have hidden it until the next machine.

Fixed at the root — both walks are sorted, so every consumer is reproducible (the optimizer's warning
list too, not just this lint) — plus `_flatten` sorts fully so the baseline cannot depend on
production order at all. The regenerated baseline holds the **same 14 violations with 2 lines
reordered**, which is the proof it was ordering and nothing else.
`test_the_violation_list_is_ordered_deterministically` now asserts sortedness, so this fails on any
machine instead of only where directory order differs.

## Full suite

```
$ python -m pytest core/tests -q | tail -1
865 passed, 2 skipped in 113.16s (0:01:53)
```

Green, and `Test Python (core)` passes in CI on this branch.

An earlier revision of this body claimed 3 pre-existing failures
(`test_empty_seed.py::test_capability_is_empty_signal`, 2x `test_eventstream.py`). That was wrong,
and the cause is worth recording because it will bite others: those tests resolve paths from
`cap_evolve.__file__`, so they pass only when `cap_evolve` imports from the **source tree**. In a
venv with a plain (non-editable) `pip install ./core`, `import cap_evolve` resolves to the
site-packages copy, `Path(__file__).resolve().parents[2] / "skills"` then points inside the venv,
`_capability_is_empty` returns `None`, and the test fails. Same class of problem as the stale
`core/build/lib/` shadowing filed as #349, one layer further out — purging `core/build` did not fix
it; putting the source tree first (`PYTHONPATH=core`, or an editable install, which is what CI
effectively gets) is green.

## Merge order and the baseline

The baseline test is *designed* to fail when the skill tree changes, so this PR should merge **after**
the skill-content PRs, with the baseline regenerated once against the improved tree.

Measured by applying #348's `skills/capabilities/tools/` over this branch and re-running the lint:
**14 → 11 violations**. #348 clears 3 of `tools`' 4:

| `tools` violation | After #348 |
|---|---|
| body 741 lines | cleared (244) |
| body ~12222 tokens | cleared |
| `optimizer-playbook.md` → `examples.md` ref→ref | cleared |
| `references/examples.md` no TOC | **still fails, and grows 378 → 397 lines** |

Worth flagging to #348: adding ≥ 3 `[section](#anchor)` links to the top of `examples.md` clears
`tools` completely. Remaining after #348: `agent-optimize` 3, `evograph` 4, `skill-package` 2,
`tools` 1, `using-cap-evolve` 1.

## Deliberately out of scope

Splitting `tools` and `agent-optimize`, adding the two TOCs, and fixing `using-cap-evolve`'s
description all belong to the concurrent rewrites (#322-#339) — this PR hands them the measured
checklist instead of racing them for the same files. The lint flips blocking in the PR that empties
the baseline.
