### PR TITLE
report: pin the output contract, stop the false seal claim, and report the numbers the reducer already has

### DIFF
--- a/skills/phases/report/SKILL.md
+++ b/skills/phases/report/SKILL.md
@@ -2,7 +2,7 @@
 name: report
 description: Summarize a run for a human — baseline val → best val → sealed test, the winning candidate, iterations spent, and pass^k. Use after finalize. Writes report.md and prints a compact JSON summary; the source of truth for "did this optimization actually work, and by how much".
 component: phase
-argument-hint: "--run-dir DIR"
+argument-hint: "--run-dir DIR [--terminal] [--no-dashboard]"
 allowed-tools: Read, Write, Bash
 provides: [report]
 needs: []
@@ -11,96 +11,89 @@ sources: [evo]
 
 # report — did it work, and by how much?
 
-The result of an optimization run is not "we made edits" — it is a defensible
-answer to *did this actually work, and by how much.* report reads the run dir's
-`baseline.json` and `final.json` and lays them side by side: where the seed
-started (val), where the best candidate landed (val), and the single **held-out
-test** number that actually counts. It is the source of truth a human reads to
-decide whether to ship the optimized capability.
+The result of a run is not "we made edits" — it is a defensible answer to *did this
+actually work, and by how much.* report lays three numbers side by side: where the
+seed started (val), where the best candidate landed (val), and the single **held-out
+test** number that counts. It is what a human reads to decide whether to ship.
 
-## Inputs / outputs (manifest tokens)
-- **needs:** *(reads the run dir directly — baseline.json / final.json / events /
-  per-task rollouts / git store)*.
-- **provides:** `report` — `report.md`, a compact JSON summary, a self-contained
-  `dashboard.html`, and an on-demand ANSI terminal report.
+Runs standalone as `/cap-evolve:report`, or headlessly as the last step of
+`cap-evolve run` — same `scripts/run.py` either way. There is no `cap-evolve report`
+subcommand; invoke the script.
 
 ## How to read the three numbers
 The honest reading is always **test vs baseline**, with val as a sanity check in
-between:
+between. `scripts/run.py` produces the numbers; this is the judgment you add on top:
 
-- **test ≈ baseline** → no real gain. The val improvement was overfitting or
-  noise the gate let through. Do not ship; tighten `gate_k_se` or add trials.
+- **test ≈ baseline** → no real gain. The val improvement was overfitting or noise
+  the gate let through. Do not ship; tighten `gate_k_se` or add trials.
 - **test ≫ baseline** → genuine improvement on data the optimizer never saw. Ship.
