### PR TITLE
refactor(core): drop the dead write-only optimizer-memory API and fix the cache docstring (#114)

### DIFF
--- a/core/cap_evolve/cache.py
+++ b/core/cap_evolve/cache.py
@@ -10,8 +10,10 @@ Honesty notes:
   * It is keyed on candidate-file content, so an edit (even whitespace) busts the
     key — a stale score can never be served for changed files.
   * It is an optimization, not a source of truth: ``events.jsonl`` still records
-    every evaluation. Wiring into ``evaluate_candidate`` is OFF by default and gated
-    behind a flag (see ``maybe_cached_score``) so it cannot silently change behavior.
+    every evaluation.
+  * Scope: GEPA only. ``gepa`` constructs one cache and consults it inside its
+    minibatch eval; ``harness.evaluate_candidate`` never touches it, so a plain
+    hill-climb / skillopt run is unaffected.
 
 Pure stdlib (hashlib + json).
 """

--- a/core/cap_evolve/gepa.py
+++ b/core/cap_evolve/gepa.py
@@ -579,7 +579,7 @@ def gepa_loop(
         refl_summary = _write_reflection(workdir, parent_mb)
         focus_label = _write_focus(workdir, comps, focus)
         instructions = _instructions(refl_summary, focus_label, mb)
-        instructions = _augment_instructions(instructions, workdir, run_dir, rejected, history)
+        instructions = _augment_instructions(instructions, workdir, run_dir)
 
         # Seal the eval surface for this child. GEPA runs the optimizer itself rather
         # than via ``harness.run_step``, so it needs the same two calls. None = off.

--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -874,18 +874,7 @@ def _journal_tail(workdir: Path) -> str:
     return tail.replace(_JOURNAL_MARK, "").strip()
 
 
-def _latest_journal_note(workdir: Path, *, max_chars: int = 900) -> str | None:
-    """The newest journal entry, capped — stored in the factual ledger as the candidate's
-    one-line lineage note. Returns ``None`` when the optimizer appended nothing."""
-    tail = _journal_tail(workdir)
-    if not tail:
-        return None
-    if len(tail) > max_chars:
-        tail = tail[:max_chars].rstrip() + " …"
-    return tail
-
-
-def _build_ledger(workdir: Path, run_dir: RunDir, rejected, history) -> None:
+def _build_ledger(workdir: Path, run_dir: RunDir) -> None:
     """Write the FACTUAL, framework-owned LEDGER.md: one row per prior iteration with
     its outcome + the exact tasks it broke/fixed. Deterministic — the objective record;
     the optimizer's own narrative lives in JOURNAL.md."""
@@ -1059,8 +1048,7 @@ def _build_runmap(workdir: Path, run_dir: RunDir) -> None:
     (workdir / "RUNMAP.md").write_text(text, encoding="utf-8")
 
 
-def _augment_instructions(instructions: str, workdir: Path, run_dir: RunDir,
-                          rejected, history) -> str:
+def _augment_instructions(instructions: str, workdir: Path, run_dir: RunDir) -> str:
     """Give the optimizer its four cross-iteration files + a prompt pointer to each.
 
     Clean ownership (see the file-header comment near ``_JOURNAL_SEED``):
@@ -1070,7 +1058,7 @@ def _augment_instructions(instructions: str, workdir: Path, run_dir: RunDir,
       - RUNMAP.md + prior_iterations/ — framework manifest + copies of every prior
         iteration's PROCESS.md and capability diff (real prior-work-dir access).
     """
-    _build_ledger(workdir, run_dir, rejected, history)
+    _build_ledger(workdir, run_dir)
     _seed_journal(workdir, run_dir)
     if not (workdir / "PROCESS.md").exists():
         (workdir / "PROCESS.md").write_text(_PROCESS_SEED, encoding="utf-8")
@@ -1462,7 +1450,7 @@ def run_step(
                               capabilities=capabilities, optimizer_name=optimizer_name,
                               capability_sources=capability_sources, project_dir=project_dir)
 
-    instructions = _augment_instructions(instructions, workdir, run_dir, rejected, history)
+    instructions = _augment_instructions(instructions, workdir, run_dir)
 
     # Seal the eval surface (hash manifest + best-effort read-only bits) AFTER the
     # context injection wrote its scratch files, so nothing we add ourselves reads as
@@ -1575,26 +1563,16 @@ def run_step(
     run_dir.record_spend_warnings()
 
     # update optimizer memory + commit the iteration to the version store so the
-    # whole process stays inspectable (git log / LEDGER / JOURNAL). The `note` is the
-    # optimizer's own handover (its approach + lesson), taken from the entry it appended
-    # to JOURNAL.md this iteration so the lineage record carries what was tried, not just Δ/SE.
+    # whole process stays inspectable (git log / LEDGER / JOURNAL).
     delta = cand_val.reward - current_val.reward
     summary = f"candidate {cid} (val {cand_val.reward:.3f}, Δ {delta:+.3f})"
     # Fold the optimizer's appended JOURNAL entry into the run-level append-only journal
-    # (so handover accumulates across accepted AND rejected iterations), and reuse it as
-    # the candidate's lineage note in the factual ledger.
+    # (so handover accumulates across accepted AND rejected iterations).
     _reconcile_journal(workdir, run_dir, cid, accepted=accepted,
                        val=cand_val.reward, delta=delta)
-    note = _latest_journal_note(workdir)
-    # Per-task broke/fixed lists vs the parent (from the rollouts just persisted), so
-    # MEMORY records the SPECIFIC tasks a candidate broke — not just a category — and
-    # the next iteration won't retry the regression. Best-effort; None when not
-    # comparable (e.g. parent rollouts absent).
-    impact = _candidate_task_impact(run_dir, cid, "val",
-                                    parent_of={cid: parent_id})
     if accepted:
         if history is not None:
-            history.add(cid, summary, cand_val.reward, note=note, impact=impact)
+            history.add(cid, summary, cand_val.reward)
     elif decision.indecisive:
         # Do NOT record an indecisive step as a rejection. The rejected list is fed
         # back to the optimizer as "these edits did not work" guidance, and an
@@ -1605,7 +1583,7 @@ def run_step(
                           n_tasks=cand_val.n_tasks)
     else:
         if rejected is not None:
-            rejected.add(cid, summary, decision.reason, cand_val.reward, note=note, impact=impact)
+            rejected.add(cid, summary, decision.reason, cand_val.reward)
     if store is not None:
         store.commit(f"iter {run_dir.spent.iterations}: "
                      f"{'ACCEPT' if accepted else 'reject'} {summary}",

--- a/core/cap_evolve/memory.py
+++ b/core/cap_evolve/memory.py
@@ -1,14 +1,15 @@
 """Optimizer memory: rejected approaches + accepted history.
 
-Two append-only records that survive across iterations:
+Two append-only, WRITE-ONLY-BY-DESIGN audit records in the run dir:
 
-- ``RejectedMemory`` — every candidate the gate rejected, with the reason. Its
-  ``render()`` produces a markdown block fed into the *next* proposal prompt as
-  STEERING: don't re-submit a regressed edit verbatim, but a better-designed version
-  of the same idea may still work — so a high-value cluster is not permanently
-  abandoned (prior agent-optimization work's RejectedMemory / evo-graph's Rejected Memory Store).
-- ``History`` — every accepted candidate, so the loop can show the optimizer
-  what worked and reconstruct the best-so-far lineage.
+- ``RejectedMemory`` — every candidate the gate rejected, with the reason.
+- ``History`` — every accepted candidate, so the run's lineage is reconstructable.
+
+Nothing in the core re-reads them. The readers are the dashboard
+(``GET /api/runs/{id}/memory`` → the Deep-Dive Memory panel, and the static
+export) and any optimizer prompt that greps ``rejected.jsonl`` itself. What the
+optimizer is *told* each iteration comes from the framework-owned LEDGER.md /
+JOURNAL.md instead (see ``harness._augment_instructions``).
 
 Backed by jsonl files in the run dir; pure stdlib.
 """
@@ -20,89 +21,21 @@ from pathlib import Path
 from typing import Optional
 
 
-def _store_impact(rec: dict, impact: Optional[dict]) -> None:
-    """Attach a candidate's per-task broke/fixed lists to its memory record.
-
-    ``impact`` is the dict produced by ``harness._candidate_task_impact``
-    (``{"broke": [...], "fixed": [...], ...}``). Only the non-empty broke/fixed
-    lists are stored, so old records (impact=None) stay byte-identical and the
-    memory file is not bloated when there was no per-task movement."""
-    if not impact:
-        return
-    broke = [str(t) for t in (impact.get("broke") or [])]
-    fixed = [str(t) for t in (impact.get("fixed") or [])]
-    if broke:
-        rec["broke"] = broke
-    if fixed:
-        rec["fixed"] = fixed
-
-
-def _render_impact(e: dict) -> Optional[str]:
-    """One-line per-task impact for a memory entry, or None when there is none."""
-    broke = e.get("broke") or []
-    fixed = e.get("fixed") or []
-    if not broke and not fixed:
-        return None
-    parts = []
-    if broke:
-        parts.append("broke {" + ", ".join(str(t) for t in broke) + "}")
-    if fixed:
-        parts.append("fixed {" + ", ".join(str(t) for t in fixed) + "}")
-    return "per-task impact: " + "; ".join(parts)
-
-
 class RejectedMemory:
     def __init__(self, path: Path):
         self.path = Path(path)
         self.path.parent.mkdir(parents=True, exist_ok=True)
 
-    def add(self, candidate_id: str, summary: str, reason: str, val: Optional[float] = None,
-            note: Optional[str] = None, impact: Optional[dict] = None) -> None:
+    def add(self, candidate_id: str, summary: str, reason: str,
+            val: Optional[float] = None) -> None:
         rec = {
             "candidate_id": candidate_id,
             "summary": summary.strip(),
             "reason": reason.strip(),
             "val": val,
         }
-        if note and note.strip():
-            rec["note"] = note.strip()
-        _store_impact(rec, impact)
         with self.path.open("a", encoding="utf-8") as f:
             f.write(json.dumps(rec) + "\n")
-
-    def entries(self) -> list[dict]:
-        if not self.path.exists():
-            return []
-        out = []
-        for line in self.path.read_text(encoding="utf-8").splitlines():
-            line = line.strip()
-            if line:
-                out.append(json.loads(line))
-        return out
-
-    def render(self, limit: int = 20) -> str:
-        """Markdown block for the proposal prompt: approaches that regressed AS
-        IMPLEMENTED — steering, not a permanent ban-list."""
-        items = self.entries()[-limit:]
-        if not items:
-            return "_No regressed approaches yet._"
-        lines = [
-            "## Approaches that regressed AS IMPLEMENTED",
-            "These exact edits were rejected by the gate. Don't re-submit them verbatim — "
-            "but a better-designed version of the same idea MAY still work, so don't "
-            "permanently abandon a high-value cluster. Each shows its reject reason "
-            "(and per-task impact) so you can redesign rather than repeat.",
-        ]
-        for e in items:
-            v = f" (val={e['val']:.4f})" if e.get("val") is not None else ""
-            lines.append(f"- **{e['summary']}** — rejected: {e['reason']}{v}")
-            note = (e.get("note") or "").strip()
-            if note:
-                lines.append(f"  - approach + lesson: {note}")
-            imp = _render_impact(e)
-            if imp:
-                lines.append(f"  - {imp}")
-        return "\n".join(lines)
 
 
 class History:
@@ -110,36 +43,7 @@ class History:
         self.path = Path(path)
         self.path.parent.mkdir(parents=True, exist_ok=True)
 
-    def add(self, candidate_id: str, summary: str, val: float,
-            note: Optional[str] = None, impact: Optional[dict] = None) -> None:
+    def add(self, candidate_id: str, summary: str, val: float) -> None:
         rec = {"candidate_id": candidate_id, "summary": summary.strip(), "val": val}
-        if note and note.strip():
-            rec["note"] = note.strip()
-        _store_impact(rec, impact)
         with self.path.open("a", encoding="utf-8") as f:
             f.write(json.dumps(rec) + "\n")
-
-    def entries(self) -> list[dict]:
-        if not self.path.exists():
-            return []
-        out = []
-        for line in self.path.read_text(encoding="utf-8").splitlines():
-            line = line.strip()
-            if line:
-                out.append(json.loads(line))
-        return out
-
-    def render(self, limit: int = 10) -> str:
-        items = self.entries()[-limit:]
-        if not items:
-            return "_No accepted edits yet (this is the baseline)._"
-        lines = ["## Accepted edits so far (what worked)"]
-        for e in items:
-            lines.append(f"- {e['summary']} → val={e['val']:.4f}")
-            note = (e.get("note") or "").strip()
-            if note:
-                lines.append(f"  - approach + lesson: {note}")
-            imp = _render_impact(e)
-            if imp:
-                lines.append(f"  - {imp}")
-        return "\n".join(lines)

--- a/core/tests/test_core.py
+++ b/core/tests/test_core.py
@@ -130,14 +130,16 @@ def test_combined_stderr_zero_for_single_certain_task():
 
 # ---- rejected memory ------------------------------------------------------
 
-def test_rejected_memory_roundtrip_and_render(tmp_path):
-    rm = RejectedMemory(tmp_path / "rejected.jsonl")
+def test_rejected_memory_writes_the_jsonl_the_dashboard_reads(tmp_path):
+    """RejectedMemory is a write-only audit record: one json object per line with the
+    fields the dashboard's memory panel renders. Nothing in core re-reads it."""
+    import json as _json
+    path = tmp_path / "rejected.jsonl"
+    rm = RejectedMemory(path)
     rm.add("c1", "added verbose preamble", "Δ<=0 on val", val=0.41)
     rm.add("c2", "removed the schema hint", "regressed val", val=0.30)
-    assert len(rm.entries()) == 2
-    rendered = rm.render()
-    assert "added verbose preamble" in rendered
-    # The block is reframed as STEERING (regressed-as-implemented), not a hard ban:
-    # it must still steer the optimizer away from re-submitting the rejected edit.
-    low = rendered.lower()
-    assert "regressed" in low and "re-submit" in low
+    recs = [_json.loads(ln) for ln in path.read_text(encoding="utf-8").splitlines() if ln.strip()]
+    assert len(recs) == 2
+    assert recs[0] == {"candidate_id": "c1", "summary": "added verbose preamble",
+                       "reason": "Δ<=0 on val", "val": 0.41}
+    assert recs[1]["candidate_id"] == "c2"

--- a/core/tests/test_per_task_impact.py
+++ b/core/tests/test_per_task_impact.py
@@ -56,7 +56,7 @@ def test_per_task_impact_lists_broken_task():
     # broken/fixed task ids are surfaced in cand_0001's row.
     import tempfile as _tf
     workdir = Path(_tf.mkdtemp())
-    harness._build_ledger(workdir, rd, rejected, None)
+    harness._build_ledger(workdir, rd)
     ledger = (workdir / "LEDGER.md").read_text(encoding="utf-8")
     assert "cand_0001" in ledger
     # Row format: | iter | candidate | parent | outcome | val | Δ | broke {..} | fixed {..} |

--- a/dashboard/frontend/src/components/MemoryPanel.tsx
+++ b/dashboard/frontend/src/components/MemoryPanel.tsx
@@ -7,7 +7,8 @@ import { pct } from '../lib/format'
 import { Card } from './ui/Card'
 import { Skeleton } from './ui/Skeleton'
 
-/** Optimizer memory: accepted history, rejected ("do-not-re-propose"), and the
+/** Optimizer memory: accepted history, rejected candidates (an audit trail — the core
+ * does not re-read it to avoid re-proposing), and the
  * per-candidate snapshot files (PROCESS.md explainability / INSTRUCTIONS.md / the
  * capability files). */
 export function MemoryPanel({ runId, graph }: { runId: string; graph: RunGraph }) {


### PR DESCRIPTION
Fresh minimal reimplementation of #212 against current main (`d94fb336`). Not a rebase of
`refactor/issue-114-drop-write-only-memory` — written from scratch, guided by the review.

Net: **+39 / −152** across 7 files. Pure deletion; no new files, no new abstractions, no deps.

## What was removed, and the grep proving each was dead

### 1. The prompt-facing optimizer-memory API

```
$ grep -rn '_store_impact\|_render_impact\|\.render()\|\.entries()' core/ skills/ docs/ templates/ examples/ dashboard/ \
    --include='*.py' --include='*.md' --include='*.ts' --include='*.tsx' | grep -v build/
core/cap_evolve/memory.py:23:def _store_impact(rec: dict, impact: Optional[dict]) -> None:
core/cap_evolve/memory.py:40:def _render_impact(e: dict) -> Optional[str]:
core/cap_evolve/memory.py:69:        _store_impact(rec, impact)
core/cap_evolve/memory.py:86:        items = self.entries()[-limit:]
core/cap_evolve/memory.py:102:            imp = _render_impact(e)
core/cap_evolve/memory.py:118:        _store_impact(rec, impact)
core/cap_evolve/memory.py:133:        items = self.entries()[-limit:]
core/cap_evolve/memory.py:142:            imp = _render_impact(e)
core/tests/test_core.py:137:    assert len(rm.entries()) == 2
core/tests/test_core.py:138:    rendered = rm.render()
```

Eight hits are `memory.py` calling itself. The only other two are a test that exercised
nothing but the dead function. Nothing in `core/cap_evolve`, `skills/`, `examples/`, or
`dashboard/` ever called `render()`/`entries()` — **no rendered memory block reached any
optimizer prompt.** `memory.py`: 145 → 48 lines.

**The jsonl WRITES are kept — deliberately.** `RejectedMemory.add` / `History.add`,
`rundir.py`'s `rejected_path` / `history_path`, and both files stay, because they have live
readers:

```
$ grep -rn 'rejected.jsonl\|history.jsonl' dashboard/ skills/ --include='*.py' --include='*.md' | grep -v build/
dashboard/backend/capevolve_dashboard/memory.py:31:        "history": _read_jsonl(root / "history.jsonl"),
dashboard/backend/capevolve_dashboard/memory.py:32:        "rejected": _read_jsonl(root / "rejected.jsonl"),
skills/algorithms/agent-optimize/SKILL.md:237:**Read `$R/rejected.jsonl` and make each proposal STRUCTURALLY different [...]
```

`GET /api/runs/{id}/memory` → `MemoryPanel.tsx` (Deep-Dive Memory tab) + `export_static.py`,
plus the agent-optimize skill greps the file directly. Deleting the writes would blank a
shipped UI panel. Issue #114's step-1 parenthetical ("the dashboard reads events.jsonl, not
these") is **wrong**; following it literally would have been a regression.

### 2. Dead `rejected` / `history` params

```
$ grep -rn '_augment_instructions\|_build_ledger' core/cap_evolve/ core/tests/ | grep -v build/
core/cap_evolve/harness.py:888:def _build_ledger(workdir: Path, run_dir: RunDir, rejected, history) -> None:
core/cap_evolve/harness.py:1062:def _augment_instructions(instructions: str, workdir: Path, run_dir: RunDir,
core/cap_evolve/harness.py:1073:    _build_ledger(workdir, run_dir, rejected, history)
core/cap_evolve/harness.py:1465:    instructions = _augment_instructions(instructions, workdir, run_dir, rejected, history)
core/cap_evolve/gepa.py:582:        instructions = _augment_instructions(instructions, workdir, run_dir, rejected, history)
core/tests/test_per_task_impact.py:59:    harness._build_ledger(workdir, rd, rejected, None)
```

`_augment_instructions` used them *only* to forward to `_build_ledger`, whose body never
reads either (its one `rejected` match in `harness.py:888-935` is the prose string
`"the gate accepted vs rejected."`). Four dead params threaded through three call sites.

### 3. `_latest_journal_note` — one caller, and it fed the dead kwarg

```
$ grep -rn '_latest_journal_note' core/ skills/ docs/ templates/ examples/ | grep -v build/
core/cap_evolve/harness.py:877:def _latest_journal_note(workdir: Path, *, max_chars: int = 900) -> str | None:
core/cap_evolve/harness.py:1588:    note = _latest_journal_note(workdir)
```

Its sole consumer was `note=note` on the memory writes. `_journal_tail` (its helper) is
**kept** — `_reconcile_journal` at `harness.py:967` still uses it.

### 4. Redundant per-iteration disk re-read

`_candidate_task_impact(run_dir, cid, "val", parent_of={cid: parent_id})` at `harness.py:1592-1593`
re-read rollouts from disk every iteration; its only consumers were `impact=impact` on the two
dead-kwarg calls. No signal lost: `_build_ledger` (`harness.py:917`) and `_reconcile_journal`
(`harness.py:975`) each call `_candidate_task_impact` independently, and the per-task
broke/fixed lists still reach the optimizer via the framework-owned `LEDGER.md`.

### 5. The misleading cache docstring — it named a function that does not exist

```
$ grep -rn 'maybe_cached_score' core/ skills/ docs/ templates/ examples/ dashboard/ | grep -v build/
core/cap_evolve/cache.py:14:    behind a flag (see ``maybe_cached_score``) so it cannot silently change behavior.
```

**One hit — its own docstring.** No such function, no such flag, no such wiring. The only
`EvalCache` consumer is GEPA (`gepa.py:499` constructs it; `gepa.py:154/159/189` use it in
`_eval_minibatch`); `harness.evaluate_candidate` never touches it. Replaced with the real scope.

### 6. Two more false in-code claims corrected

- `harness.py:1566-1573` — comments describing the `note` as "the candidate's lineage note in
  the factual ledger"; nothing stored or read it.
- `dashboard/frontend/src/components/MemoryPanel.tsx:10` — called rejected a
  `"do-not-re-propose"` list. Nothing re-reads it to avoid re-proposing. Now says it is an
  audit trail. **This is the only frontend change: a 1-line comment, no code, no behavior.**

## Symbols checked and NOT removed

- `RejectedMemory` / `History` stay exported from `core/cap_evolve/__init__.py` (`__all__`
  lines 61-62) — the writers are live.
- `_journal_tail`, `_candidate_task_impact`, `_reconcile_journal`, `RunDir.rejected_path` /
  `history_path`, `EvalCache` — all have live readers.

## Test result (full suite, pasted)

`pip install ./core` in this repo installs a **stale copy** (setuptools reuses the
`core/build/lib` artifact — its `_capability_is_empty` differs from source and fails
`test_empty_seed.py`), so the suite is run against source via `PYTHONPATH=core`, as the
review did.

```
$ PYTHONPATH=core python -m pytest core/tests -q
........................................................................ [ 90%]
........................................................................ [ 99%]
.......                                                                  [100%]
789 passed, 12 skipped in 133.72s (0:02:13)
```

Same tree on `main` (`d94fb336`), same command: `789 passed, 12 skipped` — **no test lost**.
One test was rewritten, not deleted: `test_core.py::test_rejected_memory_roundtrip_and_render`
asserted on the removed `render()`/`entries()`, so it is replaced by
`test_rejected_memory_writes_the_jsonl_the_dashboard_reads`, which asserts the on-disk record
shape the dashboard actually consumes — real behavior, not an import.
`test_per_task_impact.py:59` was updated for `_build_ledger`'s new signature.

## Zero-API end-to-end proof (pasted)

```
$ bash examples/toy_calc/run.sh 2>&1 | tail -15
{"baseline_val":0.0,"best_id":"cand_0001","dashboard":".capevolve/run_demo/dashboard.html","dashboard_server":"http://127.0.0.1:7890","iterations":3,"run_dir":".capevolve/run_demo","test_baseline_reward":0.0,"test_delta":1.0,"test_pass_k":{"1":1.0},"test_reward":1.0}
```

Gate-accepted `cand_0001`, sealed test reward **1.0** (Δ +1.0) over 3 iterations.

## Not done / deliberately left

- **No failure-memory reader built.** #222 / issues #128/#129 propose making rejected memory
  genuinely read again (`approach_signature`, dead-end constraints). Nothing scaffolded for it
  here — this PR only removes what is dead today. If #222 lands after this, it must re-update
  `MemoryPanel.tsx:10` (its whole point is to make "do-not-re-propose" true again).
- **The jsonl writes and both file paths kept** — see above; removing them blanks a shipped panel.
- **`core/build/lib/cap_evolve/` untouched** — stale build artifact, excluded from every grep.
  Its stale-install behavior is noted above but not fixed here (out of scope).
- **`dashboard/backend` tests not run** — no backend Python changed; the only dashboard edit is
  a frontend comment.
- **Docs left alone where they were already true.** `skills/algorithms/skillopt/SKILL.md:28`
  ("with RejectedMemory/History") and `references/concepts.md:65` ("the global RejectedMemory in
  `run_step` still records all rejects") remain accurate now that the writes stay — no edit needed.
- **`harness.py:1580`'s comment** ("the rejected list is fed back to the optimizer") kept: it is
  true via `agent-optimize/SKILL.md:237`, which greps `rejected.jsonl` directly.

Closes #114.
