### PR TITLE
fix: docs and skills invoked cap-evolve subcommands that do not exist (#203)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,12 @@ jobs:
             "README.md" "docs/**/*.md" "examples/**/*.md" "*.md"
           fail: true
 
+      # Docs/skills must not instruct agents to run a `cap-evolve <sub>` that does not
+      # exist (issue #203). The valid set is parsed out of core/cap_evolve/cli.py, so no
+      # install is needed and the check cannot drift from the CLI.
+      - name: Check documented cap-evolve subcommands exist
+        run: python3 ci/check_cli_subcommands.py
+
   spellcheck:
     name: Spellcheck (docs)
     runs-on: ubuntu-latest

--- a/ci/check_cli_subcommands.py
+++ b/ci/check_cli_subcommands.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Fail if a doc or skill invokes a `cap-evolve <subcommand>` the CLI does not implement.
+
+Docs and several algorithm skills used to instruct agents to run `cap-evolve finalize`
+and `cap-evolve report` — neither exists (both phases are scripts, invoked by
+`cap-evolve run` via `skill_run(step)`), so an agent following them ran a command that
+fails at the end of a run that may have cost real money (issue #203).
+
+The valid set is READ OUT OF THE CODE — the `COMMANDS` dict in `core/cap_evolve/cli.py`,
+parsed with `ast` so nothing needs installing — not hardcoded here, so it stays correct
+as commands are added or removed.
+
+Only backticked/fenced invocations are checked; prose like "cap-evolve optimizes any
+capability" is not a command. Usage: `python ci/check_cli_subcommands.py [root ...]`.
+"""
+from __future__ import annotations
+
+import ast
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+CLI = ROOT / "core" / "cap_evolve" / "cli.py"
+SUFFIXES = {".md", ".yaml", ".yml", ".txt"}
+DEFAULT_ROOTS = ("skills", "docs", "templates", "plugins", "ci", "site", "examples",
+                 "core/README.md", "README.md", "RUN.md", "llms.txt")
+# CHANGELOG records what past releases claimed; built run artifacts are generated.
+SKIP = ("CHANGELOG.md", "core/build/", "node_modules/", "/run_full/")
+
+# The two forms a real invocation takes: a backticked span (`cap-evolve x`) and a line
+# inside a ``` fence. Unfenced prose ("cap-evolve runs intake ...") is not a command and is
+# deliberately not matched. ponytail: no shell parsing — a fence line must be the command at
+# column 0 (indented fence lines are prose notes); widen if a phantom ever hides mid-pipeline.
+INLINE = re.compile(r"`+cap-evolve\s+([a-z][a-z0-9-]*)")
+FENCED = re.compile(r"^\$? ?cap-evolve\s+([a-z][a-z0-9-]*)")
+# ...and an unfenced line that is plainly a copy-pasteable command (carries a `--flag`).
+BARE = re.compile(r"^\$? ?cap-evolve\s+([a-z][a-z0-9-]*)(?=.*\s--)")
+
+
+def invocations(text):
+    """Yield (subcommand, line_no) for every real `cap-evolve <sub>` invocation."""
+    fenced = False
+    for n, line in enumerate(text.split("\n"), 1):
+        if line.lstrip().startswith("```"):
+            fenced = not fenced
+            continue
+        pats = (FENCED,) if fenced else (INLINE, BARE)
+        for m in (m for pat in pats for m in pat.finditer(line)):
+            yield m.group(1), n
+
+
+def cli_commands() -> set[str]:
+    """The subcommand names `cap-evolve` actually dispatches, straight from cli.py."""
+    tree = ast.parse(CLI.read_text(encoding="utf-8"))
+    names: set[str] = set()
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and any(
+            isinstance(t, ast.Name) and t.id == "COMMANDS" for t in node.targets
+        ):
+            names |= {k.value for k in node.value.keys if isinstance(k, ast.Constant)}
+    if not names:
+        sys.exit(f"error: no COMMANDS table found in {CLI} — update this check")
+    return names | {"help", "version"}  # -h/--help/-V/--version aliases
+
+
+def files(roots):
+    for r in roots:
+        p = ROOT / r
+        for f in ([p] if p.is_file() else sorted(p.rglob("*"))):
+            rel = f.relative_to(ROOT).as_posix()
+            if f.is_file() and f.suffix in SUFFIXES and not any(s in rel for s in SKIP):
+                yield f, rel
+
+
+def main(argv) -> int:
+    valid = cli_commands()
+    bad = []
+    for f, rel in files(argv or list(DEFAULT_ROOTS)):
+        for sub, line in invocations(f.read_text(encoding="utf-8", errors="replace")):
+            if sub not in valid:
+                bad.append(f"{rel}:{line}: `cap-evolve {sub}` is not a subcommand")
+    if bad:
+        print("\n".join(bad))
+        print(f"\n{len(bad)} phantom cap-evolve subcommand reference(s).")
+        print(f"Valid: {' '.join(sorted(valid))}")
+        print("Phases (finalize/report/baseline/...) are SCRIPTS: run "
+              "`python skills/phases/<phase>/scripts/run.py`, or `/cap-evolve:<phase>`, "
+              "or let `cap-evolve run` sequence them.")
+        return 1
+    print(f"ok: no phantom cap-evolve subcommands (valid: {' '.join(sorted(valid))})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/core/README.md
+++ b/core/README.md
@@ -25,8 +25,8 @@ cap-evolve run   --spec .capevolve/project/capevolve.yaml \
             --project .capevolve/project
 cap-evolve run   --spec .capevolve/project/capevolve.yaml \
             --project .capevolve/project --run-ts full --resume  # continue an interrupted run
-cap-evolve check --spec .capevolve/project/capevolve.yaml   # validate adapter
-cap-evolve report                                        # regenerate dashboard
+cap-evolve check --project .capevolve/project                # validate adapter
+cap-evolve dashboard                                     # serve the live dashboard
 ```
 
 See the [cap-evolve repository](https://github.com/skillberry-ai/cap-evolve) for full

--- a/core/cap_evolve/cli.py
+++ b/core/cap_evolve/cli.py
@@ -695,7 +695,7 @@ def _cmd_run(argv):
     # coding agent, so the plan reflects only what this process actually runs.
     if orchestration_mode == "agent":
         sequence = ["intake", "implement-and-check", "baseline",
-                    "<handoff: agent drives the loop, then `cap-evolve finalize`>"]
+                    "<handoff: agent drives the loop, then the finalize phase>"]
     else:
         sequence = ["intake", "implement-and-check", "baseline", algorithm_name, "finalize", "report"]
 
@@ -826,14 +826,15 @@ def _cmd_run(argv):
 
     # Agent mode: the coding agent drives the optimization loop itself (reading the
     # algorithm's "Agent-mode loop"), writing run-dir artifacts via cap-evolve
-    # primitives, and sealing with `cap-evolve finalize`. cap-evolve run does
+    # primitives, and sealing with the finalize phase script. cap-evolve run does
     # setup+baseline, then hands off here — no algorithm subprocess, no auto-finalize.
     if orchestration_mode == "agent":
         print(json.dumps({"mode": "agent", "run_dir": run_dir, "algorithm": algorithm_name,
                           "spec_path": str(spec_path), "dashboard": dash_url or "off",
                           "stop_condition": str(spec.get("stop_condition", "")),
                           "next": "drive via the orchestrate Agent-mode loop; "
-                                  "seal with `cap-evolve finalize`"}))
+                                  "seal with the finalize phase "
+                                  "(skills/phases/finalize/scripts/run.py)"}))
         return done(0)
 
     # 2) algorithm (hill-climb variants select their schedule via --focus)

--- a/core/cap_evolve/dashboard.py
+++ b/core/cap_evolve/dashboard.py
@@ -486,7 +486,7 @@ def _derive_status(*, events: list, now: float, budget, spent, agent_mode: bool,
         # about it is the exact class of wrong status the old logic produced.
         return "awaiting_agent", (
             "baseline is done and `cap-evolve run` handed off — the agent has not "
-            "committed a candidate yet (agent-mode runs end with `cap-evolve finalize`)")
+            "committed a candidate yet (agent-mode runs end with the finalize phase)")
 
     last_t = 0.0
     for e in reversed(events):

--- a/core/tests/test_stop_hook_agent_mode.py
+++ b/core/tests/test_stop_hook_agent_mode.py
@@ -2,7 +2,7 @@
 
 The hook blocks a Stop (exit 2) once per chain when an agent-mode run is not yet
 finalized, so the coding agent keeps driving its loop until it seals with
-`cap-evolve finalize`. Deterministic runs, finalized runs, and a relenting chain
+the finalize phase. Deterministic runs, finalized runs, and a relenting chain
 (`stop_hook_active`) are all unaffected.
 
 We unit-test `decide()` directly. The green-check itself (`_check_failed_reason`)

--- a/docs/AGENT_ORCHESTRATION.md
+++ b/docs/AGENT_ORCHESTRATION.md
@@ -96,10 +96,10 @@ python "$S/phases/finalize/scripts/run.py" --run-dir "$R" --project "$P" --n-tri
 python "$S/phases/report/scripts/run.py"   --run-dir "$R"
 ```
 
-> **Note — there is no `cap-evolve finalize` subcommand.** The orchestrate/host prose uses
-> `cap-evolve finalize` as shorthand; sealing is done by the finalize *phase script* above
-> (`skills/phases/finalize/scripts/run.py`), which scores the best candidate on test once and
-> burns the seal. A second finalize raises `TestSealError`.
+> **Note — finalize and report are phase scripts, not CLI subcommands.** Sealing is done by
+> the finalize *phase script* above (`skills/phases/finalize/scripts/run.py`), which scores the
+> best candidate on test once and burns the seal. A second finalize raises `TestSealError`.
+> `ci/check_cli_subcommands.py` fails the build if any doc or skill invents a subcommand.
 
 ## Honesty invariants (both modes)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -26,7 +26,7 @@ prioritizes what makes cap-evolve best-in-class and widely adopted.
   obra/superpowers) — verified headless commands; adding one is a single YAML row.
 - Honest-eval upgrades: paired significance gate (default), seal-on-success test,
   structured `Rollout.error` infra signal, per-trial seed for real pass^k variance.
-- Rich **self-contained** `dashboard.html` + `cap-evolve report --terminal` ANSI report.
+- Rich **self-contained** `dashboard.html` + ANSI terminal report (`/cap-evolve:report --terminal`).
 - Host-agnostic installer + Claude Code plugin (honesty hooks in core-owned scripts,
   diagnoser/proposer subagents, router) — `claude --plugin-dir ./plugins/cap-evolve`.
 - Real proof: tau2-bench airline (gpt-oss-120b agent + user simulator) optimized

--- a/plugins/cap-evolve/hooks/require_green_check.py
+++ b/plugins/cap-evolve/hooks/require_green_check.py
@@ -163,7 +163,8 @@ def decide(payload: dict) -> int:
             "cap-evolve (agent mode): the run is not finalized. Re-read your "
             "stop_condition — if it isn't met and budget remains, keep driving the "
             "algorithm's Agent-mode loop (evaluate->gate->accept/revert), verifying each "
-            "round wrote its run-dir artifacts. When done, seal with `cap-evolve finalize`."
+            "round wrote its run-dir artifacts. When done, seal with the finalize phase "
+            "(/cap-evolve:finalize)."
         )
     return 0
 

--- a/skills/algorithms/agent-optimize/SKILL.md
+++ b/skills/algorithms/agent-optimize/SKILL.md
@@ -815,7 +815,7 @@ produced nulls that nobody could interpret:
 
 ## See your constraints every few steps
 
-There is no `cap-evolve status` command. **Every 2–3 rounds** (and always before a fan-out)
+There is no cap-evolve status subcommand. **Every 2–3 rounds** (and always before a fan-out)
 run the readout and compare it to the goal:
 
 ```bash
@@ -863,8 +863,8 @@ generalisation**, with the overlap counted; and `best_id == "seed"` prints a `wa
 every delta is 0 by construction and must be reported as a **null result with a diagnosed
 cause**, not as a 0.000 improvement.
 
-(There is **no `cap-evolve finalize` subcommand** — the orchestrate/host prose uses that as
-shorthand; the real seal is the finalize phase script / `measure.py`, which scores the best
+(Sealing has **no `cap-evolve` subcommand** — it is the finalize phase script
+(`skills/phases/finalize/scripts/run.py`) / `measure.py`, which scores the best
 on test once and burns the seal. A second finalize raises `TestSealError`.) A run with no
 finalize has no result.
 

--- a/skills/algorithms/evograph/SKILL.md
+++ b/skills/algorithms/evograph/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   Each round re-evaluates the train split, clusters failures into a shared Obsidian-style markdown
   "weakness graph", dispatches one solver agent per weakness in its own git worktree scoped to that
   weakness's frozen affected_tasks, merges verified improvements, reverts a whole round on regression,
-  and repeats until the spec's stop_condition — then seals the test once via `cap-evolve finalize`.
+  and repeats until the spec's stop_condition — then seals the test once via the finalize phase.
   Writes its wiki into the run dir; the cap-evolve dashboard reads those files directly and renders
   the Weakness graph tab — no second server, no embedded view to launch.
   USE when algorithm_skill: evograph and orchestration_mode: agent.
@@ -36,7 +36,7 @@ cap-evolve's:
 | its own setup Q&A (`questions.md`) | **cap-evolve `intake`** — read the spec (`capevolve.yaml`); ask nothing of your own |
 | "discover & run the bench yourself" | **cap-evolve adapter + harness** — evaluate through `cap-evolve` (writes run-dir rollouts/results) |
 | its own train/test split | **cap-evolve seeded splits** (`splits.json`); train each round, **test sealed** |
-| its own final-test.json + cost prompt | **`cap-evolve finalize`** produces the sealed number; mirror it into the wiki for the view |
+| its own final-test.json + cost prompt | the **finalize phase** (`/cap-evolve:finalize`) produces the sealed number; mirror it into the wiki for the view |
 | wiki under `.evograph/` | wiki under the **cap-evolve run dir** (`<run_dir>/wiki/…`) so the dashboard tab reads it |
 | primary/secondary from its own config | the spec's `metric_primary` / `metrics_display` (**#38**) — gate on the primary only |
 
@@ -58,7 +58,7 @@ terms/formats out of the run dir:
 ## Hard rules (honesty — never violate)
 
 1. **The sealed test split is untouchable until the end.** Evaluate only on train (rounds) / the
-   affected_tasks; never score test until the final `cap-evolve finalize` (which owns the seal —
+   affected_tasks; never score test until the final finalize phase (which owns the seal —
    `RunDir.reserve_test`/`commit_test`). One test scoring, ever.
 2. **Acceptance is gated on the primary metric.** A merge/solution is kept only if it improves the
    primary metric over its baseline on the relevant tasks; a whole round reverts if the round-start
@@ -129,10 +129,12 @@ solution cards + logs present, standard events/rollouts emitted). Re-read `stop_
 (2.1) or halt.
 
 ## Step 3 — Final test (once, after halt)
-Call `cap-evolve finalize` — it scores the best candidate on the sealed test split exactly once and
+Run the finalize phase — `/cap-evolve:finalize`, i.e.
+`python "$S/phases/finalize/scripts/run.py" --run-dir "$R" --project "$P"` (there is no `cap-evolve`
+subcommand for it) — it scores the best candidate on the sealed test split exactly once and
 burns the seal (unfakeable headline number). Mirror that number into `<run_dir>/wiki/results/final-test.json`
 (`"split":"test"`, `"round":"final"`) so evograph's tab shows it in its Final-test panel. Then
-`cap-evolve report`.
+run the report phase, `/cap-evolve:report`.
 
 ## Cost — use cap-evolve's cost system (not a separate one)
 Do **not** run a bespoke end-of-run cost prompt. Cost is cap-evolve's job: every eval you drive

--- a/skills/algorithms/evograph/scripts/check.py
+++ b/skills/algorithms/evograph/scripts/check.py
@@ -49,7 +49,7 @@ def main() -> int:
     skill = (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
     for needle, label in [
         ("Round loop", "agent-mode round loop"),
-        ("finalize", "seal via cap-evolve finalize"),
+        ("finalize", "seal via the finalize phase"),
         ("primary metric", "primary-metric gating"),
         ("orchestration_mode: agent", "agent-mode gating"),
     ]:

--- a/skills/algorithms/evograph/scripts/run.py
+++ b/skills/algorithms/evograph/scripts/run.py
@@ -43,7 +43,8 @@ def main(argv=None) -> int:
             "evograph has no deterministic engine. Set `orchestration_mode: agent` in "
             "capevolve.yaml and run it agent-driven: cap-evolve does intake/check/baseline "
             "then hands the loop to the coding agent, which follows this skill's "
-            "'Step 2 — Round loop' and seals with `cap-evolve finalize`."
+            "'Step 2 — Round loop' and seals with the finalize phase script "
+            "(skills/phases/finalize/scripts/run.py)."
         ),
     }))
     return 2

--- a/skills/algorithms/gepa/SKILL.md
+++ b/skills/algorithms/gepa/SKILL.md
@@ -103,7 +103,7 @@ Reports the frontier/pool, best candidate, accepts, merges, and metric-calls spe
 test stays sealed for `finalize`.
 
 ## Agent-mode loop
-When `orchestration_mode: agent`, drive gepa yourself: maintain the candidate pool/Pareto frontier; each round pick a parent (per gepa's selection), reflect on its val feedback to propose an edit, evaluate on **val** via cap-evolve, gate Δ>k·SE, accept→snapshot & add to the frontier / reject→drop. Metric-calls is the primary budget. Log rounds to the run dir; between rounds verify rollouts+results landed so the dashboard reflects the frontier. Re-read `stop_condition`; stop on it/budget. Seal once with `cap-evolve finalize`, then `report`.
+When `orchestration_mode: agent`, drive gepa yourself: maintain the candidate pool/Pareto frontier; each round pick a parent (per gepa's selection), reflect on its val feedback to propose an edit, evaluate on **val** via cap-evolve, gate Δ>k·SE, accept→snapshot & add to the frontier / reject→drop. Metric-calls is the primary budget. Log rounds to the run dir; between rounds verify rollouts+results landed so the dashboard reflects the frontier. Re-read `stop_condition`; stop on it/budget. Seal once with `/cap-evolve:finalize`, then `/cap-evolve:report`.
 
 ## References
 

--- a/skills/algorithms/hill-climb/SKILL.md
+++ b/skills/algorithms/hill-climb/SKILL.md
@@ -50,7 +50,7 @@ mean improves.
 Back-compat: `--focus all-at-once` is accepted and treated as `all`.
 
 ## Agent-mode loop
-When `orchestration_mode: agent`, drive hill-climb yourself: from the baseline best, each iteration — propose ONE edit to the capability (per `--focus`: all / cyclic / hardest-first), evaluate the candidate on **val** via cap-evolve (writes rollouts+results), gate Δ>k·SE, accept→snapshot via the store / reject→revert. Log each iteration to the run dir's event log. Re-read `stop_condition`; stop on it or on stall/budget. Between iterations, confirm the run dir got this iteration's rollouts + event so the dashboard stays current. Seal once with `cap-evolve finalize`, then `report`.
+When `orchestration_mode: agent`, drive hill-climb yourself: from the baseline best, each iteration — propose ONE edit to the capability (per `--focus`: all / cyclic / hardest-first), evaluate the candidate on **val** via cap-evolve (writes rollouts+results), gate Δ>k·SE, accept→snapshot via the store / reject→revert. Log each iteration to the run dir's event log. Re-read `stop_condition`; stop on it or on stall/budget. Between iterations, confirm the run dir got this iteration's rollouts + event so the dashboard stays current. Seal once with `/cap-evolve:finalize`, then `/cap-evolve:report`.
 
 ## References
 - `references/focus-schedules.md` — how each schedule builds its focus set.

--- a/skills/algorithms/skillopt/SKILL.md
+++ b/skills/algorithms/skillopt/SKILL.md
@@ -80,7 +80,7 @@ significance test has signal. Only the slow update is a "meta" step — it is st
 budget (toggle with `--no-slow-update`).
 
 ## Agent-mode loop
-When `orchestration_mode: agent`, drive skillopt yourself: single-lineage climb with a textual learning rate over epochs/minibatches — each step propose an edit sized to the current LR, evaluate on **val** (minibatch then full as skillopt prescribes) via cap-evolve, gate Δ>k·SE, accept→snapshot / reject→revert & decay. Log steps to the run dir; between steps verify rollouts+results landed for the dashboard. Re-read `stop_condition`; stop on it/stall/budget. Seal once with `cap-evolve finalize`, then `report`.
+When `orchestration_mode: agent`, drive skillopt yourself: single-lineage climb with a textual learning rate over epochs/minibatches — each step propose an edit sized to the current LR, evaluate on **val** (minibatch then full as skillopt prescribes) via cap-evolve, gate Δ>k·SE, accept→snapshot / reject→revert & decay. Log steps to the run dir; between steps verify rollouts+results landed for the dashboard. Re-read `stop_condition`; stop on it/stall/budget. Seal once with `/cap-evolve:finalize`, then `/cap-evolve:report`.
 
 ## References
 - `references/concepts.md` — the SkillOpt loop in detail, the textual-LR schedule,

--- a/skills/orchestrate/orchestrate/SKILL.md
+++ b/skills/orchestrate/orchestrate/SKILL.md
@@ -52,7 +52,7 @@ Rules:
 2. **Honesty is self-policed:** never touch the sealed test split until the end; revert on regression; acceptance is val-only.
 3. **Between rounds, verify the run dir has what the dashboard needs** before continuing: the round's events are logged, results/rollouts are written, and each accepted candidate is snapshotted. If a round produced no run-dir artifacts, the dashboard will be blank — fix that before proceeding.
 4. **Re-read `stop_condition` each round.** Stop when it is met, or budget/stall hits.
-5. **Seal once, at the end:** call `cap-evolve finalize` (scores the best candidate on the sealed test split exactly once) then `cap-evolve report`. A run with no finalize has no result.
+5. **Seal once, at the end:** run the **finalize** phase — `/cap-evolve:finalize`, i.e. `python "$S/phases/finalize/scripts/run.py" --run-dir "$R" --project "$P"` (scores the best candidate on the sealed test split exactly once) — then the **report** phase, `/cap-evolve:report`. There is no `cap-evolve` CLI subcommand for either; both are phase scripts. A run with no finalize has no result.
 
 ## How to run
 ```

--- a/skills/phases/intake/inputs/INPUTS.md
+++ b/skills/phases/intake/inputs/INPUTS.md
@@ -171,7 +171,7 @@ path, how to obtain it, and the alternatives. Never invent a NEEDED input.
   - `metric_primary`: the single metric that decides accept/reject (= the scalar reward). Blank = use the reward directly.
   - `metrics_display` + `metric_directions`: extra SHOWN-ONLY metrics and each one's direction (`higher`|`lower`). These never affect the gate — display only.
 - **github_integration** (default `false`): if `true`, intake runs `gh auth status`; when authed, cap-evolve may mirror the algorithm's work items as issues and ship the winner as a PR (`Closes #n`). WHAT gets mirrored is algorithm-specific — the chosen `algorithm_skill` defines it (e.g. evograph mirrors *weaknesses*; a candidate-based algorithm might mirror candidates/iterations). GitHub is NEVER the source of truth — the run dir is. If unauthed, intake offers `gh auth login` or skip.
-- **orchestration_mode** (default `deterministic`): `deterministic` = cap-evolve sequences the loop (code-enforced honesty). `agent` = the coding agent drives the loop via cap-evolve primitives and seals with `cap-evolve finalize`. Agent mode also uses `stop_condition`.
+- **orchestration_mode** (default `deterministic`): `deterministic` = cap-evolve sequences the loop (code-enforced honesty). `agent` = the coding agent drives the loop via cap-evolve primitives and seals with the finalize phase (`/cap-evolve:finalize`). Agent mode also uses `stop_condition`.
 - **stop_condition** (default empty): agent-mode free-text halt rule, re-read each round. Deterministic mode ignores it and uses the budget knobs.
 
 - **baseline traces** (optional): prior rollouts to seed diagnosis. Default: none

--- a/templates/project/capevolve.yaml
+++ b/templates/project/capevolve.yaml
@@ -34,7 +34,7 @@ target_profile_file: ""
 # --- how to iterate ---------------------------------------------------------
 algorithm_skill: hill-climb              # algorithms/<skill>: hill-climb | gepa | skillopt | agent-optimize | evograph (agent-optimize and evograph REQUIRE orchestration_mode: agent)
 algorithm_focus: all                     # hill-climb schedule: all | cyclic | hardest-first
-orchestration_mode: deterministic        # deterministic (cap-evolve sequences the loop) | agent (the coding agent drives the loop via cap-evolve primitives, sealing with `cap-evolve finalize`)
+orchestration_mode: deterministic        # deterministic (cap-evolve sequences the loop) | agent (the coding agent drives the loop via cap-evolve primitives, sealing with the finalize phase)
 
 # --- what context the optimizer gets (hill-climb) ---------------------------
 # The per-iteration optimizer prompt is RENDERED from this template (intake authors it,


### PR DESCRIPTION
Closes #203.

## The bug

Docs and five algorithm/orchestrate skills instructed agents to run **`cap-evolve finalize`** and **`cap-evolve report`**. Neither subcommand exists. The real command table (`core/cap_evolve/cli.py:1654-1670`) is:

```
help init doctor algorithms diff version splits check run estimate dashboard tail watch replay
```

Both phases are **scripts only** — `cap-evolve run` invokes them via `skill_run(step)` (`core/cap_evolve/cli.py:614`, `:957-961`), and a human runs them standalone as `/cap-evolve:finalize` / `/cap-evolve:report`, i.e. `python skills/phases/finalize/scripts/run.py --run-dir DIR --project DIR`.

So an agent that followed the instructions ran a command that does not exist, **at the end of a run that may have cost real money**. A correctness bug in the instructions, not a docs nit.

## Root cause, not just the symptom

`cap-evolve run` **itself** emitted the phantom command in its agent-mode handoff JSON:

```
"next": "drive via the orchestrate Agent-mode loop; seal with `cap-evolve finalize`"
```

The plugin Stop hook repeated it, and the dashboard's agent-mode empty state said it too. Every skill that restated it was copying the CLI. All three fixed here.

## Grep, before → after

Scope from the issue, excluding the built `examples/tau2_airline/run_full/ui/assets/*.js` artifact:

**Before — 13 files** (`skills/phases/report/` had 0 hits, so no conflict with #362):

| file | hits |
|---|---|
| `skills/algorithms/evograph/SKILL.md` | 5 |
| `docs/AGENT_ORCHESTRATION.md` | 2 (disclaimer) |
| `skills/algorithms/evograph/scripts/run.py` | 1 |
| `skills/algorithms/evograph/scripts/check.py` | 1 |
| `skills/algorithms/gepa/SKILL.md` | 1 |
| `skills/algorithms/hill-climb/SKILL.md` | 1 |
| `skills/algorithms/skillopt/SKILL.md` | 1 |
| `skills/algorithms/agent-optimize/SKILL.md` | 1 (disclaimer) |
| `skills/orchestrate/orchestrate/SKILL.md` | 1 |
| `skills/phases/intake/inputs/INPUTS.md` | 1 |
| `docs/ROADMAP.md` | 1 |
| `templates/project/capevolve.yaml` | 1 |
| `plugins/cap-evolve/hooks/require_green_check.py` | 1 |

Plus, outside the issue's grep scope, the **root cause** in `core/`: `cli.py` (3), `dashboard.py:489`, `core/README.md:29`.

PR #362's count of seven was an undercount — it looks to have grepped only `skills/` + `docs/`.

**After:**

```
$ grep -rn "cap-evolve finalize\|cap-evolve report" skills/ docs/ README.md RUN.md llms.txt \
    templates/ examples/ site/ plugins/ ci/ | grep -v index-CA4Zb19R.js
ci/check_cli_subcommands.py
4:Docs and several algorithm skills used to instruct agents to run `cap-evolve finalize`
5:and `cap-evolve report` — neither exists (both phases are scripts, invoked by
```

Only the guard's own docstring, describing what it forbids.

Two files (`docs/AGENT_ORCHESTRATION.md`, `agent-optimize/SKILL.md`) already carried a *disclaimer* — "there is no `cap-evolve finalize` subcommand, the prose uses it as shorthand". Once no prose uses the shorthand, the disclaimer is what keeps the wrong string in the corpus for the next reader to copy. Both rewritten to state the fact without printing the phantom command.

**Left alone deliberately:** `core/cap_evolve/dashboard.py:1506` — `title = f" cap-evolve report · {run_id} "` is the ANSI report's *panel title*, not an invocation, and `core/tests/test_dashboard.py:211` asserts it. `CHANGELOG.md:806` is a historical release note. Neither instructs anyone to type anything.

## The guard (`ci/check_cli_subcommands.py`)

Fails when any doc or skill invokes a `cap-evolve <sub>` the CLI does not implement.

**Derived from the code, not hardcoded.** It parses the `COMMANDS` dict out of `core/cap_evolve/cli.py` with `ast` — so it needs no install (fits the docs-only CI job), and adding or removing a subcommand updates the valid set automatically:

```python
def cli_commands() -> set[str]:
    tree = ast.parse(CLI.read_text(encoding="utf-8"))
    ...
    names |= {k.value for k in node.value.keys if isinstance(k, ast.Constant)}
```

Non-flaky by construction: it matches only the two shapes a real invocation takes — a backticked span, or a command at column 0 inside a ``` fence (plus an unfenced line carrying a `--flag`). Ordinary prose like "cap-evolve runs intake → check → baseline" is not a command and is not matched.

### Evidence: fails on a deliberately-bad reference, then passes

```
$ printf '\n- Seal with `cap-evolve finalize`, then `cap-evolve report`.\n' >> docs/ROADMAP.md
$ printf 'cap-evolve summarize --run-dir X\n' >> docs/ROADMAP.md
$ python3 ci/check_cli_subcommands.py
docs/ROADMAP.md
68: `cap-evolve finalize` is not a subcommand
68: `cap-evolve report` is not a subcommand
69: `cap-evolve summarize` is not a subcommand

3 phantom cap-evolve subcommand reference(s).
Valid: algorithms check dashboard diff doctor estimate help init replay run splits tail version watch
Phases (finalize/report/baseline/...) are SCRIPTS: run `python skills/phases/<phase>/scripts/run.py`,
or `/cap-evolve:<phase>`, or let `cap-evolve run` sequence them.
$ echo $?
1

$ git checkout docs/ROADMAP.md
$ python3 ci/check_cli_subcommands.py
ok: no phantom cap-evolve subcommands (valid: algorithms check dashboard diff doctor estimate help init replay run splits tail version watch)
$ echo $?
0
```

**Wired by extending** the existing `docs-links` / "Docs link check" job (one `run:` step, no new job, no new runner, no dependency).

## Reverse direction — documented flags that were removed

Swept every documented `cap-evolve <valid-sub> --flag` against that subcommand's live `--help`. One real hit, same one-line class, fixed:

```
core/README.md:28  cap-evolve check --spec .capevolve/project/capevolve.yaml
$ cap-evolve check --spec x.yaml
check: unknown option '--spec'  (usage: cap-evolve check [project_dir])
```

`check` takes `--project`. Also `core/README.md:29`'s `cap-evolve report  # regenerate dashboard` → `cap-evolve dashboard`, which is the command that actually does that. No other missing flags across `check`, `dashboard`, `diff`, `estimate`, `replay`, `run`, `watch`.

## Verification

```
$ PYTHONPATH="$PWD/core:$PWD/dashboard/backend" python -m pytest core/tests -q
789 passed, 12 skipped in 128.43s (0:02:08)
```

Matches clean main (see #349 for why `PYTHONPATH` is pinned in a worktree).

```
$ bash examples/toy_calc/run.sh
"best_id": "cand_0001", "baseline_val": 0.0,
"test_reward": 1.0, "test_baseline_reward": 0.0, "test_delta": 1.0,
"test_pass_k": {"1": 1.0}, "iterations": 3
```

Gate-accepted, sealed test 1.0.

Every touched skill's `scripts/check.py` passes:

| skill | result |
|---|---|
| `evograph` | `ok: true` — note now reads "SKILL.md declares seal via the finalize phase" |
| `hill-climb` | `ok: true` |
| `gepa` | `ok: true` |
| `skillopt` | `ok: true` |
| `agent-optimize` | `ok: true`, `problems: []` |
| `orchestrate` | `ok: true`, `problems: []` |
| `intake` | `ok: true`, `problems: []` |

## Note for parallel skill work

Per `SKILL_OWNERSHIP.md` this crosses several skill directories, so every edit is deliberately kept to the single sentence carrying the wrong command — no restructuring, no line moves — to minimise conflicts with the in-flight skill reviews. `skills/phases/report/` is untouched; PR #362 owns it.
