### PR TITLE
gepa: reconcile SKILL.md against gepa.py and explain the paper's mechanism

### DIFF
--- a/skills/_registry/manifest.json
+++ b/skills/_registry/manifest.json
@@ -55,7 +55,7 @@
     "gepa": {
       "component": "algorithm",
       "path": "algorithms/gepa",
-      "summary": "Real GEPA \u2014 sample-efficient reflective Pareto optimization with a cheap minibatch local gate in front of the honest full-val gate, trace-based reflective dataset, per-instance frontier parent sampling, round-robin component focus, and system-aware merge.",
+      "summary": "GEPA \u2014 sample-efficient reflective Pareto optimization: a cheap train-minibatch local gate in front of the honest full-val gate, a trace-based reflective dataset, per-instance frequency-weighted parent sampling, round-robin component focus, and system-aware merge.",
       "entry": "scripts/run.py",
       "abstract": "scripts/abstract.py",
       "check": "scripts/check.py",

--- a/skills/algorithms/gepa/SKILL.md
+++ b/skills/algorithms/gepa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gepa
-description: Runs the real GEPA optimization loop (arXiv:2507.19457) — sample-efficient reflective Pareto search. Use when rollouts are expensive and the scorer gives informative per-task feedback, and you want the most quality per evaluation. Each iteration samples a parent from a per-instance Pareto frontier, evaluates it on a cheap minibatch of train tasks with full traces, builds a reflective dataset over the failures, asks the optimizer for one targeted component edit, re-checks the child on the same minibatch (a cheap local gate), and only on pass pays for a full-val eval behind the honest significance gate. Adds round-robin component focus and a system-aware merge across complementary lineages. Prefer over hill-climb when feedback is rich and budget is tight; use hill-climb for the first baseline run or feedback-poor binary tasks.
+description: Runs the GEPA optimization loop (arXiv:2507.19457) — sample-efficient reflective Pareto search. A cheap train-minibatch pre-gate decides whether a proposal is worth an expensive val evaluation, and parents are sampled from a per-instance frontier so specialists survive instead of being averaged away. Use when rollouts are expensive and the scorer returns informative per-task feedback, and you want the most quality per evaluation. Use hill-climb instead for a first baseline run or for feedback-poor binary pass/fail tasks.
 component: algorithm
 argument-hint: "--run-dir DIR --project DIR --optimizer 'CMD {workdir} {prompt}' [--max-metric-calls N --minibatch-size 4 --component-selector round_robin|all --max-merges 2 --resume]"
 allowed-tools: Read, Write, Bash
@@ -9,85 +9,129 @@ needs: [scores, traces, reflective_dataset, candidate]
 sources: [gepa]
 ---
 
-# gepa — the real sample-efficient reflective Pareto loop
+# gepa — sample-efficient reflective Pareto search
 
-GEPA (Agrawal et al., 2025, arXiv:2507.19457) is the highest-ceiling member of the
-family. Its power comes from a **two-stage economy** that spends cheap rollouts to
-decide whether a candidate is worth an expensive honest evaluation, plus reflection
-on **traces** (not scalars) and a **per-instance Pareto frontier** that keeps
-specialists alive. This skill is a thin wrapper over `cap_evolve.gepa.gepa_loop`;
-all honesty-critical machinery (splits, gate, seal, stats, cache) is the engine's.
+`algorithms/hill-climb` owns the mechanics every algorithm shares: parent →
+proposal → val gate → commit. Read it first. This page states only what GEPA
+(Agrawal et al., 2025) does **differently**, and why those differences are the
+paper's actual contribution rather than decoration. A thin wrapper over
+`cap_evolve.gepa.gepa_loop`.
 
-## The loop
+## The two mechanisms, and why removing either turns GEPA back into hill-climb
 
-1. **Select a parent** by sampling the per-instance Pareto frontier *frequency-
-   weighted* — each non-dominated candidate's weight is how many val instances it is
-   best at, so a specialist that uniquely tops one task is kept (seeded RNG, logged).
-2. **Sample a minibatch** of `--minibatch-size` (default 4) **train** ids.
-3. **Eval the parent on the minibatch with traces** (cheap; eval-cached).
-4. **Build a reflective dataset** over the parent's FAILING minibatch tasks — input
-   + the agent's output/trajectory + feedback — written as `REFLECTION.md` in the
-   optimizer workdir, plus a round-robin **component focus** as `FOCUS.md`. Invoke
-   the optimizer.
-5. **Eval the child on the SAME minibatch**; **local gate** `sum(child) >
-   sum(parent)`. This is the economy: a proposal that doesn't even help the
-   minibatch is rejected here, before any full-val cost.
-6. **On local-gate pass only**, pay for a **full-val** eval and apply the honest
-   significance gate (paired, val-only — the same gate hill-climb uses). On accept,
-   the child joins the pool and the per-instance frontier.
-7. **System-aware merge** (every `--merge-cadence` accepts, up to `--max-merges`):
-   find two frontier dominators sharing a common ancestor both beat, recombine
+**1. The parent is sampled from per-instance winners, not from the global best.**
+A mean is a lossy summary. A candidate that fixes one genuinely hard task while
+regressing three easy ones has a *worse* mean than the incumbent, so a
+best-parent rule discards it — and with it the only text in the pool that has
+ever solved that task. GEPA instead scores per val instance and samples
+frequency-weighted over candidates that (co-)win at least one, so specialists and
+stepping-stones stay reachable as parents while their mean is still behind. That
+is the quality-diversity argument (MAP-Elites): keep the *set* that covers the
+task distribution, not the single champion. Sampling is stochastic and seeded, so
+the exploration is reproducible.
+
+**2. A cheap train minibatch pre-gates the expensive val evaluation.** Rollouts
+dominate cost and a full-val eval costs `|val| · n_trials` of them. Most
+proposals are bad; paying full price to find that out is what makes naive
+reflective search unaffordable, and GEPA's headline "~35× fewer rollouts" comes
+almost entirely from *not* paying it. So parent and child are evaluated on the
+**same** small train minibatch (`2 · minibatch-size` rollouts, eval-cached) and
+the child is dropped unless `sum(child) > sum(parent)`. The minibatch never
+*decides* acceptance — it decides whether acceptance is worth measuring.
+
+A side benefit of (2): reflection reads **train** traces, so the proposer never
+sees the split its gate is computed on.
+
+## What differs from hill-climb, step by step
+
+1. **Parent** — frequency-weighted sample over per-instance (co-)winners
+   (`--selection-strategy`, default `pareto_per_instance`), not the current best.
+2. **Signal** — a minibatch of `--minibatch-size` (default 4) **train** ids,
+   evaluated with traces, instead of the whole train focus set.
+3. **Reflective dataset** — `REFLECTION.md` in the optimizer workdir, over the
+   parent's failing minibatch tasks (`phases/diagnose` owns what one is and what
+   shape it takes). "Failing" is the hard threshold `reward < 1.0`, so with a
+   graded scorer that never reaches 1.0 every sampled task is listed and the
+   header always reads `0/N pass` — read it as "sampled tasks, worst first". Each
+   entry is truncated to ~800 chars and at most 12 tasks are written: a summary,
+   not an archive; untruncated rollouts stay in `rollouts/train/`. The prompt also
+   carries the run's cross-iteration files (`LEDGER.md`, `PROCESS.md`, `RUNMAP.md`
+   + `prior_iterations/`) so a proposal builds on prior work.
+4. **Local gate** — child on the same minibatch, `sum(child) > sum(parent)`, else
+   dropped with no val spend. This is the extra stage; everything after it is
+   hill-climb's.
+5. **Merge** — every `--merge-cadence` accepts, find two strict-frontier
+   dominators sharing a common ancestor both beat and recombine them
    component-by-component (each component from whichever descendant changed it),
