### PR TITLE
GEPA candidate snapshots: pass the existing ignore list (#110)

### DIFF
--- a/core/cap_evolve/gepa.py
+++ b/core/cap_evolve/gepa.py
@@ -60,6 +60,7 @@ from .harness import (
     _live,
     _paired_deltas,
     _resolve_workers,
+    _SNAPSHOT_IGNORE,
     evaluate_candidate,
     split_result_from_rollouts,
 )
@@ -665,7 +666,7 @@ def gepa_loop(
         summary = (f"candidate {cid} (val {cand_val.reward:.3f}, "
                    f"Δ {cand_val.reward - parent_result.reward:+.3f})")
         if accepted:
-            run_dir.snapshot(cid, workdir)
+            run_dir.snapshot(cid, workdir, ignore=_SNAPSHOT_IGNORE)
             child_dir = run_dir.candidate_dir(cid)
             pool.append(_entry(cid, child_dir, cand_val, parent=parent["id"]))
             lineage[cid] = parent["id"]
@@ -829,7 +830,7 @@ def _try_merge(
     run_dir.update_spent(iterations=1, accepted=accepted)
     summary = f"merge {mid} of {a['id']}+{b['id']} (val {cand_val.reward:.3f})"
     if accepted:
-        run_dir.snapshot(mid, workdir)
+        run_dir.snapshot(mid, workdir, ignore=_SNAPSHOT_IGNORE)
         pool.append(_entry(mid, run_dir.candidate_dir(mid), cand_val, parent=base_parent["id"]))
         lineage[mid] = base_parent["id"]
         history.add(mid, summary, cand_val.reward)

--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -1839,9 +1839,17 @@ _DEFAULT_INSTRUCTIONS_TEMPLATE = (
 # snapshot and surface via RUNMAP/prior_iterations. LEDGER/JOURNAL/RUNMAP + prior_iterations/
 # are framework-injected read-context (LEDGER/RUNMAP regenerated, JOURNAL is run-level),
 # so they must not bloat candidates/ or pollute diffs.
+# FOCUS.md/REFLECTION.md are GEPA's own per-iteration scratch (gepa.py writes them into the
+# workdir it snapshots); hill-climb never writes them, so listing them is a no-op there.
+# The vendor dirs/files below mirror every skills_dir/instructions_file in
+# skills/optimizers/registry.yaml, so a new row must be added here too —
+# test_native_skills.test_snapshot_ignores_every_vendor_dir_the_registry_declares enforces that.
+# (Kept literal rather than read from the registry: an installed core has no skills/ tree
+# beside it, so the literal list has to be complete anyway.)
 _SNAPSHOT_IGNORE = ("trajectories", "guidance", "prior_iterations",
                     "LEDGER.md", "JOURNAL.md", "RUNMAP.md",
-                    ".claude", ".agents", ".gemini", ".opencode", ".bob",
+                    "FOCUS.md", "REFLECTION.md",
+                    ".claude", ".agents", ".gemini", ".opencode", ".bob", ".cursor",
                     "CLAUDE.md", "AGENTS.md", "GEMINI.md")
 
 

--- a/core/tests/test_gepa.py
+++ b/core/tests/test_gepa.py
@@ -274,3 +274,28 @@ def test_merge_skips_gracefully_monolith(tmp_path):
         if "merge_of" in s:
             assert "accepted" in s and "local_gate" in s
     assert res["best_val"] == 1.0
+
+
+def test_accepted_candidate_snapshot_is_capability_only(tmp_path):
+    """Regression (#110): GEPA candidate snapshots must be capability-only.
+
+    GEPA writes its own scratch (REFLECTION.md, FOCUS.md) plus the harness-injected
+    LEDGER/JOURNAL/RUNMAP into the workdir it snapshots, so a candidate diff showed
+    framework churn on top of the one real edited line. PROCESS.md is the deliberate
+    exception — it is the per-candidate explainability record.
+    """
+    from cap_evolve import gepa, harness
+    adapter, run_dir, base = _setup(tmp_path, "g_clean", max_iterations=8, max_metric_calls=500)
+    optimizer = harness.optimizer_from_command(
+        ["python3", str(MOCK_RUN), "--name", "mock", "--workdir", "{workdir}", "--prompt", "{prompt}"])
+    res = gepa.gepa_loop(adapter, run_dir=run_dir, optimizer=optimizer, seed_val=base,
+                         max_metric_calls=400, max_iterations=6, minibatch_size=3,
+                         max_merges=0, seed=0,
+                         gate_kwargs={"mode": "significant", "k_se": 1.0})
+    assert res["accepts"] >= 1
+    cands = [d for d in sorted(run_dir.candidates.iterdir()) if d.is_dir() and d.name != "seed"]
+    assert cands, "no accepted candidate snapshot to inspect"
+    for cand in cands:
+        names = {p.name for p in cand.iterdir()}
+        assert not names & set(harness._SNAPSHOT_IGNORE), f"{cand.name} dirty: {sorted(names)}"
+        assert "PROCESS.md" in names, f"{cand.name} lost its explainability record"

--- a/core/tests/test_native_skills.py
+++ b/core/tests/test_native_skills.py
@@ -106,3 +106,29 @@ def test_mock_optimizer_has_no_native_placement(tmp_path):
     assert (workdir / "guidance" / "system-prompt" / "SKILL.md").exists()
     assert not (workdir / ".claude").exists()
     assert not (workdir / "CLAUDE.md").exists()
+
+
+def test_snapshot_ignores_every_vendor_dir_the_registry_declares():
+    """Everything the registry injects must be excluded from candidate snapshots.
+
+    ``_SNAPSHOT_IGNORE`` hand-lists the per-agent vendor dirs/files that
+    ``_inject_native_skills`` drops into the workdir. This test is what keeps that
+    list from drifting behind ``optimizers/registry.yaml``: add a row with a new
+    ``skills_dir``/``instructions_file`` and forget the ignore entry, and candidate
+    snapshots silently gain injected read-context (the #110 failure mode).
+    """
+    from cap_evolve.harness import _SNAPSHOT_IGNORE
+    from cap_evolve.specfile import read_yaml
+
+    reg = REPO / "skills" / "optimizers" / "registry.yaml"
+    rows = read_yaml(reg.read_text(encoding="utf-8")) or {}
+    missing = set()
+    for name, row in rows.items():
+        if not isinstance(row, dict):
+            continue
+        sd = str(row.get("skills_dir") or "").strip()
+        inst = str(row.get("instructions_file") or "").strip()
+        for want in ((sd.split("/")[0] if sd else ""), inst):
+            if want and want not in _SNAPSHOT_IGNORE:
+                missing.add(f"{name}: {want}")
+    assert not missing, f"registry declares injected paths absent from _SNAPSHOT_IGNORE: {sorted(missing)}"


### PR DESCRIPTION
Fixes #110. Minimal redesign of #211 (+226/-29) against current main: **+63/-3**, no new
shared constant.

## Root cause and call sites fixed

`RunDir.snapshot(candidate_id, src_dir, ignore=None)` (`core/cap_evolve/rundir.py:418`) copies
everything when `ignore` is not passed. Hill-climb passes it; GEPA did not:

| call site | before | after |
|---|---|---|
| `core/cap_evolve/harness.py:1383` (hill-climb) | `ignore=_SNAPSHOT_IGNORE` | unchanged |
| `core/cap_evolve/harness.py:1557` (hill-climb) | `ignore=_SNAPSHOT_IGNORE` | unchanged |
| `core/cap_evolve/gepa.py:669` (accept path) | **no `ignore=`** | `ignore=_SNAPSHOT_IGNORE` |
| `core/cap_evolve/gepa.py:833` (merge accept path) | **no `ignore=`** | `ignore=_SNAPSHOT_IGNORE` |
| `harness.py:507`, `harness.py:566` (`"seed"`) | no `ignore=` | unchanged — the seed dir is capability-only |

Those are the only `snapshot()` calls under `core/cap_evolve/` (`grep -rn "copytree\|_SNAPSHOT_IGNORE\|shutil.copy" core/cap_evolve/ | grep -v build/`); every other
`copytree` either reads from an already-clean `candidates/` dir or is unrelated (check sandbox,
trajectory copies).

`gepa.py` now imports the constant from `.harness` (`gepa.py:63`) as #110 asks, so the two
algorithms cannot drift again.

Three names added to `harness._SNAPSHOT_IGNORE` (`harness.py:1848`):

- `FOCUS.md`, `REFLECTION.md` — GEPA's own per-iteration scratch (`gepa.py:261`, `gepa.py:285`
  write them into the workdir it snapshots). Hill-climb never writes them, so this is a no-op there.
- `.cursor` — `skills/optimizers/registry.yaml` declares `cursor: skills_dir: .cursor/skills`,
  which `_inject_native_skills` drops into the workdir, but the ignore list never covered it. A
  live second instance of the same bug, found while checking the list against the registry.

`PROCESS.md` and `INSTRUCTIONS.md` stay in snapshots deliberately (`harness.py:1838`) — that is
the per-candidate explainability record. Both tests pin that.

## Failing → passing

Before the fix (`core/tests/test_gepa.py::test_accepted_candidate_snapshot_is_capability_only`):

```
        for cand in cands:
            names = {p.name for p in cand.iterdir()}
>           assert not names & set(harness._SNAPSHOT_IGNORE), f"{cand.name} dirty: {sorted(names)}"
E           AssertionError: gepa_0001 dirty: ['FOCUS.md', 'INSTRUCTIONS.md', 'JOURNAL.md',
E                           'LEDGER.md', 'PROCESS.md', 'REFLECTION.md', 'RUNMAP.md', 'prompt.txt']

core/tests/test_gepa.py:300: AssertionError
=========================== short test summary info ============================
FAILED core/tests/test_gepa.py::test_accepted_candidate_snapshot_is_capability_only
1 failed in 4.02s
```

8 entries for a one-file (`prompt.txt`) capability. After the fix the snapshot is
`['INSTRUCTIONS.md', 'PROCESS.md', 'prompt.txt']` — byte-identical to what hill-climb stores:

```
$ python -m pytest core/tests/test_gepa.py::test_accepted_candidate_snapshot_is_capability_only -q
.                                                                        [100%]
1 passed in 4.14s
```

The second test, `test_native_skills.py::test_snapshot_ignores_every_vendor_dir_the_registry_declares`,
reads `registry.yaml` and asserts every declared `skills_dir` root and `instructions_file` is in
`_SNAPSHOT_IGNORE`. It also failed before the fix, which is how `.cursor` was found:

```
E   AssertionError: registry declares injected paths absent from _SNAPSHOT_IGNORE: ['cursor: .cursor']
```

It is the CI guard for the next registry row.

## Full suite

Run against source (`PYTHONPATH=core`, from a clean `git archive` of this commit, to avoid the
stale `core/build/lib/cap_evolve/` tree shadowing the edits):

```
$ PYTHONPATH=core python -m pytest core/tests -q
791 passed, 12 skipped in 129.42s (0:02:09)
```

789 on main + the 2 new tests.

## toy_calc

```
$ bash examples/toy_calc/run.sh
{
  "run_dir": ".capevolve/run_demo",
  "best_id": "cand_0001",
  "baseline_val": 0.0,
  "test_reward": 1.0,
  "test_baseline_reward": 0.0,
  "test_delta": 1.0,
  "test_pass_k": { "1": 1.0 },
  "iterations": 3,
  ...
}
```

Gate-accepted candidate, sealed test 1.0.

## Deliberately not done

Dropped from #211's 226-line version:

- **`rundir.SCRATCH_NAMES` / `LEGACY_SCRATCH_NAMES` / `NON_CAPABILITY_NAMES` (rundir.py +57).**
  Main already unified this list at `types.py:26` (`NON_CAPABILITY_FILES`), consumed by
  `gepa.py:75`, `cache.py:28`, `diffview.py:41` — with the same "copies drifted" rationale #211
  argues for. A second canonical list is worse than either alone.
- **Deriving `_SNAPSHOT_IGNORE` from `types.NON_CAPABILITY_FILES`.** That set contains
  `PROCESS.md` and `INSTRUCTIONS.md`, which are deliberately kept in snapshots. The two sets are
  genuinely different; `_SNAPSHOT_IGNORE` stays its own tuple.
- **Root-anchoring `rundir.snapshot`'s ignore matching** (basename → root-anchored lambda). Not in
  #110, and it changes hill-climb's snapshot behavior too. The concern looks real (a basename match
  at any depth could drop `src/prompts/STATE.md`) but it needs its own issue and test.
- **Root-anchoring `cache.hash_candidate_dir`.** Changes the eval-cache key, invalidating every
  existing cache. Needs its own blast-radius review.
- **Deriving the ignore patterns from `registry.yaml` at runtime** (suggested during review). An
  installed core has no `skills/` tree beside it (`Path(__file__).parents[2]` misses), so the
  literal list has to stay complete regardless — derivation would be additive redundancy, not
  deduplication. The registry-coverage *test* gives the same guarantee for zero core complexity,
  and a comment at `harness.py:1843-1847` points the next row-adder at it.
- **Patching `dashboard._DIFF_SKIP` / `harness._CAP_DIFF_SKIP`.** Diff-time filtering is a separate
  concern from snapshot content, and #211 missed `diffview.py:41`, which already derives from
  `types.NON_CAPABILITY_FILES`. Deriving the three residual inline literals
  (`harness.py:744`, `dashboard.py:1381`, `skillopt.py:411`) is worth a follow-up PR — pure
  deletion, no behavior change.

Also: #211's stated merge order (#199 → #197 → it) is stale — #197 is closed, #199 is still open —
so it is cheaper to land this against main and close #211 than to rebase it.

## Merge sequencing

Touched line ranges, for agents editing `harness.py` concurrently:

- `core/cap_evolve/harness.py` — **1841-1851 only** (the `_SNAPSHOT_IGNORE` comment block + tuple).
  No overlap with the stderr-capture path (~600) or a `record_iteration` seam.
- `core/cap_evolve/gepa.py` — 63 (import), 669, 833.
- `core/tests/test_gepa.py` — appended at EOF.
- `core/tests/test_native_skills.py` — appended at EOF.
