### PR TITLE
evaluate: reconcile the skill with the code, cover infra-errors-are-not-zeros (#333)

### DIFF
--- a/skills/phases/evaluate/SKILL.md
+++ b/skills/phases/evaluate/SKILL.md
@@ -6,65 +6,130 @@ argument-hint: "--run-dir DIR --project DIR --candidate ID --split val"
 allowed-tools: Read, Bash
 provides: [scores, traces]
 needs: [candidate]
-sources: [tau2bench]
 ---
 
 # evaluate — honest, multi-trial scoring
 
 Turns a candidate into a score you can *trust*. A reward number is only as honest
-as the variance around it: agents are stochastic, so the same candidate run twice
-gives two scores. evaluate's job is to produce a point estimate **and** the
-uncertainty that lets the gate decide whether a difference is real. The honesty
-math lives in `cap_evolve.stats`; this skill drives the adapter and aggregates.
-
-## Inputs / outputs (manifest tokens)
-- **needs:** `candidate` — a capability variant to score (an id in the run dir or
-  a directory path).
-- **provides:** `scores` (the aggregate `SplitResult`) and `traces` (per-task
-  rollouts + feedback — the raw material `diagnose` turns into a learning signal).
+as the variance around it and as the denominator under it: agents are stochastic,
+and infrastructure fails. evaluate produces a point estimate, its uncertainty, and
+the count of tasks that actually produced a measurement. The math lives in
+`cap_evolve.stats`; this skill drives the adapter and aggregates.
 
 ## What it produces
-A `SplitResult` containing:
-- **`reward`** — mean reward across tasks (each task's reward is itself the mean
-  over its trials). This is the headline point estimate.
-- **`stderr`** — the *combined* standard error: between-task variance (do
-  different tasks agree?) folded together with within-task trial variance (is the
-  agent consistent on a fixed task?). One SE that honestly reflects both sources
-  of noise — not the smaller of the two.
+A `SplitResult` (`core/cap_evolve/loop.py:59-115`):
+- **`reward`** — the mean, over the tasks that were **scored**, of each task's mean
+  over its **valid** trials (`harness.py:405-414`, `loop.py:127-131`). Not the mean
+  over every task in the split — see the next section.
+- **`n_tasks` / `n_scored`** (and `coverage = n_scored/n_tasks`, `loop.py:79-84`) —
+  the honest denominator. Read these on every result, never `reward` alone.
+- **`stderr`** — the *combined* SE of that reported mean: between-task variance
+  (do different tasks agree?) folded with within-task trial variance (is the agent
+  consistent on a fixed task?), `stats.combined_stderr`. This is what the report
+  prints and what the gate's `significant` mode consumes — **not** what the default
+  gate reads; see "What the gate actually consumes".
 - **`pass_k`** — when trials > 1, the estimated probability that **all** k i.i.d.
-  trials pass (τ-bench reliability). Optionally `pass@k`, the probability that
-  **at least one** of k trials passes (capability). They answer opposite
-  questions; see `references/concepts.md`.
-- **per-task scores + feedback** — the learning signal `diagnose` reads.
+  trials pass (reliability). Also `pass_at_k` — at least one of k passes
+  (capability). Opposite questions; see `references/concepts.md`.
+- **per-task scores + feedback**, and the rollout files `diagnose` reads:
+  `<run-dir>/rollouts/<split>/<task>__<tag>__t<k>.json` (`harness.py:334`).
 
-## Dual-mode
-This phase runs two ways from the **same** SKILL.md: standalone as the slash command `/cap-evolve:evaluate` (the `argument-hint` shows its run.py args), and orchestrator-callable — `cap-evolve run` / the `orchestrate` skill invokes the same `scripts/run.py` headlessly and threads the run dir between phases.
+## A crashed rollout is missing data, not a zero
+The single largest honesty mechanism in the eval path. Two ways a trial produces
+no measurement:
+- the runner errored (`rollout.error` set) — the target never ran;
+- the rollout *succeeded* and the **scorer** could not grade it (crashed grading
+  harness, missing report file). There is no `rollout.error`, so adapters must flag
+  it by setting `Score.raw["errored"]` (`harness.py:308-323`). An adapter that
+  doesn't is how a scorer outage becomes a real 0.0.
+
+Such a trial is excluded from the mean (`harness.py:324-331`), and a task with zero
+valid trials is dropped from **every** statistic (`loop.py:118-127`). Averaging its
+0.0 in would state that the capability failed a task it was never given — which is
+how a registry rate-limit storm produced `val 0.000` and taught the optimizer to
+"fix" content that was never at fault. The rollout file is still written, for
+forensics.
+
+**What to check.** `raw.valid_trials == 0` on a per-task record means unmeasured,
+not failed. A `reward` computed over a third of a split describes the
+infrastructure, not the edit. Below `coverage 0.6` the gate returns
+`indecisive=True` and declines to judge rather than calling it a regression
+(`gate.py:137-146`) — a run producing repeated indecisive steps has an
+infrastructure fault, not a bad optimizer. Pinned by
+`core/tests/test_infra_errors_not_zeros.py` (518 lines).
+
+## What the gate actually consumes
+When per-task data is available the loop sets gate mode to `paired`
+(`harness.py:1524-1526`), and paired mode **recomputes** the SE from the per-task
+deltas against the same tasks (`gate.py:156-160`); `SplitResult.stderr` is never
+read on that path. So what extra trials buy you under the default gate is a more
+stable *per-task* mean, which shrinks the paired delta variance — not a smaller
+`stderr`. `stderr` feeds the report and the `significant` fallback used when
+paired data is unavailable (`gate.py:184-207`).
 
 ## How to run
 ```
 python scripts/run.py --run-dir .capevolve/run_XXXX --project .capevolve/project \
     --candidate seed --split val --n-trials 3
 ```
-`--split` accepts only `train` or `val` — **evaluate can never touch test.**
-Test belongs to `finalize`, which scores it exactly once. Use multiple trials
-when the target is stochastic: a single trial reports `stderr=0`, which is a lie
-that lets the gate accept noise as progress.
+- `--split` accepts only `train` or `val`, enforced by argparse choices
+  (`scripts/run.py:25`) — a `--split test` invocation exits non-zero. The
+  enforcement lives in *this CLI*, not in `harness.evaluate_candidate` (issue #361),
+  so never "helpfully" widen those choices.
+- `--n-trials` **defaults to 1**. On a stochastic target that is the degenerate
+  case below; run.py prints a warning to stderr when it happens.
+- `--ks` picks the k values for pass^k; it defaults to `1..n_trials`, so
+  `--n-trials 3` reports pass^1..pass^3. Any k above a task's trial count is
+  omitted rather than reported as 0.0 (`loop.py:134-147`).
+- `CAPEVOLVE_WORKERS=N` generates rollouts through a thread pool
+  (`harness.py:49-57`); scoring stays serial so the numbers match a serial run.
+  Keep it at 1 if `run_target` is not thread-safe (shared scratch dir, one live
+  container, module-global client) — `harness.py:225-227`.
+- A subset/triage eval (`ids=`) is **never** gateable: its `n_tasks` is the subset,
+  so `coverage` reads 1.0 (`harness.py:229-237`).
 
-## Choosing the number of trials
-- **Deterministic scorer + greedy decode (temp 0):** 1 trial is honest.
-- **Any sampling / temperature / tool nondeterminism:** ≥3–4 trials. More trials
-  shrink `stderr` ∝ 1/√(trials) and make pass^k / pass@k estimable.
-- Trials cost budget linearly. Spend them where variance actually threatens the
-  decision — usually on the val split the gate reads, not on every probe.
+## How much measurement do you need
+Two axes, and the trials axis is the one people get wrong.
+
+- **Trials.** Deterministic scorer + greedy decode: 1 trial is honest. Any
+  sampling / temperature / tool nondeterminism: ≥3–4. Trials are only independent
+  draws if the adapter **forwards the per-trial seed** — trial `k` runs with
+  `seed = base_seed + k` (`harness.py:374`, `trials.py:10-13`) and the adapter
+  contract requires passing it to a stochastic runner (`adapter.py:52-54`). An
+  adapter that drops it gives you n identical copies: per-task `stderr` is 0,
+  `pass^k` is exactly 0 or 1, and the whole apparatus looks healthy while measuring
+  nothing. `cap-evolve check` can prove it: with
+  `CAPEVOLVE_N_TRIALS=3 CAPEVOLVE_CHECK_TRIAL_PROBE=1` it fires two real rollouts at
+  different seeds and warns if they are byte-identical
+  (`core/cap_evolve/check.py:169-190`). It is opt-in because the probe costs real
+  rollouts — run it once per adapter, and treat the warning as "every variance number
+  here is fiction".
+- **Tasks.** `stats.stderr` returns 0.0 below 2 tasks and `combined_stderr`'s
+  between-task term is 0 below 2 (`stats.py:28-30, 47-50`), so a 1-task val gives
+  `stderr = 0`, a bar of 0, and the gate degenerates to strict ("any Δ>0 wins") with
+  a logged warning (`gate.py:40-60`). Below roughly 5 val tasks the `k·SE` bar is
+  dominated by sample size and is optimistic — issue #113. An empty val presents as
+  `coverage 1.0` with `reward 0.0` (`loop.py:79-84`).
+
+**A one-task gain is not reliably bankable.** Under the shipped default
+(`mode: paired`, `k_se: 1.0`) a candidate that improves exactly one val task and
+changes nothing else has `Δ̄ == SE(Δ)` *algebraically*, so the strict `>` at
+`gate.py:176` is settled by floating-point representation — rejected at n=4, 8, 50,
+accepted at n=20, identical printed numbers. Issue #351, open; derivation in
+`references/concepts.md`. Do not read a rejection of a single-task fix as evidence
+the edit was bad — check how many tasks moved.
 
 ## What good vs bad looks like
-- **Good:** `n_trials ≥ 3` on a stochastic agent; `stderr` reported and non-zero;
-  pass^k present and inspected alongside the mean.
-- **Bad:** single-trial scores on a stochastic agent feeding a significance gate
-  (every marginal "win" is noise); reading the test split "just to check"; trusting
-  a high mean when pass^k is low (the gain is fragile across trials).
+- **Good:** `n_trials ≥ 3` on a stochastic agent with the seed forwarded; `stderr`
+  non-zero; `n_scored == n_tasks`; pass^k inspected alongside the mean.
+- **Bad:** a plausible low reward that is an infrastructure outage, not a capability
+  measurement (check `coverage` first, always); single-trial scores feeding a
+  significance gate; identical trial rewards across seeds; trusting a high mean when
+  pass^k is low (the gain is fragile).
 
 ## References
-- `references/concepts.md` — variance decomposition, combined standard error,
-  pass^k vs pass@k with their unbiased estimators, multi-trial budgeting, and
-  bootstrap CIs, with sources.
+- `references/concepts.md` (125 lines) — the variance decomposition and the
+  combined-SE formula, where these statistics break down on small samples (including
+  the #351 `Δ̄ == SE` derivation), pass^k vs pass@k with their unbiased estimators,
+  bootstrap CIs, where the test-split refusal is enforced, and sources. Load it when
+  you need the statistics themselves rather than how to run an evaluation.

--- a/skills/phases/evaluate/references/concepts.md
+++ b/skills/phases/evaluate/references/concepts.md
@@ -2,8 +2,7 @@
 
 > A reward without its uncertainty is half a measurement. Agents are stochastic;
 > the same candidate scored twice gives two numbers. This note is the statistical
-> backbone of `evaluate` (and therefore of the gate, which consumes its `stderr`).
-> The implementation is `cap_evolve/stats.py`.
+> backbone of `evaluate`. The implementation is `cap_evolve/stats.py`.
 
 ## Two sources of variance, one standard error
 
@@ -24,14 +23,53 @@ Reporting only one understates uncertainty. The honest figure folds both into a
 SE_total = sqrt( between_task_var / n_tasks  +  mean(per_task_SE^2) / n_tasks )
 ```
 
-This is exactly `cap_evolve.stats.combined_stderr`: the between-task term is the
-SE of the task means; the within-task term averages each task's squared trial SE.
-The gate compares candidate-vs-current using this combined SE, so getting it
-right is what stops the optimizer from "accepting" noise.
+This is exactly `cap_evolve.stats.combined_stderr` (`stats.py:35-53`): the
+between-task term is the SE of the task means; the within-task term averages each
+task's squared trial SE. It is the honest SE of the number `evaluate` *reports*.
+The gate's `significant` mode compares candidate-vs-current with it
+(`gate.py:184-207`) — but that mode is the fallback: the loop's default is `paired`,
+which recomputes an SE from the per-task deltas (`gate.py:148-182`) and never reads
+this one. See the SKILL.md section "What the gate actually consumes".
 
 **Single trial ⇒ within-task SE is 0** and pass^k/pass@k are undefined. That is
 why a stochastic agent scored at `n_trials=1` produces a falsely confident
 `stderr` and should never feed a significance gate.
+
+## Small samples: where these statistics stop meaning anything
+
+Both terms above are sample statistics, and they degrade quietly:
+
+- **Below 2 tasks** the between-task variance is defined as 0 (`stats.py:47-50`) and
+  `stats.stderr` returns 0 (`stats.py:28-30`). A 1-task val therefore reports
+  `stderr = 0`, giving a significance bar of 0; the gate logs a warning and falls
+  back to strict, accepting any Δ>0 (`gate.py:40-60, 186-196`).
+- **Below roughly 5 tasks** the `k·SE` bar is dominated by sample size rather than by
+  the effect, so it is optimistic — a couple of lucky per-task deltas clear it. There
+  is no t-based small-sample correction today; issue #113 tracks adding one (and a
+  minimum-val-size guard), and its own third bullet asks that the current bar at
+  minimum be *documented* as optimistic on tiny val sets. This paragraph is that
+  documentation.
+- **An empty val** presents as fully covered (`coverage` returns 1.0 when
+  `n_tasks == 0`, `loop.py:79-84`) with `reward 0.0` — also issue #113.
+
+### The degenerate single-task delta (issue #351, open)
+
+Under the shipped default gate (`mode: paired`, `k_se: 1.0`), a candidate that
+improves exactly one val task by `m` and changes nothing else gives paired deltas
+`[m, 0, …, 0]` over `n` tasks:
+
+```
+Δ̄   = m/n
+var = [ m²(1 − 1/n)² + (n−1)(m/n)² ] / (n−1) = m²/n
+SE  = sqrt(var/n) = m/n = Δ̄
+```
+
+`Δ̄ == SE` exactly, for every `m` and every `n` — neither a bigger gain nor a bigger
+val split rescues it, because both scale identically. Since `gate.py:176` tests a
+strict `Δ̄ > k·SE`, the verdict reduces to `x > x` and is settled by floating-point
+representation: rejected at n=4, 8, 50; accepted at n=20; identical printed numbers
+in every case. So a single-task improvement is not reliably bankable under the
+current default, and a rejection of one says nothing about the edit's quality.
 
 ## pass^k vs pass@k — opposite questions
 
@@ -64,13 +102,17 @@ implements this deterministically (fixed seed → reproducible CI). Koehn's poin
 made for MT metrics but general — is that without resampling you cannot tell
 whether a score *difference* is real or an artifact of the particular test items.
 
-## Why evaluate must never touch test
+## Where the test-split refusal is enforced
 
-evaluate runs on `train` or `val` only. Every val score informs an accept/reject
-decision, so val is "used up" as a tuning signal. The moment test informs *any*
-decision during search it stops being held out and the final number becomes a fit
-metric. Sealing test for `finalize` is what makes the headline number honest; see
-the finalize and gate references.
+Not in prose: `scripts/run.py:25` declares `--split` with
+`choices=["train", "val"]`, so `--split test` exits 2 with
+`invalid choice: 'test'`. Behind that, `harness.evaluate_candidate` reserves the
+seal for a test split (`harness.py:240-241`) and `splits.check_test_unused` /
+`rundir.begin_test_attempt` raise `TestSealError`. Note the argparse guard is
+`evaluate`'s only refusal — `harness.evaluate_candidate(split="test")` is reachable
+from any other caller and would write into `rollouts/test/`, which then blocks a
+*legitimate* finalize (`rundir.py:385-399`) — issue #361 tracks moving the refusal
+into core. Do not widen those choices.
 
 ## Sources
 - τ-bench (Yao, Shinn, Razavi, Narasimhan, 2024) — pass^k reliability; the

--- a/skills/phases/evaluate/scripts/check.py
+++ b/skills/phases/evaluate/scripts/check.py
@@ -1,5 +1,10 @@
-"""Contract: evaluate aggregates split × trials — it scores exactly the tasks in
-the requested split, runs n_trials per task, and reports a mean over them.
+"""Contract: evaluate aggregates split × trials HONESTLY — it scores exactly the
+tasks in the requested split, runs n_trials per task, reports a mean over the VALID
+trials of the SCORED tasks, and reports a non-zero SE when the tasks disagree.
+
+The last two are the properties the skill exists for: an infra-errored trial must
+leave the mean (so a crash is missing data, not a capability failure of 0.0), and
+the SE must actually be measured (an SE of 0 degenerates the significance gate).
 """
 
 from __future__ import annotations
@@ -13,21 +18,48 @@ import _bootstrap  # noqa: F401
 from cap_evolve import Rollout, Score, Task, harness
 from cap_evolve.skillcheck import Checker, import_run, temp_run_dir
 
+# 8 ids at a 50/25/25 split give a val of 2 — enough for a between-task SE to exist
+# at all (stats.combined_stderr defines it as 0 below 2 tasks).
+_IDS = ("a", "b", "c", "d", "e", "f", "g", "h")
+
 
 class _Adapter:
     """Synthetic adapter: reward = 1 on even trials, 0 on odd → mean 0.5 over 2 trials."""
 
     def tasks(self, split):
-        return [Task(id=t, input={}) for t in ("a", "b", "c", "d")]
+        return [Task(id=t, input={}) for t in _IDS]
 
     def run_target(self, task, ctx, *, seed=0):
         return Rollout(task_id=task.id, output=str(seed))
 
     def score(self, task, rollout):
+        # An errored rollout is still handed to score() — the harness discards the
+        # number afterwards, but the scorer must not crash on it.
+        if rollout.output is None:
+            return Score(task_id=task.id, reward=0.0)
         return Score(task_id=task.id, reward=1.0 if int(rollout.output) % 2 == 0 else 0.0)
 
     def materialize(self, candidate_dir):
         return {}
+
+
+class _SplitAdapter(_Adapter):
+    """Tasks disagree (reward keyed off the task id), so the between-task SE is > 0."""
+
+    def score(self, task, rollout):
+        return Score(task_id=task.id, reward=1.0 if task.id in ("a", "c", "e", "g") else 0.0)
+
+
+class _FlakyAdapter(_Adapter):
+    """One task's runner always errors: the target never ran on it."""
+
+    def __init__(self, dead: str):
+        self.dead = dead
+
+    def run_target(self, task, ctx, *, seed=0):
+        if task.id == self.dead:
+            return Rollout(task_id=task.id, error="infra: runner exploded")
+        return super().run_target(task, ctx, seed=seed)
 
 
 def main() -> int:
@@ -35,12 +67,11 @@ def main() -> int:
     c.require_main(import_run())
 
     with tempfile.TemporaryDirectory() as d:
-        rd, splits = temp_run_dir(Path(d), ids=("a", "b", "c", "d"), seed=0)
-        adapter = _Adapter()
+        rd, splits = temp_run_dir(Path(d), ids=_IDS, seed=0)
         cand = Path(d) / "cand"
         cand.mkdir()
 
-        res = harness.evaluate_candidate(adapter, cand, run_dir=rd, split="val",
+        res = harness.evaluate_candidate(_Adapter(), cand, run_dir=rd, split="val",
                                          n_trials=2, base_seed=0, tag="chk")
         # only the val split's tasks are scored
         c.check(len(res.per_task) == len(splits.val),
@@ -52,6 +83,34 @@ def main() -> int:
                 note="reward is the mean over n_trials per task")
         c.check(all(pt.get("n", 0) == 2 for pt in res.per_task),
                 "n_trials not recorded per task")
+        c.check(res.n_scored == res.n_tasks == len(splits.val),
+                f"honest denominator wrong on a healthy split: "
+                f"n_scored={res.n_scored} n_tasks={res.n_tasks}",
+                note="n_scored == n_tasks when nothing errored")
+
+        # An infra-errored task is MISSING DATA, not a 0.0: it leaves the mean and
+        # shrinks the denominator, so coverage exposes the decimated split.
+        dead = sorted(splits.val)[0]
+        flaky = harness.evaluate_candidate(_FlakyAdapter(dead), cand, run_dir=rd,
+                                           split="val", n_trials=2, base_seed=0, tag="flaky")
+        c.check(flaky.n_scored < flaky.n_tasks and flaky.coverage < 1.0,
+                f"errored task not excluded from the denominator: "
+                f"n_scored={flaky.n_scored} n_tasks={flaky.n_tasks}",
+                note=f"errored trials leave the mean (coverage {flaky.coverage:.2f})")
+        c.check(abs(flaky.reward - 0.5) < 1e-9,
+                f"errored task dragged the mean to {flaky.reward} instead of leaving it "
+                "at the scored tasks' 0.5 (a crash was averaged in as a 0.0)")
+        c.check((rd.rollouts / "val" / f"{dead}__flaky__t0.json").exists(),
+                "errored rollout file not kept for forensics")
+
+        # A measured SE: tasks that disagree must produce stderr > 0, otherwise the
+        # significance gate has no bar and silently degenerates to strict.
+        spread = harness.evaluate_candidate(_SplitAdapter(), cand, run_dir=rd, split="val",
+                                            n_trials=2, base_seed=0, tag="spread")
+        c.check(spread.stderr > 0.0,
+                f"stderr is {spread.stderr} on a split whose tasks disagree "
+                f"({[pt['reward'] for pt in spread.per_task]}) — the gate bar would be 0",
+                note=f"between-task SE is measured (stderr={spread.stderr:.4f})")
 
     return c.emit()
 

--- a/skills/phases/evaluate/scripts/run.py
+++ b/skills/phases/evaluate/scripts/run.py
@@ -24,7 +24,26 @@ def main(argv=None) -> int:
     p.add_argument("--candidate", required=True, help="candidate id or dir to evaluate")
     p.add_argument("--split", default="val", choices=["train", "val"])
     p.add_argument("--n-trials", type=int, default=1)
+    p.add_argument("--ks", default=None,
+                   help="comma-separated k values for pass^k/pass@k "
+                        "(default: 1..n-trials, so the k you paid for is reported)")
     args = p.parse_args(argv)
+
+    # ks defaults to every k the trials can support. The harness default is (1, 2),
+    # which silently drops pass^3 from a --n-trials 3 run — the exact reliability
+    # figure the extra trial was bought for. A k above a task's trial count is
+    # omitted by aggregate_scores, so over-wide ks is safe, never a misleading 0.0.
+    ks = (tuple(int(x) for x in args.ks.split(",") if x.strip()) if args.ks
+          else tuple(range(1, max(1, args.n_trials) + 1)))
+
+    if args.n_trials <= 1:
+        # Loud and auditable rather than a silently falsely-confident number: with one
+        # trial every per-task stderr is 0, so the combined SE is between-task only and
+        # pass^k is undefined beyond k=1. Same posture as gate._warn_se_zero.
+        print("evaluate: --n-trials=1 — within-task variance is unmeasured (per-task "
+              "stderr=0) and pass^k is only defined at k=1. Honest only for a "
+              "deterministic target; pass --n-trials 3+ for a stochastic one.",
+              file=sys.stderr)
 
     run_dir = RunDir.open(Path(args.run_dir))
     adapter = load_adapter(Path(args.project))
@@ -32,7 +51,7 @@ def main(argv=None) -> int:
     cand_dir = cand if cand.exists() else run_dir.candidate_dir(args.candidate)
     result = harness.evaluate_candidate(adapter, cand_dir, run_dir=run_dir,
                                         split=args.split, n_trials=args.n_trials,
-                                        tag=cand_dir.name)
+                                        ks=ks, tag=cand_dir.name)
     print(json.dumps(result.to_dict(), indent=2))
     return 0
 


### PR DESCRIPTION
Closes #333.

`SKILL.md` **70 → 135 lines**, `references/concepts.md` **84 → 126 lines**. Both far under the
500-line / 5000-token budget (SKILL.md ≈ 2.1k tokens). The growth is mechanism, not ceremony —
~14 lines of restatement were deleted to pay for it.

---

## 1. SE / pass^k / seed reconciliation

Every claim verified against the code, file:line.

### The SE the skill sold is not the SE the gate consumes

| the skill said | the code does |
|---|---|
| `stderr` is "the uncertainty that lets the gate decide whether a difference is real" (old `SKILL.md:14-18, 29-33`), and `concepts.md:29-30` "The gate compares candidate-vs-current using this combined SE" | The loop sets `gate_kwargs["mode"] = "paired"` whenever per-task data exists — `harness.py:1524-1526`. Paired mode **recomputes** the SE from the per-task deltas (`gate.py:156-160`: `var = sum((d-mean_d)**2)/(n-1); se = sqrt(var/n)`). `SplitResult.stderr` is never read on that path. |

`stats.combined_stderr` exists and is correct — `concepts.md:24`'s formula matches `stats.py:35-53`
exactly (`within_se_sq = sum(s*s)/(n*n)` ≡ `mean(s²)/n`). It is just not the gate's default input.
It feeds the report, the event log (`harness.py:275-276`), and `gate.py:184-207`'s `significant`
mode, which is the fallback when `_paired_deltas` returns `None` (`harness.py:646-669`).

**Fixed:** new `## What the gate actually consumes` section states the default is paired and that
what trials buy on that path is a stabler *per-task* mean (which shrinks the paired delta
variance), not a smaller `stderr`. `concepts.md:26-32` corrected to match, and the header's "(and
therefore of the gate, which consumes its `stderr`)" removed.

### `reward` was described wrong

Old `SKILL.md:28-29`: "mean reward across tasks (each task's reward is itself the mean over its
trials)". Actually: the mean over **scored** tasks (`loop.py:127-131`, `scored = [s for s in
scores if has_valid_trials(s)]`) of the mean over each task's **valid** trials
(`harness.py:330-331`, `harness.py:405-414`). A reader could take `reward: 0.08` off stdout with
34 of 50 tasks never having run. Corrected, and `n_tasks` / `n_scored` / `coverage`
(`loop.py:59-115`, `79-84`) — all three previously absent from the skill — are now listed with
"read these on every result, never `reward` alone".

### pass^k was capped at k ≤ 2 with no way to widen it

`harness.py:202` defaults `ks=(1, 2)` and `435`, `490`, `2243` repeat it; `scripts/run.py` never
passed `ks`. Verified on a real run — `--n-trials 3` reported only `pass^1` and `pass^2`:

```
$ python skills/phases/evaluate/scripts/run.py ... --candidate cand_0001 --split val --n-trials 3
pass_k {'1': 1.0, '2': 1.0}                 # BEFORE — no pass^3
```

The skill told you to buy trials to "make pass^k / pass@k estimable" and then discarded the k you
paid for. **Fixed** with `--ks` in `run.py` defaulting to `tuple(range(1, n_trials + 1))`:

```
pass_k {'1': 1.0, '2': 1.0, '3': 1.0}       # AFTER
pass_at_k {'1': 1.0, '2': 1.0, '3': 1.0}
```

Safe because `loop.py:134-147` already omits any `k > min(trials)` rather than emitting a
misleading 0.0.

### Each trial does get its own seed — but nothing checks the adapter honours it

`harness.py:374` — `seed = base_seed + k`, and `trials.py:10-13` / `trials.py:49` do the same on
the pooled path, so the *harness* side of the seed contract is real. `base_seed` defaults to the
frozen splits seed (`harness.py:244-249`). `adapter.py:52-56` states adapters wrapping a
stochastic runner **MUST** forward it.

The silent failure the skill never mentioned: an adapter that drops `seed` yields n identical
trials — per-task `stderr` 0, `pass^k` exactly 0 or 1, and the entire multi-trial apparatus
reporting health while measuring nothing. **Fixed**, including the precise invocation of the
existing probe: `core/cap_evolve/check.py:169-190` warns on byte-identical rollouts at different
seeds, but only under `CAPEVOLVE_N_TRIALS>1` **and** `CAPEVOLVE_CHECK_TRIAL_PROBE=1` (it fires
real rollouts, so it is opt-in — the skill now says so rather than implying `cap-evolve check`
does it by default).

---

## 2. Is the test-split prohibition enforced in CODE?

**Yes for this skill — argparse, quoted:**

```python
# skills/phases/evaluate/scripts/run.py:25
p.add_argument("--split", default="val", choices=["train", "val"])
```

```
$ python skills/phases/evaluate/scripts/run.py --run-dir /tmp/nope --project /tmp/nope \
      --candidate seed --split test
