### PR TITLE
gate: correct the documented modes to match the code, delete unreachable simplicity_tiebreak

### DIFF
--- a/core/cap_evolve/gate.py
+++ b/core/cap_evolve/gate.py
@@ -1,9 +1,20 @@
 """Acceptance gate — the rule that decides whether a candidate edit is kept.
 
-The default is the *significance* gate (prior agent-optimization work's ``val_improvement_significant``):
-accept only when the val improvement exceeds k standard errors, so noise does
-not get mistaken for progress. All gates compare on VAL and never on TRAIN —
-``decide`` takes an explicit ``split`` and refuses anything but ``val``.
+**The default for every real run is the ``paired`` gate.** The optimization loop
+builds the aligned per-task delta vector and selects ``paired`` unless the caller
+pinned a mode (``harness.py:1524-1526``, ``gepa.py:741-743``), and the shipped
+config says so (``templates/project/capevolve.yaml``: ``gate_mode: paired``).
+``decide``'s own ``mode=`` parameter defaults to ``significant`` only as the
+fallback for a bare caller that has no per-task data.
+
+The bar is ``Δ > k·SE``, not ``Δ > 0``, because search is a noise amplifier:
+screen enough candidates and the best-looking one is best by luck, so a ``Δ > 0``
+rule banks noise as progress and the val curve climbs while nothing improved.
+Requiring the gain to clear ``k`` standard errors of its own measurement error is
+what makes an accept mean something.
+
+All gates compare on VAL and never on TRAIN — ``decide`` takes an explicit
+``split`` and refuses anything but ``val``.
 """
 
 from __future__ import annotations
