### PR TITLE
tools capability: split the 749-line SKILL.md into progressive-disclosure references

### DIFF
--- a/skills/capabilities/tools/SKILL.md
+++ b/skills/capabilities/tools/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tools
-description: Optimize an agent's OWN tool surface (tools it implements, not an external MCP server). Use when the agent mis-selects tools, fills arguments wrong, or has a confusing/redundant toolset. You may edit tool names, descriptions, parameter docs, in-description examples, the JSON schema/API, the tool code itself, ADD tools (including composite tools that call existing tools), and REMOVE tools — all under an action policy so risky edits can be locked off.
+description: Optimize an agent's OWN tool surface (tools it implements, not an external MCP server). Use when the agent mis-selects tools, fills arguments wrong, calls the same tool N times in a row, or has a confusing, redundant, or oversized toolset. Covers tool names and descriptions, parameter docs, tool schemas, handler code, function-calling accuracy, and adding or removing tools.
 component: capability
 argument-hint: "--path DIR"
 allowed-tools: Read, Write, Edit, Bash
@@ -12,418 +12,153 @@ sources: [gepa, tau2bench]
 # Capability: tools (full control)
 
 This capability treats the agent's **entire tool surface as the optimizable
-artifact**. When an agent *owns* its tools — it implements the handlers, defines
-the wire schema, and controls every caller — then names, descriptions, parameter
-docs, in-description examples, the JSON Schema, *and the implementation code* are
-all fair game.
-
-Use this capability when the agent OWNS its tools — it implements the handlers and
-controls the wire schema, so the code itself is editable. (When the tools come from an
-external server you can only re-describe, not re-implement, the action policy here is
-tightened to documentation-only edits.)
+artifact**. It applies when the agent *owns* its tools — it implements the handlers,
+defines the wire schema, and controls every caller — so names, descriptions,
+parameter docs, in-description examples, the JSON Schema, *and the implementation
+code* are all fair game. (When the tools come from an external server you can only
+re-describe, not re-implement: that is `mcp-tool`, whose policy is tightened to
+documentation-only edits.)
 
 ## What you can change here
 
-> **Confirm which parts of a docstring the framework actually SENDS — some of it may be
-> discarded.** A docstring is not the wire schema. One benchmark harness builds each
-> tool's schema `description` from the docstring **summary plus the prose before `Args:`**, and
-> drops the `Returns:` section entirely. Measured across a 14-tool toolset there: **5469 of 12929
-> docstring characters (42%) never reached the model**, and on the one tool whose return had
-> been documented most carefully it was **1791 of 1906 — 94% dropped**. Rounds of behavioural
-> guidance had been written into that void, and one edit credited as "verified" turned out to
-> work only because the return **VALUE** changed shape (which the model does see at call time),
-> not because anything documented it. So there are three delivered surfaces — the summary and
-> pre-`Args:` prose, the per-parameter `Args:` descriptions, and the returned value itself —
-> and one that looks identical and does nothing. Render the live toolset and count the
-> delivered characters per candidate rather than trusting the file; the same render also
-> catches a docstring that raises at REGISTRATION time, which fails every rollout as an
-> infrastructure error rather than a low score.
-
-
-> **A tool return is re-read on every later turn, so enriching it is not free — measure it.**
-> Measured on a multi-turn tool-use benchmark with a mid-tier runner: one round accepted an edit that CONSTRAINED
-> behaviour (in-code preconditions, val 0.5889 → 0.6778, +8.9pp) while **four separate edits
-> that ADDED information all landed at or below the same parent**: richer docs + derived
-> facts merged onto the winner **0.6444**, composite tools **0.6556**, argument derivation
-> **0.6666** (identical to that round's null control), and a structural policy rewrite
-> **0.5777** (also identical to the control). Multi-turn rollouts have a step budget and the
-> whole conversation is re-read each turn, so verbose returns crowd out the signal they were
-> meant to supply. Keep what the agent ACTS on — amounts, eligibility, the corrective hint —
-> and cut what it can read off the object it already has. When in doubt, run the subtraction
-> as its own gated candidate; it is as legitimate a hypothesis as the addition, and here the
-> additive ones were the losers.
-
-> **Changing a return SHAPE can corrupt the learning signal without touching the score.**
-> Optimizer-side code that parses tool returns to build feedback is written against the
-> PRISTINE shape, and a candidate is entitled to change it. Observed: a candidate that nested
-> summary objects under a list key the feedback code read as bare ids made that code `str()` the
-> dicts, so its feedback claimed the id was *"not among"* the held ids — for calls whose id was
-> perfectly valid. The reward
-> was never affected — it comes from the harness's own DB/action checks, which never read a
-> tool's return — but one optimiser spent a whole iteration hunting a scoring bug that did not
-> exist, and another concluded the key name was capping its score. Two lessons, in order:
-> **audit the measurement before you believe a defect**, and make return-parsing tolerant of
-> shapes a candidate may legitimately introduce (extract ids from `str` *or* `dict` entries)
-> rather than forbidding the enrichment. The signal degrades exactly when the candidate is
-> most interesting, which is the worst possible time.
-
-**The tool's docstring AND its return value are what the agent SEES — make both
+**The tool's documentation AND its return value are what the agent SEES — make both
 clear and recovery-oriented.** The doc surface (description, important-notes,
-per-param, `Raises:`, examples) drives *which* tool the model calls and *how* it
-fills the arguments; the return value (and especially the error text) steers the
-*next* turn. Each lever below is an edit class; in ONE pass, apply EVERY edit class
-the traces call for — a validation wrapper AND a loop tool AND enriched
-returns/errors AND doc fixes across all implicated tools can and should all ship in
-the same candidate. (1-line generic examples; worked bodies in
-[`references/examples.md`](references/examples.md), depth below and in
-[`references/concepts.md`](references/concepts.md).)
+per-param, error/`Raises` text, examples) drives *which* tool the model calls and
+*how* it fills the arguments; the return value (and especially the error text) steers
+the *next* turn. Confirm which parts of a docstring your runtime actually SENDS before
+writing into it — some frameworks discard whole sections, and guidance written into
+that void does nothing (`references/field-notes.md` §1).
 