usage: evaluate [-h] --run-dir RUN_DIR --project PROJECT --candidate CANDIDATE
                [--split {train,val}] [--n-trials N_TRIALS] [--ks KS]
evaluate: error: argument --split: invalid choice: 'test' (choose from train, val)
```

Defence in depth behind it: `harness.py:240-241` reserves the seal, `splits.py:43-65` raises
`TestSealError`, `rundir.py:385-399` refuses a second finalize.

**But the guard is CLI-owned, not core-owned**, and the residual hole is worse than a bypass:

```
$ python /tmp/ev333_testleak.py
evaluate_candidate(split='test') SUCCEEDED: reward=1.0
test rollouts written: ['d__oops__t0.json']
seal still unburned: True
a legitimate finalize is now BLOCKED: TestSealError: TEST split was already SCORED by an
  earlier finalize attempt in this run (1 test rollout(s) under .../rollouts/test) ...
```

One out-of-band `harness.evaluate_candidate(split="test")` observes the held-out set, does *not*
record the observation as the seal (only `finalize` commits it), and then permanently bricks the
run's real finalize. **Filed as #361** — per the brief, not implemented here. The skill and
`concepts.md` now say plainly that the refusal lives in this CLI and point at #361.

---

## 3. Infrastructure errors must not be scored as zeros — the largest addition

Not mentioned once in the old skill or reference, despite 518 lines of tests. What the code
actually does:

- **Two** ways a trial produces no measurement, not one. The runner errored (`rollout.error`
  set) — `harness.py:301-303`. Or the rollout **succeeded** and the *scorer* could not grade it;
  there is no `rollout.error` in that case, so adapters must flag it with
  `Score.raw["errored"]` — `harness.py:308-323`, whose comment cites a real run publishing
  `mean reward 0.000 → 0.000` with `conclusion: success` over 5 never-graded swebench tasks.
- The reward leaves the mean — `harness.py:324-331`: *"An errored trial never ran the target, so
  its reward is not a measurement — it is missing data. Averaging its 0.0 in would state that the
  capability failed a task it was never given, which is how a Docker Hub 429 storm became a val
  score of 0.000 and taught the optimizer to 'fix' content that was never at fault."*
  `if not errored: per_task_trials[tid].append(sc.reward)`.
- `raw.valid_trials` (`harness.py:405-414`) — 0 means excluded from the split mean.
- `aggregate_scores` drops such tasks from **every** statistic and exposes the real denominator —
  `loop.py:118-127`, `n_tasks` / `n_scored`, `coverage` at `loop.py:79-84`.
- Below `min_coverage=0.6` the gate returns `indecisive=True` and refuses to judge —
  `gate.py:137-146` — and an indecisive step does not touch the stall counter
  (`harness.py:1560-1564`).
- `_paired_deltas` drops a task when *either* side is unscored (`harness.py:653-659`): otherwise
  one unscored candidate task the parent passed contributes a full −1.0, "exactly how a Docker Hub
  429 storm produced `paired Δ̄=-0.6400`".

Demonstrated end to end against the shipped harness — 4 val tasks, one runner error, one
ungradeable score:

```
reward=1.0 stderr=0.0 n_tasks=4 n_scored=2 coverage=0.50
  a: reward=0.0 valid_trials=0 errored=True     # runner errored
  b: reward=0.0 valid_trials=0 errored=True     # ran fine, scorer could not grade
  c: reward=1.0 valid_trials=2 errored=False
  d: reward=1.0 valid_trials=2 errored=False