-- **val ≫ test** → the classic overfit signature: the optimizer learned the val
-  set, not the capability. The gap *is* the overfitting, quantified.
-- **wide pass^k drop vs pass^1** → the gain is *fragile* across trials — the agent
+- **val ≫ test** → the classic overfit signature: the optimizer learned the val set,
+  not the capability. The reported val→test gap *is* the overfitting, quantified.
+- **pass^k far below pass^1** → the gain is *fragile* across trials; the agent
   sometimes succeeds but not reliably. A high mean with low pass^k is not a
   dependable win (τ-bench's point).
 
-Always report the **test stderr / CI**, not just the point: "0.71" and
-"0.71 ± 0.08" support very different decisions.
+Every number is rendered with its stderr when one was measured, because "0.71" and
+"0.71 ± 0.08" support very different decisions. A gain smaller than the noise floor
+is not a result — say so plainly rather than quoting the point estimate alone.
 
-When the run declared a **consuming LLM** (the `target_profile` in the run summary —
-the runtime model the capabilities were optimized FOR, distinct from the optimizer
-model that proposed the edits), print it alongside the optimizer model so the two LLM
-roles stay visibly distinct: e.g. "optimized for gpt-oss-120b (tier mid); edits proposed
-by claude-opus". Omit the line for profile-agnostic runs (no `target_profile`).
+## Output contract
+`scripts/run.py` owns both artifacts and writes them deterministically from the run
+dir — do not hand-write or paraphrase them, or two runs stop being comparable.
 
-## Dual-mode
-This phase runs two ways from the **same** SKILL.md: standalone as the slash command `/cap-evolve:report` (the `argument-hint` shows its run.py args), and orchestrator-callable — `cap-evolve run` / the `orchestrate` skill invokes the same `scripts/run.py` headlessly and threads the run dir between phases.
+`report.md` is exactly this skeleton (bracketed lines appear only when they apply):
+
+```
+# cap-evolve run report — <run_id>
+
+[> **NOT FINALIZED** — no held-out test number. Run the finalize phase first; …]
+[> **No holdout** (train == val == test). The test number below is a *fit* metric, …]
+
+- Best candidate: `<best_id>`
+- Baseline val: <r> ± <se>
+- Best val: <r> ± <se>
+- **Held-out test (optimized skills): <r> ± <se>**  (pass^1=…, pass^k=…)
+[- Held-out test (baseline `<baseline_id>` skills): <r> ± <se>]
+[- **Test improvement (optimized − baseline): <+Δ>**]
+[- Val→test gap: <+Δ> — selection optimism on val; this gap IS the overfitting]
+- Iterations: <n>
+[- Optimized for: <consuming model> (tier <t>)]
+
+[<sealed note — omitted entirely when the run was never finalized>]
+```
+
+stdout is **exactly one** JSON object — `cap-evolve run` echoes it as its own result, so
+it is the machine contract for everything downstream. Keys (null for whatever the run
+dir does not carry; an unfinalized run is `finalized: false` with null test numbers):
+`run_dir`, `best_id`, `finalized` bool, `no_holdout` bool, `baseline_val`,
+`baseline_val_stderr`, `best_val`, `test_reward`, `test_stderr`,
+`test_baseline_reward`, `test_baseline_stderr`, `test_delta`, `test_pass_k` (k→float),
+`val_test_gap`, `iterations`, `target_profile` (`{model,tier,resolution_note}`), plus
+`dashboard` / `dashboard_server` / `*_error` on the paths that produce them.
 
 ## How to run
 ```
-python scripts/run.py --run-dir .capevolve/run_XXXX            # JSON summary + report.md + dashboard.html
-python scripts/run.py --run-dir .capevolve/run_XXXX --terminal # colored in-chat ANSI report (no browser)
+python scripts/run.py --run-dir .capevolve/run_XXXX            # JSON + report.md + dashboard.html
+python scripts/run.py --run-dir .capevolve/run_XXXX --terminal # colored in-chat ANSI report
 python scripts/run.py --run-dir .capevolve/run_XXXX --no-dashboard
 ```
+`--dashboard-mode` / `--dashboard-port` / `--dashboard-url` are orchestrator-supplied.
+Re-reporting by hand after `cap-evolve run` needs `--dashboard-url <the URL run printed>`
+or `--no-dashboard` — launching is deliberately not idempotent, so a bare re-run spawns
+a second server on a second port and reports that one instead.
 
-### The dashboard (`dashboard.html`)
-A **fully self-contained** static file — inline CSS + vanilla JS + inline SVG, **no
-CDN, no server, no network**. It is the single shareable artifact; open it by
-double-clicking (works from `file://`). The builder first **reduces** the event log
-(plus baseline/final, per-task rollouts, and the git store) into a candidate **graph
-+ run-summary**, then renders eight panels:
-
-1. **KPI strip** — best / baseline / %Δ-vs-baseline (abs Δ off a zero baseline),
-   counts by status (accepted/rejected/failed/seed), frontier, sealed test, wall
-   clock, cost split **optimizer vs runner**, tokens.
-2. **Cumulative-best stair** over a per-iteration scatter — running-best step
-   polyline, champion star, record-holder rings, hover tooltip (id/status/val/Δ).
-3. **tasks×iterations pass/fail heatmap** — rows sorted worst-first; reveals
-   regressions, persistent failures, and per-task specialists the mean hides; click
-   a cell for that task's feedback.
-4. **Diff vs parent** — prompt/skill/tools diff of a candidate against its parent
-   (split/unified toggle), computed from the candidate dirs.
-5. **Lineage tree** — parent→child DAG (merges = multi-parent), best-lineage spine
-   highlighted.
-6. **Cost / tokens / latency** — per-iteration + cumulative, split optimizer vs
-   runner, plus a cumulative-cost-vs-best-score plot.
-7. **Annotations & diagnoses** — gate reasons + diagnose/optimizer-error output.
-8. **Candidate leaderboard** + the git iteration-store log.
-
-All values pass through a recursive **secret redactor** first, so a shared dashboard
-never leaks `RITS_API_KEY` / `BOBSHELL_API_KEY` / `WATSONX_*` etc. Optional panels
-**degrade silently** when per-task data, diffs, or finalize are missing.
-
-### The terminal report (`--terminal` / `--ansi`)
-A colored cumulative-best chart + one-line KPI strip + top-N candidate table for
-in-chat progress without opening the browser. Sized to the terminal width and
-**CLAUDECODE-margin-aware** (subtracts ~6 cols when `CLAUDECODE=1` so it doesn't wrap
-inside the tool-output frame). `--no-color` / `NO_COLOR=1` for plain text;
-`--top-n N` sets the table size.
-
-## What good vs bad looks like
-- **Good:** test reported with its uncertainty and pass^k; the baseline→val→test
-  story told honestly, including a no-gain or overfit result when that is what
-  happened; a no-holdout run clearly labelled as a fit metric.
-- **Bad:** reporting val as if it were the result; a bare point estimate with no
-  variance; spinning a `val ≫ test` overfit as success.
+## The dashboard (`dashboard.html`)
+One self-contained static file (inline CSS/JS/SVG, no CDN, no server, no network — opens
+from `file://`); the single shareable artifact. Eight panels reduced from the event log
+plus baseline/final, rollouts and the git store; every value passes a recursive secret
+redactor so a shared dashboard leaks no API keys; optional panels degrade silently when
+per-task data, diffs, or finalize are missing. `--terminal` renders the same reduction
+as an ANSI chart for in-chat progress.
 
 ## References
-- `references/concepts.md` — reading baseline/val/test honestly, the val-test gap
-  as overfitting, pass^k fragility, and reporting uncertainty, with sources.
-- `references/dashboard.md` — the reduced graph + summary schema, what each of the
-  eight panels reads from, the `--terminal`/`--ansi` mode, secret redaction, and the
-  graceful-degradation rules.
+- `references/concepts.md` — why the val→test gap measures overfitting, pass^k
+  fragility, reporting uncertainty, with sources. Load when writing the human
+  interpretation and you want the reasoning or a citation.
+- `references/dashboard.md` — the reduced graph + summary schema, per-panel field
+  sources, `--terminal`, redaction, degradation matrix. Load when changing or
+  debugging the dashboard; not needed to run the phase.

--- a/skills/phases/report/meta.yaml
+++ b/skills/phases/report/meta.yaml
@@ -4,6 +4,11 @@ summary: Summarize baseline to best-val to sealed-test and name the winner.
 entry: scripts/run.py
 abstract: scripts/abstract.py
 check: scripts/check.py
+# The real dependency is finalize's sealed test number: without final.json this phase
+# can only emit a val-only, NOT-FINALIZED report. That ordering is deliberately NOT
+# expressed as a token today because finalize also `provides: [report]`, so there is no
+# distinct token to need. Expressing it means finalize `provides: [sealed_test]` and
+# report `needs: [sealed_test]` — a two-file change owned by finalize, tracked in #336.
 needs: []
 provides: [report]
 compatible_with:

--- a/skills/phases/report/scripts/check.py
+++ b/skills/phases/report/scripts/check.py
@@ -37,23 +37,58 @@ def _synthetic_events():
     ]
 
 
