### PR TITLE
agent-optimize: split the 922-line SKILL.md and strip retrospective narrative

### DIFF
--- a/skills/algorithms/agent-optimize/SKILL.md
+++ b/skills/algorithms/agent-optimize/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-optimize
-description: 'Fully-agentic, free-form optimization algorithm. Use in agent orchestration mode when you want the conversational agent to own the whole search — understand the benchmark/inputs first, run the baseline, then freely propose capability edits (serially, or several siblings in parallel working copies), diagnose per task from TRACES rather than from rates, accept only on a full-val paired gate measured against byte-identical control replicates in the same batch and repeated across seed blocks (one paired run cannot resolve a sub-0.10 effect here), all bounded by a free-text stop_condition parsed into re-checkable predicates and re-read from the run dir every round, and finished with one honest train/val/sealed-test measurement. Agent-mode only (orchestration_mode: agent); for a deterministic loop use hill-climb | gepa | skillopt.'
+description: 'Free-form optimization algorithm for agent orchestration mode: the conversational agent owns the whole search — proposing capability edits itself, screening them cheaply, gating each on full val, and sealing test once. Use when orchestration_mode is agent and algorithm_skill is agent-optimize. For a deterministic loop use hill-climb, gepa or skillopt instead.'
 component: algorithm
 argument-hint: "agent-mode only — set orchestration_mode: agent + algorithm_skill: agent-optimize"
 allowed-tools: Read, Write, Edit, Bash, Task
@@ -10,18 +10,12 @@ needs: [scores, traces, candidate]
 
 # agent-optimize — the free-form loop you own
 
