### PR TITLE
fix(core): route every algorithm through one iteration-record + journal step (#216, #224)

### DIFF
--- a/core/cap_evolve/dashboard.py
+++ b/core/cap_evolve/dashboard.py
@@ -324,12 +324,19 @@ _ALGO_MARKERS = (
 )
 
 #: Every event kind that means "one candidate was proposed and judged". Every algorithm
-#: now writes ``step`` via ``harness.record_iteration`` (#216/#224) — including gepa,
-#: which used to write only ``gepa_val_gate``, and agent-mode ``commit.py``, whose
-#: ``accept``/``reject`` are kept here so run dirs recorded BEFORE that fix still render.
-#: ``skillopt_step`` / ``gepa_val_gate`` are deliberately absent: they duplicated the
-#: same candidate's iteration (see the per-candidate dedup below).
-_STEP_KINDS = ("step", "accept", "reject")
+#: now writes ``step`` via ``harness.record_iteration`` (#216/#224).
+#:
+#: The legacy kinds STAY here — ``gepa_val_gate`` and agent-mode ``commit.py``'s
+#: ``accept``/``reject`` — because run dirs recorded BEFORE that fix have no ``step``
+#: events at all (that was the bug), and this reducer is what renders them. Dropping
+#: ``gepa_val_gate`` took a historic gepa run's graph from 2 nodes to 1, retroactively.
+#: They cost nothing on a new run: the loop below keys one iteration per CANDIDATE, so
+#: the extra kind lands on the node ``step`` already created.
+#:
+#: ``skillopt_step`` is the one kind deliberately absent, and for a different reason —
+#: it is not a legacy record but epoch DETAIL logged alongside a ``step`` for the same
+#: candidate on the same (current) runs, so it never carried a graph anyone needs.
+_STEP_KINDS = ("step", "gepa_val_gate", "accept", "reject")
 
 #: Kinds whose presence means "this candidate was accepted" without an ``accept`` field.
 _ACCEPT_KINDS = ("accept",)

--- a/core/cap_evolve/dashboard.py
+++ b/core/cap_evolve/dashboard.py
@@ -323,12 +323,13 @@ _ALGO_MARKERS = (
     ("hill-climb", ("convergence", "step")),
 )
 
-#: Every event kind that means "one candidate was proposed and judged". The
-#: deterministic loops log ``step``/``skillopt_step``/``gepa_val_gate``; the AGENT-mode
-#: loops (agent-optimize, evograph) log ``accept``/``reject`` via the algorithm's
-#: ``commit.py``. The reducer used to know only the first three, so every free-form
-#: agentic run rendered as a graph with nothing but a seed node.
-_STEP_KINDS = ("step", "skillopt_step", "gepa_val_gate", "accept", "reject")
+#: Every event kind that means "one candidate was proposed and judged". Every algorithm
+#: now writes ``step`` via ``harness.record_iteration`` (#216/#224) — including gepa,
+#: which used to write only ``gepa_val_gate``, and agent-mode ``commit.py``, whose
+#: ``accept``/``reject`` are kept here so run dirs recorded BEFORE that fix still render.
+#: ``skillopt_step`` / ``gepa_val_gate`` are deliberately absent: they duplicated the
+#: same candidate's iteration (see the per-candidate dedup below).
+_STEP_KINDS = ("step", "accept", "reject")
 
 #: Kinds whose presence means "this candidate was accepted" without an ``accept`` field.
 _ACCEPT_KINDS = ("accept",)

--- a/core/cap_evolve/eventstream.py
+++ b/core/cap_evolve/eventstream.py
@@ -73,8 +73,11 @@ BOOKKEEPING_KINDS = ("minibatch", "optimizer_context_warning", "target_profile",
                      "gepa_merge_skip", "gepa_merge_local", "skillopt_slow_eval",
                      "skillopt_slow_update")
 
-# The one-iteration-finished events, each carrying the optimizer's own spend.
-_STEP_KINDS = ("step", "gepa_val_gate", "skillopt_step")
+# The one-iteration-finished event, carrying the optimizer's own spend. Exactly ONE
+# kind: every algorithm writes it via ``harness.record_iteration`` (#216/#224).
+# ``gepa_val_gate`` is gone and ``skillopt_step`` is auxiliary epoch detail — listing
+# either here rendered two rows and summed ``opt_cost_usd`` twice for one iteration.
+_STEP_KINDS = ("step",)
 
 
 def read_new_events(path: Path, offset: int) -> tuple[list[dict], int]:
@@ -356,10 +359,7 @@ def format_event(ev: dict, totals: dict | None = None, *,
     elif kind in _STEP_KINDS:
         ok = bool(ev.get("accept"))
         verdict = "ACCEPT" if ok else "reject"
-        where = ""
-        if kind == "skillopt_step":
-            where = f" e{ev.get('epoch')}s{ev.get('step_in_epoch')}"
-        body = (f"{verdict}{where}  {ev.get('candidate')}  val={_num(ev.get('val'))}"
+        body = (f"{verdict}  {ev.get('candidate')}  val={_num(ev.get('val'))}"
                 f" (parent {_num(ev.get('parent_val'))})")
         if ev.get("reason"):
             body += f"  — {ev['reason']}"

--- a/core/cap_evolve/eventstream.py
+++ b/core/cap_evolve/eventstream.py
@@ -71,12 +71,13 @@ FOLLOW_END = "_follow_end"
 BOOKKEEPING_KINDS = ("minibatch", "optimizer_context_warning", "target_profile",
                      "seed_dir_created", "splits_warning", "gepa_resume",
                      "gepa_merge_skip", "gepa_merge_local", "skillopt_slow_eval",
-                     "skillopt_slow_update")
+                     "skillopt_slow_update", "skillopt_step")
 
 # The one-iteration-finished event, carrying the optimizer's own spend. Exactly ONE
 # kind: every algorithm writes it via ``harness.record_iteration`` (#216/#224).
-# ``gepa_val_gate`` is gone and ``skillopt_step`` is auxiliary epoch detail — listing
-# either here rendered two rows and summed ``opt_cost_usd`` twice for one iteration.
+# ``gepa_val_gate`` is no longer emitted at all, and ``skillopt_step`` is auxiliary
+# epoch detail that duplicated the same candidate's row — it is skipped in the terminal
+# via BOOKKEEPING_KINDS above (the dashboard still shows it).
 _STEP_KINDS = ("step",)
 
 

--- a/core/cap_evolve/gepa.py
+++ b/core/cap_evolve/gepa.py
@@ -61,6 +61,7 @@ from .harness import (
     _paired_deltas,
     _resolve_workers,
     evaluate_candidate,
+    record_iteration,
     split_result_from_rollouts,
 )
 from .loop import SplitResult, aggregate_scores, has_valid_trials
@@ -611,9 +612,10 @@ def gepa_loop(
             if not report.ok:
                 run_dir.log_event("tamper_detected", candidate=cid, parent=parent["id"],
                                   report=report.to_dict(), reason=report.reason)
-                run_dir.update_spent(iterations=1, accepted=None)
-                run_dir.log_event("step_indecisive", candidate=cid,
-                                  reason="indecisive (integrity): " + report.reason)
+                _reason = "indecisive (integrity): " + report.reason
+                record_iteration(run_dir, workdir, cid, parent_id=parent["id"],
+                                 accepted=False, reason=_reason, indecisive=True)
+                run_dir.log_event("step_indecisive", candidate=cid, reason=_reason)
                 steps.append({"candidate_id": cid, "parent_id": parent["id"], "minibatch": mb,
                               "accepted": False, "candidate_val": None,
                               "tamper": report.to_dict(), "optimizer_error": opt_error,
@@ -638,8 +640,12 @@ def gepa_loop(
         }
 
         if not local_pass:
-            # Cheap rejection — no full-val spend. Record it for memory + audit.
-            run_dir.update_spent(iterations=1, accepted=False)
+            # Cheap rejection — no full-val spend, so ``val`` stays None: the minibatch
+            # reward is NOT a val number and must never be written into that field.
+            record_iteration(run_dir, workdir, cid, parent_id=parent["id"], accepted=False,
+                             reason="local minibatch gate: sum(child) <= sum(parent)",
+                             parent_val=parent["result"].reward, focus=focus_label,
+                             mb_child=child_mb.reward, mb_parent=parent_mb.reward)
             rejected.add(cid, f"candidate {cid} (mb {child_mb.reward:.3f} vs parent "
                               f"{parent_mb.reward:.3f})",
                          "local minibatch gate: sum(child) <= sum(parent)", child_mb.reward)
@@ -660,7 +666,7 @@ def gepa_loop(
         step["decision"] = decision_dict
         step["candidate_val"] = cand_val.to_dict()
         step["accepted"] = accepted
-        run_dir.update_spent(iterations=1, accepted=accepted)
+        # NB: the iteration was charged inside ``_full_val_gate`` (record_iteration).
 
         summary = (f"candidate {cid} (val {cand_val.reward:.3f}, "
                    f"Δ {cand_val.reward - parent_result.reward:+.3f})")
@@ -760,9 +766,14 @@ def _full_val_gate(
         if regressions:
             accepted = False
             decision.reason += f"; REJECTED by no-regression gate (broke {regressions})"
-    run_dir.log_event("gepa_val_gate", candidate=cid, accept=accepted,
-                      reason=decision.reason, val=cand_val.reward,
-                      parent=parent_id, parent_val=parent_result.reward)
+    # The iteration record + journal reconcile, through the ONE shared step (#216/#224).
+    # Both callers (the main loop and ``_try_merge``) end their iteration here, so
+    # neither charges the budget itself.
+    record_iteration(run_dir, workdir, cid, parent_id=parent_id, accepted=accepted,
+                     reason=decision.reason, val=cand_val.reward,
+                     parent_val=parent_result.reward,
+                     runner_seconds=round(cand_val.seconds, 2),
+                     cost_usd=cand_val.cost_usd, tokens=cand_val.tokens)
     return decision.to_dict(), accepted, cand_val
 
 
@@ -826,7 +837,7 @@ def _try_merge(
     step["decision"] = decision_dict
     step["candidate_val"] = cand_val.to_dict()
     step["accepted"] = accepted
-    run_dir.update_spent(iterations=1, accepted=accepted)
+    # NB: the iteration was charged inside ``_full_val_gate`` (record_iteration).
     summary = f"merge {mid} of {a['id']}+{b['id']} (val {cand_val.reward:.3f})"
     if accepted:
         run_dir.snapshot(mid, workdir)

--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -960,10 +960,14 @@ def _seed_journal(workdir: Path, run_dir: RunDir) -> None:
 
 
 def _reconcile_journal(workdir: Path, run_dir: RunDir, cid: str, *,
-                       accepted: bool, val: float, delta: float) -> None:
+                       accepted: bool, val: float | None, delta: float | None) -> None:
     """Fold the optimizer's newly-appended journal entry into the run-level JOURNAL,
     stamped with the framework's objective outcome. Append-only at the run level so the
-    handover truly accumulates across accepted AND rejected iterations."""
+    handover truly accumulates across accepted AND rejected iterations.
+
+    ``val``/``delta`` are None for an iteration that never bought a val eval (gepa's
+    minibatch-local reject) or whose measurement is void (an indecisive tamper step):
+    the entry is still folded in, with "—" where the number would be."""
     tail = _journal_tail(workdir)
     run_journal = run_dir.root / "JOURNAL.md"
     base = run_journal.read_text(encoding="utf-8") if run_journal.exists() else _JOURNAL_SEED
@@ -979,10 +983,12 @@ def _reconcile_journal(workdir: Path, run_dir: RunDir, cid: str, *,
     guidance = ("" if accepted else
                 " — its WHOLE batch was reverted; re-introduce only the edits that did NOT "
                 "break a task above, dropping/redesigning the ones that did.")
-    stamp = (f"\n\n> **RESULT (framework, objective):** {verdict} · val={val:.3f} "
-             f"Δ={delta:+.3f} · fixed={{{fixed}}} · broke={{{broke}}}.{guidance}\n"
+    vs = f"{val:.3f}" if isinstance(val, (int, float)) else "—"
+    ds = f"{delta:+.3f}" if isinstance(delta, (int, float)) else "—"
+    stamp = (f"\n\n> **RESULT (framework, objective):** {verdict} · val={vs} "
+             f"Δ={ds} · fixed={{{fixed}}} · broke={{{broke}}}.{guidance}\n"
              f"<!-- {cid}: {'ACCEPTED' if accepted else 'rejected'} "
-             f"val={val:.3f} Δ={delta:+.3f} -->")
+             f"val={vs} Δ={ds} -->")
     tail = tail.strip()
     # Dedup guard: if the optimizer dropped the marker without appending (so the tail
     # fallback returned an entry already recorded in the run-level journal), do NOT
@@ -994,6 +1000,49 @@ def _reconcile_journal(workdir: Path, run_dir: RunDir, cid: str, *,
         run_journal.write_text(new, encoding="utf-8")
     except Exception as e:  # noqa: BLE001
         run_dir.log_event("optimizer_context_warning", what="JOURNAL.md", error=str(e)[:300])
+
+
+def record_iteration(run_dir: RunDir, workdir: Path, cid: str, *,
+                     parent_id: str | None, accepted: bool, reason: str,
+                     val: float | None = None, parent_val: float | None = None,
+                     indecisive: bool = False, **extra) -> None:
+    """THE one place an iteration is recorded. EVERY algorithm ends its iteration here.
+
+    Three things must happen exactly once per iteration, and they used to be
+    open-coded per algorithm — so gepa, which bypasses ``run_step`` by design
+    (``gepa._full_val_gate``), silently did none of them (#216, #224):
+
+      1. charge the iteration against the budget (``update_spent``);
+      2. write the canonical ``step`` event — the ONLY iteration record. Every
+         consumer reads it: ``_parent_map`` / ``_build_ledger`` / ``_build_runmap``
+         (so ``LEDGER.md`` / ``RUNMAP.md`` / ``prior_iterations/`` are populated for
+         the optimizer, which the prompt tells it to read), the dashboard graph, the
+         event stream, and the TUI;
+      3. reconcile the run-level append-only ``JOURNAL.md`` with the handover entry
+         the optimizer appended in ``workdir`` — otherwise ``_seed_journal`` discards
+         it on the next iteration and the run has no handover history at all.
+
+    Algorithm-specific detail (``focus``, ``epoch``, minibatch sums, …) stays on the
+    algorithm's own events; pass anything that belongs on the iteration record itself
+    through ``**extra``. ``val``/``parent_val`` are None when no full-val number was
+    bought — never substitute a minibatch or screen reward, that field is the gated
+    val reward the ledger and the dashboard's val curve read.
+
+    ``indecisive=True`` leaves the stall counter untouched (the candidate was never
+    validly judged, so it is not evidence the optimizer ran out of ideas); the caller
+    still logs its own ``step_indecisive`` with whatever detail it has.
+
+    NOTE deliberately NOT here: ``snapshot``/``set_best``. Their correct arguments are
+    algorithm-specific (run_step snapshots every candidate with ``_SNAPSHOT_IGNORE``,
+    gepa only accepted ones) and they are not silently-droppable the way the three
+    above were.
+    """
+    run_dir.update_spent(iterations=1, accepted=None if indecisive else accepted)
+    run_dir.log_event("step", candidate=cid, accept=accepted, reason=reason,
+                      val=val, parent=parent_id, parent_val=parent_val, **extra)
+    delta = (val - parent_val if isinstance(val, (int, float))
+             and isinstance(parent_val, (int, float)) else None)
+    _reconcile_journal(workdir, run_dir, cid, accepted=accepted, val=val, delta=delta)
 
 
 def _build_runmap(workdir: Path, run_dir: RunDir) -> None:
@@ -1381,11 +1430,11 @@ def _tamper_step(run_dir: RunDir, *, cid: str, parent_id, workdir: Path,
     run_dir.log_event("tamper_detected", candidate=cid, parent=parent_id,
                       report=report.to_dict(), reason=report.reason)
     run_dir.snapshot(cid, workdir, ignore=_SNAPSHOT_IGNORE)  # forensics only — never best
-    run_dir.update_spent(iterations=1, accepted=None)
-    run_dir.log_event("step", candidate=cid, accept=False, reason=reason, val=None,
-                      parent=parent_id, parent_val=current_val.reward,
-                      optimizer_seconds=round(optimizer_seconds, 2),
-                      opt_cost_usd=round(opt_cost_usd, 6), opt_tokens=opt_tokens)
+    record_iteration(run_dir, workdir, cid, parent_id=parent_id, accepted=False,
+                     reason=reason, val=None, parent_val=current_val.reward,
+                     indecisive=True,
+                     optimizer_seconds=round(optimizer_seconds, 2),
+                     opt_cost_usd=round(opt_cost_usd, 6), opt_tokens=opt_tokens)
     run_dir.log_event("step_indecisive", candidate=cid, reason=reason)
     run_dir.record_spend_warnings()
     return {
@@ -1560,18 +1609,19 @@ def run_step(
     # ``accepted=None`` leaves the stall counter untouched. An indecisive step is not
     # evidence that the optimizer has run out of ideas — the candidate was never
     # judged — so it must not push the run toward an early "stalled" stop.
-    run_dir.update_spent(iterations=1,
-                         accepted=None if decision.indecisive else accepted)
     _step_extra = {}
     if isinstance(opt_report, dict):
         _step_extra["optimizer_report"] = opt_report
-    run_dir.log_event("step", candidate=cid, accept=accepted, reason=decision.reason,
-                      val=cand_val.reward, parent=parent_id, parent_val=current_val.reward,
-                      optimizer_seconds=round(optimizer_seconds, 2),
-                      runner_seconds=round(cand_val.seconds, 2),
-                      cost_usd=cand_val.cost_usd, tokens=cand_val.tokens,
-                      opt_cost_usd=round(opt_cost_usd, 6), opt_tokens=opt_tokens,
-                      **_step_extra)
+    # Charge the budget, write the iteration record, fold the JOURNAL — the shared step
+    # every algorithm routes through (see ``record_iteration``).
+    record_iteration(run_dir, workdir, cid, parent_id=parent_id, accepted=accepted,
+                     reason=decision.reason, val=cand_val.reward,
+                     parent_val=current_val.reward, indecisive=decision.indecisive,
+                     optimizer_seconds=round(optimizer_seconds, 2),
+                     runner_seconds=round(cand_val.seconds, 2),
+                     cost_usd=cand_val.cost_usd, tokens=cand_val.tokens,
+                     opt_cost_usd=round(opt_cost_usd, 6), opt_tokens=opt_tokens,
+                     **_step_extra)
     run_dir.record_spend_warnings()
 
     # update optimizer memory + commit the iteration to the version store so the
@@ -1580,11 +1630,8 @@ def run_step(
     # to JOURNAL.md this iteration so the lineage record carries what was tried, not just Δ/SE.
     delta = cand_val.reward - current_val.reward
     summary = f"candidate {cid} (val {cand_val.reward:.3f}, Δ {delta:+.3f})"
-    # Fold the optimizer's appended JOURNAL entry into the run-level append-only journal
-    # (so handover accumulates across accepted AND rejected iterations), and reuse it as
-    # the candidate's lineage note in the factual ledger.
-    _reconcile_journal(workdir, run_dir, cid, accepted=accepted,
-                       val=cand_val.reward, delta=delta)
+    # ``record_iteration`` above already folded the optimizer's appended JOURNAL entry
+    # into the run-level append-only journal; reuse it as the lineage note.
     note = _latest_journal_note(workdir)
     # Per-task broke/fixed lists vs the parent (from the rollouts just persisted), so
     # MEMORY records the SPECIFIC tasks a candidate broke — not just a category — and

--- a/core/cap_evolve/tui.py
+++ b/core/cap_evolve/tui.py
@@ -917,8 +917,9 @@ def algo_panel(stats: dict | None, summary: dict) -> tuple[str, list[str]]:
         if (stats or {}).get("mb_pass") or (stats or {}).get("mb_fail"):
             bits.append(f"minibatch gate {stats.get('mb_pass', 0)}✓ "
                         f"{stats.get('mb_fail', 0)}✗")
-        if kinds.get("gepa_val_gate"):
-            bits.append(f"full-val gates {kinds['gepa_val_gate']}")
+        # "full-val gates N" used to count ``gepa_val_gate``; gepa now writes the shared
+        # ``step`` record instead (#216/#224), which also covers minibatch-local rejects,
+        # so it is no longer a full-val count. ``minibatch gate N✓`` above is that number.
         if summary.get("frontier") is not None:
             bits.append(f"pareto frontier {summary['frontier']}")
         if (stats or {}).get("minibatch_size"):

--- a/core/tests/test_iteration_record_parity.py
+++ b/core/tests/test_iteration_record_parity.py
@@ -1,0 +1,194 @@
+"""Every algorithm writes the SAME iteration record + run-level JOURNAL (#216, #224).
+
+The bug this locks down: an algorithm can only be seen by its consumers if it routes
+through the one step that records an iteration. GEPA has its own loop and bypassed
+``harness.run_step`` by design, so it charged iterations against the budget while
+writing NO ``step`` event and NEVER reconciling the run-level ``JOURNAL.md`` — its
+``LEDGER.md`` / ``RUNMAP.md`` / ``prior_iterations/`` stayed empty for the whole run
+while the optimizer prompt told it to read them, and every handover entry its
+optimizer wrote was silently discarded by the next iteration's ``_seed_journal``.
+
+The fix is a shared seam, ``harness.record_iteration``, so this test is parametrized
+over EVERY algorithm: a sixth algorithm that ends its iteration without routing
+through the seam fails here rather than silently producing a partial record.
+
+Offline, deterministic, zero API — the mock optimizer skill over toy_calc.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+CORE = REPO / "core"
+EXAMPLE = REPO / "examples" / "toy_calc"
+MOCK_RUN = REPO / "skills" / "optimizers" / "run-optimizer" / "scripts" / "run.py"
+AGENT_COMMIT = REPO / "skills" / "algorithms" / "agent-optimize" / "scripts" / "commit.py"
+
+sys.path.insert(0, str(CORE))
+sys.path.insert(0, str(EXAMPLE))
+
+
+@pytest.fixture(autouse=True)
+def _env():
+    old = dict(os.environ)
+    os.environ["CAPEVOLVE_CORE"] = str(CORE)
+    os.environ["CAPEVOLVE_TOY_DATA"] = str(EXAMPLE)
+    os.environ["CAPEVOLVE_MOCK_SCRIPT"] = str(EXAMPLE / "mock_script.json")
+    yield
+    os.environ.clear()
+    os.environ.update(old)
+
+
+def _toy_adapter():
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("toy_calc_adapter", EXAMPLE / "adapter.py")
+    toy = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(toy)
+    return toy.Adapter()
+
+
+def _setup(tmp_path, ts):
+    from cap_evolve import Budget, RunDir, harness
+    adapter = _toy_adapter()
+    seed = tmp_path / f"seed_{ts}"
+    shutil.copytree(EXAMPLE / "capability", seed)
+    run_dir = RunDir.create(tmp_path / ".capevolve", ts=ts,
+                            budget=Budget(max_iterations=6, max_metric_calls=400, stall=6))
+    harness.ensure_splits(adapter, run_dir, seed=0)
+    base = harness.baseline(adapter, seed, run_dir=run_dir)
+    return adapter, run_dir, base, seed
+
+
+def _mock_optimizer():
+    from cap_evolve import harness
+    return harness.optimizer_from_command(
+        ["python3", str(MOCK_RUN), "--name", "mock",
+         "--workdir", "{workdir}", "--prompt", "{prompt}"])
+
+
+GATE = {"mode": "significant", "k_se": 1.0}
+
+
+# --- one runner per algorithm ----------------------------------------------
+
+def _run_hill_climb(tmp_path):
+    from cap_evolve import harness
+    adapter, run_dir, base, _ = _setup(tmp_path, "hc")
+    harness.hill_climb_loop(adapter, run_dir=run_dir, optimizer=_mock_optimizer(),
+                            current_val=base, max_iterations=3, gate_kwargs=dict(GATE))
+    return run_dir
+
+
+def _run_gepa(tmp_path):
+    from cap_evolve import gepa
+    adapter, run_dir, base, _ = _setup(tmp_path, "gp")
+    gepa.gepa_loop(adapter, run_dir=run_dir, optimizer=_mock_optimizer(), seed_val=base,
+                   max_iterations=3, max_metric_calls=300, minibatch_size=3,
+                   max_merges=0, seed=0, gate_kwargs=dict(GATE))
+    return run_dir
+
+
+def _run_skillopt(tmp_path):
+    from cap_evolve import skillopt
+    adapter, run_dir, base, _ = _setup(tmp_path, "so")
+    skillopt.skillopt_loop(adapter, run_dir=run_dir, optimizer=_mock_optimizer(),
+                           current_val=base, epochs=1, batch_size=2, slow_update=False,
+                           gate_kwargs=dict(GATE))
+    return run_dir
+
+
+def _run_agent_optimize(tmp_path):
+    """agent-optimize / evograph are AGENT-mode: the loop is the coding agent, and its
+    end-of-iteration is ``agent-optimize/scripts/commit.py`` (evograph's SKILL.md points
+    at the same seam). Drive that script exactly as the agent would."""
+    _adapter, run_dir, _base, seed = _setup(tmp_path, "ao")
+    work = tmp_path / "cand_r1"
+    shutil.copytree(seed, work)
+    (work / "prompt.txt").write_text("[CALC] answer the arithmetic.\n", encoding="utf-8")
+    env = dict(os.environ, PYTHONPATH=str(CORE))
+    for cid, decision, val in (("cand_r1", "accept", "1.0"), ("cand_r2", "reject", "0.5")):
+        out = subprocess.run(
+            [sys.executable, str(AGENT_COMMIT), "--run-dir", str(run_dir.root),
+             "--candidate-id", cid, "--from-dir", str(work), "--decision", decision,
+             "--val", val, "--note", f"{decision} via commit.py"],
+            capture_output=True, text=True, env=env, cwd=str(AGENT_COMMIT.parent))
+        assert out.returncode == 0, out.stdout + out.stderr
+    return run_dir
+
+
+ALGORITHMS = {
+    "hill-climb": _run_hill_climb,
+    "gepa": _run_gepa,
+    "skillopt": _run_skillopt,
+    "agent-optimize": _run_agent_optimize,
+}
+
+
+def _events(run_dir, kind):
+    return [json.loads(ln) for ln in
+            run_dir.events_path.read_text(encoding="utf-8").splitlines() if ln.strip()
+            if json.loads(ln).get("kind") == kind]
+
+
+@pytest.mark.parametrize("algorithm", sorted(ALGORITHMS))
+def test_every_algorithm_writes_the_iteration_record_and_journal(algorithm, tmp_path):
+    run_dir = ALGORITHMS[algorithm](tmp_path)
+
+    steps = _events(run_dir, "step")
+    assert steps, f"{algorithm} recorded NO iteration — it bypasses harness.record_iteration"
+
+    # One record per iteration charged. This single assertion is what caught #109/#216:
+    # gepa charged 3 iterations and wrote 1 gepa_val_gate (and no `step` at all).
+    assert len(steps) == run_dir.spent.iterations, (
+        f"{algorithm}: {len(steps)} iteration records for "
+        f"{run_dir.spent.iterations} charged iterations")
+
+    # ...and exactly one per candidate: skillopt used to log `step` AND `skillopt_step`
+    # for the same candidate, so consumers counted the iteration twice.
+    cids = [s.get("candidate") for s in steps]
+    assert all(cids) and len(set(cids)) == len(cids), f"{algorithm}: duplicate records {cids}"
+
+    # Every record carries the lineage edge `_parent_map` / LEDGER / RUNMAP read.
+    for s in steps:
+        assert s.get("parent"), f"{algorithm}: record {s.get('candidate')} has no parent"
+        assert "accept" in s, f"{algorithm}: record {s.get('candidate')} has no verdict"
+
+    # The run-level append-only JOURNAL — the whole of #216.
+    journal = run_dir.root / "JOURNAL.md"
+    assert journal.exists(), f"{algorithm} wrote no run-level JOURNAL.md"
+    text = journal.read_text(encoding="utf-8")
+    assert text.strip(), f"{algorithm}: JOURNAL.md is empty"
+    for s in steps:
+        assert s["candidate"] in text, \
+            f"{algorithm}: {s['candidate']} missing from JOURNAL.md"
+
+
+@pytest.mark.parametrize("algorithm", sorted(ALGORITHMS))
+def test_no_consumer_is_left_empty(algorithm, tmp_path):
+    """The optimizer-facing files rebuilt from the iteration record must be populated.
+
+    #109's symptom: gepa's LEDGER said "(baseline only)" and "Current best: seed" for a
+    run with real accepted candidates, because both are rebuilt from ``step`` events.
+    """
+    from cap_evolve import harness
+    run_dir = ALGORITHMS[algorithm](tmp_path)
+    steps = _events(run_dir, "step")
+
+    assert harness._parent_map(run_dir), f"{algorithm}: empty parent map"
+
+    wd = tmp_path / f"ledger_{algorithm}"
+    wd.mkdir()
+    harness._build_ledger(wd, run_dir, None, None)
+    harness._build_runmap(wd, run_dir)
+    ledger = (wd / "LEDGER.md").read_text(encoding="utf-8")
+    runmap = (wd / "RUNMAP.md").read_text(encoding="utf-8")
+    assert "(baseline only)" not in ledger, f"{algorithm}: LEDGER shows no iterations"
+    assert "(no prior iterations yet)" not in runmap, f"{algorithm}: RUNMAP shows none"
+    for s in steps:
+        assert s["candidate"] in ledger, f"{algorithm}: {s['candidate']} missing from LEDGER"

--- a/core/tests/test_iteration_record_parity.py
+++ b/core/tests/test_iteration_record_parity.py
@@ -8,9 +8,14 @@ writing NO ``step`` event and NEVER reconciling the run-level ``JOURNAL.md`` —
 while the optimizer prompt told it to read them, and every handover entry its
 optimizer wrote was silently discarded by the next iteration's ``_seed_journal``.
 
-The fix is a shared seam, ``harness.record_iteration``, so this test is parametrized
-over EVERY algorithm: a sixth algorithm that ends its iteration without routing
-through the seam fails here rather than silently producing a partial record.
+The fix is a shared seam, ``harness.record_iteration``. This file checks it two ways:
+
+  * the parametrized tests run each algorithm that HAS a runnable loop today and assert
+    the record + journal it produces. They enumerate — a sixth algorithm is invisible to
+    them until someone adds it here, which is the same forgetting this PR exists to stop;
+  * ``test_exactly_one_place_charges_an_iteration`` closes that gap by asserting on the
+    SOURCE that only ``record_iteration`` charges an iteration at all. That one holds for
+    an algorithm nobody has written yet.
 
 Offline, deterministic, zero API — the mock optimizer skill over toy_calc.
 """
@@ -192,3 +197,54 @@ def test_no_consumer_is_left_empty(algorithm, tmp_path):
     assert "(no prior iterations yet)" not in runmap, f"{algorithm}: RUNMAP shows none"
     for s in steps:
         assert s["candidate"] in ledger, f"{algorithm}: {s['candidate']} missing from LEDGER"
+
+
+# --- the invariant itself, asserted on the SOURCE ---------------------------
+
+def _iteration_charge_sites():
+    """Every ``update_spent(iterations=...)`` call in the tree, as (file, line, enclosing
+    function). Parsed with ``ast`` — no import side effects, and it sees algorithms this
+    test file has never heard of, which a parametrized list of known algorithms cannot."""
+    import ast
+    roots = [REPO / "core" / "cap_evolve", REPO / "skills"]
+    sites = []
+    for root in roots:
+        for py in sorted(root.rglob("*.py")):
+            if "build/lib" in py.as_posix():  # stale build artifact
+                continue
+            tree = ast.parse(py.read_text(encoding="utf-8"), filename=str(py))
+            # enclosing function for every node, resolved by walking down from each def
+            for fn in [n for n in ast.walk(tree)
+                       if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))]:
+                for node in ast.walk(fn):
+                    if (isinstance(node, ast.Call)
+                            and isinstance(node.func, ast.Attribute)
+                            and node.func.attr == "update_spent"
+                            and any(kw.arg == "iterations" for kw in node.keywords)):
+                        sites.append((py.relative_to(REPO).as_posix(), node.lineno, fn.name))
+    return sites
+
+
+def test_exactly_one_place_charges_an_iteration():
+    """The invariant behind this whole PR, enforced instead of asserted in prose.
+
+    An algorithm becomes visible to LEDGER/RUNMAP/JOURNAL/the dashboard only by routing
+    through ``harness.record_iteration``. The only way to make that unforgettable is to
+    make charging an iteration and recording it the SAME call — so there must be exactly
+    one ``update_spent(iterations=...)`` call site in the tree, inside
+    ``record_iteration``.
+
+    Unlike the parametrized tests above (which can only cover algorithms someone
+    remembered to list), this holds for an algorithm that does not exist yet: add a sixth
+    loop that charges its own iterations and this fails, naming the file and line.
+    """
+    sites = _iteration_charge_sites()
+    assert len(sites) == 1, (
+        "an iteration must be charged in exactly ONE place — "
+        "harness.record_iteration, which also writes the `step` record and reconciles "
+        f"JOURNAL.md. Found {len(sites)}: {sites}. If one of these is a new algorithm's "
+        "loop, call harness.record_iteration instead of update_spent(iterations=...)."
+    )
+    path, _line, func = sites[0]
+    assert path == "core/cap_evolve/harness.py", f"unexpected charge site: {path}"
+    assert func == "record_iteration", f"charge site moved out of the seam into {func}()"

--- a/skills/algorithms/agent-optimize/scripts/commit.py
+++ b/skills/algorithms/agent-optimize/scripts/commit.py
@@ -8,9 +8,12 @@ Does exactly what the deterministic loops do at the end of a step:
   * ``snapshot`` the working copy as a candidate (always — the audit trail should
     show rejects too),
   * ``set_best`` on accept only,
-  * ``log_event`` the accept/reject, and
-  * ``update_spent`` with ``iterations=1`` **and** ``accepted=`` so the stall
-    counter that ``budget_exhausted()`` reads actually moves.
+  * ``log_event`` the accept/reject (agent-mode detail the other scripts read), and
+  * ``harness.record_iteration`` — the ONE shared iteration step every algorithm
+    routes through (#216/#224): charges ``iterations=1`` **and** ``accepted=`` so the
+    stall counter that ``budget_exhausted()`` reads actually moves, writes the
+    canonical ``step`` record every consumer enumerates, and reconciles the
+    run-level ``JOURNAL.md``. Do NOT open-code those three here again.
 
 Runner-side spend (metric_calls / usd / tokens / seconds) is already recorded by the
 evaluate phase; ``--optimizer-*`` is for the *proposer's* own cost, which in agent
@@ -29,7 +32,7 @@ from pathlib import Path
 # cap_evolve imports below; not "unused" — deleting it breaks standalone runs.
 import _bootstrap  # noqa: F401  # side-effect import, see above
 
-from cap_evolve import RunDir
+from cap_evolve import RunDir, harness
 
 
 def _prior_decision(run_dir: RunDir, candidate_id: str) -> dict | None:
@@ -114,6 +117,9 @@ def main(argv=None) -> int:
         print(json.dumps({"error": "--reject-basis is meaningless on an accept",
                           "fix": "drop it, or pass --decision reject"}, indent=2))
         return 2
+    # The parent this candidate was gated against — ``gate_check --current`` defaults to
+    # ``best_id``, so read it BEFORE ``set_best`` moves it.
+    parent_id = run_dir.best_id or "seed"
     run_dir.snapshot(args.candidate_id, src)
     if accepted:
         run_dir.set_best(args.candidate_id)
@@ -128,10 +134,19 @@ def main(argv=None) -> int:
                       opt_cost_usd=args.optimizer_usd or None,
                       opt_tokens=args.optimizer_tokens or None,
                       opt_seconds=args.optimizer_seconds or None)
-    spent = run_dir.update_spent(iterations=1, accepted=accepted,
-                                 optimizer_usd=args.optimizer_usd,
-                                 optimizer_tokens=args.optimizer_tokens,
-                                 optimizer_seconds=args.optimizer_seconds)
+    run_dir.update_spent(optimizer_usd=args.optimizer_usd,
+                         optimizer_tokens=args.optimizer_tokens,
+                         optimizer_seconds=args.optimizer_seconds)
+    # The shared iteration step: charges iterations/stall, writes the canonical ``step``
+    # record, reconciles the run-level JOURNAL.md. ``parent_val`` is unknown in agent mode
+    # (the agent gates via gate_check, which prints but does not persist the parent mean),
+    # so it stays None rather than being guessed.
+    harness.record_iteration(run_dir, src, args.candidate_id, parent_id=parent_id,
+                             accepted=accepted, reason=args.note or args.decision,
+                             val=args.val,
+                             opt_cost_usd=args.optimizer_usd or None,
+                             opt_tokens=args.optimizer_tokens or None)
+    spent = run_dir.spent
     run_dir.record_spend_warnings()
     stop, reason = run_dir.budget_exhausted()
     print(json.dumps({"decision": args.decision, "candidate": args.candidate_id,

--- a/skills/algorithms/evograph/SKILL.md
+++ b/skills/algorithms/evograph/SKILL.md
@@ -124,7 +124,14 @@ ship the merge as a PR (`Closes #n`) — GitHub is **mirror-only**, the run dir 
 
 ### 2.6 Stop check + dashboard verify
 Stamp `completed_at`, log the round to the run dir event log, snapshot the accepted candidate via the
-store. **Verify the run dir has what both dashboards need** (round results written, weakness nodes +
+store. **Record the round as an iteration through the one shared step** —
+`cap_evolve.harness.record_iteration(run_dir, <candidate_dir>, <cand_id>, parent_id=…, accepted=…,
+reason=…, val=…)`, or equivalently `agent-optimize/scripts/commit.py`, which calls it. That single
+call charges the iteration, writes the canonical `step` record every consumer enumerates
+(`LEDGER.md`, `RUNMAP.md`, `prior_iterations/`, both dashboards), and reconciles the run-level
+`JOURNAL.md`. Do **not** hand-roll `update_spent` + `log_event` instead: an algorithm that skips this
+step charges budget while leaving every one of those surfaces empty (#216, #224).
+**Verify the run dir has what both dashboards need** (round results written, weakness nodes +
 solution cards + logs present, standard events/rollouts emitted). Re-read `stop_condition`; continue
 (2.1) or halt.
 


### PR DESCRIPTION
## Root cause (one sentence)

An iteration was only recorded by whichever algorithm happened to open-code the calls, so GEPA — which bypasses `run_step` by design (`gepa._full_val_gate`'s own docstring says so) — charged iterations against the budget while writing **no `step` event** and **never reconciling the run-level `JOURNAL.md`**.

Two symptoms, one cause: #216 (no `JOURNAL.md` on a GEPA run) and #109-as-restated-in-#224 (`_parent_map` / `_build_ledger` / `_build_runmap` filter `kind == "step"`, so GEPA's `LEDGER.md` / `RUNMAP.md` / `prior_iterations/` stayed empty for the whole run **while the optimizer prompt instructed it to read them**, and told it its best was `seed`).

## The shared seam

`harness.record_iteration(run_dir, workdir, cid, *, parent_id, accepted, reason, val=None, parent_val=None, indecisive=False, **extra)` — `harness.py:1005-1047`.

Three things must happen exactly once per iteration, and they were open-coded per algorithm:

1. charge the iteration (`update_spent(iterations=1, accepted=…)`);
2. write the canonical **`step`** event — the one iteration record every consumer enumerates (`_parent_map`, `_build_ledger`, `_build_runmap`, the dashboard graph, the event stream, the TUI);
3. reconcile the run-level append-only `JOURNAL.md` with the entry the optimizer appended in `workdir` — otherwise `_seed_journal` silently discards it on the next iteration.

**The enforcement is a test, not a convention:** `record_iteration` is the *only* place `update_spent(iterations=…)` is called anywhere in the tree, and `test_exactly_one_place_charges_an_iteration` asserts that on the source with `ast`:

```
core/cap_evolve/harness.py:1040:    run_dir.update_spent(iterations=1, accepted=None if indecisive else accepted)
```

Charging an iteration and recording it are now the same call, so an algorithm cannot do the first without the second. `len(step records) == spent.iterations` follows — which is also why the test needs no `step_indecisive` caveat: `record_iteration` writes a `step` on the indecisive path too, and the caller keeps its own `step_indecisive` detail event.

### Call sites routed through it (six)

| Site | Was |
|---|---|
| `harness.run_step` (hill-climb, skillopt) | `update_spent` + `log_event("step")` + `_reconcile_journal`, open-coded |
| `harness._tamper_step` | `update_spent` + `log_event("step")`, **no journal** |
| `gepa._full_val_gate` (main loop **and** `_try_merge`) | `log_event("gepa_val_gate")`, no journal; callers charged separately |
| `gepa` minibatch-local reject | `update_spent` only — the iteration was **invisible** |
| `gepa` indecisive tamper path | `update_spent` + `step_indecisive`, no `step`, no journal |
| `agent-optimize/scripts/commit.py` | `log_event("accept"/"reject")` + `update_spent`, no `step`, no journal |

`evograph` has no deterministic engine (its `run.py` refuses to run); its loop is prose, and §2.6 said only "log the round to the run dir event log". It now names the seam explicitly, so the one algorithm that *can only* forget is told exactly what to call.

Deliberately **not** in the seam: `snapshot` / `set_best`. Their correct arguments are genuinely algorithm-specific (`run_step` snapshots every candidate with `_SNAPSHOT_IGNORE`, gepa only accepted ones) and neither is silently droppable the way the three above were.

### Also: the duplicate direction of the same bug

`_STEP_KINDS` in `eventstream.py` and `dashboard.py` listed `gepa_val_gate` and `skillopt_step` alongside `step`. skillopt logs `skillopt_step` *after* `run_step` already logged `step` for the same candidate → **two rendered rows per iteration**. `skillopt_step` leaves both tuples and is added to `eventstream.BOOKKEEPING_KINDS` — which is what makes the duplicate row actually go away rather than fall through to the generic key dumper:

```
before : [16:40:24] ACCEPT  so_e01s01  val=1.0000 (parent 0.0000)  — paired Δ̄=+1.0000 > 0 …
         [16:40:24] ACCEPT e1s1  so_e01s01  val=1.0000 (parent ?)          <-- duplicate
after  : [16:40:24] ACCEPT  so_e01s01  val=1.0000 (parent 0.0000)  — paired Δ̄=+1.0000 > 0 …
         (skillopt_step → None, skipped in the terminal; the dashboard still shows it)
```

**Correction to an earlier version of this description:** it claimed the duplicate also double-summed `opt_cost_usd` in the cost ledger. That was wrong — `skillopt_step` carries only `epoch / step_in_epoch / global_step / edit_budget / requested_edits / applied_changes / accept / candidate / val`, and `gepa_val_gate` only `candidate / accept / reason / val / parent / parent_val`. Neither carries `opt_cost_usd`, so `eventstream._accumulate` added `float(None or 0.0)` = 0.0. There was never a cost error, only duplicate rows. The code change is unaffected.

### Why `gepa_val_gate` stays in the dashboard tuple but `skillopt_step` does not

Not symmetry — they fail differently.

`gepa_val_gate` is a **legacy iteration record**. Run dirs already on disk from before this fix have *no* `step` events at all (that is the bug), so `dashboard.reduce_run` is the only thing rendering them and `gepa_val_gate` is the only record it has. An earlier revision of this PR dropped it and silently regressed every historic gepa run's lineage graph from 2 nodes to 1. It is restored. Same reasoning keeps agent-mode `commit.py`'s `accept`/`reject` there.

`skillopt_step` is **not** a legacy record: it is epoch detail logged *alongside* a `step` for the same candidate, on current runs. It never carried a graph anyone needs, so it is the one kind that leaves.

Keeping the legacy kinds is free on a new run because the reducer keys one iteration per **candidate**, not per event — the extra kind lands on the node `step` already created:

```
$ # HISTORIC gepa run dir (pre-fix: gepa_val_gate only, ZERO step events)
without gepa_val_gate : graph nodes: 1 -> ['seed']                       <-- the regression
with    gepa_val_gate : graph nodes: 2 -> ['gepa_0001', 'seed']          <-- restored

$ # NEW runs — no duplicate nodes reintroduced
NEW gepa (post-fix)    : 4 nodes -> ['gepa_0001','gepa_0002','gepa_0003','seed']  (unique: True)
NEW skillopt (post-fix): 4 nodes -> ['seed','so_e01s01','so_e02_slow','so_e02s01'] (unique: True)
```

## Evidence: zero-API end-to-end, per algorithm

`examples/toy_calc` via `cap-evolve run` (deterministic, no API key).

### GEPA — the core before/after pair

**BEFORE** (`algorithm_skill: gepa`, 3 iterations charged):
```
$ ls -la .capevolve/run_demo/JOURNAL.md
ls: JOURNAL.md: No such file or directory

$ grep -o '"kind": "[a-z_]*"' events.jsonl | sort | uniq -c
   3 "kind": "gepa_local_gate"
   3 "kind": "gepa_select"
   1 "kind": "gepa_start"
   1 "kind": "gepa_val_gate"        <-- 1 record for 3 charged iterations
   ...                              <-- ZERO "step" events
```

**AFTER** (same spec):
```
$ ls -la .capevolve/run_demo/JOURNAL.md
-rw-r--r--  1 osherelhadad  wheel  2902 Aug 22 17:02 JOURNAL.md

$ grep -o '"kind": "[a-z_]*"' events.jsonl | sort | uniq -c
   3 "kind": "gepa_local_gate"
   3 "kind": "gepa_select"
   1 "kind": "gepa_start"
   3 "kind": "step"                 <-- 3 records == 3 charged iterations

$ tail -14 JOURNAL.md
## Iteration gepa_0001 — (no handover written by the optimizer)

> **RESULT (framework, objective):** ACCEPTED (new champion) · val=1.000 Δ=+1.000 · fixed={a1, a4} · broke={—}.
<!-- gepa_0001: ACCEPTED val=1.000 Δ=+1.000 -->

## Iteration gepa_0002 — (no handover written by the optimizer)

> **RESULT (framework, objective):** REJECTED (champion unchanged) · val=— Δ=— · fixed={—} · broke={—}. …
<!-- gepa_0002: rejected val=— Δ=— -->

## Iteration gepa_0003 — (no handover written by the optimizer)

> **RESULT (framework, objective):** REJECTED (champion unchanged) · val=— Δ=— · fixed={—} · broke={—}. …
<!-- gepa_0003: rejected val=— Δ=— -->
```
`gepa_0002`/`gepa_0003` are the minibatch-local rejects that were previously invisible. `val=—`, not a number: they never bought a full-val eval, and a minibatch reward must never be written into the field the ledger and the dashboard's val curve read. ("no handover written by the optimizer" is correct — the `mock` optimizer writes none.) `_reconcile_journal` now accepts `val=None`/`delta=None` for exactly this case.

### agent-optimize — the third recording path, same before/after

Agent mode, so `cap-evolve run` does baseline then hands off; its end-of-iteration is `commit.py`, driven here exactly as the agent would (`--decision accept` then `--decision reject`).

**BEFORE** (pre-fix `commit.py` from `HEAD`):
```
JOURNAL.md: No such file or directory
   1 "kind": "accept"
   1 "kind": "reject"                <-- ZERO "step" events
```
**AFTER**:
```
-rw-r--r--  1 osherelhadad  wheel  2526 Aug 22 17:04 JOURNAL.md
   1 "kind": "accept"
   1 "kind": "reject"
   2 "kind": "step"

{"kind": "step", "candidate": "cand_r1", "accept": true,  "val": 1.0, "parent": "seed",    …}
{"kind": "step", "candidate": "cand_r2", "accept": false, "val": 0.5, "parent": "cand_r1", …}
```
Note `cand_r2`'s parent is `cand_r1` — `commit.py` now reads `best_id` *before* `set_best` moves it, so the lineage edge is real rather than the dashboard's `last_accepted` guess.

### hill-climb and skillopt — unchanged behaviour, confirmed not regressed

| algorithm | JOURNAL.md before → after | `step` records / charged iterations |
|---|---|---|
| hill-climb | present → present (3 entries) | 3 / 3 |
| skillopt | present → present (3 entries) | 3 / 3, plus 2 `skillopt_step` now correctly auxiliary |
| gepa | **absent → present (3 entries)** | **1 → 3 / 3** |
| agent-optimize | **absent → present (2 entries)** | **0 → 2 / 2** |
| evograph | no engine (agent-prose loop) | SKILL.md §2.6 now names the seam |

All four runnable algorithms reach `test_reward 1.0` from `baseline_val 0.0` with the test split sealed — the fix changes bookkeeping, not the optimization or the gate.

## The parametrized regression test

`core/tests/test_iteration_record_parity.py` — parametrized over `hill-climb`, `gepa`, `skillopt`, `agent-optimize` (8 cases), offline and zero-API:

- `len(step records) == spent.iterations` — the single assertion the issue asked for, and the one that would have caught all of #109/#216/the skillopt double-count;
- exactly one record per candidate (the duplicate direction);
- every record carries `parent` and `accept` (the lineage edge `_parent_map`/LEDGER/RUNMAP read);
- a non-empty run-level `JOURNAL.md` naming every candidate;
- and a second test asserting the *consumers* are not left empty — `_parent_map` non-empty, `LEDGER.md` not `"(baseline only)"`, `RUNMAP.md` not `"(no prior iterations yet)"`, every candidate present in the ledger. That is #109's exact symptom, asserted per algorithm.

**These tests enumerate, and enumeration is exactly the failure mode this PR is about** — a sixth algorithm is invisible to them until someone remembers to add it to the dict, which is the same forgetting the seam exists to prevent. So the file also carries the invariant itself, asserted on the source rather than on a list of algorithms:

`test_exactly_one_place_charges_an_iteration` parses every `.py` under `core/cap_evolve/` and `skills/` with `ast`, collects every `update_spent(iterations=…)` call site with its enclosing function, and asserts there is exactly one — `harness.record_iteration`. It holds for an algorithm nobody has written yet. Verified by adding a rogue charge site to `skillopt.py`:

```
E  AssertionError: an iteration must be charged in exactly ONE place — harness.record_iteration,
E  which also writes the `step` record and reconciles JOURNAL.md. Found 2:
E  [('core/cap_evolve/harness.py', 1040, 'record_iteration'),
E   ('core/cap_evolve/skillopt.py', 506, '_fake_sixth_algorithm_loop')].
E  If one of these is a new algorithm's loop, call harness.record_iteration instead of
E  update_spent(iterations=...).
```

```
$ PYTHONPATH="$PWD/core:$PWD/dashboard/backend" python3 -m pytest core/tests/test_iteration_record_parity.py -q
.........                                                                [100%]
9 passed in 14.12s
```

## Which of #224's four claimed bugs this fixes — and which it does not

| # | Claim | This PR |
|---|---|---|
| **#109** — consumers filter `kind == "step"`, so GEPA's LEDGER/RUNMAP/`prior_iterations/` are permanently empty | **FIXED** at the source: GEPA writes `step`. Asserted per algorithm by `test_no_consumer_is_left_empty`. |
| **#216** — `_reconcile_journal` only reachable from `run_step`, so GEPA never writes a run-level `JOURNAL.md` | **FIXED**. Before/after above; `Closes #216`. Also fixes it for `_tamper_step` and agent-optimize, which had the same gap. |
| **SkillOpt double-count** — two rows per iteration, second with `parent=None` | **FIXED** at the source: `skillopt_step` is out of both `_STEP_KINDS` tuples and into `eventstream.BOOKKEEPING_KINDS`, so one row per iteration. No cost effect — see the correction above; the event carries no `opt_cost_usd`. The severe half of the original claim — "poisoned `_parent_map` / premature plateau `stop`" — was **not real on main**: it described PR #199's shared reader, which was never merged. |
| **#110** — 4-5 copies of the optimizer-scratch name list | **NOT in this PR.** Already mostly fixed on main by `types.NON_CAPABILITY_FILES`. The residual (`FOCUS.md`/`REFLECTION.md` missing from `harness._SNAPSHOT_IGNORE`, and gepa's `snapshot` calls not passing `ignore=`) is snapshot hygiene, a different concern, and is owned by the #110/PR #211 work — deliberately left out to keep this diff to the one root cause. |

### Explicitly not done

**Iterations do not get a new stable identity.** #224's headline proposal — a new gated-iteration record type, a typed `RunDir.iteration_events()` as the only enumeration path, and making the kind constants private — is **not** implemented, and is not required for the routing fix to be correct. `step` already carries every field the proposed record would (`candidate`, `parent`, `accept`, `reason`, `val`, `parent_val`); the bug was one algorithm not writing it. Adding a second representation to fix "consumers re-derive iteration-ness" would leave *both* representations and double the surface a sixth algorithm can forget. With `update_spent(iterations=…)` now callable from exactly one function, the identity is enforced where it matters — at the write, not at every read.

Two further items left alone, both cosmetic and pre-existing:
- GEPA's optimizer spend is still recorded via `update_spent` only, not carried on its `step` event, so the dashboard cost ledger cannot attribute it per candidate. Threading `opt_cost_usd` into `_full_val_gate` is a separate change.
- `dashboard._ALGO_MARKERS` identifies `hill-climb` by a bare `step`. Now that agent-mode `commit.py` also writes `step`, a hand-built run dir with no `run_config` event and no `screen` event could be mislabelled `hill-climb` instead of "not recorded". Real runs are unaffected: `run_config` is emitted by the CLI and wins over kind inference.

## Full suite

```
$ PYTHONPATH="$PWD/core:$PWD/dashboard/backend" python3 -m pytest core/tests -q
798 passed, 12 skipped in 130.73s (0:02:10)
```
(clean main is `789 passed, 12 skipped`; +9 are this PR's new tests.) Zero existing test changes were needed — including `test_gepa.py` (all cases green: the local gate still short-circuits before any full-val spend, the metric-call budget still caps the run, the merge path still works) and `test_dashboard_status_cost_log.py`'s skillopt dedup case.

## Merge coordination

Per `.review/MERGE_PLAN.md` the order is **350 → 346 → 355 → this PR**. #355 restructures the same iteration path, so expect to rebase this on top of it.


`harness.py` hunks touch only two regions, both away from the other in-flight work:
- `963-1047` — `_reconcile_journal` signature/format + the new `record_iteration` (inserted after it);
- `1433` (`_tamper_step`) and `1611-1635` (`run_step`'s tail).

No overlap with the optimizer-stderr path (~line 600) or `_SNAPSHOT_IGNORE` (~line 1842).
