### PR TITLE
implement-and-check: make the hard gate honest about what it actually verifies (#337)

### DIFF
--- a/skills/phases/implement-and-check/SKILL.md
+++ b/skills/phases/implement-and-check/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: implement-and-check
-description: The HARD GATE that must pass before any optimization budget is spent. Use right after intake. Walks the agent through implementing the 3 required adapter methods plus any defaulted hooks that need overriding (and any selected skill's abstract methods), then runs `cap-evolve check` on the project plus each involved skill's check.py, refusing to proceed until everything is implemented and deterministic — and listing exactly what is still stubbed.
+description: Runs the hard gate that has to pass before any optimization budget is spent. Use right after intake. Walks the agent through implementing the 3 required adapter methods plus any defaulted hooks that need overriding (and any selected skill's abstract methods), then runs `cap-evolve check` on the project plus each involved skill's check.py, listing exactly what is still stubbed or non-deterministic and what to do about each kind of failure.
 component: phase
 argument-hint: "--project .capevolve/project --skill-check PATH"
 allowed-tools: Read, Write, Edit, Bash
@@ -11,102 +11,120 @@ sources: [skillopt]
 
 # implement-and-check — make the contract real
 
-Optimizing against a half-wired adapter produces a number that means nothing: if
-the scorer is a stub, every candidate scores the same; if `tasks()` is empty, the
-mean is computed over nothing; if `run_target` is non-deterministic in a way the
-scorer can't see, the gate chases ghosts. This phase is the **hard gate** that
-ensures the contract holds *before* a single unit of budget is spent. It is
-cheaper to fail here than after a full optimization run.
-
-## Inputs / outputs (manifest tokens)
-- **needs:** `project` — the scaffolded `.capevolve/project/` from intake.
-- **provides:** `checked` — the proof that the adapter (and any involved skill)
-  is fully implemented and deterministic. `baseline` will not run without it.
+Optimizing against a half-wired adapter produces a number that means nothing: a stub
+scorer gives every candidate the same reward, an empty `tasks()` averages over nothing,
+a non-deterministic scorer makes the gate chase measurement noise. This phase proves the
+measurement apparatus works *before* budget is spent. It is cheaper to fail here than
+after a full run.
 
 ## Steps
-1. **Implement the 3 required adapter methods** in
-   `.capevolve/project/adapters/adapter.py` (see `docs/ADAPTER_CONTRACT.md`). These
-   three are `@abstractmethod` — the gate refuses to run until all three are real:
-   - `tasks(split)` — yield the evaluation tasks (non-empty, stable across calls).
-   - `run_target(task, ctx, *, seed=0)` — run the agent under test with the candidate
-     live as `ctx`; capture output + trace into a `Rollout`. Forward `seed` if the
-     runner is stochastic.
-   - `score(task, rollout)` — return a reward in `[0,1]` + general feedback (no
-     gold-answer leakage — it becomes the diagnosis signal).
 
-   Then override a **defaulted hook** only if its default does not fit your capability:
-   `materialize(candidate_dir, edits=None)` (default: pure write of each
-   `{component: text}` edit as a file under `candidate_dir` — override to support a
-   capability-specific patch format),
-   `live(candidate_dir)` (context manager yielding `ctx`), `apply(candidate_dir, edits=None)`
-   (back-compat inject), `trajectories(split, ctx=None)` / `runner_model()` (both default
-   to `None`). Separately, `run_batch` / `run_trials` / `score_batch` are not on the base
-   class — the harness feature-detects them with `hasattr` and uses them if you define them.
-2. **Implement any selected skill's `scripts/abstract.py`** (most are concrete and
-   need nothing).
+1. **Implement the 3 required adapter methods** in
+   `.capevolve/project/adapters/adapter.py`. These are the `@abstractmethod`s
+   (`core/cap_evolve/adapter.py:77-106`) — the gate refuses to run until all three are real:
+   - `tasks(split)` → `list[Task]` for `'train'|'val'|'test'|'all'`; non-empty, same list
+     every call.
+   - `run_target(task, ctx, *, seed=0)` → `Rollout`. Run the agent under test with the
+     candidate live as `ctx`; capture output + trace + tool calls + cost. Do not score
+     here. Forward `seed` if the runner is stochastic; set `Rollout.error` on an infra
+     failure so the engine treats it as noise, not as a low score.
+   - `score(task, rollout)` → `Score`: reward in `[0,1]` + general feedback (it becomes
+     the diagnosis signal, so never leak the gold answer).
+
+   Override a **defaulted hook** only when its default does not fit:
+   `materialize(candidate_dir, edits=None)` (pure write of `{component: text}`),
+   `live(candidate_dir)` (context manager yielding `ctx`),
+   `apply(candidate_dir, edits=None)` (back-compat inject),
+   `trajectories(split, ctx=None)` and `runner_model()` (both default `None`).
+   Three **optional fast paths** are not on the base class at all — the harness
+   feature-detects them with `hasattr` and uses them only if you define them:
+   `run_batch(tasks, ctx, *, seed)` (drive a benchmark's own batch runner *instead of*
+   `run_target`), `run_trials(tasks, ctx, *, n_trials, base_seed)` (all trials in one
+   concurrent run), `score_batch(tasks, rollouts)` (score a whole trial in one external
+   harness call). `docs/ADAPTER_CONTRACT.md` is the full contract, including the
+   shown-only `metrics` catalog `score()` may return.
+
+   Note `capability_sources` is **not** an adapter method — it is a `capevolve.yaml` key
+   (the data-model/types files copied into the optimizer's context), owned by intake.
+
+2. **Implement any selected skill's `scripts/abstract.py`** (most are concrete and need
+   nothing).
+
 3. **Run the gate:**
    ```
    python scripts/run.py --project .capevolve/project \
        --skill-check <skills>/capabilities/<cap>/scripts/check.py
    ```
-   It runs `cap-evolve check` (adapter: no stubs, `tasks` non-empty + stable, scorer
-   deterministic, `materialize()` probed) and each named skill's `check.py`. **Exit 0 =
-   green; the JSON lists exactly what is still stubbed or non-deterministic.**
-4. **Pipeline-wiring self-test (runs automatically once the check is green).** A
-   green adapter is necessary but not sufficient — the optimizer also needs its
-   *context* wired. After the check passes, `run.py` runs `pipeline_selftest.py`,
-   a cheap, benchmark-agnostic check (no API cost) that asserts the plumbing the
-   optimizer depends on:
-   - the optimizer-prompt template is scaffolded at `optimizer/INSTRUCTIONS.md`
-     and still carries its `{{...}}` placeholders (intake must not delete them);
-   - `capevolve.yaml::optimizer_instructions_file` points at a file that EXISTS;
-   - rendering that template through the REAL harness renderer leaves NO `{{`
-     placeholder behind (every dynamic block substitutes);
-   - the adapter either DEFINES `trajectories()` (native traj dir → copied verbatim
-     into the optimizer's `./trajectories/`) or intentionally inherits the base
-     default (cap-evolve falls back to its per-rollout JSON) — both valid, reported.
+   Exit 0 = green. The JSON has three fields with three different meanings — see the
+   table below before you react to it.
 
-   It reports the precise missing/broken artifact so you can iterate until green.
-   (Pass `--no-pipeline-selftest` to skip it; run it standalone with
-   `python scripts/pipeline_selftest.py --project .capevolve/project`.)
+4. **Pipeline-wiring self-test (automatic once the check is green).** A green adapter is
+   necessary but not sufficient — the optimizer also needs its *context* wired. `run.py`
+   then runs `pipeline_selftest.py` (zero API cost): the optimizer-prompt template named
+   by `capevolve.yaml::optimizer_instructions_file` exists, still carries its `{{...}}`
+   placeholders, and renders through the real harness renderer with none left over; and
+   whether the adapter defines `trajectories()` or inherits the base default (both valid,
+   both reported). The template checks are **skipped with a note** for an algorithm that
+   never reads the template — only `hill-climb` is passed `--instructions-file`
+   (`cli.py:869-876`). `--no-pipeline-selftest` skips it; it also runs standalone.
 
-   A full one-iteration mock run is intentionally NOT done here: it would need a
-   baseline + frozen split + run dir that do not exist yet at gate time, and those
-   are benchmark-specific. This self-test exercises the same workdir-building and
-   prompt-rendering code paths instead — the wiring an optimizer actually consumes.
+   A full one-iteration mock run is deliberately not attempted: it would need a baseline,
+   a frozen split and a run dir that do not exist yet at gate time, and building them is
+   benchmark-specific. This exercises the same workdir-building and prompt-rendering paths.
 
-## What the check actually verifies (and why)
-- **No stubs** — a `NotImplementedError`/`pass` body means the method silently
-  returns nothing; the resulting score is meaningless.
-- **`tasks` non-empty and stable** — an empty or shuffling task set makes the
-  mean and the split irreproducible.
-- **Scorer determinism** — score the same rollout twice; differing rewards mean
-  the "reward" includes scorer noise the optimizer cannot learn from. (Target
-  *stochasticity* is fine and is handled by multi-trial evaluation; *scorer*
-  nondeterminism is a bug.)
-- **`materialize()` probed** — an edit that cannot be materialized cannot be
-  evaluated, so the check calls it against a temp copy (pure, so the host is untouched).
-  This one is a probe, not an assertion: a raise is reported as a **note** and does not
-  fail the check (`core/cap_evolve/check.py:166-167`), because a real adapter may need its
-  full environment. Green here means "callable or explained", not "edit path verified".
+## When it is red — what to do, per failure kind
 
-## Do not proceed until green
-If it reports stubs or non-determinism, fix them and re-run. This is the standard
-validation-gate discipline for self-improving systems: prove the measurement
-apparatus works before you trust any measurement it produces. A green check is
-the only honest entry into `baseline`.
+`CheckReport` has three fields (`core/cap_evolve/check.py:30-38`) and only `problems`
+affects `ok`. Treating a note as a failure is how an agent gets stuck in a loop.
 
-## What good vs bad looks like
-- **Good:** `{"ok": true}` with all 3 required methods concrete, a deterministic scorer,
-  and every involved skill's check green.
-- **Bad:** proceeding on a red check "to save time"; a scorer that returns
-  different rewards for the same rollout; an empty/placeholder `tasks()`; feedback
-  that leaks the gold answer (passes the wiring check but corrupts diagnosis).
+| report field / message | what it means | do this |
+|---|---|---|
+| `stubs: ["<name>"]` | that method still raises the `IMPLEMENT ME` marker | write the method in `adapters/adapter.py`; nothing later was even probed (`check.py:102-107`) |
+| `"could not load adapter: ..."` | import/instantiation failed — often an unimplemented `@abstractmethod` (`TypeError`) or a bad sibling import | fix the import or define all three abstract methods; the adapter's own dir is on `sys.path`, so sibling helpers import plainly |
+| `"tasks('val') raised: ..."` | the data path is wrong | point `tasks()` at real data; check the `split` argument is being honored |
+| `"tasks('val') returned an empty list"` | the split has no tasks | usually a filter or path that matched nothing — print the list before returning |
+| `"tasks('val') is not stable across calls"` | ids differ between two calls | remove `set`/`dict` iteration order and any per-call shuffle; sort explicitly |
+| `"scorer is non-deterministic: X vs Y"` | `score()` returned two rewards for one rollout | remove the RNG, or pin an LLM judge's decoding (temperature 0) and cache nothing that hides the variance |
+| `"score(...) raised on a probe rollout"` | the scorer cannot survive an unfamiliar output | make `score()` total — an unparseable output is reward 0 with feedback, not an exception |
+| `notes: [...]` | informational, incl. the `materialize()` probe raise and the consuming-model tier mismatch | read; do **not** treat as failure |
+| skill `check.py` red | that capability/algorithm skill's own contract is unmet | run its `check.py` directly; its JSON names the assertion |
+
+Re-run until green. Green is the entry condition for `baseline`.
+
+## What the gate does and does not guarantee
+
+Determinism is genuinely executed, not asserted: `check.py:133-142` scores one fixed
+rollout twice and reports a problem when the rewards differ. Do not read more into green
+than that. Measured on this checkout (issue #358):
+
+- **`run_target` is never called** on the default path, so a `pass`-body runner goes
+  green and fails later, after the split is frozen.
+- The scorer probe uses a **synthetic** rollout (`output="__probe_output__"`), so a
+  scorer that short-circuits on unrecognizable output — every LLM-judge scorer — is not
+  really tested. Both `score()` calls happen on one in-process instance, so a memoized
+  scorer is unfalsifiable here.
+- `materialize()` is a **probe, not an assertion**: a raise is a note and does not fail
+  the check (`check.py:166-167`), because a real adapter may need its full environment.
+  Green means "callable or explained", not "edit path verified".
+- `cap-evolve run` fails closed: `cli.py:721-726` returns 1 before creating a run dir, so
+  no split and no spend. The **standalone** `/cap-evolve:*` chain does not —
+  `baseline/scripts/run.py` contains no check, and `provides: checked` is a static
+  ordering token, not a runtime precondition.
+
+If your scorer calls a judge, say so in `PROJECT.md` along with how its decoding is
+pinned — the gate cannot see it. The one failure mode nothing here can catch: feedback
+that leaks the gold answer passes every wiring check and still corrupts diagnosis.
 
 ## Dual-mode
-This phase runs two ways from the **same** SKILL.md: standalone as the slash command `/cap-evolve:implement-and-check` (the `argument-hint` shows its run.py args), and orchestrator-callable — `cap-evolve run` / the `orchestrate` skill invokes the same `scripts/run.py` headlessly and threads the run dir between phases.
+
+Standalone as `/cap-evolve:implement-and-check`; orchestrator-callable — but uniquely for
+this phase, `cap-evolve run` does **not** invoke `scripts/run.py`. It calls the core check
+inline and shells straight to `baseline`, so `--skill-check` and the pipeline self-test run
+in standalone mode only. Run this phase yourself before either `cap-evolve run` or
+`/cap-evolve:baseline` if you want them — and, per the previous section, the standalone
+chain has no gate of its own.
 
 ## References
-- `references/concepts.md` — the adapter contract, why each check exists, the
-  scorer-determinism-vs-target-stochasticity distinction, and the
-  validation-gate-before-budget rationale, with sources.
+- `references/concepts.md` — why each check exists, the
+  scorer-determinism-vs-target-stochasticity distinction (load this when deciding whether
+  your scorer's variance is a bug or a measurement), and the sources.

--- a/skills/phases/implement-and-check/references/concepts.md
+++ b/skills/phases/implement-and-check/references/concepts.md
@@ -4,24 +4,16 @@
 > is trusted. A green check is the only honest entry into the optimization loop.
 > Implementation: `cap_evolve.check.run_check` + each skill's `scripts/check.py`.
 
-## The adapter is the contract
+## What a stub actually costs
 
-cap-evolve measures everything through **3 required methods** the user implements
-(plus defaulted hooks). The check verifies each required one is real:
+The method list itself is in SKILL.md step 1 and `docs/ADAPTER_CONTRACT.md`. What matters
+here is what each one being fake does to the number:
 
-| method                             | contract                                            | failure if stubbed                |
-|------------------------------------|-----------------------------------------------------|-----------------------------------|
-| `tasks(split)`                     | non-empty, stable across calls                      | mean over nothing; unstable split |
-| `run_target(task, ctx, *, seed=0)` | runs the agent, captures output + trace into Rollout| no behavior to score              |
-| `score(task, rollout)`             | reward ∈ [0,1] + general feedback, deterministic    | every candidate scores the same   |
-
-Beyond those three, `materialize(candidate_dir, edits=None)`, `live(candidate_dir)`,
-`apply(candidate_dir, edits=None)`, `trajectories(split, ctx=None)` and `runner_model()`
-are **defaulted hooks** — they are defined on the base class with working defaults (the
-last two `return None`) and are called unconditionally, so override them only when the
-default does not fit. Separately, `run_batch` / `run_trials` / `score_batch` are **not** on
-the base class at all; the harness feature-detects them with `hasattr` and uses them only
-when an adapter defines them.
+| method                             | failure if stubbed or fake                          |
+|------------------------------------|-----------------------------------------------------|
+| `tasks(split)`                     | mean over nothing; unstable or non-disjoint split   |
+| `run_target(task, ctx, *, seed=0)` | no behavior to score — every rollout is empty       |
+| `score(task, rollout)`             | every candidate scores the same; the gate is blind  |
 
 If any required method is a stub, the optimization still *runs* — it just produces a number
 that measures nothing. The whole point of a pre-budget gate is to make that

--- a/skills/phases/implement-and-check/scripts/check.py
+++ b/skills/phases/implement-and-check/scripts/check.py
@@ -1,5 +1,15 @@
-"""Contract: implement-and-check is a real gate — it reports ok=False (and exit
-nonzero) for a project whose adapter is missing or stubbed, rather than passing.
+"""Contract: implement-and-check is a real gate, not a no-op.
+
+Asserts the three behaviours the phase actually promises:
+  1. a project with NO adapter is refused;
+  2. a LOADABLE adapter whose method raises the IMPLEMENT-ME marker is named in
+     ``rep.stubs`` (the old fixture was an ABC with unimplemented abstractmethods, so
+     instantiation raised TypeError and ``stub_methods`` was never reached);
+  3. a non-deterministic ``score()`` yields a "non-deterministic" problem — the one
+     assertion the whole honesty story of this phase rests on.
+
+Known gaps in the core gate are tracked in issue #358 and documented in SKILL.md under
+"What the gate does and does not guarantee"; they are deliberately NOT asserted here.
 """
 
 from __future__ import annotations
@@ -13,30 +23,64 @@ import _bootstrap  # noqa: F401
 from cap_evolve.check import run_check
 from cap_evolve.skillcheck import Checker, import_run
 
+_HEAD = (
+    "from cap_evolve import CapabilityAdapter\n"
+    "from cap_evolve.types import Task, Rollout, Score\n"
+)
+
+# Loadable (all three abstract methods overridden) but `score` re-raises the marker.
+_MARKER_STUB = _HEAD + (
+    "class Adapter(CapabilityAdapter):\n"
+    "    def tasks(self, split): return [Task(id='t1', input='1+1', target='2')]\n"
+    "    def run_target(self, task, ctx, *, seed=0): return Rollout(task_id=task.id, output='2')\n"
+    "    def score(self, task, rollout):\n"
+    "        raise NotImplementedError('IMPLEMENT ME: score(task, rollout)')\n"
+)
+
+_RNG_SCORER = _HEAD + (
+    "import random\n"
+    "class Adapter(CapabilityAdapter):\n"
+    "    def tasks(self, split): return [Task(id='t1', input='1+1', target='2')]\n"
+    "    def run_target(self, task, ctx, *, seed=0): return Rollout(task_id=task.id, output='2')\n"
+    "    def score(self, task, rollout):\n"
+    "        return Score(task_id=task.id, reward=random.random(), feedback='rng')\n"
+)
+
+
+def _project(tmp: str, source: str) -> Path:
+    proj = Path(tmp) / "project"
+    (proj / "adapters").mkdir(parents=True)
+    (proj / "adapters" / "adapter.py").write_text(source, encoding="utf-8")
+    return proj
+
 
 def main() -> int:
     c = Checker("implement-and-check")
     c.require_main(import_run())
 
-    # A project with no adapter must NOT pass the gate.
+    # 1. No adapter at all must not pass the gate.
     with tempfile.TemporaryDirectory() as d:
         empty = Path(d) / "project"
         empty.mkdir()
         rep = run_check(empty)
-        c.check(not rep.ok and rep.problems,
+        c.check(not rep.ok and bool(rep.problems),
                 "check passed a project with no adapter (gate is a no-op)",
-                note="refuses a project with no/stubbed adapter")
+                note="refuses a project with no adapter")
 
-    # A stubbed adapter (IMPLEMENT-ME methods) must be flagged as stubs.
+    # 2. A loadable, marker-stubbed method must be NAMED in rep.stubs.
     with tempfile.TemporaryDirectory() as d:
-        proj = Path(d) / "project"
-        (proj / "adapters").mkdir(parents=True)
-        (proj / "adapters" / "adapter.py").write_text(
-            "from cap_evolve import CapabilityAdapter\n"
-            "class Adapter(CapabilityAdapter):\n    pass\n", encoding="utf-8")
-        rep = run_check(proj)
-        c.check(not rep.ok, "check passed a stubbed adapter",
-                note="flags unimplemented adapter methods")
+        rep = run_check(_project(d, _MARKER_STUB))
+        c.check(not rep.ok and "score" in rep.stubs,
+                f"stubbed score() not reported in stubs (got stubs={rep.stubs}, "
+                f"problems={rep.problems})",
+                note="names the unimplemented method in stubs[]")
+
+    # 3. A non-deterministic scorer must produce a "non-deterministic" problem.
+    with tempfile.TemporaryDirectory() as d:
+        rep = run_check(_project(d, _RNG_SCORER))
+        c.check(not rep.ok and any("non-deterministic" in p for p in rep.problems),
+                f"RNG scorer passed the determinism probe (problems={rep.problems})",
+                note="detects a non-deterministic score()")
 
     return c.emit()
 

--- a/skills/phases/implement-and-check/scripts/pipeline_selftest.py
+++ b/skills/phases/implement-and-check/scripts/pipeline_selftest.py
@@ -13,14 +13,19 @@ that build the optimizer's working dir, using the real harness renderer, and
 reports precisely which artifact is missing so the intake agent can iterate.
 
 It asserts:
-  1. the optimizer-prompt template is scaffolded at ``optimizer/INSTRUCTIONS.md``
-     and still carries its ``{{...}}`` placeholders (intake must NOT delete them);
-  2. ``capevolve.yaml::optimizer_instructions_file`` points at a file that EXISTS;
+  1. ``capevolve.yaml`` exists (intake must scaffold the spec);
+  2. the optimizer-prompt template named by ``optimizer_instructions_file`` EXISTS and
+     still carries its ``{{...}}`` placeholders (intake must NOT delete them);
   3. rendering that template through the REAL harness renderer leaves NO ``{{``
      placeholder behind (the harness fills them per iteration);
   4. the adapter EITHER defines ``trajectories()`` (returns the native traj dir) OR
      intentionally inherits the base default (cap-evolve falls back to its own
      per-rollout JSON) — both are valid; we just report which.
+
+Assertions 2-3 are SKIPPED WITH A NOTE for an algorithm that never reads the template
+(see ``_TEMPLATE_CONSUMERS``): this phase declares ``algorithms: ["*"]``, so failing a
+gepa/evograph run on an artifact it will never open would be an algorithm-specific
+false negative. Assertions 1 and 4 always run.
 
 Exit 0 = wiring green; non-zero = a named artifact is missing/broken.
 """
@@ -39,6 +44,12 @@ from cap_evolve.adapter import CapabilityAdapter
 from cap_evolve.check import load_adapter
 from cap_evolve.harness import _focus_instructions
 from cap_evolve.loop import SplitResult
+
+# Algorithms whose runner actually reads ``optimizer_instructions_file``. ``cli.py`` passes
+# ``--instructions-file`` only when the algorithm is hill-climb, and that flag exists in
+# exactly one algorithm's argparse (``skills/algorithms/hill-climb/scripts/run.py``). Add a
+# name here when another algorithm's run.py grows the flag.
+_TEMPLATE_CONSUMERS = frozenset({"hill-climb"})
 
 
 def _synthetic_val() -> SplitResult:
@@ -70,40 +81,49 @@ def selftest(project: Path) -> dict:
     if not spec_path.exists():
         problems.append(f"missing spec: {spec_path} (intake must scaffold capevolve.yaml)")
 
-    instr_rel = str(spec.get("optimizer_instructions_file") or "optimizer/INSTRUCTIONS.md")
-    instr_path = project / instr_rel
-    if not instr_path.exists():
-        problems.append(
-            f"optimizer_instructions_file points at a missing file: {instr_rel} "
-            f"(expected an existing template under {project}/)")
-        template = ""
+    # The template checks only apply to an algorithm that actually READS the template.
+    # ``cli.py`` passes ``--instructions-file`` for hill-climb only, and that flag exists
+    # in exactly one algorithm's argparse — so gating a gepa/evograph/agent-optimize run on
+    # an artifact it will never open is a benchmark/algorithm-specific false failure.
+    algo = str(spec.get("algorithm_skill") or "hill-climb")
+    if algo not in _TEMPLATE_CONSUMERS:
+        notes.append(f"algorithm '{algo}' does not consume optimizer_instructions_file "
+                     "— optimizer-template checks skipped")
     else:
-        template = instr_path.read_text(encoding="utf-8")
-        if "{{" not in template:
+        instr_rel = str(spec.get("optimizer_instructions_file") or "optimizer/INSTRUCTIONS.md")
+        instr_path = project / instr_rel
+        if not instr_path.exists():
             problems.append(
-                f"template {instr_rel} has NO {{{{...}}}} placeholders — intake must "
-                "KEEP them (the harness fills FOCUS_SUMMARY/FAILURES/CAP_BRIEF/"
-                "ALGO_BRIEF/BENCH_REPO per iteration); did you over-customize it?")
+                f"optimizer_instructions_file points at a missing file: {instr_rel} "
+                f"(expected an existing template under {project}/)")
+            template = ""
         else:
-            notes.append(f"optimizer template OK with intact placeholders: {instr_rel}")
+            template = instr_path.read_text(encoding="utf-8")
+            if "{{" not in template:
+                problems.append(
+                    f"template {instr_rel} has NO {{{{...}}}} placeholders — intake must "
+                    "KEEP them (the harness fills FOCUS_SUMMARY/FAILURES/CAP_BRIEF/"
+                    "ALGO_BRIEF/BENCH_REPO per iteration); did you over-customize it?")
+            else:
+                notes.append(f"optimizer template OK with intact placeholders: {instr_rel}")
 
-    # 3) render through the REAL harness renderer; no {{ may survive
-    if template and "{{" in template:
-        caps = [c for c in (spec.get("capabilities") or []) if c]
-        rendered = _focus_instructions(
-            _synthetic_val(), None, "pipeline self-test",
-            capabilities=caps, algorithm=str(spec.get("algorithm_skill") or "hill-climb"),
-            instructions_file=instr_path,
-            bench_repo=(str(spec.get("runner_repo_path")) or None),
-        )
-        if "{{" in rendered:
-            leftovers = sorted({tok.split("}}")[0] for tok in rendered.split("{{")[1:]})
-            problems.append(
-                "rendered INSTRUCTIONS.md still has leftover placeholder(s): "
-                + ", ".join("{{" + x + "}}" for x in leftovers)
-                + " — the harness did not substitute them (a placeholder typo?)")
-        else:
-            notes.append("rendered INSTRUCTIONS.md has no leftover {{ placeholders")
+        # 3) render through the REAL harness renderer; no {{ may survive
+        if template and "{{" in template:
+            caps = [c for c in (spec.get("capabilities") or []) if c]
+            rendered = _focus_instructions(
+                _synthetic_val(), None, "pipeline self-test",
+                capabilities=caps, algorithm=algo,
+                instructions_file=instr_path,
+                bench_repo=(str(spec.get("runner_repo_path")) or None),
+            )
+            if "{{" in rendered:
+                leftovers = sorted({tok.split("}}")[0] for tok in rendered.split("{{")[1:]})
+                problems.append(
+                    "rendered INSTRUCTIONS.md still has leftover placeholder(s): "
+                    + ", ".join("{{" + x + "}}" for x in leftovers)
+                    + " — the harness did not substitute them (a placeholder typo?)")
+            else:
+                notes.append("rendered INSTRUCTIONS.md has no leftover {{ placeholders")
 
     # 4) trajectories(): defined OR intentionally inherited (both valid)
     try:


### PR DESCRIPTION
Closes #337 (the skill half). Core half filed as #358.

## The central question: is the hard gate actually hard?

**Yes for determinism — and that is the headline, because it comes out clean.** `cap-evolve
check` does not merely assert `score()` exists. `core/cap_evolve/check.py:133-142` calls it
**twice on identical input and compares the rewards**, appending a problem when they differ
by more than `tolerance`. Verified empirically against a `random.random()` scorer.

Not hard in three places, all measured, none of them prose-only. Those are #358; this PR
makes the skill stop implying coverage the code does not have.

### Experiment 1 — stub detection and `score()` determinism

Nine throwaway adapters through `run_check` (`/tmp/gate337/mk.py`, script inline in #358):

```
$ CORE="$PWD/core" python /tmp/gate337/mk.py
A_stub_marker_score                ok=False stubs=['score'] problems=['unimplemented adapter methods: score — implement them in adapters/adapter.py']
B_run_target_pass_body             ok=True  stubs=[] problems=[]
C_score_truly_random               ok=False stubs=[] problems=['scorer is non-deterministic: 0.2634411904610948 vs 0.7457569935463084 on identical input']
D_score_random_but_shortcircuits   ok=True  stubs=[] problems=[]
E_score_memoized                   ok=True  stubs=[] problems=[]
F_score_pass_body                  UNCAUGHT AttributeError: 'NoneType' object has no attribute 'reward'
G_all_real                         ok=True  stubs=[] problems=[]
H_tasks_empty                      ok=False stubs=[] problems=["tasks('val') returned an empty list"]
I_tasks_unstable                   ok=False stubs=[] problems=["tasks('val') is not stable across calls (must be deterministic)"]
```

- **A / C / H / I pass the gate correctly.** Marker stubs, RNG scorers, empty splits and
  shuffling `tasks()` are all caught, in code.
- **B: a `pass`-body `run_target` goes green.** `run_target` is never called on the default
  path — only inside the doubly opt-in degenerate-trials probe (`check.py:177-179`), and
  `stub_methods` only detects the `IMPLEMENT ME` marker (`adapter.py:212-214`), which a
  `pass` body never raises.
- **D: a judge-style scorer whose non-determinism sits behind a plausibility guard goes
  green.** The probe uses `Rollout(output="__probe_output__")` (`check.py:132`), which
  short-circuits before the RNG. That is the shape of every LLM-judge scorer — the exact
  class `references/concepts.md` tells users is acceptable at temperature 0.
- **E: a memoized RNG scorer goes green.** Both calls hit one in-process instance.
- **F: `score()` returning `None` crashes.** `s1.reward` (`check.py:139`) is outside the
  `try` at 133-138. It fails *closed*, but the JSON report the skill promises never prints.

### Experiment 2 — does it fail closed?

Sabotaged the working `toy_calc` project's scorer with an RNG override and ran the real CLI:

```
$ bash /tmp/gate337/failclosed.sh <repo>
### cap-evolve run (nondeterministic scorer):
{"step": "implement-and-check", "error": "check failed", "report": {"ok": false, "stubs": [],
 "problems": ["scorer is non-deterministic: 0.42475758498842486 vs 0.9776611661211828 on identical input"],
 "notes": ["tasks('val') -> 8 task(s)", "materialize() callable (dry-run into temp copy; host untouched)"]}}
### exit code: 1

### run dirs created (expect NONE):
(no run_* directory — no split frozen, no budget spent)

### splits.json anywhere?
(end)
```

`cli.py:721-726` runs the check and `return 1` **before** `skill_run("baseline")` at
`cli.py:765`. No run dir, no `splits.json`, no `events.jsonl`, no spend. **`cap-evolve run`
fails closed, demonstrated not asserted.**

The standalone chain does **not**:

```
$ bash /tmp/gate337/standalone.sh
### grep run_check in baseline phase runner:
0
### running baseline directly (the /cap-evolve:baseline standalone path):
### exit: 0
### did it freeze a split anyway?
FROZEN: .../run_standalone/splits.json
{'train': 4, 'val': 2, 'test': 2, 'seed': 0, 'test_used': False}
```

Same red-check adapter, exit 0, split frozen, baseline eval spent. `provides: checked` is a
**static ordering token** validated over the declared sequence
(`orchestrate/scripts/run.py:61-81`) — it never observes runtime state. So the old
`SKILL.md:24` claim "`baseline` will not run without it" was **false on the very path the
skill itself documents**. Corrected, not papered over.

## What changed in the skill

**SKILL.md 112 → 130 lines.** It grew, deliberately: the two things it was missing are a
per-failure action table and an honest statement of the gate's limits. Everything ceremonial
came out to pay for them.

1. **Actionability (job 4).** "Do not proceed until green" was three sentences of discipline,
   not instruction. Replaced with a `stubs` / `problems` / `notes` → action table covering
   nine message kinds, stating that **only `problems` affects `ok`** — an agent that treats
   the `materialize()` probe note or the consuming-model tier note as a failure loops forever,
   and nothing told it otherwise.
2. **New "What the gate does and does not guarantee".** States, with `file:line`, that
   determinism *is* executed, and then that `run_target` is unverified, the scorer probe is
   synthetic and in-process, `materialize()` is a probe not an assertion, and `cap-evolve run`
   fails closed while the standalone chain does not. References #358.
3. **Dual-mode corrected.** The paragraph is byte-identical across eight phase skills — and
   here it is *false*: `cap-evolve run` never invokes this phase's `run.py`
   (`skill_run("implement-and-check")` appears nowhere), it calls the core check inline. So
   `--skill-check` and the pipeline self-test — the only two things this skill adds over the
   core check — are silently skipped in orchestrated mode. Now said plainly.
4. **Adapter contract completed (job 3).** Verified line-by-line against
   `core/cap_evolve/adapter.py:77-183` and `docs/ADAPTER_CONTRACT.md:8-60`. The skill was
   already right about the shape (3 abstract + defaulted hooks, not "4 methods"). Added: the
   `score_batch` fast path (was missing), the `'all'` split value, a pointer to the shown-only
   `metrics` catalog, and an explicit note that **`capability_sources` is a `capevolve.yaml`
   key, not an adapter method** — the review brief's list conflated them.
5. **`scripts/check.py` now tests the phase's actual contract.** The old stub fixture was
   `class Adapter(CapabilityAdapter): pass` — an ABC with unimplemented abstractmethods, so
   `mod.Adapter()` raised `TypeError`, `run_check` returned `problems=["could not load
   adapter: ..."]` with `stubs=[]`, and `stub_methods` was never reached. It passed while
   asserting almost nothing; determinism was not tested at all. Now: a *loadable*
   marker-stubbed adapter asserting `"score" in rep.stubs`, and an RNG scorer asserting a
   `"non-deterministic"` problem. Those two assertions are the entire behavioural contract of
   this phase.
6. **`pipeline_selftest.py` is no longer algorithm-specific.** It hard-failed on a missing or
   placeholder-stripped `optimizer/INSTRUCTIONS.md`, but only **hill-climb** consumes that
   template — `cli.py:869-876` passes `--instructions-file` under
   `if algorithm_name == "hill-climb"` and the flag exists in exactly one algorithm's argparse
   — while `meta.yaml:11` declares `algorithms: ["*"]`. A gepa/evograph run was gated on an
   artifact it never opens: a CONTEXT.md principle-1 violation. Now skipped with a note;
   assertions 1 and 4 still always run:

   ```
   ### algorithm_skill: hill-climb (no optimizer/INSTRUCTIONS.md scaffolded)
   "problems": ["optimizer_instructions_file points at a missing file: optimizer/INSTRUCTIONS.md ..."]
   ### exit: 1

   ### algorithm_skill: gepa (no optimizer/INSTRUCTIONS.md scaffolded)
   "ok": true
   "algorithm 'gepa' does not consume optimizer_instructions_file — optimizer-template checks skipped"
   "adapter inherits trajectories() default → falls back to cap-evolve's per-rollout JSON"
   ### exit: 0
   ```

## Ownership contract (#340) — lines removed

| what | lines | note |
|---|---|---|
| `## Inputs / outputs (manifest tokens)` | 4 | deleted per SKILL_OWNERSHIP defect 2. Frontmatter `provides`/`needs` left exactly as they were — no new consumers invented. |
| Honesty-invariant restatement | 5 | "A green check is the only honest entry into `baseline`" + the surrounding validation-gate-discipline paragraph. Owners: `gate` / `finalize` / `report`. The one sentence kept is the *factual* one ("green is the entry condition for `baseline`"), which is this phase's own output, not the split/gate/test invariants. |
| Body↔reference duplication | 14 | `## What the check actually verifies (and why)` restated `concepts.md:30-42` bullet for bullet, same `check.py:166-167` citation in both. Body now carries the *limits* (novel, measured); `concepts.md` keeps the *rationale*. |
| `concepts.md` method-list duplicate | 12 | the defaulted-hooks/feature-detection paragraph was near-identical to SKILL.md step 1. |

**Agent-mode loop (owner `orchestrate`) and failure taxonomy (owner `diagnose`): neither
appears in this skill.** Nothing to delete — reporting it so no one goes looking.

**What other skills should drop** (not touched, per the coordination rule): the seven other
phase skills carry the same byte-identical `## Dual-mode` paragraph
(`baseline:58`, `finalize:41`, `evaluate:41`, `diagnose:159`, `gate:63`, `intake:216`,
`report:50`). It should become a one-line pointer to `using-cap-evolve`. This skill cannot
join that reduction because the shared sentence is factually wrong here (finding 3 above), so
it keeps a corrected paragraph of its own.

## Deliberate deviations from #337's acceptance criteria

- **Criteria 1, 2, 3, 12 are core changes** (`check.py`, `cli.py`) and are #358, per the
  review's scope boundary: a skill that overclaims is the bug being fixed here; core surgery
  inside a skill PR just relocates the risk. The skill now names its own blind spots and
  points at #358.
- **Criterion 5** (`baseline/scripts/run.py` enforces `run_check`) is another skill's
  directory — filed in #358 as its item 4. Took the documented alternative the criterion
  itself offers.
- **Criterion 8's "body under 90 lines"** was not met — 130. The mapping table (job 4) and
  the measured-limits section are ~30 lines of net-new required content; the alternative was
  keeping the skill terse and dishonest. Everything ceremonial was cut instead. Still 3.8×
  under the 500-line budget; description 442 chars.
- **Criterion 11** (`scripts/__pycache__/*.pyc`) was already clean: `git ls-files` shows six
  tracked files, no `.pyc`, and `.gitignore:2` already has `__pycache__/`. No change needed.
- **Criterion 10** (`## Dual-mode` reduced across the phase skills) is cross-skill —
  documented above for the owning agents.

## Evidence

```
$ wc -l skills/phases/implement-and-check/SKILL.md      # before: 112
     130

$ CAPEVOLVE_CORE="$PWD/core" python skills/phases/implement-and-check/scripts/check.py
{
  "skill": "implement-and-check",
  "ok": true,
  "problems": [],
  "notes": [
    "run entry exposes main()",
    "refuses a project with no adapter",
    "names the unimplemented method in stubs[]",
    "detects a non-deterministic score()"
  ]
}
exit=0

$ PYTHONPATH="$PWD/core:$PWD/dashboard/backend" python -m pytest core/tests -q
789 passed, 12 skipped in 106.81s          # matches clean main (#349)

$ bash examples/toy_calc/run.sh
"baseline_val": 0.0, "test_reward": 1.0, "test_delta": 1.0,
"test_pass_k": {"1": 1.0}, "iterations": 3
```

Core untouched — `git status` shows four files, all under
`skills/phases/implement-and-check/`.
