### PR TITLE
system-prompt: cut the prompt-folklore and make the never-delete invariant mechanical

### DIFF
--- a/core/tests/test_system_prompt_rule_preservation.py
+++ b/core/tests/test_system_prompt_rule_preservation.py
@@ -1,0 +1,83 @@
+"""The never-delete-a-needed-rule invariant is reported, not merely documented.
+
+`docs/ARCHITECTURE.md` states prompt edits must "change / consolidate / add, don't
+delete". Before #327 that was prose only: `validate()` asserted non-emptiness, so an
+`op: "set"` replacing a whole policy with one line validated `ok`. These tests pin the
+constraint-line accounting that now surfaces such an edit as a warning (never a hard
+failure — a legitimate consolidation trips it too).
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+ABSTRACT = (Path(__file__).resolve().parents[2] / "skills" / "capabilities"
+            / "system-prompt" / "scripts" / "abstract.py")
+
+POLICY = (
+    "# Refund policy\n"
+    "\n"
+    "Require a manager code before any refund.\n"
+    "Confirm before any destructive action.\n"
+    "State the record ID in every reply.\n"
+    "---\n"
+)
+
+
+@pytest.fixture(scope="module")
+def sp():
+    spec = importlib.util.spec_from_file_location("sp_abstract_rules", ABSTRACT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_rule_lines_ignores_structure_and_counts_rules(sp):
+    """Headings, fences and rules structure a prompt; only the rest can carry a rule."""
+    assert sp.rule_lines(POLICY) == 3
+    assert sp.rule_lines("# Title\n\n```\ncode\n```\n===\n") == 1  # only the fenced body line
+    assert sp.rule_lines("") == 0
+
+
+def test_set_that_wipes_the_policy_is_flagged(sp, tmp_path):
+    """The edit the invariant exists to catch: a whole-file replacement losing rules."""
+    (tmp_path / "prompt.txt").write_text(POLICY, encoding="utf-8")
+    rep = sp.apply(tmp_path, [{"file": "prompt.txt", "op": "set", "text": "Be helpful.\n"}])
+    assert rep["changed"] == ["prompt.txt"]
+    assert len(rep["warnings"]) == 1
+    assert "3 -> 1" in rep["warnings"][0]
+    # Still a warning, not a failure — the candidate remains valid and evaluable.
+    assert sp.validate(tmp_path)["ok"] is True
+
+
+def test_additive_and_consolidating_edits_do_not_warn(sp, tmp_path):
+    """An add keeps every rule; a merge of two lines into one keeps every constraint."""
+    (tmp_path / "prompt.txt").write_text(POLICY, encoding="utf-8")
+    add = sp.apply(tmp_path, [{"file": "prompt.txt", "op": "append", "text": "Cite sources.\n"}])
+    assert add["warnings"] == []
+    merged = POLICY.replace(
+        "Require a manager code before any refund.\nConfirm before any destructive action.\n",
+        "Require a manager code before any refund, and confirm before any destructive action.\n",
+    )
+    # A real consolidation does drop a line, so it warns too — the warning asks for a
+    # justification, it cannot distinguish a merge from a loss.
+    con = sp.apply(tmp_path, [{"file": "prompt.txt", "op": "set", "text": merged}])
+    assert con["warnings"], "a consolidation is flagged for justification, not silently accepted"
+
+
+def test_validate_reports_stats_and_always_carries_warnings(sp, tmp_path):
+    """`stats` turns 'the preamble is too long' into a number; `warnings` never KeyErrors."""
+    (tmp_path / "prompt.txt").write_text(POLICY, encoding="utf-8")
+    v = sp.validate(tmp_path)
+    assert v["warnings"] == []
+    assert v["stats"]["prompt.txt"]["rule_lines"] == 3
+    assert v["stats"]["prompt.txt"]["lines"] == 6
+    assert sp.validate(tmp_path / "missing")["warnings"] == []  # empty-seed branch
+
+
+def test_validate_against_a_baseline_sees_the_drop(sp, tmp_path):
+    """The agent-edit path: compare the candidate to the parent it was derived from."""
+    (tmp_path / "prompt.txt").write_text("Be helpful.\n", encoding="utf-8")
+    assert sp.validate(tmp_path, baseline={"prompt.txt": POLICY})["warnings"]
+    assert sp.validate(tmp_path, baseline={"prompt.txt": "Be helpful.\n"})["warnings"] == []

--- a/skills/capabilities/system-prompt/SKILL.md
+++ b/skills/capabilities/system-prompt/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: system-prompt
-description: Optimize an agent's system prompt or policy text — the instructions that shape its behavior. Use when the thing you want to improve is a prompt/policy file (not tools or a skill package). Covers what is safely editable, how prompt wording changes agent behavior, common failure modes (over-long preambles, conflicting instructions, missing output contracts), and what to measure. Provides concrete materialize/apply/validate handlers for prompt artifacts.
+description: Optimize an agent's system prompt, developer message, or policy text — the instructions that shape its behavior. Use when the artifact to improve is a prompt or policy file rather than tools or a skill package: the agent lacks a rule, misses the required output format, or applies the wrong decision criterion. Covers the safe edit classes (rewrite, consolidate, add a sourced rule, reorder, tighten the output contract, soften over-strong wording), how to keep an edit general instead of overfitting one task, and the rule that a needed constraint is never deleted. A failure where the agent already knows the rule and skips the action belongs to the capability that edits tool code, not here.
 component: capability
 argument-hint: "--path DIR"
 allowed-tools: Read, Write, Edit, Bash
@@ -11,188 +11,126 @@ sources: [tau2bench]
 
 # Capability: system prompt
 
-The system prompt is the cheapest, highest-leverage parameter of most agents: a
-few words can flip success on a whole class of tasks. This capability treats one
-or more prompt/policy text files (`prompt.txt`, `policy.md`, `SYSTEM.md`) as the
-optimizable artifact.
+This capability treats one or more prompt/policy text files (`prompt.txt`,
+`policy.md`, `SYSTEM.md`) as the optimizable artifact — whatever text the runtime
+prepends to the agent's context as its instructions, output contract, and decision
+policy.
 
-## What you can change here
+Prose is the right lever when the agent lacks something it could be *told*: a
+format, a rule, a decision criterion. It is the wrong lever when the agent already
+has the rule and does not act on it — that needs the behavior enforced in code, so
+it belongs to whatever capability edits the agent's tools, not here. Classify the
+failure clusters first (`./guidance/diagnose/SKILL.md`, when present) and spend
+prose only on the clusters this capability can actually move.
 
-The prompt is **HIGH-VALUE to edit, not a last resort.** When the traces show the
-agent doesn't know a rule, a format, or a decision criterion, a sharper prompt is
-the fastest fix. Each lever below is a safe, bounded edit class — pick the one
-that fixes the biggest failure cluster. (1-line generic examples; depth in
-[`references/concepts.md`](references/concepts.md).)
+## Pick the lever
 
-1. **Rewrite a rule for clarity / positive framing** — say what TO do, specifically.
+Each item is a bounded edit class. Fix the biggest cluster with the narrowest lever
+that reaches it; ship every class the traces call for in one candidate. Examples are
+1-line and generic; depth is in [`references/concepts.md`](references/concepts.md).
+
+1. **Rewrite a rule for clarity, positively framed** — say what TO do, specifically.
+   A prohibition fences off one wrong path; a positive instruction names the target.
    *Ex:* "Don't be vague" → "State the record ID in every reply."
-2. **Add the WHY to a bare rule** — append the reason so the model generalizes.
-   *Ex:* "Never use ellipses" → "Never use ellipses — output is read by a TTS
-   engine that can't pronounce them."
+2. **Add the reason to a bare rule** — a rule paired with its rationale extends to
+   cases the rule's author never wrote down; a bare imperative does not.
+   *Ex:* "Never use ellipses" → "Never use ellipses — the output is read by a TTS
+   engine that cannot pronounce them."
 3. **Consolidate redundant rules** — merge duplicates into one, keeping every
    distinct constraint. *Ex:* three "confirm before deleting" lines → one "Confirm
    before any destructive action (delete, overwrite, send)."
-4. **Add a missing rule grounded in the source/policy** — add a rule the source
-   requires but the prompt omits (must trace to a real source, never invented). The
-   added rule must be ADDITIVE (a constraint/predicate the prompt lacked) or NARROWING
-   (a stricter condition) — NEVER one that LOOSENS or broadens an existing
-   permission/decision, which regresses the whole class.
-   *Ex:* source says refunds need a manager code → "Require a manager code before
-   any refund." (A *narrowing* add. Adding "anyone may refund without a code" would be
-   a loosening — forbidden.)
-5. **Add an example** — 1, up to 3–5, `<example>`-tagged exemplars to pin format.
-   *Ex:* add one `<example>` showing the exact JSON envelope expected.
-6. **Reorder** — long context/data to the top, query + instructions last; group
-   mixed content under headers / XML tags. *Ex:* move a long reference block above
-   the task instruction.
-7. **Add a role / goal line** — one sentence on who the agent is and its objective.
-   *Ex:* "You are a careful support agent; resolve the request in one turn."
+4. **Add a rule the source requires but the prompt omits** — it must trace to a real
+   source (the policy doc, the runner, the task spec), never be invented. The added
+   rule may introduce a constraint the prompt lacked, or state a stricter condition on
+   an existing one. It may not broaden an existing permission or flip a decision the
+   agent currently gets right: that changes behavior for every task in the class,
+   including the passing ones whose gold answer was the stricter behavior. When a
+   cluster needs different behavior, name the exact condition that separates the
+   qualifying cases instead. *Ex:* the source says refunds need a manager code →
+   "Require a manager code before any refund."
+5. **Add an example** — one or a few `<example>`-tagged exemplars to pin a format
+   that is hard to describe in prose. *Ex:* one `<example>` showing the exact JSON
+   envelope expected. Examples are re-read every turn, so add the smallest set that
+   pins the shape and treat a larger set as a hypothesis to gate, not a free win.
+6. **Restructure** — separate instructions, context, examples, and input into their
+   own sections or tags so the model does not conflate them, and put long reference
+   data before the instruction that acts on it.
+7. **Add a role / goal line** — one sentence on who the agent is and what "done"
+   means, when the prompt has none. *Ex:* "You are a careful support agent; resolve
+   the request in one turn."
 8. **Tighten the output contract** — make the required shape explicit and exact.
-   *Ex:* "Reply with only a JSON object `{status, reason}` — no prose."
-   **If the eval scores COMMUNICATION of computed values** (totals, refunds, savings,
-   counts, balances), the contract must require the agent to STATE each computed figure
-   explicitly in its final message. The agent often performs the DB action correctly
-   but never reports the number, and the eval marks the omission as a miss. This is a
-   KNOWLEDGE / output-contract gap — prose-fixable here — and is DISTINCT from a missing
-   DB action/write (a behavioral execution failure, which prose cannot fix and is out of
-   scope for this capability). *Ex:* "After computing a total/refund/savings, state the exact figure in
-   your final message (e.g. 'Your refund is $42.00')."
-9. **Soften over-strong language** — downgrade `CRITICAL/MUST/ALWAYS` to "Use …
-   when …" when a cluster shows over-eagerness/over-triggering on current models.
-   *Ex:* "CRITICAL: you MUST call the tool" → "Use the tool when you need live data."
+   *Ex:* "Reply with only a JSON object `{status, reason}` — no prose." If the scorer
+   reads the agent's final message, the contract must require the agent to state every
+   value the scorer checks: agents routinely perform the action correctly and never
+   report the result, and the scorer sees only the omission. (A missing action, as
+   opposed to a missing report of it, is not fixable here — see the scope note above.)
+9. **Soften over-strong wording** — when a cluster shows the agent over-doing rather
+   than under-doing (excess tool calls, over-engineering, triggering a behavior where
+   it did not apply), downgrade `CRITICAL/MUST/ALWAYS` to "Use … when …". The edit
+   that fixes an over-eagerness cluster is a cut, not an addition.
 
-> **NEVER drop a needed rule — change, consolidate, or add; don't delete.** When an
-> edit removes text, every distinct constraint that text carried must survive
-> somewhere (rewritten, merged, or relocated). Deletion is legitimate only when the
-> information is genuinely redundant or contradicted by the source — and even then,
-> prefer rewriting the conflicting rule. Consolidation cuts *words*, never *rules*.
+## Never drop a needed rule — change, consolidate, or add
 
-The good practices, failure modes, and the full never-drop rule are in
-[`references/concepts.md`](references/concepts.md) — read it before a non-trivial edit.
+When an edit removes text, every distinct constraint that text carried must survive
+somewhere: rewritten, merged into a combined rule, or relocated. Deletion is
+legitimate when the information is genuinely redundant, contradicted by the source,
+or now enforced deterministically elsewhere — and in the first two cases prefer
+rewriting the conflicting rule. Consolidation cuts *words*, never *rules*.
 
-## What can be optimized
-- **Role line** — a single sentence stating who the agent is. A known cheap win:
-  one role sentence focuses behavior and tone.
-- **Task framing** — what "done" means.
-- **Output contract** — exact format the downstream/eval expects (a frequent
-  silent failure: the agent is *capable* but formats wrong). **Diagnose
-  output-shape failures first** — right content / wrong shape scores zero, and is
-  the cheapest class to fix.
-- **Decision rules** — when to call which tool, when to ask vs. act, refusal
-  rules (many agents are scored on adherence to such decision rules).
-  **DANGER — a global decision/permission/refusal rule has UNBOUNDED blast radius.**
-  Loosening or broadening one to fix a failing cluster (e.g. relaxing "restricted
-  records may not be modified", or "any role may approve the request") flips behavior
-  for the WHOLE class and
-  regresses every currently-passing task where the original, stricter behavior was the
-  gold answer. NEVER loosen a global decision rule to fix a cluster. If a cluster needs
-  different behavior, state the EXACT discriminating CONDITION that NARROWS the rule to
-  the qualifying cases only. A prompt edit to a decision rule is safe ONLY when it ADDS
-  a predicate the agent lacked or NARROWS the rule — never when it broadens a permission
-  or flips a decision the
-  agent currently gets right.
-- **Few-shot exemplars / reasoning scaffolds** — 3–5 diverse, relevant examples
-  wrapped in `<example>` tags steer format (caveat: long example dumps can hurt
-  reasoning models — keep it to a handful).
+An optimizer that deletes a needed rule can make one iteration's metric go up and
+leave the class permanently broken, so the check is mechanical as well as stated:
+`apply()` counts constraint-bearing lines before and after every edit and reports a
+net loss in `report["warnings"]`. A warning is not a failure — a legitimate
+consolidation triggers it too — it is a prompt to state, in `PROCESS.md`, where each
+dropped constraint went. `op: "set"` on a whole file is the edit most likely to lose
+one silently.
 
-## How to write the edit (authoring rules)
-These are *how* to phrase a prompt edit so it actually changes behavior:
+## Keep the edit general
 
-- **State instructions positively — say what TO do, not just what not to do.**
-  "Respond in flowing prose paragraphs" beats "don't use markdown." Positive
-  phrasing gives the model a target; prohibitions only fence off one wrong path.
-- **Explain the WHY, not bare MUSTs.** A rule with its reason generalizes; a bare
-  `MUST`/`CRITICAL` does not. "Never use ellipses" works far better as "your output
-  is read by a TTS engine that can't pronounce ellipses." Teach the optimizer to
-  write the reason, not the command.
-- **Model-sensitivity caveat — sometimes the fix is to REMOVE or soften an
-  instruction.** Newer models over-comply: stale anti-laziness phrasing
-  (`CRITICAL`/`MUST`/`ALWAYS`) now causes over-eagerness and over-engineering.
-  Prefer plain "Use … when …". If a cluster shows over-doing rather than
-  under-doing, the edit is to *cut or soften* an instruction, not add one.
-- **Ordering / structure.** Put long context first and the query / output contract
-  last (end-placement can lift quality on long inputs); separate
-  instructions / context / examples with lightweight `<xml>` tags so the model
-  doesn't conflate them.
-- **Generalize, never hardcode.** A prompt rule must state the GENERAL policy that
-  holds across the whole class of inputs, never a specific task's case or answer.
-  *Good:* "Reverse the charge to the original payment method on file." *Bad:* "If the
-  record id is `<TASK_SPECIFIC_ID>`, apply the exact amount that one task expects."
-  Baking one task's id/value/date/answer into
-  the prompt overfits, fails the held-out gate, and can mislead other tasks. Use a
-  failing task's specifics only to understand the class, then write the general rule.
-- **Ground new rules in a source; don't fabricate.** You MAY add a rule the source
-  or policy requires but the prompt omits (menu item 4) — that is a high-value edit.
-  What you must not do is invent a normative rule, exception, or workaround that no
-  source supports and that conflicts with the existing instructions. Trace every
-  added rule to a real source (the policy doc, the runner, the benchmark spec). If
-  two existing rules conflict, rewrite toward the more restrictive one rather than
-  dropping either.
-
-## Prose fixes KNOWLEDGE gaps — behavioral failures are OUT OF SCOPE here
-The system prompt is the right lever when a failure is a *knowledge* gap — the
-agent doesn't know the required output format, a decision criterion, or a rule.
-Telling it teaches it, and behavior changes. The prompt is the WRONG lever when a
-failure is *behavioral* — the agent already "knows" what to do (it analyzes,
-explains, even confirms) but then skips the action (e.g. stalls before issuing a
-write and stops). More prose does not fix a behavior the model already agreed to
-and declined: that class of failure is OUT OF SCOPE for the prompt — only enforcing
-the action deterministically (outside this capability) fixes it. So before reaching
-for a prompt edit, classify each cluster as KNOWLEDGE (fix here) vs behavioral
-(not a prompt fix), and spend prose only on the knowledge gaps.
-
-**If a rule is a VIOLATION the agent commits despite knowing it (not a knowledge
-gap), do NOT add prose.** Adding another sentence to a rule the agent already read
-and broke just grows the prompt without changing behavior — a known-but-broken rule
-needs deterministic enforcement the prompt cannot provide, so it is out of scope here.
-
-**A DECISION / PERMISSION cluster is NOT a knowledge gap — never loosen a global rule
-to fix it.** When a cluster shows the agent making the wrong ACT-vs-REFUSE call, the
-agent usually already "knows" the rule; the real condition is just more specific than
-the prose. Relaxing the global rule makes the agent act on the WHOLE class and regresses
-every task where refusing/escalating was the gold answer (unbounded blast radius). The
-only safe prompt fix is a NARROWING rule that states the EXACT discriminating predicate
-that separates the qualifying cases — a prompt edit may only ADD knowledge or NARROW,
-never broaden a permission or flip a decision the agent currently gets right. If the
-condition cannot be expressed as a narrowing rule, it is out of scope for the prompt.
-
-**Each prompt iteration should also CONSOLIDATE.** When a rule is now enforced
-deterministically elsewhere (no longer dependent on the prompt), REMOVE its
-now-redundant prose so the prompt stays sharp — the deterministic enforcement is
-authoritative and the duplicate sentence only dilutes attention. This prevents prose
-pile-up: the prompt should get shorter as constraints become enforced, not longer.
-(This is consolidation under the never-drop rule — the constraint still lives,
-enforced elsewhere, so removing its prose drops no rule.)
-
-## How agents use it
-The prompt is prepended to context every turn. Agents read it literally and are
-sensitive to ordering, contradictions, and verbosity. Long preambles dilute
-attention; conflicting instructions resolve unpredictably.
-
-## Common problems (see references/pitfalls.md)
-- Over-long, redundant instructions → worse, not better.
-- Missing/loose output contract → correct content, wrong shape, zero reward.
-- Instructions that fight the model's defaults → inconsistent behavior.
+- **Never hardcode a task's specifics.** A rule must state the general policy that
+  holds across the class, not one task's case or answer. *Good:* "Reverse the charge
+  to the original payment method on file." *Bad:* "If the record id is
+  `<TASK_SPECIFIC_ID>`, apply the amount that task expects." Baking an id, value,
+  date, or answer into the prompt overfits, gets rejected by the held-out gate, and
+  can mislead other tasks. Use a failing task's specifics to identify the class, then
+  write the general rule. The test for any edit: *would this help on a task the
+  optimizer has never seen?*
+- **Resolve conflicts, don't stack rules.** Before editing, list the rules that
+  govern the same action and check that no two give a different verdict on the same
+  input; rewrite toward the stricter one rather than dropping either. A contradiction
+  is the one failure mode detectable by reading the artifact alone, so it is worth
+  the pass.
+- **Consolidate as constraints move out of the prompt.** When a rule is now enforced
+  deterministically elsewhere, remove its now-redundant prose: the enforcement is
+  authoritative and the duplicate sentence only competes for attention. The prompt
+  should get shorter as constraints become enforced, not longer. (This drops no rule
+  — the constraint still lives, enforced elsewhere.)
+- **Watch length, but measure it.** `validate()` reports each file's line, token, and
+  constraint-line counts. There is no universal length threshold worth quoting;
+  compare a candidate against the accepted candidates of your own run and treat a
+  prompt that grows every iteration without moving val as the signal to prune.
 
 ## Handlers (scripts/abstract.py)
-`materialize(dir) -> {file: text}` · `apply(dir, edits) -> report` ·
-`validate(dir) -> {ok, files, problems}`. Edit ops: `set`, `append`,
-`ensure_contains`. A project adapter's `apply` can call these directly.
 
-## Optimizing it each iteration (analyze → ideate → edit)
-The optimizer should **analyze before editing**: from the traces + the current
-prompt, identify (a) the recurring failures clustered by root cause (the rule the
-agent keeps breaking) and (b) the good behavior seen only on some trials that
-should be made consistent; then make prompt edits for EVERY knowledge-gap cluster,
-paired with the tool-code fixes for the behavioral clusters in the SAME candidate,
-and reinforce (b) — sharpen or correct the offending rules rather than appending
-more preamble.
+`materialize(dir) -> {file: text}` · `apply(dir, edits) -> {changed, warnings}` ·
+`validate(dir, baseline=None) -> {ok, files, stats, problems, warnings}` ·
+`is_empty(dir) -> bool`. Edit ops: `set`, `append`, `ensure_contains`. Pass
+`baseline` (a directory or a `{file: text}` dict, e.g. the parent candidate) to have
+`validate` report a constraint-line drop against it. A project adapter's `apply` can
+call these directly.
 
 ## How to run
+
 ```
 python scripts/check.py
-python scripts/run.py --path <capability_dir>     # prints the candidate + validity
+python scripts/run.py --path <capability_dir>                        # candidate + validity
+python scripts/run.py --path <candidate_dir> --baseline <parent_dir>  # + rule-loss check
 ```
 
 ## References
-- `references/concepts.md` — why prompts are high-leverage; what to optimize; pitfalls.
+
+- [`references/concepts.md`](references/concepts.md) — what the prompt controls, the
+  six authoring practices and five failure modes in full, how to adapt a prompt to
+  the runtime reader's capability tier, pitfalls, and cited sources. **Read once
+  before your first non-trivial edit**, and again when a candidate is accepted but
+  barely moves the metric.

--- a/skills/capabilities/system-prompt/references/concepts.md
+++ b/skills/capabilities/system-prompt/references/concepts.md
@@ -1,141 +1,110 @@
 # Concepts — optimizing a system prompt
 
-> The system prompt (a.k.a. the instructions, the developer message, or the
-> decision rules / output contract an agent is held to) is the cheapest,
-> highest-leverage parameter of most LLM agents: a few words can flip success on
-> a whole class of inputs.
+Depth behind `SKILL.md`'s lever menu: what the prompt actually controls, the
+authoring practices and failure modes in full, how to adapt to the runtime reader,
+and the pitfalls that look like improvements.
 
 ## What the system prompt controls
+
 - **Role & task framing** — who the agent is and what "done" means.
-- **Output contract** — the exact format the downstream/eval expects. A frequent
-  *silent* failure is a capable agent that formats its answer wrong and scores 0.
-- **Decision rules** — when to call which tool, when to ask vs. act, refusal and
-  safety rules. (Many agents are scored on adherence to such decision rules.)
-- **Reasoning scaffolds & few-shot exemplars** — added inline to shape how the
-  model thinks before it answers.
+- **Output contract** — the exact shape the downstream consumer or scorer expects.
+  The common silent failure is a capable agent that formats its answer wrong and
+  scores zero, so diagnose shape before content.
+- **Decision rules** — when to call which tool, when to ask versus act, refusal and
+  escalation rules. Many agents are scored on adherence to such rules.
+- **Reasoning scaffolds & exemplars** — added inline to shape how the model works
+  through the task before answering.
 
-## Knowledge gaps vs. behavioral gaps (what prose can and cannot fix)
-Prose is the right tool for KNOWLEDGE/format/decision-criteria gaps: a missing
-output contract, an unstated rule, an ambiguous criterion — telling the agent
-fixes it. Prose is WEAK for BEHAVIORAL failures the model already "knows" but
-skips: it analyzes, explains, confirms, then fails to perform the action (the
-classic stall before a write). You cannot instruct a model out of a behavior it
-already agreed to and then declined — that class is OUT OF SCOPE for the prompt; it
-needs the action enforced deterministically (outside this capability). Classify each
-failure cluster before editing and spend prose only on the knowledge gaps.
+## Adapting to the runtime reader
 
-## How agents consume it
-The system prompt is prepended to context every turn, so the model is highly
-sensitive to its **ordering, contradictions, and length**. Long, redundant
-preambles dilute attention and can *lower* accuracy; conflicting instructions
-resolve unpredictably; instructions that fight the model's defaults produce
-inconsistent behavior. This is why "more instructions" is not "better."
+The right prompt edit depends on WHO reads this prompt at runtime (see the
+`THE READER` block in your instructions, if present). Most of the advice here — soften
+imperatives, explain the reason, keep exemplars minimal — assumes a strong reader.
+Flip it for a weaker one:
 
-## Adapting to the reader's capability tier
-The right edit depends on WHO reads this prompt at runtime (see the `THE READER` block
-in your instructions, if present). Much of the advice in this file — "soften MUSTs",
-"explain the why", "newer models over-comply" — is a **frontier/strong-reader** tactic.
-Flip it for weaker readers:
+- **strong reader:** lean, reasoning-first prose; give the reason; keep exemplars
+  minimal; soften brittle imperatives, because over-constraining hurts this reader.
+- **mid / weak reader:** be explicit. Prefer imperative step-by-step rules; include at
+  least one worked exemplar per non-trivial behavior; keep decision chains short; make
+  the output contract rigid and literal; and push behavioral rules into tool code
+  rather than prose this reader will skip.
 
-- **frontier / strong reader:** lean, reasoning-first prose; explain the WHY; keep
-  few-shot minimal; soften brittle imperatives — over-constraining *hurts* this reader.
-- **mid / weak reader:** be EXPLICIT. Prefer imperative step-by-step rules; include at
-  least one worked few-shot example per non-trivial behavior; keep decision chains short;
-  make the output contract rigid and literal; and push behavioral rules into tool CODE
-  (see the `tools` capability) rather than prose the reader will skip.
+When no reader is declared, default to the strong-reader advice — and say so in
+`PROCESS.md` so a later run can set the tier deliberately.
 
-When no reader is declared (`target_model` empty), default to the frontier/strong advice
-below — but say so in `PROCESS.md` so a later run can set the tier.
+## The six authoring practices
 
-## What to optimize (and how)
-- Add a one-sentence **role line** if absent — a cheap, well-documented win that
-  focuses behavior and tone.
-- Sharpen the **task framing** and make the **output contract** explicit and
-  unambiguous (this alone recovers many "capable-but-mis-formatted" failures);
-  diagnose output-shape failures *before* content failures.
-- Tighten the **decision policy**: name the precondition for each tool/action.
-- **Remove** instructions that don't pull their weight (measure, don't assume).
-- Prefer explaining the *why* over piling on ALL-CAPS MUSTs — modern models follow
-  reasoning better than brittle rules, and over-constraining hurts generalization.
-- Add a **minimal** exemplar only when the format/behavior is hard to describe.
-
-## How to phrase the edit
-- **Positive instruction.** Tell the model what TO do, not only what not to do —
-  "respond in flowing prose paragraphs" steers better than "don't use markdown,"
-  because a prohibition fences off one path while a positive instruction names the
-  target. Treat the model as a brilliant new hire with no context: if a colleague
-  with minimal context would be confused by the instruction, so will the model.
-- **Explain the WHY.** A rule paired with its rationale generalizes to unseen
-  cases; a bare `MUST`/`CRITICAL` does not. "Output is read by a TTS engine that
-  can't pronounce ellipses" beats "never use ellipses."
-- **Model-sensitivity.** Newer models over-comply, so stale anti-laziness phrasing
-  (`CRITICAL`/`ALWAYS`/`MUST`) now over-triggers — prefer plain "Use … when …".
-  When a cluster shows over-eagerness or over-engineering, the right edit is to
-  **remove or soften** an instruction, not add one.
-- **Ordering / structure.** Long context first, query / output contract last;
-  separate instructions / context / examples with `<xml>` tags. End-placed
-  instructions are acted on more reliably on long inputs.
-- **Ground new rules in a source.** Adding a rule the source/policy requires but
-  the prompt omits is a high-value edit (menu item 4). What regresses is *inventing*
-  a normative rule that no source supports and that conflicts with the existing
-  instructions — trace every added rule to a real source. Behavioral failures (the
-  model knows the rule but skips the action) belong in **code/tools**, not more prose.
-
-## The six good practices
-1. **Be clear, direct, specific — write for a capable new hire with no context.**
-   If a colleague with minimal context would be confused, so will the model. Spell
-   out the desired output and constraints; number steps when order matters.
-2. **Give the reason, not just the command.** Context lets the model generalize;
-   the TTS-ellipses rewrite is the canonical before/after.
-3. **Tell it what TO do, not what NOT to do (positive framing).** "Compose your
-   reply in flowing prose" beats "do not use markdown."
-4. **Structure with sections / XML tags and order deliberately.** Wrap
-   instructions, context, examples, inputs in their own tags; long data at the top,
-   the query / contract last (end-placement can lift quality on long inputs).
-5. **Use a few diverse examples (3–5) and define an explicit output contract.**
-   Examples are the most reliable way to steer format; prefer a schema / enum tool
-   over prefill for structured output.
-6. **Keep prompts lean and self-consistent; tune trigger strength to the model.**
-   Over-long, redundant preambles and conflicting instructions dilute attention; on
-   current models, soften `CRITICAL/MUST` rather than piling on more.
+1. **Be clear, direct, and specific — write for a capable new hire with no context.**
+   If a colleague with minimal context would be confused by the instruction, so will
+   the model. Spell out the desired output and the constraints; number steps when the
+   order matters.
+2. **Give the reason, not just the command.** A rule with its rationale extends to
+   cases the author never enumerated. The canonical rewrite: "never use ellipses" →
+   "the output is read by a TTS engine that cannot pronounce ellipses."
+3. **Say what TO do, not only what NOT to do.** "Compose your reply in flowing prose"
+   beats "do not use markdown" — a prohibition fences off one path, a positive
+   instruction names the target.
+4. **Structure deliberately.** Wrap instructions, context, examples, and input in
+   their own sections or tags so the model does not conflate them; put long reference
+   data before the instruction that acts on it, and keep the output contract adjacent
+   to the point where the model produces the output rather than buried mid-preamble.
+5. **Define the output contract explicitly, and use exemplars where prose cannot
+   describe the shape.** For structured output, a schema or enum in the tool surface
+   constrains it more reliably than prose asking for it.
+6. **Keep the prompt lean and self-consistent, and tune trigger strength to the
+   reader.** Redundant preambles and conflicting clauses compete for attention; when a
+   cluster shows over-eagerness, soften `CRITICAL/MUST/ALWAYS` rather than adding more.
 
 ## The five failure modes
-1. **Missing or loose output contract** — right content, wrong shape → zero reward
-   (the most common silent prompt failure; diagnose shape before content).
-2. **Conflicting / over-broad instructions** — a later clause contradicts an
-   earlier one; the model resolves it unpredictably and behavior gets *worse*.
-3. **Over-long, redundant preamble** — repeated or stale guidance dilutes
-   attention; length is not safety.
-4. **Negative-only phrasing** — "don't do X" without the positive alternative
-   underperforms "do Y."
-5. **Stale over-strong language → over-eagerness** — anti-laziness `MUST/ALWAYS`
-   prompting that helped older models now causes over-engineering, excessive tool
-   use, and over-triggering on current models.
 
-## The never-drop rule (non-negotiable)
-**Never delete a rule, policy, or constraint the agent still needs — change,
-consolidate, or add instead.** When an edit removes text, every distinct constraint
-that text carried must survive somewhere (rewritten more clearly, merged into a
-combined rule, or relocated). Deletion is legitimate only when the information is
-genuinely redundant or contradicted by the source — and even then, prefer rewriting
-the conflicting rule over dropping it. Consolidation reduces *words*, never *rules*.
+1. **Missing or loose output contract** — right content, wrong shape, zero reward.
+   The most common silent prompt failure; diagnose shape before content. When the
+   scorer reads the final message, the contract must require the agent to state every
+   value the scorer checks. *Illustration:* on a customer-service benchmark scored on
+   communicated figures (a total, a refund, a saving, a count, a balance), agents
+   performed the write correctly and never reported the number — "After computing a
+   refund, state the exact figure in your final message (e.g. 'Your refund is
+   $42.00')" recovered the class. Read it as one instance of the general shape, not as
+   a rule about money.
+2. **Conflicting or over-broad instructions** — a later clause contradicts an earlier
+   one and the resolution is not predictable. Detectable by reading the artifact
+   alone: list the rules governing the same action, check for two different verdicts on
+   one input, rewrite toward the stricter.
+3. **Redundant preamble** — repeated or stale guidance competes with the rules that
+   matter. Length is not safety, and `validate()` reports the counts so growth is
+   visible across iterations.
+4. **Negative-only phrasing** — "don't do X" with no positive alternative leaves the
+   model to guess what Y is.
+5. **Stale over-strong language** — anti-laziness `MUST/ALWAYS` phrasing that helped
+   an older reader produces over-engineering, excess tool calls, and behaviors
+   triggered where they did not apply. The fix for an over-doing cluster is a cut.
 
 ## Edit model
-Artifact = one or more text files (`prompt.txt`, `policy.md`, `SYSTEM.md`). Edit
-ops mirror the optimizer: `set`, `append`, `ensure_contains`. `validate` requires
-at least one non-empty prompt file.
+
+Artifact = one or more text files (`prompt.txt`, `policy.md`, `SYSTEM.md`). Edit ops:
+`set`, `append`, `ensure_contains`. `validate` requires at least one non-empty prompt
+file, reports per-file line/token/constraint-line counts, and — given a `baseline` —
+warns when the candidate carries fewer constraint-bearing lines than its parent. That
+warning implements `SKILL.md`'s never-drop rule mechanically; it flags a net loss for
+a human or the optimizer to justify, and cannot tell a legitimate consolidation from a
+lost rule.
 
 ## Pitfalls
-- Verbosity creep: each iteration tends to *add*; periodically prune.
-- Over-fitting the prompt to the eval's quirks rather than the task (the val gate
-  + held-out test guard against this, but watch the val→test gap).
-- Burying the output contract at the bottom; put format requirements where the
-  model will act on them.
-- Prompt-injection surface: instructions that can be overridden by task input.
+
+- **Verbosity creep** — each iteration tends to add. Prune deliberately; the counts
+  from `validate()` make the trend visible.
+- **Overfitting to the scorer's quirks** rather than the task — watch the val→test
+  gap on an accepted candidate.
+- **Prompt-injection surface** — a rule that task input can override is not a rule.
+  Prefer phrasing that survives adversarial input, and enforce anything security-
+  relevant in code.
+- **Editing prose where the failure was never a knowledge gap** — the most expensive
+  wasted iteration in this capability, because a longer prompt looks like progress.
 
 ## Sources
+
 - OpenAI / Anthropic prompt-engineering guides (instruction following, output
-  contracts, few-shot) — https://platform.openai.com/docs/guides/prompt-engineering ,
+  contracts, exemplars) — https://platform.openai.com/docs/guides/prompt-engineering ,
   https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/overview
 - "Large Language Models Are Human-Level Prompt Engineers" (APE), arXiv:2211.01910.
 - "Large Language Models as Optimizers" (OPRO), arXiv:2309.03409.

--- a/skills/capabilities/system-prompt/scripts/abstract.py
+++ b/skills/capabilities/system-prompt/scripts/abstract.py
@@ -7,6 +7,14 @@ library a project adapter's ``apply`` can call.
 
 Edit schema (what an optimizer may emit, mirrored by the mock ops):
     {"file": "prompt.txt", "op": "set"|"append"|"ensure_contains", "text": "..."}
+
+``apply`` and ``validate`` also account for CONSTRAINT-BEARING lines, so the
+never-drop-a-needed-rule invariant is reported rather than merely documented: an
+optimizer that deletes a rule to make one iteration's metric go up leaves the class
+permanently broken, and ``op: "set"`` can do it in a single edit. The accounting is a
+crude line count -- it flags a net loss for a human or the optimizer to justify and
+cannot tell a legitimate consolidation from a lost rule -- so it is a warning, never a
+failure.
 """
 
 from __future__ import annotations