+#: The stdout contract (CONTRIBUTING.md: "scripts/run.py must print a single JSON object").
+#: `dashboard` / `dashboard_server` are added only on the paths that produce them.
+_SUMMARY_KEYS = {
+    "run_dir", "best_id", "finalized", "no_holdout", "baseline_val", "baseline_val_stderr",
+    "best_val", "test_reward", "test_stderr", "test_baseline_reward", "test_baseline_stderr",
+    "test_delta", "test_pass_k", "val_test_gap", "iterations", "target_profile",
+}
+
+
+def _parse_one_json(c, text: str, label: str):
+    """Assert stdout is exactly one JSON object carrying the documented key set."""
+    try:
+        obj = json.loads(text)
+    except Exception as e:  # noqa: BLE001
+        c.check(False, f"[{label}] stdout is not a single JSON object ({e}): {text!r}")
+        return None
+    c.check(isinstance(obj, dict), f"[{label}] stdout JSON is not an object: {obj!r}",
+            note="stdout is exactly one JSON object")
+    if isinstance(obj, dict):
+        missing = _SUMMARY_KEYS - set(obj)
+        c.check(not missing, f"[{label}] summary missing documented keys: {sorted(missing)}",
+                note="summary carries the documented key set")
+    return obj if isinstance(obj, dict) else None
+
+
 def main() -> int:
     c = Checker("report")
     run = import_run()
     c.require_main(run)
 
-    # --- 1. report.md: baseline → sealed test ----------------------------
+    # --- 1. report.md + stdout contract: baseline → best val → sealed test ----
     with tempfile.TemporaryDirectory() as d:
         rd, _ = temp_run_dir(Path(d))
