### PR TITLE
fix(optimizer): a step that never got its prompt must not look like a step that proposed nothing (#251, #252)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,10 @@ See [docs/EXTENDING.md](docs/EXTENDING.md) for the token vocabulary and wiring.
   into a skill. Gate on val, seal test, report variance.
 - **Skills stay host-agnostic.** `scripts/run.py` must print a single JSON object
   to stdout (the contract), and must not depend on a specific agent host.
+- **Subprocess streams: stdout is captured and parsed, stderr is RELAYED** — on the
+  zero-exit path too. A step that exits 0 after explaining a problem must not look
+  like a step that had nothing to say. (Optimizer stderr is additionally persisted to
+  `work/<cand>.optimizer.stderr` and logged as an `optimizer_stderr` event.)
 - **Zero runtime deps in core.** Optional features go behind extras.
 - Add a test for any core change (`core/tests/`). Run `python -m compileall core skills`.
 

--- a/core/cap_evolve/cli.py
+++ b/core/cap_evolve/cli.py
@@ -687,7 +687,15 @@ def _cmd_run(argv):
     py = sys.executable
 
     def run(cmd):
-        return subprocess.run(cmd, capture_output=True, text=True, cwd=str(workdir))
+        proc = subprocess.run(cmd, capture_output=True, text=True, cwd=str(workdir))
+        # Relay a SUCCESSFUL step's stderr too. Only the failure paths below read
+        # proc.stderr, so a step that printed a real diagnostic and exited 0 (the
+        # optimizer's relayed warnings among them) was silently discarded here.
+        # Guarded by _stderr_is_usable(): under `2>&-` this would land in stdout and
+        # break the one-JSON-document contract.
+        if proc.returncode == 0 and proc.stderr and proc.stderr.strip() and _stderr_is_usable():
+            print(_clip(proc.stderr, head=0, tail=8000), file=sys.stderr, flush=True)
+        return proc
 
     # The run sequence is built from the manifest + spec (orchestrate validates the
     # needs/provides DAG); it now includes intake + the check gate before baseline.
@@ -868,18 +876,29 @@ def _cmd_run(argv):
     # as read-only optimizer context. Both are resolved project-relative if not absolute.
     # The instructions file defaults to the scaffolded project/optimizer/INSTRUCTIONS.md.
     if algorithm_name == "hill-climb":
+        from .specfile import resolve_project_path
         instr = spec.get("optimizer_instructions_file") or "optimizer/INSTRUCTIONS.md"
-        instr_p = Path(instr)
-        if not instr_p.is_absolute() and not instr_p.exists():
-            instr_p = Path(project) / instr
+        # ONE resolution rule, shared with implement-and-check's pipeline_selftest:
+        # a relative spec path is PROJECT-relative. It used to be probed against the
+        # caller's cwd first, so the same key resolved to a different file depending on
+        # where `cap-evolve run` was invoked from — and on a miss the flag was silently
+        # dropped and the optimizer got the generic template instead of the
+        # capability-scoped one intake authored (#252).
+        # proj_abs, not the relative `project`: resolving against a relative project
+        # dir is still cwd-dependent, which is the bug (#252). An absolute path is also
+        # safer for the subprocess, which runs with cwd=workdir.
+        instr_p = resolve_project_path(proj_abs, instr)
         if instr_p.exists():
             alg_cmd += ["--instructions-file", str(instr_p)]
+        elif _stderr_is_usable():
+            print(f"warning: optimizer_instructions_file {instr!r} does not exist "
+                  f"(resolved project-relative to {instr_p}) — the optimizer will get "
+                  f"cap-evolve's GENERIC template, not your capability-scoped one; "
+                  f"`cap-evolve check` and the implement-and-check self-test catch this",
+                  file=sys.stderr, flush=True)
         repo = spec.get("runner_repo_path")
         if repo:
-            repo_p = Path(str(repo))
-            if not repo_p.is_absolute() and not repo_p.exists():
-                repo_p = Path(project) / str(repo)
-            alg_cmd += ["--bench-repo", str(repo_p)]
+            alg_cmd += ["--bench-repo", str(resolve_project_path(proj_abs, str(repo)))]
         # Supporting source files (data models / types the tools import) copied verbatim
         # into the optimizer's ./guidance/sources/ so it can write correct code. Resolved
         # project-relative by the harness; we pass them through as given.

--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -609,10 +609,40 @@ def optimizer_from_command(cmd_template: list[str]) -> OptimizerFn:
             err.cost = _parse_optimizer_cost(proc.stdout)  # type: ignore[attr-defined]
             raise err
         # Capture optimizer spend (cost_usd/tokens) from run-optimizer's JSON payload
-        # so it counts against the budget and shows in the dashboard. Returns None
+        # so it counts against the budget and shows in the dashboard. Cost is None
         # when the agent CLI emitted no structured cost (spend stays unmeasured).
-        return _parse_optimizer_cost(proc.stdout)
+        report = _parse_optimizer_cost(proc.stdout) or {}
+        # Optimizer stderr on the SUCCESS path: keep it. A CLI that explains itself and
+        # then exits 0 (rate limit, model fallback, auth warning, "no script found") is
+        # the case where discarding stderr turns a step that never got what it needed
+        # into a step that merely proposed nothing. The caller persists it into the run
+        # dir and logs it; it is deliberately not dumped to the terminal on success.
+        if proc.stderr and proc.stderr.strip():
+            report["stderr"] = proc.stderr
+        return report or None
     return _run
+
+
+def _record_optimizer_stderr(run_dir, cid: str, text) -> None:
+    """Persist a SUCCESSFUL optimizer step's stderr and announce it in the event log.
+
+    Always captured, always written to ``work/<cid>.optimizer.stderr`` (durable and
+    reviewable next to the candidate that produced it), and surfaced as an
+    ``optimizer_stderr`` event with a tail — rather than dumped to the terminal,
+    which on a long run would bury the progress output the user is watching.
+    """
+    if not text or not str(text).strip():
+        return
+    text = str(text)
+    rel = f"work/{cid}.optimizer.stderr"
+    try:
+        dst = run_dir.root / rel
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        dst.write_text(text, encoding="utf-8")
+    except OSError as e:
+        rel = f"<unwritable: {e}>"
+    run_dir.log_event("optimizer_stderr", candidate=cid, path=rel,
+                      chars=len(text), tail=text[-2000:])
 
 
 def _optimizer_failure_detail(proc: "subprocess.CompletedProcess") -> str:
@@ -1483,6 +1513,7 @@ def run_step(
         if isinstance(opt_report, dict):
             opt_cost_usd = float(opt_report.get("cost_usd") or 0.0)
             opt_tokens = int(opt_report.get("tokens") or 0)
+            _record_optimizer_stderr(run_dir, cid, opt_report.get("stderr"))
     except Exception as e:  # noqa: BLE001
         # A failed proposal (e.g. a transient optimizer/API error) must not abort a
         # long run — leave the workdir as the parent copy so the candidate == parent
@@ -2042,16 +2073,27 @@ def _focus_instructions(current_val: SplitResult, focus_ids, label: str,
     }
 
     tmpl_path = Path(instructions_file) if instructions_file else _DEFAULT_INSTRUCTIONS_TEMPLATE
-    tmpl = None
+    tmpl = why = None
     try:
         if tmpl_path.exists():
             tmpl = tmpl_path.read_text(encoding="utf-8")
-    except Exception:  # noqa: BLE001
-        tmpl = None
+        else:
+            why = "does not exist"
+    except OSError as e:
+        why = f"could not be read ({e})"
     if tmpl and "{{FOCUS_SUMMARY}}" in tmpl:
         for k, v in repl.items():
             tmpl = tmpl.replace(k, v)
         return tmpl
+    if tmpl:
+        why = "has no {{FOCUS_SUMMARY}} placeholder, so it cannot be rendered"
+    # Falling back is a fact worth stating: the optimizer is about to read cap-evolve's
+    # GENERIC template instead of the capability-scoped one the spec named, and a step
+    # that did not get what it needed must not look like a step that had nothing to
+    # propose (#252). Named file => always a diagnostic; unnamed => nothing to say.
+    if instructions_file:
+        print(f"warning: optimizer instructions template {tmpl_path} {why} — "
+              f"falling back to cap-evolve's generic template", file=sys.stderr, flush=True)
 
     # Fallback (template unreadable): assemble a minimal but complete prompt so a run
     # never breaks just because the template file is missing.

--- a/core/cap_evolve/specfile.py
+++ b/core/cap_evolve/specfile.py
@@ -103,6 +103,23 @@ def read_frontmatter(md_path: Path) -> dict:
     return read_yaml(txt[3:end]) if end != -1 else {}
 
 
+def resolve_project_path(project, value) -> Path:
+    """Resolve a spec path key against the PROJECT dir — the one rule, for every reader.
+
+    A relative path in ``capevolve.yaml`` means "relative to the project dir that
+    contains the spec". Absolute paths are returned unchanged.
+
+    This exists because it used to be resolved twice, differently: ``cap-evolve check``
+    (``pipeline_selftest``) resolved project-relative and reported a missing file, while
+    ``cap-evolve run`` probed the caller's *cwd* first. The same key therefore named a
+    different file depending on where ``run`` was invoked from, and on a miss ``run``
+    dropped the flag without a word — so the optimizer silently received cap-evolve's
+    generic template instead of the capability-scoped instructions intake authored (#252).
+    """
+    v = Path(str(value))
+    return v if v.is_absolute() else Path(project) / v
+
+
 def spec_for_run(run_dir, project: Path | None = None) -> dict:
     """The spec THIS run was started with, read from the run dir first.
 

--- a/core/tests/test_optimizer_subprocess_silence.py
+++ b/core/tests/test_optimizer_subprocess_silence.py
@@ -1,0 +1,145 @@
+"""An optimizer step that did not get what it needed must not look like a step that
+had nothing to propose.
+
+Three regressions, one theme (see #251, #252):
+  A. a named-but-missing ``--prompt`` file used to become an EMPTY prompt at exit 0,
+     so the 10 ``{prompt_text}`` registry rows billed a real agent CLI to run with no
+     instructions at all;
+  B. the optimizer's stderr was discarded on the ZERO-exit path by three layers
+     (run.py / harness / cli), so a CLI that explained itself and exited 0 was silent;
+  C. a relative ``optimizer_instructions_file`` resolved differently under ``check``
+     than under ``run``, and ``run`` fell back to the generic template without a word.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+CORE = REPO / "core"
+sys.path.insert(0, str(CORE))
+
+from cap_evolve import specfile  # noqa: E402
+from cap_evolve.harness import optimizer_from_command  # noqa: E402
+
+RUN_PY = REPO / "skills" / "optimizers" / "run-optimizer" / "scripts" / "run.py"
+SELFTEST = REPO / "skills" / "phases" / "implement-and-check" / "scripts" / "pipeline_selftest.py"
+
+
+def _run_optimizer(*args, env=None):
+    e = {**__import__("os").environ, "PYTHONPATH": str(CORE)}
+    if env:
+        e.update(env)
+    return subprocess.run([sys.executable, str(RUN_PY), *args],
+                          capture_output=True, text=True, env=e)
+
+
+# ---- A. a missing prompt file is a hard, loud failure ----------------------
+
+def test_missing_prompt_file_is_a_hard_error_not_an_empty_prompt(tmp_path):
+    proc = _run_optimizer("--name", "mock", "--workdir", str(tmp_path),
+                          "--prompt", str(tmp_path / "NOPE.md"))
+    assert proc.returncode != 0, "a named-but-missing --prompt must NOT exit 0"
+    payload = json.loads(proc.stdout.strip().splitlines()[-1])
+    assert "NOPE.md" in payload["error"], payload
+    # and the agent CLI must never have been reached with an empty prompt
+    assert "returncode" not in payload, payload
+
+
+def test_existing_prompt_file_still_runs(tmp_path):
+    (tmp_path / "INSTRUCTIONS.md").write_text("do the thing", encoding="utf-8")
+    proc = _run_optimizer("--name", "mock", "--workdir", str(tmp_path),
+                          "--prompt", str(tmp_path / "INSTRUCTIONS.md"))
+    assert proc.returncode == 0, proc.stderr
+    assert json.loads(proc.stdout.strip().splitlines()[-1])["cli_present"] is True
+
+
+# ---- B. stderr survives the zero-exit path --------------------------------
+
+def _stub_agent(tmp_path, msg="STUB-DIAGNOSTIC: model fell back"):
+    stub = tmp_path / "stub_agent.sh"
+    stub.write_text(f'#!/bin/sh\necho "{msg}" >&2\nexit 0\n', encoding="utf-8")
+    stub.chmod(0o755)
+    return stub
+
+
+def test_run_py_relays_child_stderr_on_success_and_keeps_stdout_one_json(tmp_path):
+    stub = _stub_agent(tmp_path)
+    (tmp_path / "INSTRUCTIONS.md").write_text("x", encoding="utf-8")
+    proc = _run_optimizer("--name", "generic", "--workdir", str(tmp_path),
+                          "--prompt", str(tmp_path / "INSTRUCTIONS.md"),
+                          env={"CAPEVOLVE_OPTIMIZER_CMD": f"{stub} --workdir {{workdir}}"})
+    assert proc.returncode == 0
+    assert "STUB-DIAGNOSTIC" in proc.stderr, "child stderr was discarded on exit 0"
+    # #217: stdout stays exactly one JSON object, so the relay cannot corrupt it.
+    assert json.loads(proc.stdout)["returncode"] == 0
+
+
+def test_harness_keeps_optimizer_stderr_on_the_zero_exit_path(tmp_path):
+    stub = _stub_agent(tmp_path)
+    import os
+    os.environ["CAPEVOLVE_OPTIMIZER_CMD"] = f"{stub} --workdir {{workdir}}"
+    try:
+        run = optimizer_from_command([sys.executable, str(RUN_PY), "--name", "generic",
+                                      "--workdir", "{workdir}", "--prompt", "{prompt}"])
+        report = run(tmp_path, "instructions")
+    finally:
+        os.environ.pop("CAPEVOLVE_OPTIMIZER_CMD", None)
+    assert isinstance(report, dict), "stderr-carrying report must not collapse to None"
+    assert "STUB-DIAGNOSTIC" in report["stderr"]
+
+
+def test_recorded_optimizer_stderr_is_persisted_and_logged(tmp_path):
+    from cap_evolve.harness import _record_optimizer_stderr
+    from cap_evolve.rundir import RunDir
+    rd = RunDir.create(tmp_path, ts="t")
+    _record_optimizer_stderr(rd, "cand_0001", "rate limited, retrying\n")
+    saved = rd.root / "work" / "cand_0001.optimizer.stderr"
+    assert saved.read_text(encoding="utf-8") == "rate limited, retrying\n"
+    kinds = [json.loads(l)["kind"] for l in rd.events_path.read_text().splitlines() if l.strip()]
+    assert "optimizer_stderr" in kinds
+    # nothing to say when the optimizer said nothing
+    _record_optimizer_stderr(rd, "cand_0002", "   ")
+    assert not (rd.root / "work" / "cand_0002.optimizer.stderr").exists()
+
+
+# ---- C. one resolution rule, and a loud fallback --------------------------
+
+def test_relative_spec_path_is_project_relative_regardless_of_cwd(tmp_path, monkeypatch):
+    project = tmp_path / ".capevolve" / "project"
+    (project / "optimizer").mkdir(parents=True)
+    want = project / "optimizer" / "INSTRUCTIONS.md"
+    want.write_text("t", encoding="utf-8")
+    # a cwd-relative decoy at the SAME relative path must never win
+    (tmp_path / "optimizer").mkdir()
+    (tmp_path / "optimizer" / "INSTRUCTIONS.md").write_text("decoy", encoding="utf-8")
+    for cwd in (tmp_path, Path(tmp_path.anchor)):
+        monkeypatch.chdir(cwd)
+        got = specfile.resolve_project_path(project, "optimizer/INSTRUCTIONS.md")
+        assert got.resolve() == want.resolve(), f"cwd {cwd} changed the resolution"
+    assert specfile.resolve_project_path(project, "/abs/x.md") == Path("/abs/x.md")
+
+
+def test_check_and_run_share_the_resolver():
+    """`check` (pipeline_selftest) and `run` (cli) must call the SAME resolver, so a
+    spec the gate passes cannot have a path the run resolves to a different file."""
+    for f in (SELFTEST, REPO / "core" / "cap_evolve" / "cli.py"):
+        src = f.read_text(encoding="utf-8")
+        assert "resolve_project_path" in src, f"{f.name} resolves spec paths its own way"
+
+
+def test_named_but_unrenderable_template_warns_instead_of_falling_back_silently(tmp_path, capsys):
+    from cap_evolve.harness import _focus_instructions
+    from cap_evolve.loop import SplitResult
+    val = SplitResult(split="val", reward=0.0, stderr=0.0,
+                      per_task=[{"task_id": "t", "reward": 0.0, "trial_rewards": [0.0],
+                                 "feedback": "nope"}])
+    bad = tmp_path / "INSTRUCTIONS.md"
+    bad.write_text("a template with no placeholder at all", encoding="utf-8")
+    for path in (bad, tmp_path / "GONE.md"):
+        _focus_instructions(val, None, "focus", instructions_file=path)
+        assert str(path) in capsys.readouterr().err, f"silent fallback for {path.name}"
+    # an UNNAMED template (the built-in default) has nothing to warn about
+    _focus_instructions(val, None, "focus", instructions_file=None)
+    assert "falling back" not in capsys.readouterr().err

--- a/examples/toy_calc/run.sh
+++ b/examples/toy_calc/run.sh
@@ -15,6 +15,9 @@ mkdir -p "$D/.capevolve/project/adapters"
 cp "$REPO/examples/toy_calc/adapter.py"   "$D/.capevolve/project/adapters/"
 cp -R "$REPO/examples/toy_calc/capability" "$D/seed_capability"
 cp "$REPO/templates/project/capevolve.yaml"   "$D/.capevolve/project/capevolve.yaml"
+# The spec names optimizer/INSTRUCTIONS.md; ship it, or the run warns and hands the
+# optimizer cap-evolve's generic template instead of the project's own.
+cp -R "$REPO/templates/project/optimizer" "$D/.capevolve/project/optimizer"
 
 echo "Working directory: $D"
 python3 -m cap_evolve.cli run \

--- a/skills/optimizers/run-optimizer/SKILL.md
+++ b/skills/optimizers/run-optimizer/SKILL.md
@@ -26,6 +26,12 @@ new skill directory.
 3. It runs that command with `cwd = workdir`, so the agent edits the candidate
    files directly. Output is summarized as JSON (`returncode`, `auth_present`,
    `stdout_tail`).
+4. Streams: **stdout is exactly one JSON object**; the agent CLI's **stderr is
+   relayed** to the runner's stderr on success as well as failure, so a CLI that
+   prints a diagnostic and exits 0 is not silently successful.
+5. `--prompt` must name an **existing** file — the caller resolves the path. A
+   missing one is an error (exit 2), never an empty prompt: the `{prompt_text}` rows
+   would otherwise bill a real agent CLI to run with no instructions at all.
 
 ### Template placeholders
 | placeholder | expands to |

--- a/skills/optimizers/run-optimizer/scripts/_mock_apply.py
+++ b/skills/optimizers/run-optimizer/scripts/_mock_apply.py
@@ -65,8 +65,12 @@ def main(argv=None) -> int:
     workdir = Path(args.workdir)
     script = _find_script(workdir)
     if script is None:
-        print(json.dumps({"optimizer": "mock", "applied": [],
-                          "note": "no mock_script.json found; no edits made"}))
+        # The note goes to STDERR: stdout is the machine-readable payload, and a
+        # diagnostic buried in it is dropped by every layer that only parses cost.
+        note = "no mock_script.json found; no edits made"
+        print(f"mock optimizer: {note} (looked under {workdir} and $CAPEVOLVE_MOCK_SCRIPT)",
+              file=sys.stderr, flush=True)
+        print(json.dumps({"optimizer": "mock", "applied": [], "note": note}))
         return 0
     edits = json.loads(script.read_text(encoding="utf-8")).get("edits", [])
     applied = apply_edits(workdir, edits)

--- a/skills/optimizers/run-optimizer/scripts/run.py
+++ b/skills/optimizers/run-optimizer/scripts/run.py
@@ -246,7 +246,15 @@ def main(argv=None) -> int:
     # it absolute keeps file edits landing in the candidate dir, not a subdir of it.
     workdir = str(Path(args.workdir).resolve())
     prompt_path = Path(args.prompt).resolve()
-    prompt_text = prompt_path.read_text(encoding="utf-8") if prompt_path.exists() else ""
+    # A named-but-missing prompt is a HARD error, never an empty prompt. For the rows
+    # whose command_template inlines {prompt_text}, substituting "" would bill a real
+    # agent CLI to run with NO instructions and still exit 0 — a step that never got
+    # its prompt would then be indistinguishable from a step that proposed nothing.
+    if not prompt_path.exists():
+        print(json.dumps({"optimizer": name, "error":
+              f"--prompt file does not exist: {prompt_path}"}))
+        return 2
+    prompt_text = prompt_path.read_text(encoding="utf-8")
 
     cmd = build_command(str(row.get("command_template", "")), workdir=workdir,
                         prompt=str(prompt_path), prompt_text=prompt_text,
@@ -296,9 +304,15 @@ def main(argv=None) -> int:
     env.update(auth["env"])
 
     proc = subprocess.run(cmd, cwd=workdir, capture_output=True, text=True, env=env)
+    # Relay the agent CLI's stderr to OUR stderr, on success as well as failure: a CLI
+    # that prints a real diagnostic (rate limit, model fallback, auth warning) and then
+    # exits 0 must not look silently successful. stdout stays exactly one JSON object
+    # (CONTRIBUTING.md's stdout contract), so the relay cannot corrupt the payload.
+    if proc.stderr:
+        print(proc.stderr, file=sys.stderr, end="", flush=True)
     result = {"optimizer": name, "cli_present": True, "returncode": proc.returncode,
               "auth_present": auth["present"],
-              "stdout_tail": proc.stdout[-800:], "stderr_tail": proc.stderr[-500:]}
+              "stdout_tail": proc.stdout[-800:], "stderr_tail": proc.stderr[-800:]}
     # Best-effort cost capture: only when --json requested AND the row had a json_flag.
     # The prose-fed path (no --json, or empty json_flag) never reaches here, so the
     # offline/mock and generic flows are unchanged.

--- a/skills/phases/implement-and-check/scripts/pipeline_selftest.py
+++ b/skills/phases/implement-and-check/scripts/pipeline_selftest.py
@@ -71,7 +71,9 @@ def selftest(project: Path) -> dict:
         problems.append(f"missing spec: {spec_path} (intake must scaffold capevolve.yaml)")
 
     instr_rel = str(spec.get("optimizer_instructions_file") or "optimizer/INSTRUCTIONS.md")
-    instr_path = project / instr_rel
+    # Same resolver `cap-evolve run` uses, so a spec this gate passes cannot have a
+    # path run resolves differently (#252).
+    instr_path = specfile.resolve_project_path(project, instr_rel)
     if not instr_path.exists():
         problems.append(
             f"optimizer_instructions_file points at a missing file: {instr_rel} "


### PR DESCRIPTION
Three verified bugs in the optimizer invocation path. One PR, because they are all the
same failure: **the optimizer subprocess doesn't get what it needed, and nobody finds out.**

The unifying rule this PR enforces: *an optimizer step that did not get what it needed must
not look like a successful step that had nothing to propose.* That confusion does not waste
one iteration — it corrupts the run's evidence, because the gate's "rejected: no
improvement" becomes indistinguishable from "the optimizer was never given a chance".

Fixes #354 (opened for bug A, which had no issue), #251, #252.

---

## A — silent empty prompt (#354)

`run.py:249` substituted `prompt_text = ""` when `--prompt` named a missing file, and exited 0.
For the **10 rows that inline `{prompt_text}`** that expands to e.g. `claude -p '' …` — a real,
billed agent invocation with no instructions.

**Before**
```
$ python skills/optimizers/run-optimizer/scripts/run.py --name mock \
    --workdir /tmp/rotestA --prompt /tmp/rotestA/NOPE.md
{"optimizer": "mock", "cli_present": true, "returncode": 0, "auth_present": [],
 "stdout_tail": "{\"optimizer\": \"mock\", \"applied\": [], \"note\": \"no mock_script.json found; no edits made\"}\n",
 "stderr_tail": ""}
EXIT=0
```

**After**
```
$ python skills/optimizers/run-optimizer/scripts/run.py --name mock \
    --workdir /tmp/rotestA --prompt /tmp/rotestA/NOPE.md
{"optimizer": "mock", "error": "--prompt file does not exist: /private/tmp/rotestA/NOPE.md"}
EXIT=2

$ ... --prompt /tmp/rotestA/INSTRUCTIONS.md          # existing file, unchanged
{"optimizer": "mock", "cli_present": true, "returncode": 0, ...}
EXIT=0
```

The runner never reaches the agent CLI, so nothing is billed. `--prompt` was already
mandatory; a mandatory path that resolves to `""` is strictly worse than a missing flag.

---

## B — discarded stderr (#251)

All three `capture_output=True` layers still dropped the optimizer's stderr on the **zero-exit**
path, confirmed on `main` (PR #248's fix is not present).

**Repro: a stub "optimizer" that writes a real diagnostic and exits 0**
```sh
$ cat /tmp/rotestB/stub_agent.sh
#!/bin/sh
echo "STUB-DIAGNOSTIC: rate limit hit, model fell back to a cheaper one" >&2
exit 0
$ export CAPEVOLVE_OPTIMIZER_CMD="/tmp/rotestB/stub_agent.sh --workdir {workdir} --prompt {prompt}"
```

**Before**
```
# layer 1 — run.py
$ python .../run.py --name generic --workdir /tmp/rotestB --prompt /tmp/rotestB/INSTRUCTIONS.md 2>err
{"optimizer": "generic", ..., "returncode": 0, "stderr_tail": "STUB-DIAGNOSTIC: ...\n"}
EXIT=0
run.py OWN stderr: []                        <- buried inside the JSON, never relayed

# layer 2 — harness.optimizer_from_command
optimizer_from_command returned: None
harness caller's stderr: []                  <- the whole payload dropped on returncode 0

# layer 3 — cli.py `run()` reads proc.stderr only on the failure branches
```

**After**
```
# layer 1
run.py OWN stderr: [STUB-DIAGNOSTIC: rate limit hit, model fell back to a cheaper one]
EXIT=0
stdout json objects: 1
stdout parses as exactly one JSON object: OK          <- #217 intact

# layer 2
optimizer_from_command returned: {"stderr": "STUB-DIAGNOSTIC: rate limit hit, ...\n"}
```

**End to end** (the toy wiring with no `mock_script.json`, i.e. #251's own founding example —
a real optimizer that explains itself and exits 0):
```
--- persisted in the run dir ---
$D/.capevolve/run_e2e/work/cand_0001.optimizer.stderr
$D/.capevolve/run_e2e/work/cand_0002.optimizer.stderr
--- content ---
mock optimizer: no mock_script.json found; no edits made (looked under .../cand_0001 and $CAPEVOLVE_MOCK_SCRIPT)
--- event stream ---
"kind": "optimizer_stderr", "candidate": "cand_0001", "path": "work/cand_0001.optimizer.stderr", "chars": 212, "tail": "mock optimizer: no mock_script.json found; ..."
```

### Volume: what goes where, and why

| stream | choice | reason |
|---|---|---|
| `run.py` → its own stderr | **always relay**, verbatim | the runner is the only place that has the child's stderr as a stream; `stdout` is the one-JSON contract (#217) so `stderr` is the free channel, and a stream survives the layers above |
| harness → run dir + event stream | **capture, persist to `work/<cand>.optimizer.stderr`, log `optimizer_stderr` with a 2 KB tail** | an agent CLI can be extremely chatty over a 50-iteration run. Dumping it to the terminal on success would bury the progress output the user is actually watching, and the interesting case is usually read *after* the run, next to the candidate that produced it. Durable + attributable + greppable beats transient |
| cli.py phase steps → terminal stderr | **relay on success**, tail-clipped to 8 KB, guarded by the existing `_stderr_is_usable()` | there are only four phase steps per run and their stderr is normally empty, so volume is a non-issue; this is the half that makes a diagnostic actually reach a human in real time — and it is what carries bug C's new warning to the terminal |
| `stderr_tail` in the JSON | cap raised 500 → 800 to match `stdout_tail` | once stderr is a relayed stream, the tail is only a convenience field; the asymmetric 500 was just noise |

`_mock_apply.py`'s "no mock_script.json found" note also moved from **stdout to stderr** — it was
on the wrong stream *and* discarded by both layers above, which is why #251 says adding that
warning changed nothing.

Contract now stated in `CONTRIBUTING.md` next to the stdout half: **stdout is captured and
parsed, stderr is relayed** — on the zero-exit path too.

---

## C — instructions-path resolution (#252)

One relative `optimizer_instructions_file`, **three different answers**. Repro fixture: a
project-scoped template at `$D/.capevolve/project/optimizer/INSTRUCTIONS.md` and a cwd-relative
decoy at the same relative path, each marked, then read back from what the optimizer *actually
received* (`candidates/*/INSTRUCTIONS.md`).

**Before**
```
--- (1) check / pipeline_selftest resolution (project-relative) ---
  "ok": true,
    "optimizer template OK with intact placeholders: optimizer/INSTRUCTIONS.md"
--- (2) run, invoked from $D (cwd == workdir) ---
    optimizer actually received: CWD-DECOY-MARKER
--- (3) run, invoked from /tmp (different cwd, absolute --project) ---
    optimizer actually received: NEITHER (silent generic-template fallback)
```

**After**
```
--- (1) check / pipeline_selftest resolution (project-relative) ---
  "ok": true, ...
--- (2) run, invoked from $D (cwd == workdir) ---
    optimizer actually received: PROJECT-SCOPED-MARKER
--- (3) run, invoked from /tmp (different cwd, absolute --project) ---
    optimizer actually received: PROJECT-SCOPED-MARKER
```

- `specfile.resolve_project_path(project, value)` is the **single rule**: a relative spec path
  is project-relative; absolute is returned unchanged. Used by `cap-evolve run` *and*
  `implement-and-check`'s `pipeline_selftest`, so a spec the gate passes cannot have a path the
  run resolves to a different file. A test asserts both call it.
- It resolves against the **absolute** project dir. Resolving against the relative
  `".capevolve/project"` was case 3: "project-relative" was still cwd-dependent. Also applied to
  the sibling `runner_repo_path`, which had the identical two-probe shape.
- A miss now **warns**, naming the path tried:
  ```
  warning: optimizer_instructions_file 'optimizer/INSTRUCTIONS.md' does not exist (resolved
  project-relative to /.../.capevolve/project/optimizer/INSTRUCTIONS.md) — the optimizer will
  get cap-evolve's GENERIC template, not your capability-scoped one; `cap-evolve check` and the
  implement-and-check self-test catch this
  ```
- `_focus_instructions`' silent fallbacks are gone: the bare `except` is now `except OSError` with
  a reason, and the third silent path (a named, readable template that lacks `{{FOCUS_SUMMARY}}`)
  also announces itself. A template that was never *named* stays quiet — there is nothing to report.
- **Not made fatal, deliberately.** Missing capability-scoped instructions ≠ no instructions:
  there is a complete built-in template, so the proportionate response is a loud diagnostic, not
  killing a long run. The empty *prompt* (bug A) is the one that must be fatal, because there the
  optimizer gets literally nothing. This satisfies #252's "fails **or warns visibly**".
- `examples/toy_calc/run.sh` now copies `templates/project/optimizer/` — its spec names
  `optimizer/INSTRUCTIONS.md` and the example never shipped it, so the toy was silently running on
  the generic fallback (and would now warn on every run). One line; the shipped example is
  correctly wired and quiet.

Note how B and C interlock: C's warning reaches a terminal **only because** of B's layer-3 fix.
That is exactly #251's point — a warning nobody can see is not a fix.

---

## Evidence

```
$ python -m pytest core/tests -q 2>&1 | tail -25
797 passed, 12 skipped in 114.02s (0:01:54)

$ python skills/optimizers/run-optimizer/scripts/check.py
{"notes":[...],"ok":true,"problems":[],"skill":"run-optimizer"}

$ bash examples/toy_calc/run.sh 2>&1 | tail -15
{
  "run_dir": ".capevolve/run_demo",
  "best_id": "cand_0001",
  "baseline_val": 0.0,
  "test_reward": 1.0,
  "test_baseline_reward": 0.0,
  "test_delta": 1.0,
  "test_pass_k": {"1": 1.0},
  "iterations": 3,
  ...
}
```

### Regression tests

New file `core/tests/test_optimizer_subprocess_silence.py` (8 tests) — deliberately a **new
file**, to avoid colliding with the agents concurrently editing `core/tests/test_core.py`.
Verified to fail before the fix and pass after:

```
# with the source changes reverted, the new tests only:
7 failed, 1 passed          (the 1 pass is the "an existing prompt still runs" control)
# with the fix:
8 passed
```

| test | bug |
|---|---|
| `test_missing_prompt_file_is_a_hard_error_not_an_empty_prompt` | A |
| `test_existing_prompt_file_still_runs` | A (control) |
| `test_run_py_relays_child_stderr_on_success_and_keeps_stdout_one_json` | B, layer 1 (+ #217) |
| `test_harness_keeps_optimizer_stderr_on_the_zero_exit_path` | B, layer 2 |
| `test_recorded_optimizer_stderr_is_persisted_and_logged` | B, persistence + event |
| `test_relative_spec_path_is_project_relative_regardless_of_cwd` | C (asserts a cwd decoy never wins) |
| `test_check_and_run_share_the_resolver` | C (`check` and `run` cannot diverge again) |
| `test_named_but_unrenderable_template_warns_instead_of_falling_back_silently` | C (all three fallbacks) |

---

## Merger notes — exact lines touched in shared files

`harness.py` is the highest-collision file in flight, so the diff there is surgical.
**Post-merge line numbers:**

| range | what | collides with |
|---|---|---|
| 612–621 | `optimizer_from_command._run`: keep `proc.stderr` on the zero-exit path in the returned report | nothing — no other agent is on the stderr path |
| 626–647 | **new** `_record_optimizer_stderr()` helper, inserted immediately before `_optimizer_failure_detail` | nothing; pure addition |
| 1516 | **one added line** in `run_step`'s propose block: `_record_optimizer_stderr(run_dir, cid, opt_report.get("stderr"))` | nothing |
| 2076–2096 | `_focus_instructions`' template-resolution block: `except OSError` + a reason instead of a bare `except`, and a warning before the generic fallback | ⚠️ **this is inside the optimizer-context assembly.** Contained to the ~10 lines around `tmpl_path = …` / the fallback boundary; the `repl` dict, every placeholder, and the whole fallback prose body are untouched. Whoever owns the context-assembly change should be able to take both. |

`_SNAPSHOT_IGNORE` (~1842) is **not touched** — that is the other agent's change, and none of
these three bugs need it.

Other files: `cli.py` (the `run()` helper + the hill-climb `--instructions-file` /
`--bench-repo` block), `specfile.py` (pure addition), `run.py`, `_mock_apply.py`,
`pipeline_selftest.py` (one line), `CONTRIBUTING.md`, `SKILL.md`,
`examples/toy_calc/run.sh` (one line).

Zero new runtime deps; no vendor branch anywhere — all 14 optimizers keep living as registry
rows (CONTEXT.md principle 1).

### Deliberately out of scope
- The rest of `run-optimizer`'s review (`_LEGACY_ALIASES` dead code, `_SNAPSHOT_IGNORE`
  derivation, `build_command`'s model-drop peek, SKILL.md's registry-field table, checked-in
  `__pycache__`) — real, but unrelated to "the subprocess failed and nobody found out".
- #252's wider audit of `dataset_source` / `split_ids_file` / `capability_path`. Fixed here:
  `optimizer_instructions_file` and `runner_repo_path`, the two that shared the broken two-probe
  shape at the same call site. The others are consumed elsewhere and deserve their own pass.
- Auditing every remaining `capture_output=True` on a scoring path (#251's own follow-up).