@@ -14,6 +22,40 @@ from __future__ import annotations
 from pathlib import Path
 
 DEFAULT_FILES = ["prompt.txt", "policy.md", "SYSTEM.md"]
+
+# Markdown scaffolding that carries no constraint on its own.
+_STRUCTURE_CHARS = set("-=*_ \t")
+
+
+def rule_lines(text: str) -> int:
+    """Count the constraint-bearing lines of a prompt.
+
+    Headings, code fences and horizontal rules structure a prompt without stating a
+    rule; every other non-blank line might state one. Deliberately crude: the number
+    only has to make a NET LOSS visible, not judge meaning.
+    """
+    n = 0
+    for line in text.splitlines():
+        s = line.strip()
+        if not s or s.startswith("#") or s.startswith("```") or set(s) <= _STRUCTURE_CHARS:
+            continue
+        n += 1
+    return n
+
+
+def _stats(parts: dict) -> dict:
+    """Per-file size signals so "the preamble is too long" becomes a number."""
+    return {
+        name: {"lines": len(text.splitlines()),
+               "tokens": len(text) // 4,  # ~chars/4, the same estimate skill-package uses
+               "rule_lines": rule_lines(text)}
+        for name, text in parts.items()
+    }
+
+
+def _rule_loss(before: str, after: str) -> int:
+    """How many constraint-bearing lines an edit removed (0 when it added or held)."""
+    return max(0, rule_lines(before) - rule_lines(after))
 
 
 def materialize(capability_dir: Path) -> dict:
@@ -34,7 +76,7 @@ def materialize(capability_dir: Path) -> dict:
 def apply(capability_dir: Path, edits: list[dict] | None = None) -> dict:
     """Apply edits to the prompt files. Returns a report of what changed."""
     capability_dir = Path(capability_dir)
-    report = {"changed": []}
+    report = {"changed": [], "warnings": []}
     for e in edits or []:
         target = capability_dir / e["file"]
         op = e.get("op", "set")
@@ -49,8 +91,16 @@ def apply(capability_dir: Path, edits: list[dict] | None = None) -> dict:
         else:
             raise ValueError(f"unknown op {op!r}")
         if new != cur:
+            lost = _rule_loss(cur, new)
             target.write_text(new, encoding="utf-8")
             report["changed"].append(e["file"])
+            if lost:
+                report["warnings"].append(
+                    f"{e['file']}: op {op!r} removed {lost} constraint-bearing line(s) "
+                    f"({rule_lines(cur)} -> {rule_lines(new)}). Change/consolidate/add rather "
+                    f"than delete: confirm every dropped constraint survives somewhere "
+                    f"(rewritten, merged, or enforced deterministically) and say where in "
+                    f"PROCESS.md.")
     return report
 
 
@@ -63,16 +113,36 @@ def is_empty(capability_dir: Path) -> bool:
     return not any(v.strip() for v in materialize(Path(capability_dir)).values())
 
 