@@ -91,8 +102,6 @@ def decide(
     candidate_stderr: float = 0.0,
     current_stderr: float = 0.0,
     threshold: float = 0.0,
-    candidate_size: int | None = None,
-    current_size: int | None = None,
     paired_deltas: list | None = None,
     coverage: float | None = None,
     min_coverage: float = 0.6,
@@ -111,9 +120,8 @@ def decide(
         as INDEPENDENT samples — correct only when they were not scored on the
         same tasks; less powerful than ``paired``).
       - ``threshold``:   accept iff delta > ``threshold`` (a flat margin).
-      - ``strict``:      accept iff delta > 0 (any improvement).
-      - ``simplicity_tiebreak``: like strict, but on a (near-)tie prefer the
-        smaller candidate (``candidate_size`` < ``current_size``).
+      - ``strict``:      accept iff delta > 0 (any improvement). Only safe with a
+        near-zero-variance scorer: with a noisy one it banks noise as progress.
 
     ``coverage`` is the fraction of val tasks that produced a real measurement
     (``SplitResult.coverage``). Below ``min_coverage`` the gate REFUSES TO JUDGE and
@@ -213,19 +221,5 @@ def decide(
     if mode == "strict":
         ok = delta > 0
         return GateDecision(ok, f"Δ={delta:+.4f} {'>' if ok else '<='} 0", delta, 0.0)
-
-    if mode == "simplicity_tiebreak":
-        if delta > 0:
-            return GateDecision(True, f"Δ={delta:+.4f} > 0", delta, 0.0)
-        tie = abs(delta) <= 1e-9
-        if tie and candidate_size is not None and current_size is not None and candidate_size < current_size:
-            return GateDecision(
-                True,
-                f"tie (Δ={delta:+.4f}); accepted smaller candidate "
-                f"({candidate_size} < {current_size})",
-                delta,
-                0.0,
-            )
-        return GateDecision(False, f"Δ={delta:+.4f} <= 0 (no simpler tie)", delta, 0.0)
 
     raise ValueError(f"unknown gate mode: {mode!r}")

--- a/core/tests/test_core.py
+++ b/core/tests/test_core.py
@@ -78,10 +78,12 @@ def test_strict_gate_accepts_any_improvement():
     assert decide(0.5, 0.5, split="val", mode="strict").accept is False
 
 
-def test_simplicity_tiebreak_prefers_smaller_on_tie():
-    d = decide(0.5, 0.5, split="val", mode="simplicity_tiebreak",
-               candidate_size=10, current_size=20)
-    assert d.accept is True
+def test_removed_modes_are_rejected_not_silently_accepted():
+    # simplicity_tiebreak was unreachable dead code (nothing ever populated the
+    # sizes) so it silently behaved as `strict`. Removed — an unknown mode must
+    # raise, never quietly become a weaker gate.
+    with pytest.raises(ValueError):
+        decide(0.5, 0.5, split="val", mode="simplicity_tiebreak")
 
 
 # ---- stats ----------------------------------------------------------------

--- a/docs/ADAPTER_CONTRACT.md
+++ b/docs/ADAPTER_CONTRACT.md
@@ -91,6 +91,10 @@ The gate reads only the **primary** metric (the scalar `reward`). Any shown-only
 secondaries a `score()` returns are carried through for display but can never move an
 accept/reject decision or the sealed number.
 
+The acceptance gate itself (`gate_mode`, default `paired`, and why the bar is
+`Δ > k·SE` rather than `Δ > 0`) is documented once in
+[HONEST_EVAL.md](HONEST_EVAL.md#the-four-guarantees).
+
 ## Everything else is provided
 
 Splits, trials, gating, pass^k, rejected-memory, run-dir state, parent selection, the

--- a/docs/HONEST_EVAL.md
+++ b/docs/HONEST_EVAL.md
@@ -16,10 +16,27 @@ construction*, and the rules below are enforced in code, not just documented.
    produced exactly once, at `finalize`. (See `splits.py`, `rundir.py`.)
 
 3. **Acceptance is gated on val, with significance.** `gate.decide(...)` refuses
-   any split but `val` (`TrainGateError`) and, by default, accepts a candidate
-   only when the improvement exceeds `k · SE` — so noise is not mistaken for
-   progress (`mode="significant"`). Other modes (`strict`, `threshold`,
-   `simplicity_tiebreak`) exist but never relax the val-only rule. The gate reads
+   any split but `val` (`TrainGateError`) and accepts a candidate only when the
+   improvement exceeds `k · SE`. The bar is `Δ > k·SE` and not `Δ > 0` because
+   search is a noise amplifier: screen enough candidates and the best-looking one
+   is best by *luck*, so a `Δ > 0` rule banks noise and the val curve climbs while
+   nothing actually improved. Clearing `k` standard errors of the measurement's own
+   error is what makes an accept mean something — which is why turning the gate
+   down to `strict` on a stochastic scorer quietly invalidates the whole run.
+
+   **Gate modes** (`gate_mode` in `capevolve.yaml`, `gate_k_se` sets `k`):
+
+   | mode | rule | when |
+   |---|---|---|
+   | `paired` | mean(per-task Δ) > `k`·SE(Δ) over the **same** val tasks | **the default** — every run takes it when per-task data exists; cross-task difficulty cancels, so it is strictly more powerful |
+   | `significant` | Δ > `k`·√(SE_cand² + SE_curr²) | unpaired fallback — only correct when the two sides were *not* scored on the same tasks |
+   | `threshold` | Δ > `T` | you have a domain minimum worth banking |
+   | `strict` | Δ > 0 | only a near-zero-variance (deterministic) scorer |
+
+   Any other value raises. `decide()`'s own `mode=` parameter defaults to
+   `significant` purely as the bare-caller fallback; the loop overrides it to
+   `paired` (`harness.py:1524-1526`, `gepa.py:741-743`) and the shipped template
+   sets `gate_mode: paired`. No mode relaxes the val-only rule. The gate reads
    only the **primary** metric (the scalar `reward`); any shown-only secondary
    metrics a scorer emits (`Score.metrics`) are for display and cannot move the
    decision.

--- a/docs/OPTIMIZE_YOUR_OWN.md
+++ b/docs/OPTIMIZE_YOUR_OWN.md
@@ -100,9 +100,11 @@ you want intake to ask):
 - max_optimizer_usd:    <cumulative optimizer-only $ cap; 0 = unlimited>
 - optimizer_usd_per_iter: <PER-ITERATION $ cap enforced by the optimizer CLI itself, e.g. claude `--max-budget-usd N`>
 - optimizer_max_turns:  <per-iteration WORK cap passed to the agent CLI, e.g. claude `--max-turns N`>
-- gate:                 <significant (k_se) | strict | threshold>
-                        # significant: accept only if Δ > k_se · SE — k_se is how many standard errors
-                        # the val gain must clear (e.g. 0.2 = lenient, 1.0 = strict) so noise isn't mistaken for progress
+- gate_mode:            <paired (default) | significant | threshold | strict>
+- gate_k_se:            <how many standard errors the val gain must clear (0.2 = lenient, 1.0 = strict)>
+                        # paired: accept only if mean(per-task Δ) > gate_k_se · SE(Δ) over the SAME val
+                        # tasks. The bar is Δ > k·SE and not Δ > 0 because search amplifies noise — with
+                        # enough candidates the best-looking one is best by luck. See docs/HONEST_EVAL.md.
 - stall:                <stop after N consecutive rejects; 0 = run all max_iterations>
 - store:                git          # versions every iteration as a commit for an inspectable process
 ```

--- a/examples/tau2_airline/capevolve.yaml
+++ b/examples/tau2_airline/capevolve.yaml
@@ -39,7 +39,7 @@ split_ids_file: split_ids.json
 num_trials: 10              # gpt-oss is stochastic; 10 trials → mean+stderr + pass^k
 
 # --- acceptance gate --------------------------------------------------------
-gate_mode: paired                        # paired (recommended) | significant | strict | threshold | simplicity_tiebreak
+gate_mode: paired                        # paired (recommended) | significant | strict | threshold
 #   paired tests mean(per-task Δ) on the SAME tasks both sides → SE ~2-3x smaller than
 #   the combined-SE `significant` test, so a real 1-task gain actually banks instead of
 #   being lost in between-task variance. Falls back to significant when no per-task data.

--- a/skills/algorithms/agent-optimize/scripts/gate_check.py
+++ b/skills/algorithms/agent-optimize/scripts/gate_check.py
@@ -97,8 +97,7 @@ def main(argv=None) -> int:
     p.add_argument("--current", default=None,
                    help="tag to compare against; default = the run's current best_id")
     p.add_argument("--mode", default="paired",
-                   choices=["paired", "significant", "strict", "threshold",
-                            "simplicity_tiebreak"])
+                   choices=["paired", "significant", "strict", "threshold"])
     p.add_argument("--k-se", type=float, default=1.0)
     p.add_argument("--threshold", type=float, default=0.0)
     p.add_argument("--veto-regressions", action="store_true",

--- a/skills/phases/gate/SKILL.md
+++ b/skills/phases/gate/SKILL.md
@@ -25,30 +25,42 @@ reward beats the current best by **more than `k` standard errors**.
 - **provides:** `decision` — `{accept, reason, delta, threshold}`, the audit
   record of why a candidate was kept or rejected.
 
-## The significance rule (default)
+## The significance rule
 ```
-SE = sqrt(candidate_stderr^2 + current_stderr^2)     # SE of the difference
-accept  ⟺  Δ = candidate_val − current_val  >  k · SE
+paired (the default):   accept ⟺ mean(Δ[t]) > k · SE(Δ)     over the SAME val tasks
+significant (fallback): accept ⟺ Δ = cand − curr > k · sqrt(cand_se² + curr_se²)
 ```
-This is the standard test for "is the difference real?": the SE of a difference
-of two independent means is the root-sum-of-squares of their SEs, and `Δ > k·SE`
-asks whether the gap clears `k` standard errors of that difference. `k=1` is
+The bar is `Δ > k·SE` and **not `Δ > 0`** because search is a noise amplifier:
+screen enough candidates and the best-looking one is best by *luck*, so `Δ > 0`
+banks noise as progress and the val curve climbs while nothing improved. Clearing
+`k` standard errors of the measurement's own error is what makes an accept mean
+something — turn this down and the run's numbers stop being evidence. `k=1` is
 lenient (~1σ); raise it to be stricter. It is the textual-optimization analogue of
-Koehn's bootstrap significance test for metric differences — accept only when the
-gap is unlikely to be noise.
+Koehn's bootstrap significance test for metric differences.
+
+`paired` is stronger because both sides were scored on the *same* val tasks, so
+per-task difficulty cancels and only the paired variance counts; `significant`
+treats the two means as independent samples and is only correct when they are.
 
 **Single-trial scores report `stderr=0`, collapsing `k·SE` to 0** — then
 `significant` silently degrades to `strict` and accepts any positive blip. If you
 run the significance gate, score with multiple trials (see `evaluate`).
 
 ## Modes
-- `significant` (default): `Δ > k·SE` — variance-aware, the honest choice.
-- `strict`: `Δ > 0` — any improvement. Only safe with a near-zero-variance scorer
-  (deterministic, single correct answer).
+- `paired` (**the default**): `mean(per-task Δ) > k·SE(Δ)`. The loop selects it
+  whenever per-task val data exists (`harness.py:1524-1526`, `gepa.py:741-743`)
+  and `capevolve.yaml` ships `gate_mode: paired`.
+- `significant`: `Δ > k·SE_combined` — the **unpaired fallback**, used when the two
+  sides aren't aligned per task. `decide()`'s own `mode=` parameter defaults here
+  for bare callers with no per-task data; that is not the default of a real run.
 - `threshold`: `Δ > T` — a flat margin (use when you have a domain minimum
   worthwhile gain, e.g. "don't bother unless +2pp").
-- `simplicity_tiebreak`: like strict, but on a (near-)tie prefer the smaller
-  candidate — an Occam bias against bloated edits that don't earn their size.
+- `strict`: `Δ > 0` — any improvement. Only safe with a near-zero-variance scorer
+  (deterministic, single correct answer).
+
+Anything else raises. There is no simplicity/size mode: it was unreachable dead
+code (nothing ever supplied a size) so it silently behaved as `strict`, and it has
+been removed rather than documented.
 
 ## No-regression (the second gate)
 A mean can rise while previously-passing tasks silently break. Pair the
@@ -71,7 +83,7 @@ Algorithms call the gate internally every iteration via the harness; this skill
 exists so a human or agent can reproduce and *understand* a single decision.
 
 ## What good vs bad looks like
-- **Good:** `significant` mode with real multi-trial SEs; a no-regression check on
+- **Good:** `paired` mode (the default) with real multi-trial SEs; a no-regression check on
   top; every accept/reject logged with its `reason`.
 - **Bad:** gating on `train` (the tool refuses this — it overfits the optimizer to
   the data it edits against); `strict` mode on a noisy agent (accepts noise);

--- a/skills/phases/gate/references/concepts.md
+++ b/skills/phases/gate/references/concepts.md
@@ -71,12 +71,15 @@ mean can quietly trade away reliability.
 
 ## Modes, briefly
 
-| mode                  | rule                              | when                                  |
-|-----------------------|-----------------------------------|---------------------------------------|
-| `significant`         | Δ > k·SE                          | default; any stochastic scorer        |
-| `strict`              | Δ > 0                             | only near-zero-variance scorers       |
-| `threshold`           | Δ > T                             | you have a domain "minimum worth it"  |
-| `simplicity_tiebreak` | Δ > 0, else prefer smaller on tie | bias against edits that bloat for free |
+| mode          | rule                              | when                                        |
+|---------------|-----------------------------------|---------------------------------------------|
+| `paired`      | mean(per-task Δ) > k·SE(Δ)        | **default**; both sides scored on the same val tasks, so difficulty cancels |
+| `significant` | Δ > k·√(SE_c² + SE_p²)            | unpaired fallback; the two sides are independent samples |
+| `strict`      | Δ > 0                             | only near-zero-variance scorers             |
+| `threshold`   | Δ > T                             | you have a domain "minimum worth it"        |
+
+Any other value raises. The bar is `Δ > k·SE` rather than `Δ > 0` because the max
+over many noisy candidates is biased upward — `Δ > 0` promotes the luckiest draw.
 
 ## Sources
 - Koehn, "Statistical Significance Tests for Machine Translation Evaluation"

--- a/skills/phases/gate/scripts/run.py
+++ b/skills/phases/gate/scripts/run.py
@@ -31,7 +31,7 @@ import _bootstrap  # noqa: F401
 
 from cap_evolve.gate import decide
 
-_MODES = ["significant", "strict", "threshold", "simplicity_tiebreak", "paired"]
+_MODES = ["paired", "significant", "strict", "threshold"]
 
 
 def main(argv=None) -> int:

--- a/skills/phases/intake/inputs/INPUTS.md
+++ b/skills/phases/intake/inputs/INPUTS.md
@@ -164,7 +164,7 @@ path, how to obtain it, and the alternatives. Never invent a NEEDED input.
 
 - **gate**: `gate_mode` (**paired** recommended — per-task paired SE on the same tasks
   both sides, ~2-3x smaller than combined-SE `significant`, so real 1-task gains bank;
-  also: significant|strict|threshold|simplicity_tiebreak), `gate_k_se` (default 1.0; the
+  also: significant|strict|threshold), `gate_k_se` (default 1.0; the
   examples use 0.2). Add `--no-regression` to forbid breaking passing tasks.
 
 - **metrics (display)**: which numbers to surface and which one GATES.

--- a/templates/project/capevolve.yaml
+++ b/templates/project/capevolve.yaml
@@ -77,7 +77,7 @@ github_integration: false    # mirror-only: mirror the algorithm's work items as
 stop_condition: ""           # agent-mode free-text halt rule, re-read each round (e.g. "stop when val acc >= 0.9 or 5 rounds")
 
 # --- acceptance gate --------------------------------------------------------
-gate_mode: paired                        # paired (recommended: per-task paired SE, same tasks both sides — banks real 1-task gains) | significant | strict | threshold | simplicity_tiebreak
+gate_mode: paired                        # paired (recommended: per-task paired SE, same tasks both sides — banks real 1-task gains) | significant (unpaired fallback) | strict | threshold
 gate_k_se: 1.0
 
 # --- budget -----------------------------------------------------------------


### PR DESCRIPTION
Fixes #104. Fixes #206.

Scoped-down redesign of #198 against current `main`. #198 was authored ~2026-07-29 and two of its three parts are now obsolete or out of scope; the surviving part — the doc/docstring correction — is re-authored from `main` here. See "Dropped from the original PR" at the bottom.

## 1. The gate modes that actually exist, and the real default

Read `core/cap_evolve/gate.py` in full (231 lines before this change). The list is exhaustive — anything else hits `raise ValueError(f"unknown gate mode: {mode!r}")` at `gate.py:231`.

| mode | rule | `gate.py` line (pre-change) |
|---|---|---|
| `paired` | `mean(per-task Δ) > k_se·SE(Δ)`, `SE = sqrt(var(Δ)/n)` with the `n−1` denominator; falls back to `significant` when `paired_deltas` is empty; `SE=0` → warn + strict fallback | `148-182` |
| `significant` | `Δ > k_se·sqrt(SE_cand² + SE_curr²)`; `SE=0` → warn + strict fallback | `184-207` |
| `threshold` | `Δ > threshold` (param defaults to `0.0`, i.e. identical to `strict` unless set) | `209-211`, param at `93` |
| `strict` | `Δ > 0` | `213-215` |
| `simplicity_tiebreak` | `Δ > 0` accepts; on `abs(Δ) ≤ 1e-9` accept if `candidate_size < current_size` | `217-229` — **deleted, see §2** |

**The real default is `paired`.** `decide()`'s own signature says `mode: str = "significant"` (`gate.py:89`), which is what every doc surface copied — but no real run ever takes that branch:

- `core/cap_evolve/harness.py:1524-1526` — `paired_deltas = _paired_deltas(...)`; `if "mode" not in gate_kwargs and paired_deltas is not None: gate_kwargs["mode"] = "paired"`
- `core/cap_evolve/gepa.py:741-743` — the same three lines in `_full_val_gate`
- `templates/project/capevolve.yaml:80` — ships `gate_mode: paired`
- `core/cap_evolve/cli.py:709` — reports the mode as `"auto (paired)"`
- the algorithm skills pass `--gate-mode auto`, which means "pin nothing, let the engine pick `paired`" (`skills/algorithms/hill-climb/scripts/run.py:127-128`)

So `significant` is only the fallback for a bare caller with no per-task data. Confirmed empirically by the `toy_calc` run below, whose gate reasons all read `paired Δ̄=…`.

`paired` is not a cosmetic variant: both sides are scored on the *same* val tasks, so per-task difficulty cancels and only the paired variance counts. It accepts and rejects differently from `significant` on identical data. Documenting `significant` as the default meant a reader working out why a candidate was accepted was reading the formula for a test that never ran.

## 2. `simplicity_tiebreak` is unreachable — deleted

The tiebreak branch at `gate.py:221` requires **both** sizes to be non-`None`. Nothing in the repo populates them. Evidence, run before deleting:

```
$ grep -rn "simplicity_tiebreak\|candidate_size\|current_size" core/ skills/ docs/ templates/ examples/ | grep -v build/
core/cap_evolve/gate.py:94:    candidate_size: int | None = None,
core/cap_evolve/gate.py:95:    current_size: int | None = None,
core/cap_evolve/gate.py:115:      - ``simplicity_tiebreak``: like strict, but on a (near-)tie prefer the
core/cap_evolve/gate.py:116:        smaller candidate (``candidate_size`` < ``current_size``).
core/cap_evolve/gate.py:217:    if mode == "simplicity_tiebreak":
core/cap_evolve/gate.py:221:        if tie and candidate_size is not None and current_size is not None and candidate_size < current_size:
core/cap_evolve/gate.py:225:                f"({candidate_size} < {current_size})",
core/tests/test_core.py:81:def test_simplicity_tiebreak_prefers_smaller_on_tie():
core/tests/test_core.py:82:    d = decide(0.5, 0.5, split="val", mode="simplicity_tiebreak",
core/tests/test_core.py:83:               candidate_size=10, current_size=20)
skills/algorithms/agent-optimize/scripts/gate_check.py:101:                            "simplicity_tiebreak"])
skills/phases/gate/references/concepts.md:79:| `simplicity_tiebreak` | Δ > 0, else prefer smaller on tie | ...
skills/phases/intake/inputs/INPUTS.md:167:  also: significant|strict|threshold|simplicity_tiebreak), `gate_k_se` ...
skills/phases/gate/SKILL.md:50:- `simplicity_tiebreak`: like strict, but on a (near-)tie prefer the smaller
skills/phases/gate/scripts/run.py:34:_MODES = ["significant", "strict", "threshold", "simplicity_tiebreak", "paired"]
docs/HONEST_EVAL.md:22:   `simplicity_tiebreak`) exist but never relax the val-only rule. ...
templates/project/capevolve.yaml:80:gate_mode: paired   # ... | simplicity_tiebreak
examples/tau2_airline/capevolve.yaml:42:gate_mode: paired   # ... | simplicity_tiebreak
```

The **only** producer of `candidate_size` / `current_size` in the entire repo is `core/tests/test_core.py:83` — its own unit test. Neither `harness.run_step`, nor `gepa._full_val_gate`, nor `skillopt`, nor any CLI, skill script, or yaml ever passes a size. Every remaining hit is a parameter declaration, a docstring, the dead branch itself, or a doc/enum entry advertising the mode. No live path populates the fields.

Consequence: a user who set `gate_mode: simplicity_tiebreak` silently got `strict` — the gate is the honesty invariant, so a mode that lies about which rule it applies is the worst possible defect there. It was advertised in 9 places.

Deleted rather than documented as "behaves like strict today" (which is what #198 did), per the scope decision:
- `gate.py:217-229` (the branch), `gate.py:94-95` (the two dead params), `gate.py:115-116` (its docstring entry)
- `core/tests/test_core.py:81-84` replaced by `test_removed_modes_are_rejected_not_silently_accepted`, which asserts `decide(..., mode="simplicity_tiebreak")` now **raises `ValueError`** — pinning that the removal can never regress into a silent weaker gate
- the enum/comment entry in each of the 7 other files

Net deletion in `core/`. If an Occam bias is ever wanted, the right shape is a size penalty on the *score*, owned by the capability — not a gate mode in core, which would force a capability-specific notion of "size" into `core/gate.py` and brush the generic-not-specific principle.

## 3. Every doc surface corrected (code is the source of truth)

| surface | was | now |
|---|---|---|
| `core/cap_evolve/gate.py:3` (module docstring) | "The default is the *significance* gate" | `paired` is the default for every real run, with the `harness.py:1524-1526` / `gepa.py:741-743` / `capevolve.yaml` citations, and the `decide()`-parameter asymmetry stated explicitly |
| `core/cap_evolve/gate.py` `decide()` docstring | listed `simplicity_tiebreak` | mode gone; `strict` now carries its "only safe with a near-zero-variance scorer" caveat |
| `docs/HONEST_EVAL.md:19-22` | wrong default (`mode="significant"`), `paired` absent from the mode list entirely, `simplicity_tiebreak` listed | one **canonical modes table** (4 modes, `paired` marked default) + the `Δ > k·SE` rationale — this is the cross-link target #104 asked for |
| `docs/OPTIMIZE_YOUR_OWN.md:103` | `- gate: <significant (k_se) \| strict \| threshold>` — **wrong key name** and 2 of 5 modes missing | real keys `gate_mode` / `gate_k_se`, correct mode list, `paired` marked default, pointer to `HONEST_EVAL.md` |
| `docs/ADAPTER_CONTRACT.md` `## The gate` | a section titled "The gate" that never named a single mode | one-line pointer to the canonical table (no seventh copy) |
| `skills/phases/gate/SKILL.md:28-38` | `## The significance rule (default)` showing **only** the unpaired `sqrt(cand²+curr²)` formula as the default | both formulas, `paired` labelled the default, plus one sentence on why `paired` is more powerful |
| `skills/phases/gate/SKILL.md:44-51` | `## Modes`: `significant (default) \| strict \| threshold \| simplicity_tiebreak` — **`paired` absent entirely** | `paired` first and marked default with code citations; `significant` demoted to "unpaired fallback"; the removed mode noted with why |
| `skills/phases/gate/SKILL.md:74` | "**Good:** `significant` mode …" | "**Good:** `paired` mode (the default) …" |
| `skills/phases/gate/references/concepts.md:74-79` | modes table marking `significant` "default", `paired` omitted, `simplicity_tiebreak` present | `paired` first and marked default; `simplicity_tiebreak` row dropped; the `Δ > k·SE` vs `Δ > 0` reason added |
| `skills/phases/gate/scripts/run.py:34` | `_MODES = ["significant", "strict", "threshold", "simplicity_tiebreak", "paired"]` | `["paired", "significant", "strict", "threshold"]` |
| `skills/algorithms/agent-optimize/scripts/gate_check.py:101` | `--mode` choices included `simplicity_tiebreak` | dropped |
| `templates/project/capevolve.yaml:80` | mode comment ended `\| simplicity_tiebreak` | dropped; `significant` annotated as the unpaired fallback |
| `examples/tau2_airline/capevolve.yaml:42` | same | dropped |
| `skills/phases/intake/inputs/INPUTS.md:167` | `significant\|strict\|threshold\|simplicity_tiebreak` | `significant\|strict\|threshold` |

