### PR TITLE
finalize skill: real seal semantics, the two-candidate test eval, and the refusal states

### DIFF
--- a/skills/phases/finalize/SKILL.md
+++ b/skills/phases/finalize/SKILL.md
@@ -11,31 +11,73 @@ sources: [tau2bench]
 
 # finalize — the one honest number
 
-Optimization hill-climbs on val: every accept decision consumed the val split as
-a tuning signal, so by the end of search val is *optimistic* — it has been
-selected against. The number you **report** must come from data nothing was
-tuned against. finalize scores the run's best candidate on the sealed `test`
-split exactly once and writes `final.json`. That single number is the result.
+Optimization hill-climbs on val: every accept decision consumed val as a tuning
+signal, so by the end of search val is *optimistic* — it has been selected
+against. The number you **report** must come from data nothing was tuned against.
+finalize scores the run's best candidate on the sealed `test` split, once, and
+writes `final.json`. That file is the run's result.
 
-## Inputs / outputs (manifest tokens)
-- **needs:** `candidate` — the run's best candidate (selected on val).
-- **provides:** `report` — `final.json` with the test reward, `stderr`, and pass^k.
+## One finalize is two evals, not one
+
+A bare test number cannot be defended — a reader cannot tell whether it beat the
+capability you started with. So one finalize scores test **twice**: the best
+candidate as tag `FINAL`, and the untouched `seed` candidate as `FINAL_seed`
+(`harness.finalize`). `final.json` therefore carries `test`, `test_baseline`,
+`baseline_id`, and `test_delta` — the held-out *improvement*, which is the figure
+`report`, the dashboard, and the event stream all headline. If the best candidate
+IS the seed (nothing was accepted), the second eval is skipped and `test_delta` is
+0 by construction.
+
+So budget `--n-trials 3` as 3 trials × **2 candidates** × |test| rollouts — twice
+what the flag looks like it buys on a paid benchmark.
+
+Both evals sit inside **one** attempt and neither is a selection event: the delta
+is *reported*, never chosen on. That is why the seal counts attempts, not evals.
 
 ## The seal (why "exactly once")
