### PR TITLE
fix(install): fail loudly on a broken install, and prove it in CI (#208)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,66 @@ jobs:
             && echo "$out" | grep -q '"test_reward": 1.0' \
             || { echo "::error::toy_calc did not reach baseline_val 0.0 -> test_reward 1.0"; exit 1; }
 
+  install-smoke:
+    name: Install smoke (./install.sh, then run from the install)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install cap-evolve-core
+        run: pip install ./core
+
+      - name: Install via ./install.sh through the --host mapping
+        env:
+          # A clean HOME so `--host claude` lands somewhere this job owns.
+          HOME: ${{ runner.temp }}/fakehome
+        run: |
+          set -euo pipefail
+          # Unset, or detect_dest short-circuits to the checkout and the --host
+          # mapping plus the copy loop are never exercised (what toy-example does).
+          unset CAPEVOLVE_SKILLS_DIR
+          mkdir -p "$HOME"
+          ./install.sh --host claude
+          # The installed tree must carry the optimizer registry, not just skill dirs.
+          test -f "$HOME/.claude/skills/optimizers/registry.yaml"
+
+      - name: cap-evolve entry point is importable and runnable
+        run: |
+          set -euo pipefail
+          python -c 'import cap_evolve, cap_evolve.cli'
+          cap-evolve --version
+
+      - name: Run toy_calc FROM THE INSTALL, outside the repo tree
+        env:
+          HOME: ${{ runner.temp }}/fakehome
+        run: |
+          set -euo pipefail
+          R="$PWD"; D="$(mktemp -d)"
+          mkdir -p "$D/.capevolve/project/adapters"
+          cp    "$R/examples/toy_calc/adapter.py"     "$D/.capevolve/project/adapters/"
+          cp -R "$R/examples/toy_calc/capability"     "$D/seed_capability"
+          cp    "$R/templates/project/capevolve.yaml" "$D/.capevolve/project/capevolve.yaml"
+          # OUTSIDE the repo: run.py's parent-walk would otherwise find the checkout's
+          # optimizers/registry.yaml and this assertion would prove nothing.
+          cd "$D"
+          export CAPEVOLVE_SKILLS_DIR="$HOME/.claude/skills"
+          export CAPEVOLVE_TOY_DATA="$R/examples/toy_calc"
+          export CAPEVOLVE_MOCK_SCRIPT="$R/examples/toy_calc/mock_script.json"
+          out="$(cap-evolve run --spec "$D/.capevolve/project/capevolve.yaml" \
+                                --project "$D/.capevolve/project" --run-ts ci)"
+          echo "$out"
+          # Assert the OUTCOME, not the exit code: an install that cannot run an
+          # optimizer keeps the seed and reports test_reward 0.0 while exiting 0.
+          echo "$out" | grep -q '"test_reward": 1.0' \
+            || { echo "::error::the installed tree ran but optimized nothing"; exit 1; }
+
   docs-links:
     name: Docs link check
     runs-on: ubuntu-latest

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -67,6 +67,10 @@ pip install ./core           # or: export CAPEVOLVE_CORE="$PWD/core"
 Destination precedence: `$CAPEVOLVE_SKILLS_DIR` > `--host` mapping > `./.claude/skills` >
 `~/.claude/skills` > `~/.capevolve/skills`.
 
+`install.sh` verifies the installed tree before it reports success, and **exits non-zero**
+naming what is missing if anything did not land — so `./install.sh && pip install ./core`
+stops instead of leaving you with an install that cannot run an optimizer.
+
 ### C. Manual adapter + CLI (any language/agent)
 
 ```bash

--- a/install.sh
+++ b/install.sh
@@ -67,7 +67,8 @@ echo "  from: $SRC"
 echo "  to:   $DEST"
 
 shopt -s nullglob
-for comp in orchestrate phases capabilities algorithms optimizers; do
+COMPONENTS=(orchestrate phases capabilities algorithms optimizers)
+for comp in "${COMPONENTS[@]}"; do
   for skill in "$SRC/$comp"/*/; do
     [[ -d "$skill" ]] || continue
     name="$(basename "$skill")"
@@ -80,13 +81,57 @@ for comp in orchestrate phases capabilities algorithms optimizers; do
     fi
     echo "  + $comp/$name"
   done
+  # Component-level plain files, not just skill dirs. `optimizers/registry.yaml` is
+  # one, and without it every install is unable to run an optimizer at all — the
+  # directory-only glob above silently dropped it. Copy the whole class, keeping the
+  # component dir so run-optimizer's parent-walk finds `optimizers/registry.yaml`.
+  for f in "$SRC/$comp"/*; do
+    [[ -f "$f" ]] || continue
+    mkdir -p "$DEST/$comp"
+    if [[ "$LINK" -eq 1 ]]; then
+      ln -sfn "$f" "$DEST/$comp/$(basename "$f")"
+    else
+      cp "$f" "$DEST/$comp/"
+    fi
+    echo "  + $comp/$(basename "$f")"
+  done
 done
 
 # (Re)build the manifest for both the repo (component layout) and the installed
 # tree (flat layout). build_manifest handles either, so `cap-evolve run` works whether
 # it points at the repo skills or the installed dir.
-python3 "$SRC/_registry/build_manifest.py" "$SRC" || true
-python3 "$SRC/_registry/build_manifest.py" "$DEST" || true
+python3 "$SRC/_registry/build_manifest.py" "$SRC"
+python3 "$SRC/_registry/build_manifest.py" "$DEST"
+
+# Verify the install before claiming success. An installer that exits 0 on a broken
+# install is worse than one that fails: CI and users both believe it, and the damage
+# only surfaces later as an optimizer that quietly keeps the seed and reports 0.0.
+missing=()
+for comp in "${COMPONENTS[@]}"; do
+  for skill in "$SRC/$comp"/*/; do
+    [[ -f "$DEST/$(basename "$skill")/SKILL.md" ]] || missing+=("$(basename "$skill")/SKILL.md")
+  done
+  for f in "$SRC/$comp"/*; do
+    [[ -f "$f" ]] || continue
+    [[ -e "$DEST/$comp/$(basename "$f")" ]] || missing+=("$comp/$(basename "$f")")
+  done
+done
+[[ -f "$DEST/_registry/manifest.json" ]] || missing+=("_registry/manifest.json")
+
+if ((${#missing[@]})); then
+  {
+    echo
+    echo "cap-evolve: INSTALL FAILED — $DEST is not usable."
+    echo "Missing from the installed tree:"
+    printf '  - %s\n' "${missing[@]}"
+    echo
+    echo "Fix it by reinstalling from a complete checkout:"
+    echo "  cd $REPO_DIR && git status --short && ./install.sh --dest $DEST"
+    echo "If it still fails, install in dev mode instead:"
+    echo "  cd $REPO_DIR && ./install.sh --link --dest $DEST"
+  } >&2
+  exit 1
+fi
 
 cat <<EOF
 


### PR DESCRIPTION
Closes #208.

The review verdict on #208 was **KEEP-AND-FIX, P1** — and the reason is not testing hygiene.
`./install.sh` on main today produces an installation that **cannot run an optimizer**, and it
**exits 0** while doing so. An installer that reports success on a broken install is the worst
failure mode available, because CI and users both believe it.

Everything below was run. Nothing is inferred.

---

## 1. Before — the silent failure, reproduced

`install.sh` exits 0:

```
$ ./install.sh --dest /tmp/i208/skills
EXIT=0
Done. Skills installed to: /tmp/i208/skills
```

but `optimizers/registry.yaml` is not in the install:

```
$ find /tmp/i208 -name registry.yaml
(nothing)
```

Root cause — the copy loop globs `"$SRC/$comp"/*/` with a `[[ -d ]]` guard, directories only
(`install.sh:72-73` on main). The only component-level plain file in the tree is precisely the
casualty:

```
$ find skills/{orchestrate,phases,capabilities,algorithms,optimizers} -maxdepth 1 -type f
skills/optimizers/registry.yaml
```

The installed optimizer runner therefore hard-raises, from anywhere:

```
$ cd /tmp && python3 /tmp/i208/skills/run-optimizer/scripts/run.py --list
EXIT=1
  File "/tmp/i208/skills/run-optimizer/scripts/run.py", line 53, in _registry_path
    raise FileNotFoundError("optimizers/registry.yaml not found (set CAPEVOLVE_OPTIMIZER_REGISTRY)")
FileNotFoundError: optimizers/registry.yaml not found (set CAPEVOLVE_OPTIMIZER_REGISTRY)
```

**And the end-to-end run stays silent.** Same toy, same core, same spec; cwd outside the repo,
`CAPEVOLVE_SKILLS_DIR` pointing at the install:

```
spec: /private/tmp/i208run/.capevolve/project/capevolve.yaml
{
  "run_dir": ".capevolve/run_i208",
  "best_id": "seed",
  "baseline_val": 0.0,
  "test_reward": 0.0,
  "test_baseline_reward": 0.0,
  "test_delta": 0.0,
  "test_pass_k": { "1": 0.0 },
  "iterations": 2,
  ...
}

RUN_EXIT=0
```

`best_id: seed`, `test_reward: 0.0`, **exit 0**. Any smoke job asserting only on exit codes
would have been green through all of this.

---

## 2. After — the failure is loud

Counter-proof: with the fix's verification in place, I reintroduced the original
directory-only glob on the copy line and re-ran.

```
$ ./install.sh --dest /tmp/i208c/skills
EXIT=1

cap-evolve: INSTALL FAILED — /tmp/i208c/skills is not usable.
Missing from the installed tree:
  - optimizers/registry.yaml

Fix it by reinstalling from a complete checkout:
  cd <repo> && git status --short && ./install.sh --dest /tmp/i208c/skills
If it still fails, install in dev mode instead:
  cd <repo> && ./install.sh --link --dest /tmp/i208c/skills
```

Non-zero, names what is missing, gives the command that fixes it.

With the full fix, the file lands and the install actually works:

```
$ ./install.sh --dest /tmp/i208b/skills
EXIT=0
  + optimizers/registry.yaml
$ find /tmp/i208b -name registry.yaml
/tmp/i208b/skills/optimizers/registry.yaml

$ cd /tmp && python3 /tmp/i208b/skills/run-optimizer/scripts/run.py --list
EXIT=0
{ "optimizers": [ "antigravity", "claude-code", "codex", "copilot", "cursor", "droid", ... ] }
```

and the same outside-the-repo end-to-end run that reported `0.0` now reports `1.0`:

```
{
  "run_dir": ".capevolve/run_i208",
  "best_id": "cand_0001",
  "baseline_val": 0.0,
  "test_reward": 1.0,
  "test_baseline_reward": 0.0,
  "test_delta": 1.0,
  "test_pass_k": { "1": 1.0 },
  "iterations": 3,
  ...
}
```

`--link` mode also verified (symlinks the component-level files rather than copying):

```
$ ./install.sh --link --dest /tmp/i208link/skills   # EXIT=0
$ ls -l /tmp/i208link/skills/optimizers/registry.yaml
... -> <repo>/skills/optimizers/registry.yaml
```

### What the fix is

Three parts, ~48 lines in `install.sh`:

1. **Copy component-level plain files, not just skill dirs.** Fixes the class rather than
   special-casing `registry.yaml`, and keeps the component dir so run-optimizer's parent-walk
   (`run.py:46-52`) resolves `optimizers/registry.yaml`.
2. **Verify before claiming success.** Every skill's `SKILL.md`, every component-level file,
   and the rebuilt `_registry/manifest.json`. Anything missing → print it plus the fix, exit 1.
3. **Drop `|| true` from the two `build_manifest.py` calls.** They swallowed the same class of
   failure silently.

---

## 3. `python -m pytest core/tests -q | tail -20`

```
2 failed, 787 passed, 12 skipped in 116.70s (0:01:56)
FAILED core/tests/test_eventstream.py::test_dashboard_stream_reexports_the_shared_helper
FAILED core/tests/test_eventstream.py::test_follower_thread_reports_instead_of_dying_silently
```

**Both are pre-existing on main and unrelated to this diff.** Verified by `git stash` and
re-running the identical command on clean `d94fb336`:

```
2 failed, 787 passed, 12 skipped in 118.78s (0:01:58)
FAILED core/tests/test_eventstream.py::test_dashboard_stream_reexports_the_shared_helper
FAILED core/tests/test_eventstream.py::test_follower_thread_reports_instead_of_dying_silently
```

Byte-identical failure set. They are thread-timing flakes that pass in isolation:

```
$ python -m pytest core/tests/test_eventstream.py -q
38 passed in 6.97s
```

This diff touches `install.sh`, `.github/workflows/ci.yml`, and `docs/INSTALL.md` only —
`grep -rln "install.sh" core/tests` is empty, so no test can observe it.

---

## 4. `bash examples/toy_calc/run.sh | tail -15`

```
{
  "run_dir": ".capevolve/run_demo",
  "best_id": "cand_0001",
  "baseline_val": 0.0,
  "test_reward": 1.0,
  "test_baseline_reward": 0.0,
  "test_delta": 1.0,
  "test_pass_k": { "1": 1.0 },
  "iterations": 3,
  "dashboard": ".capevolve/run_demo/dashboard.html",
  ...
}
```

Gate-accepted, `test_reward 1.0`.

---

## 5. The CI job, and why it would have caught this

```yaml
  install-smoke:
    name: Install smoke (./install.sh, then run from the install)
    runs-on: ubuntu-latest

    steps:
      - name: Checkout repository
        uses: actions/checkout@v4

      - name: Set up Python 3.11
        uses: actions/setup-python@v5
        with:
          python-version: '3.11'

      - name: Install cap-evolve-core
        run: pip install ./core

      - name: Install via ./install.sh through the --host mapping
        env:
          # A clean HOME so `--host claude` lands somewhere this job owns.
          HOME: ${{ runner.temp }}/fakehome
        run: |
          set -euo pipefail
          # Unset, or detect_dest short-circuits to the checkout and the --host
          # mapping plus the copy loop are never exercised (what toy-example does).
          unset CAPEVOLVE_SKILLS_DIR
          mkdir -p "$HOME"
          ./install.sh --host claude
          # The installed tree must carry the optimizer registry, not just skill dirs.
          test -f "$HOME/.claude/skills/optimizers/registry.yaml"

      - name: cap-evolve entry point is importable and runnable
        run: |
          set -euo pipefail
          python -c 'import cap_evolve, cap_evolve.cli'
          cap-evolve --version

      - name: Run toy_calc FROM THE INSTALL, outside the repo tree
        env:
          HOME: ${{ runner.temp }}/fakehome
        run: |
          set -euo pipefail
          R="$PWD"; D="$(mktemp -d)"
          mkdir -p "$D/.capevolve/project/adapters"
          cp    "$R/examples/toy_calc/adapter.py"     "$D/.capevolve/project/adapters/"
          cp -R "$R/examples/toy_calc/capability"     "$D/seed_capability"
          cp    "$R/templates/project/capevolve.yaml" "$D/.capevolve/project/capevolve.yaml"
          # OUTSIDE the repo: run.py's parent-walk would otherwise find the checkout's
          # optimizers/registry.yaml and this assertion would prove nothing.
          cd "$D"
          export CAPEVOLVE_SKILLS_DIR="$HOME/.claude/skills"
          export CAPEVOLVE_TOY_DATA="$R/examples/toy_calc"
          export CAPEVOLVE_MOCK_SCRIPT="$R/examples/toy_calc/mock_script.json"
          out="$(cap-evolve run --spec "$D/.capevolve/project/capevolve.yaml" \
                                --project "$D/.capevolve/project" --run-ts ci)"
          echo "$out"
          # Assert the OUTCOME, not the exit code: an install that cannot run an
          # optimizer keeps the seed and reports test_reward 0.0 while exiting 0.
          echo "$out" | grep -q '"test_reward": 1.0' \
            || { echo "::error::the installed tree ran but optimized nothing"; exit 1; }
```

Parsed and confirmed to load as YAML:
`jobs = ["test-python", "build-dashboard", "toy-example", "install-smoke", "docs-links", "spellcheck"]`, 6 steps.

**Why nothing on main caught this.** No workflow ran `install.sh` at all —
`grep -rn "install.sh" .github/` was empty. `toy-example` looks like coverage but is not: it
runs `examples/toy_calc/run.sh`, whose line 9 is `export CAPEVOLVE_SKILLS_DIR="$REPO/skills"`,
which takes `detect_dest`'s **first** precedence branch. The `--host` mapping and the copy loop
were never executed by any job in any workflow.

**Four properties make this job non-vacuous** — remove any one and it stops proving anything:

1. `CAPEVOLVE_SKILLS_DIR` **unset** during install → `detect_dest` cannot short-circuit to the
   checkout, so the `--host` mapping and the copy loop actually run. This is exactly why
   `toy-example` was blind.
2. `test -f .../optimizers/registry.yaml` → the exact artifact the copy loop dropped.
3. **cwd outside the repo** for the run → `run.py`'s parent-walk would otherwise climb into the
   checkout and find the repo's own `registry.yaml`, silently rescuing a broken install.
4. **Assert `"test_reward": 1.0`, never exit 0** → §1 shows a dead optimizer exiting 0 with
   `0.0`. Only the outcome distinguishes a working install from a broken one.

Against the original bug: step 4 would have failed at `test -f`, and even with that line deleted
the final step would have failed on `test_reward 0.0`. Both verified locally above.

Zero new dependencies. Zero-API — the mock optimizer comes from the template spec, so the job
costs nothing beyond a checkout, a `pip install ./core`, and a ~3-iteration toy run.

Deliberately out of scope (YAGNI): parametrising over all 12 `--host` rows and over `--link`
mode. One proven destination beats twelve asserted ones, and per-host destination grading is
#143 / PR #245's axis, not this job's.

---

## 6. `cap-evolve doctor`'s exit code — checked, and NOT changed

The task asked me to check the neighbouring bug: `doctor` printing "2 blocking problem(s)"
while exiting 0. **I could not reproduce it, and the code is already correct.**

`_cmd_doctor` at `core/cap_evolve/cli.py:1387` is documented "Exit 0 when nothing FAILs, 1
otherwise" and ends `return 1 if fails else 0` (line 1441); the `--json` path returns 1 too
(line 1404). `main()` returns `fn(argv[1:])` unchanged, and the console script
(`cap-evolve = "cap_evolve.cli:main"`) wraps it in `sys.exit(main())`. Empirically, on both
entry points:

```
$ python -m cap_evolve.cli doctor --project /tmp/nonexistent-project
DOCTOR_EXIT=1
  FAIL  spec        no /tmp/nonexistent-project/capevolve.yaml
  1 blocking problem(s). Fix the arrows above, then re-run `cap-evolve doctor`.

$ cap-evolve doctor      # in a project with a broken adapter
DOCTOR_EXIT=1
  FAIL  adapter     tasks('val') raised: [Errno 2] No such file or directory: ...
  1 blocking problem(s). Fix the arrows above, then re-run `cap-evolve doctor`.
```

So no change made. The most likely origin of the exit-0 observation is reading `$?` after a
pipe — `cap-evolve doctor | tail` reports `tail`'s status, not doctor's. Worth knowing when
scripting against it, but it is not a defect in `doctor`.

---

## Salvage from PR #245

Per `verdict-245.md`, §3's four design constraints were the only part worth keeping, and they
are the spec this job is built to: temp `$HOME`, `CAPEVOLVE_SKILLS_DIR` unset, cwd outside the
repo, assert `test_reward 1.0` rather than exit 0. All four are present and each is annotated
inline with what it is load-bearing for.

PR #245 is not the delivery vehicle: it declares hard dependencies on #193 and #202 (both
**closed unmerged**), and bundles `hosts.py`, `hosts.yaml`, `doctor.py`, `HOST_SUPPORT.md`, and
34 tests — #143's scope, ~1290 lines the maintainers already rejected. It is also built on the
premise that #193 fixed `registry.yaml`; it did not merge, so #245's own job would have
red-lined main on arrival. This PR ships the ~48 real lines standalone, with no dependency on
either stalled PR.

---

## 7. The job, green in real CI on this PR

`install-smoke` ran on this PR in **14s** and the assertions actually fired
([job log](https://github.com/skillberry-ai/cap-evolve/actions/runs/32577486762/job/97041821782)):

```
  + optimizers/run-optimizer
  + optimizers/registry.yaml          <- the file main silently dropped, now installed
{"cap-evolve": "0.1.0"}               <- entry point importable and runnable
  "best_id": "cand_0001",
  "test_reward": 1.0,
  "test_baseline_reward": 0.0,
  "test_delta": 1.0,
  "test_pass_k": { "1": 1.0 },
  "iterations": 3,
```

Run from `mktemp -d` outside the checkout, against `$HOME/.claude/skills` produced by
`./install.sh --host claude` with `CAPEVOLVE_SKILLS_DIR` unset. 14s, no API calls, no new
dependencies.

Every other job on this PR is green too, including **Test Python (core) — pass, 46s**, which
confirms the two local `test_eventstream.py` failures in §3 are macOS-local thread-timing
flakes rather than anything this diff introduced.