### Why the bar is `Δ > k·SE` and not `Δ > 0`

The gate is an honesty invariant owned by core, so each corrected surface now says in a sentence or two why the bar is a significance bar: search is a noise amplifier — screen enough candidates and the best-looking one is best by *luck*, so a `Δ > 0` rule banks noise as progress and the val curve climbs while nothing improved. Requiring the gain to clear `k` standard errors of its own measurement error is what makes an accept mean something. Without that, a reader sees only a knob that rejects their candidates and turns it down to `strict`.

`git diff main --stat`: 12 files, +93 / −60; `core/cap_evolve/gate.py` alone is +17 / −23.

## 4. Verification

### Full suite

```
$ python -m pytest core/tests -q 2>&1 | tail -20
FAILED core/tests/test_empty_seed.py::test_capability_is_empty_signal - Asser...
FAILED core/tests/test_eventstream.py::test_dashboard_stream_reexports_the_shared_helper
FAILED core/tests/test_eventstream.py::test_follower_thread_reports_instead_of_dying_silently
3 failed, 786 passed, 12 skipped in 138.63s (0:02:18)
```

**All 3 failures are pre-existing on `main` and unrelated to the gate.** Verified by running the identical suite on the base commit (`d94fb336`) with these changes reverted:

```
FAILED core/tests/test_core.py::test_simplicity_tiebreak_prefers_smaller_on_tie   <- the test this PR replaces
FAILED core/tests/test_empty_seed.py::test_capability_is_empty_signal
FAILED core/tests/test_eventstream.py::test_dashboard_stream_reexports_the_shared_helper
FAILED core/tests/test_eventstream.py::test_follower_thread_reports_instead_of_dying_silently
4 failed, 785 passed, 12 skipped
```