-This is the one algorithm with **no deterministic subprocess** and **no per-iteration
-optimizer**. You — the conversational agent that ran intake — are the optimizer, the
-scheduler, and the stopping rule. `cap-evolve run` (with `orchestration_mode: agent`)
-does check → baseline, prints a handoff with the `run_dir`, and returns. From there the
-search is yours: what to edit, what to evaluate, when to evaluate it, when to call it
-done. Your freedom is bounded by exactly two things — the **honesty invariants** below
-(most of which core enforces whether you cooperate or not) and the project's free-text
-**`stop_condition`**.
-
-Nothing new lives in core for this. You drive the *existing* cap-evolve primitives (the
-phase scripts, this skill's `scripts/`, and the `RunDir` API), so `events.jsonl` /
-rollouts / results / snapshots stay populated and the dashboard renders unchanged.
+The one algorithm with **no deterministic subprocess** and **no per-iteration optimizer**: you — the
+agent that ran intake — are the optimizer, the scheduler and the stopping rule. `cap-evolve run` (with
+`orchestration_mode: agent`) does check → baseline, prints a handoff with the `run_dir`, and returns.
+From there the search is yours, bounded by the invariants core enforces and the project's free-text
+**`stop_condition`**. You drive the *existing* primitives, so the run dir and the dashboard stay
+populated exactly as in a deterministic run.
 
 ## Shell variables used by every command below
 
@@ -33,68 +27,46 @@ A="$S/algorithms/agent-optimize/scripts"       # this skill's helpers
 mkdir -p "$R/work"                             # working copies live here (RunDir does NOT create it)
 ```
 
-Every script here (and every phase script) does its own `import _bootstrap`, so it finds
-`cap_evolve` without you exporting `PYTHONPATH`. All of them print JSON on stdout.
+Every script does its own `import _bootstrap`, so it finds `cap_evolve` without `PYTHONPATH`, and all
+of them print JSON on stdout.
 
 ## Phase 0 — understand before you optimize
 
-Do this once, before any edit, and **ask the user any blocking question here** (mirror
-intake's ask-if-missing discipline) so the loop then runs unattended:
+Once, before any edit, and **ask the user any blocking question here** so the loop then runs unattended.
+Read `PROJECT.md`, `capevolve.yaml`, the adapter and every file under `capability_path`, and understand
+what **one evaluation** does: what a task is, what `run_target` produces, what `score()` rewards, and
+what the per-task **feedback** says — that is your learning signal. Note the val/test sizes,
+`num_trials`, `gate_mode`/`gate_k_se` and the allowed edit surface.
 
-- Read `PROJECT.md`, `capevolve.yaml`, the adapter (`adapters/adapter.py`), and every file
-  under `capability_path` (the seed capability you'll edit).
-- Understand what **one evaluation** does: what a task is, what `run_target` produces, what
-  `score()` rewards, and what the per-task **feedback** says (that is your learning signal).
-- Note the **val and test sizes**, `num_trials`, `gate_mode`/`gate_k_se`, and the capabilities
-  under optimization (the allowed edit surface, e.g. `system-prompt`, `tools`).
-- Read the free-text **`stop_condition`** — then let `spend.py` parse it for you rather than
-  restating it from memory. It prints `constraints.predicates`: each concrete check
-  (`target_val_score`, `max_usd`, `max_wallclock_seconds`, `max_iterations`, `max_stall`,
-  `max_metric_calls`, `protect_task`) with its measured actual, plus the prose verbatim.
-  **If `constraints.ambiguous` is non-empty, ASK THE USER before the loop starts** — a
-  vague clause ("don't spend too much", a bare number with no unit) is reported, never
-  guessed at, and this is the one moment where asking is cheap.
+Then read the free-text **`stop_condition`** and let `spend.py` parse it rather than restate it from
+memory: it prints `constraints.predicates`, every concrete check it could extract with its measured
+actual. **If `constraints.ambiguous` is non-empty, ASK THE USER before the loop starts** — a vague
+clause ("don't spend too much", a bare number with no unit) is reported, never guessed at, and this is
+the one moment where asking is cheap.
 
 ## Agent-mode loop
 
-Baseline has already scored the seed on val and set `best_id = seed`; read its val
-mean/stderr from `$R/baseline.json`, or from the readout in step 0 below.
+Baseline has scored the seed on val and set `best_id = seed`. Each round:
 
-Each round:
-
-**0. Check you can afford the round — for the number of candidates you actually intend
-to run.** Budget, stall, wallclock and the parsed constraints all live in / are derived
-from the run dir; read them *before* spending, not after. Pass `--n-siblings N` whenever
-you plan N candidates this round (N=1 for a serial round):
+**0. Check you can afford the round — for the number of candidates you actually intend to run**, with
+`--n-siblings N` whenever you plan N of them, *before* spending:
 
 ```bash
 python "$A/spend.py" --run-dir "$R" --project "$P" --n-siblings 3
 ```
 
-Act on the single `recommendation`:
+Act on the single `recommendation`: **`stop`** (a ceiling breached, `budget_exhausted()` true, or the
+score goal met on FULL val) → go to **Stop & seal**; **`narrow_scope`** (≥80% of some ceiling consumed,
+goal unmet) → ONE cheap candidate screened at tier 1, no fan-out; **`continue`** → run the round you
+planned.
 
-| `recommendation` | what it means | what you do |
-| --- | --- | --- |
-| `stop` | a ceiling is breached (or `budget_exhausted()` is true), or the score goal is met on FULL val | go to **Stop & seal** |
-| `narrow_scope` | ≥80% of some ceiling consumed, goal unmet | ONE cheap candidate, screened at tier 1; no fan-out |
-| `continue` | room left, goal unmet | run the round you planned |
+`afford.affordable: false` (with `afford.blockers` naming the ceiling) means **do not fan out N** —
+check it BEFORE dispatching proposers, since N candidates can blow a budget with room for one. And read
+`afford.runner_spend_metered`: $0 after real rollouts is *unmetered*, not free, and taken as 0.0 it
+leaves `max_usd` unable to block anything, so bound such a run with `max_metric_calls` and report
+**rollout counts, not dollars**.
 
-`afford.affordable: false` (with `afford.blockers` naming the ceiling) means **do not
-fan out N** — drop to a smaller N, or to a subset-screened single candidate. The $ figure
-uses this run's own **measured** `usd_per_rollout` (`spent.usd / spent.metric_calls`), and
-is honestly `null` before the first rollout is paid for. Check this BEFORE dispatching
-proposers: N candidates can blow a budget that had room for one.
-
-**Read `afford.runner_spend_metered`.** Some serving paths return no cost at all (an
-OpenAI-compatible litellm proxy typically does: litellm logs "model isn't mapped yet" and
-reports `0.0`). A measured rate of exactly $0 after real rollouts is *unmetered*, not
-free — treating it as 0.0 would make `usd_needed` 0.0, so a `max_usd` ceiling could never
-block anything and every fan-out would come back `affordable: true`. When
-`runner_spend_metered` is `false`, bound the run with `max_metric_calls` /
-`max_iterations`, and report **rollout counts, not dollars**.
-
-**1. Read the signal.** This is free — no new evaluation. Cluster the current best's
-failing rollouts:
+**1. Read the signal.** Free — no new evaluation:
 
 ```bash
 BEST="$(python "$A/spend.py" --run-dir "$R" | python -c 'import json,sys;print(json.load(sys.stdin)["best_id"])')"
@@ -102,23 +74,14 @@ python "$S/phases/diagnose/scripts/run.py" --run-dir "$R" --tag "$BEST" --split 
 python "$S/phases/diagnose/scripts/run.py" --run-dir "$R" --tag "$BEST" --split val
 ```
 
-Read `clusters` for what to fix and **`kept_good`** for what you must not break — those
-are exactly the tasks the no-regression check in step 4 protects.
+Read `clusters` for what to fix and `kept_good` for what you must not break. **With a disjoint train
+split, diagnose it too and compare its cluster signatures to val's** — free, and it decides whether the
+round can work at all: if the two are disjoint, no train-driven edit can move the val mean, and every
+candidate is rejected for a reason that looks exactly like a null result. Say which it is in the
+report. (Baseline scores only val, so pay one `evaluate --split train` first.)
 
-**Diagnose TRAIN when the spec has a disjoint train split, and compare its clusters to
-val's.** Val is what the gate scores, so reading the learning signal off val and then
-gating on val fits the split you are judged on; train is the honest surface. It only
-works if the two share failure modes, and that is a **free** thing to check before you
-spend: if train's cluster signatures and val's are disjoint, no train-driven edit can
-ever move the val mean and every candidate will be correctly rejected for a reason that
-looks exactly like a null result. Say which it is, in the report, either way. (Train
-rollouts have to exist first — baseline only scores val, so pay one
-`evaluate --split train` for the seed if you want this signal.)
-
-**Read the per-task pass rate, not the per-task pass/fail.** At `num_trials: n` a task's
-reward is `k/n`, and that fraction *is* the learning signal — it separates the defects from
-the noise, which is the distinction four consecutive null runs on one benchmark failed
-to make:
+**Read the per-task pass rate, not the per-task pass/fail.** At `num_trials: n` a task's reward is
+`k/n`, and that fraction is what separates defects from noise:
 
 | per-task rate | what it is | what to do |
 | --- | --- | --- |
@@ -126,72 +89,28 @@ to make:
 | `4/10` – `7/10` | genuinely unstable behaviour | fix by *removing* ambiguity, not adding rules |
 | `8/10` – `9/10` | noise around a working path | **leave it alone**; "fixing" it is how churn starts |
 
-A task that "regressed" from `10/10` to `9/10` between two rounds is a re-measurement of
-the same capability, not damage. Chasing it is the single most expensive mistake available
-here: `gate_check.py`'s old no-regression veto did exactly that and rejected a
-byte-identical copy of the seed 43% of the time at 5 trials.
+A task that "regressed" from `10/10` to `9/10` between rounds is a re-measurement, not damage.
 
-**Audit the MEASUREMENT before you credit a failure.** A failing task is a claim by the
-scorer, and a scorer can be wrong in ways that look exactly like a capability gap. Spend the
-first minutes of round 1 on this, because it is free and because every optimizer that skipped
-it optimized against its own instrumentation:
+**Audit the MEASUREMENT before you credit a failure**, in round 1 while it is still free (scoring
+re-derives on persisted rollouts): a failing task is a claim by the scorer, and an optimizer that skips
+this optimizes against its own instrumentation. Does the feedback name the **defect** or only the tool;
+does any helper fail **silently**; is *silent* distinguished from *wrong*; did the rollout **run**, or
+is this missing data wearing a 0.0; which components actually **gate**? The checklist, with the failure
+behind each item: `references/edit-design-lessons.md`.
 
-- **Does the feedback name the actual defect, or only the tool?** If it says "Failed action(s):
-  a write tool" when the real defect is a wrong *argument value*, no edit can be
-  localized. (Measured on this benchmark: argument-value errors are the majority of failed
-  gold actions. A predecessor read the wrong field name for the action check, reported "0
-  actions missed" for every task, and stayed blind to the dominant failure mode for an entire
-  effort.) Fix the adapter's feedback, then re-derive — scoring is deterministic on persisted
-  rollouts, so this costs zero rollouts.
-- **Does any feedback helper fail SILENTLY?** Grep the adapter for bare `except` around signal
-  construction and make each one loud. On this benchmark a localizer called a helper method
-  that did not exist; the `AttributeError` was swallowed, so every failed numeric check
-  degraded to the generic *"1 required piece(s) of information were not clearly
-  communicated"*. An optimiser read that as "the checker is unsatisfiable" and spent **seven
-  rounds** instructing the agent to state a value it was already stating. The repaired signal
-  distinguishes *never stated a figure* from *stated one and it was wrong* — and re-deriving
-  it over 125 already-persisted rollouts cost nothing.
-- **Distinguish "silent" from "wrong" for every value-bearing check.** They are different
-  defects needing opposite edits (add a REQUIRED slot vs. fix arithmetic/scope), and a message
-  that conflates them sends the round in the wrong direction. Report the value the AGENT
-  stated, never the expected one — a check's `info` field often *is* the expected value
-  (one benchmark stores a bare `"1628"`), so use its SHAPE and never echo it.
-- **Did the rollout run, or did the infrastructure fail?** A wallclock timeout, a starved
-  endpoint or a dropped connection is missing data, not a zero. If it lands in the mean as
-  0.0, a whole evaluation can read as a catastrophic capability with no error anywhere.
-  Check `termination_reason` and the coverage the gate reports — a low-coverage split must be
-  `indecisive`, never a score.
-- **Would a clearly-wrong candidate score worse?** If not, the metric is not discriminating
-  and no gate built on it can work.
+**When two rounds of edits are rejected, read the candidate's TRACE before writing a third** — not
+"was the rule right" but "did the agent follow it at all". Never exercised ⇒ the **form** is wrong, so
+take a different row below; exercised and still wrong ⇒ the content is.
 
-**When two rounds of edits are rejected, read the candidate's TRACE before writing a third.**
-The question is not "was the rule right" but "did the agent follow it at all". If the trace
-shows the new rule was never exercised, the content is not the problem — the **form** is, so
-take a different row of the table below. If it was exercised and the outcome was still wrong,
-the content is wrong and the rule needs different substance. Guessing between those two is
-how a budget disappears into variants of one idea.
-
-**2. Propose an edit per candidate — and address EVERY cluster the round can afford.**
-One round should not fix one thing. Take the ranked clusters from step 1 and cover as many
-as the budget allows, either as **sibling candidates** (one cluster each, gated
-independently — the safe default) or as **one bold multi-part edit** (several clusters in
-one candidate — higher variance, but it is the only way a fix that needs a prompt change
-*and* a tool change lands together).
-
-The failure mode to design against is **churn**, and it is measured, not hypothetical: in
-a real run two of three candidates had an *identical* mean to their parent while a
-different set of tasks passed — each fixed 2 tasks and broke 2. A mean-only gate calls
-that a tie; the **no-regression veto in step 5 is what rejects it**, and it is the reason
-a multi-part edit is safe to attempt at all. So when you bundle, keep the parts
-*independent* (different files or different rules) so that if the bundle is vetoed you can
-resubmit the surviving part alone next round — and read `regressed` out of the screen and
-the gate to know which part to drop.
-
-Copy the current best into a fresh working copy, then edit it (consult the `system-prompt`
-/ `tools` capability skills for guidance — but *you* make the edit):
+**2. Propose an edit per candidate — and address EVERY cluster the round can afford**, as **sibling
+candidates** (one cluster each, gated independently — the safe default) or as **one bold multi-part
+edit** (higher variance, but the only way a fix needing a prompt change *and* a tool change lands
+together). If you bundle, keep the parts *independent* — different files, different rules — so a
+rejected bundle can be resubmitted as its surviving part, and read `regressed` (screen) and
+`regressions` (gate) to know which to drop. That is also what stops **churn**, a candidate whose mean
+matches its parent while a *different* set of tasks passes, from reading as a tie.
 
 ```bash
-BEST="$(python "$A/spend.py" --run-dir "$R" | python -c 'import json,sys;print(json.load(sys.stdin)["best_id"])')"
 TAG="cand_1"                                   # unique per candidate — it IS the rollout tag
 cp -r "$R/candidates/$BEST" "$R/work/$TAG"
 # …now edit the files under $R/work/$TAG that your capability actually owns.
@@ -199,724 +118,220 @@ cp -r "$R/candidates/$BEST" "$R/work/$TAG"
 #  tools/tools.py; read capability_path in Phase 0 for the real layout.)
 ```
 
-Every edit must encode a **general rule** — never hardcode a task's id, gold value, or answer.
+Every edit must encode a **general rule** — never a task's id, gold value, or answer.
 
-**Choose the edit FORM from the failure TYPE — before you write a word.** Which form you
-reach for matters more than how well you word it, because the form that repairs one failure
-type measurably backfires on another. Classify the cluster first, then take its row:
+**Choose the edit FORM from the failure TYPE — before you write a word.** The form matters more than
+the wording, because the form that repairs one failure type measurably backfires on another:
 
 | the failure you observed | the form that fixes it | the form that makes it worse |
 | --- | --- | --- |
-| the rule is stated and the agent skips it under pressure | a prohibition plus the symptom that precedes it ("if you are about to X, you have already failed") | another restatement of the rule — this is the case where a mid-tier model gets *less* compliant, measured |
-| the agent complies but the output/call has the wrong shape | a **positive recipe**: state what the correct call IS, its parts, in order | a list of things not to do — on shaping problems this produced *more* unwanted output than no guidance at all |
-| a required element is simply missing | a **structural REQUIRED slot** the agent has to fill, or a code-level precondition | a prose reminder somewhere in the middle of the document |
-| behaviour should differ by situation | a conditional on an **observable predicate** the agent can actually evaluate from tool output | an unconditional rule plus exemptions |
+| the rule is stated and the agent skips it under pressure | a prohibition plus the symptom that precedes it ("if you are about to X, you have already failed") | restating the rule — a mid-tier model gets *less* compliant |
+| the agent complies but the output/call has the wrong shape | a **positive recipe**: what the correct call IS, its parts, in order | a list of things not to do — it produced *more* unwanted output than no guidance |
+| a required element is simply missing | a **structural REQUIRED slot**, or a code-level precondition | a prose reminder mid-document |
+| behaviour should differ by situation | a conditional on an **observable predicate** the agent can evaluate from tool output | an unconditional rule plus exemptions |
 
-Two findings that cost other runs real budget:
+Then: **no nuance clauses**; **exemption clauses do not scope** ("this limit does not apply to X" still
+suppresses X); and **prefer an in-code guard to a prose rule where the capability owns its tools** —
+prose is right when the agent *lacks* a decision criterion, code when it has one and violates it. What
+each cost, and the guard-closure trap the third brings: `references/edit-design-lessons.md`.
 
-- **No nuance clauses.** Appending one qualifying clause to an otherwise-winning recipe
-  degraded it from consistent to noisy. If a rule needs a caveat, restructure the rule.
-- **Exemption clauses do not scope.** "This limit does not apply to X" still suppresses X.
-  Restructure so the rule cannot reach the exempt case in the first place.
+**Every round evaluates a null control**: copy the current best byte-for-byte into `$R/work/ctl_null`
+and evaluate it like any candidate — one eval buys the round's own noise floor, and a candidate inside
+that band is not evidence of anything. Do it first, not after a surprising result. And **read
+`$R/rejected.jsonl` and make each proposal STRUCTURALLY different from what is in it**: a different
+form, surface, or cluster — never a narrower version of a rejected rule.
 
-**Prefer an in-code guard to a prose rule when the capability owns its tools.** The only
-edit that has ever carried a large accepted gain on this benchmark was tool-level
-(`tools.py` 593 → 832 lines, +0.176 val): a precondition that refuses the illegal write and
-returns a recovery-oriented error changes behaviour deterministically, where a policy
-sentence changes it only probabilistically. Prose is the right form when the agent *lacks*
-a decision criterion; code is the right form when it has one and violates it.
-
-**Every round evaluates a null control alongside the candidates.** Copy the current best
-byte-for-byte into `$R/work/ctl_null` and evaluate it like any candidate. It costs one eval
-and buys the round's own noise floor: whatever `ctl_null` measures away from its parent is
-what *zero change* looks like today, so a candidate inside that band is not evidence of
-anything. Three of the four null runs discovered this reactively, after the fact — do it
-first. (Skill authoring calls this the mandatory-simultaneous-baseline rule; it is the same
-discipline, applied to an optimizer.)
-
-**Read `$R/rejected.jsonl` and make each proposal STRUCTURALLY different from what is in
-it.** Not a narrower version of a rejected rule, not the same rule with a caveat — a
-different form from the table above, a different surface (policy vs tools), or a different
-failure cluster. Re-proposing a variant of a rejected edit is how a run burns its whole
-budget re-measuring one idea.
-
-**3. Cheap SUBSET screen — the promotion ladder.** Do not pay full val to learn that an
-edit is bad. Screen it on a small, deterministically chosen, informative subset of val
-first:
+**3. Cheap SUBSET screen — the promotion ladder.** Do not pay full val to learn that an edit is bad:
 
 ```bash
 python "$A/screen.py" --run-dir "$R" --project "$P" \
        --candidate "$R/work/$TAG" --tier 1 --k-se 1.0
 ```
 
-In one paragraph: the parent side is free (its full-val rollouts are already on disk, so only
-the candidate pays, and only for the subset); the subset is seeded, recorded to
-`$R/screens/<tag>__tier<N>.json`, and deliberately informative rather than random — currently-
-failing and high-variance tasks, plus a random `holdout` drawn from tasks the parent passes,
-which is the only part that can see a regression; rungs are cumulative, so `tier 2` pays only
-for the ids it adds; `savings.net_rollouts` books the real cost (`+ (full_val − fired)` on a
-kill, `− fired` on a promote). `decision` is `kill` or `promote` — **never accept** — and it
-kills only on proven harm, because a false kill discards a good edit silently while a false
-promote costs one eval the honest gate then decides correctly. Full detail:
-[`references/algorithm.md`](references/algorithm.md#subset-screening-where-the-cost-actually-goes-and-why-a-screen-may-not-accept).
+Only the candidate pays, and only for the subset. `decision` is `kill` or `promote` — **never accept** —
+and it kills only on proven harm. **Check the arithmetic before relying on a screen at all:**
+`savings.breakeven_kill_rate` (`fired / full_val_rollouts`) is the fraction of candidates it must kill
+to pay for itself, and `savings.net_rollouts` books what it cost. Screen only when that break-even sits
+below your observed kill rate — on a small val the tier-1 floor makes it unreachable, so pay full val
+directly — and read a screen as evidence about the tasks the edit targeted, never as a gate decision.
+Its subset composition, cumulative rungs, seed and measured kill rates are under *Subset screening* in
+[`references/algorithm.md`](references/algorithm.md).
 
-**At `val_n <= 30`, skip the ladder and pay full val directly.** Check the arithmetic before
-you rely on a screen: `savings.breakeven_kill_rate` is `fired / full_val_rollouts` — the
-fraction of candidates the screen must kill just to pay for itself. At `val_n 12` the tier-1
-floor of 6 makes that **0.5**, and across four real runs the screen killed **0 of 8**
-promoted candidates while producing one documented false positive (a 3-task tier-1 reported
-`fixed: ["44"]` for a candidate that full val showed never fixed 44 — which is why the floor
-is 6, not 3). A ladder that cannot pay for itself and mis-reports is worse than no ladder.
-
-Where a screen *is* worth paying for (large val, cheap tier), read it as **direct evidence
-about the tasks the edit targeted**, not as a statistical test: a tier-1 subset containing
-every failing val task that comes back 0-for-N on them is a sound reason to stop spending on
-that candidate. Commit that as a budget decision on screen evidence, not a gate decision.
-
-**4. Honest gate on FULL val.** Evaluate on the whole val split (this writes
-rollouts + results into the run dir under tag `$TAG`, because the evaluate phase tags by
-the candidate **dir name**):
+**4. Honest gate on FULL val.** Evaluate the whole split (this writes rollouts + results under tag
+`$TAG`, since the evaluate phase tags by the candidate **dir name**), then decide off those rollouts:
 
 ```bash
 python "$S/phases/evaluate/scripts/run.py" --run-dir "$R" --project "$P" \
        --candidate "$R/work/$TAG" --split val --n-trials <num_trials>
-```
-
-Then take the decision — the **paired** significance gate, read straight off the persisted
-rollouts:
-
-```bash
 python "$A/gate_check.py" --run-dir "$R" --candidate "$TAG" --k-se <gate_k_se>
 ```
 
-It prints `gate` (`accept`, `reason`, `delta`, `threshold`), `paired_n`, `regressions`, and a
-combined `verdict`. Accept **only** on `"verdict": "accept"` — Δ̄ > k·SE over the paired
-per-task deltas. A `"verdict": "indecisive"` is not a rejection: too little of val actually
-ran, so fix the runner before spending more budget.
+Accept **only** on `"verdict": "accept"`; `"indecisive"` is not a rejection but a signal that too
+little of val ran, so fix the runner before spending more. **`regressions` is diagnosis, not a veto** —
+it names which part of a bundled edit to drop next round, but a per-task drop at `n` trials is an
+estimate, not proof of harm, and the old no-regression veto rejected byte-identical copies of the seed
+often enough to dominate the false rejects. `--veto-regressions` restores it if you want a
+zero-regression guarantee and will pay that rate. `phases/gate/scripts/run.py` reaches the same paired
+gate in rollout mode but books no decision, so use it to inspect, never to decide.
 
-**`regressions` is diagnosis, not a veto.** It lists val tasks the parent measured-and-passed
-that dropped, and it is the most actionable line in the output — it names which part of a
-bundled edit to drop next round. It does **not** block an accept. The old no-regression veto
-did, and it was the measured cause of four consecutive null results: it fires on a
-byte-identical copy of the seed 42.8% of the time at 5 trials, and in one run it vetoed
-*both* candidates that had passed the significance test. The paired test already accounts for
-per-task movement in both directions, so churn (fix 2 / break 2 at an unchanged mean)
-correctly fails it for the right reason. `--veto-regressions` restores the old behaviour if
-you specifically want a zero-regression guarantee and are willing to pay that false-veto rate.
-
-> `phases/gate/scripts/run.py` is the human-inspection front-end. In **rollout mode** it
-> reaches the same paired gate off the same files, so it is a faithful way to re-derive
-> just the significance half of a decision:
-> ```bash
-> python "$S/phases/gate/scripts/run.py" --mode paired --k-se <gate_k_se> \
->        --run-dir "$R" --current-tag <best_id> --candidate-tag "$TAG"
-> ```
-> It is still **not** the round's gate: it does not read `regressions`, so it cannot tell
-> you which part of a bundled edit to drop, and it does not book the decision.
-> Decide with `gate_check.py`; use this to inspect. (Passing scalar `--current`/
-> `--candidate` instead of a run dir cannot do a paired test — two means carry no
-> per-task deltas — so that combination is refused rather than quietly downgraded.)
-
-**5. Commit the decision through the run dir** (so the dashboard, `best_id`, the stall
-counter and the audit log all stay real):
+**5. Commit the decision through the run dir**, so `best_id`, the stall counter, the dashboard and the
+audit log stay real. `--decision reject` keeps the old best; either way it snapshots the candidate, logs
+the event and advances `iterations` + stall:
 
 ```bash
 python "$A/commit.py" --run-dir "$R" --candidate-id "$TAG" --from-dir "$R/work/$TAG" \
        --decision accept --val <cand_mean> --note "<one line: the general rule you added>"
 ```
 
-Use `--decision reject` to keep the old best. Either way it snapshots the candidate,
-logs the event, and advances `iterations` + the stall counter.
+**On a reject, pass `--reject-basis`** — `screen.py`'s "promote" means "could not prove harm", never
+"was evaluated on full val", and conflating its verdict with the driver's disposition makes a run's
+artifacts contradict themselves:
 
-**On a reject, pass `--reject-basis` — it says what the reject rests on.** The screen's
-`decision` and the driver's disposition are two different facts; conflating them made one
-run's artifacts contradict themselves. `screen.py`'s `decision` is the screen's own
-statistical verdict only, so "promote" means "could not prove harm", never "was evaluated on
-full val". What happened next is `--reject-basis`:
+`gate` (a full-val paired gate ran and said reject — the only basis that asserts this), `screen_kill`
+(the screen proved significant harm), `ceiling` (arithmetic proved no accept was reachable, so full val
+was never paid), `budget` (screen evidence plus a budget call, not a gate decision), `infra` (missing
+data, not a judgement).
 
-| basis | meaning |
-| --- | --- |
-| `gate` | a full-val paired gate ran and said reject — the only basis that asserts this |
-| `screen_kill` | the screen proved significant harm |
-| `ceiling` | arithmetic proved no accept was reachable, so full val was never paid |
-| `budget` | screen evidence plus a budget call; not a gate decision |
-| `infra` | missing data, not a judgement |
-
-So `screen: promote` + `reject_basis: ceiling` is one coherent story, and a reader never
-has to guess whether a promoted candidate reached the gate.
-
-`commit.py` **refuses a `--candidate-id` that already carries an accept/reject event** in
-`events.jsonl` (`--force` only to repair a record deliberately). A real run had two concurrent
-drivers both tag a candidate `cand_r2`: two reject events, ONE set of rollouts, so one edit
-was judged on the other's evidence. The check reads the log, not memory, so it holds across
-processes.
-
-Add
-`--optimizer-usd/--optimizer-tokens/--optimizer-seconds` for **your own** proposal cost —
-the runner's `metric_calls`/`usd`/`seconds` are already recorded by the evaluate phase, but
-nothing else records the proposer's, so cost-based stop conditions under-count without it.
+So `screen: promote` + `reject_basis: ceiling` is one coherent story. `commit.py` **refuses a
+`--candidate-id` that already carries an accept/reject event** (`--force` only to repair a record
+deliberately), because two drivers tagging a candidate alike otherwise produce two decision events over
+ONE set of rollouts. Pass `--optimizer-usd/--optimizer-tokens/--optimizer-seconds` for **your own**
+proposal cost: the evaluate phase records the runner's, nothing records the proposer's.
 
 ## Parallel round (optional, and only as described)
 
-**The whole of steps 3–4 for a round is one command.** Once the working copies exist,
-`round.py` builds the null control, evaluates every tag in parallel processes (safe: each
-process does its own adapter `apply()`, which mutates a *process-global* registry and so
-must never be shared), then gates them serially and prints one table:
+**The whole of steps 3–4 for a round is one command.** `round.py` builds the null control, evaluates
+every tag in parallel *processes* (each does its own adapter `apply()`, which mutates a
+process-global registry and so must never be shared), gates them serially, and prints one table:
 
 ```bash
 python "$A/round.py" --run-dir "$R" --project "$P" \
        --candidates cand_1,cand_2,cand_3 \
-       --n-trials <num_trials> --k-se <gate_k_se> --concurrency 300 --max-parallel 4
+       --n-trials <num_trials> --k-se <gate_k_se> --concurrency 8 --max-parallel 2
 ```
 
-Read `noise_floor_from_control` FIRST. It is what zero change measured today; a candidate
-whose `delta_vs_parent` sits inside that band is not evidence, whatever its verdict says.
-`round.py` deliberately does not commit — deciding which part of a bundled edit to keep is
-yours, and `regressions` is the input to it.
+`--concurrency` is the gate's *measurement* concurrency and defaults deliberately low; `round.py` warns
+once you raise it past what a gate can resolve, so do not raise it to buy wall clock. Read
+`noise_floor_from_control` FIRST — a candidate inside that band is not evidence, whatever its verdict
+says — and note that `round.py` never commits: which part of a bundle to keep is your judgement.
 
-Everything below is why those defaults are what they are. Fan-out buys real wall-clock, and
-costs real budget, so it is bounded by five invariants — state them before every fan-out:
+Fan-out buys wall-clock and costs budget, so state these five invariants before every fan-out:
 
-1. **Diagnosis fans out freely.** It is read-only and costs zero rollouts. Dispatch one
-   `cap-evolve-diagnoser` subagent per failure cluster / rollout shard, then merge their
-   JSON. No limit worth enforcing.
-2. **Proposal fans out across distinct working copies with distinct tags.** N siblings from
-   the same parent, each `cp -r`'d to its own `$R/work/<tag>` (a git worktree if the
-   capability lives in a repo), each dispatched to its own `cap-evolve-proposer`. **The tag
-   must be unique per sibling**: rollout files are `<task>__<tag>__t<k>.json`, so two
-   concurrent evals sharing a tag interleave into the same filenames and silently corrupt
-   both candidates' scores. Never two proposers on the *same* candidate dir.
-3. **The gate stays serial.** `set_best` mutates run state, and paired deltas are computed
-   against whatever the baseline is *right now*. So: gate + commit siblings **one at a
-   time**, and after any accept, **re-run `gate_check.py` for every remaining sibling
-   against the new best** before committing it. Skipping the re-gate double-counts the same
-   gain and admits an edit that never actually beat the candidate it is now stacked on.
-4. **Never fan out across the test split.** The seal is single-use; only finalize touches
-   test, once, serially.
-5. **Pay before you fan out.** Every sibling's full-val eval is a real charge. Run
-   `spend.py --n-siblings N` and require `afford.affordable: true` **before** dispatching
-   N, not after — N candidates can blow a budget that had room for one.
+1. **Diagnosis fans out freely** — read-only, zero rollouts: one `cap-evolve-diagnoser` per failure
+   cluster or rollout shard, then merge their JSON.
+2. **Proposal fans out across distinct working copies with distinct tags** — N siblings from one
+   parent, each `cp -r`'d to its own `$R/work/<tag>` (a git worktree if the capability lives in a
+   repo). **The tag must be unique per sibling**: rollout files are `<task>__<tag>__t<k>.json`, so two
+   concurrent evals sharing a tag interleave into the same filenames and corrupt both scores.
+3. **The gate stays serial.** `set_best` mutates run state and paired deltas are computed against
+   whatever the baseline is *right now*, so gate + commit siblings **one at a time**, and after any
+   accept **re-run `gate_check.py` for every remaining sibling against the new best** — skipping the
+   re-gate double-counts one gain and admits an edit that never beat what it now stacks on.
+4. **Never fan out across the test split**, and **pay before you fan out** — `spend.py --n-siblings N`
+   must say `affordable: true` before you dispatch N.
 
-Shape of a parallel round:
-
-```
-spend.py --n-siblings N       → afford.affordable? recommendation != stop?
-diagnose  ──fan out──►  M read-only diagnosers ──► merge clusters      (free)
-propose   ──fan out──►  N proposers, N distinct $R/work/<tag> dirs     (costs proposer time)
-round.py  ──fan out──►  ctl_null + N full-val evals in parallel        (costs rollouts)
-             SERIAL ──►  gate_check per candidate, table with the noise floor
-commit      SERIAL ──►  commit.py per candidate; on accept, re-gate the rest
-```
-
-(`screen` sits between propose and evaluate only when its `breakeven_kill_rate` can actually
-pay — at `val_n <= 30` it cannot; see step 3.)
-
-Three independent sources of concurrency — use all three, they compose:
-
-1. **Inside one evaluation**, if the adapter has `run_batch`/`run_trials` it already runs
-   the whole task grid at its own concurrency (some adapters do, via their own
-   concurrency env var). Otherwise `screen.py --workers N` — or `CAPEVOLVE_WORKERS=N`
-   in the environment, which every phase script honours since none of them take a
-   `--workers` flag — pools rollout *generation* through `trials.run_trials_pool`.
-   Scoring and persistence stay serial and in task order, so pass^k, SE and the gate see
-   byte-identical numbers to a serial run. Opt in only when `run_target` is thread-safe
-   (no shared scratch dir, no single live container, no module-global client):
-
-   ```bash
-   CAPEVOLVE_WORKERS=4 python "$S/phases/evaluate/scripts/run.py" \
-          --run-dir "$R" --project "$P" --candidate "$R/work/$TAG" --split val --n-trials 1
-   ```
-2. **Across candidates**, one evaluate/screen process per sibling, each with its **own
-   unique tag**.
-3. **Across diagnosers**, freely — read-only, zero rollouts.
-
-The gate is the one thing that never parallelizes (invariant 3).
-
-**But concurrency composes only up to the endpoint's sustainable rate, and past it the failure
-is silent.** These three sources multiply: K optimisers x C concurrency each is K*C in flight,
-and the serving endpoint does not know about your fan-out. Measured on this run: nine per-task
-optimisers at concurrency 8 put ~72 requests in flight against a proxy whose sustainable band
-is 24-90, and a single per-task eval went from ~4 minutes to ~50. Nothing errored — latency
-just grew, so it read as "the model got slower" rather than "I oversubscribed". An earlier
-incident on the same proxy is the extreme version: concurrency 300 pushed 292 of 300 rollouts
-into wallclock timeouts and the evaluation reported **0.0067** as capability. So: measure the
-sustainable band once, divide it by the number of concurrent optimisers, and treat a sudden
-wall-clock blowout as an oversubscription symptom before you treat it as anything else.
-
-If in doubt, run the serial loop. A correct serial round beats a fast wrong one — and a
-double-counted gain is invisible in the val number that produced it.
+Concurrency composes from three places: inside one evaluation (an adapter's own `run_batch`, or
+`screen.py --workers N` / `CAPEVOLVE_WORKERS=N`, which pools rollout *generation* while scoring stays
+serial and in task order, so the numbers are byte-identical to a serial run), across candidates, and
+across diagnosers. Opt in only when `run_target` is thread-safe: no shared scratch dir, no single live
+container, no module-global client. `references/algorithm.md` has which steps parallelise safely.
 
 ## Per-task fan-out — the cheap gradient
 
-Use this when the baseline's `k/n` bands show the loss is **concentrated in a few named
-tasks** rather than spread thin. It is the highest-leverage shape in this skill, and the one
-the first five rounds of one long run failed to use.
-
-**Why.** A full-val gate round costs `val_n × n_trials` rollouts and returns *one bit per
-candidate*: accept or reject. A single task at `n_trials` costs `n_trials` rollouts and
-returns the same bit — about the failure that actually exists. At `val_n = 30, n_trials = 10`
-that is 300 rollouts per learning step versus 10: **a 30× cheaper gradient**, on the unit the
-defect lives in. Measured on one long run: five classic rounds spent ~1500 rollouts to
-produce **10 learning steps and 1 accept**. The same budget under this shape buys **nine
-optimisers × six iterations = ~54 steps**, each aimed at one measured defect, and the
-per-task evals run concurrently so the wall-clock cost is one round's.
-
-**A screening band is not a baseline.** Per-task rates from a small trial count tell you where
-to *look*; they do not tell you where you *are*. In one run, ten tasks whose 3-trial
-bands summed to 2.33 measured **4.04** at n=10 — the screen understated the artifact by 1.71
-task-equivalents (0.057 of val), and one task went the other way (0.33 → 0.10). Every "0.0
-DEFECT" label was suspect: three of them measured 0.30, 0.444 and 0.60. So: screen at low `n`,
-but re-measure at the gate's `n` before you quote a number, compute headroom, or tell an
-optimiser what its starting point is — and never let a low-`n` band be the thing a delta is
-computed against. This is the same error as the canary bands, one level up.
-
-**First compute the BINOMIAL floor. Most of what looks like mysterious nondeterminism is n.**
-Each rollout is pass/fail, so a task's rate is a binomial proportion and an arm mean over `m` tasks
-at `n` trials has
-
-    SE(arm difference) = sqrt( sum_over_tasks 2·p(1-p)/n ) / m
-
-Do that arithmetic BEFORE blaming the provider, the seeds, or the load. Measured here on 10 tasks
-at n=10 with p≈0.35: predicted SE **0.0615**, observed gap between two byte-identical arms
-**0.0778** — a ratio of **1.27**, i.e. plain sampling. Mean per-task movement was 0.0978 against a
-binomial prediction of 0.1445, so the observed movement was *smaller* than chance requires. There
-was nothing left to explain.
-
-One precision about what this is and is not. At temperature 0 with identical seeds a fully
-deterministic system would return *identical* arms, so this is not sampling error in the textbook
-sense — there is no sample being drawn. What the arithmetic shows is that the observed variation is
-**statistically indistinguishable in magnitude from independent per-rollout coin flips**. That
-matters because it means no further mechanism needs to be posited to explain it, and — whatever its
-physical cause — the remedy is the same one that works for binomial noise: more trials. Do not
-report it as "sampling noise" without that caveat, and do not go hunting for a cause you have no
-evidence for.
-
-That reframes the concurrency result rather than cancelling it: at conc 25 per-task movement was
-0.250, genuinely **above** the 0.1445 floor, and dropping to conc 8 removed that excess and exposed
-the floor underneath. Lowering concurrency fixes what it can; the rest is n.
-
-The consequence is uncomfortable and worth stating plainly: **an aggregate mean over a dozen HARD
-tasks at n=10 cannot resolve any realistic edit.** Reaching 2 SE on a +0.05 effect on that subset
-needs ~60 trials per task.
-
-But be careful about the obvious inference, which is wrong. Narrowing to the hard tasks makes the
-measurement *worse*, not better, for judging an artifact — because a task sitting at 1.00
-contributes signal to the mean with almost no variance, so dropping it removes a free denominator.
-Computed from this benchmark's own per-task rates:
-
-| arm | rollouts/arm | SE of paired difference |
-|---|--:|--:|
-| 12 hard tasks, n=10 | 120 | **0.0496** |
-| full val 30 tasks, n=10 | 300 | **0.0262** |
-| full val 30 tasks, n=20 | 600 | 0.0185 |
-
-Full val at n=10 is nearly twice as precise as the hard subset, and the four prior gate rounds here
-were run at full val n=5 (SE 0.0371) — so their problem was never the task set. It was that they
-ran at a concurrency carrying excess noise on top of that, and chased effects smaller than the sum.
-
-So the two questions need opposite designs, and conflating them is the actual error:
-
-| you want to know | measure | why |
-|---|---|---|
-| does this mechanism work | ONLY the tasks where it fires, at high n, per-task test | a mechanism firing on 2 tasks is diluted to nothing in a 30-task mean |
-| does it break anything | canaries, cheap precisely because they sit at 1.00 | zero variance means a single drop is real |
-| what is the artifact worth | FULL val, both arms in one batch | the 1.00 tasks are free precision for the mean |
-
-A mechanism that fires on two tasks and lifts them 0.15 → 0.45 is resolvable at n=40 on those two
-tasks (≈3 SE) and invisible in a 12-task mean at n=10 (≈0.5 SE). Same edit, same rollout budget,
-one design answers the question and the other cannot.
-
-**Run the GATE at low concurrency — most of the re-measurement noise is load-induced.** This is the
-one lever that makes everything else measurable, and it is cheap to verify: measure the same bytes
-on the same seeds twice at your search concurrency, then twice again at a low one.
-
-| identical bytes and seeds, 12 tasks | conc 25 | conc 8 |
-|---|--:|--:|
-| arm-level \|delta\| between the two runs | **0.1167** | **0.0333** |
-| mean \|per-task\| movement | **0.250** | **0.100** |
-| tasks that moved at all | 10 / 12 | 5 / 12 |
-
-Five of the twelve tasks became perfectly repeatable at conc 8 having each moved 0.20-0.40 at conc
-25. So the practical split is: **search fast, gate slow.** Per-task exploration can run at high
-concurrency because its output is a mechanism you verify from a trace, not a rate; the accept
-decision must run at a concurrency where the null actually reproduces, which costs roughly 3x wall
-clock for the one evaluation that matters.
-
-Two caveats to state whenever you quote this, both real: the low-concurrency runs here were
-sequential, so load and elapsed-time drift are confounded; and 12 tasks x 2 runs makes the variance
-comparison thin. The direction was consistent across all three metrics, which is why it is worth
-acting on, but it is not settled.
-
-**A guard that forbids the harmless option can force the harmful one. Ask what the agent does
-INSTEAD.** Measured: a guard refusing an itinerary change that changes nothing ("this call would
-change nothing, so do not quote a price") is locally correct — an unchanged record genuinely
-cannot produce a refund. On the task where the right answer was *make no change at all*, it cost
-0.288. Removing that one guard, policy byte-identical, halved the damage (−0.288 → −0.147, no longer
-resolvable) while the paired task kept its +0.498.
-
-The failure is not the guard's logic, it is the guard's *closure*. Refusing the no-op left the agent
-with only real changes to choose from, and it chose one. So before adding a refusal, name the action
-set it leaves behind, and check that "do nothing" is still reachable — a refusal that removes the
-correct answer converts a pass into a fail while looking like a safety improvement.
-
-This is also why the first ablation was worth running even though it refuted its own hypothesis:
-the paragraph I suspected turned out mildly *helpful* (removing it cost the paired task 0.141), and
-without that null I would have shipped the wrong fix and kept the real cause.
-
-**Auto-repair can accelerate a wrong action — a rejected call is sometimes a brake.** When a tool
-bounces a recoverable argument slip, the agent spends a turn recovering, and turns are scarce, so
-repairing the slip inside the tool looks like a free win. Measured counter-example: a booking whose
-payment id used an unrecognised alias and omitted the amount was rejected by the parent and repaired
-by the candidate — but that booking was itself premature, made with a defaulted payment method the
-customer had never been asked about, and the customer then asked for a different one, forcing a
-undo-and-redo that left an extra stale row in the database. The rejection had been
-holding back a wrong write.
-
-So before shipping a repair, ask what the rejected call would have DONE had it succeeded. If it
-would have written the right thing a turn later, repair it. If it would have written the wrong
-thing immediately, the repair needs to be paired with the precondition that makes the call correct
-— not shipped alone, and not abandoned either.
-
-**Draw canaries from the WHOLE suite, not from the neighbourhood of your mechanisms.** This is the
-mistake that sank an artifact whose individual mechanisms all measured positive. The canary set was
-nine tasks picked near the targets; the artifact then damaged four high scorers that nobody was
-watching — two at 1.00, one at 0.90, one at 0.80 — and the gate failed on exactly that collateral.
-**A canary set that only covers what you aimed at cannot catch what you hit by accident.**
-
-`integrate.py --canary-auto BASELINE.json` selects them mechanically: every task at or above
-`--canary-floor` (default 0.90) that is not a target, lowest-rate-first so the most fragile high
-scorers are the ones kept. Run against this round's own baseline it recovers three of the four
-tasks that were actually damaged.
-
-The fourth is the honest limit and worth stating: it sat at **0.80**, under the floor. Lowering the
-floor catches it and admits a noisier guard — a task at 0.80 moves about ±0.13 at n=10 by chance, so
-it will veto good work at random. There is no floor that is both complete and quiet. Pick it
-deliberately: 0.90 for a wide sweep where false vetoes are expensive, lower when you are integrating
-one mechanism and can afford to investigate every flag.
-
-**And a per-task effect that clears 2 SE once can still be wrong.** Measured this round: a task
-regression of −0.288 at n=40 (z −2.61, resolvable) read −0.80 in one full-val block and **+0.30** in
-the next. A single powered reading is not the floor for a per-task claim — agreement across
-separately-seeded occasions is.
-
-**A canary needs two separately-launched readings, not 20 trials in one.** Measured: a task read
-1.00 in 20/20 rollouts and then 2/5 the next day on byte-identical code at the same seeds. It had
-been promoted to canary on the strength of that 20/20 — evidence which does not support the claim,
-because repeats launched inside one occasion share whatever makes the task come out the way it
-does. Two separate readings caught it; more trials in the first reading never would have.
-
-The consequence cuts both ways, and both matter:
-
-* a task that disagrees between occasions must be dropped from the canary set, **and** must not be
-  used to judge a candidate either — two of twelve target tasks here moved +0.45 between
-  occasions, so a per-task delta on them is uninterpretable;
-* the discipline itself survives — the other eight canaries read exactly 1.00 on both occasions —
-  so the fix is the selection criterion, not the idea.
-
-Cross-occasion drift on a hosted gateway turned out NOT to be the dominant term: mean per-task
-movement was 0.123 across a day at low load versus 0.100 within a day, against 0.250 at high load.
-Load dominates elapsed time. Check it rather than assuming either way.
-
-**A multi-branch artifact is assembled with `integrate.py`, never by one merge.** Stated as a rule
-because the author of that script skipped it on the very round it was written: six branches were
-merged in one step, and the resulting artifact gated at **−0.0146** with seven replicated per-task
-losses against two replicated gains — while the same round's *single*-mechanism artifact gated at
-**+0.0115**. Fewer mechanisms beat more mechanisms, and a one-shot merge cannot tell you that,
-because it yields one number for N simultaneous changes.
-
-    python integrate.py --base BEST --branches B1 B2 B3 --tasks <targets> \
-        --canary-auto BASELINE.json --n 10 --conc 8 --floor <measured null>
-
-`funcmerge` merging cleanly is **not** evidence the branches compose — every branch retained cleanly
-in that failed artifact, with zero conflicts and no undefined attributes. Clean merge is a syntactic
-property; composition is an empirical one.
-
-**Gate the SUM, not each addend.** Measured here: one tool-level mechanism is worth roughly
-0.04–0.13 on the one or two tasks it touches, and resolving an effect that size at 2 SE needs about
-**n=100 trials on that task**. Certifying seven mechanisms that way is ~1400 rollouts to establish
-by rate what a deterministic replay establishes for free. So the economical order is:
-
-1. **Prove it engages** — replay a real failing payload against the edited tool and show the guard
-   fires; replay the passing payload and show it does not. Costs zero rollouts, and it is a
-   stronger statement about the mechanism than any rate.
-2. **Establish incidence from rollouts you already have** — how often does the condition occur, and
-   is it skewed toward failures? Also free. One guard here fired on 8 of 76 matching calls, 8 in
-   failures and 0 in passes.
-3. **Confirm the sign at modest n, with canaries** — you are checking for a regression and a
-   direction, not measuring a size.
-4. **Gate the accumulated artifact ONCE on full val**, where SE is 0.0262 at n=10 and several
-   mechanisms can clear it together even though none clears it alone.
-
-Expect the measured per-task effect to land well below the upper bound incidence implies — here
-~40% of it — because the guard fires correctly and the agent then still fails for an unrelated
-reason. That gap is not evidence the mechanism failed; check the task's other reward components
-before concluding anything.
-
-**A parallel optimiser's deliverable is a MECHANISM WITH TRACE PROOF, not a rate.** This follows
-from the load fact above and it is the part that changes how you brief a fan-out. K optimisers each
-evaluating is K processes, so a fan-out is BY CONSTRUCTION a high-load regime — the very regime in
-which a per-task rate cannot resolve the effect anyone is looking for. Briefing K subagents to
-"measure whether your edit helps" therefore asks them for the one thing their situation cannot
-provide, and what comes back is K rate deltas drawn from a distribution whose width is larger than
-the effect. Several prior rounds did exactly this and accepted edits on it.
-
-Ask instead for evidence that does not depend on load:
-
-| evidence | load-sensitive? | good for |
-|---|---|---|
-| the guard fired on the observed call | no | proving the mechanism engages |
-| the agent's next action changed after it fired | no | proving the mechanism works |
-| a direct call with the exact bad payload now succeeds / still refuses | no | proving repair logic, deterministically |
-| the delivered docstring text contains the keys | no | proving the description reaches the model |
-| count of clarification turns before the first write | barely | proving a behavioural prose change |
-| per-task pass rate | **yes, heavily** | almost nothing, at fan-out load |
-
-Then gate the surviving mechanisms yourself, serialised, on a quiet machine. The division of labour
-is: **the fan-out finds falsifiable mechanisms and proves them structurally; the driver alone turns
-mechanisms into numbers.** A subagent that reports "indistinguishable from noise" while showing its
-guard firing correctly has done its job completely.
-
-**The knob is TOTAL IN-FLIGHT REQUESTS, not the runner's per-process concurrency flag.** That is per-process,
-so it does not bound load when several evaluations run at once — and running them at once is the
-normal case, because a fan-out of K optimisers each evaluating is K processes. A gate launched at
-`--conc 8` alongside four exploring optimisers at `--conc 12` puts about 56 requests in flight, so
-it is a HIGH-load measurement wearing a low-load flag, and it will reproduce the wide null rather
-than the narrow one. Serialise the gate: let the fan-out finish, or pause it, and run the gate arms
-alone. Both arms still belong in the same batch as each other — pairing is what removes drift — but
-that batch must be the only thing running. If you cannot quiet the machine, say so next to the
-verdict instead of quoting a per-process number as though it were the load.
-
-**Take the error ACROSS whole runs, not across tasks within one run.** A single paired run's SE is
-computed over tasks, so it cannot see run-to-run nondeterminism at all — and on this benchmark that
-is the dominant term. Repeat the entire paired comparison on distinct seed blocks and use the
-spread of the per-run deltas:
-
-| seed block | candidate | control | paired Δ |
-|---|--:|--:|--:|
-| 0-4 | 0.7333 | 0.6467 | +0.0867 |
-| 100-104 | 0.6867 | 0.6667 | +0.0200 |
-| **combined** | | | **+0.0533, SE 0.0333 across runs (t ~ 1.6) — NOT demonstrated** |
-
-```bash
-# one paired run per seed block, both arms in the SAME batch, then combine ACROSS runs
-python "$A/taskeval.py" "$R/work/cand" <val ids> --n 5 --base-seed 0   --json /tmp/c0.json
-python "$A/taskeval.py" "$R/work/ctl"  <val ids> --n 5 --base-seed 0   --json /tmp/k0.json
-python "$A/taskeval.py" "$R/work/cand" <val ids> --n 5 --base-seed 100 --json /tmp/c1.json
-python "$A/taskeval.py" "$R/work/ctl"  <val ids> --n 5 --base-seed 100 --json /tmp/k1.json
-python "$A/multirep.py" /tmp/c0.json:/tmp/k0.json /tmp/c1.json:/tmp/k1.json
-```
-
-`multirep.py` refuses to return a verdict from a single paired run at all, because that is exactly
-where the retracted accept came from. `--base-seed` matters: raising `--n` only extends the same
-seed block, so a rerun at the same seeds is a determinism check.
-
-The first run alone reported SE 0.0548 across tasks and an "accept". Two runs show the same
-candidate at +0.0867 and +0.0200, and a byte-identical control re-run moved +0.0800 by itself. The
-across-run estimator needs no assumption about where the noise comes from, which matters because on
-this run its source was never identified: LLM sampling, seed assignment, concurrent batching,
-timeouts, infra accounting and set-iteration order were each ruled out by direct measurement, and
-the leading remaining hypothesis (transient errors below the `max_errors` threshold being fed back
-into the conversation) stayed unverified.
-
-Budget for it up front: a credible verdict on a sub-0.10 effect here is **several full paired runs**,
-not one. If that is unaffordable, the honest output of the round is "not resolvable at this budget"
-— which is a result, and is what the earlier single-run accept should have been.
-
-### Running the fan-out, merging it, and remembering what it found
-
-Each optimiser evaluates its own task at full trials **plus a canary of tasks measured 1.0 at
-baseline**, in one call, and writes traces so the next edit aims at an observed decision:
-
-```bash
-python "$A/taskeval.py" "$R/work/$TAG" <its-tasks> --project "$P" --n <num_trials> \
-       --canary <stable-task-ids> --canary-n 3 --conc <low> --traces /tmp/tr_$TAG.json
-```
-
-Run every eval **detached** (`nohup ... &`, then poll for the output file): under endpoint
-contention a per-task eval can take 15-50 minutes, and a harness-level timeout has killed an eval
-that was still healthy.
-
-Findings go in a shared ledger, never in the coordinator's head — independent optimisers on
-different tasks keep rediscovering one cause, and two of them implementing the same fix collide at
-merge with only one of the two actually measured:
-
-```bash
-python "$A/mechanisms.py" list --run-dir "$R" --task "$TASK" --compact
-python "$A/mechanisms.py" add --run-dir "$R" --owner "$TAG" --status proposed \
-       --mechanism "<the cause, one sentence>" --evidence "<what you measured>" \
-       --touches <function-the-fix-edits>
-python "$A/mechanisms.py" add --run-dir "$R" --owner "$TAG" --status rejected \
-       --supersedes <seq> --mechanism "<what turned out to be false>" --evidence "<the test>"
-```
-
-Assemble the result **one branch at a time**, measuring after each — never in a single merge:
-
-```bash
-python "$A/integrate.py" --base "$R/work/<parent>" --branches "$R/work/t7" "$R/work/t17" \
-       --out "$R/work/cand_merged" --tasks <targets> --canary-auto "$R/<baseline-per-task>.json" \
-       --n <num_trials> --conc <low> --floor <measured-null-delta>
-python "$A/round.py" --run-dir "$R" --project "$P" --candidates cand_merged \
-       --n-trials <num_trials> --k-se <gate_k_se>
-```
-
-`funcmerge.py` is the merge engine `integrate.py` drives per step; call it directly only to inspect
-a single combination, and read its `dropped_additions` — a line a branch ADDED that the merge did
-not carry is how a rejected subtraction gets silently re-applied:
-
-```bash
-python "$A/funcmerge.py" --base <parent>/<file> --out /tmp/try.py \
-       --inputs <branchA>/<file> <branchB>/<file> --union-pure-insertions --json /tmp/fm.json
-```
-
-`merge_taskopt.py` remains for the whole-file case (a capability whose artifact is prose, where
-per-function merging does not apply):
-
-```bash
-python "$A/merge_taskopt.py" --root "$R/work" --base "$R/work/<parent>" \
-       --out "$R/work/cand_merged" --include t7 t17
-```
-
-### Measurement discipline — the contract
-
-Full evidence, with the numbers that bought each rule: **`references/measured-lessons.md`**. The
-non-negotiable core, because skipping any of these is how four consecutive rounds of this loop
-produced nulls that nobody could interpret:
-
-1. **Compute the binomial floor before blaming anything.** Each rollout is pass/fail, so an arm
-   mean over `m` tasks at `n` trials has `SE = sqrt(Σ 2·p(1-p)/n) / m`. Do that arithmetic first.
-   Measured: two byte-identical arms differed by 0.0778 against a predicted 0.0615 — **1.27×**,
-   i.e. nothing to explain. Hunting a cause you have not shown exists is how rounds get spent.
-2. **Measure the null, twice.** Two byte-identical copies of the parent, same seeds, same load.
-   Their gap is the round's bar; a candidate inside it has shown nothing whatever its verdict says.
-3. **Explore fast, gate slow, and gate ALONE.** The load variable is *total in-flight requests*,
-   not any per-process flag — a fan-out is by construction the noisy regime. Serialise gate arms.
-4. **Different questions need opposite designs.** A *mechanism* is judged only on the tasks where
-   it fires, at high `n`, per task. An *artifact* is judged on the FULL task set, because tasks at
-   1.00 add signal with almost no variance — full val at n=10 measured **2× more precise** than the
-   hard subset at n=10.
-5. **Two independently-seeded blocks, and they must agree in sign.** This is the single check that
-   catches a null a one-block reading calls positive. It rejected an artifact at +0.0263 / −0.0032
-   and refuted a per-task mechanism story of −0.50 that read +0.20 in the second block.
-6. **Canaries from the WHOLE suite, chosen mechanically** (`integrate.py --canary-auto`), lowest
-   rate first. A set picked near your mechanisms cannot catch what you hit by accident: four high
-   scorers were damaged unguarded and the artifact failed on exactly that collateral.
-7. **Assemble multi-branch artifacts with `integrate.py`, one branch at a time.** A clean
-   `funcmerge` is a *syntactic* property; composition is an empirical one. Six individually-positive
-   mechanisms gated at **−0.0146** while one alone gated at **+0.0115**.
-8. **State the ceiling before you spend.** Sum `1 - rate` over val at the real trial count, subtract
-   what each task's own reward components cap it at, and say whether the target is reachable. A
-   target never costed against measured headroom is a wish.
-9. **When effects sit below the floor, pre-register directional predictions and use a sign test.**
-   9/10 positive gave **p = 0.0107** where no individual z reached 2. Write each prediction down
-   *before* its arm runs, or the test is worthless.
-10. **A per-task effect that clears 2 SE once can still be wrong.** A −0.288 at n=40 (z −2.61) read
-    −0.80 and then **+0.30** across two full-val blocks. Agreement across occasions is the floor for
-    a per-task claim, not a single powered reading.
-
-## See your constraints every few steps
-
-There is no `cap-evolve status` command. **Every 2–3 rounds** (and always before a fan-out)
-run the readout and compare it to the goal:
-
-```bash
-python "$A/spend.py" --run-dir "$R" --project "$P"
-```
-
-It prints the current `best_id` + full-val mean, all recorded `spent` fields
-(`iterations`, `metric_calls`, `usd`, `optimizer_usd`, tokens, seconds), the measured
-`wallclock_seconds`, the `budget`, `budget_exhausted()` as `stop`/`stop_reason`, the
-free-text `stop_condition` **parsed into per-predicate satisfied/violated rows with their
-measured actuals**, the `remaining` headroom per ceiling, anything `ambiguous`, and
-`test_sealed`. Everything comes from the run dir on each call — never from a total you are
-carrying in your head. Then act on `recommendation`. (The Stop hook also re-nudges you
-across turns so you keep driving until the run is finalized.)
+Use this when the baseline's `k/n` bands show the loss **concentrated in a few named tasks** rather than
+spread thin: a full-val round buys one bit per candidate for `val_n × n_trials` rollouts, while one task
+at `n_trials` buys the same bit about a failure that actually exists. Economics, briefing contract,
+canary discipline and every command: [`references/per-task-fanout.md`](references/per-task-fanout.md).
+Two rules decide whether the shape is safe at all, so they live here.
+
+**A parallel optimiser's deliverable is a MECHANISM WITH TRACE PROOF, not a rate.** A fan-out is by
+construction a high-load regime — the one regime where a per-task rate cannot resolve the effect anyone
+is looking for — so ask for load-independent evidence (the guard fired on the observed call; the next
+action changed; a direct call with the bad payload now behaves correctly), then gate the survivors
+yourself, serialised.
+
+**A multi-branch artifact is assembled with `integrate.py`, never by one merge**, one branch at a time
+with a measurement after each: fewer mechanisms routinely beat more, and one number for N simultaneous
+changes cannot tell you that. `funcmerge` merging cleanly is **not** evidence the branches compose —
+Clean merge is a syntactic property; composition is an empirical one.
+
+The helpers, in order: `taskeval.py` (one optimiser's step — its task at full trials plus a canary,
+`--traces` on, run **detached**, since a per-task eval can outlive a harness timeout while healthy);
+`mechanisms.py` (the shared ledger — `list` before you diagnose, `add` when you find, `--supersedes`
+when one turns out false, or two optimisers implement one fix and collide at merge with only one
+measured); `integrate.py` (sequential assembly; `--canary-auto`, `--floor`); `funcmerge.py` (its
+per-function merge engine — read `dropped_additions`); `merge_taskopt.py` (whole-file case). Then gate
+the artifact once on full val via `round.py`.
+
+## Measurement discipline
+
+Two rules decide whether a round's number means anything, so they belong here; the rest of the
+contract — the ceiling arithmetic, the binomial floor, why an artifact is judged on the FULL task set
+while a mechanism is judged only where it fires, gating the sum rather than each addend, and the sign
+test for effects below the floor — is in
+[`references/measured-lessons.md`](references/measured-lessons.md), each rule with the measurement
+that bought it.
+
+1. **Measure the null, twice.** Two byte-identical copies of the parent, same seeds, same load: their
+   gap is the round's bar, and a bar smaller than that is not a gate.
+2. **Explore fast, gate slow, gate ALONE.** The load knob is *total in-flight requests*, not any
+   per-process flag — K processes at concurrency C is K·C in flight, and past the endpoint's
+   sustainable rate the failure is silent: latency grows, so it reads as "the model got slower" rather
+   than "I oversubscribed". Pause the fan-out, run the gate arms in one batch (pairing removes drift)
+   and let that batch be the only thing running; if you cannot quiet the machine, say so next to the
+   verdict.
+3. **Two independently-seeded blocks, agreeing in sign, before a small effect is a result.** A paired
+   run's SE is computed over *tasks*, so it cannot see run-to-run nondeterminism at all: `multirep.py`
+   takes the error across whole runs and refuses a verdict from one of them (`--base-seed` picks the
+   block; raising `--n` only extends the same one, so a rerun at the same seeds is a determinism check,
+   not a replication). If several full paired runs are unaffordable, "not resolvable at this budget" is
+   the honest output of the round — and a result.
 
 ## Stop & seal, then MEASURE (exactly once)
 
-Stop when `spend.py`'s `recommendation` is `stop`. Then produce the run's one honest
-result table — seed vs best on **val**, on **train** when the spec defines a train split
-worth reporting, and on the **sealed test** split scored exactly once:
+There is no `cap-evolve status` command: **every 2–3 rounds** (and always before a fan-out) run
+`spend.py`. Everything it reports is re-read from the run dir, never from a total you carry in your head
+— which is what keeps a `$6.00` cap from becoming `$6.01`. (The Stop hook re-nudges you across turns
+until the run is finalized.) Stop when `recommendation` is `stop`, then produce the run's one honest
+table — seed vs best on **val**, on **train** when the spec defines one worth reporting, and on the
+**sealed test** split scored once:
 
 ```bash
 python "$A/measure.py" --run-dir "$R" --project "$P" --train auto
 python "$S/phases/report/scripts/run.py" --run-dir "$R"
 ```
 
-`measure.py` reads val straight off the rollouts the gate used (free), evaluates train
-only when it adds information (`--train auto` skips it when the train ids equal the val
-ids, because the numbers would be a copy), and seals test through the same
-`harness.finalize` the finalize phase calls — so it is interchangeable with:
+`measure.py` reads val off the rollouts the gate already used (free), evaluates train only when it adds
+information, and seals test through the same `harness.finalize` the finalize phase calls, so it is
+interchangeable with `phases/finalize/scripts/run.py`. It refuses to flatter the run: an **empty** split
+says `empty`, not 0.0; a **no-holdout** spec is a **FIT metric, not generalisation**, with the overlap
+counted; a negative `screen_ledger.net_rollouts` says screening was pure overhead; and
+`best_id == "seed"` is a **null result with a diagnosed cause**, never a 0.000 gain. (There is **no
+`cap-evolve finalize` subcommand** — a second finalize raises `TestSealError`.) No finalize, no result.
 
-```bash
-python "$S/phases/finalize/scripts/run.py" --run-dir "$R" --project "$P" --n-trials <num_trials>
-```
+## Honesty invariants specific to driving this by hand
 
-For every split it prints mean, stderr, n (scored / in split), the paired per-task delta
-vector's mean + SE + n, the recomputed gate decision (val only — `gate.decide` refuses any
-other split), the per-task `fixed` / `broke` / `unchanged` movement, a `screen_ledger`
-totalling every recorded screen's MEASURED rollout economics (a negative `net_rollouts`
-honestly says screening was pure overhead because nothing was killed), and a `holdout`
-verdict. It refuses to flatter the run: an **empty** split says `empty` instead of
-reporting 0.0; a **no-holdout** spec (test overlapping train/val, as some benchmarks default to
-`split_ids.json` where all three are the same 50 ids) is labelled a **FIT metric, not
-generalisation**, with the overlap counted; and `best_id == "seed"` prints a `warning` that
-every delta is 0 by construction and must be reported as a **null result with a diagnosed
-cause**, not as a 0.000 improvement.
-
-(There is **no `cap-evolve finalize` subcommand** — the orchestrate/host prose uses that as
-shorthand; the real seal is the finalize phase script / `measure.py`, which scores the best
-on test once and burns the seal. A second finalize raises `TestSealError`.) A run with no
-finalize has no result.
-
-## Honesty invariants (non-negotiable; core enforces most of these)
-
-1. **Accept/reject and the score-goal check are ALWAYS on FULL val through the gate.** A
-   subset screen may **kill** a candidate; it may **never accept** one. `screen.py` prints
-   only `kill`/`promote` and has no code path to `accept`; `spend.py` checks
-   `target_val_score` against the full-val mean only. A subset result's `coverage` looks
-   like 1.0 (its denominator *is* the subset), so never hand one to `gate_check.py`.
-2. **No-regression is part of acceptance, not a nicety.** A mean gain that strictly drops a
-   val task the current best measured and passed is a **reject** — `gate_check.py` folds this
-   into `verdict`, and diagnose's `kept_good` is the list it protects.
-3. **The test split stays sealed until the single finalize.** You never score test during the
-   loop — the evaluate phase physically restricts `--split` to `train|val`; only finalize
-   touches test, once. Never in parallel.
-4. **Never edit** `splits.json`, anything under `rollouts/test/`, or gold/test files (a
-   PreToolUse hook blocks it and core owns the seal).
-5. **Generalize, don't overfit** — every edit is a general rule, never a task-specific answer.
-6. **Drive through cap-evolve primitives, never around them** — every val eval via the
-   evaluate phase, every decision via `gate_check.py`, every commit via `commit.py`
-   (`snapshot` + `set_best` + `log_event` + `update_spent`). A round that produced no run-dir
-   artifacts is a bug: fix it before continuing.
-7. **One tag per candidate, one gate at a time.** Unique tags keep concurrent evals from
-   overwriting each other's rollouts; a serial gate keeps a moved baseline from letting two
-   siblings claim the same gain.
-8. **Record what you spent.** `iterations` + stall via `commit.py` every round, and your own
-   proposal cost via `--optimizer-*`; otherwise a cost-based `stop_condition` is unenforceable.
-9. **Constraints are re-read, never remembered.** Every round's affordability decision comes
-   from `spend.py` reading the run dir (spend, wallclock, splits, rollouts). A budget carried
-   in an agent's context is how a $6.00 cap becomes $6.01. Where the prose is ambiguous, say
-   so (`constraints.ambiguous`) and ask — never invent a ceiling.
-10. **Always finish with `measure.py` (or finalize) + report** — the full train/val/sealed-test
-    table, with the `holdout` verdict stated. A val number alone is the training signal, not
-    a result.
-
-## What good vs bad looks like
-
-- **Good:** Phase 0 done, `constraints.ambiguous` cleared with the user up front; every
-  round covers as many diagnosed clusters as it can afford; obviously-bad candidates killed
-  at tier 1 for a quarter of an eval with the subset + seed recorded in `$R/screens/`; each
-  accepted candidate has full-val rollouts under its own tag plus a `set_best`/`accept`
-  event; parallel siblings gated one at a time with a re-gate after each accept; the run
-  ends with `measure.py`'s train/val/sealed-test table and an explicit `holdout` verdict —
-  even when the honest answer is "no significant gain".
-- **Bad:** gating on a triage subset, or letting a screen `promote` stand in for an accept;
-  killing a candidate on 3 noisy tasks (the screen is built to refuse this — do not lower
-  `--k-se` to make it decisive); accepting a mean gain that regresses a passing task, or
-  accepting a churn bundle whose gains and losses cancel; two concurrent evals sharing a tag;
-  committing two parallel siblings without re-gating the second; fanning out N evals with
-  budget for one; re-deriving the budget from memory instead of `spend.py`; peeking at test
-  mid-run; quoting a val number as the result without ever measuring the sealed test.
+Core owns the split seal, the val-only gate and the tamper guard and enforces them whether you
+cooperate or not (`skills/phases/{evaluate,gate,finalize}` document them). Two are yours, because no
+script can do them for you: **never hand a subset result to `gate_check.py`** — its `coverage` reads
+1.0 because its denominator *is* the subset; and **a round that produced no run-dir artifacts is a
+bug**, so fix it before continuing rather than driving around the primitives.
 
 ## References
-- `references/algorithm.md` — why free-form + how honesty survives full agent autonomy, with sources.
+
+One level deep — each is read on its own, and none points at another.
+
+- [`references/algorithm.md`](references/algorithm.md) — the rationale: why free-form, how the honesty
+  invariants survive full autonomy, the subset-screening arithmetic and its break-even, which steps
+  parallelise safely, and the constraint surface. **Load** before relying on a screen, or for the
+  reasoning behind a rule you are tempted to skip.
+- [`references/measured-lessons.md`](references/measured-lessons.md) — the measurement contract's
+  evidence, each rule with the number that bought it: the binomial floor, why full val beats a hard
+  subset, the load-vs-noise tables, the across-runs estimator. **Load** before your first gate decision
+  on a new benchmark, or when a result surprises you.
+- [`references/per-task-fanout.md`](references/per-task-fanout.md) — the fan-out's economics, what to
+  ask a subagent for, canary selection, and every command. **Load** when the loss is concentrated in a
+  few named tasks.
+- [`references/edit-design-lessons.md`](references/edit-design-lessons.md) — auditing the scorer, guard
+  closure, and the measured backfires behind the edit-form table. **Load** before editing a surface for
+  the first time, or after two rejects.

--- a/skills/algorithms/agent-optimize/references/algorithm.md
+++ b/skills/algorithms/agent-optimize/references/algorithm.md
@@ -77,7 +77,9 @@ holdout** drawn from tasks the parent *passes*. The holdout is the only part of 
 can see a regression, and it is why the classic churn candidate (fixes 2, breaks 2, identical
 mean) at least surfaces its `regressed` list at tier 1 instead of looking like a tie. It is a
 partial correction, not a complete one: with small k, a regression outside the holdout screens
-clean and is caught later by the full-val no-regression veto. Selection is deterministic given
+clean and only shows up in the full-val gate's `regressions` list (which is diagnosis — it names
+which part of a bundle to drop — and blocks an accept only under `--veto-regressions`). Selection
+is deterministic given
 the seed, and the whole record (ids, seed, holdout fraction, deltas, decision, measured
 rollout economics) is written to `$R/screens/<tag>__tier<N>.json`, so a kill is auditable
 after the fact rather than a decision that happened once inside an agent's context.
@@ -86,6 +88,40 @@ Rungs are cumulative — tier 2 merges tier 1's rollouts across `<tag>__screen*`
 only for the ids it adds — and savings are reported as measured integers
 (`+ (full_val − fired)` on a kill, `− fired` on a promote) so a run's ledger sums to the truth
 instead of to a flattering estimate.
+
+### The break-even, and when the ladder cannot pay for itself
+
+Screening is an economic bet, not a free improvement, and the arithmetic is one division:
+`savings.breakeven_kill_rate = fired / full_val_rollouts` — the fraction of candidates the screen
+must **kill** just to recover what its own rollouts cost. Screen only when that number sits below
+the kill rate you have actually observed on this project.
+
+The floor is what makes it unreachable on a small val. `screen.py` never fires a rung below an
+absolute minimum number of tasks (currently 6), because a rung decided on two or three tasks is a
+coin flip dressed as evidence. So on a 12-task val the tier-1 subset is half the split and the
+break-even is **0.5** — every second candidate must be provably harmful. Measured across four real
+runs on that project: the screen killed **0 of 8** promoted candidates while producing one
+documented false positive (a 3-task tier-1 reported `fixed: ["44"]` for a candidate that full val
+showed never fixed 44 — which is why the floor is 6, not 3). A ladder that cannot pay for itself and
+mis-reports is worse than no ladder: pay full val directly.
+
+Where the screen *is* worth paying for (large val, cheap tier), read it as **direct evidence about
+the tasks the edit targeted**, not as a statistical test: a tier-1 subset containing every failing
+val task that comes back 0-for-N on them is a sound reason to stop spending on that candidate. Book
+that as a budget decision on screen evidence (`--reject-basis budget`), never as a gate decision.
+
+### `phases/gate` is an inspection front-end, not the round's gate
+
+`phases/gate/scripts/run.py --mode paired` reaches the *same* paired gate off the *same* persisted
+rollouts, so it is a faithful way to re-derive the significance half of a decision by hand — but
+only in **rollout mode** (`--run-dir` plus `--current-tag`/`--candidate-tag`). Passing scalar
+`--current`/`--candidate` means cannot do a paired test at all, since two means carry no per-task
+delta vector, so that combination is refused rather than quietly downgraded to an unpaired test
+whose number would look the same and mean something else.
+
+It is still not the round's gate, for two reasons that matter to the audit trail: it does not read
+`regressions`, so it cannot tell you which part of a bundled edit to drop, and it does not book the
+decision into the run dir. Decide with `gate_check.py`; use this to inspect.
 
 ## The constraint surface: free-text stop_condition, parsed and re-read
 

--- a/skills/algorithms/agent-optimize/references/edit-design-lessons.md
+++ b/skills/algorithms/agent-optimize/references/edit-design-lessons.md
@@ -1,0 +1,99 @@
+# Edit design — what the scorer audit found, and how guards backfire
+
+Read this before writing an edit on a surface you have not edited before, and always when two rounds
+have been rejected. SKILL.md carries the checklist and the edit-form table; this file carries the
+failures that produced them, with what each one cost.
+
+The numbers come from real runs on a multi-turn tool-use benchmark with a mid-tier agent model. The
+*shape* of each finding transfers; the figures are that run's.
+
+## Auditing the measurement before you credit a failure
+
+Every optimizer that skipped this step optimized against its own instrumentation. Scoring is
+deterministic on persisted rollouts, so each repair below re-derives at **zero** rollout cost.
+
+**Does the feedback name the actual defect, or only the tool?** If it says "Failed action(s): a
+write tool" when the real defect is a wrong *argument value*, no edit can be localized. Measured:
+argument-value errors were the majority of failed gold actions. A predecessor read the wrong field
+name for the action check, reported "0 actions missed" for every task, and stayed blind to the
+dominant failure mode for an entire effort. Fix the adapter's feedback, then re-derive.
+
+**Does any feedback helper fail SILENTLY?** Grep the adapter for bare `except` around signal
+construction and make each one loud. Measured: a localizer called a helper method that did not
+exist; the `AttributeError` was swallowed, so every failed numeric check degraded to the generic
+*"1 required piece(s) of information were not clearly communicated"*. An optimiser read that as "the
+checker is unsatisfiable" and spent **seven rounds** instructing the agent to state a value it was
+already stating. The repaired signal distinguishes *never stated a figure* from *stated one and it
+was wrong* — and re-deriving it over 125 already-persisted rollouts cost nothing.
+
+**Distinguish "silent" from "wrong" for every value-bearing check.** They are different defects
+needing opposite edits (add a REQUIRED slot vs. fix arithmetic/scope), and a message that conflates
+them sends the round in the wrong direction. Report the value the AGENT stated, never the expected
+one — a check's `info` field often *is* the expected value (one benchmark stores a bare `"1628"`), so
+use its SHAPE and never echo it.
+
+**Did the rollout run, or did the infrastructure fail?** A wallclock timeout, a starved endpoint or a
+dropped connection is missing data, not a zero. If it lands in the mean as 0.0, a whole evaluation
+can read as a catastrophic capability with no error anywhere. Check `termination_reason` and the
+coverage the gate reports — a low-coverage split must be `indecisive`, never a score.
+
+**Would a clearly-wrong candidate score worse?** If not, the metric is not discriminating and no gate
+built on it can work.
+
+## Why churn needs a bundle you can take apart
+
+The failure mode to design against is churn, and it is measured, not hypothetical: in a real run two
+of three candidates had an *identical* mean to their parent while a different set of tasks passed —
+each fixed 2 tasks and broke 2. A mean-only gate calls that a tie; the paired gate rejects it because
+it sees per-task movement in both directions. That is why a multi-part edit is safe to attempt at
+all — and why, when you bundle, the parts must be *independent* (different files or different rules),
+so that a rejected bundle can be resubmitted as its surviving part next round. Read `regressed` out
+of the screen and `regressions` out of the gate to know which part to drop.
+
+## Form, not wording
+
+- **No nuance clauses.** Appending one qualifying clause to an otherwise-winning recipe degraded it
+  from consistent to noisy. If a rule needs a caveat, restructure the rule. This applies to refusal
+  text too: adding two *correct* discrimination clauses to a working refusal took a task 0.2 → 0.1,
+  with all ten trials failing. The clauses were right; the longer refusal traded follow-through for
+  precision. A refusal has a budget — every sentence competes with the one saying what to do next.
+- **Exemption clauses do not scope.** "This limit does not apply to X" still suppresses X.
+  Restructure so the rule cannot reach the exempt case in the first place.
+- **Prefer an in-code guard to a prose rule when the capability owns its tools.** The only edit that
+  ever carried a large accepted gain on that benchmark was tool-level (`tools.py` 593 → 832 lines,
+  +0.176 val): a precondition that refuses the illegal write and returns a recovery-oriented error
+  changes behaviour deterministically, where a policy sentence changes it only probabilistically.
+  Prose is the right form when the agent *lacks* a decision criterion; code is the right form when it
+  has one and violates it.
+
+## Guard closure: a guard that forbids the harmless option can force the harmful one
+
+**Ask what the agent does INSTEAD.** Measured: a guard refusing a change that changes nothing ("this
+call would change nothing, so do not quote a price") is locally correct — an unchanged record
+genuinely cannot produce a credit. On the task where the right answer was *make no change at all*, it
+cost 0.288. Removing that one guard, policy byte-identical, halved the damage (−0.288 → −0.147, no
+longer resolvable) while the paired task kept its +0.498.
+
+The failure is not the guard's logic, it is the guard's *closure*. Refusing the no-op left the agent
+with only real changes to choose from, and it chose one. So before adding a refusal, name the action
+set it leaves behind and check that "do nothing" is still reachable — a refusal that removes the
+correct answer converts a pass into a fail while looking like a safety improvement.
+
+This is also why the first ablation was worth running even though it refuted its own hypothesis: the
+paragraph suspected of causing the loss turned out mildly *helpful* (removing it cost the paired task
+0.141), and without that null the round would have shipped the wrong fix and kept the real cause.
+
+## Auto-repair can accelerate a wrong action — a rejected call is sometimes a brake
+
+When a tool bounces a recoverable argument slip, the agent spends a turn recovering, and turns are
+scarce, so repairing the slip inside the tool looks like a free win. Measured counter-example: a
+transaction whose payment id used an unrecognised alias and omitted the amount was rejected by the
+parent and repaired by the candidate — but that transaction was itself premature, made with a
+defaulted payment method the customer had never been asked about, and the customer then asked for a
+different one, forcing an undo-and-redo that left an extra stale row in the database. The rejection
+had been holding back a wrong write.
+
+So before shipping a repair, ask what the rejected call would have DONE had it succeeded. If it would
+have written the right thing a turn later, repair it. If it would have written the wrong thing
+immediately, the repair needs to be paired with the precondition that makes the call correct — not
+shipped alone, and not abandoned either.

--- a/skills/algorithms/agent-optimize/references/measured-lessons.md
+++ b/skills/algorithms/agent-optimize/references/measured-lessons.md
@@ -1,15 +1,29 @@
 # Measured lessons — what a number on this loop can and cannot resolve
 
-Every rule here was paid for by a measurement on a real run, and each states the number that
-bought it. They live outside SKILL.md because the loop has to stay readable: the body carries the
-contract, this file carries the evidence behind it.
+## Contents
 
-Read this before your first gate decision on a new benchmark, and again whenever a result surprises
-you. The specific figures come from a multi-turn tool-use benchmark with a mid-tier agent model; the
-*shape* of each finding is what transfers, and where a number is likely benchmark-specific the rule
-says so.
+- [Measurement discipline — what a number here can and cannot resolve](#measurement-discipline--what-a-number-here-can-and-cannot-resolve)
+  — per-task gradient noise, re-running the null, what the gate can resolve, the ceiling, the three
+  phases of a fan-out, merge granularity and what a merge silently drops, and the four things that
+  keep the phase honest.
+- [The binomial floor, and what an aggregate mean can resolve](#the-binomial-floor-and-what-an-aggregate-mean-can-resolve)
+  — the SE formula against a measured null, why temperature 0 does not make it "sampling error", and
+  why narrowing to the hard tasks makes an artifact measurement worse.
+- [Load is the other half of the noise](#load-is-the-other-half-of-the-noise) — the concurrency
+  tables, the oversubscription incidents, and why total in-flight requests is the knob.
+- [Gate the sum, not each addend](#gate-the-sum-not-each-addend) — the six-branch merge that gated
+  negative, and the cost of certifying each mechanism by rate.
+- [Take the error ACROSS whole runs](#take-the-error-across-whole-runs) — the two-seed-block table
+  and the accept that had to be retracted.
 
-### Measurement discipline — what a number here can and cannot resolve
+Every rule here was paid for by a measurement on a real run, and each states the number that bought
+it. They live outside SKILL.md because the loop has to stay readable: the body carries the contract,
+this file carries the evidence behind it. Read it before your first gate decision on a new benchmark,
+and again whenever a result surprises you. The figures come from a multi-turn tool-use benchmark with
+a mid-tier agent model; the *shape* of each finding is what transfers, and where a number is likely
+benchmark-specific the rule says so.
+
+## Measurement discipline — what a number here can and cannot resolve
 
 Everything below is about the instrument, not the edits. It is placed inside the fan-out section
 because that is where it was learned, but it applies to every round: on this benchmark the
@@ -247,12 +261,12 @@ available loss, say so in the report before the first rollout, not after the las
 **Each optimiser's loop** — target task at full `n_trials`, plus a canary of tasks measured
 **1.0** at baseline, in the same call:
 
+The inner step is one optimiser's own task at full trials plus the canary, in a single call; after
+the fan-out, combine and gate the merge like any other candidate:
+
 ```bash
-# one optimiser's inner step: its own task at full trials, plus the canary, one call
 python "$A/taskeval.py" "$R/work/$TAG" 7,17 --project "$P" --n <num_trials> \
        --canary 0,3,12 --canary-n 3 --traces /tmp/tr_$TAG.json
-
-# after the fan-out: combine, then gate the merge like any other candidate
 python "$A/merge_taskopt.py" --root "$R/work" --base "$R/work/<parent>" \
        --out "$R/work/cand_merged" --include t7 t17 u33
 python "$A/round.py" --run-dir "$R" --project "$P" --candidates cand_merged \
@@ -539,4 +553,191 @@ bytes, not the last one), and treat any single-reading per-task comparison as a 
 per-task rate was always a training number; this is the second reason not to quote it as a result.
 The full-val gate against its own control is the arbiter precisely because it averages 30 tasks
 instead of trusting one.