+        rd.events_path.write_text(
+            "\n".join(json.dumps(e) for e in _synthetic_events()) + "\n", encoding="utf-8")
         (rd.root / "baseline.json").write_text(
-            json.dumps({"val": {"reward": 0.4}, "best_id": "seed"}), encoding="utf-8")
-        (rd.root / "final.json").write_text(
-            json.dumps({"test": {"reward": 0.8, "pass_k": 0.7}, "best_id": "cand_0001"}),
+            json.dumps({"val": {"reward": 0.4, "stderr": 0.05}, "best_id": "seed"}),
+            encoding="utf-8")
+        (rd.root / "final.json").write_text(json.dumps({
+            "test": {"reward": 0.8, "stderr": 0.06, "pass_k": 0.7},
+            "test_baseline": {"reward": 0.5, "stderr": 0.07},
+            "baseline_id": "seed", "test_delta": 0.3, "best_id": "cand_0001"}),
             encoding="utf-8")
 
-        with quiet():
+        with quiet() as out:
             rc = run.main(["--run-dir", str(rd.root), "--no-dashboard"])
         c.check(rc == 0, "report returned nonzero")
+
+        # stdout IS the machine contract: `cap-evolve run` prints report's stdout as its
+        # own result (cli.py `print(last)`), so exactly one parseable JSON object with the
+        # documented keys is the thing every automation downstream depends on.
+        summary = _parse_one_json(c, out.getvalue(), "--no-dashboard")
 
         md_path = rd.root / "report.md"
         c.check(md_path.exists(), "report.md was not written", note="writes report.md")
@@ -63,6 +98,56 @@ def main() -> int:
                 note="report carries baseline → sealed test")
         c.check("sealed" in md.lower(),
                 "report does not state the test was scored once on the sealed split")
+        # Uncertainty is the phase's own headline rule ("0.71" and "0.71 ± 0.08" justify
+        # different decisions), so a bare point estimate beside a known stderr is a bug.
+        c.check("0.8 ± 0.06" in md and "0.4 ± 0.05" in md,
+                f"report.md renders a bare point estimate despite a known stderr:\n{md}",
+                note="renders reward ± stderr when stderr is known")
+        if summary is not None:
+            c.check(summary.get("test_stderr") == 0.06
+                    and summary.get("test_baseline_stderr") == 0.07,
+                    f"summary drops the stderr finalize measured: {summary}",
+                    note="JSON summary carries test/baseline stderr")
+            c.check(summary.get("best_val") == 0.75
+                    and summary.get("val_test_gap") == round(0.75 - 0.8, 6),
+                    f"summary missing best_val / val→test gap: {summary}",
+                    note="JSON summary carries best_val + val→test gap")
+            c.check(summary.get("finalized") is True, f"finalized not True: {summary}")
+        c.check("Best val: 0.75" in md and "Val→test gap:" in md,
+                f"report.md missing best val / val→test gap:\n{md}",
+                note="report.md carries best val + the val→test gap")
+
+    # --- 1b. an unfinalized run must NOT claim a seal that never happened ----
+    with tempfile.TemporaryDirectory() as d:
+        rd, _ = temp_run_dir(Path(d))
+        (rd.root / "baseline.json").write_text(
+            json.dumps({"val": {"reward": 0.4}, "best_id": "seed"}), encoding="utf-8")
+        with quiet() as out:
+            rc = run.main(["--run-dir", str(rd.root), "--no-dashboard"])
+        c.check(rc == 0, "report on an unfinalized run returned nonzero")
+        md = (rd.root / "report.md").read_text()
+        c.check("sealed" not in md.lower(),
+                f"report claims the test split was sealed+scored on a run that never "
+                f"finalized:\n{md}", note="no false seal claim before finalize")
+        c.check("NOT FINALIZED" in md, f"unfinalized report is not labelled:\n{md}")
+        s = _parse_one_json(c, out.getvalue(), "unfinalized")
+        if s is not None:
+            c.check(s.get("finalized") is False, f"finalized not False: {s}")
+
+    # --- 1c. a no-holdout run's report.md must say the number is a fit metric --
+    with tempfile.TemporaryDirectory() as d:
+        rd, _ = temp_run_dir(Path(d))
+        rd.events_path.write_text(json.dumps(
+            {"kind": "splits", "train": ["t1"], "val": ["t1"], "test": ["t1"], "seed": 0}
+        ) + "\n", encoding="utf-8")
+        (rd.root / "final.json").write_text(
+            json.dumps({"test": {"reward": 0.8}, "best_id": "seed"}), encoding="utf-8")
+        with quiet():
+            run.main(["--run-dir", str(rd.root), "--no-dashboard"])
+        md = (rd.root / "report.md").read_text()
+        c.check("No holdout" in md,
+                f"no-holdout run's report.md presents a fit metric as held-out:\n{md}",
+                note="labels a no-holdout run as a fit metric")
 
     # --- 2. reducer → well-formed graph from a synthetic event log -------
     from cap_evolve import dashboard