-> **A docstring section header can silently break tool registration — always render the
-> live toolset after editing.** Observed: adding a worked example under an
-> `Example:` / `Examples:` header made `docstring_parser` return a `DocstringExample`
-> object, that harness's `Tool` model required `examples: list[str]`, so building the environment
-> raised and **all 90 rollouts of that candidate died as `INFRASTRUCTURE_ERROR`** — an
-> entire evaluation spent on a parse error, not on the edit. Keep the example text, but put
-> it under ordinary prose (e.g. "A correct call looks like:"), and prove the toolset still
-> builds before you spend rollouts:
-> ```bash
-> # Apply the candidate, then build the toolset the way the HARNESS builds it and list what
-> # registered. The last line is harness-specific -- substitute your runner's own construction
-> # call; the point is that it must be the real one, not an import.
-> python -c "import sys; sys.path.insert(0,'<project>/adapters'); from adapter import Adapter; \
-> from pathlib import Path; Adapter().apply(Path('<candidate_dir>')); \
-> tools = <your harness's get_tools() call>; \
-> print(len(tools), sorted(t.name for t in tools))"
-> ```
-> An import check is NOT enough — the file imported fine; it was *registration* that failed. If
-> the adapter exposes a render/validate helper, call that instead and keep it in the loop.
+**Ship MULTIPLE fixes per iteration — but every one must be REAL (targets a
+currently-failing task), SAFE (cannot change a passing task's behavior), and VERIFIED
+(proven to fix its target).** Several such fixes beat a long list that includes a
+speculative edit: one edit that regresses a passing task sinks the whole candidate at
+the val gate. Never add an edit to hit a count, and never re-add a rule or tool the run
+already tried and rejected.
 
-**Read this skill in full before editing. Ship MULTIPLE fixes per iteration — but
-every one must be REAL (targets a currently-failing task), SAFE (cannot change a
-passing task's behavior), and VERIFIED (proven to fix its target).** Several such fixes
-beat a long list that includes a speculative edit: one edit that regresses a passing
-task can sink the whole candidate at the gate. Quality over churn — never add an edit
-to hit a count, and never re-add a rule/tool the run already tried and rejected.
+**Per-change SAFETY (the rule that makes multi-change work).** Scope every guard to
+fire ONLY on the exact violating condition, and check its blast radius: run it on the
+args of 1–2 currently-PASSING tasks that use the same tool and confirm it does NOT
+fire. A guard that fires on a passing task is a regression — rescope or drop it.
 
-**Per-change SAFETY (the rule that makes multi-change work).** Scope every guard to fire
-ONLY on the exact violating condition, and check its blast radius: run it on the args of
-1–2 currently-PASSING tasks that use the same tool and confirm it does NOT fire. A guard
-that fires on a passing task is a regression — rescope or drop it. This is how you ship
-many changes without net-zero churn.
+## Pick the lever by failure type
 
-**Pick the lever by failure type — the in-body guard is the DEFAULT strong move:**
-- **Edit the BODY of an EXISTING tool (reach for this FIRST for a rule violation).** When
-  the agent VIOLATES a rule a tool already owns (a wrong field value, an id not on file,
-  an action on a record whose state forbids it), convert the prose rule into a scoped
-  in-body guard. This is the highest-yield, lowest-regression edit; expect to touch
-  SEVERAL existing bodies in one iteration.
-- **ADD a NEW code-bearing tool — for a genuine CAPABILITY GAP or action STALL.** A
-  composite atomic-WRITE tool for a multi-step action the agent narrates/confirms then
-  fails to execute is the canonical case (the primitive is what it skips; the composite
-  makes the action un-skippable; then REMOVE the raw primitives). New tools are
-  available and encouraged WHEN they close a real gap — but add one ONLY if the agent
-  will actually call it AND it changes the graded outcome. Do NOT add read/compute/summary
-  helper tools that a guard or a prompt line would subsume, and never add a tool just to
-  "ship a new tool" — that is churn the gate punishes.
+Each item is an edit class. In ONE pass, apply EVERY class the traces call for — a
+validation wrapper AND a loop tool AND enriched returns/errors AND doc fixes across all
+implicated tools can and should ship in the same candidate. The in-body guard is the
+default strong move; reach for a documentation edit only after asking "can this rule be
+code in the existing body instead?"
 
-- **DECISION / PERMISSION cluster → a discriminating-predicate guard (the BOUNDED-blast-
-  radius alternative to a prompt change).** When a cluster is about ACT-vs-REFUSE (the
-  agent acted where it should have refused/escalated, or vice versa), the WRONG fix is
-  loosening a global decision rule in the prompt — that has UNBOUNDED blast radius and
-  regresses every task where the original behavior was gold. The RIGHT fix lives here:
-  an in-body guard on the tool that owns the action, expressing the EXACT policy
-  predicate, that refuses/raises ONLY when the qualifying condition is/isn't met. It
-  fires only on the narrow violating condition, so its blast radius is bounded to the
-  failing inputs — the SAFEST edit, preferred over any prompt/permission change.
-- **HARD-ZERO / capability-gap cluster → a REAL targeted tool, never prose.** A task
-  scoring 0.00 that needs a compute / composite / discriminating-predicate tool stays
-  0.00 after any docstring or prompt reword. Ship a tool the agent will CALL that
-  changes the graded state.
-
-The two failure modes to avoid: (1) leaving a rule the agent keeps breaking as loose
-prose instead of a guard, or loosening a global permission rule (unbounded regression)
-instead of a scoped guard; (2) padding the candidate with low-value helper tools or
-cosmetic rewrites that move no graded task.
-
-1. **Edit the CODE of EXISTING tools to enforce rules deterministically (the most
-   common high-leverage edit)** — most violated textual rules govern a tool that
-   ALREADY exists, and the fix is an in-body guard *there*, not a new tool. Bake the
-   precondition / normalization / actionable refusal into the body so correctness
-   doesn't depend on the LLM. *Ex:* add `if not rec["cancellable"]: raise
-   ValueError("not cancellable; reason=...; do X instead")` to the existing
-   `cancel_record` body. Expect to touch the BODIES of SEVERAL existing tools per
-   iteration — one per violated rule.
-2. **Add a new tool (first-class — reach for it freely)** — give the agent a
-   capability it lacks or a safe path it keeps skipping, built as a thoughtful
-   workflow/validation tool, not a thin wrapper. *Ex:* `search_logs` returns only
-   the relevant lines instead of a raw dump; or a `find_duplicate_records` the agent
-   has no way to compute today. For a STALL or capability-gap cluster this is the
-   right move even when a primitive exists — see item 7 (composite atomic-WRITE).
-3. **Replace / wrap a tool** — superset an existing tool and route the old behavior
+1. **Edit the CODE of an EXISTING tool (reach for this FIRST for a rule violation).**
+   Most violated textual rules govern a tool that ALREADY exists, and the fix is an
+   in-body guard *there*, not a new tool: bake the precondition, normalization, or
+   actionable refusal into the body so correctness does not depend on the LLM. *Ex:*
+   add `if not rec["cancellable"]: raise ValueError("not cancellable; reason=...; do X
+   instead")` to the existing `cancel_record` body. Expect to touch the BODIES of
+   SEVERAL existing tools per iteration — one per violated rule. A deterministic guard
+   beats a sentence in a prompt: prose makes the model *more likely* to comply, code
+   makes the right behavior the only thing that can happen.
+2. **Add a composite atomic-WRITE tool — the fix for a behavioral STALL.** When the
+   agent analyzes, explains, even confirms the action, then never issues the write call
+   and stops, *more prose does not fix it* — you cannot instruct a model out of a
+   behavior it already agreed to and skipped. Encapsulate the ENTIRE multi-step action
+   in one tool whose body performs all the steps in order via the existing primitives,
+   then **`remove` the raw primitives** so the action is un-skippable. *Ex:*
+   `apply_change_plan(record_id, steps)` validates → applies each → returns final state
+   as one call. This is the *correct* fix even though a write primitive already exists,
+   because the primitive is exactly what the agent declines to call.
+3. **DECISION / PERMISSION cluster → a discriminating-predicate guard.** When a cluster
+   is about ACT-vs-REFUSE, the WRONG fix is loosening a global decision rule in the
+   prompt — unbounded blast radius, regresses every task where the original behavior was
+   gold. The RIGHT fix is an in-body guard on the tool that owns the action, expressing
+   the EXACT policy predicate, refusing only when the qualifying condition is (or is
+   not) met. Bounded blast radius makes this the safest edit available.
+4. **HARD-ZERO / capability-gap cluster → a real targeted tool, never prose.** A task
+   scoring 0.00 that needs a compute / composite / predicate tool stays 0.00 after any
+   docstring or prompt reword. Ship a tool the agent will CALL that changes the graded
+   state — *Ex:* a `find_duplicate_records` it has no way to compute today, or a
+   `search_logs` that returns the relevant lines instead of a raw dump.
+5. **Add a loop tool** — replace N repeated single-item calls with one list call. *Ex:*
+   `get_records(ids: [...])` replaces N× `get_record(id)`.
+6. **Replace / wrap a tool** — superset an existing tool and route the old behavior
    through it. *Ex:* wrap `find_record`+`charge_payment` behind one
    `charge_record(record_id)` that resolves then charges.
-4. **Improve a tool's documentation** — sharpen description / important-notes /
-   `Raises:` / per-param docs / examples; rename for least surprise. *Ex:*
-   `lookup(record)` → `get_record(record_id: str)` with "returns an error object if
-   not found."
-5. **Improve RETURN VALUES for recoverability** — high-signal fields, stable
-   human-readable ids, and **actionable error text with a next-step hint and what
-   NOT to do**. *Ex:* error returns "payment method not on file; available:
-   ['card_1'] — pass one of these" instead of a raw traceback.
-6. **Add a loop tool** — replace N repeated single-item calls with one list call.
-   *Ex:* `get_records(ids: [...])` replaces N× `get_record(id)`.
-7. **Add a composite atomic-WRITE / workflow tool (first-class — the fix for STALLS
-   and multi-step writes)** — for a recurring, failure-prone multi-step action
-   (especially one the agent narrates/confirms then fails to execute, e.g. a
-   multi-step update that must cancel/undo then re-create a record), a deterministic
-   tool whose body performs ALL the steps in order via the
-   existing primitives, then `remove` the raw primitives so the action is
-   un-skippable. *Ex:* `apply_change_plan(record_id, steps)` validates → applies each
-   → returns final state as one reliable call. Reach for this whenever a cluster
-   STALLS at the action boundary — do not settle for a prose "be sure to act" rule.
-8. **Remove-with-replacement** — remove a redundant/overlapping tool *only* after a
-   replacement preserving its capability exists. *Ex:* drop `query` once
-   `get_record` + `search_records` cover it.
+7. **Improve a tool's documentation** — sharpen description / important-notes / error
+   conditions / per-param docs / examples; rename for least surprise. *Ex:*
+   `lookup(record)` → `get_record(record_id: str)` with "returns an error object if not
+   found."
+8. **Improve RETURN VALUES for recoverability** — high-signal fields, stable
+   human-readable ids, and **actionable error text with a next-step hint and what NOT to
+   do**. *Ex:* an error returning "payment method not on file; available: ['card_1'] —
+   pass one of these" instead of a raw traceback. Adding to a return is not free,
+   though: it is re-read every turn, so treat enrichment as a hypothesis to gate, not a
+   free win (`references/field-notes.md` §2).
+9. **Remove-with-replacement** — remove a redundant/overlapping tool *only* after a
+   replacement preserving its capability exists. *Ex:* drop `query` once `get_record` +
+   `search_records` cover it.
 
-**Before/after — convert a violated prose rule into an in-body guard (the default
-edit).** The rule "a record can only be cancelled when it is cancellable" lives as
-prose in the prompt and the agent keeps breaking it. Don't add a tool — edit the
-EXISTING `cancel_record` body:
+The two ways to waste an iteration: leaving a rule the agent keeps breaking as loose
+prose instead of a guard (or loosening a global permission rule instead of scoping a
+guard); and padding the candidate with low-value helper tools or cosmetic rewrites that
+move no graded task.
 
-```diff
-  def cancel_record(record_id):
-+     rec = get_record(record_id)
-+     if not rec["cancellable"]:
-+         raise ValueError(
-+             "not cancellable; reason=" + rec.get("status", "unknown")
-+             + "; do X instead (e.g. offer a change_record)")
-      return _backend.cancel(record_id)
-```
+## Guardrails
 
-And the rule "amounts are in whole cents and the method must be on file" — edit the
-EXISTING `book` (or `charge`) body to normalize the field then raise an actionable
-error:
-
-```diff
-  def book(record_id, amount, payment_id):
-+     amount = int(round(amount))            # normalize: callers pass dollars
-+     methods = {m["id"] for m in get_record(record_id)["payment_methods"]}
-+     if payment_id not in methods:
-+         raise ValueError(
-+             f"payment method {payment_id!r} not on file; "
-+             f"available={sorted(methods)} — pass one of these")
-      return _backend.book(record_id, amount, payment_id)
-```
-
-Both fixes touch a tool that ALREADY exists; no new tool is needed. A docstring-only
-or new-tool-only iteration that leaves these rules as prose is under-used.
-
-**Guardrails (depth below):** encode deterministic logic in code, not prose (a
-tool body the model cannot skip beats a sentence it can forget); keep the toolset
-small and namespaced (aim **< ~20** active tools); ship correct, bug-free code
-(every code edit needs validation + a `validate` run); and **never remove a tool
-without a capability-preserving replacement** (add → verify → swap, see the SAFE
-TOOL-REPLACEMENT PROTOCOL).
-
-**Generalize, never hardcode.** Every in-code guard must fire on the GENERAL
-condition that defines the failure class, never on a literal value from one task.
-*Good:* `if payment_id not in user_payment_methods: raise ...`. *Bad:*
-`if record_id == "<TASK_SPECIFIC_ID>": raise ...` — that overfits to one task, gets
-rejected by the held-out gate, and helps nothing else. Use a failing task's
-specifics only to identify the class, then write the general check.
-
-A discriminating-predicate guard for a decision/permission cluster must encode the
-GENERAL policy condition that separates the qualifying cases from the rest (e.g.
-`if record.tier == "restricted" and action == "modify": raise ...`), NOT a global
-behavior flip and NOT a task literal. The guard NARROWS — it fires only on the cases
-the policy actually governs — so passing tasks outside that condition keep their
-behavior unchanged.
-
-## The highest-leverage edit: deterministic CODE (usually in an EXISTING tool body)
-
-**Start here. A deterministic guard in code beats a sentence in the prompt.** A
-docstring or system-prompt rule only makes the model *more likely* to comply — it
-can be forgotten, mis-read, or out-reasoned on the next task. Code (a precondition
-check, a normalization, a loop) makes the right behavior *the only thing that can
-happen* — it cannot be "forgotten." When the traces show a rule the agent keeps
-breaking, a multi-step action it keeps fumbling, or — most importantly — an action
-it *stalls on and never executes*, **do not just reword a description — put the
-behavior in code.**
-
-**Two code-bearing edits, chosen by failure type — both first-class.** For a rule
-VIOLATION, enforce the rule in the body of the EXISTING tool that owns it — "only
-cancel a cancellable record" governs `cancel_record`, "amounts in whole cents"
-governs `book`/`charge`; add an in-body guard there and expect to touch SEVERAL
-existing bodies per iteration. For a CAPABILITY GAP or an action STALL, write a NEW
-code-bearing tool — a loop tool to collapse a multi-call chain, or (the big one) a
-**composite atomic-WRITE tool** to encapsulate a multi-step write the agent keeps
-skipping. Do not treat the new tool as a last resort: when a cluster stalls at the
-action boundary, the composite is the *correct* fix even though a write primitive
-already exists, because the primitive is exactly what the agent declines to call.
-(See the before/after diffs above, the three patterns below, and the worked bodies
-in [`references/examples.md`](references/examples.md).)
-
-**Prose cannot fix a BEHAVIORAL failure.** There is a sharp distinction the
-optimizer must make. If the agent *does not know* something (a format, a rule, a
-decision criterion), prose can teach it — that is a KNOWLEDGE gap, and it belongs
-in the prompt. But if the agent demonstrably *knows* what to do and still doesn't
-do it — it analyzes the situation, explains the plan, even gets the user's
-confirmation, and then simply **fails to CALL the action tool and stops** — that
-is a BEHAVIORAL failure, and *more prose does not fix it*. You cannot instruct a
-model out of a behavior it already "agreed" to and then skipped. The only
-reliable fix is to move the behavior into CODE: encapsulate the whole action in a
-tool whose body performs it, so executing it is no longer a choice the model can
-decline mid-conversation. Telling the agent to "be sure to act" is exactly the
-kind of edit the traces show failing.
-
-Three patterns carry almost all the gain (worked bodies below and in
-[`references/examples.md`](references/examples.md)):
-
-1. **Validation / rule-enforcement tool (wrap, then delegate).** When a rule or
-   precondition that today lives only in the prompt is GENERAL — it always
-   applies, not just to one task — implement it as code in a NEW tool that:
-   validates / normalizes the inputs → enforces the rule → calls the existing
-   primitive → returns a clear result (or a clean refusal). Then **remove the raw
-   primitive from the exposed set** if the agent should only ever reach it
-   through the safe path. Example: `cancel_record_safely(record_id)` reads the
-   record, refuses unless it is cancellable, then calls the raw `cancel_record`.
-
-2. **Workflow / loop tool (collapse a recurring multi-step sequence).** When a
-   small multi-step workflow recurs, or the agent calls one primitive N times in
-   a row (and drops or mis-threads a result), implement it as ONE tool with real
-   loops/code that calls the existing tools internally and returns the finished
-   result. Example: a tool that loops over a list of ids calling `get_record`
-   once each and returns them aligned, instead of the agent issuing N calls.
-
-3. **Write / workflow COMPOSITE tool — make a stalled action un-skippable
-   (co-equal PRIMARY pattern).** This is the fix for the single most common
-   BEHAVIORAL failure: the agent reliably **stalls at the action/write boundary**
-   — it analyzes, explains, even confirms with the user, then never issues the
-   write call and stops, leaving the task half-done. The cure is *not* a stronger
-   rule. Encapsulate the ENTIRE multi-step action (analyze → confirm → act) as
-   ONE composite tool whose body performs *all* the steps in code — calling the
-   existing primitives in the right sequence and looping where needed — so the
-   action completes the moment the tool is called and **cannot be skipped
-   mid-conversation**. Then **`remove` the raw primitives** so the composite is
-   the only path; the safe, complete behavior is then the only behavior reachable.
-   Generic example: an `apply_change_plan(record_id, steps)` that performs a
-   multi-step update atomically — validating each step, applying them in order via
-   the existing write primitives, and returning the final state — so the agent
-   hands over the plan in one call instead of narrating it and then failing to
-   execute. (Worked body in [`references/examples.md`](references/examples.md) §3e.)
-
-**Lean caveat — replace, don't accumulate.** Every exposed tool enters the
-agent's context, and too many tools degrade selection (see §3 of concepts.md).
-So PREFER consolidating over piling on: when you add a safer or looped tool,
-**`remove` the now-redundant primitive** so the net tool count stays small and
-sharp. Do not add many narrow tools. One sharp tool that subsumes a primitive
-beats two overlapping ones.
-
-**SAFE TOOL-REPLACEMENT PROTOCOL (never bare-remove a tool).** To replace or
-consolidate a tool, follow these steps in order — never delete a tool without a
-replacement that subsumes it:
-
-1. **ADD a wrapper tool whose body CALLS the existing tool** — after validation,
-   normalization, or the extra steps you want guaranteed. The wrapper delegates to
-   the primitive; it does not re-implement it.
-2. **VERIFY** the wrapper (run `validate`; confirm the body actually calls the
-   primitive and returns a sane result).
-3. **Only then SWAP the registration**: `remove` the raw primitive from the active
-   / exposed set and register the wrapper as the path the agent uses.
-
-Bare-removing a primitive with no replacement strands every task that needed it
-("no applicable tool"); adding a wrapper but leaving the primitive exposed lets the
-model route around the guard and reproduce the original failure. The add-verify-swap
-order is what makes the safe path the *only* path without a coverage gap.
-
-**You must write the BODY.** A `compose`/`add`/`code` edit whose body is `...`,
-a bare `pass`, or docstring-only is NOT this edit — it does nothing. Emit a real
-implementation: the loop, the precondition check, the calls to the existing
-tools (`get_record(i)` — or `self.get_record(i)` if your adapter binds tools as
-methods). Worked examples with full bodies are below under
-[Add tools that call existing tools](#add-tools-that-call-existing-tools-the-highest-leverage-edit).
-
-**SECONDARY (last resort): passthrough / "think" / reasoning-only tools.** A tool
-whose body just returns (or echoes) its argument, with the actual rule living only
-in the *docstring* (e.g. a `think(thought)`/`check_policy(text)` tool that does no
-real work), is the WEAKEST form of this edit — it is prose wearing a tool's
-costume, and the model can ignore or mis-apply it exactly like any prompt sentence.
-**If a rule can be encoded as code, encode it as code** — validate, normalize, and
-enforce it in the body (patterns 1 and 2 above), don't leave it as docstring prose.
-Reach for a reasoning-only tool only when the behavior genuinely cannot be made
-deterministic (e.g. you want to *prompt* a planning step), never as a substitute
-for a check you could have written in a few lines of code.
+- **Encode deterministic logic in code, not prose** — a tool body the model cannot skip
+  beats a sentence it can forget. A tool whose body enforces nothing (a `think()` /
+  `check_policy()` passthrough with the rule only in its docstring) is prose in a tool's
+  costume; reach for it only when the behavior genuinely cannot be made deterministic.
+- **You must write the BODY.** A `compose`/`add`/`code` edit whose body is `...`, a bare
+  `pass`, or docstring-only is not this edit — it does nothing. Emit the real loop, the
+  real precondition check, the real calls to existing tools (`get_record(i)` — or
+  `self.get_record(i)` if your adapter binds tools as methods).
+- **Never remove a tool without a capability-preserving replacement.** Add → verify →
+  swap (`references/concepts.md` §8). Bare-removing strands every task that needed it;
+  adding a wrapper but leaving the primitive exposed lets the model route around the
+  guard and reproduce the original failure.
+- **Keep the toolset small and namespaced** — aim for **< ~20** active tools; selection
+  degrades sharply past that. Prefer consolidating over piling on: when you add a safer
+  or looped tool, `remove` the now-redundant primitive.
+- **Ship correct, bug-free code** — every code edit needs validation plus a `validate`
+  run, and proof the toolset still *registers* (an import check is not a registration
+  check — `references/field-notes.md` §3).
+- **Generalize, never hardcode.** Every guard must fire on the GENERAL condition that
+  defines the failure class, never on a literal value from one task. *Good:* `if
+  payment_id not in user_payment_methods: raise ...`. *Bad:* `if record_id ==
+  "<TASK_SPECIFIC_ID>": raise ...` — that overfits, gets rejected by the held-out gate,
+  and helps nothing else. Use a failing task's specifics only to identify the class,
+  then write the general check. The test for any edit: *would this help on a task the
+  optimizer has never seen?*
 
 ## How agents fail (and how tools fix it)
 
-Map the trace symptom to the code-bearing edit. Each row is a failure the model
-*could* "know" how to avoid yet keeps producing — so the fix is code, not prose:
-
-These four rows carry most of the recoverable gain — diagnose for them FIRST, and
-verify the fix you ship actually FIRES on the failing trace (run the new body on the
-exact arguments from that trajectory; a guard that never triggers on the failing task
-is dead code, not a fix). These rows are independent: fix as MANY of them as appear in
-the trajectories in one candidate, not just the first — each guarded tool is its own
-bounded fix.
+Map the trace symptom to the edit. This table is the single canonical statement of what
+to ship for what failure. The rows are independent: fix as MANY of them as appear in the
+trajectories in one candidate, not just the first — each guarded tool is its own bounded
+fix. Verify the fix you ship actually FIRES on the failing trace (run the new body on
+the exact arguments from that trajectory; a guard that never triggers on the failing
+task is dead code, not a fix).
 
 | Trace symptom | Fix |
 |---------------|-----|
-| **Wrong ARGUMENT the tool could validate** — a write whose id / reference / count / unit is not consistent with the agent-visible state (an id not in the record, a count exceeding what's available, the wrong unit). Right tool, bad argument; partial credit or a corrupted write. | **Normalize-then-call wrapper**: wrap the write in a body that RESOLVES / VALIDATES the argument against the current state, and on mismatch returns `available=[...]` (the valid options) or raises an actionable error naming what's wrong and what to pass instead — never let a write proceed on an unvalidated reference. Coerce units, resolve ids, check the field is on file, then delegate to the primitive. |
-| **Escalate / bail-out abandoning a REQUIRED, eligible action** — the agent hands off or gives up when it could and should have completed the action itself; this is a behavioral STALL, not a missing capability. | **Composite WRITE tool**: encapsulate the eligible-action batch in ONE tool whose body executes the steps in code (skipping any ineligible item with a recorded reason), then `remove` the raw primitives so completing the batch is the only path. Do NOT add a "don't bail out" prose rule — the agent already chose to bail; only code removes the choice. |
-| **Recoverable error that strands the agent** — a tool raises an opaque traceback / bare code, the agent retries the same bad call or gives up. | **Enriched RETURN that aids recovery**: on a recoverable error, return what's wrong + the valid options + the recommended next action (e.g. `{"error": "id not found", "available": [...], "next": "call search_x to resolve the id"}`), so the model self-corrects on the next turn instead of repeating the failure. |
-| **Execution stalls at the action boundary** — the agent analyzes, explains, even confirms, then never calls the write tool and stops (the task is left half-done). | **Composite WRITE tool** (pattern 3): one tool whose body performs the whole analyze→confirm→act sequence, then `remove` the raw primitives so the action is un-skippable. |
-| **The same primitive called N times in a row** — looping over a list in the agent's own context, dropping or mis-threading results. | **Loop tool** (pattern 2): one tool that takes the list and loops inside a single call. |
-| **A rule stated in the prompt but repeatedly violated** — a required order ("read before write"), a precondition the API doesn't enforce. | **Validation wrapper** (pattern 1): enforce the rule in the tool body; `remove` the unguarded primitive. |
+| **Wrong ARGUMENT the tool could validate** — a write whose id / reference / count / unit is not consistent with the agent-visible state. Right tool, bad argument; partial credit or a corrupted write. | **Normalize-then-call wrapper**: wrap the write in a body that RESOLVES / VALIDATES the argument against current state, and on mismatch returns `available=[...]` or raises an actionable error naming what is wrong and what to pass instead. Never let a write proceed on an unvalidated reference. |
+| **Execution stalls at the action boundary** — the agent analyzes, explains, even confirms, then never calls the write tool and stops (task left half-done). | **Composite WRITE tool** (lever 2): one tool whose body performs the whole analyze→confirm→act sequence, then `remove` the raw primitives so the action is un-skippable. Not a "be sure to act" prose rule. |
+| **Escalate / bail-out abandoning a REQUIRED, eligible action** — the agent hands off or gives up where it could and should have completed the action. A behavioral STALL, not a missing capability. | **Composite WRITE tool**: encapsulate the eligible-action batch in ONE tool whose body executes the steps in code (skipping any ineligible item with a recorded reason), then `remove` the raw primitives so completing the batch is the only path. |
+| **Recoverable error that strands the agent** — a tool raises an opaque traceback / bare code; the agent retries the same bad call or gives up. | **Enriched RETURN that aids recovery**: on a recoverable error return what is wrong + the valid options + the recommended next action (`{"error": "id not found", "available": [...], "next": "call search_x to resolve the id"}`) so the model self-corrects next turn. |
+| **The same primitive called N times in a row** — looping over a list in the agent's own context, burning turns and dropping or mis-threading results. | **Loop tool** (lever 5): one tool that takes the list and loops inside a single call. |
+| **A rule stated in the prompt but repeatedly violated** — a required order ("read before write"), a precondition the API does not enforce, a normalization the model forgets. | **In-body guard / validation wrapper** (lever 1): enforce the rule in the body of the tool that owns it; `remove` the unguarded primitive if the safe path must be the only one. |
+| **A DECISION / PERMISSION the model gets wrong (ACT vs REFUSE)** — it acts where policy says refuse/escalate, or refuses where it should act. | **Discriminating-predicate guard** (lever 3) on the tool that owns the action. Do NOT loosen the global rule in the prompt. |
+| **Mis-selection** — the agent calls the wrong tool, calls none when one applied, or invents a tool that does not exist. | **Name + description fix**: selection is driven almost entirely by the name and description — sharpen what/when/when-not and the boundary against the nearest sibling (`references/doc-contract.md`). |
+| **Bad argument-filling** — right tool, wrong arguments: a missing required field, the wrong enum value, free text where a structured object was expected. | **Schema + per-parameter docs**: close the value set with an `enum`, pin units/format/default per parameter, add an in-description example. |
+| **A bloated or overlapping toolset** — too many tools, or several that do nearly the same thing, distracting the agent. | **Consolidate then `remove`** the originals (lever 9). Remove for *overlap/confusion*, not for low call-count. |
+| **A real behavioral bug in a handler** — the tool returns the wrong thing. | **`code` edit**: because you own the code, fix it directly. |
 
 The throughline: a failure the agent *knows better than* but still commits is
 behavioral, and behavioral failures are fixed by removing the choice — putting the
 behavior in code and `remove`-ing the path that let it go wrong.
 
-## When to use this
-
-Reach for `tools` when a trace shows one of these failure signatures:
-
-- **Execution stall at the action/write boundary (BEHAVIORAL)** — the agent
-  reaches the point of acting, narrates or confirms the action, then **fails to
-  call the write tool and stops**. This is not a knowledge gap and prose will not
-  fix it; encapsulate the whole action in a composite WRITE tool and remove the
-  raw primitives so completing it is the only path (§"highest-leverage edit",
-  pattern 3).
-- **Mis-selection** — the agent calls the wrong tool, or calls none when one
-  applied, or invents a tool that does not exist. Selection is driven almost
-  entirely by the tool *name* and *description*, so this is a documentation fix.
-- **Bad argument-filling** — the right tool, wrong arguments: a missing required
-  field, the wrong enum value, a free-text string where a structured object was
-  expected. This is a parameter-schema and per-parameter-description fix.
-- **Repeated multi-call sequences the agent fumbles** — the agent must chain
-  `search` → `filter` → `fetch` every time and keeps getting the order or the
-  glue wrong. A single well-named **composite** tool collapses the sequence.
-- **The same primitive called N times in a row** — the agent loops over a list
-  in *its own context* (calls `get_record(id)` once per id, or `search(a,b,date)`
-  once per date/route combination), burning turns and often dropping or
-  mis-threading a result. A tool that takes the **list** and loops *inside one
-  call* collapses N calls into 1.
-- **An invariant the model keeps violating** — a required order of operations
-  ("read before write"), a precondition the API does not itself enforce, or a
-  normalization the model forgets. A tool that **enforces the rule in code**
-  (validates, normalizes, or performs the steps in the right order) makes the
-  mistake impossible rather than merely discouraged.
-- **A DECISION / PERMISSION the model gets wrong (ACT vs REFUSE)** — the agent acts
-  where the policy says refuse/escalate (or refuses where it should act). Do NOT fix
-  this by loosening the global rule in the prompt — that changes behavior for the whole
-  class and regresses every task where the original behavior was correct (unbounded
-  blast radius). Encode the EXACT discriminating policy predicate as an in-body guard on
-  the tool that owns the action: it refuses/raises ONLY on the qualifying condition, so
-  its blast radius is bounded to the violating cases. This is the SAFE, preferred
-  alternative to a permission-rule prompt edit.
-- **A bloated or overlapping toolset** — too many tools, or several that do
-  nearly the same thing, distracting the agent. Remove or consolidate.
-- **A real behavioral bug in a handler** — the tool returns the wrong thing.
-  Because you own the code, you can fix it directly.
-
-If the problem is *what the agent is told to do* rather than *what it can do*, it is
-out of scope for this capability (it belongs to whatever capability edits the agent's
-instructions).
+If the problem is *what the agent is told to do* rather than *what it can do*, it
+belongs to whatever capability edits the agent's instructions, not here.
 
 ## What can be optimized (default policy = all of these)
 
@@ -433,290 +168,29 @@ instructions).
 | `params` | per-parameter descriptions / defaults | drives correct *argument-filling* |
 | `examples` | example call strings | shows concrete well-formed calls |
 | `schema` | the full JSON Schema (types, `required`, `enum`) | constrains/guides the model's output |
-| `code` | **the handler body of an EXISTING tool** | **the default high-leverage edit** — convert a violated prose rule into an in-body guard (precondition, normalization, actionable refusal); expect to edit SEVERAL existing bodies per iteration |
-| `compose` | add a code-bearing tool that calls existing tools | enforce a rule, collapse a multi-call chain, or perform a whole stalled WRITE action in code — use when no existing tool owns the rule |
+| `code` | **the handler body of an EXISTING tool** | **the default high-leverage edit** — convert a violated prose rule into an in-body guard; expect to edit SEVERAL bodies per iteration |
+| `compose` | add a code-bearing tool that calls existing tools | enforce a rule, collapse a multi-call chain, or perform a whole stalled WRITE action in code |
 | `add` / `remove` | introduce / delete a tool | shape and shrink the toolset (replace primitives; keep it lean) |
 
-The `code` row (editing an EXISTING tool's body) is the **first edit to reach
-for**, with `compose`/`add` close behind — a deterministic guard beats a sentence
-in a prompt (see below). For each violated rule, first ask "which EXISTING tool
-governs this, and what in-body check enforces it?" — usually the answer is editing
-that tool's body, not adding a new one. Reword descriptions *after* you've asked
-"can this rule be code in the existing body instead?" In ONE pass, apply EVERY edit
-class the traces call for — in-body guards across SEVERAL existing tools AND a loop
-tool where needed AND enriched returns/errors AND doc fixes across all implicated
-tools can and should all ship in the same candidate; do not stop after a single
-edit.
+`policy.json` in the capability dir is the safety boundary between "reword the docs" and "rewrite the
+program" — the same artifact is edited in very different trust settings, so tighten the
+allowed set to match your deployment's blast radius (a frozen-API deployment might allow
+only `["description", "params", "examples"]`). `apply()` refuses anything outside the
+allowed set and *reports* the refusal, so an over-tight policy surfaces as visible
+refusals rather than silent no-ops.
 
-Lock any of these off via `inputs/policy.json`. For example, in a frozen-API
-deployment you might allow only `["description", "params", "examples"]` so an
-optimizer can reword tools but never change the wire contract or the code.
-`apply()` refuses anything outside the allowed set and reports the refusal — it
-never silently drops or silently applies a disallowed edit.
+## Adapting to the runtime reader's capability tier
 
-## How tool-using agents actually read a tool
-
-An LLM never sees your implementation. At call time it sees, for every available
-tool, a serialized block of `{name, description, parameters-schema, examples}`
-injected into its context (this is literally how the Anthropic and OpenAI tool
-APIs work, and how an MCP host presents `tools/list` results). Two decisions
-follow, and each is driven by a different part of that block:
-
-1. **Selection** — *which* tool (or none) to call. Decided primarily from the
-   **name** and **description**. Anthropic's own guidance is blunt: the
-   description "is by far the most important factor in tool performance," and
-   they recommend at least 3–4 sentences covering *what the tool does, when to
-   use it, and when not to*. A name like `lookup` selects worse than
-   `get_order_by_id`.
-2. **Argument-filling** — *how* to populate the call. Decided from the
-   **parameter schema** (types, `required`, `enum`, descriptions) plus any
-   **examples**. An `enum` turns "guess a status string" into "pick from this
-   closed set"; prefer it for every closed value set, and use the provider's
-   **strict / schema-validated mode** where available so the model adheres to the
-   schema instead of guessing. A per-field description ("ISO-8601 date, e.g.
-   2025-06-14"; "amount in whole US cents") turns a malformed argument into a
-   correct one — always pin **units, format, and default** per parameter. Add
-   schema-validated **`input_examples`** for complex / nested / format-sensitive
-   params (a few help; long dumps hurt reasoning models). And **don't make the
-   model fill arguments you already know** — pass them in code (a wrapper) instead
-   of asking for them.
-
-**Namespace by service/resource** so selection stays unambiguous as the set grows
-(`github_list_prs`, `payments_charge`), and keep the **active toolset small** — aim
-for **fewer than ~20 tools per turn** (OpenAI's heuristic); selection degrades
-sharply past that. This is the number behind the lean caveat above.
-
-## Adapting to the reader's capability tier
-Scale the edit to WHO calls these tools at runtime (see the `THE READER` block in your
-instructions, if present). For a **mid/weak** reader, push harder on this skill's
-already-preferred **code enforcement** (in-body guards, composite atomic-write tools) — a
-weak reader skips a prose rule but a guard fires regardless — and write **literal,
-example-bearing per-parameter slot-filling docs** on every tool (name the exact format,
-units, and one concrete valid value, e.g. `date: ISO-8601 "2026-07-20"`). A weak reader
-mis-fills under-documented arguments far more often, so the marginal value of explicit
-parameter docs and a smaller, less-confusable toolset is highest there. For a **frontier**
+Scale the edit to WHO calls these tools at runtime (if your instructions state the
+runtime reader's capability tier, use it). For a **mid/weak** reader, push harder on
+this skill's already-preferred **code enforcement** (in-body guards, composite
+atomic-write tools) — a weak reader skips a prose rule but a guard fires regardless —
+and write **literal, example-bearing per-parameter slot-filling docs** on every tool
+(exact format, units, and one concrete valid value, e.g. `date: ISO-8601 "2026-07-20"`).
+A weak reader mis-fills under-documented arguments far more often, so explicit parameter
+docs and a smaller, less-confusable toolset are worth most there. For a **frontier**
 reader, terser parameter docs and fewer worked examples suffice; spend the budget on
 removing redundant tools instead.
-
-## Shape the RESULT, not just the call (output/response design)
-
-What a tool *returns* steers the next turn as much as its description steers
-selection. A bloated or opaque result causes hallucinated ids, wasted context, and
-redundant calls. Design the response:
-
-- **Return high-signal fields only.** Strip low-value noise (internal uuids, mime
-  types, 256-px thumbnail urls, audit columns). Return the semantic fields the
-  agent will actually act on.
-- **Use stable, human-readable identifiers, not raw UUIDs.** Models hallucinate and
-  mis-copy long opaque ids; a `get_order(order_id)` projection should surface
-  `order_id="A-1042"` over `4f3c…-uuid`. If the backend only has a UUID, attach a
-  readable handle alongside it.
-- **Paginate / filter / truncate with sane defaults**, and offer a
-  **`verbosity`/`response_format`** control (e.g. `"concise"` vs `"full"`) so the
-  agent asks for detail only when needed instead of drowning in it.
-- **Make error messages ACTIONABLE — they are a steering surface, not just a
-  failure.** A raw traceback or opaque code teaches the model nothing. Return a
-  specific, example-bearing message that tells the agent how to recover:
-  `"payment method not on file; available: ['card_1','gift_4'] — pass one of these"`
-  or `"date must be ISO-8601 YYYY-MM-DD, got '6/14/25'"`. The model reads the error
-  and self-corrects on the next call instead of retrying the same bad one. Wrappers
-  (patterns 1–3) are the natural place to produce these.
-
-## Document every tool comprehensively
-
-A tool's documentation is its contract. Every tool — primitive or wrapper — needs
-**all** of these, or the model is left guessing:
-
-- a **crisp description**: what it does, when to use it, and when NOT to (the
-  boundary against the nearest sibling tool);
-- an **"important points"** note for any non-obvious behavior or precondition;
-- a **Raises / errors** section listing the failure conditions (keep these — see
-  below; they are a guard rail, not clutter);
-- a **per-parameter description** with units / format / allowed values / default;
-- one **generic, always-valid usage example** (the shape of a call, never one
-  task's literal id/date/city).
-
-**The description is the model's contract, not flavor text.** It is the *only*
-information the model has about *which* tool to call and *what argument values
-are legal*. A good description always states, in always-true terms (never one
-task's specifics):
-
-- **When to use / when not to use** — explicit triggers, and the boundary
-  against the nearest sibling tool ("use X for a single record by id; use Y to
-  search across records").
-- **Argument semantics** — for each parameter: its meaning, **units**, **allowed
-  values / format**, and **default**. "amount in whole US cents" beats "the
-  amount"; "ISO-8601 date `YYYY-MM-DD`" beats "the date".
-- **Preconditions and failure modes** — what must be true *before* the call, and
-  what the tool **raises / returns on error**. This is the model's chance to
-  avoid a bad call. **Do NOT strip `Raises:`/error-condition text to make the
-  description "cleaner."** Knowing a call raises `ValueError: gift card balance
-  too low` is exactly what lets the model pick a different payment method instead
-  of failing the task. Stripping error info removes a guard rail; it does not
-  improve selection.
-- **A short, always-valid usage example** — one concrete well-formed call that is
-  correct for *any* input (e.g. the shape of a list element), never a single
-  benchmark task's literal values.
-
-Selection degrades as the toolset grows: benchmarks like the Berkeley
-Function-Calling Leaderboard include a dedicated "relevance detection" category
-precisely because models hallucinate calls when no tool fits, and ToolLLM had to
-add a *retriever* to cope with thousands of tools. The practical implication for
-this capability: **fewer, sharper, non-overlapping tools beat many vague ones.**
-
-## Concrete before/after
-
-**Selection fix (description).** A trace shows the agent calling a generic
-`query` tool for order lookups, then failing.
-
-```diff
-- "name": "query", "description": "Run a query."
-+ "name": "get_order", "description": "Look up a single order by its ID and
-+   return status, line items, and shipping. Use when the user references a
-+   specific order (an ID, 'my last order', or an order in the current thread).
-+   Do NOT use for searching across orders — use search_orders for that."
-```
-
-**Argument-filling fix (schema + enum).** The agent keeps sending
-`status="done"` when the backend expects `"fulfilled"`.
-
-```diff
-  "parameters": { "type": "object", "properties": {
--   "status": { "type": "string", "description": "the status" }
-+   "status": { "type": "string", "enum": ["pending","fulfilled","cancelled"],
-+               "description": "Order status to filter by." }
-  }, "required": ["status"] }
-```
-
-**Collapse a fumbled chain (compose).** The agent must `search_orders` then
-`get_order` on the first hit, and often forgets the second call.
-
-```json
-{ "kind": "compose", "value": {
-    "name": "find_order",
-    "description": "Search orders by free text and return the full record of the
-      best match. Use this instead of search_orders+get_order when you want one order.",
-    "code": "def find_order(q):\n    hit = search_orders(q)[0]\n    return get_order(hit['id'])"
-}}
-```
-
-## Add tools that call existing tools (the highest-leverage edit)
-
-A docstring edit can only make the model *more likely* to do the right thing.
-A new tool whose body calls existing tools can make the right thing *the only
-thing the model can do*, and can turn many calls into one. These are the two
-PRIMARY patterns (§"highest-leverage edit" above) plus the normalize variant —
-all benchmark-agnostic, and each shows a REAL body you are expected to write:
-
-1. **Workflow / loop — collapse repeated primitive calls into one list call.** If the agent calls
-   `get_record(id)` once per id, or `search(origin, dest, date)` once per
-   route/date combination, add a tool that takes the **list** and loops inside a
-   single call, returning all results together. The agent makes one call instead
-   of N; nothing is dropped or mis-threaded.
-   ```json
-   { "kind": "compose", "value": {
-       "name": "get_records",
-       "description": "Fetch the FULL details of EVERY record in `ids` in one call. Use this instead of calling get_record once per id when you have several ids (e.g. all of a user's records). Returns a list aligned with `ids`; an entry is an error object if that id is not found.",
-       "parameters": {"type":"object","properties":{"ids":{"type":"array","items":{"type":"string"}}},"required":["ids"]},
-       "code": "def get_records(ids):\n    out = []\n    for i in ids:\n        try:\n            out.append(get_record(i))\n        except Exception as e:\n            out.append({'id': i, 'error': str(e)})\n    return out" }}
-   ```
-
-2. **Validation / rule-enforcement — enforce a rule or required order
-   deterministically (wrap, then delegate).** If a write must be preceded by a
-   read, or a precondition the API does not itself check must hold, put the check
-   in code: validate/normalize the inputs, enforce the rule, then call the
-   existing primitive — so a violation returns a clear refusal instead of
-   corrupting state. The model literally cannot skip the step. Then **`remove`
-   the raw primitive** so the only path is the safe one.
-   ```json
-   { "kind": "compose", "value": {
-       "name": "cancel_record_safely",
-       "description": "Cancel a record after verifying it is cancellable. Reads the record first and REFUSES (returns an error) if the cancellation preconditions are not met, so you never need to call get_record yourself before cancelling. Use this for every cancellation.",
-       "parameters": {"type":"object","properties":{"record_id":{"type":"string"}},"required":["record_id"]},
-       "code": "def cancel_record_safely(record_id):\n    rec = get_record(record_id)\n    if not rec.get('cancellable'):\n        return {'error': 'not cancellable', 'record': rec}\n    return cancel_record(record_id)" }}
-   ```
-   ...paired with a `{ "tool": "cancel_record", "kind": "remove" }` so the unsafe
-   primitive leaves the choice set entirely.
-
-3. **Normalize / return richer, ready-to-use results.** Have the new tool do the
-   glue the model otherwise improvises (resolve an id, attach the related record,
-   coerce units), so the model gets a result it can act on directly.
-
-**Then remove the error-prone original** deliberately (the lean caveat). This
-`remove` step is not optional polish — it is what makes the safe/complete tool the
-*only* path. A wrapper that enforces a rule, or a composite that performs a whole
-write, achieves nothing if the raw primitive is still exposed: the model can (and
-under pressure will) route around the guard straight to the primitive and
-reproduce the exact failure. Observed in real runs, optimizers add wrappers but
-**never `remove` the primitives they wrap**, so the unsafe path survives and the
-metric barely moves. To *replace* a confusing or now-redundant tool,
-`add`/`compose` the clearer one and `remove` the old name so it leaves the choice
-set — don't keep both, or selection gets harder (§3 of concepts.md). Net tool
-count should stay small and sharp: prefer one tool that subsumes a primitive over
-two that overlap. Pair every wrapper/composite with the matching `remove` unless
-the primitive is still independently needed for a *different*, safe purpose.
-
-## What good vs bad tool edits look like
-
-Drawn from real runs where the optimizer left most of the gain on the table.
-
-**Bad — what under-performs (do not stop here):**
-
-- **Stripping `Raises:` / error info** "to clean up" the docstring. Observed: an
-  accepted candidate deleted every `Raises:` section. It barely moved the metric
-  and left the model blind to why calls fail. Error conditions are guidance, not
-  clutter — keep them.
-- **Cosmetic description rewording** — reflowing sentences, adding commas,
-  restating the obvious ("Cancel the record" → "Cancel an entire record"). No new
-  always-true information, so no behavior change.
-- **Baking one task's specifics into a description** — naming a particular id,
-  date, or city. It overfits and can mislead on the next task.
-- **Adding tools that duplicate ones the agent already uses fine** — enlarges the
-  choice set and *hurts* selection for no gain.
-
-**Good — what actually moves accuracy and cuts calls:**
-
-- **A loop/composite tool** that collapses the repeated-primitive pattern from the
-  traces (e.g. the agent fetching records one id at a time, or sweeping a search across
-  many parameter combinations) into a single list call.
-- **A rule-enforcing tool** that reads-before-writes or validates a precondition
-  the underlying API does not, turning a silent bad write into a clear refusal.
-- **Precise descriptions** that add genuinely new, always-true content: explicit
-  when/when-not triggers, per-argument units/allowed-values/defaults, retained
-  failure modes, and one always-valid example call.
-- **Replace, don't accumulate** — add the clearer tool and `remove` the
-  error-prone original so the surface stays small and sharp.
-
-The test: *would this edit help on a task the optimizer has never seen?* A loop
-tool, a precondition check, and a unit-pinned argument description pass. A comma
-and a deleted `Raises:` line do not.
-
-## Failure modes to avoid
-
-- **Over-describing into contradiction.** Adding a fifth "use when" clause that
-  conflicts with the first makes selection *worse*. Keep descriptions internally
-  consistent; state the boundary against the nearest sibling tool, not every tool.
-- **Schema changes that break callers.** You own the callers here, but a `code`
-  edit and a `schema` edit must stay in sync — change both in one batch, then run
-  `validate`. In a frozen-API setting, lock `schema`/`code` off via policy.
-- **Composite-tool sprawl.** A composite is worth it only if the chain is
-  frequent and error-prone. Adding one for a two-call path the agent already
-  handles just enlarges the toolset and hurts selection.
-- **Removing a tool that's rarely-but-critically needed.** Check the traces:
-  remove for *overlap/confusion*, not merely for low call-count.
-- **Examples that fight reasoning models.** A few examples sharpen formatting, but
-  long example dumps can degrade reasoning-tuned models — prefer a crisp schema
-  over many examples.
-
-## The action policy (safety knob)
-
-`inputs/policy.json` is the safety boundary between "reword the docs" and "rewrite
-the program." It exists because the same artifact is edited in very different
-trust settings: an optimizer you trust to polish descriptions should not be free
-to change the wire schema of a tool other systems depend on, or to inject
-arbitrary handler code. The default here is the **full** set; tighten it to match
-your deployment's blast radius. Every refused edit is reported, so a policy that's
-too tight surfaces as visible refusals rather than silent no-ops.
 
 ## Artifact + handlers
 
@@ -726,8 +200,8 @@ too tight surfaces as visible refusals rather than silent no-ops.
   (`tool.<name>.description`, `.parameters`, `.examples`) for a text optimizer.
 - `apply(dir, edits)` — policy-enforced edits incl. `schema`/`code`/`compose`;
   returns `{changed, refused}`.
-- `validate(dir)` — schema well-formedness, empty-description and duplicate-name
-  checks.
+- `validate(dir)` — schema well-formedness, empty-description and duplicate-name checks.
+- `is_empty(dir)` — whether the artifact is an empty seed (no tools yet).
 
 ## How to run
 
@@ -738,12 +212,33 @@ python scripts/run.py --path <capability_dir>     # candidate + policy + validit
 
 ## References
 
-- [`references/concepts.md`](references/concepts.md) — the mental model (select vs.
-  fill, toolset design, the policy) with cited sources.
-- [`references/examples.md`](references/examples.md) — worked before/after edits.
-- [`references/pitfalls.md`](references/pitfalls.md) — failure modes and how to detect them.
+Each is standalone — read the one that matches what you are about to do.
+
+- [`references/examples.md`](references/examples.md) — worked before/after edits with
+  full bodies, ordered by leverage: in-body guards (§0), description/schema fixes
+  (§1–§2), loop and composite/write tools (§3b–§3e), result shaping (§3f), the doc
+  contract in practice (§3g), removal and refusals (§4–§7). **Load when you are about to
+  write an edit** and want the exact JSON and a real body to model.
+- [`references/concepts.md`](references/concepts.md) — how an LLM turns tool definitions
+  into a call (select from name+description, fill from schema+examples), toolset-size
+  limits, response shaping, the safe replacement protocol, and the action-policy model,
+  with cited sources. **Read once per project**, before your first candidate.
+- [`references/doc-contract.md`](references/doc-contract.md) — the full documentation
+  contract for one tool: what/when/when-not, important-points, error conditions,
+  per-parameter units and formats, one always-valid example. **Load when the fix is
+  documentation rather than code.**
+- [`references/pitfalls.md`](references/pitfalls.md) — edits that look like improvements
+  and regress (stripped error conditions, cosmetic rewording, task-overfitted
+  descriptions, composite sprawl, example dumps, an exposed primitive behind a wrapper),
+  each with how to detect it. **Read before shipping a docs-only candidate**, and when
+  an accepted candidate barely moved the metric.
+- [`references/field-notes.md`](references/field-notes.md) — observations from real runs:
+  how much of a docstring the runtime actually delivers, why enriching a return is not
+  free, a docstring header that broke tool registration, and a return shape that
+  corrupted the feedback signal. **Read before your first candidate on a new harness**,
+  and whenever an edit "verified" green without an explanation you can point at.
 - [`references/optimizer-playbook.md`](references/optimizer-playbook.md) — what the
   authored optimizer INSTRUCTIONS must demand when `tools` is selected: the
   existing-tool-code mandate, the depth mandate's tools wording, and the two-phase
-  (diagnose fan-out → implement fan-out → merge) subagent pattern. `intake` points
-  here rather than inlining it.
+  (diagnose fan-out → implement fan-out → merge) subagent pattern. **Read when authoring
+  or reviewing those instructions** (`intake` points here rather than inlining it).

--- a/skills/capabilities/tools/SKILL.md
+++ b/skills/capabilities/tools/SKILL.md
@@ -58,26 +58,21 @@ code in the existing body instead?"
    SEVERAL existing tools per iteration — one per violated rule. A deterministic guard
    beats a sentence in a prompt: prose makes the model *more likely* to comply, code
    makes the right behavior the only thing that can happen.
-2. **Add a composite atomic-WRITE tool — the fix for a behavioral STALL.** When the
-   agent analyzes, explains, even confirms the action, then never issues the write call
-   and stops, *more prose does not fix it* — you cannot instruct a model out of a
-   behavior it already agreed to and skipped. Encapsulate the ENTIRE multi-step action
-   in one tool whose body performs all the steps in order via the existing primitives,
-   then **`remove` the raw primitives** so the action is un-skippable. *Ex:*
-   `apply_change_plan(record_id, steps)` validates → applies each → returns final state
-   as one call. This is the *correct* fix even though a write primitive already exists,
-   because the primitive is exactly what the agent declines to call.
-3. **DECISION / PERMISSION cluster → a discriminating-predicate guard.** When a cluster
-   is about ACT-vs-REFUSE, the WRONG fix is loosening a global decision rule in the
-   prompt — unbounded blast radius, regresses every task where the original behavior was
-   gold. The RIGHT fix is an in-body guard on the tool that owns the action, expressing
-   the EXACT policy predicate, refusing only when the qualifying condition is (or is
-   not) met. Bounded blast radius makes this the safest edit available.
-4. **HARD-ZERO / capability-gap cluster → a real targeted tool, never prose.** A task
-   scoring 0.00 that needs a compute / composite / predicate tool stays 0.00 after any
-   docstring or prompt reword. Ship a tool the agent will CALL that changes the graded
-   state — *Ex:* a `find_duplicate_records` it has no way to compute today, or a
-   `search_logs` that returns the relevant lines instead of a raw dump.
+2. **Add a composite atomic-WRITE tool** — for a stalled or abandoned multi-step action,
+   encapsulate the ENTIRE action in one tool whose body performs all the steps in order
+   via the existing primitives, then **`remove` the raw primitives** so the action is
+   un-skippable. *Ex:* `apply_change_plan(record_id, steps)` validates → applies each →
+   returns final state as one call. Reach for this even though a write primitive already
+   exists: the primitive is exactly what the agent declines to call.
+3. **Add a discriminating-predicate guard** for an ACT-vs-REFUSE cluster — an in-body
+   guard on the tool that owns the action, expressing the EXACT policy predicate, that
+   refuses only when the qualifying condition is (or is not) met. It is the narrowest
+   edit available here and the tool-side alternative to changing a global rule.
+4. **Add a real targeted tool for a capability gap** — a task that needs a compute /
+   composite / predicate tool it does not have stays failing after any docstring reword.
+   Ship a tool the agent will CALL that changes the graded state — *Ex:* a
+   `find_duplicate_records` it has no way to compute today, or a `search_logs` that
+   returns the relevant lines instead of a raw dump.
 5. **Add a loop tool** — replace N repeated single-item calls with one list call. *Ex:*
    `get_records(ids: [...])` replaces N× `get_record(id)`.
 6. **Replace / wrap a tool** — superset an existing tool and route the old behavior
@@ -142,20 +137,19 @@ task is dead code, not a fix).
 | Trace symptom | Fix |
 |---------------|-----|
 | **Wrong ARGUMENT the tool could validate** — a write whose id / reference / count / unit is not consistent with the agent-visible state. Right tool, bad argument; partial credit or a corrupted write. | **Normalize-then-call wrapper**: wrap the write in a body that RESOLVES / VALIDATES the argument against current state, and on mismatch returns `available=[...]` or raises an actionable error naming what is wrong and what to pass instead. Never let a write proceed on an unvalidated reference. |
-| **Execution stalls at the action boundary** — the agent analyzes, explains, even confirms, then never calls the write tool and stops (task left half-done). | **Composite WRITE tool** (lever 2): one tool whose body performs the whole analyze→confirm→act sequence, then `remove` the raw primitives so the action is un-skippable. Not a "be sure to act" prose rule. |
-| **Escalate / bail-out abandoning a REQUIRED, eligible action** — the agent hands off or gives up where it could and should have completed the action. A behavioral STALL, not a missing capability. | **Composite WRITE tool**: encapsulate the eligible-action batch in ONE tool whose body executes the steps in code (skipping any ineligible item with a recorded reason), then `remove` the raw primitives so completing the batch is the only path. |
+| **The action never happens** — the agent analyzes, explains, even confirms, then never calls the write tool and stops; or it hands off / gives up on an action it could have completed. Task left half-done. | **Composite WRITE tool** (lever 2): one tool whose body performs the whole sequence — or the whole eligible-action batch, skipping any ineligible item with a recorded reason — then `remove` the raw primitives so completing it is the only path. Not a "be sure to act" prose rule. |
 | **Recoverable error that strands the agent** — a tool raises an opaque traceback / bare code; the agent retries the same bad call or gives up. | **Enriched RETURN that aids recovery**: on a recoverable error return what is wrong + the valid options + the recommended next action (`{"error": "id not found", "available": [...], "next": "call search_x to resolve the id"}`) so the model self-corrects next turn. |
 | **The same primitive called N times in a row** — looping over a list in the agent's own context, burning turns and dropping or mis-threading results. | **Loop tool** (lever 5): one tool that takes the list and loops inside a single call. |
 | **A rule stated in the prompt but repeatedly violated** — a required order ("read before write"), a precondition the API does not enforce, a normalization the model forgets. | **In-body guard / validation wrapper** (lever 1): enforce the rule in the body of the tool that owns it; `remove` the unguarded primitive if the safe path must be the only one. |
-| **A DECISION / PERMISSION the model gets wrong (ACT vs REFUSE)** — it acts where policy says refuse/escalate, or refuses where it should act. | **Discriminating-predicate guard** (lever 3) on the tool that owns the action. Do NOT loosen the global rule in the prompt. |
+| **A wrong ACT-vs-REFUSE call** — the agent acts where policy says refuse/escalate, or refuses where it should act. | **Discriminating-predicate guard** (lever 3) on the tool that owns the action. |
 | **Mis-selection** — the agent calls the wrong tool, calls none when one applied, or invents a tool that does not exist. | **Name + description fix**: selection is driven almost entirely by the name and description — sharpen what/when/when-not and the boundary against the nearest sibling (`references/doc-contract.md`). |
 | **Bad argument-filling** — right tool, wrong arguments: a missing required field, the wrong enum value, free text where a structured object was expected. | **Schema + per-parameter docs**: close the value set with an `enum`, pin units/format/default per parameter, add an in-description example. |
 | **A bloated or overlapping toolset** — too many tools, or several that do nearly the same thing, distracting the agent. | **Consolidate then `remove`** the originals (lever 9). Remove for *overlap/confusion*, not for low call-count. |
-| **A real behavioral bug in a handler** — the tool returns the wrong thing. | **`code` edit**: because you own the code, fix it directly. |
+| **A bug in a handler** — the tool returns the wrong thing. | **`code` edit**: because you own the code, fix it directly. |
 
-The throughline: a failure the agent *knows better than* but still commits is
-behavioral, and behavioral failures are fixed by removing the choice — putting the
-behavior in code and `remove`-ing the path that let it go wrong.
+The throughline: a failure the agent *knows better than* but still commits is fixed by
+removing the choice — putting the behavior in code and `remove`-ing the path that let it
+go wrong.
 
 If the problem is *what the agent is told to do* rather than *what it can do*, it
 belongs to whatever capability edits the agent's instructions, not here.

--- a/skills/capabilities/tools/references/concepts.md
+++ b/skills/capabilities/tools/references/concepts.md
@@ -109,6 +109,31 @@ finds documentation, not examples, is what carries usage. Deleting error
 conditions to shorten a description removes guidance and is a common
 *non-improving* edit.
 
+## 5. The action policy is the safety boundary
+
+`inputs/policy.json` lists the allowed edit kinds. It exists because the same
+artifact is edited in different trust settings. Rewording a description is low
+risk; rewriting a handler's `code` or changing a `schema` other systems depend on
+is high risk. The policy lets you grant exactly the blast radius you intend:
+
+- Frozen API / shared schema → allow `["description","params","examples"]` only.
+- You own everything → allow the full set (the default in this capability).
+
+This mirrors the *mutation-lock* idea from agent-optimization tooling: let an
+automatic optimizer change the safe surface, forbid the rest. `apply()` reports
+every refusal, so an over-tight policy is visible, not silent.
+
+## 6. Automatic optimization of tool text
+
+The same loop a human runs here — propose a description/schema edit, score it on a
+held-out task set, keep what helps — is what automatic prompt/instruction
+optimizers do. **GEPA** evolves prompt/instruction text by reflecting in natural
+language over sampled trajectories and reports beating RL (GRPO) and DSPy's
+MIPROv2 on several tasks; **DSPy** optimizers (MIPROv2, GEPA) tune instructions
+and demonstrations against a metric. Tool descriptions and examples are
+exactly this kind of optimizable text, which is why this capability `materialize`s
+them as named components an optimizer can rewrite.
+
 ## 7. Output / response shaping
 
 Selection and filling decide the *call*; the **response** decides the next turn.
@@ -149,31 +174,6 @@ needed it. Both are regressions. The safe sequence to replace/consolidate a tool
 Never bare-remove without a replacement that calls the original. Add-verify-swap
 makes the safe path the only path with no coverage gap (and keeps the count lean —
 one tool subsuming a primitive beats two overlapping ones).
-
-## 5. The action policy is the safety boundary
-
-`inputs/policy.json` lists the allowed edit kinds. It exists because the same
-artifact is edited in different trust settings. Rewording a description is low
-risk; rewriting a handler's `code` or changing a `schema` other systems depend on
-is high risk. The policy lets you grant exactly the blast radius you intend:
-
-- Frozen API / shared schema → allow `["description","params","examples"]` only.
-- You own everything → allow the full set (the default in this capability).
-
-This mirrors the *mutation-lock* idea from agent-optimization tooling: let an
-automatic optimizer change the safe surface, forbid the rest. `apply()` reports
-every refusal, so an over-tight policy is visible, not silent.
-
-## 6. Automatic optimization of tool text
-
-The same loop a human runs here — propose a description/schema edit, score it on a
-held-out task set, keep what helps — is what automatic prompt/instruction
-optimizers do. **GEPA** evolves prompt/instruction text by reflecting in natural
-language over sampled trajectories and reports beating RL (GRPO) and DSPy's
-MIPROv2 on several tasks; **DSPy** optimizers (MIPROv2, GEPA) tune instructions
-and demonstrations against a metric. Tool descriptions and examples are
-exactly this kind of optimizable text, which is why this capability `materialize`s
-them as named components an optimizer can rewrite.
 
 ## Sources
 

--- a/skills/capabilities/tools/references/doc-contract.md
+++ b/skills/capabilities/tools/references/doc-contract.md
@@ -1,0 +1,50 @@
+# The documentation contract for one tool
+
+Load this when the fix is documentation rather than code — you are sharpening a
+description, per-parameter docs, or error text and want to know what a complete tool
+doc contains. A worked, fully-documented tool is `examples.md` §3g.
+
+## Every tool needs all of these
+
+A tool's documentation is its contract. Every tool — primitive or wrapper — needs
+**all** of these, or the model is left guessing:
+
+- a **crisp description**: what it does, when to use it, and when NOT to (the boundary
+  against the nearest sibling tool);
+- an **"important points"** note for any non-obvious behavior or precondition;
+- a **Raises / errors** section listing the failure conditions (keep these — see below;
+  they are a guard rail, not clutter);
+- a **per-parameter description** with units / format / allowed values / default;
+- one **generic, always-valid usage example** (the shape of a call, never one task's
+  literal id/date/city).
+
+## The description is the model's contract, not flavor text
+
+It is the *only* information the model has about *which* tool to call and *what
+argument values are legal*. A good description always states, in always-true terms
+(never one task's specifics):
+
+- **When to use / when not to use** — explicit triggers, and the boundary against the
+  nearest sibling tool ("use X for a single record by id; use Y to search across
+  records").
+- **Argument semantics** — for each parameter: its meaning, **units**, **allowed values
+  / format**, and **default**. "amount in whole US cents" beats "the amount"; "ISO-8601
+  date `YYYY-MM-DD`" beats "the date".
+- **Preconditions and failure modes** — what must be true *before* the call, and what
+  the tool **raises / returns on error**. This is the model's chance to avoid a bad
+  call. **Do NOT strip `Raises:`/error-condition text to make the description
+  "cleaner."** Knowing a call raises `ValueError: gift card balance too low` is exactly
+  what lets the model pick a different payment method instead of failing the task.
+  Stripping error info removes a guard rail; it does not improve selection.
+- **A short, always-valid usage example** — one concrete well-formed call that is
+  correct for *any* input (e.g. the shape of a list element), never a single benchmark
+  task's literal values.
+
+## Why fewer, sharper tools beat many vague ones
+
+Selection degrades as the toolset grows: benchmarks like the Berkeley Function-Calling
+Leaderboard include a dedicated "relevance detection" category precisely because models
+hallucinate calls when no tool fits, and ToolLLM had to add a *retriever* to cope with
+thousands of tools. The practical implication for this capability: **fewer, sharper,
+non-overlapping tools beat many vague ones** — so a documentation pass that reduces
+overlap between two siblings is worth more than one that polishes either alone.

--- a/skills/capabilities/tools/references/examples.md
+++ b/skills/capabilities/tools/references/examples.md
@@ -20,6 +20,25 @@ strands the agent → an enriched RETURN that names what's wrong + the valid opt
 the next action (§3f). Always VERIFY the fix fires on the exact failing-trace
 arguments before shipping it.
 
+## Contents
+- [0. Turning N prose rules into N in-body checks (the DEFAULT edit)](#0-turning-n-prose-rules-into-n-in-body-checks-the-default-edit)
+- [1. Selection fix — sharpen a vague description](#1-selection-fix--sharpen-a-vague-description)
+- [2. Argument-filling fix — close the value set with an enum](#2-argument-filling-fix--close-the-value-set-with-an-enum)
+- [3. Collapse a fumbled chain — compose](#3-collapse-a-fumbled-chain--compose)
+- [3b. Collapse repeated primitive calls — a loop-in-one-call tool](#3b-collapse-repeated-primitive-calls--a-loop-in-one-call-tool)
+- [3c. Validation / rule-enforcement tool — wrap, then delegate](#3c-validation--rule-enforcement-tool--wrap-then-delegate-then-remove-the-primitive)
+- [3c-bis. Validate-and-normalize inputs before a primitive](#3c-bis-validate-and-normalize-inputs-before-a-primitive)
+- [3c-ter. Wrong ARGUMENT the tool could validate](#3c-ter-wrong-argument-the-tool-could-validate--resolvevalidate-against-state-return-available)
+- [3c-quater. A required, eligible action abandoned via bail-out](#3c-quater-a-required-eligible-action-abandoned-via-bail-out--escalation--encapsulate-the-batch-as-a-composite-write)
+- [3d. Keep failure modes — improve, do not delete, `Raises:`](#3d-keep-failure-modes--improve-do-not-delete-raises)
+- [3e. Make a STALLED action un-skippable — a composite WRITE tool](#3e-make-a-stalled-action-un-skippable--a-composite-write-tool-then-remove-the-primitives)
+- [3f. Shape the result — high-signal fields, readable ids, actionable errors](#3f-shape-the-result--high-signal-fields-readable-ids-actionable-errors)
+- [3g. A comprehensively documented tool (the doc contract)](#3g-a-comprehensively-documented-tool-the-doc-contract)
+- [4. Shrink an overlapping toolset — remove + consolidate](#4-shrink-an-overlapping-toolset--remove--consolidate)
+- [5. Behavior bug — code edit](#5-behavior-bug--code-edit)
+- [6. A policy refusal (what tightening looks like)](#6-a-policy-refusal-what-tightening-looks-like)
+- [7. SECONDARY (last resort) — a passthrough / reasoning-only tool](#7-secondary-last-resort--a-passthrough--reasoning-only-tool)
+
 ## 0. Turning N prose rules into N in-body checks (the DEFAULT edit)
 
 The most common high-leverage edit is NOT adding a tool — it is editing the BODIES
@@ -232,6 +251,21 @@ the agent can no longer hand off a task it was equipped to finish; ineligible it
 are skipped with a reason rather than blocking the batch. (Verify: run the body on the
 record from the bail-out trace and confirm it processes the eligible items.)
 
+## 3d. Keep failure modes — improve, do not delete, `Raises:`
+
+Anti-symptom: an optimizer "cleaned up" a description by deleting its `Raises:`
+section. Do the opposite — keep the error conditions and pair each with the
+recovery action.
+
+```json
+{ "tool": "charge_payment", "kind": "description",
+  "value": "Charge `amount` (whole US cents) to the payment method `payment_id` from the user's profile. Use after the user confirms the total. Fails if the payment method is not on file (pick another from get_user_details) or if a gift-card balance is below `amount` (split across methods or choose a card). Example: charge_payment(payment_id='gift_card_42', amount=1299)." }
+```
+
+Why it works: the model now knows the units (cents), the precondition (method on
+file), and exactly what to do on each failure — instead of retrying the same bad
+call.
+
 ## 3e. Make a STALLED action un-skippable — a composite WRITE tool (then remove the primitives)
 
 Trace symptom (the most common behavioral failure): the agent analyzes a
@@ -266,21 +300,6 @@ Why it works: the analyze→apply sequence lives entirely in the tool body, so a
 single call performs all of it — the agent can no longer narrate a plan and then
 fail to execute it. Removing the raw `update_record` makes the composite the only
 reachable write path, so the stall cannot recur by routing around it.
-
-## 3d. Keep failure modes — improve, do not delete, `Raises:`
-
-Anti-symptom: an optimizer "cleaned up" a description by deleting its `Raises:`
-section. Do the opposite — keep the error conditions and pair each with the
-recovery action.
-
-```json
-{ "tool": "charge_payment", "kind": "description",
-  "value": "Charge `amount` (whole US cents) to the payment method `payment_id` from the user's profile. Use after the user confirms the total. Fails if the payment method is not on file (pick another from get_user_details) or if a gift-card balance is below `amount` (split across methods or choose a card). Example: charge_payment(payment_id='gift_card_42', amount=1299)." }
-```
-
-Why it works: the model now knows the units (cents), the precondition (method on
-file), and exactly what to do on each failure — instead of retrying the same bad
-call.
 
 ## 3f. Shape the result — high-signal fields, readable ids, actionable errors
 

--- a/skills/capabilities/tools/references/examples.md
+++ b/skills/capabilities/tools/references/examples.md
@@ -4,22 +4,6 @@ Each example is an edit you would emit to `apply()`. Edit shape:
 `{"tool": <name>, "kind": <action>, "value": <...>}`. For `add`/`compose` the
 value is a full tool def; for `remove` the value is ignored.
 
-**Ordered by leverage.** The DEFAULT, most common edit is §0 — editing the BODY of
-an EXISTING tool to convert a violated prose rule into an in-body check. The other
-PRIMARY edits are the code-bearing tools in §3b (workflow/loop) and §3c
-(validation/rule-enforcement) — a deterministic body beats a prompt sentence. Reach
-for the description/schema edits (§1, §2) *after* asking "can this rule be code in
-the existing body instead?" A passthrough / reasoning-only tool (§7) is the
-SECONDARY, last-resort form — prose in a tool's costume.
-
-**First-class failure→fix patterns** (diagnose for these first): a wrong ARGUMENT the
-tool could validate → resolve/validate against state, return `available=[...]`
-(§3c-ter); a required eligible action abandoned via bail-out / transfer-to-human →
-encapsulate the batch as a COMPOSITE WRITE (§3c-quater, §3e); a recoverable error that
-strands the agent → an enriched RETURN that names what's wrong + the valid options +
-the next action (§3f). Always VERIFY the fix fires on the exact failing-trace
-arguments before shipping it.
-
 ## Contents
 - [0. Turning N prose rules into N in-body checks (the DEFAULT edit)](#0-turning-n-prose-rules-into-n-in-body-checks-the-default-edit)
 - [1. Selection fix — sharpen a vague description](#1-selection-fix--sharpen-a-vague-description)
@@ -38,6 +22,22 @@ arguments before shipping it.
 - [5. Behavior bug — code edit](#5-behavior-bug--code-edit)
 - [6. A policy refusal (what tightening looks like)](#6-a-policy-refusal-what-tightening-looks-like)
 - [7. SECONDARY (last resort) — a passthrough / reasoning-only tool](#7-secondary-last-resort--a-passthrough--reasoning-only-tool)
+
+**Ordered by leverage.** The DEFAULT, most common edit is §0 — editing the BODY of
+an EXISTING tool to convert a violated prose rule into an in-body check. The other
+PRIMARY edits are the code-bearing tools in §3b (workflow/loop) and §3c
+(validation/rule-enforcement) — a deterministic body beats a prompt sentence. Reach
+for the description/schema edits (§1, §2) *after* asking "can this rule be code in
+the existing body instead?" A passthrough / reasoning-only tool (§7) is the
+SECONDARY, last-resort form — prose in a tool's costume.
+
+**First-class failure→fix patterns** (diagnose for these first): a wrong ARGUMENT the
+tool could validate → resolve/validate against state, return `available=[...]`
+(§3c-ter); a required eligible action abandoned via bail-out / transfer-to-human →
+encapsulate the batch as a COMPOSITE WRITE (§3c-quater, §3e); a recoverable error that
+strands the agent → an enriched RETURN that names what's wrong + the valid options +
+the next action (§3f). Always VERIFY the fix fires on the exact failing-trace
+arguments before shipping it.
 
 ## 0. Turning N prose rules into N in-body checks (the DEFAULT edit)
 

--- a/skills/capabilities/tools/references/field-notes.md
+++ b/skills/capabilities/tools/references/field-notes.md
@@ -1,0 +1,92 @@
+# Field notes — observations from real optimization runs
+
+Evidence gathered while optimizing tool surfaces on specific harnesses and runners.
+These are **observations, not rules**: the numbers belong to the runs that produced
+them, and the harness details (Python docstrings, one framework's schema builder) are
+that framework's, not this capability's. Read them for the *mechanism*, then verify the
+equivalent on your own runtime.
+
+Read before your first candidate on a new harness, and whenever an edit "verified"
+green without an explanation you can point at.
+
+## Contents
+- [1. Not all of a tool's documentation reaches the model](#1-not-all-of-a-tools-documentation-reaches-the-model)
+- [2. Enriching a return is a hypothesis, not a free win](#2-enriching-a-return-is-a-hypothesis-not-a-free-win)
+- [3. A docstring header can break tool REGISTRATION](#3-a-docstring-header-can-break-tool-registration)
+- [4. Changing a return SHAPE can corrupt the learning signal](#4-changing-a-return-shape-can-corrupt-the-learning-signal)
+
+## 1. Not all of a tool's documentation reaches the model
+
+A docstring is not the wire schema. One benchmark harness built each tool's schema
+`description` from the docstring **summary plus the prose before `Args:`**, and dropped
+the `Returns:` section entirely. Measured across a 14-tool toolset there: **5469 of
+12929 docstring characters (42%) never reached the model**, and on the one tool whose
+return had been documented most carefully it was **1791 of 1906 — 94% dropped**.
+Rounds of behavioural guidance had been written into that void, and one edit credited
+as "verified" turned out to work only because the return **VALUE** changed shape
+(which the model does see at call time), not because anything documented it.
+
+So on that harness there were three delivered surfaces — the summary and pre-`Args:`
+prose, the per-parameter `Args:` descriptions, and the returned value itself — and one
+that looked identical and did nothing. **Render the live toolset the way the runtime
+builds it and count the delivered characters per candidate** rather than trusting the
+file. Your runtime will have its own cut line; find it before you write into it.
+
+## 2. Enriching a return is a hypothesis, not a free win
+
+A tool return is re-read on every later turn, so adding to it is not free — measure it.
+Measured on a multi-turn tool-use benchmark with a mid-tier runner: one round accepted
+an edit that CONSTRAINED behaviour (in-code preconditions, val 0.5889 → 0.6778,
++8.9pp) while **four separate edits that ADDED information all landed at or below the
+same parent**: richer docs + derived facts merged onto the winner **0.6444**, composite
+tools **0.6556**, argument derivation **0.6666** (identical to that round's null
+control), and a structural policy rewrite **0.5777** (also identical to the control).
+
+Multi-turn rollouts have a step budget and the whole conversation is re-read each turn,
+so verbose returns crowd out the signal they were meant to supply. Keep what the agent
+ACTS on — amounts, eligibility, the corrective hint — and cut what it can read off the
+object it already has. When in doubt, run the subtraction as its own gated candidate;
+it is as legitimate a hypothesis as the addition, and here the additive ones lost.
+
+## 3. A docstring header can break tool REGISTRATION
+
+Observed: adding a worked example under an `Example:` / `Examples:` header made
+`docstring_parser` return a `DocstringExample` object; that harness's `Tool` model
+required `examples: list[str]`, so building the environment raised and **all 90
+rollouts of that candidate died as `INFRASTRUCTURE_ERROR`** — an entire evaluation
+spent on a parse error, not on the edit. Keep the example text, but put it under
+ordinary prose (e.g. "A correct call looks like:").
+
+**An import check is NOT a registration check** — the file imported fine; it was
+registration that failed. Prove the toolset still builds the way the runtime builds it
+before you spend rollouts. If the adapter exposes a render/validate helper, call that
+and keep it in the loop. Otherwise construct it directly, substituting your own
+runner's construction call for the last line, which is harness-specific:
+
+```bash
+python -c "import sys; sys.path.insert(0,'<project>/adapters'); from adapter import Adapter; \
+from pathlib import Path; Adapter().apply(Path('<candidate_dir>')); \
+tools = <your harness's get_tools() call>; \
+print(len(tools), sorted(t.name for t in tools))"
+```
+
+The same render is what lets you count delivered characters (§1).
+
+## 4. Changing a return SHAPE can corrupt the learning signal
+
+This one is a caveat about the *measurement*, not about tool surfaces — keep it in mind
+when a defect appears without a cause.
+
+Optimizer-side code that parses tool returns to build feedback is written against the
+PRISTINE shape, and a candidate is entitled to change it. Observed: a candidate that
+nested summary objects under a list key the feedback code read as bare ids made that
+code `str()` the dicts, so its feedback claimed the id was *"not among"* the held ids —
+for calls whose id was perfectly valid. The reward was never affected (it came from the
+harness's own DB/action checks, which never read a tool's return), but one optimizer
+spent a whole iteration hunting a scoring bug that did not exist, and another concluded
+the key name was capping its score.
+
+Two lessons, in order: **audit the measurement before you believe a defect**, and make
+return-parsing tolerant of shapes a candidate may legitimately introduce (extract ids
+from `str` *or* `dict` entries) rather than forbidding the enrichment. The signal
+degrades exactly when the candidate is most interesting.

--- a/skills/capabilities/tools/references/optimizer-playbook.md
+++ b/skills/capabilities/tools/references/optimizer-playbook.md
@@ -31,10 +31,10 @@ in-body guard there, not a new tool. State plainly: *a docstring-only iteration 
 one that only adds a single new tool + rewords docstrings, leaving rules as prose)
 is under-used.*
 
-The edit classes this mandate ranges over — and the before/after diffs that show an
-in-body guard replacing a prose rule — are in
-[`../SKILL.md`](../SKILL.md) ("What you can change here", "The highest-leverage
-edit") and [`examples.md`](examples.md).
+The edit classes this mandate ranges over are in
+[`../SKILL.md`](../SKILL.md) ("What you can change here", "Pick the lever by failure
+type"), which also points at the worked before/after diffs showing an in-body guard
+replacing a prose rule.
 
 ## The explicit TWO-PHASE subagent pattern
 

--- a/skills/capabilities/tools/references/pitfalls.md
+++ b/skills/capabilities/tools/references/pitfalls.md
@@ -126,3 +126,23 @@ the name is read first and weighs heavily.
 - **Detect:** `apply()` returns `changed: []` and a non-empty `refused`.
 - **Fix:** widen `inputs/policy.json` deliberately, or re-express the change as an
   allowed edit kind.
+
+## The positive mirror — what actually moves accuracy and cuts calls
+
+Every pitfall above has a shape that works. When an accepted candidate barely moved the
+metric, check it against this list:
+
+- **A loop/composite tool** that collapses the repeated-primitive pattern from the traces
+  (fetching records one id at a time, sweeping a search across many parameter
+  combinations) into a single list call.
+- **A rule-enforcing tool** that reads-before-writes or validates a precondition the
+  underlying API does not, turning a silent bad write into a clear refusal.
+- **Precise descriptions** that add genuinely new, always-true content: explicit
+  when/when-not triggers, per-argument units/allowed-values/defaults, retained failure
+  modes, and one always-valid example call.
+- **Replace, don't accumulate** — add the clearer tool and `remove` the error-prone
+  original so the surface stays small and sharp.
+
+The test: *would this edit help on a task the optimizer has never seen?* A loop tool, a
+precondition check, and a unit-pinned argument description pass. A comma and a deleted
+`Raises:` line do not.

--- a/skills/capabilities/tools/scripts/check.py
+++ b/skills/capabilities/tools/scripts/check.py
@@ -28,15 +28,35 @@ def main() -> int:
             {"tool": "search", "kind": "code", "value": "def search(q, n=10): ..."},
             {"kind": "compose", "value": {"name": "search_top", "description": "search then top-n",
                                           "code": "def search_top(q): return search(q, 1)"}},
+            # remove-with-replacement: search_top subsumes search, so drop the primitive.
+            {"tool": "search", "kind": "remove"},
         ])
         if rep["refused"]:
             report["problems"].append(f"full policy refused allowed edits: {rep['refused']}")
         if "schema:search" not in rep["changed"] or not any(c.startswith("compose") for c in rep["changed"]):
             report["problems"].append(f"expected schema+compose edits applied, got {rep['changed']}")
+        if "remove:search" not in rep["changed"]:
+            report["problems"].append(f"expected remove:search applied, got {rep['changed']}")
+        names = [t.get("name") for t in json.loads((cap / "tools.json").read_text())["tools"]]
+        if names != ["search_top"]:
+            report["problems"].append(f"after compose+remove expected ['search_top'], got {names}")
         v = abstract.validate(cap)
         if not v["ok"]:
             report["problems"].append(f"validate failed: {v['problems']}")
-        report["notes"].append("full action set (schema/code/compose) allowed by default")
+        report["notes"].append("full action set (schema/code/compose/remove) allowed by default")
+
+        # A tightened policy must REFUSE, not silently drop or silently apply.
+        (cap / "policy.json").write_text(
+            json.dumps({"allow": ["description"]}), encoding="utf-8")
+        rep2 = abstract.apply(cap, [
+            {"tool": "search_top", "kind": "description", "value": "Search and return the top hit."},
+            {"tool": "search_top", "kind": "code", "value": "def search_top(q): return 1"},
+        ])
+        if not rep2["refused"]:
+            report["problems"].append("tightened policy did not refuse a 'code' edit")
+        if "description:search_top" not in rep2["changed"]:
+            report["problems"].append(f"tightened policy dropped an allowed edit: {rep2['changed']}")
+        report["notes"].append("tightened policy refuses disallowed kinds and reports them")
     report["ok"] = not report["problems"]
     print(json.dumps(report, indent=2))
     return 0 if report["ok"] else 1


### PR DESCRIPTION
Closes #323.

## Before / after

```
$ git show main:skills/capabilities/tools/SKILL.md | wc -l
     749
$ wc -l skills/capabilities/tools/SKILL.md
     238 skills/capabilities/tools/SKILL.md
```

**749 → 238 body lines** (68% smaller, comfortably under the 500-line budget). Total
skill content is roughly unchanged — it moved from the every-trigger tier to the
load-on-demand tier:

| File | before | after |
|---|---:|---:|
| `SKILL.md` (paid on every trigger) | 749 | **238** |
| `references/examples.md` | 377 | 397 (added a TOC) |
| `references/concepts.md` | 196 | 196 (reordered only) |
| `references/pitfalls.md` | 128 | 149 |
| `references/optimizer-playbook.md` | 53 | 53 |
| `references/field-notes.md` | — | **93 (new)** |
| `references/doc-contract.md` | — | **51 (new)** |

I touched **only `skills/capabilities/tools/`**. `mcp-tool/` is untouched — what it
should drop is listed at the bottom for #326.

## Complete section → destination mapping

Every original line range, and where it went. Line numbers are `main`'s
`skills/capabilities/tools/SKILL.md`.

| Source (`SKILL.md` on main) | What it is | Destination |
|---|---|---|
| `1-10` | frontmatter | body (description rewritten, see below) |
| `12-19` | what the capability owns | body, intro (7 lines) |
| `20-23` | ownership boundary — restates `14-18` | body, folded into the intro parenthetical |
| `27-40` | field note: delivered docstring characters, `Args:`/`Returns:`, 5469/12929, 94% dropped | **`references/field-notes.md` §1**; the generalizable kernel ("confirm which parts your runtime actually SENDS") stays in the body |
| `43-54` | field note: enriching a return, val 0.5889→0.6778 and the four null additions | **`references/field-notes.md` §2**; kernel kept as one clause on lever 8 |
| `56-68` | field note: a changed return shape corrupting the optimizer's feedback parser | **`references/field-notes.md` §4**, explicitly flagged as a measurement caveat rather than a tools rule |
| `70-79` | doc-and-return-are-what-the-agent-sees | body, "What you can change here" |
| `81-99` | field note: `Example:` header broke registration, all 90 rollouts died; the `python -c` render snippet | **`references/field-notes.md` §3**; kernel ("an import check is not a registration check") stays in Guardrails |
| `101-107` | multi-fix + REAL/SAFE/VERIFIED + gate consequence | body, compressed to 6 lines (gate named as the consequence, not re-explained) |
| `108-112` | per-change SAFETY | body, kept |
| `114-146` | lever bullets (in-body guard, new tool, decision/permission, hard-zero) | body, merged into the single ordered lever list (items 1–4) |
| `148-186` | numbered lever list 1–8 | body, merged into the same list (items 1–9, no duplication) |
| `188-220` | two before/after in-body-guard diffs (`cancel_record`, `book`) | **deleted from body** — verbatim-equivalent to `examples.md` §0a–0d, already there |
| `221-226` | guardrails (code-not-prose, small toolset, valid code, no bare remove) | body, `## Guardrails` |
| `228-240` | generalize-never-hardcode + the discriminating-predicate variant | body, `## Guardrails` last bullet (the predicate variant is lever 3) |
| `242-264` | "The highest-leverage edit" intro — re-derives levers 1/2/7 | **deleted** (see "deliberately removed") |
| `266-277` | "Prose cannot fix a BEHAVIORAL failure" | **`references/pitfalls.md`** "Trying to fix a BEHAVIORAL stall with prose" (already there); one clause survives in lever 2 |
| `279-313` | three patterns — re-derives levers 1/6/7 | **deleted**; worked bodies are `examples.md` §3b/§3c/§3e |
| `315-320` | lean caveat, replace-don't-accumulate | body Guardrails bullet 4; depth in `concepts.md` §8 |
| `322-337` | SAFE TOOL-REPLACEMENT PROTOCOL | **`concepts.md` §8** (already there, verbatim equivalent); body keeps "add → verify → swap" + the pointer |
| `339-344` | "You must write the BODY" (no `...`/`pass`/docstring-only) | body, `## Guardrails` bullet 2 (kept — it is short and prevents a no-op candidate) |
| `346-355` | SECONDARY passthrough / "think" tools | **`examples.md` §7** (already there); one clause in Guardrails bullet 1 |
| `357-381` | the failure→fix table | body — now the **single canonical statement**, extended by 5 rows (below) |
| `382-426` | "When to use this" — third pass over the same content | **deleted**; the four signatures it uniquely carried became table rows: *Mis-selection*, *Bad argument-filling*, *A bloated or overlapping toolset*, *A real behavioral bug in a handler*. The DECISION/PERMISSION bullet (`411-418`) became a table row too. `424-426` (out-of-scope clause) kept as a one-line note under the table. |
| `428-438` | optimizable-actions table | body, kept |
| `440-449` | prose re-arguing code-first + multi-edit | **deleted** — duplicates `101-112` and the `code` row of the table it sits under |
| `451-455` | policy note | body, merged with `711-719` into one 5-line paragraph |
| `457-487` | how an LLM reads a tool (select vs fill, namespacing, <20 tools) | **`concepts.md` §1–§3** (already there); body keeps the `< ~20` number in Guardrails and points at concepts |
| `489-499` | reader capability tier | body, reworded per F4 (no `THE READER` section name) |
| `501-523` | shape the RESULT / actionable errors | **`concepts.md` §7** + **`pitfalls.md`** "Opaque errors and UUID-heavy responses" (already there); body keeps it as lever 8 and a table row |
| `525-560` | the per-tool documentation contract | **`references/doc-contract.md` (new)** |
| `561-565` | BFCL / ToolLLM "fewer sharper tools" | **`references/doc-contract.md`** closing section (also in `concepts.md` §3) |
| `567-601` | "Concrete before/after" (`query`→`get_order`, status enum, `find_order`) | **deleted from body** — character-identical to `examples.md` §1/§2/§3 |
| `603-644` | "Add tools that call existing tools" (`get_records`, `cancel_record_safely`, normalize variant) | **deleted from body** — character-identical to `examples.md` §3b/§3c |
| `645-657` | "Then remove the error-prone original" | **`pitfalls.md`** "Wrapping a primitive but leaving it exposed" + `concepts.md` §8 (already there) |
| `659-676` | "Bad — what under-performs" (4 bullets) | **`pitfalls.md`** (all four already there: stripping `Raises:`, cosmetic rewording, overfitting, duplicate tools) |
| `677-692` | "Good — what actually moves accuracy" + the never-seen-task test | **`pitfalls.md` new closing section "The positive mirror"**; the never-seen-task test line also kept in the body Guardrails |
| `694-709` | "Failure modes to avoid" (5 bullets) | **deleted from body** — all five in `pitfalls.md:65-103`, same order |
| `711-719` | the action policy (safety knob) | body, merged into the policy paragraph under the actions table |
| `721-731` | artifact + handlers | body, kept + `is_empty` added (it was missing) |
| `732-737` | how to run | body, kept verbatim (a 6-line invocation block is the cheap kind of duplication; de-duplicating it across 13 skills is a repo-wide call) |
| `739-749` | references list | body, rewritten as six pointers each stating **what it holds AND when to load it** |

### Deliberately removed (not moved anywhere)

1. **`242-264` "The highest-leverage edit" opening (23 lines).** It re-derives lever
   items 1, 2 and 7 and then points at the diffs above it. Every claim in it appears in
   the lever list, the failure→fix table, or `pitfalls.md`. Kept only its one novel
   sentence — "the primitive is exactly what the agent declines to call" — inside lever 2.
2. **`279-313` the "three patterns" block (35 lines).** Same three patterns as levers 1,
   5 and 2, at three times the length, with the worked bodies already in `examples.md`
   §3b/§3c/§3e.
3. **`382-426` "When to use this" (45 lines).** A third statement of when-to-use in the
   body, which skill-creator puts in the description ("All 'when to use' info goes here,
   not in the body"). Its four unique failure signatures became table rows, so no
   routing information is lost — only the third restatement.
4. **`440-449` (10 lines).** Repeats "the `code` row is the first edit to reach for" and
   "do not stop after a single edit", both stated already at `101-112` and in the table
   cell directly above it.
5. **`188-220`, `567-601`, `603-644`, `694-709`, `457-487`, `501-523` (~150 lines).** Not
   removed but *de-duplicated*: each was verbatim-or-equivalent to a passage in
   `examples.md`, `concepts.md`, or `pitfalls.md`. The reference copy is the survivor; I
   verified each pairing line by line before deleting.

Nothing was cut for being wrong. The four block quotes at `27-99` were the only content
that violated GENERIC-NOT-SPECIFIC, and they were *moved*, not dropped — `field-notes.md`
labels them as observations from named runs and states the generalizable mechanism first,
so the capability no longer reads as tied to Python docstrings or one benchmark.

### Frontmatter description

```
before (453 chars): … You may edit tool names, descriptions, parameter docs, in-description
                    examples, the JSON schema/API, the tool code itself, ADD tools
                    (including composite tools that call existing tools), and REMOVE
                    tools — all under an action policy so risky edits can be locked off.

after  (389 chars): Optimize an agent's OWN tool surface (tools it implements, not an
                    external MCP server). Use when the agent mis-selects tools, fills
                    arguments wrong, calls the same tool N times in a row, or has a
                    confusing, redundant, or oversized toolset. Covers tool names and
                    descriptions, parameter docs, tool schemas, handler code,
                    function-calling accuracy, and adding or removing tools.
```

Third person, states WHAT and WHEN, keeps the near-miss boundary against `mcp-tool` in
the first clause, drops the second-person edit enumeration (that lives in the body's
actions table), adds keywords a user would type ("function calling", "tool schemas",
"tool descriptions", "oversized toolset"), 389 chars, no CRITICAL/ALWAYS/MUST.

## Evidence

**1. Line counts**

```
$ git show main:skills/capabilities/tools/SKILL.md | wc -l
     749
$ wc -l skills/capabilities/tools/SKILL.md
     238 skills/capabilities/tools/SKILL.md
```

**2. `python skills/capabilities/tools/scripts/check.py`**

```
{
  "skill": "tools",
  "ok": true,
  "problems": [],
  "notes": [
    "full action set (schema/code/compose/remove) allowed by default",
    "tightened policy refuses disallowed kinds and reports them"
  ]
}
exit=0
```

It now covers the two gaps from F12: a `remove` edit (asserting the toolset is
`['search_top']` after compose+remove) and a tightened `{"allow":["description"]}` policy
asserting a non-empty `refused` while the allowed edit still lands.

> Note found while writing that test: the effective policy file is
> **`<capability_dir>/policy.json`**, not `inputs/policy.json`.
> `cap_evolve.tool_surface.load_policy` reads `Path(capability_dir) / "policy.json"`
> (`core/cap_evolve/tool_surface.py:36`) while its own docstring, both capability
> SKILL.mds, `concepts.md`, `pitfalls.md` and `examples.md` all say `inputs/policy.json`.
> An optimizer that follows the docs writes a policy file that is silently ignored. I
> corrected the wording in my body only (out-of-scope files left alone) — worth its own
> issue to fix `tool_surface`'s docstring and the sibling docs together.

**3. Link checker** (`/tmp/capreview/linkcheck-323.py` — walks every `.md` under the
skill dir, resolves every relative markdown link, and flags any link from a file in
`references/` to another file in `references/`)

```
$ python /tmp/capreview/linkcheck-323.py skills/capabilities/tools
checked 7 relative links in .../skills/capabilities/tools
OK: no broken links, no reference-to-reference links
exit=0
```

Also verified every `#anchor` in the new tables of contents resolves to a real heading
(`examples.md`, `field-notes.md`, `optimizer-playbook.md` — 0 bad anchors). Two
*plain-text* cross-references remain (`pitfalls.md:85` and `examples.md:84` say "see
concepts.md §3"); they are prose citations, not navigation links, so the checker does not
count them and no reference instructs the agent to load another reference.

**4. `pytest core/tests` — green, with imports pinned**

```
$ PYTHONPATH="$PWD/core:$PWD/dashboard/backend" python -m pytest core/tests -q
789 passed, 12 skipped in 107.16s (0:01:47)
```

Exactly clean `main`. The pin is required in a worktree: 45 files in `core/tests` do
`sys.path.insert(0, CORE)` while the venv's editable install points at the main checkout,
so an unpinned run imports two `cap_evolve` module trees at once and identity/monkeypatch
tests fail spuriously — that is issue #349, not this diff. An earlier revision of this
body reported the unpinned run (`2 failed, 787 passed`) and mis-attributed those two
`test_eventstream.py` failures to thread-timing flakiness; that diagnosis was wrong. The
pinned run above is the evidence.

**5. Zero-API end-to-end**

```
$ bash examples/toy_calc/run.sh 2>&1 | tail -15
{"baseline_val":0.0,"best_id":"cand_0001","dashboard":".capevolve/run_demo/dashboard.html",
 "dashboard_server":"http://127.0.0.1:7889","iterations":3,"run_dir":".capevolve/run_demo",
 "test_baseline_reward":0.0,"test_delta":1.0,"test_pass_k":{"1":1.0},"test_reward":1.0}
```

**6. Does the harness carry `references/` into the optimizer's working dir? — YES.**

`core/cap_evolve/harness.py:1193-1207` copies each selected capability skill wholesale:

```python
skills_root = Path(__file__).resolve().parents[2] / "skills" / "capabilities"
for c in caps:
    src = skills_root / c
    ...
    shutil.copytree(
        src, workdir / "guidance" / c,
        ignore=shutil.ignore_patterns("__pycache__", "scripts", "*.pyc"),
    )
```

`copytree` is recursive and the ignore list names only `__pycache__`, `scripts` and
`*.pyc` — so `references/` lands at `workdir/guidance/<cap>/references/`, alongside
`SKILL.md`. The body's links are relative (`references/concepts.md`), so they resolve
identically in the copied tree, and the instructions point the optimizer at
`./guidance/<cap>/SKILL.md` (harness.py:1758, 1990, 2064) from which those links hang.
**No bug here — reference-based skills keep their depth at optimization time.** One
observation, not a defect: `scripts/` is deliberately excluded, so any guidance that told
the optimizer to run a capability skill's own script would be broken in the workdir; this
skill's body only tells the *author* to run `scripts/check.py`, so it is unaffected.

## What `mcp-tool` should drop (for #326 — I did not touch it)

`mcp-tool/SKILL.md` is 235 lines and under budget, so nothing here is urgent, but these
are now duplicated with a `tools` body that no longer restates them. **`tools` should own
the shared mechanics** — it is the capability whose scope includes the code, so it is the
natural home — and `mcp-tool` should keep only what the ownership boundary changes:

| Duplicated content | `mcp-tool` lines | Suggestion |
|---|---|---|
| "How agents consume MCP tools" — select from name+description, fill from `inputSchema` | `90-98` | keep the MCP-specific half (host merges servers' `tools/list`, `list_changed` curation) and drop the generic select-vs-fill restatement; its own `concepts.md` already carries it |
| "Adapting to the reader's capability tier" | `104-111` | keep — but reword away from naming `THE READER` (same fix I applied at `tools/SKILL.md`), since it names a section of `intake`'s output file |
| "Errors are a steering surface" | `174-183` | keep the MCP-specific part (`isError` vs JSON-RPC protocol error); the generic "actionable error text" doctrine is in its `concepts.md` |
| "remove for overlap/confusion, not low frequency" | `190-191` | keep, it is one line |
| The action policy as a safety boundary | `85-88`, `202-207` | collapse to one paragraph; the restricted default *is* the point of that capability, so it should say it once |
| `## How to run` | `225-230` | leave alone — repo-wide decision |

**Two follow-ups I did not resolve** (both flagged as out of scope in #323 and both
needing a decision that spans the two skills):

1. **A live policy contradiction.** `mcp-tool/SKILL.md:216-223` says *"make ONE targeted
   SAFE edit … Be economical: one good edit, then stop"*, while this skill says *"Ship
   MULTIPLE fixes per iteration"*. On a run that selects both capabilities the same
   optimizer reads both. One of them is wrong — most likely `mcp-tool`'s, since the
   difference is the risk of each edit class, not the right number of them, but that is
   an owner call and it can change measured behavior.
2. **Merging the two `concepts.md` files** into one shared reference. I deliberately did
   *not* create `skills/capabilities/_shared/`: a reference both bodies load on every
   trigger would reproduce exactly the cost this PR removes, and whether `_shared/` is a
   supported layout (the harness copies `skills/capabilities/<cap>/`, so a sibling
   `_shared/` dir would **not** be copied into `guidance/`) needs deciding first. Worth
   noting for whoever picks it up: as things stand, a `_shared/` reference would silently
   fail to materialize in the optimizer's workdir.

---

# Follow-up commit (review round 2)

Two items from the coordinator, plus refreshed evidence.

## 1. `references/examples.md` TOC — was really still failing, for a reason worth recording

I had added a table of contents in the first commit, so I checked against the arbiter
rather than assuming. The lint (`skill-package/scripts/abstract.py` on PR #345) requires
**≥3 anchor links within the first 1500 characters** — "early" is part of the rule:

```python
LONG_REF_LINES = 300
TOC_LINK_RE = re.compile(r"\]\(#[^)\s]+\)")
TOC_SCAN_CHARS = 1500     # "early" = within the first ~1.5k chars
MIN_TOC_LINKS = 3
```

My TOC sat behind a 21-line preamble, starting at char **1305** — so only **1** of its
17 links landed inside the window and the rule still fired. Moved the Contents block up
to directly under the edit-shape paragraph:

```
before: anchors in first 1500 chars: 1   (Contents at char 1305)
after:  anchors in first 1500 chars: 9   (Contents at char ~200)
```

That is also the better reading order — the file is long precisely because it is a
jump-around reference, so the map belongs before the orientation prose, not after it.
The two orientation paragraphs ("Ordered by leverage", "First-class failure→fix
patterns") now follow the TOC.

**Arbiter lint over this branch — `tools` is clean:**

```
$ python3 -c '<load skill-package/abstract.py from origin/feat/issue-107-skill-authoring-lint>'
tools ok: True | warnings: [] | problems: []
```

**All references, with the early-anchor count:**

```
concepts.md                 197  early-anchors=0
doc-contract.md              51  early-anchors=0
examples.md                 397  early-anchors=9   <- the only >300 ref
field-notes.md               93  early-anchors=4
optimizer-playbook.md        54  early-anchors=3
pitfalls.md                 149  early-anchors=0
```

No other reference I created crossed 300 lines (`field-notes.md` 93, `doc-contract.md`
51). `field-notes.md` got a TOC anyway because it is a four-section lookup file, which is
why its count is non-zero. **4 violations → 0**, so `tools` is now clean on body lines,
body tokens, ref→ref links, and reference TOC.

### Note for the other skill rewrites: the TOC check scans only the first 1500 chars

Recording this because it cost me a round and has caught at least one other agent. The
">300-line reference needs a table of contents" rule is satisfied by **≥3 anchor links
inside the first 1500 characters of the file** — `TOC_SCAN_CHARS = 1500`,
`MIN_TOC_LINKS = 3`. A correct, complete, genuinely useful TOC placed *below* an
introductory paragraph does not count and the lint still fires. Put the Contents block
directly under the H1 (one short orienting sentence above it is fine; a 15-line preamble
is not), then let the orientation prose follow it. Quick self-check on any reference over
300 lines:

```bash
python3 -c "import re,sys; t=open(sys.argv[1]).read(); \
print(len(re.findall(r'\]\(#[^)\s]+\)', t[:1500])), 'early anchors (needs >=3)')" <ref.md>
```

## 2. Failure taxonomy — confirmed removed from the body, and NOT relocated

Answering the question directly: **my split did not move the taxonomy into a reference.
It deleted it, and this commit deletes what survived.** Verified mechanically:

```
$ grep -c "KNOWLEDGE\|BEHAVIORAL\|CAPABILITY-GAP\|HARD-ZERO\|unbounded" SKILL.md
0
$ grep -n "KNOWLEDGE\|BEHAVIORAL\|CAPABILITY-GAP\|blast radius\|unbounded" references/*.md
concepts.md:117:is high risk. The policy lets you grant exactly the blast radius you intend:   # the POLICY's blast radius, unrelated concept
pitfalls.md:18:## Trying to fix a BEHAVIORAL stall with prose                                  # pre-existing on main, see note below
```

Neither new reference (`field-notes.md`, `doc-contract.md`) contains any of it.

**Where the ~58 lines went, across both commits.** All six passages were taxonomy
*explanation*; each is deleted, not moved:

| Passage on `main` | Lines | What it restated | Removed in |
|---|---:|---|---|
| `129-137` DECISION/PERMISSION cluster bullet | 9 | the ACT-vs-REFUSE tag + the unbounded-blast-radius argument for not touching a global rule | commit 1 (compressed), commit 2 (argument deleted) |
| `138-141` HARD-ZERO / capability-gap bullet | 4 | the CAPABILITY-GAP tag and "prose won't fix it" | commit 1, commit 2 |
| `253-262` "two code-bearing edits, chosen by failure type" | 10 | the VIOLATION vs GAP split | commit 1 (section deleted) |
| `266-277` "Prose cannot fix a BEHAVIORAL failure" | 12 | the KNOWLEDGE vs BEHAVIORAL distinction in full | commit 1 (section deleted) |
| `298-313` pattern 3's stall explanation | 16 | the BEHAVIORAL stall definition again | commit 1 (section deleted) |
| `386-391` + `411-418` in `## When to use this` | 14 | the stall tag and the DECISION/PERMISSION tag with its blast-radius argument | commit 1 (section deleted) |

≈**65 gross lines**, of which ~59 went with the deleted sections in commit 1 and the
remaining restatement went in commit 2 (body 244 → 238). What commit 2 changed:

- levers 2/3/4 no longer re-derive the taxonomy. Lever 3 was *"When a cluster is about
  ACT-vs-REFUSE, the WRONG fix is loosening a global decision rule in the prompt —
  unbounded blast radius, regresses every task where the original behavior was gold…"*;
  it is now just the tool-side fix ("an in-body guard expressing the EXACT policy
  predicate… the narrowest edit available here"). Same for lever 2's *"you cannot
  instruct a model out of a behavior it already agreed to and skipped"* and lever 4's
  `HARD-ZERO / capability-gap cluster` label.
- **two near-identical composite-WRITE table rows merged into one** ("Execution stalls at
  the action boundary" and "Escalate / bail-out abandoning a REQUIRED, eligible action"
  were the same symptom and the same fix), and the taxonomy labels are gone from the
  symptom cells (*"A behavioral STALL, not a missing capability"*, *"A DECISION /
  PERMISSION the model gets wrong"* → *"A wrong ACT-vs-REFUSE call"*).

**What I deliberately kept**, because it is a *rule* only this capability can state, not a
restatement (per the contract's "deleting a restatement is required; deleting a rule is
not"):

- The **cluster → tool-edit mapping** itself (the failure→fix table). `diagnose` tags the
  cluster; which tool edit answers each tag is this skill's entire job.
- `SKILL.md:40` — *"run it on the args of 1–2 currently-PASSING tasks and confirm it does
  NOT fire"*. `diagnose` owns *identifying* a blast radius; this is the tool-specific
  **verification procedure** for a code guard, and it exists nowhere else.
- `references/pitfalls.md:18` "Trying to fix a BEHAVIORAL stall with prose" — pre-existing
  on `main`, in a load-on-demand reference (not paid per trigger), and it is a
  detect/fix pitfall rather than a taxonomy definition. Flagging rather than touching it,
  since a `diagnose`-owner may prefer to rename the heading.

## 3. Honesty invariants — not restated

```
$ grep -n "gate\|held-out" SKILL.md    # (relevant hits only)
36: … one edit that regresses a passing task sinks the whole candidate at the val gate.
123: … that overfits, gets rejected by the held-out gate, and helps nothing else.
```

Two half-clauses naming the gate as the **consequence** of an unsafe edit — the reason
per-change safety matters here. No mechanism is restated: no `Δ > k·SE`, no split-frozen-
once, no sealed-test rule, no "never edit `splits.json`". #323's own review reached the
same conclusion ("the gate framing is load-bearing *here*… but state it as the
consequence, not as a re-explanation"). Nothing further to remove.

## Refreshed evidence

```
$ git show main:skills/capabilities/tools/SKILL.md | wc -l
     749
$ wc -l skills/capabilities/tools/SKILL.md
     238 skills/capabilities/tools/SKILL.md

$ python skills/capabilities/tools/scripts/check.py
{
  "skill": "tools",
  "ok": true,
  "problems": [],
  "notes": [
    "full action set (schema/code/compose/remove) allowed by default",
    "tightened policy refuses disallowed kinds and reports them"
  ]
}
exit=0

$ python /tmp/capreview/linkcheck-323.py skills/capabilities/tools
checked 7 relative links in .../skills/capabilities/tools
OK: no broken links, no reference-to-reference links
exit=0

$ <authoring lint from PR #345, applied to this branch>
tools ok: True | warnings: [] | problems: []
```

```
$ PYTHONPATH="$PWD/core:$PWD/dashboard/backend" python -m pytest core/tests -q
789 passed, 12 skipped in 107.16s (0:01:47)
```

All TOC anchors still resolve to real headings after the move (0 bad anchors across
`examples.md`, `field-notes.md`, `optimizer-playbook.md`). `examples/toy_calc/run.sh` is
unchanged by this commit — it edits markdown only, and neither touched file is imported by
anything.

Housekeeping per the coordinator: no `git stash` was used at any point (both rounds went
straight to branch commits), and every scratch file is issue-scoped —
`/tmp/capreview/linkcheck-323.py`, `/tmp/capreview/pr-323.md`,
`/tmp/capreview/commitmsg-323*.txt`, `/tmp/capreview/lint323/`.