rollout files kept: ['a__x__t0.json', 'a__x__t1.json', 'b__x__t0.json', ...]  # forensics
gate: {'accept': False, 'indecisive': True, 'reason': 'INDECISIVE: only 50% of val tasks
   produced a valid score (< 60% required). The evaluation measured the infrastructure,
   not the edit — not counted as a rejection.'}
```

Note `reward=1.0`, not `0.5` — the two unmeasured tasks are absent from the numerator *and* the
denominator. That is the whole mechanism, and it is why `coverage` has to be read.

**Added** as `## A crashed rollout is missing data, not a zero` plus a `**What to check.**`
paragraph, and the case was added to `## What good vs bad looks like` as the first bad case: *"a
plausible low reward that is an infrastructure outage, not a capability measurement (check
`coverage` first, always)"*.

---

## 4. Variance honesty

New `## How much measurement do you need` covers both axes, replacing a trials-only section.

- **Trials:** unchanged advice (1 for deterministic + greedy, ≥3–4 otherwise), now with the seed
  precondition above — because without it the trial count is fiction.
- **Tasks:** `stats.py:28-30` returns `stderr = 0.0` below 2 samples and `stats.py:47-50` defines
  `between_var = 0.0` below 2 tasks, so a **1-task val gives `stderr = 0` → bar of 0 → the gate
  degenerates to strict** with a logged warning (`gate.py:40-60`, `186-196`). Below ~5 val tasks
  the `k·SE` bar is dominated by sample size and is optimistic (**#113**; this closes that issue's
  third bullet — *"at minimum document that the current bar is optimistic on tiny val sets"* —
  without waiting for the code change). An empty val presents as `coverage 1.0` with `reward 0.0`
  (`loop.py:79-84`, also #113).
- **#351, reproduced independently against the shipped `gate.decide`.** A candidate improving
  exactly one val task gives deltas `[m, 0, …, 0]`, hence `Δ̄ = m/n` and `SE = m/n` — equal
  algebraically, for every `m` and `n`:

```
n=  2 m=0.5  accept=False  paired Δ̄=+0.2500 <= 1.0·SE=0.2500 (SE=0.2500, n=2)
n=  4 m=1.0  accept=False  paired Δ̄=+0.2500 <= 1.0·SE=0.2500 (SE=0.2500, n=4)
n=  8 m=1.0  accept=False  paired Δ̄=+0.1250 <= 1.0·SE=0.1250 (SE=0.1250, n=8)
n= 20 m=0.5  accept=True   paired Δ̄=+0.0250 >  1.0·SE=0.0250 (SE=0.0250, n=20)
n= 20 m=1.0  accept=True   paired Δ̄=+0.0500 >  1.0·SE=0.0500 (SE=0.0500, n=20)
n= 50 m=1.0  accept=False  paired Δ̄=+0.0200 <= 1.0·SE=0.0200 (SE=0.0200, n=50)
```

  Printed `Δ̄` and `SE` are identical in every row, accepts included: `gate.py:176`'s strict `>`
  is settled by float representation. The skill now warns that **a one-task gain is not reliably
  bankable under the current default** and that a rejection of one says nothing about the edit;
  the derivation went into `concepts.md`. Not fixed here, per the brief.

---

## 5. Ownership contract (#340) — lines removed

`evaluate` is not an owner of the honesty invariants, the agent-mode loop, or the failure
taxonomy. It never restated the last two. Removed:

| removed | lines | owner |
|---|---|---|
| `## Inputs / outputs (manifest tokens)` prose restating `needs:`/`provides:` | 5 | frontmatter itself; read by nothing (contract §2) |
| `## Dual-mode` — one templated, mechanism-free paragraph identical in all 8 phase skills | 2 | `using-cap-evolve` routes the two invocation styles |
| "Test belongs to `finalize`, which scores it exactly once." | 2 | `finalize` (the seal) |
| `concepts.md` "Why evaluate must never touch test" — the val-is-used-up / sealed-test argument | 8 | `gate` / `finalize` / `report` |
| `concepts.md` header "(and therefore of the gate, which consumes its `stderr`)" | 1 | also factually wrong (§1) |
| `sources: [tau2bench]` frontmatter | 1 | see below |

**14 lines of restatement removed.** The `concepts.md` deletion was *replaced* by 10 lines stating
where the refusal is actually enforced — the enforcement fact belongs to `evaluate` (it is
`evaluate`'s own argparse), the invariant's rationale does not.

`sources: [tau2bench]` dropped: read by nothing (grep finds only the unrelated
`capability_sources`), absent from `meta.yaml` so already drift, and a specific benchmark name in
a benchmark-agnostic phase skill. τ-bench remains correctly credited in `concepts.md`'s Sources.
No new frontmatter keys added, per contract §2. `skills/_registry/build_manifest.py` re-run: the
manifest is byte-identical.

### What other skills should drop (not touched — coordination rule)

- **All 8 phase skills:** `## Dual-mode` — verbatim at `baseline:57`, `diagnose:158`,
  `finalize:40`, `gate:62`, `implement-and-check:106`, `intake:215`, `report:49`, differing only
  in the slash-command name. State it once in `using-cap-evolve`.
- **`baseline:67-68` and `74-75`, `finalize:47-48`:** the single-trial `stderr=0` explanation.
  `evaluate` computes the SE and is its owner; `gate:42` already does the right thing (a clause
  pointing here) and then restates the reasoning anyway.
- **`gate/SKILL.md`:** documents four gate modes and omits `paired`, the actual default
  (`harness.py:1524-1526`). Flagged for that reviewer; it is the single most load-bearing omission
  in the gate skill.

---

## Evidence

**Line counts.** `SKILL.md` 70 → 135. `references/concepts.md` 84 → 126. ≈2.1k tokens, description
394 chars.

**`check.py` — before, it asserted none of the properties the skill exists for.** Its 3 assertions
covered split filtering, the per-task trial mean, and that `n` was recorded; nothing about
`stderr`, `pass_k`, errored-trial exclusion, or the test refusal. Its fixture was also a
**1-task val** — the configuration in which `combined_stderr` is structurally 0:

```
BEFORE: {"notes":["run entry exposes main()","scored exactly the val split (1 tasks)",
                  "reward is the mean over n_trials per task"],"ok":true,"problems":[]}

AFTER:  {"notes":["run entry exposes main()","scored exactly the val split (2 tasks)",
                  "reward is the mean over n_trials per task",
                  "n_scored == n_tasks when nothing errored",
                  "errored trials leave the mean (coverage 0.50)",
                  "between-task SE is measured (stderr=0.5000)"],"ok":true,"problems":[]}
```

Fixture widened to 8 ids so val has 2 tasks and a between-task SE can exist at all; new adapters
assert the errored task leaves the mean (`n_scored < n_tasks`, `reward` undragged at 0.5, rollout
file still on disk) and that `stderr > 0` when tasks disagree.

**Real run — `bash examples/toy_calc/run.sh`, byte-identical before and after:**

```
{
  "run_dir": ".capevolve/run_demo",
  "best_id": "cand_0001",
  "baseline_val": 0.0,
  "test_reward": 1.0,
  "test_baseline_reward": 0.0,
  "test_delta": 1.0,
  "test_pass_k": {"1": 1.0},
  "iterations": 3
}
```

**Multi-trial run through the skill's own entrypoint** (`--n-trials 3` on the toy run dir) —
`pass_k {'1','2','3'}` after the `--ks` fix, quoted in §1. `toy_calc` is fully deterministic, so
its `stderr` is honestly 0.0 and no toy run can produce a non-zero one; the non-zero-SE and
non-trivial-pass^k evidence therefore comes from `check.py`'s new `stderr=0.5000` assertion and
the 4-task infra-error demo above, both against the shipped harness.

**`n_trials == 1` warning, and the stdout JSON contract still clean:**

```
$ ... run.py ... --split val 2>/tmp/err 1>/tmp/out
$ cat /tmp/err
evaluate: --n-trials=1 — within-task variance is unmeasured (per-task stderr=0) and pass^k
is only defined at k=1. Honest only for a deterministic target; pass --n-trials 3+ for a
stochastic one.
$ python -c "import json; print(sorted(json.load(open('/tmp/out')))[:5])"
['cost_usd', 'n_scored', 'n_tasks', 'pass_at_k', 'pass_k']
```

**Test suite** — `PYTHONPATH="$PWD/core:$PWD/dashboard/backend" python -m pytest core/tests -q`:

```
789 passed, 12 skipped in 111.35s
```

Matches clean main (#349). No core files touched.

---

## Not done here, deliberately

- The core test-split guard → **#361**.
- `gate.py`'s `Δ̄ == SE` degeneracy → **#351** (documented only).
- `#113`'s code (min-val-size guard, t-correction, empty-val refusal) → documented only, which is
  #113's own third bullet.
- Deleting `## Dual-mode` from the other 7 phase skills, and the SE restatements in `baseline` /
  `finalize` → listed above for their owners, per the coordination rule.