@@ -132,6 +217,14 @@ def main() -> int:
             rc2 = run.main(["--run-dir", str(rd.root), "--terminal", "--no-color"])
         c.check(rc2 == 0, "report --terminal returned nonzero",
                 note="ANSI terminal report mode")
+
+        # --- 5. the dashboard-on path keeps the one-JSON-object contract ---
+        # This branch is where a stray print() would creep in (it launches/records a
+        # server), and it is the path `cap-evolve run` actually takes.
+        with quiet() as out:
+            rc3 = run.main(["--run-dir", str(rd.root)])
+        c.check(rc3 == 0, "report with the dashboard on returned nonzero")
+        _parse_one_json(c, out.getvalue(), "dashboard-on")
 
     return c.emit()
 

--- a/skills/phases/report/scripts/run.py
+++ b/skills/phases/report/scripts/run.py
@@ -18,6 +18,17 @@ import _bootstrap  # noqa: F401
 from cap_evolve import RunDir
 
 
+def _pm(reward, stderr) -> str:
+    """``0.71 ± 0.08`` when the stderr is known, else the bare point estimate.
+
+    A point estimate with no noise floor invites over-reading: "0.71" and "0.71 ± 0.08"
+    justify different ship decisions.
+    """
+    if reward is None:
+        return "None"
+    return f"{reward} ± {stderr}" if isinstance(stderr, (int, float)) else f"{reward}"
+
+
 def main(argv=None) -> int:
     p = argparse.ArgumentParser(prog="report")
     p.add_argument("--run-dir", required=True)
@@ -45,9 +56,12 @@ def main(argv=None) -> int:
         return 0
 
     baseline = json.loads((run_dir.root / "baseline.json").read_text()) if (run_dir.root / "baseline.json").exists() else {}
-    final = json.loads((run_dir.root / "final.json").read_text()) if (run_dir.root / "final.json").exists() else {}
+    final_path = run_dir.root / "final.json"
+    final = json.loads(final_path.read_text()) if final_path.exists() else {}
+    finalized = bool(final.get("test"))
 
-    base_val = (baseline.get("val") or {}).get("reward")
+    base_val_obj = baseline.get("val") or {}
+    base_val = base_val_obj.get("reward")
     test = final.get("test") or {}
     test_reward = test.get("reward")
     # Baseline scored on the SAME sealed test split — the honest held-out improvement.
@@ -56,15 +70,49 @@ def main(argv=None) -> int:
     test_delta = final.get("test_delta")
     baseline_id = final.get("baseline_id")  # "seed" normally; == best_id if best IS the seed
 
+    # best val, the no-holdout verdict and the consuming-LLM profile are already computed by
+    # the engine's reducer (``cap_evolve.dashboard.reduce_run``). Read them; never recompute
+    # them here and never ask the agent to re-derive them in prose — that is how the report
+    # stopped being comparable between runs.
+    # ponytail: reduces a second time when the dashboard is also written (write_dashboard
+    # reduces again). Thread the reduced dict through write_dashboard if that ever profiles hot.
+    best_val = best_stderr = no_holdout = target_profile = None
+    try:
+        import dashboard
+        reduced = dashboard.reduce_run(run_dir)
+        s = reduced["summary"]
+        best_val = s.get("best_val")
+        best_stderr = next((n.get("stderr") for n in reduced["graph"]["nodes"]
+                            if n.get("id") == s.get("best_id")), None)
+        no_holdout = bool((s.get("splits") or {}).get("no_holdout"))
+        target_profile = s.get("target_profile")
+    except Exception:  # noqa: BLE001 — a broken reducer must never break the report
+        pass
+
+    # Search picks the candidate that scores best on val, so best_val is biased upward by
+    # exactly the selection performed. test has no such bias, so the difference measures how
+    # much the run overfit val.
+    gap = (round(best_val - test_reward, 6)
+           if isinstance(best_val, (int, float)) and isinstance(test_reward, (int, float))
+           else None)
+
     summary = {
         "run_dir": str(run_dir.root),
         "best_id": run_dir.best_id,
+        "finalized": finalized,
+        "no_holdout": no_holdout,
         "baseline_val": base_val,
+        "baseline_val_stderr": base_val_obj.get("stderr"),
+        "best_val": best_val,
         "test_reward": test_reward,
+        "test_stderr": test.get("stderr"),
         "test_baseline_reward": test_baseline_reward,
+        "test_baseline_stderr": test_baseline.get("stderr"),
         "test_delta": test_delta,
         "test_pass_k": test.get("pass_k"),
+        "val_test_gap": gap,
         "iterations": run_dir.spent.iterations,
+        "target_profile": target_profile,
     }
 
     # pass^k for k > n_trials is UNDEFINED, so aggregate_scores omits it (see