Same three, plus one that only failed because the modified package was installed. Both `test_eventstream` failures pass when that file is run alone (`38 passed`) on the base commit *and* on this branch — they are order/timing-dependent flakes in the daemon-thread tests, not a regression from this PR. `test_empty_seed::test_capability_is_empty_signal` fails identically on base in isolation.

### `toy_calc` — the real gate, end to end

This is the proof the deletion broke nothing: it exercises the actual gate on a deterministic zero-API benchmark.

```
$ bash examples/toy_calc/run.sh 2>&1 | tail -15
{
  "run_dir": ".capevolve/run_demo",
  "best_id": "cand_0001",
  "baseline_val": 0.0,
  "test_reward": 1.0,
  "test_baseline_reward": 0.0,
  "test_delta": 1.0,
  "test_pass_k": { "1": 1.0 },
  "iterations": 3,
  "dashboard": ".capevolve/run_demo/dashboard.html",
  "dashboard_server": "skipped"
}
```

Gate-accepted, sealed test score `1.0` (baseline `0.0`, Δ +1.0), `cand_0001` accepted at iteration 1. The gate reasons in that run's `events.jsonl` are independent confirmation of §1 — the default really is `paired`:

```
"reason": "paired Δ̄=+1.0000 > 0 (SE=0 → STRICT fallback, warned; n=2)"
"reason": "paired Δ̄=+0.0000 <= 0 (SE=0 → STRICT fallback, warned; n=2)"
"reason": "paired Δ̄=+0.0000 <= 0 (SE=0 → STRICT fallback, warned; n=2)"
```