+
+## The binomial floor, and what an aggregate mean can resolve
+
+**First compute the BINOMIAL floor. Most of what looks like mysterious nondeterminism is n.** Each
+rollout is pass/fail, so a task's rate is a binomial proportion and an arm mean over `m` tasks at `n`
+trials has
+
+    SE(arm difference) = sqrt( sum_over_tasks 2·p(1-p)/n ) / m
+
+Do that arithmetic BEFORE blaming the provider, the seeds, or the load. Measured on 10 tasks at n=10
+with p≈0.35: predicted SE **0.0615**, observed gap between two byte-identical arms **0.0778** — a
+ratio of **1.27**, i.e. plain sampling. Mean per-task movement was 0.0978 against a binomial
+prediction of 0.1445, so the observed movement was *smaller* than chance requires. There was nothing
+left to explain.
+
+One precision about what this is and is not. At temperature 0 with identical seeds a fully
+deterministic system would return *identical* arms, so this is not sampling error in the textbook
+sense — there is no sample being drawn. What the arithmetic shows is that the observed variation is
+**statistically indistinguishable in magnitude from independent per-rollout coin flips**. That
+matters because no further mechanism needs to be posited to explain it, and — whatever its physical
+cause — the remedy is the same one that works for binomial noise: more trials. Do not report it as
+"sampling noise" without that caveat, and do not go hunting for a cause you have no evidence for.
+
+That reframes the concurrency result rather than cancelling it: at conc 25 per-task movement was
+0.250, genuinely **above** the 0.1445 floor, and dropping to conc 8 removed that excess and exposed
+the floor underneath. Lowering concurrency fixes what it can; the rest is n.
+
+The consequence is uncomfortable and worth stating plainly: **an aggregate mean over a dozen HARD
+tasks at n=10 cannot resolve any realistic edit.** Reaching 2 SE on a +0.05 effect on that subset
+needs ~60 trials per task.
+
+But be careful about the obvious inference, which is wrong. Narrowing to the hard tasks makes the
+measurement *worse*, not better, for judging an artifact — because a task sitting at 1.00 contributes
+signal to the mean with almost no variance, so dropping it removes a free denominator. Computed from
+that benchmark's own per-task rates:
+
+| arm | rollouts/arm | SE of paired difference |
+|---|--:|--:|
+| 12 hard tasks, n=10 | 120 | **0.0496** |
+| full val 30 tasks, n=10 | 300 | **0.0262** |
+| full val 30 tasks, n=20 | 600 | 0.0185 |
+
+Full val at n=10 is nearly twice as precise as the hard subset, and the four prior gate rounds there
+were run at full val n=5 (SE 0.0371) — so their problem was never the task set. It was that they ran
+at a concurrency carrying excess noise on top of that, and chased effects smaller than the sum.
+
+So the two questions need opposite designs, and conflating them is the actual error:
+
+| you want to know | measure | why |
+|---|---|---|
+| does this mechanism work | ONLY the tasks where it fires, at high n, per-task test | a mechanism firing on 2 tasks is diluted to nothing in a 30-task mean |
+| does it break anything | canaries, cheap precisely because they sit at 1.00 | zero variance means a single drop is real |
+| what is the artifact worth | FULL val, both arms in one batch | the 1.00 tasks are free precision for the mean |
+
+A mechanism that fires on two tasks and lifts them 0.15 → 0.45 is resolvable at n=40 on those two
+tasks (≈3 SE) and invisible in a 12-task mean at n=10 (≈0.5 SE). Same edit, same rollout budget: one
+design answers the question and the other cannot.
+
+**A screening band is not a baseline.** Per-task rates from a small trial count tell you where to
+*look*; they do not tell you where you *are*. In one run, ten tasks whose 3-trial bands summed to
+2.33 measured **4.04** at n=10 — the screen understated the artifact by 1.71 task-equivalents (0.057
+of val), and one task went the other way (0.33 → 0.10). Every "0.0 DEFECT" label was suspect: three
+of them measured 0.30, 0.444 and 0.60. So screen at low `n`, but re-measure at the gate's `n` before
+you quote a number, compute headroom, or tell an optimiser what its starting point is — and never let
+a low-`n` band be the thing a delta is computed against.
+
+## Load is the other half of the noise
+
+**Run the GATE at low concurrency — most of the re-measurement noise is load-induced.** This is the
+one lever that makes everything else measurable, and it is cheap to verify: measure the same bytes on
+the same seeds twice at your search concurrency, then twice again at a low one.
+
+| identical bytes and seeds, 12 tasks | conc 25 | conc 8 |
+|---|--:|--:|
+| arm-level \|delta\| between the two runs | **0.1167** | **0.0333** |
+| mean \|per-task\| movement | **0.250** | **0.100** |
+| tasks that moved at all | 10 / 12 | 5 / 12 |
+
+Five of the twelve tasks became perfectly repeatable at conc 8 having each moved 0.20-0.40 at conc
+25. So the practical split is: **search fast, gate slow.** Per-task exploration can run high, because
+its output is a mechanism you verify from a trace, not a rate; the accept decision must run at a
+concurrency where the null actually reproduces, which costs roughly 3x wall clock for the one
+evaluation that matters.
+
+Two caveats to state whenever you quote this, both real: the low-concurrency runs were sequential, so
+load and elapsed-time drift are confounded; and 12 tasks x 2 runs makes the variance comparison thin.
+The direction was consistent across all three metrics, which is why it is worth acting on, but it is
+not settled.
+
+**Concurrency composes only up to the endpoint's sustainable rate, and past it the failure is
+silent.** The sources multiply: K optimisers x C concurrency each is K*C in flight, and the serving
+endpoint does not know about your fan-out. Measured: nine per-task optimisers at concurrency 8 put
+~72 requests in flight against a proxy whose sustainable band is 24-90, and a single per-task eval
+went from ~4 minutes to ~50. Nothing errored — latency just grew, so it read as "the model got
+slower" rather than "I oversubscribed". An earlier incident on the same proxy is the extreme version:
+concurrency 300 pushed 292 of 300 rollouts into wallclock timeouts and the evaluation reported
+**0.0067** as capability. So measure the sustainable band once, divide it by the number of concurrent
+optimisers, and treat a sudden wall-clock blowout as an oversubscription symptom first.
+
+**The knob is TOTAL IN-FLIGHT REQUESTS, not the runner's per-process concurrency flag.** That flag is
+per-process, so it does not bound load when several evaluations run at once — and running them at once
+is the normal case. A gate launched at `--conc 8` alongside four exploring optimisers at `--conc 12`
+puts about 56 requests in flight, so it is a HIGH-load measurement wearing a low-load flag, and it
+will reproduce the wide null rather than the narrow one. Serialise the gate: let the fan-out finish,
+or pause it, and run the gate arms alone. Both arms still belong in the same batch as each other —
+pairing is what removes drift — but that batch must be the only thing running. If you cannot quiet
+the machine, say so next to the verdict instead of quoting a per-process number as though it were the
+load.
+
+## Gate the sum, not each addend
+
+**A multi-branch artifact is assembled with `integrate.py`, never by one merge.** Stated as a rule
+because the author of that script skipped it on the very round it was written: six branches were
+merged in one step, and the resulting artifact gated at **−0.0146** with seven replicated per-task
+losses against two replicated gains — while the same round's *single*-mechanism artifact gated at
+**+0.0115**. Fewer mechanisms beat more mechanisms, and a one-shot merge cannot tell you that,
+because it yields one number for N simultaneous changes.
+
+`funcmerge` merging cleanly is **not** evidence the branches compose — every branch retained cleanly
+in that failed artifact, with zero conflicts and no undefined attributes. Clean merge is a syntactic
+property; composition is an empirical one.
+
+**Gate the SUM, not each addend.** Measured: one tool-level mechanism is worth roughly 0.04–0.13 on
+the one or two tasks it touches, and resolving an effect that size at 2 SE needs about **n=100 trials
+on that task**. Certifying seven mechanisms that way is ~1400 rollouts to establish by rate what a
+deterministic replay establishes for free. So the economical order is:
+
+1. **Prove it engages** — replay a real failing payload against the edited tool and show the guard
+   fires; replay the passing payload and show it does not. Costs zero rollouts, and it is a stronger
+   statement about the mechanism than any rate.
+2. **Establish incidence from rollouts you already have** — how often does the condition occur, and
+   is it skewed toward failures? Also free. One guard fired on 8 of 76 matching calls, 8 in failures
+   and 0 in passes.
+3. **Confirm the sign at modest n, with canaries** — you are checking for a regression and a
+   direction, not measuring a size.
+4. **Gate the accumulated artifact ONCE on full val**, where SE was 0.0262 at n=10 and several
+   mechanisms can clear it together even though none clears it alone.
+
+Expect the measured per-task effect to land well below the upper bound incidence implies — there
+~40% of it — because the guard fires correctly and the agent then still fails for an unrelated
+reason. That gap is not evidence the mechanism failed; check the task's other reward components
+before concluding anything.
+
+## Take the error ACROSS whole runs
+
+**Take the error across whole runs, not across tasks within one run.** A single paired run's SE is
+computed over tasks, so it cannot see run-to-run nondeterminism at all — and on that benchmark it was
+the dominant term. Repeat the entire paired comparison on distinct seed blocks and use the spread of
+the per-run deltas:
+
+| seed block | candidate | control | paired Δ |
+|---|--:|--:|--:|
+| 0-4 | 0.7333 | 0.6467 | +0.0867 |
+| 100-104 | 0.6867 | 0.6667 | +0.0200 |
+| **combined** | | | **+0.0533, SE 0.0333 across runs (t ~ 1.6) — NOT demonstrated** |
+
+```bash
+# one paired run per seed block, both arms in the SAME batch, then combine ACROSS runs
+python "$A/taskeval.py" "$R/work/cand" <val ids> --n 5 --base-seed 0   --json /tmp/c0.json
+python "$A/taskeval.py" "$R/work/ctl"  <val ids> --n 5 --base-seed 0   --json /tmp/k0.json
+python "$A/taskeval.py" "$R/work/cand" <val ids> --n 5 --base-seed 100 --json /tmp/c1.json
+python "$A/taskeval.py" "$R/work/ctl"  <val ids> --n 5 --base-seed 100 --json /tmp/k1.json
+python "$A/multirep.py" /tmp/c0.json:/tmp/k0.json /tmp/c1.json:/tmp/k1.json
+```
+
+`multirep.py` refuses to return a verdict from a single paired run at all, because that is exactly
+where the retracted accept came from. `--base-seed` matters: raising `--n` only extends the same seed
+block, so a rerun at the same seeds is a determinism check.
+
+The first run alone reported SE 0.0548 across tasks and an "accept". Two runs show the same candidate
+at +0.0867 and +0.0200, and a byte-identical control re-run moved +0.0800 by itself. The across-run
+estimator needs no assumption about where the noise comes from, which matters because on that run its
+source was never identified: LLM sampling, seed assignment, concurrent batching, timeouts, infra
+accounting and set-iteration order were each ruled out by direct measurement, and the leading
+remaining hypothesis (transient errors below the `max_errors` threshold being fed back into the
+conversation) stayed unverified.
+
+Budget for it up front: a credible verdict on a sub-0.10 effect there is **several full paired runs**,
+not one. If that is unaffordable, the honest output of the round is "not resolvable at this budget" —
+which is a result, and is what the earlier single-run accept should have been.
+
+**The false-veto rate that made `--veto-regressions` opt-in.** In one gate the byte-identical control
+reported **four** regressed tasks and the candidate reported **four** — identical counts, disjoint
+sets, one of the two artifacts provably unchanged. The old veto fired on a byte-identical copy of the
+seed **42.8%** of the time at 5 trials, and in one run it vetoed *both* candidates that had passed the
+significance test. Read `regressions` as a pointer to look at, never as a verdict, and always next to
+the control's own list.
 

