### PR TITLE
fix(core): one shared optimizer-context assembler — gepa and skillopt stop running blind (#109)

### DIFF
--- a/core/cap_evolve/cli.py
+++ b/core/cap_evolve/cli.py
@@ -378,6 +378,14 @@ _ALGO_FOCUS_ALIASES = {
 #: epoch schedule, so the spec key is inert for them — and we say so rather than drop it.
 CONVERGENCE_ALGORITHMS = frozenset({"hill-climb"})
 
+#: Algorithms whose ``run.py`` declares the optimizer-context flags (via
+#: ``harness.OptimizerContext.add_arguments``) and can therefore be handed the full
+#: read-context: capability skills, the instructions template, the benchmark repo, the
+#: optimizer name, the capability sources, and the target-reader profile. These flags used
+#: to be gated to hill-climb alone, which silently handed gepa and skillopt a strictly
+#: thinner prompt and made any cross-algorithm comparison meaningless.
+OPTIMIZER_CONTEXT_ALGORITHMS = frozenset({"hill-climb", "gepa", "skillopt"})
+
 
 def _resolve_algorithm(name: str) -> tuple[str, str | None]:
     """Map a spec ``algorithm_skill`` to (skill_name, focus).
@@ -851,23 +859,23 @@ def _cmd_run(argv):
     if algorithm_focus is not None:
         alg_cmd += ["--focus", algorithm_focus]
     # Surface the selected capability skills to the optimizer prompt so it knows the
-    # allowed edit space (e.g. tools → may add composite tools). hill-climb consumes
-    # --capabilities; algorithms without the flag ignore the extra arg via argparse error,
-    # so only pass it to those that accept it.
+    # allowed edit space (e.g. tools → may add composite tools). Passed to every
+    # algorithm that declares the optimizer-context flags, so each one prompts from the
+    # same read-context.
     caps = spec.get("capabilities") or []
     if isinstance(caps, str):
         caps = [c.strip() for c in caps.split(",") if c.strip()]
-    if caps and algorithm_name == "hill-climb":
+    if caps and algorithm_name in OPTIMIZER_CONTEXT_ALGORITHMS:
         alg_cmd += ["--capabilities", ",".join(str(c) for c in caps)]
     # Thread the resolved optimizer NAME so the harness can copy that optimizer's
     # features reference (parallel-subagent capabilities etc.) into each iteration's
-    # workdir. Only hill-climb accepts the flag; other algorithms ignore it.
-    if algorithm_name == "hill-climb":
+    # workdir and place the skills where that agent natively finds them.
+    if algorithm_name in OPTIMIZER_CONTEXT_ALGORITHMS:
         alg_cmd += ["--optimizer-name", str(optimizer_name)]
     # Optimizer-instructions template (intake-authored, per benchmark) + benchmark repo
     # as read-only optimizer context. Both are resolved project-relative if not absolute.
     # The instructions file defaults to the scaffolded project/optimizer/INSTRUCTIONS.md.
-    if algorithm_name == "hill-climb":
+    if algorithm_name in OPTIMIZER_CONTEXT_ALGORITHMS:
         instr = spec.get("optimizer_instructions_file") or "optimizer/INSTRUCTIONS.md"
         instr_p = Path(instr)
         if not instr_p.is_absolute() and not instr_p.exists():

--- a/core/cap_evolve/gepa.py
+++ b/core/cap_evolve/gepa.py
@@ -55,6 +55,8 @@ from . import integrity
 from . import selection
 from .cache import EvalCache, hash_candidate_dir
 from .harness import (
+    OptimizerContext,
+    _SNAPSHOT_IGNORE,
     _augment_instructions,
     _init_memory_store,
     _live,
@@ -473,6 +475,7 @@ def gepa_loop(
     store=None,
     resume: bool = False,
     protected_patterns=None,
+    ctx: OptimizerContext | None = None,
 ) -> dict:
     """Run GEPA's sample-efficient reflective Pareto loop.
 
@@ -495,6 +498,7 @@ def gepa_loop(
     highest-val pool member; the test split is never touched.
     """
     gate_kwargs = dict(gate_kwargs or {})
+    ctx = ctx or OptimizerContext()   # the SAME read-context assembly as its siblings
     rejected, history, store = _init_memory_store(run_dir, store)
     cache = EvalCache(run_dir.root / "eval_cache.json")
     rng = random.Random(seed)
@@ -576,9 +580,19 @@ def gepa_loop(
             comp_cursor += 1
         else:
             focus = None  # 'all'
+        # The shared optimizer read-context (capability skill(s) natively + under
+        # ./guidance/, the diagnose method, sources, the optimizer features ref). The
+        # trajectories are tagged with THIS parent's minibatch eval — gepa's parent is a
+        # frontier member, not the run's best, so the untruncated traces behind
+        # REFLECTION.md are the ones to hand over.
+        ctx.inject(adapter, run_dir, workdir, split="train", tag=f"mb_p_{n:04d}")
         refl_summary = _write_reflection(workdir, parent_mb)
         focus_label = _write_focus(workdir, comps, focus)
-        instructions = _instructions(refl_summary, focus_label, mb)
+        instructions = ctx.instructions(
+            parent_mb, mb, f"GEPA minibatch of {len(mb)} train tasks, component focus "
+                           f"{focus_label}",
+            algorithm="gepa", parent_dir=parent_dir,
+            extra=_instructions(refl_summary, focus_label, mb))
         instructions = _augment_instructions(instructions, workdir, run_dir, rejected, history)
 
         # Seal the eval surface for this child. GEPA runs the optimizer itself rather
@@ -665,7 +679,9 @@ def gepa_loop(
         summary = (f"candidate {cid} (val {cand_val.reward:.3f}, "
                    f"Δ {cand_val.reward - parent_result.reward:+.3f})")
         if accepted:
-            run_dir.snapshot(cid, workdir)
+            # ignore=: the injected read-context (trajectories/guidance/native skills) is
+            # NOT part of the candidate — same exclusion hill-climb's run_step applies.
+            run_dir.snapshot(cid, workdir, ignore=_SNAPSHOT_IGNORE)
             child_dir = run_dir.candidate_dir(cid)
             pool.append(_entry(cid, child_dir, cand_val, parent=parent["id"]))
             lineage[cid] = parent["id"]
@@ -829,7 +845,7 @@ def _try_merge(
     run_dir.update_spent(iterations=1, accepted=accepted)
     summary = f"merge {mid} of {a['id']}+{b['id']} (val {cand_val.reward:.3f})"
     if accepted:
-        run_dir.snapshot(mid, workdir)
+        run_dir.snapshot(mid, workdir, ignore=_SNAPSHOT_IGNORE)
         pool.append(_entry(mid, run_dir.candidate_dir(mid), cand_val, parent=base_parent["id"]))
         lineage[mid] = base_parent["id"]
         history.add(mid, summary, cand_val.reward)

--- a/core/cap_evolve/gepa.py
+++ b/core/cap_evolve/gepa.py
@@ -56,12 +56,12 @@ from . import selection
 from .cache import EvalCache, hash_candidate_dir
 from .harness import (
     OptimizerContext,
-    _SNAPSHOT_IGNORE,
     _augment_instructions,
     _init_memory_store,
     _live,
     _paired_deltas,
     _resolve_workers,
+    _SNAPSHOT_IGNORE,
     evaluate_candidate,
     split_result_from_rollouts,
 )

--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -2124,10 +2124,6 @@ class OptimizerContext:
 
     # ---- construction from an algorithm run.py --------------------------------
 
-    #: The context flags every algorithm's ``run.py`` declares via ``add_arguments``.
-    ARG_DESTS = ("capabilities", "instructions_file", "bench_repo", "optimizer_name",
-                 "capability_sources", "target_model", "target_profile_file")
-
     @staticmethod
     def add_arguments(p) -> None:
         """Declare the optimizer-context flags on an algorithm's argument parser.
@@ -2290,6 +2286,11 @@ def hill_climb_loop(
     ``protected_patterns`` seals the eval surface (see ``run_step``); ``convergence``
     turns on the graded plateau signal (warn → paradigm_shift → stop). Both default
     off, so a caller that passes neither runs exactly as before.
+
+    ``ctx`` is the shared optimizer read-context. When it is given it WINS: the legacy
+    per-piece kwargs below it (``capabilities`` … ``target_profile_file``) are then unused,
+    kept only for the callers/tests that predate ``OptimizerContext``. Pass one or the
+    other, not both.
     """
     gate_kwargs = dict(gate_kwargs or {})
     rejected, history, store = _init_memory_store(run_dir, store)

--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -20,6 +20,7 @@ import shutil
 import subprocess
 import sys
 import time
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable
 
@@ -1094,9 +1095,15 @@ def _augment_instructions(instructions: str, workdir: Path, run_dir: RunDir,
     return f"{instructions}\n\n{pointer}\n"
 
 
-def _copy_step_trajectories(adapter, run_dir: RunDir, workdir: Path, split: str) -> None:
+def _copy_step_trajectories(adapter, run_dir: RunDir, workdir: Path, split: str,
+                            tag: str | None = None) -> None:
     """Copy ONLY the current best/parent candidate's per-tag rollouts for ``split``
     into ``workdir/trajectories/`` — the single step the optimizer builds on.
+
+    ``tag`` overrides which rollout tag counts as "the step the optimizer builds on".
+    Algorithms whose parent is NOT the run's best (gepa samples a parent from its
+    frontier and evaluates it on a minibatch) pass their own eval tag so the optimizer
+    reads the traces of the candidate it is actually forking from.
 
     The run dir's ``rollouts/<split>/`` mixes the seed plus every accepted AND
     rejected candidate's trials, so copying it wholesale would make the optimizer
@@ -1139,6 +1146,8 @@ def _copy_step_trajectories(adapter, run_dir: RunDir, workdir: Path, split: str)
     except Exception:  # noqa: BLE001
         best_id = None
 
+    if tag and _copy_tag(str(tag)):
+        return
     if best_id and _copy_tag(str(best_id)):
         return
     if _copy_tag("seed"):
@@ -1165,7 +1174,8 @@ def _copy_step_trajectories(adapter, run_dir: RunDir, workdir: Path, split: str)
 
 def _inject_optimizer_context(adapter, run_dir: RunDir, workdir: Path, *, split: str,
                               capabilities=None, optimizer_name: str | None = None,
-                              capability_sources=None, project_dir: Path | None = None) -> None:
+                              capability_sources=None, project_dir: Path | None = None,
+                              tag: str | None = None) -> None:
     """Give the optimizer everything it needs to read, inside its own working dir.
 
     Copies, VERBATIM and without parsing:
@@ -1188,7 +1198,7 @@ def _inject_optimizer_context(adapter, run_dir: RunDir, workdir: Path, *, split:
     # this split, so the optimizer analyzes the step it builds on (not seed + every
     # rejected candidate mixed together). Always preserves the "something to read"
     # guarantee via per-tag fallback then the native dir.
-    _copy_step_trajectories(adapter, run_dir, workdir, split)
+    _copy_step_trajectories(adapter, run_dir, workdir, split, tag=tag)
 
     # 2) capability skills as local guidance
     caps = [c for c in (capabilities or []) if c]
@@ -1422,11 +1432,8 @@ def run_step(
     rejected=None,
     history=None,
     store=None,
-    capabilities=None,
     eval_split: str = "val",
-    optimizer_name: str | None = None,
-    capability_sources=None,
-    project_dir: Path | None = None,
+    ctx: "OptimizerContext | None" = None,
     protected_patterns=None,
 ) -> dict:
     """Materialize parent → optimize → evaluate on val → gate → accept/reject.
@@ -1458,9 +1465,9 @@ def run_step(
     shutil.copytree(parent_dir, workdir)
 
     # Give the optimizer the full trajectories + capability guidance, in its own dir.
-    _inject_optimizer_context(adapter, run_dir, workdir, split=eval_split,
-                              capabilities=capabilities, optimizer_name=optimizer_name,
-                              capability_sources=capability_sources, project_dir=project_dir)
+    # ``ctx`` is the SHARED assembler every algorithm passes; an absent one (a bare
+    # unit-test call) injects the unconditional pieces only.
+    (ctx or OptimizerContext()).inject(adapter, run_dir, workdir, split=eval_split)
 
     instructions = _augment_instructions(instructions, workdir, run_dir, rejected, history)
 
@@ -2089,6 +2096,128 @@ def _focus_instructions(current_val: SplitResult, focus_ids, label: str,
     return "\n".join(p for p in parts if p is not None)
 
 
+@dataclass
+class OptimizerContext:
+    """The optimizer's read-context for one iteration — assembled ONE way, for EVERY
+    algorithm.
+
+    ``docs/ARCHITECTURE.md`` ("What the optimizer receives each iteration") is a
+    property of the *harness*, not of hill-climb: the capability skill(s) (as
+    ``./guidance/<cap>/`` and natively placed), the diagnose method, the parent step's
+    trajectories, the supporting sources, and the prior candidates' per-task impact.
+    Every algorithm loop takes one of these and calls ``inject()`` + ``instructions()``,
+    so an algorithm cannot silently run on a thinner prompt than its siblings.
+
+    Deliberately algorithm-AGNOSTIC: nothing here branches on who is calling. The two
+    genuinely per-algorithm inputs are parameters — ``algorithm`` (selects the algorithm
+    brief) and ``extra`` (the caller's own block, e.g. gepa's reflective-dataset
+    pointer).
+    """
+
+    capabilities: tuple = ()
+    optimizer_name: str | None = None
+    capability_sources: tuple = ()
+    project_dir: Path | None = None
+    instructions_file: str | None = None
+    bench_repo: str | None = None
+    target_reader: str = ""
+
+    # ---- construction from an algorithm run.py --------------------------------
+
+    #: The context flags every algorithm's ``run.py`` declares via ``add_arguments``.
+    ARG_DESTS = ("capabilities", "instructions_file", "bench_repo", "optimizer_name",
+                 "capability_sources", "target_model", "target_profile_file")
+
+    @staticmethod
+    def add_arguments(p) -> None:
+        """Declare the optimizer-context flags on an algorithm's argument parser.
+
+        One definition, so `cap-evolve run` can forward the same flags to any
+        algorithm instead of gating them to whichever one happened to implement them.
+        """
+        p.add_argument("--capabilities", default="",
+                       help="comma-separated capability skills under optimization (e.g. "
+                            "'system-prompt,tools'); surfaced to the optimizer so it knows "
+                            "the allowed edit space")
+        p.add_argument("--instructions-file", default=None,
+                       help="optimizer-instructions template (intake-authored) to render the "
+                            "per-iteration prompt from; defaults to the shipped template")
+        p.add_argument("--bench-repo", default=None,
+                       help="path to the benchmark/runner source, surfaced to the optimizer "
+                            "as read-only context")
+        p.add_argument("--optimizer-name", default=None,
+                       help="resolved optimizer name (registry row); used to copy that "
+                            "optimizer's features reference into the optimizer workdir and "
+                            "to place the skills where it natively discovers them")
+        p.add_argument("--capability-sources", default="",
+                       help="comma-separated supporting source files (data models / types "
+                            "the tools import) copied verbatim into the optimizer's "
+                            "./guidance/sources/; resolved relative to --project")
+        p.add_argument("--target-model", default="",
+                       help="consuming/runtime model id or tier keyword (frontier|strong|mid|weak)")
+        p.add_argument("--target-profile-file", default=None,
+                       help="optional project-local brief overriding the tier's built-in brief")
+
+    @classmethod
+    def from_args(cls, args, run_dir: RunDir | None = None) -> "OptimizerContext":
+        """Build the context from a parsed ``argparse`` namespace (+ ``--project``).
+
+        Resolves the consuming-LLM profile once and, when ``run_dir`` is given, logs it
+        so report/dashboard surface it for every algorithm.
+        """
+        def _csv(v):
+            if not v:
+                return ()
+            return tuple(x.strip() for x in str(v).split(",") if x.strip())
+
+        from . import target_profile as _tp
+        project = getattr(args, "project", None)
+        profile = _tp.resolve(getattr(args, "target_model", "") or "",
+                              getattr(args, "target_profile_file", None),
+                              project_dir=project)
+        if run_dir is not None and not profile.is_agnostic:
+            run_dir.log_event("target_profile", model=profile.model, tier=profile.tier,
+                              suggested_num_trials=profile.suggested_num_trials,
+                              resolution_note=profile.resolution_note)
+        return cls(
+            capabilities=_csv(getattr(args, "capabilities", "")),
+            optimizer_name=getattr(args, "optimizer_name", None),
+            capability_sources=_csv(getattr(args, "capability_sources", "")),
+            project_dir=Path(project) if project else None,
+            instructions_file=getattr(args, "instructions_file", None),
+            bench_repo=getattr(args, "bench_repo", None),
+            target_reader=_tp.reader_block(profile),
+        )
+
+    # ---- the two things every algorithm needs --------------------------------
+
+    def inject(self, adapter, run_dir: RunDir, workdir: Path, *, split: str,
+               tag: str | None = None) -> None:
+        """Copy this context into ``workdir`` (trajectories + guidance + native skills)."""
+        _inject_optimizer_context(adapter, run_dir, workdir, split=split,
+                                  capabilities=list(self.capabilities),
+                                  optimizer_name=self.optimizer_name,
+                                  capability_sources=list(self.capability_sources),
+                                  project_dir=self.project_dir, tag=tag)
+
+    def instructions(self, current_val: SplitResult, focus_ids, label: str, *,
+                     algorithm: str, parent_dir: Path | None = None,
+                     extra: str = "") -> str:
+        """Render this iteration's prompt from the shared template.
+
+        ``parent_dir`` (the candidate being forked) enables the empty-seed note;
+        ``extra`` is appended verbatim for the caller's own block.
+        """
+        seed_empty = (_capability_is_empty(list(self.capabilities), parent_dir)
+                      if parent_dir is not None else None)
+        text = _focus_instructions(
+            current_val, focus_ids, label, capabilities=list(self.capabilities),
+            algorithm=algorithm, instructions_file=self.instructions_file,
+            bench_repo=self.bench_repo, optimizer_name=self.optimizer_name,
+            seed_empty=seed_empty, target_reader=self.target_reader)
+        return (text.rstrip() + "\n\n" + extra.strip() + "\n") if extra.strip() else text
+
+
 def parse_protected_paths(value) -> tuple[str, ...] | None:
     """Spec/CLI value → glob patterns, or ``None`` meaning the seal is OFF.
 
@@ -2148,6 +2277,7 @@ def hill_climb_loop(
     target_profile_file: str | None = None,
     protected_patterns=None,
     convergence: bool = False,
+    ctx: "OptimizerContext | None" = None,
 ) -> dict:
     """The loop behind the ``hill-climb`` skill's three ``--focus`` schedules
     (all / cyclic / hardest-first).
@@ -2164,10 +2294,18 @@ def hill_climb_loop(
     gate_kwargs = dict(gate_kwargs or {})
     rejected, history, store = _init_memory_store(run_dir, store)
 
-    # Resolve the consuming-LLM profile once; its brief steers every iteration's prompt.
-    from . import target_profile as _tp
-    _profile = _tp.resolve(target_model, target_profile_file, project_dir=project_dir)
-    _target_reader = _tp.reader_block(_profile)
+    # The shared optimizer read-context (see ``OptimizerContext``). Callers that pass the
+    # individual pieces instead of a ``ctx`` get one assembled from them, so hill-climb,
+    # gepa and skillopt all end up on the SAME assembly path.
+    if ctx is None:
+        from . import target_profile as _tp
+        _profile = _tp.resolve(target_model, target_profile_file, project_dir=project_dir)
+        ctx = OptimizerContext(
+            capabilities=tuple(c for c in (capabilities or []) if c),
+            optimizer_name=optimizer_name,
+            capability_sources=tuple(s for s in (capability_sources or []) if s),
+            project_dir=project_dir, instructions_file=instructions_file,
+            bench_repo=bench_repo, target_reader=_tp.reader_block(_profile))
 
     # establish a focus order over the train tasks when needed
     train_ids = run_dir.read_splits().train
@@ -2193,12 +2331,9 @@ def hill_climb_loop(
             label = f"task {focus_ids[0]}" if focus_ids else "train"
         else:
             focus_ids, label = None, focus
-        seed_empty = _capability_is_empty(capabilities, run_dir.candidate_dir(run_dir.best_id))
-        instructions = _focus_instructions(current_val, focus_ids, label,
-                                            capabilities=capabilities, algorithm=algorithm,
-                                            instructions_file=instructions_file,
-                                            bench_repo=bench_repo, optimizer_name=optimizer_name,
-                                            seed_empty=seed_empty, target_reader=_target_reader)
+        parent_dir = run_dir.candidate_dir(run_dir.best_id)
+        instructions = ctx.instructions(current_val, focus_ids, label,
+                                        algorithm=algorithm, parent_dir=parent_dir)
         if convergence:
             # Pure: recomputed from the steps so far, so a resumed run rebuilding the
             # same observation list gets the identical signal.
@@ -2214,12 +2349,11 @@ def hill_climb_loop(
                 # the prompt template.
                 instructions = instructions.rstrip() + "\n\n" + signal.advice + "\n"
         step = run_step(
-            adapter, run_dir=run_dir, parent_dir=run_dir.candidate_dir(run_dir.best_id),
+            adapter, run_dir=run_dir, parent_dir=parent_dir,
             optimizer=optimizer, instructions=instructions, current_val=current_val,
             n_trials=n_trials, gate_kwargs=gate_kwargs, no_regression=no_regression,
-            rejected=rejected, history=history, store=store, capabilities=capabilities,
-            optimizer_name=optimizer_name, capability_sources=capability_sources,
-            project_dir=project_dir, protected_patterns=protected_patterns,
+            rejected=rejected, history=history, store=store, ctx=ctx,
+            protected_patterns=protected_patterns,
         )
         steps.append(step)
         if step["accepted"]:

--- a/core/cap_evolve/skillopt.py
+++ b/core/cap_evolve/skillopt.py
@@ -214,6 +214,7 @@ def skillopt_loop(
     algorithm: str = "skillopt",
     store=None,
     protected_patterns=None,
+    ctx: harness.OptimizerContext | None = None,
 ) -> dict:
     """Run the SkillOpt epochs × mini-batches climb.
 
@@ -223,8 +224,14 @@ def skillopt_loop(
 
     Returns a result dict shaped like ``hill_climb_loop``'s, plus ``epochs`` /
     ``edit_budget_schedule`` / ``slow_updates`` / per-epoch ``epoch_stats``.
+
+    ``ctx`` is the shared ``harness.OptimizerContext`` — the capability skills, the
+    diagnose method, the sources, the optimizer features reference and the prompt
+    template. It is the SAME object hill-climb and gepa get; skillopt owns only the
+    schedule/buffer/slow-update blocks it appends.
     """
     gate_kwargs = dict(gate_kwargs or {})
+    ctx = ctx or harness.OptimizerContext()
     rejected, history, store = harness._init_memory_store(run_dir, store)
 
     train_ids = list(run_dir.read_splits().train)
@@ -288,17 +295,18 @@ def skillopt_loop(
 
             label = f"epoch {epoch}/{epochs} step {s + 1}/{steps_per_epoch} "
             label += f"(mini-batch of {len(minibatch_ids)} train tasks, L={L})"
-            instructions = harness._focus_instructions(current_val, minibatch_ids, label)
-            instructions += "\n" + _buffer_block(L, step_buffer, rejected_this_epoch)
-
             cid = f"so_e{epoch:02d}s{s + 1:02d}"
             parent_dir = run_dir.candidate_dir(run_dir.best_id)  # single lineage: always best
+            instructions = ctx.instructions(current_val, minibatch_ids, label,
+                                            algorithm=algorithm, parent_dir=parent_dir,
+                                            extra=_buffer_block(L, step_buffer,
+                                                                rejected_this_epoch))
             step = harness.run_step(
                 adapter, run_dir=run_dir, parent_dir=parent_dir,
                 optimizer=optimizer, instructions=instructions, current_val=current_val,
                 n_trials=n_trials, gate_kwargs=gate_kwargs, candidate_id=cid,
                 no_regression=no_regression, rejected=rejected, history=history, store=store,
-                protected_patterns=protected_patterns,
+                ctx=ctx, protected_patterns=protected_patterns,
             )
             if step.get("candidate_val") is None:
                 # Indecisive (protected-path tamper): no measurement exists, so it must
@@ -359,7 +367,7 @@ def skillopt_loop(
                 epoch=epoch, sample=slow_update_sample, edit_budget=schedule[-1] if schedule else edit_budget,
                 n_trials=n_trials, gate_kwargs=gate_kwargs, no_regression=no_regression,
                 rejected=rejected, history=history, store=store,
-                protected_patterns=protected_patterns,
+                protected_patterns=protected_patterns, ctx=ctx,
             )
             if slow_rec is not None:
                 slow_updates.append(slow_rec)
@@ -434,6 +442,7 @@ def _run_slow_update(
     prev_epoch_skill: SplitResult, prev_epoch_best_id, epoch: int, sample: int,
     edit_budget: int, n_trials: int, gate_kwargs: dict, no_regression: bool,
     rejected, history, store, protected_patterns=None,
+    ctx: harness.OptimizerContext | None = None,
 ) -> dict | None:
     """Re-evaluate the epoch-start skill vs current best on a small TRAIN subset,
     categorize, and run ONE extra gated step. Counted in budget; sample is small
@@ -472,16 +481,21 @@ def _run_slow_update(
                       stable_success=len(categories["stable_success"]),
                       improved=len(categories["improved"]))
 
-    instructions = _slow_update_instructions(epoch, categories)
-    instructions += "\n" + _buffer_block(edit_budget, [], [])  # carry the consolidating L budget
-
+    ctx = ctx or harness.OptimizerContext()
     cid = f"so_e{epoch:02d}_slow"
+    parent_dir = run_dir.candidate_dir(run_dir.best_id)
+    # Same shared read-context as a normal step; the longitudinal block is this step's
+    # own addition (+ the consolidating L budget).
+    extra = (_slow_update_instructions(epoch, categories) + "\n"
+             + _buffer_block(edit_budget, [], []))
+    instructions = ctx.instructions(current_val, sample_ids, f"epoch {epoch} slow/meta update",
+                                   algorithm="skillopt", parent_dir=parent_dir, extra=extra)
     step = harness.run_step(
-        adapter, run_dir=run_dir, parent_dir=run_dir.candidate_dir(run_dir.best_id),
+        adapter, run_dir=run_dir, parent_dir=parent_dir,
         optimizer=optimizer, instructions=instructions, current_val=current_val,
         n_trials=n_trials, gate_kwargs=gate_kwargs, candidate_id=cid,
         no_regression=no_regression, rejected=rejected, history=history, store=store,
-        protected_patterns=protected_patterns,
+        ctx=ctx, protected_patterns=protected_patterns,
     )
     step["epoch"] = epoch
     step["step_in_epoch"] = "slow"

--- a/core/cap_evolve/types.py
+++ b/core/cap_evolve/types.py
@@ -28,10 +28,19 @@ NON_CAPABILITY_FILES = frozenset({
     "FOCUS.md", "REFLECTION.md",
     # cross-iteration state files — scratch, not capability
     "LEDGER.md", "JOURNAL.md", "PROCESS.md", "RUNMAP.md",
+    # per-agent always-on instructions files: injection appends a pointer block to them
+    "CLAUDE.md", "AGENTS.md", "GEMINI.md",
 })
 
-#: Read-context / vcs dirs that are never the edit surface.
-NON_CAPABILITY_DIRS = frozenset({".git", "__pycache__", "prior_iterations"})
+#: Read-context / vcs dirs that are never the edit surface. This covers everything
+#: ``harness.OptimizerContext.inject()`` writes into an iteration workdir (trajectories,
+#: guidance, and the per-agent NATIVE skills dirs): now that EVERY algorithm injects that
+#: context, an un-ignored read-context dir would bust gepa's eval cache every iteration
+#: and show up to gepa as an editable "component" to optimize.
+NON_CAPABILITY_DIRS = frozenset({
+    ".git", "__pycache__", "prior_iterations", "trajectories", "guidance",
+    ".claude", ".agents", ".gemini", ".opencode", ".bob", ".cursor",
+})
 
 
 def _clamp01(x: float) -> float:

--- a/core/tests/test_optimizer_context_parity.py
+++ b/core/tests/test_optimizer_context_parity.py
@@ -1,0 +1,139 @@
+"""EVERY algorithm receives the SAME optimizer context — the guard for issue #109.
+
+`docs/ARCHITECTURE.md` ("What the optimizer receives each iteration") describes a
+property of the harness, not of hill-climb. Before this test, hill-climb was the only
+algorithm that got the full context: gepa never injected any of it and skillopt called
+the prompt renderer bare (no capability brief, no template, no bench repo — and a
+PARALLEL_NOTE that actively told a parallel-capable optimizer it was sequential).
+
+So the assertions below are parametrized over ALL algorithms, driving one real iteration
+of each with the mock (zero-API) optimizer on toy_calc and checking the assembled
+optimizer working dir + rendered prompt piece by piece. A newly added algorithm that
+forgets to thread ``harness.OptimizerContext`` fails here loudly instead of silently
+running blind.
+"""
+
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+CORE = REPO / "core"
+EXAMPLE = REPO / "examples" / "toy_calc"
+MOCK_RUN = REPO / "skills" / "optimizers" / "run-optimizer" / "scripts" / "run.py"
+sys.path.insert(0, str(CORE))
+sys.path.insert(0, str(EXAMPLE))
+
+ALGORITHMS = ("hill-climb", "gepa", "skillopt")
+# A parallel-capable optimizer row: exercises the features reference, the native skills
+# dir and the {{PARALLEL_NOTE}} that skillopt used to get wrong.
+OPTIMIZER_NAME = "claude-code"
+CAPABILITY = "system-prompt"
+SOURCE_FILE = "adapter.py"          # a real file under the toy project dir
+BENCH_REPO = "/tmp/some-bench-repo"
+
+
+@pytest.fixture(autouse=True)
+def _env(monkeypatch):
+    monkeypatch.setenv("CAPEVOLVE_CORE", str(CORE))
+    monkeypatch.setenv("CAPEVOLVE_TOY_DATA", str(EXAMPLE))
+    monkeypatch.setenv("CAPEVOLVE_MOCK_SCRIPT", str(EXAMPLE / "mock_script.json"))
+
+
+def _toy_adapter():
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("toy_calc_adapter_parity", EXAMPLE / "adapter.py")
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m.Adapter()
+
+
+def _run_one_iteration(algorithm: str, tmp_path: Path) -> Path:
+    """Run ONE iteration of ``algorithm`` with the shared context; return its workdir."""
+    from cap_evolve import Budget, RunDir, gepa, harness, skillopt
+
+    adapter = _toy_adapter()
+    seed = tmp_path / "seed"
+    shutil.copytree(EXAMPLE / "capability", seed)
+    run_dir = RunDir.create(tmp_path / ".capevolve", ts="parity",
+                            budget=Budget(max_iterations=1, stall=3))
+    harness.ensure_splits(adapter, run_dir, seed=0)
+    base = harness.baseline(adapter, seed, run_dir=run_dir)
+
+    optimizer = harness.optimizer_from_command(
+        ["python3", str(MOCK_RUN), "--name", "mock", "--workdir", "{workdir}",
+         "--prompt", "{prompt}"])
+    ctx = harness.OptimizerContext(
+        capabilities=(CAPABILITY,), optimizer_name=OPTIMIZER_NAME,
+        capability_sources=(SOURCE_FILE,), project_dir=EXAMPLE, bench_repo=BENCH_REPO)
+    common = dict(run_dir=run_dir, optimizer=optimizer, ctx=ctx,
+                  gate_kwargs={"mode": "significant", "k_se": 1.0})
+
+    if algorithm == "hill-climb":
+        harness.hill_climb_loop(adapter, current_val=base, focus="all", max_iterations=1,
+                                algorithm="hill-climb", **common)
+    elif algorithm == "gepa":
+        gepa.gepa_loop(adapter, seed_val=base, max_iterations=1, minibatch_size=2, **common)
+    elif algorithm == "skillopt":
+        skillopt.skillopt_loop(adapter, current_val=base, epochs=1, batch_size=2,
+                               slow_update=False, algorithm="skillopt", **common)
+    else:  # pragma: no cover - guard for a future algorithm added to ALGORITHMS
+        raise AssertionError(f"no driver for {algorithm}")
+
+    workdirs = sorted(p for p in (run_dir.root / "work").iterdir() if p.is_dir())
+    assert workdirs, f"{algorithm} produced no iteration workdir"
+    return workdirs[0]
+
+
+@pytest.mark.parametrize("algorithm", ALGORITHMS)
+def test_every_algorithm_gets_the_same_optimizer_context(algorithm, tmp_path):
+    if shutil.which("git") is None:
+        pytest.skip("git not available")
+    workdir = _run_one_iteration(algorithm, tmp_path)
+
+    # 1) the parent step's verbatim trajectories
+    assert (workdir / "trajectories").is_dir(), f"{algorithm}: no ./trajectories/"
+    assert any((workdir / "trajectories").iterdir()), f"{algorithm}: empty ./trajectories/"
+
+    # 2) the selected capability skill — as guidance AND placed natively for the agent
+    assert (workdir / "guidance" / CAPABILITY / "SKILL.md").exists(), \
+        f"{algorithm}: no ./guidance/{CAPABILITY}/"
+    assert (workdir / ".claude" / "skills" / CAPABILITY / "SKILL.md").exists(), \
+        f"{algorithm}: capability skill not placed natively"
+
+    # 3) the diagnose method (failure clustering)
+    assert (workdir / "guidance" / "diagnose" / "SKILL.md").exists(), \
+        f"{algorithm}: no ./guidance/diagnose/"
+
+    # 4) supporting sources / data model
+    assert (workdir / "guidance" / "sources" / SOURCE_FILE).exists(), \
+        f"{algorithm}: no ./guidance/sources/{SOURCE_FILE}"
+
+    # 5) the resolved optimizer's own features reference
+    assert (workdir / "guidance" / "optimizer" / f"{OPTIMIZER_NAME}.md").exists(), \
+        f"{algorithm}: no ./guidance/optimizer/{OPTIMIZER_NAME}.md"
+
+    # 6) per-task IMPACT of prior candidates + the protect-set
+    for name in ("LEDGER.md", "JOURNAL.md", "RUNMAP.md"):
+        assert (workdir / name).exists(), f"{algorithm}: no ./{name}"
+
+    # 7) the prompt itself: rendered from the shared template, with the capability brief,
+    # the bench-repo pointer and a PARALLEL note that matches the real optimizer.
+    instr = (workdir / "INSTRUCTIONS.md").read_text(encoding="utf-8")
+    assert "{{" not in instr, f"{algorithm}: unrendered placeholder in the prompt"
+    assert BENCH_REPO in instr, f"{algorithm}: bench repo not surfaced"
+    assert CAPABILITY in instr, f"{algorithm}: no capability brief"
+    assert "fan out" in instr.lower(), \
+        f"{algorithm}: parallel-capable optimizer not told it can fan out"
+
+
+def test_injected_context_is_not_part_of_the_candidate():
+    """The injected read-context must never be hashed, diffed or optimized as capability
+    content — otherwise gepa's eval cache misses every iteration and its component
+    selector 'edits' the guidance we just handed it."""
+    from cap_evolve.types import NON_CAPABILITY_DIRS
+
+    for d in ("trajectories", "guidance", ".claude", "prior_iterations"):
+        assert d in NON_CAPABILITY_DIRS

--- a/core/tests/test_optimizer_context_parity.py
+++ b/core/tests/test_optimizer_context_parity.py
@@ -6,11 +6,18 @@ algorithm that got the full context: gepa never injected any of it and skillopt 
 the prompt renderer bare (no capability brief, no template, no bench repo — and a
 PARALLEL_NOTE that actively told a parallel-capable optimizer it was sequential).
 
-So the assertions below are parametrized over ALL algorithms, driving one real iteration
-of each with the mock (zero-API) optimizer on toy_calc and checking the assembled
-optimizer working dir + rendered prompt piece by piece. A newly added algorithm that
-forgets to thread ``harness.OptimizerContext`` fails here loudly instead of silently
-running blind.
+So the assertions below are parametrized over each of the three algorithms that thread the
+context (``hill-climb``, ``gepa``, ``skillopt``), driving one real iteration of each with
+the mock (zero-API) optimizer on toy_calc and checking the assembled optimizer working dir
++ rendered prompt piece by piece. Each failure names the algorithm and the missing piece.
+
+SCOPE, stated plainly because the list is enumerated and not discovered: ``ALGORITHMS``
+below is a literal, so an algorithm absent from it is NOT covered — it can still run blind
+while this file stays green. ``agent-optimize`` and ``evograph`` ship today, declare none of
+the context flags and drive their own loops; they are out of scope for issue #109. Making
+this test discover algorithms instead of enumerating them is tracked separately, and until
+that lands a new algorithm must be added to ``ALGORITHMS`` (and to
+``cli.OPTIMIZER_CONTEXT_ALGORITHMS``) by hand.
 """
 
 import shutil
@@ -26,6 +33,8 @@ MOCK_RUN = REPO / "skills" / "optimizers" / "run-optimizer" / "scripts" / "run.p
 sys.path.insert(0, str(CORE))
 sys.path.insert(0, str(EXAMPLE))
 
+#: The algorithms that take a ``harness.OptimizerContext``. A LITERAL, so it is also the
+#: exact scope of this guard — see the module docstring.
 ALGORITHMS = ("hill-climb", "gepa", "skillopt")
 # A parallel-capable optimizer row: exercises the features reference, the native skills
 # dir and the {{PARALLEL_NOTE}} that skillopt used to get wrong.
@@ -50,8 +59,11 @@ def _toy_adapter():
     return m.Adapter()
 
 
-def _run_one_iteration(algorithm: str, tmp_path: Path) -> Path:
-    """Run ONE iteration of ``algorithm`` with the shared context; return its workdir."""
+def _run_one_iteration(algorithm: str, tmp_path: Path):
+    """Run ONE iteration of ``algorithm`` with the shared context.
+
+    Returns ``(run_dir, workdir)`` — the run and that iteration's optimizer working dir.
+    """
     from cap_evolve import Budget, RunDir, gepa, harness, skillopt
 
     adapter = _toy_adapter()
@@ -84,14 +96,14 @@ def _run_one_iteration(algorithm: str, tmp_path: Path) -> Path:
 
     workdirs = sorted(p for p in (run_dir.root / "work").iterdir() if p.is_dir())
     assert workdirs, f"{algorithm} produced no iteration workdir"
-    return workdirs[0]
+    return run_dir, workdirs[0]
 
 
 @pytest.mark.parametrize("algorithm", ALGORITHMS)
 def test_every_algorithm_gets_the_same_optimizer_context(algorithm, tmp_path):
     if shutil.which("git") is None:
         pytest.skip("git not available")
-    workdir = _run_one_iteration(algorithm, tmp_path)
+    _run_dir, workdir = _run_one_iteration(algorithm, tmp_path)
 
     # 1) the parent step's verbatim trajectories
     assert (workdir / "trajectories").is_dir(), f"{algorithm}: no ./trajectories/"
@@ -129,11 +141,36 @@ def test_every_algorithm_gets_the_same_optimizer_context(algorithm, tmp_path):
         f"{algorithm}: parallel-capable optimizer not told it can fan out"
 
 
-def test_injected_context_is_not_part_of_the_candidate():
-    """The injected read-context must never be hashed, diffed or optimized as capability
-    content — otherwise gepa's eval cache misses every iteration and its component
-    selector 'edits' the guidance we just handed it."""
-    from cap_evolve.types import NON_CAPABILITY_DIRS
+@pytest.mark.parametrize("algorithm", ALGORITHMS)
+def test_injected_context_never_lands_in_a_candidate(algorithm, tmp_path):
+    """Snapshotted candidates carry the capability, never the read-context we injected.
 
-    for d in ("trajectories", "guidance", ".claude", "prior_iterations"):
-        assert d in NON_CAPABILITY_DIRS
+    What actually secures this is the ``ignore=`` on each algorithm's ``snapshot()`` call
+    (``harness._SNAPSHOT_IGNORE``); the ignore-lists in ``types`` are defence-in-depth for
+    the hash/component/diff paths. Asserted per algorithm because gepa snapshots from its
+    own loop rather than through ``run_step``, so it needs the exclusion separately.
+    """
+    if shutil.which("git") is None:
+        pytest.skip("git not available")
+    run_dir, _workdir = _run_one_iteration(algorithm, tmp_path)
+
+    cand_root = run_dir.root / "candidates"
+    cands = [p for p in cand_root.iterdir() if p.is_dir()] if cand_root.is_dir() else []
+    assert cands, f"{algorithm}: no candidate was snapshotted"
+    for cand in cands:
+        for injected in ("trajectories", "guidance", ".claude"):
+            assert not (cand / injected).exists(), \
+                f"{algorithm}: injected {injected}/ leaked into candidate {cand.name}"
+
+
+def test_ignore_lists_cover_everything_injection_writes():
+    """Every path ``OptimizerContext.inject()`` creates is declared non-capability, so it
+    perturbs neither the eval-cache hash, the component list, nor a capability diff."""
+    from cap_evolve.types import NON_CAPABILITY_DIRS, NON_CAPABILITY_FILES
+
+    for d in ("trajectories", "guidance", "prior_iterations",
+              ".claude", ".agents", ".gemini", ".opencode", ".bob", ".cursor"):
+        assert d in NON_CAPABILITY_DIRS, d
+    for f in ("LEDGER.md", "JOURNAL.md", "RUNMAP.md", "INSTRUCTIONS.md",
+              "CLAUDE.md", "AGENTS.md", "GEMINI.md"):
+        assert f in NON_CAPABILITY_FILES, f

--- a/skills/algorithms/gepa/scripts/run.py
+++ b/skills/algorithms/gepa/scripts/run.py
@@ -57,6 +57,9 @@ def main(argv=None) -> int:
     p.add_argument("--resume", action="store_true",
                    help="reconstruct the pool/frontier from the run dir and continue the "
                         "search instead of restarting from the seed")
+    # The shared optimizer read-context flags — identical set to hill-climb/skillopt, so
+    # `cap-evolve run` hands gepa the same context instead of a thinner prompt.
+    harness.OptimizerContext.add_arguments(p)
     p.add_argument("--protected-paths", default="",
                    help="comma-separated globs sealing the eval surface (scorer/gold/tasks/"
                         "tests). 'default' expands to the built-in set. Empty = off. A "
@@ -92,7 +95,7 @@ def main(argv=None) -> int:
         gate_kwargs=({"k_se": args.k_se} if args.gate_mode == "auto"
                      else {"mode": args.gate_mode, "k_se": args.k_se}),
         no_regression=args.no_regression, seed=args.seed, store=store,
-        resume=args.resume,
+        resume=args.resume, ctx=harness.OptimizerContext.from_args(args, run_dir=run_dir),
         protected_patterns=harness.parse_protected_paths(args.protected_paths),
     )
     run_dir.close_observers()

--- a/skills/algorithms/hill-climb/scripts/run.py
+++ b/skills/algorithms/hill-climb/scripts/run.py
@@ -57,27 +57,8 @@ def main(argv=None) -> int:
     p.add_argument("--resume", action="store_true",
                    help="continue from the run's current best candidate (read its val "
                         "from rollouts) instead of baseline")
-    p.add_argument("--capabilities", default="",
-                   help="comma-separated capability skills under optimization (e.g. "
-                        "'system-prompt,tools'); surfaced to the optimizer so it knows "
-                        "the allowed edit space")
-    p.add_argument("--instructions-file", default=None,
-                   help="optimizer-instructions template (intake-authored) to render the "
-                        "per-iteration prompt from; defaults to the shipped template")
-    p.add_argument("--bench-repo", default=None,
-                   help="path to the benchmark/runner source, surfaced to the optimizer "
-                        "as read-only context")
-    p.add_argument("--optimizer-name", default=None,
-                   help="resolved optimizer name (registry row); used to copy that "
-                        "optimizer's features reference into the optimizer workdir")
-    p.add_argument("--capability-sources", default="",
-                   help="comma-separated supporting source files (data models / types "
-                        "the tools import) copied verbatim into the optimizer's "
-                        "./guidance/sources/; resolved relative to --project")
-    p.add_argument("--target-model", default="",
-                   help="consuming/runtime model id or tier keyword (frontier|strong|mid|weak)")
-    p.add_argument("--target-profile-file", default=None,
-                   help="optional project-local brief overriding the tier's built-in brief")
+    # The shared optimizer read-context flags (one declaration for every algorithm).
+    harness.OptimizerContext.add_arguments(p)
     p.add_argument("--protected-paths", default="",
                    help="comma-separated globs sealing the eval surface (scorer/gold/tasks/"
                         "tests). 'default' expands to the built-in set. Empty = off. A "
@@ -103,13 +84,9 @@ def main(argv=None) -> int:
     except Exception:  # noqa: BLE001
         pass
 
-    # Record the resolved consuming-LLM profile so report + dashboard can surface it.
-    from cap_evolve import target_profile as _tp
-    _prof = _tp.resolve(args.target_model, args.target_profile_file, project_dir=args.project)
-    if not _prof.is_agnostic:
-        run_dir.log_event("target_profile", model=_prof.model, tier=_prof.tier,
-                          suggested_num_trials=_prof.suggested_num_trials,
-                          resolution_note=_prof.resolution_note)
+    # The optimizer read-context (capability skills, template, sources, bench repo,
+    # optimizer features ref, consuming-LLM brief). Also logs the resolved profile.
+    ctx = harness.OptimizerContext.from_args(args, run_dir=run_dir)
     if harness.DEFAULT_WORKERS > 1:
         run_dir.log_event("parallel", workers=harness.DEFAULT_WORKERS, algorithm=ALGO)
     store = make_store({"store": args.store, "store_commit_cmd": args.store_commit_cmd}, run_dir.root)
@@ -127,13 +104,7 @@ def main(argv=None) -> int:
         gate_kwargs=({"k_se": args.k_se} if args.gate_mode == "auto"
                      else {"mode": args.gate_mode, "k_se": args.k_se}),
         algorithm=f"{ALGO}:{focus}", no_regression=args.no_regression, store=store,
-        capabilities=[c.strip() for c in args.capabilities.split(",") if c.strip()],
-        instructions_file=args.instructions_file, bench_repo=args.bench_repo,
-        optimizer_name=args.optimizer_name,
-        capability_sources=[s.strip() for s in args.capability_sources.split(",") if s.strip()],
-        project_dir=Path(args.project),
-        target_model=args.target_model,
-        target_profile_file=args.target_profile_file,
+        ctx=ctx,
         protected_patterns=harness.parse_protected_paths(args.protected_paths),
         convergence=args.convergence,
     )

--- a/skills/algorithms/skillopt/scripts/run.py
+++ b/skills/algorithms/skillopt/scripts/run.py
@@ -72,6 +72,8 @@ def main(argv=None) -> int:
     p.add_argument("--store-commit-cmd", default=None)
     p.add_argument("--resume", action="store_true",
                    help="continue from the run's current best instead of baseline")
+    # The shared optimizer read-context flags — identical set to hill-climb/gepa.
+    harness.OptimizerContext.add_arguments(p)
     p.add_argument("--protected-paths", default="",
                    help="comma-separated globs sealing the eval surface (scorer/gold/tasks/"
                         "tests). 'default' expands to the built-in set. Empty = off. A "
@@ -109,6 +111,7 @@ def main(argv=None) -> int:
                      else {"mode": args.gate_mode, "k_se": args.k_se}),
         no_regression=args.no_regression, slow_update=args.slow_update,
         slow_update_sample=args.slow_update_sample, algorithm=ALGO, store=store,
+        ctx=harness.OptimizerContext.from_args(args, run_dir=run_dir),
         protected_patterns=harness.parse_protected_paths(args.protected_paths),
     )
     run_dir.close_observers()

--- a/templates/project/capevolve.yaml
+++ b/templates/project/capevolve.yaml
@@ -36,7 +36,7 @@ algorithm_skill: hill-climb              # algorithms/<skill>: hill-climb | gepa
 algorithm_focus: all                     # hill-climb schedule: all | cyclic | hardest-first
 orchestration_mode: deterministic        # deterministic (cap-evolve sequences the loop) | agent (the coding agent drives the loop via cap-evolve primitives, sealing with `cap-evolve finalize`)
 
-# --- what context the optimizer gets (hill-climb) ---------------------------
+# --- what context the optimizer gets (hill-climb | gepa | skillopt) ---------
 # The per-iteration optimizer prompt is RENDERED from this template (intake authors it,
 # customized per benchmark). Defaults to the scaffolded optimizer/INSTRUCTIONS.md.
 optimizer_instructions_file: optimizer/INSTRUCTIONS.md


### PR DESCRIPTION
Closes #109. Supersedes #199 (that branch conflicts in 13 files against current main; this is a redesign against `d94fb336`).

Second commit addresses the merge review (`.review/merge-review-355.md`, verdict FIX-FIRST): the guard's scope claim, the undisclosed prompt-size increase, and three follow-up issues. See "Review fixes" below.

## The bug

`hill-climb` was the only algorithm that received the context `docs/ARCHITECTURE.md` promises ("What the optimizer receives each iteration"). GEPA never injected any of it; SkillOpt called the prompt renderer bare. Two of the three arms were handed a strictly worse prompt than the third, so any algorithm-vs-algorithm number on this repo's own benchmarks was confounded — "hill-climb beat gepa" was untestable. SkillOpt's `{{PARALLEL_NOTE}}` was worse than absent: `optimizer_name=None` made it *tell a parallel-capable optimizer it was sequential*.

## Parity table, re-verified against current main (`d94fb336`)

BEFORE (all line numbers from `main`, not from PR #199's stale branch):

| context piece | hill-climb | gepa | skillopt |
|---|---|---|---|
| `./trajectories/` (parent's verbatim rollouts) | YES — `harness.py:1461` via `run_step` | **NO** — no inject call anywhere; `gepa.py:571` only `copytree(parent_dir, workdir)` | YES — `skillopt.py:296` → `harness.py:1461` |
| `./guidance/<cap>/` capability skill | YES — `harness.py:2197` + `1461` `capabilities=` | **NO** | **NO** — `capabilities=` not passed (`skillopt.py:296`) |
| native skills dir (`.claude/skills/…`) | YES — same inject | **NO** | **NO** (same reason) |
| `./guidance/diagnose/` | YES | **NO** | YES (unconditional part of inject) |
| `./guidance/sources/` (`capability_sources`) | YES | **NO** | **NO** — param absent from `skillopt_loop` |
| `./guidance/optimizer/<name>.md` | YES | **NO** | **NO** |
| `{{CAP_BRIEF}}` | YES — `harness.py:2197` | **NO** — no `_focus_instructions` call at all | **EMPTY** — `skillopt.py:291` bare |
| `{{FAILURES}}` / `{{PASSING}}` | YES | **NO** | YES |
| intake-authored INSTRUCTIONS template | YES | **NO** — hand-rolled `gepa.py:289 _instructions` | **NO** — default template only |
| `{{BENCH_REPO}}` | YES | **NO** | **NO** |
| `{{PARALLEL_NOTE}}` | YES | **NO** | **WRONG** — always claims sequential |
| `{{TARGET_READER}}` | YES | **NO** | **NO** |
| `{{EMPTY_SEED}}` | YES | **NO** | **NO** (fell back to the reward heuristic → claimed an empty seed that wasn't) |
| prior impact / protect-set (LEDGER/JOURNAL/RUNMAP/`prior_iterations/`) | YES — `harness.py:1062` | YES — `gepa.py:582` | YES — via `run_step` |

Confirmed by grep on main: `_inject_optimizer_context` is defined at `harness.py:1166` and called from exactly one place, `harness.py:1461`. `skillopt.py:291` is `harness._focus_instructions(current_val, minibatch_ids, label)` — no other args. CLI gates on main: `cli.py:860` (`--capabilities`), `cli.py:865` (`--optimizer-name`), `cli.py:870` (`--instructions-file` / `--bench-repo` / `--capability-sources` / `--target-model` / `--target-profile-file`), all `algorithm_name == "hill-climb"`. And the flags did not exist downstream either — `skills/algorithms/{gepa,skillopt}/scripts/run.py` declared none of them, so un-gating the CLI alone would have crashed the run on unknown args.

AFTER (this branch) — every piece for each of the three algorithms that thread the context, from one call each:

| context piece | hill-climb | gepa | skillopt |
|---|---|---|---|
| all 14 rows above | `harness.py:2300` builds the ctx, `2335` `ctx.instructions(...)`, `1470` `ctx.inject(...)` via `run_step` | `gepa.py:501` ctx, `588` `ctx.inject(..., tag=f"mb_p_{n:04d}")`, `591` `ctx.instructions(..., extra=_instructions(...))` | `skillopt.py:234` ctx, `300` `ctx.instructions(...)`, `309` `ctx=ctx` → `harness.py:1470`; slow update at `484`/`491`/`498` |
| CLI flags | `cli.py:868/873/878` — `algorithm_name in OPTIMIZER_CONTEXT_ALGORITHMS` (`cli.py:387`) | same | same |
| run.py flag set | `harness.OptimizerContext.add_arguments(p)` | same | same |

`cli.py:681` (`algorithm_focus` gated to hill-climb) is left alone on purpose: `--focus` is genuinely a hill-climb schedule, not context.

**Scope.** `agent-optimize` and `evograph` also ship, declare none of the context flags, drive their own loops, and are in neither list — they were blind on main and remain outside this guarantee. Out of scope for #109; the real fix (discovering algorithms instead of enumerating them) is #375.

## The shared assembler, in three sentences

`harness.OptimizerContext` is a dataclass holding the read-context (capabilities, optimizer name, capability sources, project dir, instructions template, bench repo, target-reader brief) with exactly two methods: `inject()` writes it into an iteration workdir and `instructions()` renders that iteration's prompt from the shared template. All three loops accept `ctx=` and call those two methods, and `run_step`'s four threaded context params collapse into `ctx=`, so there is one assembly path rather than hill-climb's blocks copied into two more places. Nothing in it branches on the caller — the two genuinely per-algorithm inputs are parameters: `algorithm` (selects the algorithm brief) and `extra` (the caller's own block, appended verbatim: gepa's reflective-dataset pointer, skillopt's edit-budget/rejected buffer, the slow-update longitudinal block).

Three supporting changes the injection *requires*:

1. `_copy_step_trajectories`/`_inject_optimizer_context` take `tag=`. GEPA's parent is a frontier member, not the run's best, so it passes its own minibatch eval tag and the optimizer reads the untruncated traces behind its own `REFLECTION.md`. (Known limit, filed as #376: from iteration 2 the parent's minibatch eval is a cache hit that writes no rollout file, so the tag stops resolving and the fallback hands over the whole mixed `rollouts/train/`. Still strictly better than main's nothing.)
2. `gepa.py` snapshots accepted candidates with `harness._SNAPSHOT_IGNORE` (`gepa.py:684`, `848`) — the exclusion `run_step` already applied. This is what actually keeps injected context out of candidate dirs, and hence out of the merge's component lists and the next iteration's parent copy. **Duplicated by #350** (byte-compared: semantically identical); drop these three hunks here on rebase once #350 lands — see "Rebase" below.
3. `types.NON_CAPABILITY_DIRS`/`_FILES` (main's already-shared list, used by `cache.hash_candidate_dir`, `gepa._components`, `diffview`) gain the injected read-context: `trajectories`, `guidance`, the agent skills dot-dirs, and the agent instructions files. Required: `gepa.py:640` hashes the **workdir**, not a snapshot, so without this the injected ~20 KB folds into the child's hash and a cache entry written for a child can never be re-read when that child is later re-sampled as a parent from its clean candidate dir. For the component-selector path it is defence-in-depth — in-iteration ordering (`_components` runs before `inject`) plus the snapshot ignore already secure that.

## Cost: gepa's prompt grows ~15x — intentional, disclosed

Measured on the same zero-API toy_calc run at `d94fb336` and on this branch, comparing the rendered `work/<cid>/INSTRUCTIONS.md`:

| algorithm | main | this branch | delta |
|---|---|---|---|
| hill-climb | 20,936 B (it1) / 20,478 B | 20,936 B / 20,478 B | **0 — byte-identical** |
| gepa | **1,474 B / 16 lines** | **22,192 B / 279 lines** | **+20,718 B, ≈15x, ≈ +5k input tokens per iteration** |
| skillopt (normal step) | 20,648 B | 20,562 B | −86 B (a *false* EMPTY-SEED block removed) |
| skillopt (slow/meta update) | 1,825 B | 21,115 B | **+19,290 B** — the slow update now renders through the shared template too |

The gepa and skillopt-slow increases are the point of the PR (gepa was proposing off a 16-line prompt), and it is the same prompt hill-climb has always had — but on a **paid** optimizer this is a real per-iteration input-token cost increase, so it should be a conscious merge decision, not a surprise. hill-climb is unchanged to the byte.

The skillopt normal-step content change is strictly corrective: it drops a false `## EMPTY SEED — create the capability from scratch` block (main left `seed_empty=None`, so the reward heuristic claimed the capability dir was empty whenever baseline val was 0.0, though `examples/toy_calc/capability/prompt.txt` exists), fixes `Algorithm: hill-climb.` → `Algorithm: skillopt.`, and fixes the inverted parallel note.

## The guard

`core/tests/test_optimizer_context_parity.py` — parametrized over `("hill-climb", "gepa", "skillopt")`, one real zero-API iteration each (mock optimizer, `toy_calc`, `claude-code` as the resolved optimizer row so native placement and the parallel note are exercised):

- `test_every_algorithm_gets_the_same_optimizer_context` — asserts on the assembled workdir: `./trajectories/` non-empty, `./guidance/<cap>/SKILL.md`, `.claude/skills/<cap>/SKILL.md`, `./guidance/diagnose/SKILL.md`, `./guidance/sources/<file>`, `./guidance/optimizer/claude-code.md`, `LEDGER.md`/`JOURNAL.md`/`RUNMAP.md`; and on the prompt: no unrendered `{{`, the bench-repo path, the capability brief, "fan out".
- `test_injected_context_never_lands_in_a_candidate` — no snapshotted candidate may contain `trajectories/`, `guidance/` or `.claude/`. Asserted per algorithm because gepa snapshots from its own loop, not through `run_step`.
- `test_ignore_lists_cover_everything_injection_writes` — every injected path is declared non-capability, dirs and files.

**Scope is enumerated, not discovered, and the docstring says so.** `ALGORITHMS` is a literal, so an algorithm absent from it is not covered and can still run blind with this file green. That is why #375 exists.

Each arm verified RED independently. Dropping gepa's `ctx.inject(...)`:

```
E       AssertionError: gepa: no ./trajectories/
FAILED core/tests/test_optimizer_context_parity.py::test_every_algorithm_gets_the_same_optimizer_context[gepa]
1 failed, 3 passed in 3.16s
```

Reverting gepa's snapshot ignore (the change #350 duplicates) — this is what makes dropping that hunk on rebase safe in any merge order:

```
E               assert not True
E                +    where exists = (PosixPath('.../candidates/gepa_0001') / 'trajectories').exists
FAILED core/tests/test_optimizer_context_parity.py::test_injected_context_never_lands_in_a_candidate[gepa]
1 failed, 6 passed in 6.30s
```

The reviewer independently broke each of the other arms (`ctx=ctx` off skillopt's and hill-climb's `run_step` calls, skillopt reverted to main's bare renderer) and got a distinct, algorithm-named failure each time — see `.review/merge-review-355.md`.

## Review fixes (second commit)

- **B1 — overclaim removed.** The body and the test docstring said "a newly added algorithm that forgets to thread the context fails here". It does not: the algorithm list is a literal. Reworded to "each of the three algorithms that thread the context", with the scope limit and the two out-of-scope algorithms stated in the docstring, and #375 filed for the real fix.
- **B2 — prompt-size increase disclosed** with my own measurements, above (including the skillopt slow-update case the review did not cover).
- **B3 — rebase**, below.
- Reviewer nits taken: deleted the never-read `OptimizerContext.ARG_DESTS`; documented that a passed `ctx` wins over `hill_climb_loop`'s legacy per-piece kwargs; widened the ignore-list assertion to all injected dirs *and* files; corrected the commit message's claim about which change stops the component selector.
- Follow-ups filed instead of scope-creeping this PR: **#375** (parity test should discover algorithms), **#376** (gepa's `tag=` degrading from iteration 2, and the guard's blindness to it), **#378** (basename-anywhere ignore matching vs a capability that legitimately is `AGENTS.md` or lives under `.claude/`; pre-existing on main).

## Rebase (per `.review/MERGE_PLAN.md`: 350 → 346 → 355)

Neither #350 nor #346 is on `main` yet (`git log origin/main` = `d94fb336`), so this branch still carries its own copy of the gepa snapshot change — dropping it before #350 lands would regress candidate cleanliness and leave this branch unable to prove it. Mechanical instructions for the merger, verified against both branches:

1. From **#350**, drop these three hunks here (semantically identical, reviewer byte-compared): the `_SNAPSHOT_IGNORE` entry in gepa's `from .harness import (...)` block (already sorted to #350's position so the block auto-resolves), `gepa.py:684`, `gepa.py:848`. Keep this PR's two-line comment at `684`. `test_injected_context_never_lands_in_a_candidate` then proves the drop was safe. #350 owns the `_SNAPSHOT_IGNORE` *tuple*; this PR never edits it, and #350 never edits `types.py`, so there is no semantic conflict.
2. From **#346**, drop `rejected, history` from the `_augment_instructions(...)` call at `gepa.py:593` (arity change to `(instructions, workdir, run_dir)`). #346 does not touch `types.py`; it leaves `MEMORY.md` in `NON_CAPABILITY_FILES` as a harmless dead entry.

## Evidence — every run performed, verbatim

Pinned full suite per #349 (`PYTHONPATH="$PWD/core:$PWD/dashboard/backend"`); clean main is `789 passed, 12 skipped`:

```
$ PYTHONPATH="$PWD/core:$PWD/dashboard/backend" python -m pytest core/tests -q
796 passed, 12 skipped in 119.66s (0:01:59)
```

Three refreshed algorithm runs — zero-API, deterministic, real `cap-evolve run` through `cli.py` (the toy `run.sh`, with only `algorithm_skill` rewritten for the other two arms), fresh temp project each:

```
hill-climb  run_dir=.capevolve/run_demo   best_id=cand_0001   baseline_val=0.0  test_reward=1.0  test_delta=+1.0  iterations=3
gepa        run_dir=.capevolve/run_demo_gepa      best_id=gepa_0001   baseline_val=0.0  test_reward=1.0  test_delta=+1.0  iterations=3
skillopt    run_dir=.capevolve/run_demo_skillopt  best_id=so_e01s01   baseline_val=0.0  test_reward=1.0  test_delta=+1.0  iterations=3
```

Context actually on disk, gepa iteration 1 (`work/gepa_0001/`) — on main this dir has no `guidance/` and no `trajectories/` at all:

```
FOCUS.md   guidance   INSTRUCTIONS.md   JOURNAL.md   LEDGER.md
PROCESS.md   prompt.txt   REFLECTION.md   RUNMAP.md   trajectories
guidance/: diagnose  optimizer  system-prompt
```

skillopt iteration 1 (`work/so_e01s01/`):

```
guidance   INSTRUCTIONS.md   JOURNAL.md   LEDGER.md
PROCESS.md   prompt.txt   RUNMAP.md   trajectories
guidance/: diagnose  optimizer  system-prompt
```

And the accepted gepa candidate carries the capability only — no injected read-context:

```
$ ls -a run_demo_gepa/candidates/gepa_0001/
.  ..  FOCUS.md  INSTRUCTIONS.md  PROCESS.md  prompt.txt  REFLECTION.md
```

(`FOCUS.md`/`REFLECTION.md`/`INSTRUCTIONS.md` are gepa's own scratch; #350 adds the first two to `_SNAPSHOT_IGNORE`, which is another reason it lands first.)

## Principles

- **Generic, not specific**: the assembler names no benchmark, capability, optimizer or vendor and does not branch on the algorithm; per-algorithm content arrives as `algorithm=` / `extra=`. The four remaining algorithm-name literals are all in `cli.py`, which already resolves algorithms by name, and they *replace* three `== "hill-climb"` comparisons.
- **Zero deps**: `dataclasses` + `pathlib`.
- **Honesty invariants untouched**: no change to the gate, splits, seal or tamper guard. The one adjacent edit — the ignore-list — is required, and it extends main's *existing single* list rather than adding a fourth copy.
- **Deletion**: hill-climb's `run.py` loses 38 lines of flag boilerplate and its own profile-resolution block; `run_step` loses four params. No existing test was touched, relaxed or skipped (`git diff --name-status -- core/tests/` = one added file).
- Dropped from #199: `optimizer_context.py` as a new module (the assembly already lived in `harness.py`), `log_profile`, and the docstring pre-advertising itself as the extension point for seven future issues.