-def validate(capability_dir: Path) -> dict:
+def validate(capability_dir: Path, baseline: Path | dict | None = None) -> dict:
     """A prompt artifact is valid if it has at least one non-empty text file.
 
     A capability with no non-empty (non-whitespace) prompt content is accepted as a
     valid empty-seed starting state so the optimizer can create the initial content
-    from failing trajectories."""
+    from failing trajectories.
+
+    ``baseline`` is the text this candidate was derived from -- a directory (e.g. the
+    parent candidate) or an already-materialized ``{file: text}`` dict. When given,
+    a file carrying fewer constraint-bearing lines than its baseline is reported in
+    ``warnings``. ``warnings`` is always present on both branches so a caller can read
+    it without guarding.
+    """
     capability_dir = Path(capability_dir)
     if is_empty(capability_dir):
-        return {"ok": True, "empty": True, "files": [], "problems": [], "warnings": []}
+        return {"ok": True, "empty": True, "files": [], "stats": {},
+                "problems": [], "warnings": []}
     parts = materialize(capability_dir)
     nonempty = {k: v for k, v in parts.items() if v.strip()}
-    return {"ok": bool(nonempty), "files": list(nonempty),
-            "problems": [] if nonempty else ["no non-empty prompt file found"]}
+    warnings = []
+    if baseline is not None:
+        base = baseline if isinstance(baseline, dict) else materialize(Path(baseline))
+        for name, text in sorted(base.items()):
+            lost = _rule_loss(text, parts.get(name, ""))
+            if lost:
+                warnings.append(
+                    f"{name}: {lost} constraint-bearing line(s) fewer than the baseline "
+                    f"({rule_lines(text)} -> {rule_lines(parts.get(name, ''))}). A needed "
+                    f"rule must be changed, consolidated, or relocated -- not dropped; "
+                    f"record where each one went.")
+    return {"ok": bool(nonempty), "files": list(nonempty), "stats": _stats(nonempty),
+            "problems": [] if nonempty else ["no non-empty prompt file found"],
+            "warnings": warnings}

--- a/skills/capabilities/system-prompt/scripts/check.py
+++ b/skills/capabilities/system-prompt/scripts/check.py
@@ -26,7 +26,38 @@ def main() -> int:
         v = abstract.validate(cap)
         if not v["ok"]:
             report["problems"].append(f"validate failed: {v['problems']}")
+        if "warnings" not in v:
+            report["problems"].append("validate omitted 'warnings' on the non-empty branch")
         report["notes"].append("materialize/apply/validate round-trip ok")
+
+        # The two ops that can destroy content, plus the unknown-op guard.
+        abstract.apply(cap, [{"file": "prompt.txt", "op": "append", "text": "\nCite sources.\n"}])
+        if "Cite sources." not in (cap / "prompt.txt").read_text(encoding="utf-8"):
+            report["problems"].append("apply op=append did not concatenate")
+        rep = abstract.apply(cap, [{"file": "prompt.txt", "op": "set", "text": "Be helpful.\n"}])
+        if (cap / "prompt.txt").read_text(encoding="utf-8") != "Be helpful.\n":
+            report["problems"].append("apply op=set did not replace the file")
+        if not rep["warnings"]:
+            report["problems"].append("apply op=set dropped rule-bearing lines without warning")
+        report["notes"].append("set/append ops behave; a rule-dropping set is flagged")
+        try:
+            abstract.apply(cap, [{"file": "prompt.txt", "op": "nope", "text": "x"}])
+        except ValueError:
+            pass
+        else:
+            report["problems"].append("apply accepted an unknown op")
+
+        # validate against a baseline sees the loss the edit above introduced.
+        vb = abstract.validate(cap, baseline={"prompt.txt": "Rule one.\nRule two.\nRule three.\n"})
+        if not vb["warnings"]:
+            report["problems"].append("validate(baseline=) missed a rule-bearing-line drop")
+
+    # The empty-seed branch is a valid starting state, not a failure.
+    with tempfile.TemporaryDirectory() as d:
+        ve = abstract.validate(Path(d))
+        if not (ve["ok"] and ve.get("empty") and ve["warnings"] == []):
+            report["problems"].append(f"validate on an empty dir should be ok/empty: {ve}")
+        report["notes"].append("empty seed validates as a valid starting state")
     report["ok"] = not report["problems"]
     print(json.dumps(report, indent=2))
     return 0 if report["ok"] else 1

--- a/skills/capabilities/system-prompt/scripts/run.py
+++ b/skills/capabilities/system-prompt/scripts/run.py
@@ -17,9 +17,11 @@ import abstract
 def main(argv=None) -> int:
     p = argparse.ArgumentParser(prog="system-prompt")
     p.add_argument("--path", required=True, help="capability dir holding the prompt file(s)")
+    p.add_argument("--baseline", help="the dir this candidate was derived from (e.g. the parent "
+                                     "candidate); warns when a prompt file lost rule-bearing lines")
     args = p.parse_args(argv)
     parts = abstract.materialize(Path(args.path))
-    v = abstract.validate(Path(args.path))
+    v = abstract.validate(Path(args.path), baseline=Path(args.baseline) if args.baseline else None)
     cand = Candidate(id="seed", component="system-prompt", text_parts=parts, dir=str(args.path))
     print(json.dumps({"candidate": cand.to_dict(), "valid": v}, indent=2))
     return 0 if v["ok"] else 1


### PR DESCRIPTION
Closes #327. Reference shape: PR #348, which took `tools/SKILL.md` from 749 to 238
lines by deleting duplication rather than relocating it.

## 1. The never-delete-a-needed-rule invariant was NOT enforced anywhere

`docs/ARCHITECTURE.md:71-72` states it as a hard rule:

> rewrite/consolidate/add rules, add examples, tighten the output contract, but **never
> drop a needed rule** (change / consolidate / add, don't delete).

`SKILL.md:64-68` and `references/concepts.md:115-121` called it "non-negotiable".
`scripts/abstract.py:66-78` `validate()`, before this PR, in full:

```python
def validate(capability_dir: Path) -> dict:
    capability_dir = Path(capability_dir)
    if is_empty(capability_dir):
        return {"ok": True, "empty": True, "files": [], "problems": [], "warnings": []}
    parts = materialize(capability_dir)
    nonempty = {k: v for k, v in parts.items() if v.strip()}
    return {"ok": bool(nonempty), "files": list(nonempty),
            "problems": [] if nonempty else ["no non-empty prompt file found"]}
```

The only property asserted is "at least one file has non-whitespace content". Combined
with `apply()`'s `if op == "set": new = text`, an edit of
`{"file": "prompt.txt", "op": "set", "text": "Be helpful."}` deletes every rule in the
policy and validates `ok: True`. Nothing upstream covers it either — `integrity.py` and
`cli.py`'s `protected_paths` guard the *eval surface* against tampering, not rule
preservation inside the artifact. **Stated three times, enforced zero times.** That is
the failure the invariant exists to prevent: an optimizer that deletes a needed rule
makes one iteration's val go up and leaves the class permanently broken.

Enforcement is now script-local, placed where the before-state actually exists:

- `rule_lines(text)` counts constraint-bearing lines: non-blank, minus headings, code
  fences, horizontal rules. Deliberately crude — it only has to make a NET LOSS
  visible, not judge meaning. (A semantic rule-diff would need an LLM call inside
  `validate()`, which breaks the stdlib-only deterministic-check contract.)
- **`apply()`** compares before/after on every edit and reports a net loss in
  `report["warnings"]` with the counts and a request to say where each dropped
  constraint went. This covers every ops-based path (mock optimizer, adapter-driven
  apply, gepa text edits).
- **`validate(dir, baseline=...)`** takes the dir (or `{file: text}`) the candidate was
  derived from and reports the same drop, so an agent optimizer that edits files
  directly — never touching the edit ops — has a runnable check against its parent.
  `run.py --baseline DIR` exposes it.
- Warning, never a hard failure: a legitimate consolidation trips it too, and
  hard-failing would block a valid candidate mid-run. This follows
  `skill-package/scripts/abstract.py`'s precedent of warning on its own budget.
- `validate()` also reports per-file `lines` / `tokens` / `rule_lines`, and **always**
  returns a `warnings` key. It previously returned one on the empty branch and omitted
  it on the common path, so any caller reading `v["warnings"]` raised `KeyError`.

Tests: `core/tests/test_system_prompt_rule_preservation.py` (5 tests) pins the
accounting, the flagged whole-file wipe, the un-flagged additive edit, the stats, and
the baseline comparison. `scripts/check.py` gained coverage for `set`, `append`, the
unknown-op guard, the baseline warning and the empty-seed branch — it previously
exercised only `ensure_contains`, leaving both content-destroying ops untested.

## 2. Claim classification — 48 distinct claims

| class | count | action |
|---|---|---|
| **mechanism** | 23 | kept |
| **platitude** | 12 | cut |
| **unverifiable** | 13 | 4 cut, 9 re-grounded in something observable |

**Platitudes cut** — nothing the reader does changes on being told them: "the cheapest,
highest-leverage parameter of most agents" (stated twice, `SKILL.md:14` and
`concepts.md:3`), "the prompt is HIGH-VALUE to edit, not a last resort", "a sharper
prompt is the fastest fix", "agents read it literally", "sensitive to ordering,
contradictions, and verbosity" (twice), "over-long instructions → worse, not better",
"instructions that fight the model's defaults → inconsistent behavior", "remove
instructions that don't pull their weight (measure, don't assume)" — which offered no
measurement — and one duplicated "write for a capable new hire".

**Unverifiable, cut outright:** the credentialing adjectives on the role line ("a known
cheap win", "a cheap, well-documented win" — the `Sources` block ties nothing to it),
the unsourced numeric precision "3–5 diverse examples", and two duplicate copies of
model-generation and end-placement claims.

**Unverifiable, re-grounded:**
- "long preambles dilute attention" had no threshold and nothing measured it → the
  length advice now points at the counts `validate()` reports and explicitly quotes no
  universal threshold: compare a candidate against your own run's accepted candidates.
- "conflicting instructions resolve unpredictably" had no detection procedure, despite
  being the one failure mode checkable by reading the artifact alone → replaced with the
  procedure: list the rules governing the same action, check that no two give a
  different verdict on one input, rewrite toward the stricter.
- "newer models over-comply / stale anti-laziness phrasing causes over-eagerness" is a
  blanket generation claim → lever 9 is now keyed to an observable cluster (the agent
  over-doing rather than under-doing), not to a model generation.
- "long example dumps can hurt reasoning models" → grounded in the mechanism that
  actually holds: examples are re-read every turn, so add the smallest set that pins the
  shape and gate a larger one as a hypothesis.
- "end-placement can lift quality on long inputs" → the structural instruction it stood
  in for (separate instructions/context/examples so the model does not conflate them;
  put long reference data before the instruction acting on it).
- "non-negotiable" is now true — see §1.

**Mechanism kept:** the nine levers (each a bounded edit class with a before/after),
additive-or-narrowing on a decision rule, generalize-never-hardcode with its falsifiable
test ("would this help on a task the optimizer has never seen?"), ground-every-rule-in-a-
source, consolidate-as-constraints-move-into-code, diagnose shape before content, and the
reader-capability-tier flip.

## 3. Ownership contract — 50 lines of duplicated failure taxonomy removed

`phases/diagnose` owns the taxonomy. Removed from this skill:

| location | lines | what |
|---|---|---|
| `SKILL.md:81-93` | 13 | "Decision rules" with `DANGER —` / `UNBOUNDED` blast radius |
| `SKILL.md:132-147` | 16 | the whole KNOWLEDGE-vs-BEHAVIORAL section |
| `SKILL.md:149-157` | 9 | the DECISION/PERMISSION-is-not-a-knowledge-gap block |
| `SKILL.md:37-39` | 3 | lever 4 re-deriving the blast-radius argument |
| `concepts.md:17-25` | 9 | its own knowledge-vs-behavioral-gaps section |
| **total** | **50** | |

Taxonomy term hits (`KNOWLEDGE|BEHAVIORAL|DECISION / PERMISSION|blast radius|OUT OF
SCOPE`) went **15 → 1**, and the survivor is "push behavioral rules into tool code"
inside the reader-tier advice — an application, not a restatement.

**Why this is not cosmetic:** `core/cap_evolve/harness.py:1193-1243` copies the selected
capability skill **and** the `diagnose` skill into the SAME optimizer workdir
(`workdir/guidance/<cap>/` and `workdir/guidance/diagnose/`). A duplicated taxonomy
therefore reached one reader 2–3× in a single prompt, on every iteration of every run.
What survives here is the one-sentence scope boundary this capability alone owns, plus
the same boundary in the frontmatter description — where skill-creator says all
when-to-use information belongs.

Also checked: **no `## Inputs / outputs (manifest tokens)` section** existed in this
skill, so there was none to delete. **No honesty-invariant restatement** survives: the
one remaining mention of val/test is "watch the val→test gap on an accepted candidate"
inside the overfitting pitfall (the prior wording, "the val gate and the sealed test
guard against this", was cut), and "gets rejected by the held-out gate" as the *reason*
the never-hardcode rule matters. **No agent-mode-loop restatement** existed. **Reader
capability tier** is nominally owned by `capabilities/skill-package`; what is kept here
is the prompt-specific flip (what changes about *prompt* authoring for a weak reader),
not the generic tier concept — the same call PR #348 made for `tools` (its lines
176-187). Flagging it in case the owner disagrees.

## 4. Self-restatement: 66 further lines removed

Within one 198-line body: positive framing stated 2×, the WHY 2×, ordering 2×,
softening 2×, the output contract 2×; `concepts.md` stated the same six practices twice
*within itself* (its "How to phrase the edit" and "The six good practices" sections).
`SKILL.md:73-96`, `98-130` and `167-175` are gone; the two claims they uniquely carried
(decision-rule narrowing, generalize-never-hardcode) are folded into lever 4 and the
"Keep the edit general" section. `concepts.md` is now the sole home for the six
practices, five failure modes, reader tier, pitfalls and sources.

## 5. Generic, not specific

Lever 8 was 8 lines — the longest lever — baking one benchmark family's scoring shape
into a normative sub-rule: *"If the eval scores COMMUNICATION of computed values
(totals, refunds, savings, counts, balances)…"* plus `'Your refund is $42.00'`, the
manager-code refund, and "restricted records may not be modified". A capability must
hold for a prompt whose scorer reads a diff, a plan, or a proof. It is now one
scorer-agnostic sentence — if the scorer reads the agent's final message, require the
agent to state every value the scorer checks — with the money enumeration moved to
`concepts.md` failure mode 1 and explicitly marked *"Read it as one instance of the
general shape, not as a rule about money."*

## 6. Correctness fixes

- **Broken pointer removed.** `SKILL.md:172` linked `references/pitfalls.md`, which does
  not exist in this skill (only `concepts.md` does) — a copy-paste from `tools/`. An
  agent following it burned a tool call on nothing.
- **Self-contradiction resolved.** `SKILL.md:113-115` said put the output contract
  *last*; `concepts.md:132-133` listed "burying the output contract at the bottom" as a
  pitfall. A skill whose own failure mode #2 is "a later clause contradicts an earlier
  one" should not ship one. Now stated once: keep the contract adjacent to where the
  model produces the output, and put long reference data before the instruction acting
  on it.
- **ALL-CAPS 65 → 8.** `SKILL.md:104` instructed "explain the WHY, not bare MUSTs" while
  the body shouted `DANGER —`, `UNBOUNDED`, `NEVER` ×3, `MUST` ×4, `ALWAYS` ×2. The
  survivors are `JSON`, `TTS`, three filenames, and the `CRITICAL/MUST/ALWAYS` lever 9
  quotes in order to soften them. This is not aesthetics: the optimizer reads this body
  as its model of good prompt writing and then edits a prompt.

## 7. Frontmatter description

Third person, states what and when, real keywords ("system prompt", "developer
message", "policy text", "prompt or policy file"), **697 chars**, no XML, no
`CRITICAL`/`ALWAYS`/`MUST`. The old trailing "Provides concrete
materialize/apply/validate handlers for prompt artifacts" spent always-in-context budget
on implementation detail no user types and that fails to discriminate — all four sibling
capabilities provide those handlers. Replaced with the boundary that does discriminate:
*"A failure where the agent already knows the rule and skips the action belongs to the
capability that edits tool code, not here."*

## Evidence

```
SKILL.md         198 -> 136 lines  (~1954 tokens, budget 500 / 5000)
concepts.md      142 -> 111 lines

$ python skills/capabilities/system-prompt/scripts/check.py
{"skill": "system-prompt", "ok": true, "problems": [],
 "notes": ["materialize/apply/validate round-trip ok",
           "set/append ops behave; a rule-dropping set is flagged",
           "empty seed validates as a valid starting state"]}
exit=0

$ python lint_skills.py skills        # the authoring lint from #345
system-prompt findings: 0              # 0 errors, 0 advisories

links: both relative links point at references/concepts.md, which exists;
       concepts.md contains 0 markdown links, so no ref->ref. No TOC needed
       (111 lines, under the 300-line rule).

$ PYTHONPATH="$PWD/core:$PWD/dashboard/backend" python -m pytest core/tests -q
794 passed, 12 skipped                 # clean main is 789/12 (#349), +5 new

$ bash examples/toy_calc/run.sh        # this example's capability IS a prompt
{"run_dir": ".capevolve/run_demo", "best_id": "cand_0001", "baseline_val": 0.0,
 "test_reward": 1.0, "test_baseline_reward": 0.0, "test_delta": 1.0,
 "test_pass_k": {"1": 1.0}, "iterations": 3}
```

Gate-accepted sealed test score: **1.0** (baseline 0.0, delta +1.0, `cand_0001`,
3 iterations) — a real exercise of this capability's handlers, since `toy_calc`'s
capability directory is a single `prompt.txt`.

## What another skill should drop

Nothing was edited outside `skills/capabilities/system-prompt/` and the new test file.
`tools/SKILL.md:266-276` (its KNOWLEDGE-vs-BEHAVIORAL passage) and `128-137` (its
blast-radius passage) are the same doctrine from the other vantage point; PR #348
already removes them, so no action is requested there.