--- a/skills/algorithms/agent-optimize/references/per-task-fanout.md
+++ b/skills/algorithms/agent-optimize/references/per-task-fanout.md
@@ -1,0 +1,141 @@
+# Per-task fan-out — economics, briefing, canaries, assembly
+
+Read this when the baseline's per-task `k/n` shows the loss **concentrated in a few named tasks**
+rather than spread thin, and you want to spend the round's rollouts on those tasks instead of on
+full-val gate rounds. SKILL.md carries the three rules that decide whether the shape is safe; this
+file carries the arithmetic, the briefing contract, the canary-selection rule and the commands.
+
+The numbers below come from real runs on a multi-turn tool-use benchmark with a mid-tier agent
+model. The *shape* of each finding transfers; the figures are that run's.
+
+## Why it is cheaper
+
+A full-val gate round costs `val_n × n_trials` rollouts and returns *one bit per candidate*: accept
+or reject. A single task at `n_trials` costs `n_trials` rollouts and returns the same bit — about the
+failure that actually exists. At `val_n = 30, n_trials = 10` that is 300 rollouts per learning step
+versus 10: **a 30× cheaper gradient**, on the unit the defect lives in.
+
+Measured on one long run: five classic rounds spent ~1500 rollouts to produce **10 learning steps
+and 1 accept**. The same budget under this shape buys **nine optimisers × six iterations = ~54
+steps**, each aimed at one measured defect, and the per-task evals run concurrently so the
+wall-clock cost is one round's.
+
+## What to ask a parallel optimiser for
+
+**A parallel optimiser's deliverable is a MECHANISM WITH TRACE PROOF, not a rate.** K optimisers
+each evaluating is K processes, so a fan-out is BY CONSTRUCTION a high-load regime — the very regime
+in which a per-task rate cannot resolve the effect anyone is looking for. Briefing K subagents to
+"measure whether your edit helps" therefore asks them for the one thing their situation cannot
+provide, and what comes back is K rate deltas drawn from a distribution wider than the effect.
+Several prior rounds did exactly this and accepted edits on it.
+
+Ask instead for evidence that does not depend on load:
+
+| evidence | load-sensitive? | good for |
+|---|---|---|
+| the guard fired on the observed call | no | proving the mechanism engages |
+| the agent's next action changed after it fired | no | proving the mechanism works |
+| a direct call with the exact bad payload now succeeds / still refuses | no | proving repair logic, deterministically |
+| the delivered docstring text contains the keys | no | proving the description reaches the model |
+| count of clarification turns before the first write | barely | proving a behavioural prose change |
+| per-task pass rate | **yes, heavily** | almost nothing, at fan-out load |
+
+Then gate the surviving mechanisms yourself, serialised, on a quiet machine. The division of labour
+is: **the fan-out finds falsifiable mechanisms and proves them structurally; the driver alone turns
+mechanisms into numbers.** A subagent that reports "indistinguishable from noise" while showing its
+guard firing correctly has done its job completely.
+
+## Canary selection
+
+**Draw canaries from the WHOLE suite, not from the neighbourhood of your mechanisms.** This is the
+mistake that sank an artifact whose individual mechanisms all measured positive. The canary set was
+nine tasks picked near the targets; the artifact then damaged four high scorers nobody was watching
+— two at 1.00, one at 0.90, one at 0.80 — and the gate failed on exactly that collateral. **A canary
+set that only covers what you aimed at cannot catch what you hit by accident.**
+
+`integrate.py --canary-auto BASELINE.json` selects them mechanically: every task at or above
+`--canary-floor` (default 0.90) that is not a target, lowest-rate-first so the most fragile high
+scorers are the ones kept. Run against that round's own baseline it recovers three of the four tasks
+that were actually damaged.
+
+The fourth is the honest limit: it sat at **0.80**, under the floor. Lowering the floor catches it
+and admits a noisier guard — a task at 0.80 moves about ±0.13 at n=10 by chance, so it will veto good
+work at random. There is no floor that is both complete and quiet. Pick it deliberately: 0.90 for a
+wide sweep where false vetoes are expensive, lower when you are integrating one mechanism and can
+afford to investigate every flag.
+
+**A canary needs two separately-launched readings, not 20 trials in one.** Measured: a task read
+1.00 in 20/20 rollouts and then 2/5 the next day on byte-identical code at the same seeds. It had
+been promoted to canary on the strength of that 20/20 — evidence which does not support the claim,
+because repeats launched inside one occasion share whatever makes the task come out the way it does.
+Two separate readings caught it; more trials in the first reading never would have. The consequence
+cuts both ways:
+
+* a task that disagrees between occasions must be dropped from the canary set, **and** must not be
+  used to judge a candidate either — two of twelve target tasks moved +0.45 between occasions, so a
+  per-task delta on them is uninterpretable;
+* the discipline itself survives — the other eight canaries read exactly 1.00 on both occasions — so
+  the fix is the selection criterion, not the idea.
+
+**And a per-task effect that clears 2 SE once can still be wrong.** Measured: a task regression of
+−0.288 at n=40 (z −2.61, resolvable) read −0.80 in one full-val block and **+0.30** in the next. A
+single powered reading is not the floor for a per-task claim; agreement across separately-seeded
+occasions is.
+
+Cross-occasion drift on a hosted gateway turned out NOT to be the dominant term: mean per-task
+movement was 0.123 across a day at low load versus 0.100 within a day, against 0.250 at high load.
+Load dominates elapsed time. Check it rather than assuming either way.
+
+## Running the fan-out, merging it, and remembering what it found
+
+Each optimiser evaluates its own task at full trials **plus a canary of tasks measured stable at
+baseline**, in one call, and writes traces so the next edit aims at an observed decision:
+
+```bash
+python "$A/taskeval.py" "$R/work/$TAG" <its-tasks> --project "$P" --n <num_trials> \
+       --canary <stable-task-ids> --canary-n 3 --conc <low> --traces /tmp/tr_$TAG.json
+```
+
+Run every eval **detached** (`nohup … &`, then poll for the output file): under endpoint contention
+a per-task eval can take 15-50 minutes, and a harness-level timeout has killed an eval that was
+still healthy.
+
+Findings go in a shared ledger, never in the coordinator's head — independent optimisers on
+different tasks keep rediscovering one cause, and two of them implementing the same fix collide at
+merge with only one of the two actually measured:
+
+```bash
+python "$A/mechanisms.py" list --run-dir "$R" --task "$TASK" --compact
+python "$A/mechanisms.py" add --run-dir "$R" --owner "$TAG" --status proposed \
+       --mechanism "<the cause, one sentence>" --evidence "<what you measured>" \
+       --touches <function-the-fix-edits>
+python "$A/mechanisms.py" add --run-dir "$R" --owner "$TAG" --status rejected \
+       --supersedes <seq> --mechanism "<what turned out to be false>" --evidence "<the test>"
+```
+
+Assemble the result **one branch at a time, measuring after each** — never in a single merge:
+
+```bash
+python "$A/integrate.py" --base "$R/work/<parent>" --branches "$R/work/t7" "$R/work/t17" \
+       --out "$R/work/cand_merged" --tasks <targets> --canary-auto "$R/<baseline-per-task>.json" \
+       --n <num_trials> --conc <low> --floor <measured-null-delta>
+python "$A/round.py" --run-dir "$R" --project "$P" --candidates cand_merged \
+       --n-trials <num_trials> --k-se <gate_k_se>
+```
+
+`funcmerge.py` is the merge engine `integrate.py` drives per step; call it directly only to inspect
+a single combination, and read its `dropped_additions` — a line a branch ADDED that the merge did not
+carry is how a rejected subtraction gets silently re-applied:
+
+```bash
+python "$A/funcmerge.py" --base <parent>/<file> --out /tmp/try.py \
+       --inputs <branchA>/<file> <branchB>/<file> --union-pure-insertions --json /tmp/fm.json
+```
+
+`merge_taskopt.py` remains for the whole-file case (a capability whose artifact is prose, where
+per-function merging does not apply):
+
+```bash
+python "$A/merge_taskopt.py" --root "$R/work" --base "$R/work/<parent>" \
+       --out "$R/work/cand_merged" --include t7 t17
+```

