### PR TITLE
hill-climb: make the three focus schedules real, and own the shared iteration mechanism

### DIFF
--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -2008,11 +2008,16 @@ def _focus_instructions(current_val: SplitResult, focus_ids, label: str,
     the per-iteration data (the focus summary, the failure index, the capability/algorithm
     briefs, the benchmark-repo pointer) is computed here and substituted.
     """
-    per = current_val.per_task
-    if focus_ids is not None:
-        per = [pt for pt in per if pt.get("task_id") in set(focus_ids)]
+    per_all = current_val.per_task
+    per = ([pt for pt in per_all if pt.get("task_id") in set(focus_ids)]
+           if focus_ids is not None else per_all)
     errored, always_fail, flaky, solid = _classify(per)
     n = len(per)
+    # Non-regression is a constraint over the WHOLE val split, not just the focus set:
+    # an edit aimed at one focused task must still not break a passing task outside it.
+    # Classifying the focused subset alone made ``_passing_block`` empty for every
+    # narrow focus, silently dropping the only explicit protect-these-ids instruction.
+    protect = solid if focus_ids is None else _classify(per_all)[3]
 
     focus_summary = (
         f"Focus: {label}. Current val reward {current_val.reward:.3f}: "
@@ -2020,7 +2025,7 @@ def _focus_instructions(current_val: SplitResult, focus_ids, label: str,
         + (f" / {len(errored)} infra-errored" if errored else "") + f" of {n} tasks."
     )
     failures = _failures_block(always_fail, flaky, errored)
-    passing = _passing_block(solid)
+    passing = _passing_block(protect)
     cap = _capability_brief(capabilities)
     algo = _algorithm_brief(current_val, algorithm)
     bench = (f"- The benchmark / runner source is at `{bench_repo}` — read-only context "
@@ -2169,14 +2174,16 @@ def hill_climb_loop(
     _profile = _tp.resolve(target_model, target_profile_file, project_dir=project_dir)
     _target_reader = _tp.reader_block(_profile)
 
-    # establish a focus order over the train tasks when needed
-    train_ids = run_dir.read_splits().train
-    order = list(train_ids)
+    # Establish the focus order when a narrow focus is requested. It must be over VAL
+    # ids: ``_focus_instructions`` filters the parent's val per-task rows, and the
+    # splits are disjoint slices of one shuffled id list (``splits.py:117-119``), so a
+    # focus set of TRAIN ids intersects those rows in nothing at all and the optimizer
+    # prompt renders zero failures. ``current_val`` already holds every focused task's
+    # reward, so hardest-first orders straight off it — no extra evaluation to buy.
+    order = list(run_dir.read_splits().val)
     if focus == "hardest-first":
-        seed_dir = run_dir.candidate_dir("seed")
-        train_res = evaluate_candidate(adapter, seed_dir, run_dir=run_dir, split="train",
-                                       n_trials=n_trials, tag="seed_train")
-        score_by = {pt["task_id"]: pt["reward"] for pt in train_res.per_task}
+        score_by = {pt.get("task_id"): float(pt.get("reward", 0.0) or 0.0)
+                    for pt in current_val.per_task}
         order.sort(key=lambda t: score_by.get(t, 0.0))  # hardest (lowest) first
 
     steps = []
@@ -2187,10 +2194,10 @@ def hill_climb_loop(
         if exhausted:
             break
         if focus == "all":
-            focus_ids, label = None, "whole train set"
+            focus_ids, label = None, "every failing task on the val split"
         elif focus in ("cyclic", "hardest-first"):
             focus_ids = [order[i % len(order)]] if order else None
-            label = f"task {focus_ids[0]}" if focus_ids else "train"
+            label = f"task {focus_ids[0]}" if focus_ids else "the whole val split"
         else:
             focus_ids, label = None, focus
         seed_empty = _capability_is_empty(capabilities, run_dir.candidate_dir(run_dir.best_id))

--- a/core/tests/test_e2e_slice.py
+++ b/core/tests/test_e2e_slice.py
@@ -106,6 +106,45 @@ def test_cyclic_variant_also_improves(tmp_path):
     assert summary["best_val"] == 1.0
 
 
+@pytest.mark.parametrize("focus", ["cyclic", "hardest-first"])
+def test_narrow_focus_renders_the_focused_tasks_failures(tmp_path, focus):
+    """A narrow focus must focus a task the loop actually HAS per-task data for.
+
+    ``_focus_instructions`` filters the parent's VAL rows, so a focus set built from
+    TRAIN ids intersected them in nothing and every non-``all`` schedule shipped a
+    prompt with "0 failing of 0 tasks" and no failure index at all. Assert on the
+    rendered prompt, not on a tuple of schedule names — the mock optimizer applies a
+    fixed edit script and never reads the prompt, so only this can see the regression.
+    """
+    from cap_evolve import Budget, RunDir, harness
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("toy_calc_adapter", EXAMPLE / "adapter.py")
+    toy = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(toy)
+    adapter = toy.Adapter()
+    seed = tmp_path / "seed"
+    shutil.copytree(EXAMPLE / "capability", seed)
+    run_dir = RunDir.create(tmp_path / ".capevolve", ts="f", budget=Budget(max_iterations=1))
+    harness.ensure_splits(adapter, run_dir, seed=0)
+    base = harness.baseline(adapter, seed, run_dir=run_dir)
+
+    seen = []
+
+    def capturing(workdir, instructions):  # noqa: ARG001 — a no-op proposer
+        seen.append(instructions)
+        return None
+
+    harness.hill_climb_loop(adapter, run_dir=run_dir, optimizer=capturing, current_val=base,
+                            focus=focus, max_iterations=1)
+    assert len(seen) == 1
+    prompt = seen[0]
+    val_ids = run_dir.read_splits().val
+    assert any(f"Focus: task {t}." in prompt for t in val_ids), \
+        "the focused task must be a VAL id — that is the only per-task data the loop holds"
+    assert "## (a)" in prompt, "the focused task's failures must reach the optimizer"
+    assert "0 failing of 0 tasks" not in prompt
+
+
 def test_baseline_better_than_nothing_is_gated(tmp_path):
     """A no-op edit (no change) must be rejected by the significance gate."""
     from cap_evolve import RunDir, harness

--- a/skills/_registry/manifest.json
+++ b/skills/_registry/manifest.json
@@ -82,7 +82,7 @@
     "hill-climb": {
       "component": "algorithm",
       "path": "algorithms/hill-climb",
-      "summary": "Global hill-climb on the val gate with a selectable focus schedule (--focus all|cyclic|hardest-first); parent is always the current best.",
+      "summary": "Global hill-climb on the val gate with a selectable focus schedule (--focus all|cyclic|hardest-first) over the val tasks; parent is always the current best.",
       "entry": "scripts/run.py",
       "abstract": "scripts/abstract.py",
       "check": "scripts/check.py",

--- a/skills/algorithms/hill-climb/SKILL.md
+++ b/skills/algorithms/hill-climb/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hill-climb
-description: Runs a global hill-climb optimization loop where the parent is always the current best candidate and the val significance gate decides acceptance. Use as the algorithm for most runs. Pick how each iteration's reflection is focused with --focus all (whole train set), cyclic (one task at a time), or hardest-first (lowest-scoring tasks first). Replaces the former all-at-once, cyclic, and hardest-first skills.
+description: Runs a global hill-climb optimization loop where the parent is always the current best candidate and the val significance gate decides acceptance. Use as the algorithm for most runs — the first run on a new project, binary pass/fail scorers, and small task sets. Pick how each iteration's reflection is focused with --focus all (every failing val task), cyclic (one task at a time), or hardest-first (lowest-scoring first). Switch to gepa when rollouts are expensive and per-task feedback is rich, or skillopt when you want an annealed edit budget.
 component: algorithm
 argument-hint: "--run-dir DIR --project DIR --optimizer CMD [--focus all|cyclic|hardest-first]"
 allowed-tools: Read, Write, Bash
@@ -10,47 +10,141 @@ needs: [scores, traces, candidate]
 
 # hill-climb — one loop, three focus schedules
 
-Every iteration: take the current best candidate, ask the optimizer to propose an
-edit (its prompt emphasizes a *focus set* of train tasks), score the result on
-val, and accept only if it clears the significance gate. The accepted candidate
-becomes the new best. The test split is never touched here — that is `finalize`.
+Greedy search over candidates: the parent is always the run's current best, and a
+child replaces it only by clearing the val significance gate. The test split is
+never touched here — that is `finalize`.
 
-The three former hill-climb skills were byte-identical except for one constant;
-they are now one skill with `--focus`:
+**Requires `baseline` first.** Without `--resume` the loop reads the seed's val
+result from `<run-dir>/baseline.json` (`scripts/run.py:121-122`); with no run state
+it raises `FileNotFoundError: no run state at .../state.json`. `--resume` instead
+reads the current best's val from its stored rollouts, falling back to
+`baseline.json` when the run has no best yet (`run.py:118-122`).
+
+## One iteration, end to end
+
+This is the mechanism the other algorithm skills vary; they describe only their
+differences and point back here. One iteration is `harness.run_step`
+(`core/cap_evolve/harness.py:1409`):
+
+1. **Pick the parent — always the current best** (`harness.py:2224`,
+   `run_dir.candidate_dir(run_dir.best_id)`). Copy it to `work/<cand_id>/`; the
+   optimizer edits that copy in place, so the parent is never mutated
+   (`harness.py:1454-1458`).
+2. **Build the prompt.** The parent's val per-task rows are split into
+   always-failing / flaky / infra-errored / solid (`harness.py:1775-1795`), rendered
+   as the failure index plus an explicit *protect these passing ids* block
+   (`harness.py:1803-1879`), and substituted into the project's optimizer-instructions
+   template. `--focus` narrows which failures are emphasized; nothing else changes.
+3. **Inject context and memory.** Full trajectories, capability guidance, and the four
+   cross-iteration files land in the workdir (`harness.py:1062-1094`) — see
+   `references/run-step.md`.
+4. **Optimize.** The optimizer command mutates the workdir. A crash is caught, logged,
+   and left as an unchanged copy of the parent, so the gate simply rejects it — a
+   wasted iteration, not a dead run (`harness.py:1486-1500`).
+5. **Evaluate on val only** (`harness.py:1516`), at `--n-trials` trials per task.
+6. **Gate.** With per-task data on both sides the paired test is chosen automatically:
+   accept iff mean per-task Δ > `k`·SE of those paired deltas (`harness.py:1524-1532`).
+   `--no-regression` adds a second, harder condition on top.
+7. **Commit.** *Every* candidate is snapshotted — accepted and rejected — so any
+   iteration can be diffed (`harness.py:1557`); the version store commits it
+   (`harness.py:1609-1612`). Only an accepted candidate calls `set_best` and becomes
+   the next parent (`harness.py:1558-1559`); a rejected one is filed in the rejected
+   memory that feeds the next prompt (`harness.py:1607-1608`).
+
+**Why the parent is always the current best.** The gate already guarantees every
+accepted candidate is a real improvement on val, so the best candidate is the only
+one with evidence behind it — forking anything else spends budget on a lineage
+already known to be worse. The cost is that a candidate which trades one task class
+for another can never be kept as a specialist; wanting that is the reason to use
+`gepa`, whose per-instance Pareto frontier keeps specialists on purpose.
+
+**Why the bar is Δ > k·SE, not Δ > 0.** Rewards are estimates from a finite sample
+of tasks and trials, so about half of all *no-op* edits measure as a small positive
+Δ by chance. Accepting on Δ > 0 therefore ratchets on noise: val creeps up, the
+sealed test does not move, and the run reports a gain that was never there. The bar
+is the noise scale itself, so a win has to be larger than the measurement error that
+produced it. `phases/gate` owns the full statement of the decision and its modes.
+
+## Focus schedules
 
 | `--focus` | what each iteration emphasizes | when to use |
 |---|---|---|
-| `all` (default) | the whole train set — find the single edit that lifts the most tasks | broad capability gaps; the usual choice |
-| `cyclic` | one train task at a time, cycling through them | many distinct, unrelated failure modes |
-| `hardest-first` | train tasks ranked by baseline score ascending (lowest first), then cycling | a few very hard tasks dominate the gap |
+| `all` (default) | every failing val task — find the one edit that lifts the most | broad capability gaps; the usual choice |
+| `cyclic` | one val task at a time, round-robin | many distinct, unrelated failure modes |
+| `hardest-first` | val tasks ordered by the parent's per-task reward ascending, then cycling | a few very hard tasks dominate the gap |
 
-Why only the focus changes: the parent-selection rule (always the current best),
-the gate, and the honesty guarantees are identical across schedules — only the
-*attention* differs. Keeping one loop means a fix to the gate or memory wiring
-can never drift between variants.
+All three index the **val** per-task results, because those are the only per-task
+data the loop holds. Non-regression protection covers the whole val split under
+every schedule, not just the focused task. `hardest-first` costs no extra evaluation:
+it orders off the per-task rewards already in hand.
 
-## Inputs / outputs (manifest tokens)
-- **needs:** `scores` + `traces` (the per-task val results to reflect on) and
-  `candidate` (the parent to extend).
-- **provides:** `candidate` (the accepted best).
+Back-compat: `--focus all-at-once` is accepted and treated as `all` (`run.py:35`).
+
+## Key flags
+
+Beyond `--run-dir` / `--project` / `--optimizer` / `--focus` / `--max-iterations` /
+`--n-trials` / `--resume` (`scripts/run.py`):
+
+- `--gate-mode` (default `auto`) + `--k-se` (default `1.0`) — `auto` lets the engine
+  pick the paired gate; `significant|paired|strict|threshold` pin it. Raising `k-se`
+  makes acceptance stricter.
+- `--protected-paths` — globs sealing the eval surface (scorer, gold, tasks, splits;
+  `default` expands to the built-in set). A candidate that edits one is *indecisive*,
+  never scored: the measurement would grade a compromised harness, so no reward is
+  recorded, the stall counter is untouched, and best is unchanged
+  (`harness.py:1440-1446`). Leave this on for any run whose number you intend to
+  quote.
+- `--capabilities` — comma-separated capability skills under optimization. When empty
+  the optimizer receives **no** allowed-edit-space block at all
+  (`harness.py:1735-1737`), so it guesses the edit surface from the files.
+- `--no-regression` — reject a candidate that lowers any val task the parent scored
+  higher on, even when the mean improves.
+- `--convergence` — graded plateau signal (`ok` → `warn` → `paradigm_shift` → `stop`)
+  appended to the prompt, so a plateau escalates the ask instead of burning the
+  remaining iterations on more of what failed.
+- `--workers N` — concurrent rollouts per evaluation. Only safe when the adapter's
+  `run_target` is thread-safe; a shared client, temp path, or cwd will corrupt scores
+  rather than fail loudly.
+- `--store git|copy|command` (+ `--store-commit-cmd`) — how each iteration is
+  versioned; git is the default and every candidate becomes a commit.
+- `--instructions-file`, `--bench-repo`, `--capability-sources`, `--optimizer-name`,
+  `--target-model`, `--target-profile-file` — prompt and read-context wiring; `cap-evolve
+  run` fills these from the spec.
 
 ## Standalone use
 
 ```bash
 python scripts/run.py --run-dir .capevolve/run_X --project .capevolve/project \
   --optimizer 'python .../run-optimizer/scripts/run.py --name mock --workdir {workdir} --prompt {prompt}' \
-  --focus hardest-first --max-iterations 10 --n-trials 4
+  --focus hardest-first --max-iterations 10 --n-trials 4 --protected-paths default
 ```
 
-`--resume` continues from the run's current best (reading its val from rollouts)
-instead of the baseline. `--no-regression` adds a SWE-bench-style dual gate:
-reject a candidate that breaks any val task the parent already passed, even if the
-mean improves.
+## Known gate edge case (open, issue #351)
 
-Back-compat: `--focus all-at-once` is accepted and treated as `all`.
+Under the default paired gate with `k_se = 1.0`, a candidate that improves **exactly
+one** val task and changes nothing else has `Δ̄ == SE(Δ)` algebraically, so a strict
+`>` resolves it on floating-point representation alone. Expect a genuine one-task
+gain not to bank, unpredictably by split size. Do not lower `k-se` to work around it —
+that disables the bar for every candidate; prefer edits that generalize across a
+class of tasks, which is what the loop is asking for anyway.
 
-## Agent-mode loop
-When `orchestration_mode: agent`, drive hill-climb yourself: from the baseline best, each iteration — propose ONE edit to the capability (per `--focus`: all / cyclic / hardest-first), evaluate the candidate on **val** via cap-evolve (writes rollouts+results), gate Δ>k·SE, accept→snapshot via the store / reject→revert. Log each iteration to the run dir's event log. Re-read `stop_condition`; stop on it or on stall/budget. Between iterations, confirm the run dir got this iteration's rollouts + event so the dashboard stays current. Seal once with `cap-evolve finalize`, then `report`.
+## Agent mode
+
+When `orchestration_mode: agent`, drive the loop yourself with the same mechanism as
+above: parent = current best, one edit per iteration, evaluate on **val**, gate,
+accept → snapshot / reject → revert, seal once with `cap-evolve finalize`, then
+`report`. `orchestrate` owns the agent-mode rules; the hill-climb-specific obligation
+is that you must reproduce the handover surface `run_step` normally builds —
+`LEDGER.md`, `JOURNAL.md`, `PROCESS.md`, `RUNMAP.md` + `prior_iterations/` — and carry
+rejected edits into the next iteration's prompt. Skip it and the dashboard goes dark
+and the optimizer re-proposes edits already refuted.
 
 ## References
-- `references/focus-schedules.md` — how each schedule builds its focus set.
+
+- `references/run-step.md` — the shared step's exact contract: the handover files and
+  their ownership, the rejected/accepted memory, the version store, the snapshot
+  filter, and the tamper path. Load it when you need the contract verbatim, or when
+  writing an algorithm that reuses `run_step`. The sibling algorithm skills link this
+  file rather than this body.
+- `references/focus-schedules.md` — how each schedule builds its focus set. Load when
+  choosing between the three or debugging a focus set.

--- a/skills/algorithms/hill-climb/meta.yaml
+++ b/skills/algorithms/hill-climb/meta.yaml
@@ -1,6 +1,6 @@
 component: algorithm
 name: hill-climb
-summary: Global hill-climb on the val gate with a selectable focus schedule (--focus all|cyclic|hardest-first); parent is always the current best.
+summary: Global hill-climb on the val gate with a selectable focus schedule (--focus all|cyclic|hardest-first) over the val tasks; parent is always the current best.
 entry: scripts/run.py
 abstract: scripts/abstract.py
 check: scripts/check.py

--- a/skills/algorithms/hill-climb/references/focus-schedules.md
+++ b/skills/algorithms/hill-climb/references/focus-schedules.md
@@ -1,29 +1,50 @@
 # Focus schedules
 
-All three schedules share the same loop body in `harness.hill_climb_loop`; they
-differ only in how the per-iteration *focus set* of train tasks is chosen. The
-focus set drives `_focus_instructions`, which builds the optimizer prompt from the
-parent's failing val tasks (actionable failures separated from infrastructure
-errors via the structured `raw.errored` flag, not feedback substring matching).
+All three schedules share the same loop body in `harness.hill_climb_loop`; they differ
+only in how the per-iteration *focus set* is chosen. The focus set drives
+`_focus_instructions`, which builds the optimizer prompt from the parent's failing
+**val** tasks (actionable failures separated from infrastructure errors via the
+structured `raw.errored` flag, not feedback substring matching).
+
+The focus set is always drawn from **val ids** (`harness.py:2183`). That is not a
+preference: `_focus_instructions` filters the parent's val per-task rows
+(`harness.py:2011-2013`), and the splits are disjoint slices of one shuffled id list
+(`splits.py:117-119`), so a focus set of train ids would intersect those rows in
+nothing and the prompt would render `0 failing of 0 tasks` with no failure index at
+all. Train tasks are never individually scored by this loop, so there is no per-task
+signal about them to focus on.
 
 ## all (default)
-- Focus set = the whole train set (no filtering).
+
+- Focus set = every val task (no filtering).
 - The prompt asks the optimizer to find the single edit that lifts the most tasks.
 - Best when the capability has broad gaps rather than a few isolated ones.
 
 ## cyclic
-- Iteration `i` focuses on `train[i % len(train)]` — one task at a time, round-robin.
+
+- Iteration `i` focuses on `val[i % len(val)]` — one task at a time, round-robin.
 - Useful when failures are heterogeneous: forcing attention onto each task in turn
   prevents the optimizer from over-fitting to whichever failure is loudest.
 
 ## hardest-first
-- Before the loop, the seed is scored on the **train** split once; train tasks are
-  sorted by reward ascending (hardest first).
-- Iteration `i` focuses on the `i`-th hardest task (then cycles).
+
+- Val ids are sorted by the parent's per-task reward ascending (hardest first) once,
+  at loop entry, from the `current_val` the loop already holds — no extra evaluation.
+- Iteration `i` focuses on the `i`-th hardest task, then cycles.
 - Useful when a small number of very hard tasks dominate the val gap and you want
   budget spent there first.
+- The order is fixed at entry, so it reflects the parent at that moment, not the
+  running best. Restart the loop (or `--resume`) to re-rank.
+
+## Non-regression under a narrow focus
+
+The *protect these passing tasks* block is built from the whole val split, not the
+focus set (`harness.py:2016-2020`). An edit aimed at one task must still not break a
+passing task outside the focus, so narrowing attention must never narrow the
+constraint.
 
 ## Parent selection (all schedules)
+
 The parent is always the current best candidate — a strict global hill-climb. A
-per-task Pareto frontier that keeps specialists is a *different* algorithm
-(the `gepa` skill, which keeps a per-instance Pareto frontier), not a focus mode here.
+per-task Pareto frontier that keeps specialists is a *different* algorithm (the `gepa`
+skill), not a focus mode here.

--- a/skills/algorithms/hill-climb/references/run-step.md
+++ b/skills/algorithms/hill-climb/references/run-step.md
@@ -1,0 +1,78 @@
+# The shared iteration step (`harness.run_step`)
+
+The contract every algorithm in this repo reuses for one propose → gate → commit
+iteration (`core/cap_evolve/harness.py:1409`). `hill-climb/SKILL.md` states the
+mechanism at the level needed to run it; this file is the verbatim contract, for
+writing or debugging an algorithm that calls `run_step` directly.
+
+`gepa`, `skillopt`, `agent-optimize` and `evograph` differ only in **which parent
+they pick** and **which tasks they focus** — not in anything below.
+
+## Signature and what varies
+
+```
+run_step(adapter, *, run_dir, parent_dir, optimizer, instructions, current_val,
+         n_trials=1, gate_kwargs=None, candidate_id=None, parent_id=None,
+         no_regression=False, rejected=None, history=None, store=None,
+         capabilities=None, eval_split="val", optimizer_name=None,
+         capability_sources=None, project_dir=None, protected_patterns=None) -> dict
+```
+
+`parent_dir` is the algorithm's parent-selection decision — the only place a
+different search strategy enters. hill-climb passes `candidate_dir(best_id)`; gepa
+passes a candidate sampled from its per-instance Pareto frontier. `instructions` is
+the algorithm's focus decision. Everything else is fixed machinery.
+
+The returned dict carries `candidate_id`, `accepted`, `decision`, `candidate_val`,
+`parent_val`, `regressions`, the optimizer's seconds/usd/tokens, `optimizer_error`,
+and `workdir` (`harness.py:1614-1626`).
+
+## Cross-iteration files, and who owns each
+
+Written into the workdir before the optimizer runs, with a prompt pointer to all four
+(`harness.py:1062-1094`):
+
+| file | owner | lifetime |
+|---|---|---|
+| `LEDGER.md` | framework, read-only to the optimizer | regenerated each iteration; every prior outcome plus the exact tasks it broke/fixed |
+| `JOURNAL.md` | the optimizer, append-only | run-level handover; earlier entries must not be edited |
+| `PROCESS.md` | the optimizer, required | fresh each iteration; **snapshotted with the candidate** and surfaced per-iteration by the dashboard |
+| `RUNMAP.md` + `prior_iterations/<id>/` | framework | manifest plus every prior iteration's `PROCESS.md` and capability diff |
+
+`_reconcile_journal` folds the optimizer's appended entry into the run-level journal
+for accepted *and* rejected iterations, and reuses it as the candidate's lineage note
+(`harness.py:1586-1588`).
+
+## Memory across iterations
+
+`_init_memory_store` (`harness.py:1631-1646`) creates `RejectedMemory` and `History`
+and initializes the version store (git by default, with a `seed` commit on a fresh
+run only). `_augment_instructions` injects both into every prompt, so the optimizer
+sees what was already refuted and what already worked.
+
+A **rejected** step records the candidate, the gate's reason, and the per-task
+broke/fixed impact (`harness.py:1607-1608`). An **indecisive** step — tamper, or
+coverage/infra void — is deliberately *not* recorded as a rejection
+(`harness.py:1598-1605`): the edit was never evaluated, so filing it would teach the
+optimizer to avoid a change nothing is known about. It also leaves the stall counter
+untouched (`harness.py:1560-1564`).
+
+## Snapshot and store
+
+Every candidate is snapshotted, accepted or not, so any iteration can be diffed
+(`harness.py:1557`). `_SNAPSHOT_IGNORE` (`harness.py:1842-1845`) excludes injected
+read-context — `trajectories/`, `guidance/`, `prior_iterations/`, `LEDGER.md`,
+`JOURNAL.md`, `RUNMAP.md`, and the per-agent skill dirs / always-on instruction files
+— so stored candidates stay capability-only and diffs show the real edit.
+`PROCESS.md` is deliberately kept. The store then commits the iteration, tagging
+`best` on accept (`harness.py:1609-1612`).
+
+## Protected paths → indecisive, never zero
+
+With `protected_patterns` set, the protected files are hashed *after* context
+injection (so the framework's own scratch never reads as tampering), marked
+read-only, and re-verified **before any rollout is paid for**
+(`harness.py:1467-1514`). On tamper the step is indecisive: `candidate_val` is None,
+no reward is recorded, the stall counter is untouched, and best is unchanged. Scoring
+such a candidate 0.0 would be wrong in the other direction — the number would
+describe a compromised harness, not the edit.

--- a/skills/algorithms/hill-climb/scripts/abstract.py
+++ b/skills/algorithms/hill-climb/scripts/abstract.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from pathlib import Path
 
 # A focus schedule is the only "policy" this algorithm carries; the default is
-# "all" (propose against the whole train set each iteration).
+# "all" (propose against every failing val task each iteration).
 DEFAULT_POLICY = {"focus": "all"}
 
 

--- a/skills/algorithms/hill-climb/scripts/check.py
+++ b/skills/algorithms/hill-climb/scripts/check.py
@@ -30,6 +30,23 @@ def main() -> int:
                 f"legacy name {legacy!r} does not map to a valid focus")
     c.note("legacy all-at-once/cyclic/hardest-first translate to --focus")
 
+    # Behavioural: a narrow focus must render the focused task's FAILURES, not an
+    # empty prompt. Comparing focus NAMES cannot see that — the schedule set stayed
+    # correct the whole time the narrow schedules were shipping empty prompts.
+    from cap_evolve.loop import SplitResult
+    per = [{"task_id": "v1", "reward": 1.0, "feedback": "passed", "raw": {}},
+           {"task_id": "v2", "reward": 0.0, "feedback": "wrong result", "raw": {}}]
+    current_val = SplitResult(split="val", reward=0.5, stderr=0.5, per_task=per,
+                              n_tasks=2, n_scored=2)
+    rendered = harness._focus_instructions(current_val, ["v2"], "task v2")
+    c.check("## (a)" in rendered,
+            "a narrow focus renders no failure index — the focus set is not indexing "
+            "the parent's val per-task rows",
+            note="narrow focus renders the focused task's failures")
+    c.check("## Currently PASSING" in rendered,
+            "a narrow focus drops the protect-these-passing-tasks block",
+            note="non-regression protection survives a narrow focus")
+
     return c.emit()
 
 

--- a/skills/algorithms/hill-climb/scripts/run.py
+++ b/skills/algorithms/hill-climb/scripts/run.py
@@ -1,12 +1,11 @@
 """hill-climb — global hill-climb on the val gate, with a selectable focus schedule.
 
-One skill replacing the three byte-identical clones (all-at-once / cyclic /
-hardest-first); they differed ONLY in which train tasks each iteration's
-reflection emphasizes. ``--focus`` selects that schedule:
+``--focus`` selects which of the parent's failing VAL tasks each iteration's
+reflection emphasizes (val is the only per-task data the loop holds):
 
-    all            propose against the whole train set each iteration (default)
-    cyclic         focus one train task at a time, cycling through them
-    hardest-first  rank train tasks by baseline score ascending, attack hardest first
+    all            every failing val task each iteration (default)
+    cyclic         one val task at a time, cycling through them
+    hardest-first  val tasks ordered by the parent's per-task reward ascending
 
 The parent is always the current best (global hill-climb); honesty (val-only
 gate, sealed test) lives in core. This is a thin wrapper over


### PR DESCRIPTION
Closes #330.

`hill-climb` is the default algorithm and had the shortest body in the repo (56 lines).
The problem was not the number — it was that a third of the body described behaviour
that did not happen, and the parts an agent cannot run the loop without were absent.
This makes the three `--focus` schedules real, then writes the shared iteration
mechanism once, here, because per the ownership contract `hill-climb` owns it.

## 1. `--focus cyclic` / `--focus hardest-first` shipped an empty optimizer prompt (fixed)

`hill_climb_loop` built the focus set from **train** ids and `_focus_instructions`
filters the parent's **val** per-task rows. The splits are disjoint slices of one
shuffled id list (`splits.py:117-119`), so the intersection was always empty: both
narrow schedules rendered `0 failing of 0 tasks`, no failure index, and — because
`_passing_block` was also classified off the empty subset — no protect-these-passing-ids
block either. Reproduced against the real function before the fix:

```
--- all (focus_ids=None) ---
  >> Focus: x. ... 1 solid / 0 flaky / 1 failing of 2 tasks.
  >> ## (a) 1 ALWAYS-failing task(s) — fix the shared root cause ...
  >> ## Currently PASSING (1 task(s)) — your edit MUST NOT regress these
--- cyclic over TRAIN ids (before) ---
  >> Focus: x. ... 0 solid / 0 flaky / 0 failing of 0 tasks.
  >> ## No actionable failures in focus — seek a robustness/generalization gain ...
```

Fix (issue #330 option (a), the cheapest honest one — 3 hunks in `harness.py`):

- the focus order is drawn from `read_splits().val`, the only per-task data the loop
  holds;
- `hardest-first` orders off `current_val.per_task`, which the loop already has. That
  **deletes an entire pre-loop `train` evaluation** the mode used to pay for to build
  an ordering it then could not index — real spend for no effect;
- the *protect these passing tasks* block is now classified over the whole val split,
  not the focus subset. Narrowing attention must not narrow the non-regression
  constraint;
- the `all` focus label said "whole train set" to the optimizer; it now says what it is.

Guards added, because the old checks could not see this:

- `core/tests/test_e2e_slice.py::test_narrow_focus_renders_the_focused_tasks_failures`
  (parametrized over both narrow schedules) drives the real loop with a capturing
  proposer and asserts on the **rendered prompt** — the focused id is a val id, `## (a)`
  is present, `0 failing of 0 tasks` is absent. The existing
  `test_cyclic_variant_also_improves` could not catch it: the mock optimizer applies a
  fixed edit script and never reads the prompt.
- `scripts/check.py` now renders a prompt for a narrow focus and fails on a missing
  failure index or a missing passing block, instead of comparing a tuple of schedule
  names (which stayed correct throughout).

## 2. What the body was missing (the work order)

| an agent needs | where it lives | was it in the 56 lines? |
|---|---|---|
| `baseline` precondition; `--resume` fallback | `scripts/run.py:118-122` | no — the documented standalone command crashed |
| parent = current best, and *why* | `harness.py:2224` | one clause, no reason |
| what one iteration does end to end | `harness.py:1409-1626` | 4 lines, never named `run_step` |
| snapshot happens for accepted **and** rejected | `harness.py:1557` | no |
| only accept calls `set_best` | `harness.py:1558-1559` | implied |
| the gate is paired-by-default; the bar is Δ > k·SE, and why not Δ > 0 | `harness.py:1524-1532` | the bar was sold in the description, absent from the body |
| `--gate-mode` / `--k-se` | `run.py:49-51` | no |
| `--protected-paths` (eval-surface seal; tamper ⇒ *indecisive*, never 0.0) | `run.py:80-83`, `harness.py:1440-1446` | no — honesty-relevant |
| `--capabilities` empty ⇒ optimizer gets **no** edit-space block | `run.py:59-62`, `harness.py:1735-1737` | no |
| `--workers` is only safe if `run_target` is thread-safe | `run.py:46-48` | no — a correctness caveat |
| `--convergence` graded plateau signal | `run.py:84-86`, `convergence.py:47` | no |
| `--store` / `--store-commit-cmd`; every candidate is a commit | `run.py:52-53`, `harness.py:1609-1612` | no |
| the four handover files agent mode must reproduce | `harness.py:1062-1094` | alluded to as "memory wiring" |
| rejected-edit + accepted-history memory | `harness.py:1631-1646`, injected at `:1465` | no |
| indecisive ≠ rejected (not filed, stall untouched) | `harness.py:1560-1564`, `1598-1605` | no |
| when to stop using hill-climb | — | no reverse pointer to `gepa`/`skillopt` |
| the #351 gate edge case | — | no |

## 3. Structural job: the shared mechanism, stated once

Per `SKILL_OWNERSHIP.md`, `hill-climb` owns parent-selection / gate / commit mechanics.
The anchor other algorithm skills should point at:

**`skills/algorithms/hill-climb/references/run-step.md`** (78 lines) — the `run_step`
contract verbatim: signature and the two things algorithms vary (`parent_dir`,
`instructions`), the four cross-iteration files and their ownership, `RejectedMemory` /
`History`, indecisive-vs-rejected, the snapshot filter, the version store, the
protected-path path.

The body carries the mechanism at the level needed to *run* it, under the section
**`## One iteration, end to end`**. `gepa` / `skillopt` / `agent-optimize` / `evograph`
should link `references/run-step.md`, not this body — pulling a second full skill body
into context to learn one paragraph is the cost we are trying to remove.

## 4. Deletions

- "Replaces the former all-at-once, cyclic, and hardest-first skills" out of the
  description (nobody types "all-at-once"; the freed words went to the boundary), and
  the two body restatements of the same history. The back-compat note survives once, on
  the input `run.py:35` actually accepts.
- `## Inputs / outputs (manifest tokens)` — triplicated `needs`/`provides`.
- The agent-mode paraphrase of orchestrate's five rules; what remains is only the
  hill-climb-specific obligation (reproduce the handover surface, carry rejected edits
  forward) plus a pointer to the owner.

## 5. Honest, not fixed

`## Known gate edge case (open, issue #351)` states that under the default paired gate a
single-task improvement gives `Δ̄ == SE` algebraically, so acceptance turns on
floating-point representation — a practitioner needs to know a one-task gain may not
bank. No attempt to fix #351 here, and the section says explicitly not to lower `--k-se`
to work around it.

## What other skills should drop / fix (not touched — ownership contract)

- **`skillopt` has the identical train-ids-into-val-rows bug.** `skillopt.py:230` builds
  `order` from `read_splits().train` and `:291` passes those ids to
  `harness._focus_instructions`, whose filter is over val rows. Every SkillOpt
  mini-batch therefore renders no failure index. (It does now get the passing block,
  from the shared fix above.) Same one-line shape of fix.
- `skillopt/SKILL.md:20-21` claims the "rejected-edit buffer" as something it adds over
  hill-climb; hill-climb has `RejectedMemory` too (`harness.py:1636`). Narrow the claim
  to the failure-pattern clustering + LR schedule, which are genuinely its own.
- `skillopt/SKILL.md:51`, `skillopt/references/concepts.md:5`, `docs/ARCHITECTURE.md:110`,
  `docs/OPTIMIZE_YOUR_OWN.md:95,145` describe hill-climb's focus as being over the
  *train* set.
- `skillopt/SKILL.md:55-58` has the same triplicated `## Inputs / outputs` section.

## Evidence

- `SKILL.md` 56 → 150 lines (~2.3k tokens; budget 500 / 5000). References:
  `run-step.md` 78, `focus-schedules.md` 29 → 50. No reference needs a TOC.
- `python skills/algorithms/hill-climb/scripts/check.py` → `ok: true`, exit 0, with the
  two new behavioural notes.
- All three schedules run end to end on toy_calc, zero-API, each reaching a
  gate-accepted sealed test of `1.0` against a `0.0` baseline. Rendered focus lines:
  `all` → `Focus: every failing task on the val split. ... 2 failing of 2 tasks`;
  `cyclic` and `hardest-first` → `Focus: task a1. ... 1 failing of 1 tasks` (`a1` is a
  val id).
- `bash examples/toy_calc/run.sh` → `best_id: cand_0001`, `test_reward: 1.0`,
  `test_baseline_reward: 0.0`, `test_delta: 1.0`.
- `PYTHONPATH="$PWD/core:$PWD/dashboard/backend" python -m pytest core/tests -q` →
  **791 passed, 12 skipped** (clean main is 789/12 per #349; +2 is the new parametrized
  test).