-   minibatch-gate, then full-val + standard gate.
+   then minibatch-gate and val-gate the result like any other child.
 
-**Budget is in rollouts/metric-calls** (`--max-metric-calls`, primary) — both
-minibatch and full-val evals count — with `--max-iterations` as a secondary cap.
-The **test split is never touched**; minibatch/merge evals draw from train/val only.
+Note the word "frontier" covers two different sets here: the *sampling pool* in
+step 1 is every candidate with ≥1 instance win, which can include dominated
+candidates; the strict per-task Pareto frontier (`selection.pareto_frontier`) is
+a subset of it and is what the merge and the reported `frontier_size` use.
 
-## When to use vs. hill-climb / skillopt
+## Component selection
 
-| Situation | Use |
-|---|---|
-| Rich per-task feedback + expensive rollouts; want max quality/eval | **gepa** |
-| First run / need a yardstick baseline | hill-climb (`--focus all`) |
-| Binary pass/fail, no diagnosis in feedback | hill-climb (reflection has little to chew on) |
-| Tiny task set (frontier collapses to 1–2 points) | hill-climb |
-| Want a fixed edit-budget schedule + epoch slow-update | skillopt |
-| Single global-best lineage is fine and merges add no value | hill-climb / skillopt |
+A **component** is one editable file of the candidate. (Unrelated to
+hill-climb's `--focus`, which selects *tasks*; this selects *files*.)
 
-GEPA's economy (minibatch gate + frontier) pays off precisely when evaluations are
-costly and feedback is informative; otherwise the bookkeeping doesn't earn its keep.
+- **`--component-selector round_robin`** (default): one component per iteration,
+  cycled, written to `FOCUS.md`. Small attributable changes are exactly the unit
+  the merge can later recombine — a sprawling multi-file rewrite cannot be.
+- **`--component-selector all`**: list every component; the optimizer may edit
+  anywhere. Use for monolithic capabilities or genuinely cross-cutting changes.
 
-## Focus modes
-
-- **`--component-selector round_robin`** (default): each iteration focuses ONE
-  component (cycled across the parent's editable files), so every proposal is a
-  small, attributable change — the unit the merge later recombines.
-- **`--component-selector all`**: list every component in `FOCUS.md`; the optimizer
-  may edit anywhere. Use for monolithic capabilities or when changes must span files.
-
-For a single-file / monolithic capability there is only one component; round-robin
-and `all` coincide, and the system-aware merge skips gracefully (nothing independent
-to recombine) rather than producing a degenerate child.
+For a single-file capability the two coincide and the merge skips gracefully
+(`gepa_merge_skip`) rather than emitting a degenerate child.
 
 ## Key hyperparameters
 
-- `--max-metric-calls` (default 0 = unlimited): PRIMARY budget — total rollouts.
+- `--max-metric-calls` (default 0 = unlimited): PRIMARY budget, checked
+  **between** iterations. An in-flight iteration runs to completion, so actual
+  spend can exceed it by up to `2·minibatch-size + |val|·n-trials` (one more
+  minibatch on a merge iteration). Set it below your hard ceiling.
 - `--max-iterations` (default 50): secondary cap on propose→gate iterations.
 - `--minibatch-size` (default 4): train ids per cheap local gate.
-- `--n-trials` (default 1): rollouts/task on the full-val eval (raise under noise so
-  the significance gate is trustworthy).
-- `--component-selector` (`round_robin` | `all`), `--selection-strategy`
-  (default `pareto_per_instance`), `--max-merges` (default 2), `--merge-cadence`
-  (default 3).
-- `--gate-mode` / `--k-se`: the val acceptance bar (paired significance by default).
-- `--no-regression`: reject a child that breaks any previously-passing val task.
-- `--seed`: seeds the parent-sampling + minibatch RNG (logged for reproducibility).
-- `--resume`: reconstruct the pool/lineage/frontier from the run dir (a
-  `gepa_state.json` checkpoint + each accepted candidate's rollouts) and continue the
-  Pareto search where it stopped, instead of restarting from the seed. Preserved spend
-  keeps the budget honest; the parent-sampling RNG stream restarts (selection is
-  stochastic by design, so the resumed run is not byte-identical).
+- `--n-trials` (default 1): rollouts/task on the full-val eval (raise under noise
+  so the significance gate is trustworthy). Minibatch evals are always 1 trial.
+- `--max-merges` (default 2): cap on merge **attempts that built a candidate** —
+  a merge rejected at either gate consumes one. A skip (no eligible pair) is free.
+- `--merge-cadence` (default 3): accepts between merge attempts.
+- `--protected-paths` (empty = off; `default` = the built-in globs): seals the
+  eval surface (scorer/gold/tasks/tests).
+  A child that edits one is **INDECISIVE** — no reward recorded, not remembered
+  as rejected, stall counter untouched — because scoring a gold-hacking edit at
+  all would teach the optimizer that it worked.
+- `--workers` (default 1): pools the minibatch rollouts. Only safe when the
+  adapter's `run_target` is thread-safe.
+- `--store` / `--store-commit-cmd` (default `git`): where accepted candidates are
+  committed.
+- `--gate-mode` / `--k-se`, `--no-regression`, `--seed`: as hill-climb.
+- `--resume`: rebuild pool/lineage/frontier from `gepa_state.json` + each
+  accepted candidate's rollouts and continue the search. Preserved spend keeps
+  the budget honest; the parent-sampling RNG stream restarts, so a resumed run is
+  not byte-identical.
+
+## Known gaps (present tense — the shipped loop, not the paper)
+
+- The reflective dataset does **not** carry the task input, though `gepa.py`'s
+  docstring claims it does — the optimizer sees a bad answer to an unknown
+  question. And on an eval-cache hit only `{reward, feedback}` were stored, so
+  `Agent output:` comes out empty; re-sampled parents hit the cache routinely
+  (#111, PR #210).
+- Candidate snapshots keep the loop's own scratch (`REFLECTION.md`/`FOCUS.md`/…)
+  because the snapshot call omits the ignore list every other algorithm passes
+  (#110, PR #350). Those are excluded from the component list, but the
+  optimizer-agent dotfiles (`.claude/`, `CLAUDE.md`, `AGENTS.md`) are **not**, so
+  round-robin can burn an iteration on one.
+- Iterations are charged against budget while no `step` event is emitted, so
+  consumers counting iterations from `step` records see zero (#216/#224, PR #356).
+- Optimizer context reaching GEPA has been narrower than hill-climb's (#109,
+  PR #355). `JOURNAL.md` is injected as the cross-run handover but never
+  accumulates here, which is why step 3 above leaves it out of the list.
+- If `splits.train` is empty the minibatch silently falls back to **val** ids,
+  putting the gate split in front of the proposer, with no warning. Do not run
+  GEPA with a zero-size train split.
 
 ## How to run
 
@@ -99,15 +143,22 @@ python scripts/run.py --run-dir .capevolve/run_X --project .capevolve/project \
 ```
 
 Requires `baseline` first (reads the seed's full-val result from `baseline.json`).
-Reports the frontier/pool, best candidate, accepts, merges, and metric-calls spent;
-test stays sealed for `finalize`.
+Reports the pool, `frontier_size`, best candidate, accepts, merges, and
+metric-calls spent.
 
 ## Agent-mode loop
-When `orchestration_mode: agent`, drive gepa yourself: maintain the candidate pool/Pareto frontier; each round pick a parent (per gepa's selection), reflect on its val feedback to propose an edit, evaluate on **val** via cap-evolve, gate Δ>k·SE, accept→snapshot & add to the frontier / reject→drop. Metric-calls is the primary budget. Log rounds to the run dir; between rounds verify rollouts+results landed so the dashboard reflects the frontier. Re-read `stop_condition`; stop on it/budget. Seal once with `cap-evolve finalize`, then `report`.
+
+When `orchestration_mode: agent`, follow `orchestrate/orchestrate` §Agent-mode
+loop for the shared rules, and make each round GEPA-shaped: pick the parent by
+per-instance win count; sample `minibatch-size` **train** ids; evaluate parent
+then child on that same minibatch and drop the child unless `sum(child) >
+sum(parent)`; only then pay for a full **val** eval and its gate. Reflect on the
+train minibatch, never on val — val is the judge, not the teacher.
 
 ## References
 
-- `references/concepts.md` — the GEPA economy, reflective dataset / actionable side
-  information, per-instance frequency-weighted frontier, system-aware merge, the
-  metric-call budget, and the relation to the hill-climb / skillopt siblings.
-  Cites arXiv:2507.19457.
+- `references/concepts.md` — the paper's thesis (language as a richer learning
+  medium than a scalar), the frequency-weighted per-instance frontier, the
+  system-aware merge and its tie-breaking, the metric-call/eval-cache accounting,
+  and how the pieces relate to the hill-climb / skillopt siblings. Load when you
+  need the reasoning behind a knob rather than its value. Cites arXiv:2507.19457.

--- a/skills/algorithms/gepa/meta.yaml
+++ b/skills/algorithms/gepa/meta.yaml
@@ -1,6 +1,6 @@
 component: algorithm
 name: gepa
-summary: Real GEPA — sample-efficient reflective Pareto optimization with a cheap minibatch local gate in front of the honest full-val gate, trace-based reflective dataset, per-instance frontier parent sampling, round-robin component focus, and system-aware merge.
+summary: GEPA — sample-efficient reflective Pareto optimization: a cheap train-minibatch local gate in front of the honest full-val gate, a trace-based reflective dataset, per-instance frequency-weighted parent sampling, round-robin component focus, and system-aware merge.
 entry: scripts/run.py
 abstract: scripts/abstract.py
 check: scripts/check.py

--- a/skills/algorithms/gepa/references/concepts.md
+++ b/skills/algorithms/gepa/references/concepts.md
@@ -9,8 +9,8 @@ patterns, not the code.
 
 - [Why GEPA is sample-efficient](#why-gepa-is-sample-efficient)
 - [The two-stage economy: minibatch local gate → full-val gate](#the-two-stage-economy)
-- [Reflective dataset (actionable side information)](#reflective-dataset)
-- [Per-instance Pareto frontier + frequency-weighted sampling](#per-instance-pareto-frontier)
+- [Reflective dataset: source, limits, and what the writer omits](#reflective-dataset)
+- [Per-instance winners vs. the strict Pareto frontier](#per-instance-pareto-frontier)
 - [Round-robin component focus](#round-robin-component-focus)
 - [System-aware merge](#system-aware-merge)
 - [Budget in metric-calls, the eval cache, and honesty](#budget-cache-honesty)
@@ -43,28 +43,49 @@ before any full-val evaluation is paid for.
    val-only) — the identical gate hill-climb uses. This is where acceptance is
    *decided*; the minibatch never decides acceptance, only whether to pay.
 
-The minibatch is drawn from **train**, full-val from **val**, and **test is never
-touched** by the loop. That ordering is the honesty guarantee: the optimizer only
-ever sees train (via the reflective dataset) and is judged on held-out val.
+The minibatch is drawn from **train** and full-val from **val**. That ordering is
+what keeps the proposer away from the split its own gate is computed on. Caveat:
+if `splits.train` is empty the loop falls back to val ids (`gepa.py:518`) with no
+warning, which breaks exactly that separation — do not run with a zero train split.
 
 ## Reflective dataset
 
-For the parent's **failing minibatch tasks**, the loop writes `REFLECTION.md` into
-the optimizer's workdir containing, per task: the task **input**, the agent's
-**output / compacted trajectory**, and the scorer's **feedback**. This is GEPA's
-"actionable side information." It is written as a *file* (not inlined into a giant
-prompt) because agents read files far better than long prompts, and the prompt just
-points at it. Tasks that failed with an infra/run error (`Rollout.error`, surfaced
-as `raw.errored`) are listed separately and explicitly excluded from "fix this" —
-they are environment noise no edit can repair.
+For the parent's **failing minibatch tasks** (`reward < 1.0`), the loop writes
+`REFLECTION.md` into the optimizer's workdir. `phases/diagnose` owns what a
+reflective dataset is and what shape it takes; what matters here is the source and
+the limits. It is written as a *file* rather than inlined into a giant prompt
+because agents read files far better than long prompts, and the prompt just points
+at it. Tasks that failed with an infra/run error (`Rollout.error`, surfaced as
+`raw.errored`) are listed separately and explicitly excluded from "fix this" — they
+are environment noise no edit can repair.
+
+What the shipped writer actually emits, per task, is the agent's output, its
+compacted trajectory, and the scorer's feedback — each truncated (~1500 chars at
+capture, ~800 in the file), for at most 12 failing tasks. The task **input** is
+not written, although `gepa.py`'s own docstring claims it is; and on an eval-cache
+hit the cached record holds only `{reward, feedback}`, so the output line comes out
+empty (#111). Both are core bugs, not intended design: GEPA §3's "actionable side
+information" is the (input, output, feedback) triple, and dropping the input leaves
+the optimizer diagnosing a bad answer to an unknown question.
 
 ## Per-instance Pareto frontier
 
 Instead of always extending the single global best (hill-climb) the parent is
-**sampled from the per-instance Pareto frontier** (`selection.pareto_per_instance`).
-For each val task, the candidate(s) achieving the best reward on it are that task's
-winners; a candidate's sampling weight is **how many tasks it wins**
-(frequency-weighted). This keeps:
+**sampled over per-instance winners** (`selection.pareto_per_instance`). For each
+val task, the candidate(s) achieving the best reward on it are that task's winners;
+a candidate's sampling weight is **how many tasks it (co-)wins**
+(frequency-weighted), and a candidate that wins nothing is never sampled.
+
+The sampling pool is *not* the strict Pareto frontier: `_pick_pareto_per_instance`
+never calls `pareto_frontier`, so a candidate that merely ties for a win stays in
+the pool even when another candidate dominates it on every task. The strict
+frontier (`selection.pareto_frontier`) is a subset, and is what the system-aware
+merge searches and what the run's reported `frontier_size` counts. Keeping the
+looser pool is defensible — a tie-winner is still evidence that one task is
+solvable from that text — but it is a different set, so do not read "frontier" as
+one thing.
+
+Either way this keeps:
 
 - **specialists** — a candidate that uniquely tops one hard task survives even when
   its *mean* is below the incumbent's;
@@ -76,8 +97,12 @@ feeding both the loop and the dashboard.
 
 ## Round-robin component focus
 
-A candidate's **components** are its editable capability files (scratch/memory files
-and vcs dirs excluded — the same exclusion the eval cache uses). With
+A candidate's **components** are its editable capability files (`NON_CAPABILITY_FILES`
+scratch/memory files and vcs dirs excluded — the same exclusion the eval cache uses).
+Note the exclusion list does *not* cover the optimizer-agent dotfiles that
+`harness._SNAPSHOT_IGNORE` drops (`.claude/`, `CLAUDE.md`, `AGENTS.md`, `guidance/`,
+`trajectories/`), so if those are present in the candidate dir round-robin can spend
+a whole iteration focused on one of them. With
 `--component-selector round_robin` the loop focuses **one component per iteration**
 (cycled), writing the choice to `FOCUS.md`, so each proposal is a small, attributable
 change — which is exactly the unit the system-aware merge later recombines. `all`
@@ -86,12 +111,16 @@ lists every component for cross-cutting edits or monolithic capabilities.
 ## System-aware merge
 
 GEPA's **system-aware merge** is crossover across two complementary lineages. After
-an accept (gated by `--merge-cadence` and bounded by `--max-merges`) the loop looks
-for two frontier dominators that share a **common ancestor both improved on**, and
-builds a merged candidate **component-by-component**: start from the ancestor, then
-for each component take whichever descendant *changed* it (deterministic tie to the
-better-val side). The merge is then **minibatch-gated** (`>= max(parents)` on the
-minibatch) before the standard full-val gate, so a bad recombination costs little.
+an accept (gated by `--merge-cadence` and bounded by `--max-merges` **attempts** —
+a merge rejected at either gate consumes one; a skip for want of an eligible pair is
+free) the loop looks for two strict-frontier dominators that share a **common
+ancestor both improved on**, and builds a merged candidate **component-by-component**:
+start from the ancestor, then for each component take whichever descendant *changed*
+it. If both changed it the tie goes to `a`, which is simply the first of the pair in
+frontier iteration order — `_build_merge` never sees a val score. (Val order only
+decides which parent the *gate* compares against.) The merge is then
+**minibatch-gated** (`>= max(parents)` on the minibatch) before the standard
+full-val gate, so a bad recombination costs little.
 
 For a **monolithic single-component** capability there is nothing independent to
 recombine, so the merge **skips gracefully** (logged `gepa_merge_skip`) rather than
@@ -103,15 +132,19 @@ possible future refinement.)
 - **Budget is in metric-calls** (`--max-metric-calls`, primary) — every rollout, on
   the minibatch *and* on full val, is counted via `run_dir.update_spent(metric_calls=
   …)`. `--max-iterations` is a secondary cap. This makes the rollout economy the
-  thing the budget actually constrains, matching the paper's accounting.
+  thing the budget actually constrains, matching the paper's accounting. It is a
+  **stop, not a cap**: `_budget_left()` runs once per iteration, at the top, so an
+  iteration that starts one rollout under budget still spends its two (or three)
+  minibatches plus a full-val eval. Budget your ceiling with that slack.
 - **Eval cache** keys `(hash(candidate editable files), task_id) → reward/feedback`,
-  so a re-sampled parent or a byte-identical candidate pays nothing for a rollout it
-  already ran. Cache hits do **not** count toward the metric-call budget (they fired
-  no rollout); the event log still records every evaluation.
-- **Honesty is the engine's, untouched.** Acceptance is gated on val only; the gate,
-  the paired significance test, the SE-collapse warning, and the test seal are all
-  the same core code the rest of the family uses. The loop adds control flow, not new
-  scoring or gating.
+  so a re-sampled parent or a byte-identical candidate pays nothing for a **minibatch**
+  rollout it already ran. The full-val path (`harness.evaluate_candidate`) never
+  consults the cache and charges unconditionally. Cache hits do not count toward the
+  metric-call budget (they fired no rollout); the event log still records every
+  evaluation. The cache is also why reflection can come out hollow — see above.
+- **The loop adds control flow, not scoring or gating.** Acceptance, the paired
+  significance test, the SE-collapse warning and the seal are all the same core code
+  the rest of the family uses.
 
 ## Relation to the family
 


### PR DESCRIPTION
Closes #329.

`gepa` promised behavior `gepa.py` does not implement. That is the worst failure mode for a skill
the optimizer acts on, so this PR is about truthfulness first: every claim in `SKILL.md` and
`references/concepts.md` was re-derived from the current `core/cap_evolve/gepa.py` (HEAD
`d94fb336`), not from the issue's table — main has moved and four PRs are touching that file.

**`gepa.py` is not touched.** #350, #355, #356 and #210 are all in flight on it; where a divergence
needs code, the skill now states the shipped reality and names the issue.

## Corrected claim-vs-code table

| # | SKILL.md / concepts.md claim | code reality | file:line | action |
|---|---|---|---|---|
| 1 | reflective dataset = "input + the agent's output/trajectory + feedback" (`SKILL.md:28-29`, `concepts.md:53-54`) | the task input is never written; only `Agent output` / `Trajectory` / `Feedback`. `task.input` *is* captured into the rollout JSON but never reaches the file | `gepa.py:249-257` (docstring makes the same false claim at `:220`), vs `gepa.py:184` | claim removed from both files; the gap + the docstring lie stated under `## Known gaps`. Core fix flagged, not made |
| 2 | "with **full** traces" (description) | `_short()` caps at 1500 chars at capture, `_write_reflection` re-truncates to 800, and only the first 12 actionable failures are written — then `:263` calls it the "full reflective dataset" | `gepa.py:204`, `:249`, `:253-257`, `:263` | "full" dropped from the description; the ~800-char / 12-task caps stated once in the body, with a pointer to the untruncated `rollouts/train/` |
| 3 | reflection carries the agent's output for every failing task | on a cache hit `Score.raw = {"cached": True}` — no `output`, no `trace` — because `EvalCache.put` stores only `{reward, feedback}`, so `Agent output:` prints empty. GEPA re-samples parents constantly, so the parent minibatch that feeds reflection hits the cache routinely | `gepa.py:159-166`, `cache.py:86-89` | `## Known gaps` entry citing #111 / PR #210. Core |
| 4 | "each **non-dominated** candidate's weight is how many val instances it is best at" (`SKILL.md:23-25`) | `_pick_pareto_per_instance` never calls `pareto_frontier`; it samples every candidate with ≥1 (possibly tied) instance win, dominated ones included. `A=[1.0,0.0]` stays in the pool against `B=[1.0,1.0]` | `selection.py:181-186` vs `:114`, `:154` | corrected to "(co-)winners"; added the explicit note that "frontier" names two different sets here, and that the strict `pareto_frontier` is the subset used by the merge and by the reported `frontier_size` (`gepa.py:707`) |
| 5 | minibatch = "**train** ids"; "the optimizer only ever sees train" (`concepts.md:46-48`) | `train_ids = splits.train or splits.val` — a silent fallback to the gate split when `Splits.train` is empty, which `splits.py` permits. Rollouts are still filed under `rollouts/train/`, so the artifact trail hides it | `gepa.py:518`, `:142`; `splits.py:113` | `## Known gaps` entry + a caveat in `concepts.md`. Core fix flagged (hard error or a logged event) |
| 6 | `--max-metric-calls` = "PRIMARY budget — total rollouts" (`:43-44`, `:75`) | `_budget_left()` is evaluated once per iteration, at the top; nothing re-checks before the parent minibatch, the child minibatch or the full-val eval, and `evaluate_candidate` charges `len(tasks)*n_trials` in one shot | `gepa.py:522`, `:538`; `harness.py:419` | documented as a **between-iteration stop** with the named overshoot bound `2·minibatch-size + |val|·n-trials` |
| 7 | agent-mode: "reflect on its **val** feedback … evaluate on **val**" (`:106`) | the engine reflects on a **train** minibatch and applies the local gate before any val spend — the agent-mode text prescribed a frontier-sampled hill-climb with the acceptance split in front of the proposer | `gepa.py:555-663` | rewritten as the loop actually is; the restated shared rules replaced by a pointer to `orchestrate/orchestrate` §Agent-mode loop |
| 8 | merge tie goes to the "**better-val** side" (`concepts.md:92-93`) | tie goes to `a`, which is the first of the pair in frontier iteration order; `_build_merge` never sees a val. Val order only picks the parent the *gate* compares against | `gepa.py:397`, `:350-352`, `:820` | corrected in `concepts.md` |
| 9 | "up to `--max-merges`" merges (`:38`, `:81`) | `merges_done` increments for any `_try_merge` that returned a step, including one rejected at either gate. Two rejected merges exhaust the run's budget; a no-eligible-pair skip is free | `gepa.py:694` | documented as a cap on **attempts that built a candidate** |
| 10 | eval cache ⇒ "a byte-identical candidate pays nothing for a rollout it already ran" (`concepts.md:107-109`) | true for minibatch evals only; `harness.evaluate_candidate` never consults the cache and charges unconditionally | `harness.py:419` (no `EvalCache` reference anywhere in `harness.py`) | scoped to "a **minibatch** rollout" |
| 11 | "FAILING minibatch tasks" (`:27`), threshold unstated | failure ≡ `reward < 1.0`, a hard binary threshold. With a graded scorer that never reaches 1.0 — the case the description recommends gepa for — every task is "failing", the header always prints `0/N pass`, and the 12-task cap starts dropping real failures for near-passes | `gepa.py:226`, `:235` | threshold stated, with the "read it as sampled-tasks-worst-first" instruction for graded scorers |
| 12 | §Key hyperparameters is the flag list (`:73-90`) | `--protected-paths`, `--workers`, `--store`/`--store-commit-cmd` were absent. `--protected-paths` drives ~40 lines of `gepa.py`: a child that edits a protected file is **INDECISIVE** — no reward recorded, not added to rejected memory, stall counter untouched | `scripts/run.py:39-41`, `:53-54`, `:60-63`; `gepa.py:586-623` | all three added; `--protected-paths` gets the INDECISIVE consequence *and* why (scoring a gold-hacking edit at all teaches the optimizer it worked) |
| 13 | nothing about the optimizer prompt's cross-iteration files | every GEPA optimizer call injects a pointer to `LEDGER.md` / `JOURNAL.md` / `PROCESS.md` / `RUNMAP.md` + `prior_iterations/`. `JOURNAL.md` never accumulates on a GEPA run, so the prompt tells the optimizer that an empty file is how it avoids plateauing | `gepa.py:582` → `harness.py:1062-1090`, `:946` | the three that work are named in step 3; `JOURNAL.md` is deliberately excluded there and explained under `## Known gaps` (#216/#224, PR #356; #109, PR #355) |
| 14 | components = "the parent's editable files … scratch/memory files and vcs dirs excluded" (`:64`, `concepts.md:78-80`) | the filter is `NON_CAPABILITY_FILES/DIRS` only. The optimizer-agent dotfiles `harness._SNAPSHOT_IGNORE` drops (`.claude/`, `CLAUDE.md`, `AGENTS.md`, `guidance/`, `trajectories/`) are **not** excluded, so round-robin can spend a whole iteration focused on one | `gepa.py:81-103`, `types.py:26-34` vs `harness.py:1842-1846` | stated in both files. Core fix flagged |

**14 divergences, all 14 now accurate.** 10 were pure skill drift, fixed in text. 4 (#1, #3, #5,
#14) are core bugs where the skill previously described the intended behavior as delivered; it now
states the shipped behavior and names the issue.

## Mechanism, not steps

The two choices that *are* the paper are now argued, because a reader who does not understand them
will "simplify" GEPA into hill-climb and delete both:

- **Why per-instance winners instead of the global best** — a mean is a lossy summary. A candidate
  that fixes one hard task while regressing three easy ones has a worse mean, so a best-parent rule
  discards the only text in the pool that has ever solved that task. Keeping the *set* that covers
  the task distribution is the quality-diversity argument, and it is why specialists and
  stepping-stones stay reachable as parents while their mean is still behind.
- **Why a cheap minibatch before paying for full val** — a full-val eval costs `|val|·n_trials`
  rollouts and most proposals are bad. Paying full price to discover that is what makes naive
  reflective search unaffordable; the paper's ~35× rollout reduction comes almost entirely from not
  paying it. The minibatch never *decides* acceptance — it decides whether acceptance is worth
  measuring.

## Ownership contract

Deleted as restatements of concepts with another owner (~28 lines):

- **Honesty invariants** (owners `phases/gate` / `finalize` / `report`): "The **test split is never
  touched**" at `:45` and "test stays sealed for `finalize`" at `:103`; `concepts.md`'s "test is
  never touched" and its "Honesty is the engine's" bullet. `SKILL.md` now contains no occurrence of
  `sealed` / `test split` / `finalize` / `k·SE` / `stop_condition`. Which split each *stage* reads
  is kept — that is GEPA's mechanism, not an honesty restatement.
- **Agent-mode loop five rules** (owner `orchestrate/orchestrate:44-58`): the byte-identical
  "Seal once with `cap-evolve finalize`, then `report`." / "Re-read `stop_condition`" /
  "gate Δ>k·SE, accept→snapshot" tail of `:106` replaced by one pointer. `orchestrate` explicitly
  instructs the agent to read the algorithm's own section, so the section stays — it now carries
  only the GEPA-specific shape.
- **Reflective-dataset format** (owner `phases/diagnose`): the Inputs/Outputs/Feedback shape is now
  referenced, not re-specified. What stays is GEPA-specific: the *source* (parent's train
  minibatch), the `reward < 1.0` partition, and the truncation limits.
- **The 6-row routing table** (`:47-59`): two independently-worded answers to "which algorithm?"
  existed (gepa's 6 rows, `skillopt:47-53`'s 3) and they disagreed; both were already stale against
  the five-algorithm set. Reduced to the boundary clause in the description.
- **`## Inputs / outputs (manifest tokens)`**: gepa never had one — none added.

No instruction was lost: every deleted passage is a restatement whose owner states it in full, and
every rule that was only in gepa's copy (the frontier maintenance, the train minibatch, the local
gate) is kept.

### What the siblings should drop (not touched — other agents own those files)

- `hill-climb/SKILL.md:32-35` `## Inputs / outputs (manifest tokens)`; `:53`'s restated shared rules.
- `skillopt/SKILL.md:55-58` same section; `:83` same restatement; `:47-53` routing table.
- `using-cap-evolve` should own the single 5-algorithm routing table — its frontmatter already calls
  it the entry-point router, and after this PR nothing owns that table.

## Evidence

`wc -l` — `SKILL.md` 113 → 164, `references/concepts.md` 132 → 165. Body is 164/500 lines;
description 541 chars / 76 words (was ~120 words). The growth is deliberate: boilerplate out,
mechanism-why and six documented gaps in. No new reference file; existing ref stays one level deep
with its TOC.

```
$ python skills/algorithms/gepa/scripts/check.py
ok: True  problems: []
notes: run entry exposes main() / gepa.gepa_loop present / accepts=1 best_val=1.0 /
       best_val 1.000 > baseline 0.000 / metric_calls=11 /
       test split never consumed by the loop / no-op edits rejected /
       6 step(s) stopped at the local gate (no full-val spend)
```

```
$ PYTHONPATH="$PWD/core:$PWD/dashboard/backend" python -m pytest core/tests -q
789 passed, 12 skipped
```
matches clean main per #349.

Zero-API GEPA run (`examples/toy_calc`, `mock` optimizer, `algorithm_skill: gepa`) — the flow the
skill describes, end to end through the gate to a sealed test score:

```
$ python3 -m cap_evolve.cli run --spec .../capevolve.yaml --project .../project --run-ts gepa329
{
  "run_dir": ".capevolve/run_gepa329",
  "best_id": "gepa_0001",
  "baseline_val": 0.0,
  "test_reward": 1.0,
  "test_baseline_reward": 0.0,
  "test_delta": 1.0,
  "test_pass_k": {"1": 1.0},
  "iterations": 3
}
```

The run also reproduces three of the documented gaps, which is why they are in the skill:

```
$ python3 -c "collections.Counter of events.jsonl kinds"
{'splits': 1, 'evaluate': 4, 'baseline': 1, 'run_config': 1, 'gepa_start': 1,
 'gepa_select': 3, 'minibatch': 6, 'gepa_local_gate': 3, 'gate_warning': 1,
 'gepa_val_gate': 1, 'finalize': 1}
```
`spent.iterations == 3` with **zero `step` events** (#216/#224), and

```
$ ls candidates/gepa_0001/
FOCUS.md  INSTRUCTIONS.md  JOURNAL.md  LEDGER.md  PROCESS.md  prompt.txt  REFLECTION.md  RUNMAP.md
```
— the dirty snapshot of #110 (only `prompt.txt` is the capability). The run's `REFLECTION.md` has
no `Task input:` line, confirming divergence #1 on live output rather than by reading.

## Core work this leaves open

Filed against the existing issues rather than duplicated here:

- #111 / PR #210 — the parent minibatch that feeds reflection must produce a non-empty
  `Agent output:` for a cached failing task.
- #110 / PR #350 — `ignore=_SNAPSHOT_IGNORE` at `gepa.py:668` and `:832`.
- #216 / #224 / PR #356 — a GEPA iteration must emit a `step` record, or nothing may count
  iterations from them.
- #109 / PR #355 — optimizer context parity with hill-climb.
- New, not yet filed: (a) empty `splits.train` must not silently redirect the minibatch to val;
  (b) `REFLECTION.md` should carry the task input, and `gepa.py:220`'s docstring should stop
  claiming it does either way; (c) `_components` should exclude the optimizer-agent dotfiles
  `_SNAPSHOT_IGNORE` already lists; (d) a test asserting
  `metric_calls <= max_metric_calls + 2*minibatch + |val|*n_trials`, so the documented overshoot
  bound is enforced from above and not only asserted from below (`test_gepa.py:151` asserts `>= 12`
  against a budget of 12).
