### PR TITLE
skillopt: reconcile SKILL.md against skillopt.py and drop the DL analogy's unearned claims

### DIFF
--- a/skills/_registry/manifest.json
+++ b/skills/_registry/manifest.json
@@ -108,7 +108,7 @@
     "skillopt": {
       "component": "algorithm",
       "path": "algorithms/skillopt",
-      "summary": "SkillOpt single-lineage climb over epochs x mini-batches with a textual learning rate (integer edit budget on a constant|linear|cosine schedule), a within-epoch rejected-edit buffer, and a gated epoch-boundary slow/meta update.",
+      "summary": "SkillOpt single-lineage climb over epochs x mini-batches with a textual learning rate (integer edit budget on a constant|linear|cosine schedule) and a gated epoch-boundary consolidation step. Parent is always the current best; acceptance is the val significance gate.",
       "entry": "scripts/run.py",
       "abstract": "scripts/abstract.py",
       "check": "scripts/check.py",

--- a/skills/algorithms/skillopt/SKILL.md
+++ b/skills/algorithms/skillopt/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: skillopt
-description: Runs the SkillOpt single-lineage optimization loop over epochs x mini-batches with a textual learning rate (an integer edit budget that decays on a constant|linear|cosine schedule), a within-epoch rejected-edit + failure-pattern buffer injected into the optimizer prompt, and a gated epoch-boundary slow/meta update that fixes longitudinal regressions. Parent is always the current best; acceptance is the val significance gate; the test split stays sealed. Use when a run benefits from disciplined annealing and per-epoch consolidation rather than hill-climb's one-shot whole-trainset proposals or gepa's Pareto frontier.
+description: Runs the SkillOpt single-lineage optimization loop, which organizes a hill-climb into epochs over mini-batches of train tasks under a textual learning rate — an integer edit budget that decays on a constant|linear|cosine schedule — and ends each epoch with one extra gated consolidation step. Parent is always the current best; acceptance is the val significance gate. Use when a run should anneal from broad early edits to small late ones and consolidate once per epoch, rather than hill-climb's one-shot whole-trainset proposals or gepa's Pareto frontier.
 component: algorithm
-argument-hint: "--run-dir DIR --project DIR --optimizer CMD [--epochs 4] [--batch-size N] [--edit-budget 4] [--lr-schedule cosine] [--min-edit-budget 2] [--no-slow-update]"
+argument-hint: "--run-dir DIR --project DIR --optimizer CMD [--epochs 4] [--batch-size N] [--accumulation 1] [--edit-budget 4] [--min-edit-budget 2] [--lr-schedule cosine] [--no-slow-update]"
 allowed-tools: Read, Write, Bash
 provides: [candidate]
 needs: [scores, traces, candidate]
@@ -10,78 +10,130 @@ needs: [scores, traces, candidate]
 
 # skillopt — annealed single-lineage climb (epochs × mini-batches)
 
-SkillOpt (arXiv:2605.23904) borrows the deep-learning training loop. It is a
-strict single-lineage climber (parent is always the current best, like
-hill-climb) but adds three things from the DL analogy:
+SkillOpt (arXiv:2605.23904, *Executive Strategy for Self-Evolving Agent Skills*)
+organizes a hill-climb into **epochs × mini-batches** under a decaying integer
+**edit budget**. The name is the paper's; the algorithm edits whatever the
+selected capability owns — a prompt, a tool surface, a skill package — and never
+assumes which.
 
-- a **textual learning rate** — an integer **edit budget** `L` per step, large
-  early (explore broadly) and shrinking later (consolidate), on a
-  `constant | linear | cosine` schedule;
-- a per-epoch **rejected-edit + failure-pattern buffer** injected into the next
-  step's prompt (don't re-propose dead ends; these failures remain unsolved);
-- an **epoch-boundary slow / meta update**: re-evaluate the epoch-start skill vs
-  the current best on a small train sample, categorize improved / regressed /
-  persistent / stable, then run ONE extra **gated** step to fix regressions
-  without breaking stable successes.
+**Read the shared step first**, then this file. Parent materialization, the
+optimizer call, the val evaluation, the significance gate, accept/reject,
+snapshot/best, the memory and handover files: all of that is
+`harness.run_step`, documented once in `algorithms/hill-climb/SKILL.md`
+§ "One iteration, end to end" and `algorithms/hill-climb/references/run-step.md`
+(both land with PR #370; until then read `harness.run_step` itself). This file
+states only what SkillOpt does differently.
 
-Every step calls the shared `run_step` (materialize → optimize → eval-VAL →
-significance gate → accept/reject → snapshot/best, with RejectedMemory/History);
-this skill only owns the schedule, the buffer, and the slow update. Gated on val;
-test stays sealed (that's `finalize`).
+Know the bound before reaching for this algorithm: **`run_step` lets a caller
+vary exactly two things — `parent_dir` and `instructions`.** SkillOpt pins
+`parent_dir` to the current best, identical to hill-climb, so everything novel
+lives in the `instructions` string plus the choice to run one extra step per
+epoch. It is prompt shaping and step scheduling, not a different search.
 
-## The DL analogy
+## What SkillOpt does differently
 
-| deep learning | SkillOpt |
-|---|---|
-| epoch over the dataset | epoch over the **train** ids (shuffled, seeded by epoch) |
-| mini-batch / gradient accumulation | `--batch-size` train tasks × `--accumulation` per step |
-| learning-rate schedule | **edit-budget** `L` schedule (`--lr-schedule`, decays `--edit-budget` → `--min-edit-budget`) |
-| gradient step | one `run_step` (a bounded edit, gated on val) |
-| momentum / replay | the per-epoch rejected-edit + failure-pattern buffer |
-| LR warm-restart / fine-tune | the epoch-boundary **gated** slow/meta update |
+1. **A decaying integer edit budget `L`.** `lr_schedule.build_schedule` emits one
+   integer per step over `constant | linear | cosine`, clamped to
+   `[--min-edit-budget, --edit-budget]` (`core/cap_evolve/lr_schedule.py:42-55`).
+   `L` is stated to the optimizer in prose — "at most L bounded edits" — and is
+   never mechanically enforced. See the next section before you tune it.
+2. **A per-epoch rejected-edit list.** Each reject appends its candidate id and
+   val Δ, and the next step's prompt asks the optimizer to avoid them
+   (`skillopt.py:120-125`, `:322-327`). It carries no description of *what* the
+   rejected edit changed, so treat it as a weak signal — the run-global
+   `LEDGER.md` that `run_step` already injects names the tasks each prior edit
+   broke and fixed, which is strictly more useful.
+3. **One extra gated step per epoch boundary** (from epoch 2). It compares the
+   epoch-start candidate against the current best, buckets tasks as
+   regressed / persistent-failure / stable-success, and asks for a consolidating
+   edit that fixes regressions without breaking the stable passes. It goes
+   through the same `run_step` and the same val gate — it is never
+   force-accepted (`skillopt.py:479-485`). Disable with `--no-slow-update`.
+   A fourth bucket, `improved`, is computed and logged but is *not* exclusive
+   with the others and never reaches the prompt (`skillopt.py:184-191`, `:139-166`).
 
-`L` is communicated to the optimizer in **natural language only** ("make at most
-L bounded edits") — the LLM is not mechanically clipped — so the loop logs
-*requested-vs-applied* edits to surface an optimizer that ignores its budget.
+Epochs shuffle the train ids seeded by epoch number, so a rerun is reproducible.
+`steps_per_epoch = ceil(len(train) / (batch_size × accumulation))`.
 
-## When to use vs hill-climb / gepa
+## The textual learning rate, stated without the analogy
 
-| algorithm | parent | proposal unit | best when |
-|---|---|---|---|
-| `hill-climb` | current best | whole train set, one-shot each iter | broad gaps; you want the simplest loop |
-| `skillopt` | current best (single lineage) | mini-batch under a shrinking edit budget, epochs + gated slow update | you want disciplined annealing + per-epoch consolidation; a moderately sized train set |
-| `gepa` | sampled from a per-instance **Pareto frontier** | minibatch with a cheap local gate before full val | many specialists the mean hides; merge across lineages |
+The knob is real: `L` decays, it is an integer, and the schedules are correct.
+The *justification* is weaker than the ML vocabulary implies, and pretending
+otherwise would mislead anyone tuning it.
 
-## Inputs / outputs (manifest tokens)
-- **needs:** `scores` + `traces` (per-task val results to reflect on) and
-  `candidate` (the parent to extend).
-- **provides:** `candidate` (the accepted best).
+What plausibly holds: the gate accepts or rejects a whole candidate. A candidate
+bundling six edits where five help and one hurts is rejected entirely, and you
+learn nothing about which edit was the problem. Fewer edits per candidate means
+an accepted candidate is more likely to contain only good edits and a rejected
+one is cheaper to attribute and revert. That argues for small edits — it does not
+by itself argue for *decay*.
 
-## Standalone use
+What does not transfer: in SGD, LR decay exists because nothing stops a large
+step from overshooting near an optimum. Here the val significance gate already
+rejects an overshooting edit before it can become the parent. The overshoot
+protection is the gate, so the decay is not doing that job.
+
+What is unmeasured: no ablation in this repo isolates the schedule's effect.
+At realistic step counts the choice barely exists — over 12 steps from 4 down
+to 2, `linear` and `cosine` differ at 2 of 12 positions. Prefer `constant` or
+`linear` and spend your tuning budget on `--n-trials` and the gate instead. This
+is a heuristic that has not been isolated; do not present it as a proven one.
+
+## Known gaps
+
+These are shipped-behavior defects in `core/cap_evolve/skillopt.py`. The skill
+describes what the code does today, not what it intends to do.
+
+- **The mini-batch never reaches the optimizer** (issue #371). Mini-batch ids come
+  from **train** (`skillopt.py:230`) but filter the parent's **val** rows
+  (`skillopt.py:291` → `harness.py:2011-2012`; also `:315`, `:319`), and splits are
+  disjoint slices (`splits.py:117-119`). Every step renders `0 solid / 0 flaky /
+  0 failing of 0 tasks` with no task ids, and `## Failure patterns still unsolved`
+  never appears — while the `(mini-batch of N train tasks, L=…)` label still
+  prints, which is why it looked healthy. Until #371 lands the per-step signal is
+  the label plus the `L` sentence, so the epoch/mini-batch structure is
+  bookkeeping rather than focus. PR #370 fixed the same defect in hill-climb's
+  `cyclic`/`hardest-first` modes.
+- **The epoch-boundary re-evaluation scores the whole train split, not a sample.**
+  `skillopt.py:458-463` calls `evaluate_candidate(..., split="train")` twice with
+  no `ids=`, then discards everything outside the ~20 sampled ids
+  (`:464-466`). Budget it as `2 × len(train) × n_trials` rollouts per boundary.
+- **When an epoch accepted nothing, the comparison is vacuous.** The re-eval is
+  guarded by `prev_epoch_best_id != run_dir.best_id` (`skillopt.py:455`); if
+  nothing moved, both sides stay `current_val` — the same list — so 0 regressed
+  and 0 improved are reported over **val** tasks while the log line claims a
+  train sample size (`:469-470`). The consolidation step still runs.
+- **`requested_edits` vs `applied_changes` surfaces nothing.**
+  `_changed_components` (`skillopt.py:398-427`) counts files whose bytes differ,
+  not edits, and `applied_changes` is written at `:338`/`:345` and read nowhere —
+  no dashboard column, no check, no warning. A run at `L=4` logged
+  `applied_changes: 6` with no consequence.
+- **"skill" leaks into the live prompt.** `skillopt.py:147` tells the optimizer to
+  compare "the skill" regardless of which capability is under optimization. An
+  algorithm must be capability-agnostic; this text is not.
+
+## Key flags
+
+`--epochs`, `--batch-size`, `--accumulation` (mini-batches per step; multiplies
+the effective batch), `--edit-budget` / `--min-edit-budget` / `--lr-schedule`,
+`--slow-update-sample`, `--no-slow-update`. `--resume`, `--no-regression`,
+`--n-trials`, `--workers`, `--gate-mode`, `--k-se`, `--protected-paths`,
+`--store` behave as in hill-climb.
+
+`--max-iterations` is accepted and **ignored** — the loop is epoch-driven, so
+`cap-evolve run`'s iteration cap has no effect here (`scripts/run.py:42-43`, whose
+help text now says so). Control the step count with `--epochs`/`--batch-size`.
 
 ```bash
 python scripts/run.py --run-dir .capevolve/run_X --project .capevolve/project \
   --optimizer 'python .../run-optimizer/scripts/run.py --name mock --workdir {workdir} --prompt {prompt}' \
-  --epochs 4 --batch-size 8 --edit-budget 4 --lr-schedule cosine --min-edit-budget 2 \
-  --n-trials 4
+  --epochs 4 --batch-size 8 --accumulation 1 \
+  --edit-budget 4 --lr-schedule linear --min-edit-budget 2 --n-trials 4
 ```
 
-Requires `baseline.json` first (like its sibling algorithms). `--resume`
-continues from the run's current best. `--no-slow-update` disables the
-epoch-boundary meta step; `--no-regression` adds a SWE-bench-style dual gate.
-
-## Pitfall: small val sets
-
-The default gate is `significant`/`paired` (NOT naive strict-greater) so a tiny
-val set does not reject every edit on noise. With a small val set, raise
-`--n-trials` (real per-trial variance) or use a **graded** reward so the paired
-significance test has signal. Only the slow update is a "meta" step — it is still
-**gated on val**, never force-accepted, and its train sample is small + counted in
-budget (toggle with `--no-slow-update`).
-
-## Agent-mode loop
-When `orchestration_mode: agent`, drive skillopt yourself: single-lineage climb with a textual learning rate over epochs/minibatches — each step propose an edit sized to the current LR, evaluate on **val** (minibatch then full as skillopt prescribes) via cap-evolve, gate Δ>k·SE, accept→snapshot / reject→revert & decay. Log steps to the run dir; between steps verify rollouts+results landed for the dashboard. Re-read `stop_condition`; stop on it/stall/budget. Seal once with `cap-evolve finalize`, then `report`.
+Requires `baseline.json` first, like its sibling algorithms.
 
 ## References
-- `references/concepts.md` — the SkillOpt loop in detail, the textual-LR schedule,
-  the buffer/slow-update mechanics, and citations (arXiv:2605.23904).
+- `references/concepts.md` — the loop step by step, the schedule shapes with
+  worked values, and the buffer / consolidation mechanics. Load it when you need
+  to change the loop or reason about its rollout cost, not to run it.

--- a/skills/algorithms/skillopt/meta.yaml
+++ b/skills/algorithms/skillopt/meta.yaml
@@ -1,6 +1,6 @@
 component: algorithm
 name: skillopt
-summary: SkillOpt single-lineage climb over epochs x mini-batches with a textual learning rate (integer edit budget on a constant|linear|cosine schedule), a within-epoch rejected-edit buffer, and a gated epoch-boundary slow/meta update.
+summary: SkillOpt single-lineage climb over epochs x mini-batches with a textual learning rate (integer edit budget on a constant|linear|cosine schedule) and a gated epoch-boundary consolidation step. Parent is always the current best; acceptance is the val significance gate.
 entry: scripts/run.py
 abstract: scripts/abstract.py
 check: scripts/check.py

--- a/skills/algorithms/skillopt/references/concepts.md
+++ b/skills/algorithms/skillopt/references/concepts.md
@@ -1,110 +1,143 @@
 # SkillOpt — concepts
 
-SkillOpt (arXiv:2605.23904) is a single-lineage capability optimizer that adapts
-the deep-learning training loop to *textual* skill editing. It sits between
-`hill-climb` (one-shot, whole train set) and `gepa` (a per-instance Pareto
-frontier): like hill-climb the parent is always the current best, but the run is
-organized into **epochs × mini-batches** with a **decaying edit budget** and a
-per-epoch **slow/meta update** — the disciplined annealing hill-climb lacks
-without gepa's frontier bookkeeping.
+Load this when you need to change `skillopt_loop` or reason about its rollout
+cost. To *run* the algorithm, `SKILL.md` is enough.
 
-## Contents
-- [The loop](#the-loop)
-- [Textual learning rate (edit budget)](#textual-learning-rate-edit-budget)
-- [The within-epoch buffer](#the-within-epoch-buffer)
-- [The epoch-boundary slow / meta update](#the-epoch-boundary-slow--meta-update)
-- [Honesty + pitfalls](#honesty--pitfalls)
-- [Where it lives](#where-it-lives)
+SkillOpt (arXiv:2605.23904, *Executive Strategy for Self-Evolving Agent Skills*)
+is a single-lineage capability optimizer: like `hill-climb` the parent is always
+the current best, but the run is organized into epochs over mini-batches with a
+decaying integer edit budget and one extra consolidation step per epoch. It edits
+whatever the selected capability owns; nothing in the loop assumes a skill
+package, despite the name.
 
 ## The loop
 
 `cap_evolve.skillopt.skillopt_loop(adapter, *, run_dir, optimizer, current_val, …)`:
 
-1. Initialize memory + version store (`harness._init_memory_store`). Compute
-   `steps_per_epoch = ceil(len(train) / (batch_size·accumulation))`,
+1. Init memory + version store (`harness._init_memory_store`). Compute
+   `steps_per_epoch = ceil(len(train) / (batch_size · accumulation))`,
    `total_steps = epochs · steps_per_epoch`, and the integer edit-budget schedule
    `build_schedule(lr_schedule, max=edit_budget, min=min_edit_budget, total=total_steps)`
    (default `cosine`, 4 → 2).
-2. **Each epoch**: shuffle the train ids (seeded by epoch), reset the per-epoch
-   `step_buffer` and `rejected_this_epoch`, and snapshot the epoch-start skill as
-   `prev_epoch_skill`.
+2. **Each epoch**: shuffle the train ids (`random.Random(1000 + epoch)`, so a
+   rerun reproduces), reset the per-epoch `step_buffer` and `rejected_this_epoch`,
+   and record the epoch-start candidate id.
 3. **Each step**: take the accumulation window of the shuffled order as the
-   mini-batch; build focus instructions over ONLY those tasks
-   (`harness._focus_instructions(current_val, focus_ids=minibatch_ids, …)`) and
-   append the SkillOpt buffer block (the edit budget `L`, the rejected edits to
-   avoid this epoch, the unsolved failure patterns). Parent is **always the
-   current best** (single lineage). Call `harness.run_step(...)` — it materializes
-   the parent, runs the optimizer, evaluates on VAL, applies the significance
-   gate, snapshots + sets best on accept, and writes RejectedMemory/History.
+   mini-batch and build the instruction string —
+   `harness._focus_instructions(current_val, focus_ids=minibatch_ids, label)` plus
+   the SkillOpt block (`L`, the rejected ids to avoid this epoch, the unsolved
+   failure patterns). **Both the focus filter and the failure-pattern filter are
+   currently empty by construction — see the gap below.** Parent is always the
+   current best. `harness.run_step(...)` does the rest: materialize, optimize,
+   evaluate on val, apply the gate, snapshot + set best on accept, write
+   RejectedMemory/History.
 4. Append a bounded record to `step_buffer`
    (`{step, epoch, accepted, n_fail, failure_patterns, rejected id + val Δ}`),
-   capped (≤ 3 task ids per pattern, ≤ ~10 patterns, ≤ 12 steps) and **reset each
-   epoch** so the prompt cannot balloon.
-5. Update `current_val` only on accept (equivalent to reading back `run_dir.best`,
-   as hill-climb does).
-6. **End of epoch** (from epoch 2, if slow-update on): the gated slow/meta update
-   (below).
-7. Return a result dict (best id, val reward, accept/reject counts, the schedule,
-   per-epoch stats, slow-update records) — shaped like `hill_climb_loop`'s.
+   capped at ≤3 task ids per pattern, ≤10 patterns, ≤12 steps
+   (`_MAX_*` in `skillopt.py:58-60`), and reset each epoch so the prompt cannot
+   balloon. Note `_MAX_BUFFER_STEPS` — a *step* cap — is reused to slice the
+   *reject* list at `skillopt.py:122`.
+5. Update `current_val` only on accept.
+6. **End of epoch** (from epoch 2, unless `--no-slow-update`): the gated
+   consolidation step below.
+7. Return a result dict shaped like `hill_climb_loop`'s, plus `epochs`,
+   `edit_budget_schedule`, `epoch_stats` and `slow_updates`.
+
+### Gap: the mini-batch is not actually in focus (issue #371)
+
+`minibatch_ids` come from `run_dir.read_splits().train` (`skillopt.py:230`) but
+are used to filter the parent's **val** per-task rows (`skillopt.py:291`,
+`:315`, `:319` → `harness.py:2011-2012`). `make_splits` assigns train/val/test as
+disjoint slices of one shuffled list (`splits.py:117-119`), so every filter
+yields nothing. Observed on `SyntheticAdapter(n=12)`:
+
+```
+train: ['t1','t9','t8','t5','t10','t2']   val: ['t3','t7','t4']   train ∩ val: set()
+Focus: epoch 1/1 step 1/3 (mini-batch of 2 train tasks, L=4).
+Current val reward 0.000: 0 solid / 0 flaky / 0 failing of 0 tasks.
+'## Failure patterns still unsolved' ever rendered? False
+```
+
+So `n_fail` is always 0 and step 4's `failure_patterns` is always `[]`. Fixing
+this means either evaluating the mini-batch on **train** and reflecting on that
+result (gepa's `_eval_minibatch` exists for exactly this) or deriving the focus
+ids from val. The two readings imply different rollout costs; #371 is the
+decision.
 
 ## Textual learning rate (edit budget)
 
-The "learning rate" is how many edits the optimizer may make in one step: a large
-budget early to explore broadly, shrinking later to consolidate. We reuse the
-familiar `constant | linear | cosine` LR shapes from `core/lr_schedule.py` but
-emit **integers** (you cannot make 2.7 edits). `L` is passed to the optimizer in
-**natural language** ("make at most L bounded add/delete/replace edits") — the LLM
-is *not* mechanically clipped — so the loop logs **requested-vs-applied** (a
-best-effort file-diff count) to surface an optimizer that ignores its budget.
+`core/cap_evolve/lr_schedule.py`. Integers only — you cannot make 2.7 edits —
+clamped to `[min_lr, max_lr]`, `total_steps <= 0` yields `[]`, and `constant` or
+`total_steps == 1` sits at `max_lr` (`lr_schedule.py:42-55`). Worked values,
+`max=4 min=2 total=12`:
+
+```
+constant  [4,4,4,4,4,4,4,4,4,4,4,4]
+linear    [4,4,4,3,3,3,3,3,3,2,2,2]
+cosine    [4,4,4,4,3,3,3,3,2,2,2,2]
+```
+
+`linear` and `cosine` differ at 2 of 12 positions. Over a 3-value integer range
+the schedule choice is close to a no-op; `SKILL.md` § "The textual learning rate"
+argues why the decay is a heuristic rather than a demonstrated mechanism.
+
+`L` reaches the optimizer as prose only; nothing clips the edit count. The
+`requested_edits` / `applied_changes` pair logged at `skillopt.py:338` is not a
+guardrail: `_changed_components` (`:398-427`) counts files whose bytes differ,
+and `applied_changes` is read by nothing in `core/`, `dashboard/` or `skills/`.
 
 ## The within-epoch buffer
 
-Two per-epoch, bounded structures injected into the next step's prompt:
+Two per-epoch bounded structures appended to the next step's prompt:
 
-- **rejected-edit buffer** — every rejected candidate's id + val Δ, so the
-  optimizer does not re-propose a dead end *this epoch* (the global RejectedMemory
-  in `run_step` still records all rejects across the run).
-- **failure-pattern block** — the focus tasks' failing feedback clustered by a
-  normalized prefix signature (infra-errored tasks excluded via the structured
-  `raw.errored` flag), so the prompt carries *patterns* not raw prose.
+- **rejected-edit list** — each rejected candidate's id and val Δ
+  (`skillopt.py:120-125`). It does not carry the *content* of the rejected edit,
+  so an optimizer cannot avoid an approach it was never shown. The `LEDGER.md`
+  that `run_step` injects into every workdir already lists each prior edit's
+  outcome and the tasks it broke and fixed, run-global rather than per-epoch —
+  strictly stronger. Treat this list as redundant.
+- **failure-pattern block** — failing feedback clustered by a normalized 8-word
+  prefix, infra-errored tasks dropped via `raw.errored` (`skillopt.py:65-93`).
+  Sound logic, currently fed an empty list (see the gap above).
 
-Both reset at the epoch boundary; both are length-capped (`_MAX_*` constants) so
-the optimizer prompt stays small as the run grows.
+## The epoch-boundary consolidation step
 
-## The epoch-boundary slow / meta update
+From epoch 2, compare the epoch-start candidate against the current best and
+bucket each task:
 
-Paper §3.6's **gated** mode. At the end of each epoch (from epoch 2), re-evaluate
-the epoch-start skill snapshot vs the current best on a **small sampled TRAIN
-subset** (default ~20 ids), categorize each task:
-
-- **improved** — reward rose;
 - **regressed** — passed at epoch start, now failing;
-- **persistent_fail** — failing both epochs;
-- **stable_success** — passing both epochs.
+- **persistent_fail** — failing both times;
+- **stable_success** — passing both times;
+- **improved** — reward rose. Computed with a bare `if` before the exclusive
+  chain (`skillopt.py:184-191`), so a 0.2 → 0.5 task lands in both `improved` and
+  `persistent_fail`; `_slow_update_instructions` (`:139-166`) renders only the
+  first three. Read `improved` as an overlapping counter, not a partition member.
 
-Build a longitudinal instruction ("fix the REGRESSIONS and chip at the PERSISTENT
-failures without breaking any STABLE SUCCESS") and run ONE extra `run_step` —
-**gated on val exactly like a normal step**. It is *never* force-accepted and
-*never* bypasses the val gate to mutate best. The sample is small, toggleable
-(`--no-slow-update`), and counted in budget.
+The longitudinal instruction ("fix the REGRESSIONS and chip at the PERSISTENT
+failures without breaking any STABLE SUCCESS") goes through one ordinary
+`harness.run_step` (`skillopt.py:479-485`) — same val gate, never force-accepted.
+`skills/algorithms/skillopt/scripts/check.py:108-112` asserts the step carries a
+gate decision, which is the regression guard on that property.
 
-## Honesty + pitfalls
+### Gap: the cost and the comparison
 
-- **Gate on val, test sealed.** Acceptance always routes through `gate.decide` on
-  the VAL split; the test seal is only touched by `finalize`.
-- **Default to `significant`/`paired`, not strict.** A tiny val set with a naive
-  strict-greater gate rejects almost everything on noise. With a small val set,
-  raise `--n-trials` for real per-trial variance, or use a **graded** reward so
-  the paired significance test has signal.
-- **Only the slow update is "meta", and it is still gated** — never a force-accept.
-- **Reset + bound the buffer per epoch** so the optimizer prompt does not balloon.
-- **`L` is natural-language only** (no mechanical clip); log requested-vs-applied.
+- The re-evaluation calls `harness.evaluate_candidate(..., split="train")` twice
+  with **no** `ids=` (`skillopt.py:458-463`) and only then filters to the ~20
+  sampled ids (`:464-466`). Budget `2 · len(train) · n_trials` rollouts per
+  epoch boundary, not `2 · sample · n_trials`.
+- The re-eval is guarded by `prev_epoch_best_id != run_dir.best_id`
+  (`skillopt.py:455`). If the epoch accepted nothing, both sides remain
+  `current_val` — the identical list — so the buckets are computed over **val**
+  tasks and report 0 regressed / 0 improved, while the logged `sample=` is a
+  train count that was never scored (`:469-470`). The consolidation step runs
+  anyway, on an instruction describing no actual change.
+- `skillopt.py:147` writes "the skill" into that prompt for every capability
+  type. An algorithm must not name a capability it cannot know.
 
 ## Where it lives
 
 - Loop: `core/cap_evolve/skillopt.py` (`skillopt_loop`).
 - Schedule: `core/cap_evolve/lr_schedule.py` (`build_schedule`).
-- The honesty-critical step: `core/cap_evolve/harness.py` (`run_step`,
-  `evaluate_candidate`, `_focus_instructions`, `_init_memory_store`).
-
-Citation: SkillOpt, arXiv:2605.23904.
+- The shared step: `core/cap_evolve/harness.py` (`run_step`,
+  `evaluate_candidate`, `_focus_instructions`, `_init_memory_store`) — its
+  contract is documented by `algorithms/hill-climb`.

--- a/skills/algorithms/skillopt/scripts/run.py
+++ b/skills/algorithms/skillopt/scripts/run.py
@@ -40,7 +40,7 @@ def main(argv=None) -> int:
     # sequencer passes --max-iterations to every algorithm, but skillopt is
     # epoch-driven — set --epochs to control the step count.
     p.add_argument("--max-iterations", type=int, default=0,
-                   help=argparse.SUPPRESS)
+                   help="IGNORED — this loop is epoch-driven; use --epochs/--batch-size")
     p.add_argument("--batch-size", type=int, default=None,
                    help="train tasks per mini-batch (default min(8, len(train)))")
     p.add_argument("--accumulation", type=int, default=1,


### PR DESCRIPTION
Closes #331.

`skills/algorithms/skillopt/` sold three mechanisms; one of them does not reach the optimizer at
all. This PR makes the skill truthful about **shipped** behavior. **`core/cap_evolve/skillopt.py` is
not touched** — #371 owns the mini-batch fix and another agent may take it; every divergence that
needs code is stated under `## Known gaps` with `file:line` and the owning issue.

## Claim-vs-code table

| # | Claim (old file:line) | Code reality | Verdict | Action |
|---|---|---|---|---|
| 1 | mini-batch of train tasks is what the step focuses on — `SKILL.md:11`, `:36`, `concepts.md:31-35` | ids from `splits.train` (`skillopt.py:230`) filter the parent's **val** rows (`:291` → `harness.py:2011-2012`); disjoint slices (`splits.py:117-119`) → always empty | **false** | text corrected; `## Known gaps` → #371 |
| 2 | failure-pattern buffer injected into the prompt — `SKILL.md:20-21`, `concepts.md:66-69` | `_failure_patterns(cand_val.per_task, focus_ids=minibatch_ids)` (`:315`), `keep` filter at `:75-77` empties it, so `:131` is never true | **false** | same root cause, same gap entry |
| 3 | buffer records `n_fail` — `concepts.md:41` | `:319` always `0` | **false** | stated in `concepts.md` |
| 4 | rejected-edit buffer stops the optimizer re-proposing a dead end — `SKILL.md:20-21` | real (`:120-125`, `:322-327`) but emits only candidate id + val Δ, no edit content; `LEDGER.md` (already in every prompt) names the tasks each edit broke/fixed | **true but weak** | reworded as a weak signal, redundant with `LEDGER.md` |
| 5 | `constant\|linear\|cosine` integer edit budget, clamped — `SKILL.md:19` | `lr_schedule.py:20`, `:42-55`; verified `linear`/`cosine` over 12 steps 4→2 | **true** | kept, with worked values |
| 6 | epoch-boundary meta update is **gated** on val, never force-accepted — `SKILL.md:24` | `:479-485` routes through `run_step`; `scripts/check.py:108-112` asserts a gate decision | **true** | kept |
| 7 | re-eval on "a small sampled TRAIN subset (~20 ids)", "a tiny, counted cost" — `concepts.md:77-78`, `:88-89` | `:458-463` calls `evaluate_candidate(split="train")` twice with **no `ids=`**, then filters at `:464-466` | **false** | corrected to `2 × len(train) × n_trials`; gap entry |
| 8 | "re-evaluate the epoch-start skill vs the current best" — `SKILL.md:22-23` | `:455` guard skips the re-eval when the epoch accepted nothing; both sides stay `current_val` (same list) and the buckets are over **val** while `:469-470` logs a train sample size | **false in the common case** | gap entry; reproduced live below |
| 9 | improved / regressed / persistent / stable is a partition — `SKILL.md:23`, `concepts.md:78-83` | `:184` bare `if improved` before an independent `if/elif` chain → a 0.2→0.5 task is both `improved` and `persistent_fail`; `_slow_update_instructions` (`:139-166`) renders 3 of 4 | **misleading** | documented as an overlapping counter that never reaches the prompt |
| 10 | logs requested-vs-applied "to surface an optimizer that ignores its budget" — `SKILL.md:43-45` | `_changed_components` (`:398-427`) counts **files whose bytes differ**; `applied_changes` written at `:338`/`:345`, `grep` finds no reader in `core/`, `dashboard/`, `skills/` | **false** | claim removed; gap entry |
| 11 | capability-agnostic (CONTEXT.md principle 1) | `:147` puts "the **skill**" into the live optimizer prompt for any capability | **violation** | skill text made capability-neutral; core string flagged as a gap |
| 12 | `--max-iterations` honored (implied by `cap-evolve run`) | `scripts/run.py:42-43` accepts and drops it under `argparse.SUPPRESS` | **false** | documented; help text un-suppressed |
| 13 | `--accumulation` is the gradient-accumulation analogue — `SKILL.md:37` | real (`:241`) but absent from `argument-hint` and the example | **true, hidden** | added to both |
| 14 | `arXiv:2605.23904` | resolves — *SkillOpt: Executive Strategy for Self-Evolving Agent Skills* | **true** | kept, title added |

**14 rows: 10 divergences (1,2,3,7,8,9,10,11,12 + 4 as overstated) — 5 fixed in text alone
(3,4,9,12,13-as-omission), 5 flagged under `## Known gaps` because they need code (1/2/3 → #371,
7, 8, 10, 11). 4 verified-true claims kept.**

## The "textual learning rate", bluntly

The knob is real. The justification was borrowed, so the skill now argues it and concedes the parts
that do not survive:

- **What holds:** the gate accepts or rejects a *whole candidate*. Six edits where five help and one
  hurts is rejected entirely and teaches nothing. Fewer edits per candidate ⇒ an accepted candidate
  more likely contains only good edits, and a rejected one is cheaper to attribute and revert. That
  argues for **small** edits — not for **decay**.
- **What does not transfer:** in SGD, LR decay exists because nothing prevents overshoot near an
  optimum. Here the val significance gate already rejects an overshooting edit before it can become
  the parent. The overshoot protection is the gate, so the decay is not doing that job.
- **What is unmeasured:** no ablation isolates the schedule. Over 12 steps from 4→2, `linear` and
  `cosine` differ at **2 of 12** positions — a three-value tuning surface that cannot matter. The
  skill now says to prefer `constant`/`linear` and spend the budget on `--n-trials` and the gate.

The old DL analogy table (`:32-41`) is deleted. One of its rows was also backwards: it mapped
"momentum / replay" to the rejected-edit buffer, but momentum *reinforces* a direction while a
reject list *forbids* one.

## Ownership contract

`algorithms/hill-climb` owns the shared parent-selection / gate / commit mechanics. The skill now
points at `hill-climb/SKILL.md § "One iteration, end to end"` and
`hill-climb/references/run-step.md` (both land with #370 — the pointer names that dependency and
falls back to `harness.run_step` meanwhile) and states only what SkillOpt does differently.

It also states #370's finding up front, because it bounds the honest claim: **`run_step` lets a
caller vary exactly two things, `parent_dir` and `instructions`.** SkillOpt pins `parent_dir` to the
current best (identical to hill-climb), so everything novel lives in the instruction string plus the
choice to run one extra step per epoch. It is prompt shaping and step scheduling, not a different
search — and saying so is more useful than implying a new algorithm.

Deleted as restatements with another owner (**~26 lines**), per PR #369's list:

- `:55-58` `## Inputs / outputs (manifest tokens)` — 4 lines. Near-byte-identical to
  `hill-climb:32-35`, and it restated this file's own frontmatter `needs:`/`provides:` *and*
  `meta.yaml:7-8`. The frontmatter is the contract.
- `:82-83` `## Agent-mode loop` — 2 lines. Owner `orchestrate/orchestrate`; the paraphrase had
  already drifted from gepa's and hill-climb's copies of the same paragraph.
- `:47-53` the 3-row routing table — 7 lines. Owner should be `using-cap-evolve` (per #369); gepa's
  6-row table and this one disagreed and both were stale against the five-algorithm set. The
  boundary clause survives in the description.
- `:73-80` `## Pitfall: small val sets` — 8 lines. Restated `concepts.md:94-101` sentence for
  sentence, and it is a property of `gate.decide`, not of skillopt.
- `:29-30` honesty-invariant restatement ("Gated on val; test stays sealed (that's `finalize`)") and
  `concepts.md:91-101` `## Honesty + pitfalls` — 5 lines. Owners `phases/gate` / `finalize` /
  `report`; core enforces all of it. Which split each *stage* reads is kept — that is mechanism.
- `concepts.md:11-17` table of contents — 7 lines. `skill-creator/SKILL.md` asks for one only above
  300 lines; the file is 143.

No instruction was lost: every deletion is a restatement whose owner states it in full, and every
rule unique to skillopt (the schedule, the buffer bounds, the epoch boundary, the gate on the slow
step) is kept.

### Generic, not specific

The name says "skill" but the algorithm must be capability-agnostic. `SKILL.md` and `concepts.md`
now say **capability** everywhere and state once that "SkillOpt" is the paper's name. The remaining
violation is in core (`skillopt.py:147` writes "the skill" into the live prompt) and is listed under
`## Known gaps` rather than fixed here.

### What the siblings should drop (not touched — other agents own those files)

- `hill-climb/SKILL.md:32-35` `## Inputs / outputs (manifest tokens)`; `:53`'s restated shared rules.
- `using-cap-evolve` should own the single five-algorithm routing table; after #369 and this PR
  nothing owns it.

## Evidence

`wc -l`: `SKILL.md` **87 → 139**, `references/concepts.md` 110 → 143. Body is 130 lines / ~1.9k
tokens against the ≤500-line, ≤5000-token budget; description 557 chars / 85 words, third person,
no XML, no CRITICAL/ALWAYS/MUST. One reference, one level deep, with an explicit
what-it-contains + when-to-load pointer. The net growth is deliberate: ~26 lines of boilerplate out,
five documented gaps and the honest LR argument in — the same trade #369 made for `gepa`.

```
$ python skills/algorithms/skillopt/scripts/check.py
ok: True   problems: []
notes: run entry exposes main() / schedules: ('constant','linear','cosine') /
       edit-budget anneal (cosine 4->2 over 8): [4,4,4,3,3,2,2,2] /
       ran 2 epochs, 5 steps, 0 accepts /
       non-improving optimizer -> 2 rejected edits buffered /
       per-epoch buffer bounded to 12 steps /
       slow updates: [{'epoch': 2, 'action': 'rejected', 'accepted': False}] /
       slow update is gated on val (carries a gate decision) /
       test split sealed throughout (never consumed)
```

```
$ PYTHONPATH="$PWD/core:$PWD/dashboard/backend" python -m pytest core/tests -q
789 passed, 12 skipped in 111.77s
```
matches clean main per #349.

### #371 reproduced independently (the proof the gap entry is real)

Zero-API, `SyntheticAdapter(n=12)`, `harness.run_step` wrapped to capture the rendered
`instructions`:

```
train: ['t1','t9','t8','t5','t10','t2']   val: ['t3','t7','t4']   train & val: set()

Focus: epoch 1/1 step 1/3 (mini-batch of 2 train tasks, L=4).
Current val reward 0.000: 0 solid / 0 flaky / 0 failing of 0 tasks.

val ids appearing in prompt:   []
train ids appearing in prompt: []
'## Failure patterns still unsolved' ever rendered? False    (3 steps captured)
```

The label reports a real mini-batch size; the prompt contains **no task id from either split** and
the failure-pattern block never renders. Confirmed again in the full CLI run below — every
`candidates/*/INSTRUCTIONS.md` carries `0 solid / 0 flaky / 0 failing of 0 tasks`.

### Zero-API skillopt run through the gate to a sealed test score

`examples/toy_calc`, `mock` optimizer, `algorithm_skill: skillopt`:

```json
{ "run_dir": ".capevolve/run_so331", "best_id": "so_e01s01",
  "baseline_val": 0.0, "test_reward": 1.0, "test_baseline_reward": 0.0,
  "test_delta": 1.0, "test_pass_k": {"1": 1.0}, "iterations": 3 }
```

The same run reproduces three more documented gaps on live output:

```
skillopt_step  epoch=1 edit_budget=4 requested_edits=4 applied_changes=6 accept=True
skillopt_step  epoch=2 edit_budget=4 requested_edits=4 applied_changes=6 accept=False
skillopt_slow_eval epoch=2 sample=4 regressed=0 persistent_fail=0 stable_success=2 improved=0
```

`applied_changes: 6` under `L=4`, twice, with no consequence anywhere (gap 10). And
`sample=4` train ids logged while only 2 **val** rows were actually categorized — the epoch-2
boundary hit the `:455` guard (`prev_epoch_best_id == best_id`) and compared `current_val` to
itself, exactly as gap 8 describes.

## Core work this leaves open

- **#371** — the mini-batch must reach the optimizer. Decide train-eval (gepa's `_eval_minibatch`)
  vs val-derived focus ids; #370 chose val for hill-climb. `check.py` should then assert a step's
  rendered instructions contain a real task id, which is the assertion whose absence let this ship
  green.
- Pass `ids=sample_ids` to both `evaluate_candidate` calls at `skillopt.py:458-463`.
- Skip the consolidation step (record `skipped`) when the epoch accepted nothing.
- Either make `applied > L` emit an event the dashboard shows and `check.py` asserts, or delete
  `_changed_components` and the requested-vs-applied logging (~30 lines).
- `s/skill/capability/` in `skillopt.py:147` and every other prompt-bearing string.
- `_MAX_BUFFER_STEPS` (a *step* cap) is reused to slice the *reject* list at `:122`.

Not filed here as new issues to avoid duplicating #331's list; each is an acceptance criterion there.