--- a/skills/algorithms/agent-optimize/scripts/check.py
+++ b/skills/algorithms/agent-optimize/scripts/check.py
@@ -138,6 +138,46 @@ def _prose(c: Checker, skill: str) -> None:
             note="allowed-tools declares Task (parallel fan-out is actionable)")
 
 
+def _progressive_disclosure(c: Checker, skill: str) -> None:
+    """The body stays inside the 500-line budget, and every reference is pointed AT.
+
+    skill-creator: the SKILL.md body is re-read on every trigger, so it is capped at ~500 lines,
+    and each bundled reference must be linked from the body with what it contains AND when to
+    load it. References are ONE level deep: a reference that links to another reference cannot
+    be read on its own, which is the whole point of the hierarchy.
+    """
+    body = skill.splitlines()
+    c.check(len(body) < 500,
+            f"SKILL.md body is {len(body)} lines; the recurring per-trigger budget is 500 — "
+            "move depth into references/ with an explicit pointer",
+            note=f"SKILL.md body is {len(body)} lines, inside the 500-line budget")
+
+    refs = sorted(p for p in (HERE.parent / "references").glob("*.md"))
+    c.check(bool(refs), "no references/ — the split is the point of the hierarchy")
+    for ref in refs:
+        rel = f"references/{ref.name}"
+        c.check(rel in skill, f"{rel} exists but SKILL.md never links it")
+        # The pointer must say WHEN to load it, not merely that it exists.
+        c.check(f"({rel})" in skill and "**Load**" in skill,
+                f"{rel} needs a pointer in SKILL.md's `## References` stating what it contains "
+                "and when to load it")
+        text = ref.read_text(encoding="utf-8")
+        c.check("](references/" not in text,
+                f"{rel} links to another reference — references are one level deep, because a "
+                "reader may only partially read either one")
+        if len(text.splitlines()) > 300:
+            c.check("## Contents" in text,
+                    f"{rel} is over 300 lines and needs a table of contents")
+    c.note(f"{len(refs)} references, each linked with a when-to-load pointer, one level deep")
+
+    # Retrospective narrative belongs in a reference or the run log, never in the body: it is
+    # re-read on every trigger and an agent driving a round acts no differently for having it.
+    for anecdote in ("in one run", "Measured here", "A real run", "four consecutive null runs"):
+        c.check(anecdote not in skill,
+                f"SKILL.md carries retrospective narrative ({anecdote!r}) — keep the rule and the "
+                "command in the body, move the number that bought it into references/")
+
+
 def _project(tmp: Path, *, n: int) -> Path:
     """A minimal project dir the SUBPROCESS scripts can load: adapter + spec.
 
@@ -1103,6 +1143,7 @@ def main() -> int:
     _guard(c)
     _skill_text = SKILL_MD.read_text(encoding="utf-8")
     _prose(c, _skill_text)
+    _progressive_disclosure(c, _skill_text)
     _integrate_is_mandated(c, _skill_text)
     tmp = Path(tempfile.mkdtemp(prefix="agent_optimize_chk_"))
     try:

--- a/skills/algorithms/agent-optimize/scripts/linkcheck.py
+++ b/skills/algorithms/agent-optimize/scripts/linkcheck.py
@@ -1,0 +1,56 @@
+"""Link contract for this skill: every relative link resolves, and no reference links to another.
+
+Two failures this catches, both silent in review:
+  * a body pointer to `references/<x>.md` that was renamed or never created — the agent follows
+    the pointer, finds nothing, and improvises the depth the reference was supposed to carry;
+  * a reference that links to another reference. References are ONE level deep because the agent
+    may read only part of either one, so a ref->ref hop can leave it acting on half a rule.
+
+Run: python scripts/linkcheck.py   (prints JSON, exits non-zero on any problem)
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+SKILL = Path(__file__).resolve().parent.parent
+LINK = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
+
+
+def main() -> int:
+    problems: list[str] = []
+    checked = 0
+    files = [SKILL / "SKILL.md", *sorted((SKILL / "references").glob("*.md"))]
+    for f in files:
+        rel_f = f.relative_to(SKILL)
+        for target in LINK.findall(f.read_text(encoding="utf-8")):
+            if target.startswith(("http://", "https://", "#", "mailto:")):
+                continue
+            checked += 1
+            path, _, anchor = target.partition("#")
+            resolved = (f.parent / path).resolve()
+            if not resolved.is_file():
+                problems.append(f"{rel_f}: broken relative link -> {target}")
+                continue
+            if anchor:
+                slugs = {
+                    re.sub(r"[^a-z0-9\- ]", "", line.lstrip("#").strip().lower()).replace(" ", "-")
+                    for line in resolved.read_text(encoding="utf-8").splitlines()
+                    if line.startswith("#")
+                }
+                if anchor not in slugs:
+                    problems.append(f"{rel_f}: link {target} names a heading that does not exist")
+            if f.parent.name == "references" and resolved.parent.name == "references":
+                problems.append(
+                    f"{rel_f}: links to another reference ({path}) — references are one level deep")
+
+    print(json.dumps({"files": len(files), "relative_links": checked,
+                      "ok": not problems, "problems": problems}, indent=2))
+    return 1 if problems else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #324.

