### PR TITLE
baseline: real headroom verdict, hard-gate on the standalone path, degenerate-split guard (#332)

### DIFF
--- a/skills/phases/baseline/SKILL.md
+++ b/skills/phases/baseline/SKILL.md
@@ -1,61 +1,60 @@
 ---
 name: baseline
-description: Establish the starting point. Use after implement-and-check and before any algorithm. Creates the run directory, freezes the seeded train/val/test split (written once), scores the unmodified seed capability on val, and records it as the candidate every algorithm must beat. Confirms there is headroom to optimize.
+description: Establish the starting point. Use after implement-and-check and before any algorithm. Creates the run directory, freezes the seeded train/val/test split (written once), scores the unmodified seed capability on val, and records it as the candidate every algorithm must beat. Reports the remaining headroom so a saturated seed stops the run before it spends budget.
 component: phase
-argument-hint: "--base .capevolve --project DIR --capability DIR"
+argument-hint: "--base .capevolve --project DIR --capability DIR [--seed N] [--ratios a,b,c] [--n-trials N] [--split-ids FILE] [--resume] [--reuse-baseline DIR]"
 allowed-tools: Read, Write, Bash
-provides: [splits, baseline, candidate]
+provides: [splits, baseline, candidate, scores, traces]
 needs: [project, tasks]
 sources: []
 ---
 
 # baseline — freeze splits, score the seed
 
-baseline is the first phase that touches data, so it owns the most
-consequential one-time decision in the whole run: **the split**. It writes
-`splits.json` once (seeded, reproducible), scores the *unmodified* seed
-capability on val, and records that score as the candidate every algorithm must
-beat. Get the split right here and every downstream number is honest; get it
-wrong and nothing later can fix it.
+baseline is the first phase that touches data, so it owns the run's one
+irreversible decision: **the split**. It writes `splits.json` once (seeded), scores
+the *unmodified* seed capability on val, and records that score as the bar every
+algorithm must beat.
 
-## Inputs / outputs (manifest tokens)
-- **needs:** `project` (the implemented adapter) and `tasks` (the dataset).
-- **provides:** `splits` (the frozen train/val/test partition), `baseline` (the
-  seed's val score), and `candidate` (the seed, registered as the first best).
+Run `implement-and-check` first. baseline re-runs that check itself and exits
+non-zero before creating a run dir if it is red — a split frozen against a broken
+adapter poisons every number measured afterwards.
 
 ## Why it matters
 - **Fair comparison point.** Every algorithm hill-climbs *against* the baseline
   val score; a candidate that does not beat it is not progress.
-- **Headroom check.** If the seed already scores ~1.0 on val, there is little to
-  optimize — stop and save budget rather than chase noise. A near-floor baseline,
-  conversely, may signal a broken adapter rather than a hard task.
-- **Split sealing.** baseline writes the split *once*; from here on no skill
-  re-splits, and **test is untouched until finalize**. Freezing it once (seeded)
-  guarantees train/val/test stay disjoint and reproducible across reruns — the
-  precondition for the honest test number at the end.
+- **Headroom.** The printed JSON carries `headroom` (`1 - val`) and
+  `headroom_verdict`: `saturated` means the seed is already at the ceiling and
+  further iterations buy noise — stop; `floor` (val at 0) usually means a
+  mis-wired adapter rather than a hard task — re-check before spending budget;
+  `ok` means proceed. The same verdict is logged as a `headroom` event so the
+  orchestrator can stop on it with no human reading the number.
 
 ## Splitting choices
 - **Seeded ratio split** (default `0.5 / 0.25 / 0.25`): deterministic given
   `--seed`. Reproducible runs partition identically.
 - **Pinned split** (`--split-ids`): a JSON `{train,val,test}` of ids — use a
   benchmark's official split, or set all three equal to fit the whole set with
-  **no holdout** (the report will then flag the test number as a *fit* metric, not
-  a held-out result).
-- Tasks must be plentiful enough to split three ways and still leave val/test big
-  enough that their standard errors are not dominated by sample size.
+  **no holdout** (the test number is then a *fit* metric, not a held-out result;
+  the run dir records a `splits_warning` saying so).
+- A ratio split that leaves val or test empty is **refused** — the gate would
+  have nothing to decide on and the sealed test number would cover no tasks.
+  Below 5 val tasks baseline warns: the gate's bar is optimistic at that `n`, and
+  a candidate that improves exactly one val task cannot reliably clear it at all
+  (issue #351), so size val with the decisions it has to make in mind.
 
 ## Reusing a prior baseline (`--reuse-baseline PRIOR_RUN_DIR`)
-Re-scoring the seed on val every run is wasteful when the split + seed are
-unchanged. Pass `--reuse-baseline <prior run_* dir>` (spec key `reuse_baseline`,
-or `cap-evolve run --reuse-baseline ...`) and baseline copies the prior run's
-`splits.json`, `baseline.json`, the seed candidate snapshot, and the seed val
-rollouts into the fresh run dir, then **skips** the baseline eval — the algorithm
-starts at iteration 1 on the reused baseline. The **test seal stays intact**: the
-copied split's `test_used` flag is reset so this run can still finalize on test
-exactly once. Backward compatible — absent, baseline behaves exactly as before.
+Re-scoring the seed is wasteful when the split + seed are unchanged.
+`--reuse-baseline <prior run_* dir>` (spec key `reuse_baseline`) copies that run's
+`splits.json`, `baseline.json`, seed snapshot and seed val rollouts into the fresh
+run dir and skips the baseline eval; the copied `test_used` flag is reset so this
+run can still finalize on test exactly once. `--resume` is the same-run variant:
+reopen an existing run dir, skip the eval when `baseline.json` is already there.
+Budget flags (`--max-iterations`, `--stall`, `--max-usd`, …) are accepted here
+because the run dir owns the budget and later phases read it from there.
 
-## Dual-mode
-This phase runs two ways from the **same** SKILL.md: standalone as the slash command `/cap-evolve:baseline` (the `argument-hint` shows its run.py args), and orchestrator-callable — `cap-evolve run` / the `orchestrate` skill invokes the same `scripts/run.py` headlessly and threads the run dir between phases.
+Runs standalone (`/cap-evolve:baseline`) or headlessly via `cap-evolve run`; same
+`scripts/run.py` either way.
 
 ## How to run
 ```
@@ -63,17 +62,14 @@ python scripts/run.py --base .capevolve --project .capevolve/project \
     --capability seed_capability --seed 0 --ratios 0.5,0.25,0.25 \
     --max-iterations 10 --stall 2
 ```
-Prints the run-dir path (used by the algorithm + finalize) and the baseline val.
-Use `--n-trials ≥ 3` for stochastic agents so the baseline carries an honest
-`stderr` for the gate to compare against.
+Prints the run-dir path (used by the algorithm + finalize), the split sizes, the
+baseline val and the headroom verdict. Use `--n-trials ≥ 3` for stochastic
+targets so the baseline carries a real `stderr` rather than 0.
 
-## What good vs bad looks like
-- **Good:** a seeded or official split written once; baseline scored with enough
-  trials to have real variance; visible headroom between baseline and 1.0.
-- **Bad:** re-splitting later in the run (leaks test); a baseline at ~1.0 chased
-  anyway (no headroom — wasted budget); a single-trial baseline `stderr=0` that
-  makes every later significance comparison meaningless.
+The one failure mode nothing later can repair is re-splitting after this phase: a
+task migrating out of test leaks the held-out set, and every later number —
+including the sealed test score — becomes unfalsifiable.
 
 ## References
-- `references/concepts.md` — why splits are frozen once and seeded, the headroom
-  check, no-holdout fit metrics, and the train/val/test contract, with sources.
+- `references/concepts.md` — why the split is frozen once and seeded, how to read
+  the headroom verdict, and why no-holdout runs are fit metrics, with sources.

--- a/skills/phases/baseline/references/concepts.md
+++ b/skills/phases/baseline/references/concepts.md
@@ -23,17 +23,21 @@ purposes:
    identically, so results are comparable and bugs are reproducible. The seed is
    recorded in the run dir.
 
-## The headroom check
+## The headroom verdict
 
-baseline scores the *unmodified* seed on val before any optimization. The val
-number is a budget decision:
+baseline scores the *unmodified* seed on val before any optimization, then turns
+that number into a budget decision it emits (`headroom`, `headroom_verdict` in the
+printed JSON and a `headroom` event in the run dir):
 
-- **Seed ≈ 1.0:** the ceiling is already reached. Optimizing further chases noise
-  for marginal gain — stop and save budget.
-- **Seed ≈ floor (near 0):** suspicious. Often a broken adapter (wrong runner,
-  mis-wired scorer) rather than a genuinely impossible task. Re-check the
-  contract before spending budget.
-- **Seed in the middle:** real headroom — proceed.
+- **`saturated`** (val + stderr ≥ 1.0): the ceiling is already reached. Further
+  iterations chase noise for marginal gain — stop and save budget.
+- **`floor`** (val ≤ 0): suspicious. Usually a broken adapter (wrong runner,
+  mis-wired scorer) rather than a genuinely impossible task. Re-check the contract
+  before spending budget.
+- **`ok`**: real headroom — proceed.
+
+It is deliberately non-fatal. The verdict is a fact about the run, recorded where
+both a human and the orchestrator can read it; deciding to stop is theirs.
 
 Recording the baseline also gives every algorithm a fixed bar: a candidate must
 beat the baseline val (by the gate's significance margin) to count as progress.
@@ -51,11 +55,9 @@ performance. The distinction is the difference between "fits the data we have" a
 
 ## Variance starts here
 
-If the agent is stochastic, score the baseline with multiple trials. A
-single-trial baseline reports `stderr = 0`, and since the gate compares each
-candidate against the baseline using a combined standard error, a zero baseline SE
-quietly weakens every later significance test. Honest variance at the baseline is
-what lets the gate reject noise for the rest of the run.
+If the target is stochastic, score the baseline with `--n-trials >= 3`. A
+single-trial baseline reports `stderr = 0`, which the gate then inherits for the
+rest of the run — see `phases/gate` for what that does to `Δ > k·SE`.
 
 ## Sources
 - Hastie, Tibshirani, Friedman, *The Elements of Statistical Learning* — the

--- a/skills/phases/baseline/scripts/check.py
+++ b/skills/phases/baseline/scripts/check.py
@@ -1,22 +1,55 @@
 """Contract: baseline freezes a deterministic seeded split — the same seed yields
-the same train/val/test partition, and the split is written once (idempotent).
+the same train/val/test partition, and the split is written once. It also refuses
+what it must refuse: a red `cap-evolve check`, and a ratio split with no val/test.
 """
 
 from __future__ import annotations
 
+import json
 import sys
 import tempfile
 from pathlib import Path
 
 import _bootstrap  # noqa: F401
 
-from cap_evolve.skillcheck import Checker, import_run
+from cap_evolve import RunDir, harness
+from cap_evolve.check import load_adapter
+from cap_evolve.skillcheck import Checker, import_run, quiet
 from cap_evolve.splits import make_splits
+
+ADAPTER = '''
+import random  # noqa: F401
+from cap_evolve import CapabilityAdapter
+from cap_evolve.types import Task, Rollout, Score
+
+
+class Adapter(CapabilityAdapter):
+    def tasks(self, split):
+        return [Task(id=f"t{i}", input="x", target="1") for i in range(N)]
+
+    def run_target(self, task, ctx, *, seed=0):
+        return Rollout(task_id=task.id, output="1")
+
+    def score(self, task, rollout):
+        return Score(task_id=task.id, reward=REWARD, feedback="ok")
+'''
+
+
+def _project(tmp: Path, name: str, *, n: int, reward: str) -> Path:
+    proj = tmp / name
+    (proj / "adapters").mkdir(parents=True, exist_ok=True)
+    (proj / "adapters" / "adapter.py").write_text(
+        ADAPTER.replace("N", str(n)).replace("REWARD", reward), encoding="utf-8")
+    cap = proj / "seed_capability"
+    cap.mkdir(exist_ok=True)
+    (cap / "policy.txt").write_text("seed\n", encoding="utf-8")
+    return proj
 
 
 def main() -> int:
     c = Checker("baseline")
-    c.require_main(import_run())
+    run = import_run()
+    c.require_main(run)
 
     ids = [f"t{i}" for i in range(12)]
     s1 = make_splits(list(ids), seed=7, ratios=(0.5, 0.25, 0.25))
@@ -29,15 +62,51 @@ def main() -> int:
             "different seeds produced identical splits (seed ignored)")
     c.check(not (set(s1.train) & set(s1.test)), "train/test overlap in a held-out split")
 
-    # write_splits then read_splits round-trips and is stable (written once).
     with tempfile.TemporaryDirectory() as d:
-        from cap_evolve import RunDir
-        rd = RunDir.create(Path(d) / ".capevolve", ts="b")
-        rd.write_splits(s1)
-        back = rd.read_splits()
-        c.check(back.train == s1.train and back.seed == s1.seed,
+        tmp = Path(d)
+        # Written once: a second ensure_splits with a DIFFERENT seed and ratios must
+        # return the frozen partition, not re-partition (harness.py:114-115).
+        rd = RunDir.create(tmp / "once", ts="b")
+        proj = _project(tmp, "green", n=12, reward="1.0")
+        adapter = load_adapter(proj)
+        first = harness.ensure_splits(adapter, rd, seed=1, ratios=(0.5, 0.25, 0.25))
+        again = harness.ensure_splits(adapter, rd, seed=99, ratios=(0.8, 0.1, 0.1))
+        c.check((first.train, first.val, first.test) == (again.train, again.val, again.test),
+                "ensure_splits re-partitioned an existing run dir (split NOT written once)",
+                note="split written once: a second ensure_splits returns the frozen partition")
+        c.check(rd.read_splits().train == first.train,
                 "splits did not round-trip through the run dir",
                 note="split frozen + reloadable from the run dir")
+
+        # A red `cap-evolve check` must stop baseline BEFORE a run dir exists (#358).
+        red = _project(tmp, "red", n=12, reward="random.random()")
+        base = tmp / "red_base"
+        rc = run.main(["--base", str(base), "--project", str(red),
+                       "--capability", str(red / "seed_capability"), "--run-ts", "x"])
+        c.check(rc != 0, "baseline accepted a red cap-evolve check (non-deterministic scorer)",
+                note="red adapter refused: baseline exits non-zero before freezing a split")
+        c.check(not list(base.glob("run_*")), "baseline created a run dir despite a red check")
+
+        # A ratio split with no val (n=2 -> 1/0/1) must be refused, not silently run.
+        tiny = _project(tmp, "tiny", n=2, reward="1.0")
+        rc = run.main(["--base", str(tmp / "tiny_base"), "--project", str(tiny),
+                       "--capability", str(tiny / "seed_capability"), "--run-ts", "x"])
+        c.check(rc != 0, "baseline accepted a ratio split with an empty val set",
+                note="degenerate ratio split (empty val/test) refused")
+
+        # Green path: runs, warns about the tiny val, and EMITS the headroom verdict.
+        with quiet() as buf:
+            rc = run.main(["--base", str(tmp / "ok_base"), "--project", str(proj),
+                           "--capability", str(proj / "seed_capability"), "--run-ts", "x"])
+        out = json.loads(buf.getvalue()) if rc == 0 else {}
+        c.check(rc == 0, "baseline failed on a healthy 12-task project")
+        c.check(out.get("headroom_verdict") == "saturated" and out.get("headroom") == 0.0,
+                f"headroom not emitted for a seed that already scores 1.0 on val: {out!r}",
+                note="headroom is computed and emitted (saturated at val=1.0)")
+        events = (Path(out.get("run_dir", tmp)) / "events.jsonl")
+        text = events.read_text(encoding="utf-8") if events.exists() else ""
+        c.check('"headroom"' in text, "no headroom event logged for orchestrate to read")
+        c.check("val has only" in text, "no splits_warning logged for a 3-task val split")
 
     return c.emit()
 

--- a/skills/phases/baseline/scripts/run.py
+++ b/skills/phases/baseline/scripts/run.py
@@ -15,7 +15,34 @@ from pathlib import Path
 import _bootstrap  # noqa: F401
 
 from cap_evolve import Budget, RunDir, harness
-from cap_evolve.check import load_adapter
+from cap_evolve.check import load_adapter, run_check
+
+
+def _refuse_degenerate_split(splits, run_dir) -> bool:
+    """Refuse a ratio split with no val or no test; warn on a tiny val (#113).
+
+    A val-gated run with zero val tasks has nothing to decide on, and a sealed-test
+    run with zero test tasks produces its headline number over nothing — both fail
+    silently today because ``make_splits`` clamps sizes without a floor
+    (``splits.py:113-119``). Failing here costs nothing; failing at finalize costs the
+    whole run. A pinned ``--split-ids`` may be deliberately degenerate (the no-holdout
+    case), so only the ratio path is guarded.
+    """
+    if not splits.val or not splits.test:
+        msg = (f"degenerate ratio split: train={len(splits.train)} val={len(splits.val)} "
+               f"test={len(splits.test)} — the val gate and the sealed test number both "
+               "need at least one task. Add tasks, change --ratios, or pin --split-ids "
+               "deliberately.")
+        run_dir.log_event("splits_warning", msg=msg)
+        print(json.dumps({"step": "baseline", "error": msg}, indent=2), file=sys.stderr)
+        return True
+    if len(splits.val) < 5:
+        run_dir.log_event(
+            "splits_warning",
+            msg=(f"val has only {len(splits.val)} task(s) — the gate's Δ > k·SE bar is "
+                 "optimistic at this n, and a one-task improvement cannot reliably clear "
+                 "it at all (#351). Prefer >= 5 val tasks."))
+    return False
 
 
 def main(argv=None) -> int:
@@ -45,6 +72,18 @@ def main(argv=None) -> int:
     p.add_argument("--spec", default=None,
                    help="path to capevolve.yaml spec (for observer config)")
     args = p.parse_args(argv)
+
+    # The hard gate, on THIS path too. `cap-evolve run` checks the adapter before it
+    # calls us (cli.py:721-726), but /cap-evolve:baseline is reachable directly and the
+    # needs/provides DAG validates declared order, not runtime state — so without this
+    # the standalone chain would freeze a split against a knowingly-broken adapter and
+    # every number in the run would be measured against it (#358). Gate before the run
+    # dir exists so a red check leaves nothing behind.
+    rep = run_check(Path(args.project))
+    if not rep.ok:
+        print(json.dumps({"step": "baseline", "error": "check failed",
+                          "report": rep.to_dict()}, indent=2), file=sys.stderr)
+        return 1
 
     Path(args.base).mkdir(parents=True, exist_ok=True)
     budget = Budget(max_iterations=args.max_iterations, stall=args.stall,
@@ -141,6 +180,8 @@ def main(argv=None) -> int:
             split_ids = json.loads(sp.read_text(encoding="utf-8"))
         splits = harness.ensure_splits(adapter, run_dir, seed=args.seed, ratios=ratios,
                                        split_ids=split_ids)
+        if split_ids is None and _refuse_degenerate_split(splits, run_dir):
+            return 1
         # Resolve the seed capability dir robustly: as given (absolute/cwd-relative),
         # else relative to the project dir. `cap-evolve run` invokes baseline with
         # cwd=workdir, so a project-relative `capability_path: seed_capability` in
@@ -152,10 +193,21 @@ def main(argv=None) -> int:
                 cap_path = cand
         result = harness.baseline(adapter, cap_path, run_dir=run_dir, n_trials=args.n_trials)
 
+        # Headroom: the budget decision this phase exists to make. Saturated => every
+        # later Δ chases noise; floor => usually a broken adapter, not a hard task.
+        # Emitted, not just advised, so `cap-evolve run` / orchestrate can stop on it
+        # without a human reading the number. Non-fatal: recording it is the job.
+        headroom = round(max(0.0, 1.0 - result.reward), 4)
+        verdict = ("saturated" if result.reward + max(result.stderr, 0.0) >= 1.0
+                   else "floor" if result.reward <= 0.0 else "ok")
+        run_dir.log_event("headroom", headroom=headroom, verdict=verdict, val=result.reward)
+
         print(json.dumps({
             "run_dir": str(run_dir.root),
             "splits": {"train": len(splits.train), "val": len(splits.val), "test": len(splits.test)},
             "baseline_val": result.to_dict(),
+            "headroom": headroom,
+            "headroom_verdict": verdict,
         }, indent=2))
         return 0
     finally:


### PR DESCRIPTION
Closes #332. Partially closes #358 (item 4) and #113 (the split half, on the one path that
creates splits today). All changes are inside `skills/phases/baseline/` — no core change.

## 1. Verified the skill's claims against core

| claim | verdict | evidence |
|---|---|---|
| split written once | TRUE, but not by the writer | `RunDir.write_splits` (`core/cap_evolve/rundir.py:352-353`) is an unconditional atomic overwrite. Write-once comes entirely from the existence check in `harness.ensure_splits` (`core/cap_evolve/harness.py:114-115`). Other callers overwrite by design (`harness.reuse_baseline` `harness.py:558`, `skillcheck.py:93`), so hardening the writer would be wrong. |
| split is seeded / reproducible | TRUE | `make_splits` shuffles with `random.Random(seed)` (`core/cap_evolve/splits.py:99-100`) and records the seed (`splits.py:120`). |
| test sealed at this point | TRUE | `harness.baseline` evaluates `split="val"` only (`harness.py:509-510`); nothing in the phase reads test ids, and the real toy_calc run below shows `test_used: false` after baseline. |

No drift to fix on those three — they were accurate. The claim that *was* false was the
headroom check, and the implication that the hard gate protects this path.

## 2. The headroom check was described only. It is now real (script-local).

`grep -rni headroom core/cap_evolve` matched nothing relevant; `harness.baseline`
(`harness.py:490-529`) computes no headroom, and `orchestrate/SKILL.md:71` lists "no headroom"
as a stopping rule that no field could trigger. It was three paragraphs of advice to a reader
who, in orchestrator mode, does not exist.

`scripts/run.py` now derives it from the number it already has and emits it — printed JSON
`headroom` / `headroom_verdict` plus a `headroom` run-dir event:

```
{"kind": "headroom", "headroom": 1.0, "verdict": "floor", "val": 0.0}
```

Deliberately **non-fatal**: recording the verdict is baseline's job, acting on it belongs to
orchestrate/the human. `ok | saturated | floor`, where `saturated` uses `val + stderr >= 1.0`
so a noisy near-ceiling seed is not chased.

Where it *should* live long-term is `harness.baseline`, next to the number, so `report` and the
dashboard read it from `baseline.json` instead of scraping stdout — that is a core change and
out of this PR's scope; #332's AC 1 keeps it on record.

## 3. #358's standalone-chain hole: CLOSED on the baseline path

`baseline/scripts/run.py:18` imported only `load_adapter` and never called `run_check`, so
`/cap-evolve:baseline` froze a split against a knowingly-broken adapter. Three lines, same
function `cli.py:721-726` already uses, placed **before** the run dir is created so a red check
leaves nothing behind. Measured with a non-deterministic scorer:

**BEFORE** (`git show HEAD:.../run.py`, exit 0, split frozen against the red adapter):
```
{"run_dir": "/tmp/cap332/base_before/run_x", "splits": {"train": 6, "val": 3, "test": 3},
 "baseline_val": {"reward": 0.5044240716712957, "stderr": 0.1445481029873362, ...}}
### exit: 0
### FROZEN: {"train": ["t1","t9","t8","t5","t10","t2"], "val": ["t3","t7","t4"],
             "test": ["t0","t11","t6"], "seed": 0, "test_used": false}
```

**AFTER** (exit 1, no run dir, no base dir):
```
{"step": "baseline", "error": "check failed",
 "report": {"ok": false, "stubs": [],
   "problems": ["scorer is non-deterministic: 0.07347192360918453 vs 0.4208106855854168 on identical input"],
   "notes": ["tasks('val') -> 12 task(s)", "materialize() callable (dry-run into temp copy; host untouched)"]}}
### exit: 1
### run dirs created (expect none): ls: /tmp/cap332/base_after: No such file or directory
```

The check costs one `tasks()` pair, one `score()` pair and a dry-run `materialize` — no
rollouts, no spend. #358's other four items (its `run_target` probe, the vacuous determinism
probe for judge/memoised scorers, `score()` returning `None`, `cli.py:1288` saying "4 methods")
are core-side and stay with #358.

## 4. #113 — the split half, guarded here

`make_splits` clamps sizes with no floor (`splits.py:113-119`): `n<=2` yields an **empty val**
(the val-only gate has nothing to decide for the whole run), `n=3` yields an **empty test**
(finalize's headline number over zero tasks). `ensure_splits` warns for exactly one hazard,
train/test overlap (`harness.py:120-123`), and nothing else.

`_refuse_degenerate_split` in `run.py` refuses an empty val or test on the **ratio path only**
(pinned `--split-ids` may be deliberately degenerate — the disclosed no-holdout case), and logs
a `splits_warning` below 5 val tasks that also names **#351**: at tiny `n` a candidate improving
exactly one val task yields `Δ̄ == SE` algebraically and cannot reliably clear the default bar,
so the val size is a gate-design decision, not just a sample-size one. Real toy_calc run:

```
{"kind": "splits_warning", "msg": "val has only 2 task(s) — the gate's Δ > k·SE bar is optimistic
 at this n, and a one-task improvement cannot reliably clear it at all (#351). Prefer >= 5 val tasks."}
```

**The durable home is still core.** `ensure_splits` is the choke point where every split in the
system is born; a guard there covers callers that do not go through this script (`skillcheck.py:93`,
`agent-optimize/scripts/check.py:307`). Today `ensure_splits` has exactly one production caller —
`baseline/scripts/run.py:142` — so the script-local guard covers every real path, but it is a
guard on a caller, not on the function. #113 keeps that, plus the whole gate-side half
(`gate.py:101-135`: t-correction / minimum-val bar), which is not baseline's to fix.

## 5. Ownership contract

Removed from `SKILL.md` (owners in brackets):

- `## Inputs / outputs (manifest tokens)`, 4 lines — pure frontmatter restatement.
- The split-seal / disjointness / "test untouched until finalize" restatement, 4 lines
  [`gate`, `finalize`, `report`].
- The `## What good vs bad looks like` section, 6 lines, which restated the headroom and
  single-trial-stderr material from 12 lines earlier. Kept only the bullet unique to this
  phase (re-splitting later leaks test), as prose.
- The 55-word Dual-mode paragraph, byte-identical in all 8 phase skills → one sentence.
- The single-trial `stderr = 0` lecture, twice in `SKILL.md` and again in `concepts.md` →
  one actionable line (`--n-trials >= 3`) plus a pointer to `gate`, which owns the math.

No agent-mode loop and no failure taxonomy were present. `concepts.md`'s variance section
trimmed from 7 lines to 3 for the same reason.

**Drift reconciled:** `SKILL.md:7` said `provides: [splits, baseline, candidate]`, `meta.yaml:8`
said `[splits, baseline, candidate, scores, traces]`. `meta.yaml` is right — `harness.baseline`
calls `evaluate_candidate` (`harness.py:509-510`), which writes val rollouts and scores — and
`meta.yaml` is the file the manifest actually loads
(`skills/orchestrate/orchestrate/scripts/run.py:60-81`, `build_manifest.py:69-76` compares only
`name`/`component`). `SKILL.md` now matches. Per the ownership contract I did **not** add
consumers for `provides`/`needs`/`sources`; `sources: []` is left as-is rather than grown.

Also documented: `--resume` (implemented at `run.py:42-44`, `:103-112`, previously undocumented
while `--reuse-baseline` had 9 lines), why the budget flags are accepted here, and an
`argument-hint` that covers the flags the body's own example passes.

## What other skills should drop (not touched here)

- `evaluate:40-41`, `gate:62-63`, `finalize:40-41`, `diagnose:158-159`, `intake:215-216`,
  `implement-and-check:106-107`, `report:49-50` — the same Dual-mode paragraph.
- `report/scripts/run.py` — `SKILL.md`/`concepts.md` say a no-holdout run is flagged as a *fit
  metric*; the event exists (`harness.py:120-123`) and the dashboard consumes it
  (`dashboard.py:1155-1157`) but `report.md` never says it. Fix belongs in `report` (#332 AC 4);
  baseline's sentence is now scoped to what is true ("the run dir records a `splits_warning`").

## Evidence

`wc -l` before → after:

```
SKILL.md               79 → 75   (~24 lines of restatement out, ~20 of real behaviour in)
references/concepts.md 67 → 69
scripts/run.py        168 → 212
scripts/check.py       46 → 116
```

`python skills/phases/baseline/scripts/check.py`:

```json
{"skill": "baseline", "ok": true, "problems": [], "notes": [
  "run entry exposes main()",
  "seeded split is deterministic",
  "split written once: a second ensure_splits returns the frozen partition",
  "split frozen + reloadable from the run dir",
  "red adapter refused: baseline exits non-zero before freezing a split",
  "degenerate ratio split (empty val/test) refused",
  "headroom is computed and emitted (saturated at val=1.0)"]}
```

Real run, `bash examples/toy_calc/run.sh` — gate-accepted, sealed test scored once:

```
{"run_dir": ".capevolve/run_demo", "best_id": "cand_0001", "baseline_val": 0.0,
 "test_reward": 1.0, "test_baseline_reward": 0.0, "test_delta": 1.0,
 "test_pass_k": {"1": 1.0}, "iterations": 3}
```

`splits.json` written **once** (event counts from that run's `events.jsonl`):

```
Counter({'evaluate': 6, 'gate_warning': 3, 'step': 3, 'splits': 1, 'splits_warning': 1,
         'baseline': 1, 'headroom': 1, 'run_config': 1, 'finalize': 1})
{"kind": "splits", "train": 4, "val": 2, "test": 2, "seed": 0}
{"kind": "baseline", "val": 0.0, "stderr": 0.0, "n_scored": 2, "n_tasks": 2}
{"kind": "headroom", "headroom": 1.0, "verdict": "floor", "val": 0.0}
```
(`verdict: floor` is correct here — toy_calc's seed capability genuinely scores 0 on val — and
non-fatal, so the run proceeded and banked a real improvement. Exactly the intended behaviour:
the fact is recorded, the decision is not seized.)

Test suite (pinned per #349): `PYTHONPATH="$PWD/core:$PWD/dashboard/backend" python -m pytest
core/tests -q` → **789 passed, 12 skipped**, matching clean main.

## Judgement calls

- **Added `run_check` here** rather than leaving the hole to #358: three lines, in this skill's
  own script, with a test proving a red adapter is refused and no run dir created. Documenting
  "the standalone chain has no gate" would have been honest and useless.
- **Headroom in `run.py`, not `harness.py`**: keeps this PR core-free. The cost is that
  `report`/the dashboard cannot read the verdict from `baseline.json` yet.
- **Degenerate-split guard refuses *after* `ensure_splits` has written `splits.json`** — the
  script cannot intercept the write without a core change. Harmless: the run dir is fresh and
  nothing was spent, and a retry gets a new timestamped run dir.