Nothing in the run ever selected `significant`, the mode the docs called the default.

### Gate skill contract check

```
$ python skills/phases/gate/scripts/check.py
{"notes":["run entry exposes main()","refuses split=train",
          "SE=0 collapses to strict (Δ>0), not a silent pass",
          "improvement within noise is rejected"],
 "ok":true,"problems":[],"skill":"gate"}
```

Both mode enums now reject the removed mode at the CLI boundary:

```
$ python skills/phases/gate/scripts/run.py --help | grep 'mode {'
  --mode {paired,significant,strict,threshold}
$ python skills/algorithms/agent-optimize/scripts/gate_check.py --help | grep 'mode {'
  --mode {paired,significant,strict,threshold}
```

## 5. Dropped from the original PR

| dropped | reason |
|---|---|
| `--paired-deltas` flag on `skills/phases/gate/scripts/run.py` | **`main` already solved this, better.** #198's headline claim — that "every documented paired invocation exited 2" — was true at its base commit but is **not true on `main`**: `run.py` now accepts `paired` (`_MODES`, line 34) and reaches it through **rollout mode** (`--run-dir --current-tag --candidate-tag`, lines 44-80), rebuilding real per-task deltas from persisted rollouts. That cannot disagree with the rollouts; a scalar `--paired-deltas 1,0,0,…` flag can, and would be a second weaker way to do the same thing. |
| `core/tests/test_documented_cli.py` (+92) | Out of scope — its own docstring says it "catches the class in #203". A regex doc-lint globbing every `**/*.md` and shelling out `--help` per script is a fragile new CI surface; it belongs to #203, on its own merits. |
| documenting `simplicity_tiebreak` as "behaves as strict today" | Leaves a mode in the enum that is a lie by construction, in 9 places. Deleted instead (§2), per #206. |
| mirroring the modes table into `site/optimize-your-own.html` and 5 other surfaces | #198 wrote the same table into 7 files, all of which must then be kept in sync. One canonical table in `docs/HONEST_EVAL.md` plus links is the correct shape. |
| the ~68 new lines of prose in `docs/HONEST_EVAL.md` | Over-long for that file's register. The modes table and the `Δ > k·SE` rationale are the load-bearing parts; those are kept. |

Also note: #198 needed a rebase regardless (`git merge-tree` showed 2 conflicts, in `skills/phases/gate/scripts/run.py` and `skills/algorithms/agent-optimize/SKILL.md` — precisely the two files `main` moved past it), so this is re-authored from `main` rather than rebased.

## Follow-ups deliberately not done here

- **Is `gate_k_se: 1.0` the right shipped default under `paired`?** Under `paired` at `k_se = 1.0`, a candidate that improves **exactly one** of `n` val tasks can *never* be accepted: for a single task moved by `m`, `var(Δ) = m²/n` so `SE(Δ) = m/n = Δ̄` exactly, and the comparison is a strict `>`. Both `m` and `n` cancel, so this holds at any val size and any magnitude — the shipped default provably cannot bank a single-task gain. That is a design question this doc fix surfaces but must not silently settle; worth its own issue.
- The broader `skills/phases/gate/SKILL.md` rewrite (documenting the `indecisive` coverage guard, the `gate_warning` event, `--no-regression`'s default-off status, `--protected-paths`, and the level-2/level-3 duplication with `references/concepts.md`) is a separate, larger change. This PR touches only what describes gate **modes**.