-`cap_evolve` flips a `test_used` flag the first time test is scored; any second
-attempt raises `TestSealError`. This is non-negotiable. The instant test informs
-*any* choice — picking between two finalists, "double-checking" a low number,
-re-running with more trials until it looks better — it stops being held out. Each
-peek is a selection event that leaks information from test into the decision, and
-the reported number drifts from an unbiased estimate toward an optimistic fit
-metric. Selecting the best of several test scores is exactly the best-of-noise
-inflation the gate exists to prevent, now applied to the one split that was
-supposed to be clean. The seal makes that mistake impossible rather than merely
-discouraged.
+
+The instant test informs *any* choice — picking between finalists, "double-
+checking" a low number, re-running until it looks better — it stops being held
+out, because each peek is a selection event that pulls the number from an
+unbiased estimate toward an optimistic fit metric (`references/concepts.md`).
+
+`cap_evolve` enforces this in three parts (`rundir.py:358-407`), and the split
+between them is the whole design:
+
+- **reserve** — every `split="test"` eval first *checks* the seal without burning
+  it, so no phase other than finalize can reach test at all.
+- **commit** — the seal burns only after `final.json` is written, so a finalize
+  that dies *before* scoring leaves it unused and is honestly retryable. A
+  transient crash must not destroy a run's headline number.
+- **attempt guard** — seal-on-success alone cannot tell "crashed before scoring"
+  from "crashed after". A real run hit the second case: a finalize killed by a
+  timeout had already scored test, the retry scored it again, and the reported
+  headline was that second look. `begin_test_attempt` refuses a retry once test
+  rollouts exist on disk, before anything is spent.
+
+The seal refuses that mistake by default; it is not unbypassable.
+`CAPEVOLVE_ALLOW_TEST_RESCORE=1` is a deliberate opt-in override
+(`rundir.py:166`). Its own message promises the use "is recorded in the run" —
+nothing records it (issue #341), so a run that took a second look currently looks
+identical to an honest one. If you set it, disclose it in the write-up yourself.
 
 Corollary: **all selection happens before finalize.** Choose the single best
-candidate on val, *then* finalize it. If you genuinely need to compare two
-finalists, compare them on val (or a fresh held-out slice) — never on test.
+candidate on val, *then* finalize it. Finalists that genuinely need comparing get
+compared on val — never on test.
+
+## If finalize refuses
+
+A `TestSealError` is three situations with three different right moves. Tell them
+apart from `<run>/rollouts/test/` and `test_used` in `splits.json`:
+
+| State | What happened | Do this |
+|---|---|---|
+| no test rollouts, seal unused | crashed before scoring | Re-run finalize — the case seal-on-success exists for. |
+| test rollouts exist, seal unused | crashed after scoring, before commit | Do **not** re-score. Read the rollouts under `<run>/rollouts/test/` and report what that attempt already computed. |
+| `test_used: true` | the run is finalized | Read `final.json` and regenerate the human artifact with `report` alone; `cap-evolve run --resume` skips finalize for you. |
+
+Never delete test rollouts or edit `splits.json` to get past the error — that
+manufactures a clean-looking number from a split that has already been seen.
 
 ## Dual-mode
 This phase runs two ways from the **same** SKILL.md: standalone as the slash command `/cap-evolve:finalize` (the `argument-hint` shows its run.py args), and orchestrator-callable — `cap-evolve run` / the `orchestrate` skill invokes the same `scripts/run.py` headlessly and threads the run dir between phases.
@@ -44,20 +86,19 @@ This phase runs two ways from the **same** SKILL.md: standalone as the slash com
 ```
 python scripts/run.py --run-dir .capevolve/run_XXXX --project .capevolve/project --n-trials 3
 ```
-Use multiple trials so the headline carries an honest `stderr` and a pass^k
-reliability figure, not a single noisy point. If the split was configured with no
-holdout (test == train/val), the number is a *fit* metric and the report must
-flag it as such — it is not a held-out result.
+Multiple trials give the headline an honest `stderr` and a pass^k reliability
+figure instead of one noisy point. Under `cap-evolve run` the count comes from
+`num_trials` in `capevolve.yaml` and **defaults to 1** — set it to ≥3, or the
+orchestrated headline ships with `stderr` 0: the exact single point this warns
+against. If the split was configured with no holdout (test == train/val) the
+number is a *fit* metric, not a held-out result; the dashboard flags it, so say so
+in the summary too.
 
-## What good vs bad looks like
-- **Good:** one best candidate chosen on val, scored once on test with ≥3 trials;
-  `final.json` carries reward + stderr + pass^k; test ≈ val (the val gain
-  generalized).
-- **Bad:** finalizing several candidates and keeping the best test score;
-  re-running finalize "to confirm"; reporting a single-trial test number with no
-  uncertainty; presenting a no-holdout fit number as if it were held out.
+Then read the result instead of just filing it: test ≈ val means the val gain
+generalized, test ≪ val means search overfit val — a real finding, not a reason to
+re-score.
 
 ## References
-- `references/concepts.md` — held-out sealing, why each peek biases the estimate,
-  the selection-before-finalize rule, and how this maps to benchmark protocol,
-  with sources.
+- `references/concepts.md` — why each peek biases the estimate, the
+  train-fits / val-selects / test-estimates rationale, no-holdout runs, and how
+  this maps to public benchmark protocol, with sources.

--- a/skills/phases/finalize/references/concepts.md
+++ b/skills/phases/finalize/references/concepts.md
@@ -3,7 +3,7 @@
 > The whole pipeline exists to produce *one* number you can defend: how good is
 > the optimized capability on data nothing was tuned against. finalize produces
 > it, once, and the run dir enforces that "once". Implementation:
-> `harness.finalize` + the `test_used` seal in `cap_evolve/rundir.py`.
+> `harness.finalize` + the reserve/commit `test_used` seal in `cap_evolve/rundir.py`.
 
 ## Why val is not the answer
 
@@ -30,9 +30,20 @@ applied to the one split that was supposed to be clean. The result is no longer
 an unbiased estimate; it has quietly become a fit metric, and nothing in the
 output says so.
 
-cap-evolve refuses to let this happen by accident: `RunDir` flips `test_used` on
-the first test scoring, and any second attempt raises `TestSealError`. The
-honesty is enforced by the harness, not left to the operator's discipline.
+cap-evolve refuses to let this happen by accident, in three parts
+(`rundir.py:358-407`). `reserve_test` *checks* the seal on every `split="test"`
+evaluation without burning it; `commit_test` burns it only once `final.json` is
+written, so a finalize that crashes *before* scoring is honestly retryable rather
+than a destroyed headline number; and `begin_test_attempt` refuses a retry once
+test rollouts exist on disk, since a crash after scoring means the held-out set
+was already observed. Any second attempt raises `TestSealError`. The honesty is
+enforced by the harness, not left to the operator's discipline — the one bypass,
+`CAPEVOLVE_ALLOW_TEST_RESCORE=1`, is deliberately an explicit env override.
+
+The seal counts *attempts*, not evaluations, because one honest finalize scores
+test twice by design: the best candidate (`FINAL`) and the unmodified seed
+(`FINAL_seed`), so the headline is a held-out improvement rather than a bare
+number. Neither is a selection event.
 
 ## Selection happens before finalize
 


### PR DESCRIPTION
Closes #335.

The reviewer's headline finding holds up: **the seal itself is sound, its description was stale, and
the bigger problem was omission.** `skills/phases/finalize/SKILL.md` 63 → 104 lines; only the two
files inside the assigned skill dir are touched.

## What changed

**1. The seal description now matches the code.** SKILL.md:25-26 claimed the flag flips "the first
time test is scored". That has been false since `d94fb336`. The body now documents the three real
parts (`core/cap_evolve/rundir.py:358-407`):

- `reserve_test` — every `split="test"` eval *checks* the seal without burning it (`harness.py:241`),
  so no phase but finalize can reach test.
- `commit_test` — burns only after `final.json` is written, so a finalize that dies *before* scoring
  is honestly retryable.
- `begin_test_attempt` — refuses a retry once test rollouts exist, because seal-on-success cannot
  tell "crashed before scoring" from "crashed after". Included the real-run failure that motivated
  it (a finalize killed by a timeout had already scored test; the retry scored it again and the
  headline was the second look) — without that, the mechanism reads arbitrary.

The old wording had a real cost: it told an agent a crashed finalize had permanently burned the
headline number, and the plausible reactions (fresh run, re-split) are far more destructive than the
retry that is actually allowed. `references/concepts.md:33-35` had the same stale text; corrected.

**2. Dropped "makes that mistake impossible."** `CAPEVOLVE_ALLOW_TEST_RESCORE` bypasses the guard
(`rundir.py:166`). In the one skill whose subject is honest measurement, promising a guarantee a
reader can falsify in one grep is worse than describing the real one. Also noted that the override's
own message promises the use "is recorded in the run" and nothing records it (**#341**) — so the
reader knows to disclose it manually. Not fixed here; that is a core change.

**3. The omission — finalize scores TWO candidates on test.** `scripts/run.py:38-46` passes the seed
as `baseline_dir`; `harness.finalize` (`harness.py:2264-2281`) scores the best as `FINAL` and the seed
as `FINAL_seed`, writing `test_baseline`, `baseline_id`, `test_delta`. Those keys are load-bearing in
`skills/phases/report/scripts/run.py:54-98`, `dashboard.py:1337-1340`, `eventstream.py:389-390`, and
`agent-optimize/scripts/measure.py:234-250`. The skill mentioned none of it, so its stated output
contract was wrong and its cost understated 2x — someone budgeting a run from this file was off by a
factor of two. Now documented, including that `--n-trials 3` is six passes over test.

This also resolves what read as self-contradiction (old :53 "scored once" good vs :56 "finalizing
several candidates" bad): both evals sit inside **one** attempt and neither is a selection event, which
is why the seal counts attempts rather than evaluations.

**4. New `## If finalize refuses` — three states, three responses.** The skill previously said nothing
about a `TestSealError`, leaving an agent to guess. Documented as a table, distinguished by
`<run>/rollouts/test/` and `test_used`, including the recovery path `rundir.py:395-396` documents:
read the earlier attempt's rollouts, do not re-score. Plus an explicit "never delete test rollouts or
edit `splits.json` to get past this".

**5. Ownership contract.** finalize owns the seal, so it is stated in full here. The gate decision and
the report format are left to their owners (`report` is named in a clause only). Deleted the
`## Inputs / outputs (manifest tokens)` prose — frontmatter already carries it. **No agent-mode-loop
or failure-taxonomy restatement existed in this skill**, so nothing to remove there (0 lines). Cut the
body's paraphrase of `concepts.md`'s bias argument (old :26-34, near-verbatim with `concepts.md:27-29`)
down to one sentence plus a pointer — level-2 body text is a recurring per-trigger cost.

**6. Also fixed:** `num_trials` defaults to 1 under `cap-evolve run` (`cli.py:950`), so the
"use ≥3 trials" advice never reached the orchestrated path. And the no-holdout flag is now attributed
to the dashboard, which actually implements it — `report/scripts/run.py` has no such branch.

## Evidence

`wc -l skills/phases/finalize/SKILL.md`: **63 → 104**. Body ~831 words / ~1.1k tokens, description 326
chars, no CRITICAL/ALWAYS/MUST — inside the 500-line / 5000-token budget.

**Skill check (the proof the seal holds — it calls `harness.finalize` twice and asserts `TestSealError`):**
```
$ python scripts/check.py
{"skill": "finalize", "ok": true, "problems": [],
 "notes": ["run entry exposes main()", "test scored once on the sealed split",
           "second finalize refused (test seal enforced)"]}
```

**Two-candidate test scoring, from a real run** (`bash examples/toy_calc/run.sh`, exit 0):
```
$ ls <run>/rollouts/test
a7__FINAL__t0.json   a7__FINAL_seed__t0.json
a8__FINAL__t0.json   a8__FINAL_seed__t0.json      <- 2 tasks x 2 candidates

  "test_reward": 1.0,
  "test_baseline_reward": 0.0,
  "test_delta": 1.0,
```
`final.json` carries `test`, `test_baseline` (reward 0.0, `baseline_id: "seed"`) and
`test_delta: 1.0` — exactly the keys the skill now documents.

**A second finalize raises** (same run dir, via the skill's own entry point):
```
$ python skills/phases/finalize/scripts/run.py --run-dir .capevolve/run_demo --project .capevolve/project
  File ".../harness.py", line 2264, in finalize
    run_dir.begin_test_attempt()
  File ".../rundir.py", line 386, in begin_test_attempt
    splits.check_test_unused()
cap_evolve.splits.TestSealError: TEST split already scored once this run. The held-out test
set is sealed — re-scoring it would invalidate the headline number. Score val during
optimization; test is for finalize() only.
```

**Tests:**
```
$ PYTHONPATH="$PWD/core:$PWD/dashboard/backend" python -m pytest core/tests -q
789 passed, 12 skipped in 149.32s          # matches clean main exactly (#349)

$ PYTHONPATH="$PWD/core:$PWD/dashboard/backend" python -m pytest core/tests/test_test_seal_rescore_guard.py -q
6 passed in 1.36s
```

`skills/_registry/build_manifest.py` still resolves finalize under `phase (8)`.

## Deviation from the issue's acceptance criteria

AC #6 asked for "≤ ~70 lines". The result is 104. That estimate assumed finding 6 would reclaim ~12
lines to absorb findings 3-5; the reclaimed paraphrase was ~9 lines while the genuinely missing
mechanism (two-candidate eval + cost, the three-part seal, the refusal table) is ~40. Every added line
is mechanism this phase owns and nothing else states, so I kept it rather than compressing the refusal
table or the 2x cost warning back out. Still far inside the 500-line / 5000-token budget. Flagging it
explicitly rather than quietly missing the number.

## Out of scope (unchanged, as the issue directs)

- The seal implementation, the reserve/commit split, and the override's existence — the mechanism is
  correct; only its documentation was stale.
- **#341** — recording `test_rescore_override` as an event and surfacing it in `report`. Core change,
  referenced from the skill so a reader is not misled, not fixed here.
- The `report` no-holdout gap — belongs to the `report` skill.
- The verbatim `## Dual-mode` paragraph shared by all eight phase skills — repo-wide convention.

## What other skills should drop (per the ownership contract, not touched here)

Nothing new. The honesty-invariant restatements in the other ten skills are already assigned away
from finalize by the ownership table, and this PR does not rely on any of them.