@@ -78,21 +126,30 @@ def main(argv=None) -> int:
     if not isinstance(pk, dict):  # legacy run dirs stored a bare scalar
         pk = {"1": pk}
     pk_str = ", ".join(f"pass^{k}={float(pk[k]):.3f}" for k in sorted(pk, key=int))
-    test_line = f"- **Held-out test (optimized skills): {test_reward}**" + (
-        f"  ({pk_str})" if pk else "")
-    md = [
-        f"# cap-evolve run report — {run_dir.root.name}",
-        "",
+
+    md = [f"# cap-evolve run report — {run_dir.root.name}", ""]
+    if not finalized:
+        # The sealed note below is the exact claim a reader relies on. Emitting it for a run
+        # that never scored test is the worst failure mode this phase has — say the opposite.
+        md += ["> **NOT FINALIZED** — no held-out test number. Run the finalize phase first; "
+               "everything below is val-only.", ""]
+    elif no_holdout:
+        md += ["> **No holdout** (train == val == test). The test number below is a *fit* "
+               "metric, not an estimate of generalization.", ""]
+    md += [
         f"- Best candidate: `{run_dir.best_id}`",
-        f"- Baseline val: {base_val}",
-        test_line,
+        f"- Baseline val: {_pm(base_val, base_val_obj.get('stderr'))}",
+        f"- Best val: {_pm(best_val, best_stderr)}",
+        f"- **Held-out test (optimized skills): {_pm(test_reward, test.get('stderr'))}**"
+        + (f"  ({pk_str})" if pk else ""),
     ]
     # When the best candidate IS the seed (no accepted gain), baseline_id == best_id and
     # baseline == optimized — label accordingly rather than implying a separate comparison.
     best_is_seed = baseline_id is not None and baseline_id == run_dir.best_id
     if test_baseline_reward is not None and not best_is_seed:
         baseline_label = f"baseline `{baseline_id}` skills" if baseline_id else "baseline skills"
-        md.append(f"- Held-out test ({baseline_label}): {test_baseline_reward}")
+        md.append(f"- Held-out test ({baseline_label}): "
+                  f"{_pm(test_baseline_reward, test_baseline.get('stderr'))}")
         md.append(
             f"- **Test improvement (optimized − baseline): {test_delta:+}**"
             if isinstance(test_delta, (int, float)) else f"- Test improvement: {test_delta}"
@@ -109,11 +166,16 @@ def main(argv=None) -> int:
             if best_is_seed else
             "Test was scored exactly once on the sealed split."
         )
-    md += [
-        f"- Iterations: {run_dir.spent.iterations}",
-        "",
-        sealed_note,
-    ]
+    if gap is not None:
+        md.append(f"- Val→test gap: {gap:+} — selection optimism on val; this gap IS the overfitting")
+    md.append(f"- Iterations: {run_dir.spent.iterations}")
+    if target_profile and target_profile.get("model"):
+        # The consuming LLM the capabilities were optimized FOR — a different LLM role from
+        # the optimizer model that proposed the edits.
+        md.append(f"- Optimized for: {target_profile['model']}"
+                  + (f" (tier {target_profile['tier']})" if target_profile.get("tier") else ""))
+    if finalized:
+        md += ["", sealed_note]
     (run_dir.root / "report.md").write_text("\n".join(md) + "\n", encoding="utf-8")
 
     if not args.no_dashboard:


### PR DESCRIPTION
Closes #336.

`report` is the phase whose entire justification is producing a *defensible* headline.
On main it emitted a bare point estimate, no best-val, and — on a run that never
finalized — the sentence **"Test was scored exactly once on the sealed split."** That
last one is the worst failure mode available to this phase: it is the exact claim a
reader relies on, and it was untrue with exit code 0.

## The nonexistent-subcommand problem (#203) — report is clean; six other files are not

`cap-evolve report` and `cap-evolve finalize` **do not exist**. Proof — the full command
table from `cap-evolve --help`:

```
  set up    init  doctor  check  algorithms  splits
  optimize  run  estimate
  inspect   diff  watch  tail  replay  dashboard  version  help
```

and `core/cap_evolve/cli.py:1654-1670`:

```python
COMMANDS = {
    "help": _cmd_help, "init": _cmd_init, "doctor": _cmd_doctor,
    "algorithms": _cmd_algorithms, "diff": _cmd_diff, "version": _cmd_version,
    "splits": _cmd_splits, "check": _cmd_check, "run": _cmd_run,
    "estimate": _cmd_estimate, "dashboard": _cmd_dashboard, "tail": _cmd_tail,
    "watch": _cmd_watch, "replay": _cmd_replay,
}
```

Both phases exist only as scripts, invoked by `cap-evolve run` via
`skill_run(step)` (`cli.py:958-962`). This skill was already correct — it invokes
`python scripts/run.py` — and this PR makes that explicit rather than implicit
("There is no `cap-evolve report` subcommand; invoke the script.").

### What the other skills must change (ownership contract forbids me editing them)

Replace each with `python skills/phases/<phase>/scripts/run.py --run-dir …`:

| file | line | text |
|---|---|---|
| `skills/algorithms/hill-climb/SKILL.md` | 53 | "Seal once with `cap-evolve finalize`, then `report`." |
| `skills/algorithms/gepa/SKILL.md` | 106 | same sentence |
| `skills/algorithms/skillopt/SKILL.md` | 83 | same sentence |
| `skills/algorithms/evograph/SKILL.md` | 8, 39, 61, 132, 135 | five occurrences, incl. a bare "`cap-evolve report`" |
| `skills/orchestrate/orchestrate/SKILL.md` | 55 | "call `cap-evolve finalize` … then `cap-evolve report`" |
| `skills/phases/intake/inputs/INPUTS.md` | 174 | "seals with `cap-evolve finalize`" |
| `docs/ROADMAP.md` | 29 | "`cap-evolve report --terminal`" |

`skills/algorithms/agent-optimize/SKILL.md:866` and `docs/AGENT_ORCHESTRATION.md:99-100`
already carry a "there is no such subcommand" footnote — a footnote nobody reads before
typing the command they just saw in an imperative step, which is why the imperative steps
themselves are the fix.

## 2. Output format is now pinned (skill-creator "Defining output formats")

Nothing in SKILL.md said what `report.md` or the stdout JSON must contain, so the model
was free to compose a different summary every run — making runs incomparable, the
opposite of what a report is for. The new `## Output contract` pins the exact `report.md`
skeleton and the exact stdout key set, and says `run.py` owns both.

Every field name was read out of the code, not invented:
`stderr` / `pass_k` from `loop.py:86-98` (`EvalResult.to_dict`, written by
`harness.finalize` at `harness.py:2268`), `best_val` / `splits.no_holdout` /
`target_profile` from `dashboard.reduce_run` (`dashboard.py:1324`, `1150-1156`, `1360`),
`test_baseline` / `baseline_id` / `test_delta` from `harness.py:2270-2281`.

## 3. Determinism — no new script; the deterministic renderer already existed

`scripts/run.py` **is** the bundled script skill-creator asks for. The defect was not a
missing script, it was prose asking the agent to re-derive by hand what the engine
already computes — five lines on `target_profile` (old `SKILL.md:43-47`) that `run.py`
never touched, while `dashboard.py:963-964,1360` had it all along. So the fix is a
deleted paragraph plus three reads, not a second implementation. `best_val`,
`no_holdout` and `target_profile` all come from `reduce_run`; nothing honesty-related is
re-derived in the skill.

Byte-identical across two renders of the same run dir:

```
$ shasum -a 256 /tmp/d1.md /tmp/d2.md
3dace71cd110503507f5da1187d97498a1e13f19fe850c4eb3765c44b7d14d8a  /tmp/d1.md
3dace71cd110503507f5da1187d97498a1e13f19fe850c4eb3765c44b7d14d8a  /tmp/d2.md
$ shasum -a 256 /tmp/d1.json /tmp/d2.json
84c26eee795fbe06d5bc80cf9877d2d39831ce64c5fb30eb8326e6568efec380  /tmp/d1.json
84c26eee795fbe06d5bc80cf9877d2d39831ce64c5fb30eb8326e6568efec380  /tmp/d2.json
BYTE-IDENTICAL
```

## 4. Issue #217 — fixed on main; now it has a regression test

`bash examples/toy_calc/run.sh`, counting top-level JSON values on stdout with
`JSONDecoder.raw_decode`:

```
top-level JSON objects on cap-evolve run stdout: 1
```

(The one non-JSON line, `Working directory: …`, is `run.sh`'s own `echo`, not the CLI.)
The dashboard-launch object moved to stderr in `cli.py:644-650`, and `cap-evolve run`'s
single stdout object **is report's** — `cli.py:966` `last = proc.stdout`, then
`print(last)`. So report owns the most contract-critical `run.py` in the repo, and
nothing tested it: `check.py` called `run.main` inside `quiet()` and threw the output
away. `check.py` now parses that stdout and asserts one object with the documented key
set, on both the `--no-dashboard` and dashboard-on paths (the latter is where a stray
`print` would creep in, since it launches/records a server). No core change needed.

## 5. Ownership contract

`report` is an OWNER of the honest-number invariants, so it states them — the
`test ≈/≫ baseline`, `val ≫ test`, and pass^k readings, and the "always show the noise
floor" rule. It does not restate the gate decision or the seal mechanics beyond one
sentence. There was no agent-mode-loop or failure-taxonomy restatement to delete in this
file. Removed:

- `## Inputs / outputs (manifest tokens)` — frontmatter restated as prose (contract §"Two
  specific defects", item 2)
- the eight-panel dashboard enumeration, 34 of 106 lines, a lossy paraphrase of
  `references/dashboard.md:60-111` → six lines plus a load-when pointer
- the `## Dual-mode` paragraph, byte-identical in 8 of 8 phase skills → one line
- `## What good vs bad looks like` — restated the interpretation bullets directly above it
- the five `target_profile` lines (see §3)

`meta.yaml` gains a comment instead of a token: the real dependency is finalize's sealed
test number, but finalize also `provides: [report]`, so there is no distinct token to
need — and unilaterally declaring `needs: [sealed_test]` would make
`orchestrate/scripts/run.py:74-78` report an unsatisfiable dependency. **finalize should
change `provides: [report]` → `provides: [sealed_test]`**, after which report can declare
`needs: [sealed_test]`; that is a finalize-owned edit.

## Evidence

**SKILL.md 106 → 99 lines.** `python -m compileall -q core skills` clean.

`python skills/phases/report/scripts/check.py`:

```json
{"skill": "report", "ok": true, "problems": [], "notes": ["run entry exposes main()",
 "stdout is exactly one JSON object", "summary carries the documented key set",
 "writes report.md", "report carries baseline → sealed test",
 "renders reward ± stderr when stderr is known",
 "JSON summary carries test/baseline stderr",
 "JSON summary carries best_val + val→test gap",
 "report.md carries best val + the val→test gap",
 "no false seal claim before finalize", "labels a no-holdout run as a fit metric", …]}
```

Real run — `bash examples/toy_calc/run.sh` → `report.md` through the pinned template:

```markdown
# cap-evolve run report — run_demo

- Best candidate: `cand_0001`
- Baseline val: 0.0 ± 0.0
- Best val: 1.0 ± 0.0
- **Held-out test (optimized skills): 1.0 ± 0.0**  (pass^1=1.000)
- Held-out test (baseline `seed` skills): 0.0 ± 0.0
- **Test improvement (optimized − baseline): +1.0**
- Val→test gap: +0.0 — selection optimism on val; this gap IS the overfitting
- Iterations: 3

Test was scored exactly once on the sealed split, for BOTH the baseline (`seed`) and the optimized skills — the improvement above is on held-out tasks the optimizer never saw.
```

and its JSON summary (before: 8 keys, no variance, no best-val):

```json
{
  "run_dir": ".capevolve/run_demo",
  "best_id": "cand_0001",
  "finalized": true,
  "no_holdout": false,
  "baseline_val": 0.0,
  "baseline_val_stderr": 0.0,
  "best_val": 1.0,
  "test_reward": 1.0,
  "test_stderr": 0.0,
  "test_baseline_reward": 0.0,
  "test_baseline_stderr": 0.0,
  "test_delta": 1.0,
  "test_pass_k": {"1": 1.0},
  "val_test_gap": 0.0,
  "iterations": 3,
  "target_profile": null,
  "dashboard": ".capevolve/run_demo/dashboard.html",
  "dashboard_server": "http://127.0.0.1:7878"
}
```

The unfinalized case that used to claim a seal:

```markdown
# cap-evolve run report — run_chk

> **NOT FINALIZED** — no held-out test number. Run the finalize phase first; everything below is val-only.

- Best candidate: `None`
- Baseline val: 0.4 ± 0.03
- Best val: 0.4 ± 0.03
- **Held-out test (optimized skills): None**
- Iterations: 0
```

No "sealed" sentence, and `"finalized": false` in the JSON.

Test suite — matches clean main (#349), pinned imports per the worktree warning:

```
$ PYTHONPATH="$PWD/core:$PWD/dashboard/backend" python -m pytest core/tests -q
789 passed, 12 skipped in 113.58s
```

## Deliberately not done

- The seven files in the #203 table — ownership contract; listed above for the owning agents.
- Auditing every `print(` in `cli.py` for #217 — the report half is covered and tested; the rest is #217's.
- `needs: [sealed_test]` — needs finalize's `provides` changed first (see §5).
- Exiting non-zero on an unfinalized run. #336 allows either; labelling removes the lie
  without adding a failure mode to `--terminal`-style progress reporting.
- `scripts/__pycache__/*.pyc` checked into the skill dir — repo hygiene, one `.gitignore`
  line, not this issue.