## Before / after

| | before | after |
|---|--:|--:|
| `SKILL.md` body lines | **922** | **337** (−64%) |
| `SKILL.md` body tokens (lint's `len(body)//4`) | ~14678 | **~5444** (−63%) |
| references | 2 (736 L) | 4 (1213 L) |
| `check.py` assertions | 72 | **74** |

Roughly **370 of the 922 lines were narrative rather than instruction** — retrospective
evidence, incident postmortems and defensive justification. They are not deleted wholesale:
each rule kept its imperative in the body, and the measurement that bought it moved to the
reference that owns that evidence. Where a passage was a *restatement* of something with
another owner (or of something the same body already said), it was deleted outright.

## Complete section → destination mapping

Line numbers are the original 922-line body.

| original | what it was | destination |
|---|---|---|
| 1–9 frontmatter | 119-word run-on `description`, near-identical to `meta.yaml:summary` | **body, rewritten** — 50 words, trigger-first |
| 11–24 intro | what agent mode is + "nothing new lives in core" | **body**, 13 → 7 lines |
| 26–37 shell vars | `R`/`P`/`S`/`A` + `mkdir -p "$R/work"` | **body, verbatim** |
| 39–56 Phase 0 | read-first checklist + `stop_condition` parsing + ask-if-ambiguous | **body**, 18 → 13 lines |
| 58–95 step 0 (spend) | affordability, `recommendation` table, unmetered-runner rule | **body**; the 3-row `recommendation` table became prose (same three branches, same conditions) |
| 96–133 step 1 (signal) | diagnose commands, train-vs-val comparison, per-task `k/n` band table | **body, kept** (table verbatim); 129–132 veto lore → **`measured-lessons.md`** |
| 134–166 scorer audit | 6-item checklist wrapped in three debugging stories (the swallowed `AttributeError`, "seven rounds instructing the agent to state a value it was already stating", the wrong field name) | **checklist → body** (6 questions, 6 lines); **all three stories → `edit-design-lessons.md`** |
| 167–173 read-the-trace | form-vs-content diagnosis after two rejects | **body, kept** |
| 174–180 step 2 (propose) | siblings vs one bold bundle | **body, kept** |
| 181–188 churn measurement | "in a real run two of three candidates had an identical mean…" + the stale "no-regression veto in step 5" pointer | rule → **body**; measurement → **`edit-design-lessons.md`**; stale pointer **deleted** (the veto is opt-in) |
| 190–213 edit-form table | 4 failure types → the form that fixes / backfires | **body** — third column's justifying clauses shortened, all four rows and both prescriptions intact |
| 215–221 nuance/exemption clauses | two measured backfires | rules → **body** (one sentence each); measurements → **`edit-design-lessons.md`** |
| 222–228 in-code guard | prose-vs-code rule + `tools.py 593→832, +0.176 val` | rule → **body**; the instance → **`edit-design-lessons.md`** |
| 229–241 null control + `rejected.jsonl` | evaluate `ctl_null` every round; make proposals structurally different | **body, kept** |
| 243–261 step 3 (screen) | what `screen.py` does, one paragraph | **body** compressed; mechanism detail → **`algorithm.md`** (which already owned *Subset screening*) |
| 262–275 `val_n <= 30` rule + SE table | a one-benchmark threshold and SE figures stated as universal law | **body states the arithmetic** (`breakeven_kill_rate` vs your observed kill rate); **instantiated numbers → `algorithm.md`** under a heading naming the run |
| 276–296 step 4 (gate) | evaluate + `gate_check.py`, verdict semantics | **body, kept** |
| 297–306 `regressions` | already-correct "diagnosis not a veto" + the 42.8% false-veto figure | rule → **body**; the rate → **`measured-lessons.md`** |
| 307–319 `phases/gate` front-end | 13-line blockquote on the inspection path | **body** keeps 1 sentence; the rest → **`algorithm.md`** |
| 320–352 step 5 (commit) | `commit.py`, `--reject-basis` table, tag-collision guard | **body, kept** (table content preserved as prose) |
| 354–357 `--optimizer-*` | record the proposer's own cost | **body, kept** |
| 359–376 parallel round | `round.py` command + read the noise floor | **body, kept**; `--concurrency 300` → **8** (see below) |
| 377–399 five fan-out invariants | diagnosis free / unique tags / serial gate / never test / pay first | **body, kept** (5 → 4 items: "never fan out across test" and "pay first" merged) |
| 400–412 round shape diagram | ASCII pipeline | **body**, diagram → one prose sentence |
| 414–433 three concurrency sources | `run_batch`, `CAPEVOLVE_WORKERS`, per-sibling processes | **body, kept**; "which steps parallelise safely" → **`algorithm.md`** |
| 435–448 oversubscription incident | "nine optimisers … ~4 min → ~50"; "concurrency 300 → 292/300 timeouts → 0.0067" | rule ("total in-flight requests is the knob") → **body**; both incidents → **`measured-lessons.md`** |
| 449–462 fan-out economics | the 30× cheaper gradient, "five rounds spent ~1500 rollouts" | one-line rationale → **body**; the run's arithmetic → **`per-task-fanout.md`** |
| 463–471 screening band | "ten tasks whose 3-trial bands summed to 2.33 measured 4.04" | rule → **`per-task-fanout.md`** intro; measurement → **`measured-lessons.md`** |
| 473–496 binomial floor | SE formula, the 1.27 ratio, the temperature-0 methods note | formula → **body** (measurement rule 2); everything else → **`measured-lessons.md`** |
| 498–527 precision tables | hard-subset vs full-val SE table, the "two questions" table | rule ("different questions need opposite designs") → **body**; both tables → **`measured-lessons.md`** |
| 529–548 conc-25-vs-8 tables | the load/noise measurements + two caveats | rule ("explore fast, gate slow, gate ALONE") → **body**; tables → **`measured-lessons.md`** |
| 550–564 guard closure | the refusal that removed the do-nothing option (−0.288 → −0.147) | rule → **body** (one clause, in the in-code-guard bullet); measurement → **`edit-design-lessons.md`** |
| 566–578 auto-repair as brake | the premature transaction the rejection was holding back | **→ `edit-design-lessons.md`** in full (rule + measurement) |
| 580–595 canary selection | draw canaries suite-wide; `--canary-auto`; the 0.90 floor trade-off | rule → **body** (`integrate.py --canary-auto`); the four damaged high scorers → **`per-task-fanout.md`** |
| 597–618 cross-occasion drift | 2-SE-once-can-be-wrong; the 20/20-then-2/5 canary; drift vs load | rule ("two separately-launched occasions") → **body** (measurement rule 3); measurements → **`per-task-fanout.md`** |
| 620–632 six-branch merge | the −0.0146 vs +0.0115 postmortem | rule ("assembled with `integrate.py`, never by one merge" + "Clean merge is a syntactic property") → **body**; the postmortem → **`measured-lessons.md`** |
| 634–653 gate the SUM | the 4-step economical order + `n=100` / `SE 0.0262` | the 4 steps → **body** (measurement rule 4, arithmetic not instance); the figures → **`measured-lessons.md`** |
| 655–678 briefing a fan-out | mechanism-with-trace-proof + the load-sensitivity table | rule → **body**; the evidence table → **`per-task-fanout.md`** |
| 679–688 in-flight knob | the `--conc 8` alongside four optimisers = 56 in flight worked example | rule → **body**; worked example → **`measured-lessons.md`** |
| 689–724 across-runs estimator | the two-seed-block table, `multirep.py`, the un-diagnosed noise source | rule + `multirep.py` → **body** (measurement rule 3); table and the "never identified" paragraph → **`measured-lessons.md`** |
| 725–778 running the fan-out | `taskeval.py` / `mechanisms.py` / `integrate.py` / `funcmerge.py` / `merge_taskopt.py` commands | **all five helpers named in the body** with what each does; full invocations → **`per-task-fanout.md`** |
| 779–815 measurement contract | 10 numbered rules, each carrying its numbers | **body**: 4 number-free rules + the `multirep.py` command; all figures → **`measured-lessons.md`** |
| 816–833 spend readout | run `spend.py` every 2–3 rounds; the field enumeration | **body**, folded into *Stop & seal*; the field-by-field enumeration of the script's own JSON **deleted** |
| 834–869 stop & seal | `measure.py` + report, the refusals, the no-`cap-evolve finalize` note | **body, kept** |
| 871–903 honesty invariants | 10 items | **body: 2 items** + one sentence pointing at `phases/{evaluate,gate,finalize}`. Items 3/4/5/6/8/10 **deleted as restatements** of core-owned material (per the ownership contract); items 1/2/7/9 survive where the decision is actually made (steps 3–5, parallel invariants 2–3, step 0) |
| 904–919 good vs bad | 16-line recap of the whole body | **deleted** — a restatement of every rule stated above it |
| 921–922 References | listed 1 of 2 references, no pointers | **body, rewritten** — all 4, each with what-it-contains + **Load**-when |

## Narrative deleted outright, and why

Not moved to any reference — these had no instructional residue at all:

1. **`:184` "the no-regression veto in step 5 is what rejects it"** — points at a veto that no
   longer exists; step 4 in the same document already said the opposite. Contradiction, not content.
2. **`:481–497` the temperature-0 methods note** (17 lines arguing whether variance at temperature 0
   is "sampling error in the textbook sense") — a methods caveat. No agent driving a round acts
   differently for having read it. The one operative sentence ("the remedy is more trials") is
   preserved in `measured-lessons.md`.
3. **`:904–919` "What good vs bad looks like"** — every clause restates a rule stated earlier in the
   same body. Duplication paid on every trigger.
4. **`:871–903` honesty invariants 3, 4, 5, 6, 8, 10** — the split seal, never editing
   `splits.json`/`rollouts/test/*`, generalize-don't-overfit, drive-through-primitives, record-spend,
   and finish-with-finalize. Core enforces all of them (`rundir.py`, `gate.py`, `splits.py`, a
   PreToolUse hook) and `phases/{evaluate,gate,finalize}` own the prose. Per
   `SKILL_OWNERSHIP.md` these are deletions, not relocations.
5. **`:816–833`'s enumeration of every field `spend.py` prints** — documentation of a script's own
   JSON output, which the agent reads directly when it runs the command.
6. **The ASCII round-shape diagram (`:400–409`)** — restates the five invariations immediately above it.

## The three script contradictions #324 flagged, fixed

- **`:369` gated at `--concurrency 300`.** `round.py:105` defaults to **8** and warns above 12, and
  `:441–443` of the same document called 300 run-destroying (292/300 rollouts into timeouts, a
  capability read of 0.0067). Now `--concurrency 8 --max-parallel 2`; no command in the body exceeds
  the warn threshold.
- **Honesty invariant 2 claimed no-regression is part of acceptance.** `gate_check.py:132` is
  `accept = bool(d.accept) and not (regs and args.veto_regressions)` — opt-in. The body now says
  regressions are reported, not vetoed, in all three places that mentioned it (`:184` deleted,
  `:878-880` rewritten, `:915` gone with the good/bad recap). `references/algorithm.md`'s stale
  "caught later by the full-val no-regression veto" line is fixed too.
- **`:187` said to read `regressed` "out of the screen and the gate".** `screen.py:161` prints
  `regressed`, `gate_check.py:140` prints `regressions`. Both are now named for the tool that
  prints them.

## `core/tests/test_agent_optimize_skill.py` — no changes needed

It asserts on SKILL.md content, so I read it first. It requires `mkdir -p "$R/work"`, the
`## Parallel round` section, the phrases `unique per sibling` / `gate stays serial` / `re-gate`,
`Task` in `allowed-tools`, no quoted heredoc, and that any `--mode paired` invocation carries a
`--run-dir`. All still hold in the new body, and its four `gate_check.regressions` unit tests are
untouched. **5 passed, unmodified** — the test was not weakened.

`scripts/check.py` gained assertions rather than losing them (72 → 74): a new
`_progressive_disclosure()` enforces the body line budget, that every `references/*.md` is linked
from the body with a `**Load**`-when pointer, that no reference links to another reference, that any
reference over 300 lines has a `## Contents`, and that the body carries none of the
retrospective-anecdote markers this PR removed.

## Evidence

**1. Body line count, before and after**

```
$ git show HEAD~1:skills/algorithms/agent-optimize/SKILL.md | wc -l
     922
$ wc -l skills/algorithms/agent-optimize/SKILL.md
     337 skills/algorithms/agent-optimize/SKILL.md
```

**2. `python skills/algorithms/agent-optimize/scripts/check.py`**

```
$ python3 skills/algorithms/agent-optimize/scripts/check.py; echo rc=$?
{"skill": "agent-optimize", "ok": true, "problems": [], ... 74 notes ... }
rc=0

check.py ok = True | assertions = 74
```

**3. Relative links resolve; no reference-to-reference links**

New `scripts/linkcheck.py` resolves every relative link and heading anchor across `SKILL.md` and all
four references, and fails on a ref→ref hop:

```
$ python3 skills/algorithms/agent-optimize/scripts/linkcheck.py; echo rc=$?
{
  "files": 5,
  "relative_links": 7,
  "ok": true,
  "problems": []
}
rc=0
```

**4. `core/tests` green** (imports pinned per #349)

```
$ PYTHONPATH="$PWD/core:$PWD/dashboard/backend" python3 -m pytest core/tests -q | tail -3
789 passed, 12 skipped in 126.68s (0:02:06)

$ PYTHONPATH="$PWD/core:$PWD/dashboard/backend" python3 -m pytest core/tests/test_agent_optimize_skill.py -q
5 passed in 8.90s
```

Matches clean main (`789 passed, 12 skipped`).

**5. `bash examples/toy_calc/run.sh`** — still reaches a gate-accepted test score

```
{"baseline_val":0.0,"best_id":"cand_0001","dashboard":".capevolve/run_demo/dashboard.html",
 "dashboard_server":"http://127.0.0.1:7878","iterations":3,"run_dir":".capevolve/run_demo",
 "test_baseline_reward":0.0,"test_delta":1.0,"test_pass_k":{"1":1.0},"test_reward":1.0}
```

**6. Authoring lint (`skill-package/scripts/abstract.py validate`)**

```
{"name": "agent-optimize", "ok": true, "problems": [],
 "warnings": ["SKILL.md body is ~5444 tokens (>5000); ..."]}
```

`problems: []`. The two lint violations this skill carried are cleared: `measured-lessons.md` now has
a `## Contents` (placed **above** the orientation prose, so 5 anchor links land inside the 1500-char
scan window rather than 1), and the broken anchored link
`references/algorithm.md#subset-screening-…` — which the lint read as a missing file — is gone.

**Frontmatter description** — third person, states what *and* when, real keywords
(`orchestration_mode`, `algorithm_skill`, the sibling algorithm names a user would compare against),
50 words / 361 chars, no CRITICAL/ALWAYS/MUST, and no longer a copy of `meta.yaml:summary`:

> Free-form optimization algorithm for agent orchestration mode: the conversational agent owns the
> whole search — proposing capability edits itself, screening them cheaply, gating each on full val,
> and sealing test once. Use when orchestration_mode is agent and algorithm_skill is agent-optimize.
> For a deterministic loop use hill-climb, gepa or skillopt instead.

## One target not met, flagged deliberately

**The body is ~5444 tokens against the ≤5000 target** (down from ~14678). Getting the last ~450
tokens out requires deleting content that #324 explicitly identifies as earning its place, not
compressing prose — I ran out of restatements before I ran out of budget. What remains would have to
go is: the **edit-form table** (#324: "the best generic content in any algorithm skill here"), the
**per-task `k/n` band table** (#324: "earns its place"), the **`--reject-basis` vocabulary**, or one
of the six documented commands. Per `SKILL_OWNERSHIP.md` ("if you are unsure which one a passage is,
keep it and flag it in the PR body") I kept them and am flagging it. If a reviewer prefers the token
bar over the tables, moving the edit-form table into `edit-design-lessons.md` — which is loaded
exactly when an edit is being written — is the cheapest ~150 tokens and I'll make that change on
request.

## Recommendations for other skills (not touched here — #328/#329/#330/#331 own them)

- **`cap-evolve finalize` is not a subcommand** (`cap-evolve --help`: `init doctor check algorithms
  splits run estimate diff watch tail replay dashboard version help`). agent-optimize is the only
  skill that says so. `evograph/SKILL.md:39,61,132`, `orchestrate/SKILL.md:55` and the agent-mode
  paragraphs in `hill-climb:53`, `gepa:106`, `skillopt:83` all instruct the agent to run it. Fixing
  five skills and relocating the correction to one owner is its own issue.
- **The generic "When `orchestration_mode: agent`" contract** is duplicated across hill-climb, gepa
  and skillopt. agent-optimize is the natural single owner; consolidating it is a separate change.
- **`phases/diagnose`** is the right home for the reflective-dataset/cluster shape that algorithm
  skills currently gesture at; this body now points at the phase rather than re-specifying it.
