### PR TITLE
diagnose: state the taxonomy once, specify the clustering procedure, script the deterministic half

### DIFF
--- a/skills/phases/diagnose/SKILL.md
+++ b/skills/phases/diagnose/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: diagnose
-description: Extract the learning signal from execution traces — the textual analogue of a gradient. Use between evaluation and proposing edits. Reads a candidate's val rollouts, separates good signals to keep from bad signals to fix, builds a reflective dataset (per failing task — Inputs, Generated Outputs, Feedback) and groups failures into clusters by shared signature, so the optimizer knows what to change and why.
+description: Extract the learning signal from execution traces — the textual analogue of a gradient. Use between evaluation and proposing edits. Reads a candidate's rollouts and traces, separates good signals to keep from bad signals to fix, builds a reflective dataset (per failing task — Inputs, Generated Outputs, Feedback) and clusters the failures by a (failure-site, violated-expectation) signature, ranked by the score each cluster can recover, so the optimizer knows what to change and why.
 component: phase
-argument-hint: "--run-dir DIR --tag CANDIDATE_ID"
+argument-hint: "--run-dir DIR --tag CANDIDATE_ID [--project DIR] [--split train|val] [--cluster root-cause|first-words]"
 allowed-tools: Read, Bash
 provides: [reflective_dataset]
 needs: [scores, traces]
@@ -11,169 +11,159 @@ sources: [gepa, skillgrad, trace2skill, evo]
 
 # diagnose — failures into actionable side information
 
-A scalar reward says *how much* a candidate failed; it does not say *why*, and
-"why" is the only thing an editor can act on. diagnose converts raw traces into
-the signal the optimizer edits against — the **textual analogue of a gradient**.
-In reinforcement learning a scalar reward back-propagates into weight updates;
-here, natural-language feedback back-propagates into prompt/tool/skill edits. The
-richer that feedback, the larger the update you can extract from a handful of
-rollouts.
-
-## Inputs / outputs (manifest tokens)
-- **needs:** `scores`, `traces` — the per-task rewards and rollouts from
-  `evaluate` (with the scorer's textual feedback).
-- **provides:** `reflective_dataset` — the structured "what to change and why"
-  that the algorithm injects into the optimizer's proposal prompt.
+A scalar reward says *how much* a candidate failed; it does not say *why*, and "why"
+is the only thing an editor can act on. Where RL back-propagates a scalar into
+weights, natural-language feedback back-propagates into prompt/tool/skill edits —
+and the richer it is, the larger the update extractable from a handful of rollouts.
 
 ## What it produces
-- **reflective_dataset:** for each *failing* task, `{Inputs, Generated Outputs,
-  Feedback}` — GEPA's reflective-dataset shape. This triple lets the optimizer see
-  the task, what the agent actually did, and the diagnosis, instead of a bare
-  score.
-- **clusters:** ALL failing trajectories grouped by shared root cause, so the
-  optimizer can fix a whole *class* of failure with one principled edit rather
-  than patching tasks one at a time (and overfitting to each). "Failing" here is
-  not only zero-score tasks — explicitly include **partial-credit** failures (a
-  task that scored e.g. 0.5 because a write got the wrong arguments) and
-  **communication / omission** failures (the agent did the action but failed to
-  report or confirm the required information). These are real lost score and are
-  routinely missed when only total failures are clustered. Each cluster is
-  **ranked by cost** — how many tasks (and how much aggregate score) it accounts
-  for — so the biggest lever is addressed first. Cost-rank, but DON'T let a small
-  cluster that needs a STRUCTURAL fix (a new composite tool) get buried under
-  task-count: a 2-task stall cluster cracked by one new tool can outweigh a
-  many-task cluster of cosmetic misses. Each cluster is tagged with ONE of three,
-  so the optimizer knows *where* the fix belongs:
-  - **KNOWLEDGE** — the agent doesn't know a format/rule/criterion → fix in the prompt.
-  - **BEHAVIORAL** — the agent KNOWS the rule but violates it on a tool that exists
-    → fix in that EXISTING tool's body (an in-code guard).
-  - **DECISION / PERMISSION (ACT vs REFUSE)** — a cluster about *whether the agent should
-    ACT or REFUSE/escalate* on a policy-governed class (it acted where it should have
-    refused, or refused where it should have acted). Tag it SEPARATELY so it is NOT
-    "fixed" by loosening a global decision/permission/refusal rule in the prompt — a
-    global change flips behavior for the ENTIRE class and regresses every
-    currently-passing task where the original behavior was gold (UNBOUNDED blast radius;
-    this exact mistake sank a prior run). Fix = the EXACT discriminating CONDITION:
-    ideally an in-body guard (tools) that refuses/raises only on the qualifying
-    predicate; or prose-only, a NARROWING rule. Its blast radius is EVERY passing task in
-    the decision class — name them and confirm the fix won't flip their action.
-  - **CAPABILITY-GAP** — the agent has NO reliable way to do the thing, or it
-    narrates/confirms a multi-step action then STALLS and never executes it → fix with
-    the strongest STRUCTURAL lever the SELECTED capability offers (per its
-    `./guidance/<cap>/SKILL.md`): for a tools capability, a NEW code-bearing tool (a
-    composite atomic-WRITE / loop / validation tool); for a prompt/skill capability, an
-    explicit step-by-step procedure or worked example that makes the step unavoidable.
-    This is its own tag precisely so a stall/gap cluster is NOT mis-filed as BEHAVIORAL
-    and "fixed" with a weak nudge that never works.
-- **kept_good:** tasks already passing — the set the gate's no-regression check
-  must protect, so a fix for one cluster does not silently break a passing task.
 
-## The signal the optimizer iterates on (analyze → ideate → edit)
-The reflective dataset feeds a fixed three-step shape the algorithm encodes into
-the per-iteration optimizer INSTRUCTIONS — the optimizer must **analyze before it
-edits**, never patch blindly:
-1. **Analyze the trajectories DEEPLY first.** Read the traces closely (not a
-   skim) alongside the current capability, and name (a) the MAIN RECURRING root-cause
-   *clusters* — the rules and workflows the agent botches, the steps it skips, the
-   tools it mis-uses or repeats N times. Cluster **ALL** failing trajectories by
-   shared root cause, not only the zero-score ones: include **partial-credit**
-   failures (wrong arguments to a write, a missed required action) and
-   **communication / omission** failures (the action was done but the required
-   info was never reported/confirmed) — these lose real score and are easy to
-   overlook. **Rank the clusters by how much they cost** (tasks affected ×
-   score lost), biggest first, with evidence. For each cluster, tag it **KNOWLEDGE**
-   (lacks a format/rule/criterion → prompt), **BEHAVIORAL** (knows the rule but
-   violates it on an existing tool → in-code guard in that tool's body),
-   **DECISION / PERMISSION** (wrong ACT-vs-REFUSE call on a policy-governed class →
-   discriminating-condition guard, NEVER a global prompt rule change: a global change
-   regresses the whole class; the blast radius is EVERY passing task in that decision
-   class, so name them and confirm the fix doesn't flip their action), or
-   **CAPABILITY-GAP** (no reliable way to do it, or stalls at the action boundary
-   and never executes → the strongest STRUCTURAL lever the SELECTED capability offers
-   per its guidance: a NEW composite/loop/validation tool for a tools capability, or an
-   explicit procedure/worked example for a prompt/skill capability): more prose alone
-   will not fix a behavioral OR capability-gap cluster — the first needs the rule in
-   code/structure, the second a new mechanism that makes the action un-skippable.
-   Also surface a **NEAR-MISS** cluster: tasks scoring high-partial (≈0.7–0.9) that
-   need only one small correct change to flip to a pass — these are the cheapest
-   marginal gain per edit and are easy to miss when you focus on zero-score tasks.
-   For a multi-cause task, note its **secondary** cause too (a residual second-pass),
-   so one candidate can fix both the primary and the residual cause in the same edit.
-   For EACH cluster, also note its **blast radius** — the currently-PASSING tasks whose
-   behavior the fix would change. For a tool-body guard that is the tasks exercising the
-   same tool/rule/path; for a DECISION / PERMISSION cluster it is EVERY passing task in
-   the same decision class (a global rule change would flip all of them). Scope the fix
-   to fire only on the failing condition and confirm it does not change the action on any
-   passing task in that radius; and cross-check the run history (LEDGER / prior
-   iterations) to SKIP any cluster whose fix was already tried and rejected (don't
-   re-diagnose a refuted approach). A cluster's value is the score it can recover MINUS
-   the regression risk to its blast radius. List concrete passing task ids per cluster
-   (not just "the same tool") whenever you can, so the edit can be scoped to fire only on
-   the failing condition and checked against those passing tasks.
-   Then name (b) the GOOD behaviors that occur only *sometimes* (tasks whose mean
-   reward is between 0 and 1 pass on some trials and fail on others); identify what
-   the good runs do so it can be made CONSISTENT. (Always-failing tasks, mean ≈ 0,
-   are a root-cause fix; flaky tasks are a consistency/reinforcement fix — a
-   different edit. The per-task `Feedback` line is from the *last* trial and can
-   disagree with a graded mean; the reward is the honest signal.) If your coding agent
-   supports parallel sub-agents, fan them out — one per failure cluster or per
-   candidate-edit hypothesis — to analyze concurrently, then synthesize; it makes
-   each costly iteration deeper and faster.
-   **Use ground-truth / eval signals when the traces provide them.** Some benchmarks
-   copy ground-truth / expected actions / a reward breakdown into the trajectories;
-   when PRESENT, use them to pinpoint exactly what went wrong — which action,
-   argument, or value was expected vs what the agent did. You will NOT always have
-   this: if you do, use it; if not, infer from the traces + feedback. CRITICAL:
-   ground truth is for UNDERSTANDING the failure class only — the resulting EDIT must
-   still be a GENERAL rule, never a copied gold value (see the no-leak rule).
-2. **Then ideate a DRASTIC, generalizing edit.** Each iteration is costly
-   (optimize + full eval is long), so aim for a big root-cause improvement, not a
-   tiny tweak: propose the single best targeted edit (or tight set) that addresses
-   the biggest cluster from (a) and reinforces (b) — concrete, generalizing across
-   the class, never a one-off patch to one task. When the capability is the agent's
-   own tools, PREFER writing a new code-bearing tool over a docstring tweak — a
-   deterministic tool can't be forgotten the way a prompt rule can: wrap a primitive
-   to enforce a general rule (then remove the raw primitive), or collapse a recurring
-   multi-step workflow into one looped tool. Write a real body, not `...`.
-3. **Then edit and stop.** Apply it; the harness re-scores. Be economical — no
-   narration, no exploring unrelated files, do exactly what's needed and finish.
+```json
+{
+  "split": "val", "tag": "cand_003",
+  "reflective_dataset": [
+    {"task_id": "t12", "Inputs": "<what the task asked>",
+     "Generated Outputs": "<what the agent produced>",
+     "Feedback": "<the scorer's diagnosis>",
+     "Trajectory": "<path to this task's full trace>"}
+  ],
+  "clusters": [
+    {"signature": "confirm write", "tasks": ["t12", "t19"], "score_lost": 1.6,
+     "tag": "BEHAVIORAL", "blast_radius": ["t3", "t7"]}
+  ],
+  "kept_good": ["t1", "t4"]
+}
+```
 
-## Turning traces into an actionable signal (the real work)
-A good diagnosis is **specific, causal, and general**:
-- **Specific:** name the concrete failure (the wrong tool call, the missing step,
-  the misread field), not "the answer was wrong".
-- **Causal:** point at the decision that caused it, so the edit has a target.
-- **General:** describe the *pattern*, not the instance. Feedback that quotes the
-  gold answer turns the optimizer into a memorizer of the eval set and corrupts
-  the held-out number — keep it at the level of "what class of mistake", never
-  "here is the solution".
+`scripts/run.py` emits everything except `tag` (one of KNOWLEDGE, BEHAVIORAL,
+DECISION / PERMISSION, CAPABILITY-GAP) and `blast_radius`, which it leaves `null`
+because they need judgement — filling them in is the work below. `kept_good` is the
+set the gate's no-regression check protects.
 
-Clustering is what makes the signal *actionable* at scale: ten tasks failing for
-one reason should drive one edit, not ten. A flat list of failures invites
-one-off patches that raise val by overfitting; a clustered list invites a single
-generalizing change. This mirrors the lineage of "diagnose-then-edit" optimizers
-(GEPA's actionable side information; trace-analysis approaches that run parallel
-analysts; issue-clustering in evolutionary loops).
+## What counts as a failure
 
-## Dual-mode
-This phase runs two ways from the **same** SKILL.md: standalone as the slash command `/cap-evolve:diagnose` (the `argument-hint` shows its run.py args), and orchestrator-callable — `cap-evolve run` / the `orchestrate` skill invokes the same `scripts/run.py` headlessly and threads the run dir between phases.
+Not only zero-score tasks. Three kinds are real lost score and routinely missed:
+**partial credit** (scored e.g. 0.5 because one part of the action was wrong),
+**communication / omission** (the action happened but the required information was
+never reported or confirmed), and **near-miss** (≈0.7–0.9, one small correct change
+from a pass — the cheapest marginal gain per edit, easiest to overlook while staring
+at the zeros).
+
+Separate *always-failing* (mean ≈ 0 — a root-cause fix) from *flaky* (0 < mean < 1 —
+a consistency fix; find what the passing trials do and make it reliable). The reward
+is the honest signal: a per-task `Feedback` line comes from the **last** trial and
+can disagree with the graded mean.
+
+## Where the trace comes from
+
+The rollout record supplies the score and the feedback; the **trajectory** supplies
+the failure site, and the site is half of the cluster key. The runner owns the trace
+format, so never assume one — the location is asked for, not guessed:
+
+- standalone: `adapter.trajectories(split)` returns the directory (any structure,
+  any format). `run.py --project DIR` resolves it and attaches the path to each
+  entry as `Trajectory`; it never parses it. With no native store the pointer falls
+  back to the rollout record's own file, which core wrote.
+- inside an optimizer workdir: that directory has already been copied verbatim to
+  `./trajectories/`. Read it there. `scripts/` is not copied into
+  `./guidance/diagnose/`, so cluster by hand using the procedure below — it is the
+  same procedure the script runs.
+
+## Clustering: deriving the signature
+
+A cluster is ONE root cause, identified by a **(failure-site, violated-expectation)**
+pair: *where* the trajectory went wrong (the tool, field, or step the trace names)
+and *which* expectation was missed. Two failures belong to the same cluster when
+both halves agree — however differently the scorer phrased it, and whatever
+task-specific values it quoted. Derive the key like this:
+
+1. **Strip the scorer's boilerplate.** Drop the leading token run that *every*
+   failure's feedback shares. A scorer that opens each message with "Grading failed
+   because the expected outcome was not met" otherwise makes all failures look
+   identical.
+2. **Reduce to content words.** Drop quoted literals and numbers (task-specific, not
+   causal), drop stopwords, and drop outcome-generic words — `failed`, `wrong`,
+   `missing`, `expected`, `invalid` name *that* it failed, never *why*. Collapse
+   inflections (`confirm` / `confirmed` / `confirmation` are one token).
+3. **Read the survivors as the pair.** Identifiers the trace names are the site;
+   the remaining verbs are the expectation.
+4. **Same cluster iff the keys OVERLAP** — half or more of the smaller key's tokens
+   are shared — merged transitively. Overlap rather than equality is what keeps "did
+   not confirm the change", "omitted required confirmation step" and "missing
+   confirmation before the write" as one cluster instead of three.
+
+Two sanity checks on the result: one cluster per failing task means the signature is
+too fine and no generalizing edit is possible; one cluster spanning visibly
+different causes means it is too coarse — usually an unstripped preamble (step 1).
+
+## Tag each cluster
+
+The tag says *where the fix belongs*. The lever itself is the selected capability's
+business (`./guidance/<cap>/SKILL.md`); the tag tells it which kind of lever to reach
+for, and its **blast radius** is the set of currently-passing tasks the fix would
+change.
+
+- **KNOWLEDGE** — the agent cannot derive a format, rule, or criterion. Stating it
+  in prose is the right lever here. Blast radius: tasks reading the same instruction.
+- **BEHAVIORAL** — the agent knows the rule and violates it anyway. Restating it in
+  prose will not fix this; the rule has to move somewhere it cannot be skipped — the
+  strongest deterministic lever the capability offers. Blast radius: every task
+  exercising the same rule or path.
+- **DECISION / PERMISSION** — the wrong act-vs-refuse/escalate call on a
+  policy-governed class. Fix the exact discriminating **condition**, never the
+  class-wide rule: a class-wide change flips behavior for the whole class and
+  regresses every task where the original behavior was already correct. Blast radius
+  is therefore *every* passing task in that decision class — name them and confirm
+  the fix does not flip their action.
+- **CAPABILITY-GAP** — no reliable mechanism exists, or the agent narrates a
+  multi-step action and then stalls without executing it. Needs the strongest
+  STRUCTURAL lever available. Tagged separately so a stall is not mis-filed as
+  BEHAVIORAL and "fixed" with a nudge that never works.
+
+## Rank the clusters
+
+A cluster's value is **the score it can recover minus the regression risk to its
+blast radius** — which is why the radius is named per cluster and scoped to tasks
+concretely (ids, not "the same tool"), so the edit can be made to fire only on the
+failing condition. Then:
+
+- rank by cost (`score_lost`), biggest first — but do not let a small cluster whose
+  fix is STRUCTURAL sink under task count: a 2-task stall cracked by one new
+  mechanism can outweigh a many-task cluster of cosmetic misses;
+- note a multi-cause task's **secondary** cause too, so one edit can take the
+  primary and the residual together;
+- cross-check the run history (LEDGER / prior iterations) and skip any cluster whose
+  fix was already tried and rejected — do not re-diagnose a refuted approach.
+
+## Feedback quality
+
+Write each diagnosis **specific** (the wrong call, the skipped step, the misread
+field — not "the answer was wrong"), **causal** (the decision that produced it, so
+the edit has a target), and **general** (the pattern, not the instance).
+
+Some benchmarks copy ground truth or expected actions into the traces; when present
+use them to pinpoint which action, argument, or value was expected — for
+*understanding* only. Feedback that quotes the gold answer keeps the level at *what
+the right answer is* instead of *what class of mistake was made*, and the optimizer
+then memorizes the eval set (`references/concepts.md` has the full consequence).
 
 ## How to run
-```
-python scripts/run.py --run-dir .capevolve/run_XXXX --tag seed
-```
-Run it on the current best's val rollouts each round; feed `reflective_dataset` +
-`clusters` into the algorithm's proposal prompt, and hand `kept_good` to the gate.
 
-## What good vs bad looks like
-- **Good:** failures grouped into a few clear clusters; feedback names the cause
-  and the pattern; the biggest cluster is addressed first; gold answers never
-  appear in feedback.
-- **Bad:** one cluster per task (no generalization); feedback that just restates
-  the reward; the gold answer leaked into feedback (the optimizer memorizes the
-  eval); `kept_good` ignored so fixes regress passing tasks.
+```
+python scripts/run.py --run-dir .capevolve/run_XXXX --tag seed \
+    --project .capevolve/project --split val
+```
+
+Run it on the current best candidate's rollouts each round, then tag, rank, and hand
+the clusters to the algorithm's proposal prompt. `--split train` diagnoses train —
+the honest learning surface when the gate scores val. `--cluster first-words` is the
+old lexical key, kept for comparison only. The same script runs headlessly under
+`cap-evolve run` / the `orchestrate` skill, which threads the run dir between phases.
 
 ## References
-- `references/concepts.md` — the reflective dataset, feedback as a textual
-  gradient, why clustering beats per-task patching, the no-leak rule, and the
-  optimizer lineage, with sources.
+
+- `references/concepts.md` (~90 lines) — why a scalar reward is not enough, the
+  reflective dataset's provenance in GEPA, why clustering beats per-task patching,
+  the full consequence of a leaked gold answer, and the optimizer lineage with
+  sources. Load it for the *why* behind this procedure or a citation for it; the
+  procedure itself is complete above.

--- a/skills/phases/diagnose/references/concepts.md
+++ b/skills/phases/diagnose/references/concepts.md
@@ -21,9 +21,13 @@ fewer rollouts. diagnose is where that signal is manufactured.
 For each failing task, diagnose emits the triple GEPA calls a reflective dataset:
 
 - **Inputs** — what the task asked.
-- **Generated Outputs** — what the agent actually produced (and, where available,
-  the trajectory: reasoning, tool calls).
+- **Generated Outputs** — what the agent actually produced.
 - **Feedback** — the scorer's diagnosis of the failure.
+- **Trajectory** — a *path* to the full trace (reasoning, tool calls). A path and
+  not parsed content, because the trace format belongs to the runner: the location
+  comes from `Adapter.trajectories(split)`, which is documented to return "*any*
+  structure, files in *any* format". Anything that parsed it here would bind this
+  phase to one runner, which a phase skill may never do.
 
 Giving the optimizer this triple instead of a bare score is the difference
 between "you got 0.4" and "on these inputs you called the wrong tool because you
@@ -64,6 +68,26 @@ diagnose-then-edit optimizer family:
 
 A good round produces a *few* clusters; "one cluster per task" means the signature
 is too fine and no generalization is happening.
+
+### Why the signature is an overlap test, not a string match
+
+SKILL.md gives the procedure; this is why it has the shape it does. A signature
+built by hashing the leading words of the scorer's feedback fails in both
+directions, and both failures are silent:
+
+- **Fragmentation.** One root cause reaches the scorer in many phrasings — "did not
+  confirm the change", "omitted required confirmation step", "missing confirmation
+  before the write". Under string equality that is three clusters, so the optimizer
+  writes three narrow patches for one defect and overfits val three times over.
+  Requiring only *overlap* between the content-word keys keeps them together.
+- **Collapse.** A scorer whose every message opens with a fixed preamble ("Grading
+  failed for this trajectory because the expected outcome was not met: …") makes
+  every failure share its first dozen tokens. Under a prefix key the entire signal
+  becomes one cluster. Stripping the prefix that *all* failures share removes the
+  boilerplate without anyone having to configure a per-benchmark pattern.
+
+Both directions are regression-tested in `scripts/check.py`; the mechanism is
+`scripts/cluster.py`.
 
 ## Hand-off to the gate
 

--- a/skills/phases/diagnose/scripts/check.py
+++ b/skills/phases/diagnose/scripts/check.py
@@ -1,6 +1,7 @@
-"""Contract: diagnose emits a well-formed reflective dataset — carries the actual
-task INPUT (not the id), and clusters failures by the normalized-feedback
-signature so similar root causes group together.
+"""Contract: diagnose emits a well-formed reflective dataset (the real task INPUT, a
+pointer to the full trace) and clusters failures by root cause — one cause under
+several phrasings must NOT fragment, and several causes under one scorer preamble
+must NOT collapse.
 """
 
 from __future__ import annotations
@@ -12,6 +13,13 @@ from pathlib import Path
 import _bootstrap  # noqa: F401
 
 from cap_evolve.skillcheck import Checker, import_run, temp_run_dir, write_val_rollout
+
+
+def _clusters_of(run, feedbacks: dict[str, str]) -> list[dict]:
+    """Cluster a set of ``task_id -> feedback`` failures, records-free."""
+    return run.diagnose([{"input": {}, "rollout": {"output": ""},
+                          "score": {"task_id": t, "reward": 0.0, "feedback": f}}
+                         for t, f in sorted(feedbacks.items())])["clusters"]
 
 
 def main() -> int:
@@ -30,7 +38,7 @@ def main() -> int:
                           task_input={"expr": "1+1"}, output="2")
 
         records = run._load_records(rd, "seed")
-        result = run.diagnose(records, run.normalized_feedback_signature)
+        result = run.diagnose(records)
 
         rd_set = result["reflective_dataset"]
         c.check(len(rd_set) == 2, f"expected 2 failing entries, got {len(rd_set)}")
@@ -43,11 +51,47 @@ def main() -> int:
                 note="reflective dataset carries the actual task input")
         c.check(entry["Generated Outputs"] == "7", "Generated Outputs missing the rollout output")
 
+        # Every entry must be traceable back to its FULL trace, or the failure SITE
+        # (which is half the cluster key) is unrecoverable from the entry alone.
+        c.check(Path(entry["Trajectory"]).exists(),
+                f"Trajectory pointer does not resolve: {entry['Trajectory']}",
+                note="each reflective entry points at its full trace")
+        # ...and when the RUNNER has a native trace store, that pointer comes from
+        # adapter.trajectories(split) — never from a hardcoded trace layout. A phase
+        # skill that guessed the path would be bound to one runner.
+        proj = Path(d) / "project"
+        (proj / "adapters").mkdir(parents=True)
+        (proj / "adapters" / "adapter.py").write_text(
+            "from pathlib import Path\n"
+            "from cap_evolve import CapabilityAdapter, Rollout, Score\n"
+            "class Adapter(CapabilityAdapter):\n"
+            "    def tasks(self, split): return []\n"
+            "    def run_target(self, task, ctx, *, seed=0):\n"
+            "        return Rollout(task_id='x', output='')\n"
+            "    def score(self, task, rollout): return Score(task_id='x', reward=0.0)\n"
+            "    def trajectories(self, split, ctx=None):\n"
+            "        return Path('/native') / split\n", encoding="utf-8")
+        native = run.trace_dir(str(proj), "val")
+        c.check(native is not None and native.endswith("val"),
+                f"adapter.trajectories(split) was not used for the trace path: {native}",
+                note="trace location comes from adapter.trajectories(split), never a "
+                     "hardcoded trace schema")
+        c.check(run.diagnose(records, "root-cause", native)["reflective_dataset"][0]
+                ["Trajectory"] == native,
+                "the adapter's native trace dir did not reach the reflective dataset")
+        c.check(run.trace_dir(None, "val") is None
+                and run.trace_dir(str(Path(d) / "nope"), "val") is None,
+                "trace_dir must degrade to None with no project / no adapter",
+                note="a missing trace pointer never blocks a diagnosis")
+
         # the two same-root-cause failures cluster together under one signature.
         c.check(len(result["clusters"]) == 1
-                and sorted(result["clusters"][0]["tasks"]) == ["a", "b"],
-                f"normalized-feedback clustering did not group same-cause failures: {result['clusters']}",
-                note="similar feedback clusters together (not split on first 6 words)")
+                and result["clusters"][0]["tasks"] == ["a", "b"],
+                f"clustering did not group same-cause failures: {result['clusters']}",
+                note="same cause, different values -> one cluster")
+        c.check(result["clusters"][0]["score_lost"] == 2.0,
+                f"cluster is not ranked by score lost: {result['clusters']}",
+                note="clusters carry the score they can recover")
 
         # --split reads a DIFFERENT split's rollouts, and val stays the default. Four
         # other algorithms call this phase without --split, so the default must not
@@ -62,17 +106,50 @@ def main() -> int:
             '"error": null}, "score": {"task_id": "z", "reward": 0.0, '
             '"feedback": "Expected 16 but got 3", "n": 1, "stderr": 0.0, '
             '"trial_rewards": [0.0], "raw": {"errored": false}}}', encoding="utf-8")
-        tr = run.diagnose(run._load_records(rd, "seed", "train"),
-                          run.normalized_feedback_signature)
+        tr = run.diagnose(run._load_records(rd, "seed", "train"))
         c.check([e["task_id"] for e in tr["reflective_dataset"]] == ["z"],
                 f"train diagnosis returned the wrong tasks: {tr['reflective_dataset']}",
                 note="train is diagnosable — the honest learning surface when the gate "
                      "scores val")
         c.check([e["task_id"] for e in run.diagnose(
-                    run._load_records(rd, "seed"), run.normalized_feedback_signature
-                 )["reflective_dataset"]] == ["a", "b"],
+                    run._load_records(rd, "seed"))["reflective_dataset"]] == ["a", "b"],
                 "the default split is no longer val — that would change every "
                 "algorithm that calls diagnose without --split")
+
+        # REGRESSION 1 — one root cause, three phrasings. A lexical prefix key splits
+        # this into three clusters and the optimizer then writes three narrow patches.
+        one = _clusters_of(run, {
+            "p": "Task failed: the agent did not confirm the change with the user",
+            "q": "Agent omitted required confirmation step",
+            "r": "Missing confirmation before the write",
+        })
+        c.check(len(one) == 1 and one[0]["tasks"] == ["p", "q", "r"],
+                f"one root cause fragmented into {len(one)} clusters: {one}",
+                note="one cause under 3 phrasings -> 1 cluster (no fragmentation)")
+
+        # REGRESSION 2 — three causes behind one long scorer preamble. A first-N-token
+        # key collapses them into one cluster and the whole signal is lost.
+        pre = "Grading failed for this trajectory because the expected outcome was not met: "
+        many = _clusters_of(run, {
+            "p": pre + "missing confirmation before the write",
+            "q": pre + "wrong payment id supplied to the refund",
+            "r": pre + "refused a valid booking request",
+        })
+        c.check(len(many) >= 3,
+                f"3 distinct causes collapsed into {len(many)} cluster(s) behind a "
+                f"shared preamble: {many}",
+                note="shared scorer preamble is stripped -> distinct causes stay distinct")
+
+        # Determinism: same input twice, byte-identical clusters.
+        import json as _json
+        again = _clusters_of(run, {
+            "p": "Task failed: the agent did not confirm the change with the user",
+            "q": "Agent omitted required confirmation step",
+            "r": "Missing confirmation before the write",
+        })
+        c.check(_json.dumps(one, sort_keys=True) == _json.dumps(again, sort_keys=True),
+                "clustering is not deterministic across runs",
+                note="identical input -> identical output")
 
     return c.emit()
 

--- a/skills/phases/diagnose/scripts/cluster.py
+++ b/skills/phases/diagnose/scripts/cluster.py
@@ -1,0 +1,160 @@
+"""Deterministic failure clustering — the mechanical half of diagnose.
+
+A cluster is ONE root cause. Its identity is a **(site, expectation)** pair: where
+the trajectory went wrong (the tool / field / step the trace names) and which
+expectation was missed. Two failures belong to the same cluster when both halves
+agree, however differently the scorer phrased it and whatever task-specific values
+it quoted.
+
+Deriving that key from a feedback string is deterministic, so it lives here instead
+of being re-improvised in prose on every iteration:
+
+1. strip the token prefix every failure's feedback shares (a scorer boilerplate
+   preamble otherwise makes every failure look identical);
+2. reduce to content words — drop quoted literals / numbers / punctuation
+   (task-specific, not causal), drop stopwords and OUTCOME-GENERIC words which say
+   *that* it failed and never *why*, and crudely stem the rest so
+   confirm/confirmed/confirmation collapse;
+3. the surviving token set is the key — identifiers are the site, verbs the
+   expectation;
+4. two keys are the same cluster when they OVERLAP: |A∩B| / min(|A|,|B|) >= 0.5,
+   merged transitively. Overlap rather than equality is what keeps one root cause
+   from splitting into three clusters under three phrasings.
+
+Everything is sorted, so the same input always yields byte-identical output.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Words that name THAT something failed, never WHY. Keeping them lets two unrelated
+# causes look similar just because both were reported as a failure.
+_GENERIC = frozenset("""
+fail failed failure error errored wrong incorrect invalid missing miss expected
+expect expects got produce produced output outputs task tasks agent step steps
+required require unexpected instead actual result results response correct bad
+should would did does done value values return returned reward score scored
+scoring trajectory grading grade graded because only just also however issue
+problem problems reason cause caused unable cannot able
+""".split())
+
+_STOP = frozenset("""
+the a an and or but of to in on for with that this these those it its is are was
+were be been being at by from as has have had do than then when which while will
+can could all any into out no not none more most some such very over under after
+before during about again there here their them they you your our his her one two
+""".split())
+
+# Longest first so "confirmation" -> "confirm", not "confirmatio".
+_SUFFIXES = ("ations", "ation", "ements", "ement", "ingly", "ings", "ing", "edly",
+             "ness", "ions", "ion", "ive", "ed", "es", "ly", "s")
+
+_MIN_STEM = 4
+
+OVERLAP_MIN = 0.5
+
+
+def _stem(tok: str) -> str:
+    for suf in _SUFFIXES:
+        if tok.endswith(suf) and len(tok) - len(suf) >= _MIN_STEM:
+            return tok[: -len(suf)]
+    return tok
+
+
+def _words(feedback: str) -> list[str]:
+    s = (feedback or "").lower()
+    s = re.sub(r"['\"`].*?['\"`]", " ", s)   # quoted literals: task-specific
+    s = re.sub(r"[0-9]+", " ", s)            # numbers: task-specific
+    s = re.sub(r"[^a-z_ ]+", " ", s)         # punctuation (keep _: identifiers)
+    return [t for t in s.split() if len(t) > 2]
+
+
+def common_prefix(feedbacks: list[str]) -> list[str]:
+    """The longest leading token run shared by EVERY feedback (the boilerplate)."""
+    seqs = [_words(f) for f in feedbacks if (f or "").strip()]
+    if len(seqs) < 2:
+        return []
+    out: list[str] = []
+    for i in range(min(len(s) for s in seqs)):
+        tok = seqs[0][i]
+        if all(s[i] == tok for s in seqs):
+            out.append(tok)
+        else:
+            break
+    # If the shared run covers a whole feedback, the failures are not distinguishable
+    # by their prefix at all (identical wording) — stripping would delete the signal
+    # rather than boilerplate. Leave it; the generic-word filter still discriminates.
+    if out and any(len(s) == len(out) for s in seqs):
+        return []
+    return out
+
+
+def key_tokens(feedback: str, prefix: list[str] | None = None) -> frozenset[str]:
+    """The (site, expectation) key: content-word stems, boilerplate removed."""
+    toks = _words(feedback)
+    pre = prefix or []
+    if pre and toks[: len(pre)] == pre:
+        toks = toks[len(pre):]
+    stems = [_stem(t) for t in toks]
+    keep = [s for s in stems if s not in _STOP and s not in _GENERIC]
+    if not keep:                       # all-generic feedback: fall back to what we have
+        keep = [s for s in stems if s not in _STOP] or stems
+    return frozenset(keep)
+
+
+def overlap(a: frozenset[str], b: frozenset[str]) -> float:
+    if not a or not b:
+        return 0.0
+    return len(a & b) / min(len(a), len(b))
+
+
+def cluster(items: list[tuple[str, str, float]]) -> list[dict]:
+    """Group ``(task_id, feedback, score_lost)`` triples by root cause.
+
+    Clusters are sorted by score lost, then task count, then signature — a total
+    order, so the output is byte-identical on repeated runs over the same input.
+    """
+    prefix = common_prefix([f for _, f, _ in items])
+    keys = [key_tokens(f, prefix) for _, f, _ in items]
+
+    # Union-find over the overlap relation (transitive: A~B and B~C => one cluster).
+    # ponytail: O(n^2) pair scan — fine for a val split; index by token if it grows.
+    parent = list(range(len(items)))
+
+    def find(i: int) -> int:
+        while parent[i] != i:
+            parent[i] = parent[parent[i]]
+            i = parent[i]
+        return i
+
+    for i in range(len(items)):
+        for j in range(i + 1, len(items)):
+            if overlap(keys[i], keys[j]) >= OVERLAP_MIN:
+                ri, rj = find(i), find(j)
+                if ri != rj:
+                    parent[max(ri, rj)] = min(ri, rj)
+
+    groups: dict[int, list[int]] = {}
+    for i in range(len(items)):
+        groups.setdefault(find(i), []).append(i)
+
+    out = []
+    for root in sorted(groups):
+        idxs = groups[root]
+        counts: dict[str, int] = {}
+        for i in idxs:
+            for t in keys[i]:
+                counts[t] = counts.get(t, 0) + 1
+        label = " ".join(t for t, _ in
+                         sorted(counts.items(), key=lambda kv: (-kv[1], kv[0]))[:4])
+        out.append({
+            "signature": label or "unknown",
+            "tasks": sorted(items[i][0] for i in idxs),
+            "score_lost": round(sum(items[i][2] for i in idxs), 4),
+            # Judgement, not derivable here — diagnose's reader fills these in.
+            "tag": None,
+            "blast_radius": None,
+        })
+    out.sort(key=lambda c: (-c["score_lost"], -len(c["tasks"]), c["signature"]))
+    return out

--- a/skills/phases/diagnose/scripts/run.py
+++ b/skills/phases/diagnose/scripts/run.py
@@ -1,36 +1,39 @@
 """diagnose — turn rollouts/scores into an actionable learning signal.
 
-Reads the most recent val rollouts for a candidate from the run dir and emits a
-reflective dataset: per failing task ``{task_id, Inputs, Generated Outputs,
-Feedback}`` (GEPA's shape) plus failure clusters. The algorithm/optimizer consume
-this to know WHAT to change and WHY — the textual analogue of a gradient (GEPA's
-Actionable Side Information).
+Reads a candidate's persisted rollouts for one split and emits the reflective
+dataset (per failing task ``{task_id, Inputs, Generated Outputs, Feedback,
+Trajectory}`` — GEPA's shape) plus failure clusters ranked by score lost, plus
+``kept_good``. The algorithm/optimizer consume this to know WHAT to change and WHY.
 
-Two fixes over the prior version:
-  * ``Inputs`` carries the actual task INPUT recorded in the rollout file (it used
-    to wrongly carry the task id), so the optimizer sees what the task asked for.
-  * clustering is pluggable (``--cluster`` / ``CLUSTER_FNS``); the default is a
-    normalized-feedback signature (lowercased, digits/punct/quoted-literals
-    stripped), which groups "Expected 5 got 7" and "Expected 9 got 2" together
-    instead of splitting on the first 6 words.
+Trace access is schema-agnostic by construction. The rollout record (a cap-evolve
+core format) supplies the score and the feedback; the full trace lives wherever the
+RUNNER puts it, so its location comes from ``adapter.trajectories(split)`` and is
+attached as a PATH only — this script never parses a runner's trace format. With no
+``--project``, or when the adapter has no native trajectory store, the pointer falls
+back to the rollout record's own file, which core wrote and therefore owns.
+
+Clustering is deterministic and lives in ``cluster.py``; see its docstring for the
+(site, expectation) signature. ``--cluster first-words`` keeps the old lexical key
+available for comparison.
 """
 
 from __future__ import annotations
 
 import argparse
 import json
-import re
 import sys
 from collections import defaultdict
 from pathlib import Path
 
 import _bootstrap  # noqa: F401
 
+import cluster as _cluster
+
 from cap_evolve import RunDir
 
 
 def _load_records(run_dir: RunDir, tag: str, split: str = "val") -> list[dict]:
-    """Every persisted rollout for ``tag`` on ``split``.
+    """Every persisted rollout for ``tag`` on ``split``, each tagged with its path.
 
     ``split`` exists because TRAIN is the honest surface to diagnose from: val is what
     the gate scores, so reading the learning signal off val and then gating on val
@@ -42,58 +45,77 @@ def _load_records(run_dir: RunDir, tag: str, split: str = "val") -> list[dict]:
     if not vdir.exists():
         return out
     for f in sorted(vdir.glob(f"*__{tag}__t*.json")):
-        out.append(json.loads(f.read_text(encoding="utf-8")))
+        rec = json.loads(f.read_text(encoding="utf-8"))
+        rec["__file"] = str(f)
+        out.append(rec)
     return out
 
 
-def normalized_feedback_signature(feedback: str) -> str:
-    """Default clustering key: feedback with case/digits/punctuation removed.
+def trace_dir(project: str | None, split: str) -> str | None:
+    """The runner's native trajectory directory, via the adapter — never guessed.
 
-    Collapses task-specific values (numbers, ids, quoted strings) so failures that
-    share a root cause but differ in particulars land in the same cluster.
+    Returns ``None`` when there is no project to load or the adapter declares no
+    native store (the documented default); callers then fall back to the per-rollout
+    record. Any adapter failure is non-fatal: a missing trace pointer must not stop a
+    diagnosis that the rollouts alone can still produce.
     """
-    s = (feedback or "").lower()
-    s = re.sub(r"['\"`].*?['\"`]", " ", s)        # drop quoted literals
-    s = re.sub(r"[0-9]+", " ", s)                  # drop numbers
-    s = re.sub(r"[^a-z ]+", " ", s)                # drop punctuation
-    toks = [t for t in s.split() if len(t) > 2]
-    return " ".join(toks[:8]) or "unknown"
+    if not project:
+        return None
+    try:
+        from cap_evolve.check import load_adapter
+        d = load_adapter(Path(project)).trajectories(split)
+        return str(d) if d else None
+    except Exception:  # noqa: BLE001
+        return None
 
 
 def first_n_words_signature(feedback: str, n: int = 6) -> str:
-    """Legacy clustering key (kept for comparison / opt-in)."""
+    """Legacy lexical clustering key (opt-in via ``--cluster first-words``)."""
     return " ".join((feedback or "").split()[:n]) or "unknown"
 
 
-CLUSTER_FNS = {
-    "normalized-feedback": normalized_feedback_signature,
-    "first-words": first_n_words_signature,
-}
-
-
-def diagnose(records: list[dict], cluster_fn=normalized_feedback_signature) -> dict:
+def diagnose(records: list[dict], mode: str = "root-cause",
+             traces: str | None = None) -> dict:
     reflective = []
-    clusters = defaultdict(list)
+    items: list[tuple[str, str, float]] = []
     kept = []
     for rec in records:
         sc = rec.get("score", {})
         ro = rec.get("rollout", {})
-        if sc.get("reward", 0) >= 1.0:
+        reward = sc.get("reward", 0) or 0
+        if reward >= 1.0:
             kept.append(sc.get("task_id"))
             continue
-        fb = sc.get("feedback", "")
+        fb = sc.get("feedback", "") or ""
         reflective.append({
             "task_id": sc.get("task_id"),
             # The actual task INPUT (carried through the rollout file), NOT the id.
             "Inputs": rec.get("input"),
             "Generated Outputs": ro.get("output"),
             "Feedback": fb,
+            # Where the FULL trace is. A path, not parsed content: the format is the
+            # runner's business and the adapter's to expose.
+            "Trajectory": traces or rec.get("__file"),
         })
-        clusters[cluster_fn(fb)].append(sc.get("task_id"))
+        items.append((sc.get("task_id"), fb, max(0.0, 1.0 - float(reward))))
+
+    if mode == "first-words":
+        groups = defaultdict(list)
+        lost = defaultdict(float)
+        for tid, fb, sl in items:
+            k = first_n_words_signature(fb)
+            groups[k].append(tid)
+            lost[k] += sl
+        clusters = [{"signature": k, "tasks": sorted(v),
+                     "score_lost": round(lost[k], 4), "tag": None, "blast_radius": None}
+                    for k, v in groups.items()]
+        clusters.sort(key=lambda c: (-c["score_lost"], -len(c["tasks"]), c["signature"]))
+    else:
+        clusters = _cluster.cluster(items)
+
     return {
         "reflective_dataset": reflective,
-        "clusters": [{"signature": k, "tasks": v}
-                     for k, v in sorted(clusters.items(), key=lambda kv: -len(kv[1]))],
+        "clusters": clusters,
         "kept_good": kept,
     }
 
@@ -102,15 +124,19 @@ def main(argv=None) -> int:
     p = argparse.ArgumentParser(prog="diagnose")
     p.add_argument("--run-dir", required=True)
     p.add_argument("--tag", default="seed", help="candidate tag whose rollouts to read")
+    p.add_argument("--project", default=None,
+                   help="project dir — resolves the runner's native trace dir via "
+                        "adapter.trajectories(split); optional")
     p.add_argument("--split", default="val", choices=["train", "val"],
                    help="which split's rollouts to diagnose (train is the honest "
                         "learning surface; val is what the gate scores)")
-    p.add_argument("--cluster", default="normalized-feedback", choices=sorted(CLUSTER_FNS),
-                   help="failure-clustering function")
+    p.add_argument("--cluster", default="root-cause",
+                   choices=["root-cause", "first-words"],
+                   help="failure-clustering method (root-cause: site+expectation key)")
     args = p.parse_args(argv)
     run_dir = RunDir.open(Path(args.run_dir))
     result = diagnose(_load_records(run_dir, args.tag, args.split),
-                      CLUSTER_FNS[args.cluster])
+                      args.cluster, trace_dir(args.project, args.split))
     result["split"] = args.split
     result["tag"] = args.tag
     print(json.dumps(result, indent=2))


### PR DESCRIPTION
Closes #342.

`skills/phases/diagnose/` is the most repeatedly-paid skill body in the repo:
`harness.py:1193-1243` copies it into every optimizer workdir and `harness.py:2064`
requires it be read in full before diagnosing. It defined the failure taxonomy
**twice in its own body** (lines 46-69, then again at 84-112) and specified its
central mechanism — clustering — as "group failures by shared root cause", which is
not a procedure but a hope, re-improvised differently on every iteration.

## 1. The taxonomy is stated once

Per `SKILL_OWNERSHIP.md`, `phases/diagnose` OWNS the taxonomy; `tools` (~65 lines),
`system-prompt` (50) and `intake` already deleted their copies on that basis, so this
is now the single statement. Stated once, generalized, with each tag's blast radius:
KNOWLEDGE / BEHAVIORAL / DECISION / PERMISSION / CAPABILITY-GAP.

Tag naming: the ownership table writes it `DECISION-PERMISSION`, but the eight
existing references across `tools`, `system-prompt`, `intake` and both
`INSTRUCTIONS.md` templates all say `DECISION / PERMISSION`. Kept the corpus spelling
rather than forcing a rename into files I may not touch.

Deliberate divergence from the issue: **F3 asked to make `INSTRUCTIONS.md` the owner
and reduce diagnose to a pointer.** That directly contradicts the binding ownership
contract, on the strength of which four sibling skills already deleted their copies.
The contract wins; diagnose states it in full. Flagging so the conflict is visible.

## 2. The clustering procedure is now concrete

A cluster is one root cause, identified by a **(failure-site, violated-expectation)**
pair — *where* the trajectory went wrong (the tool / field / step the trace names) and
*which* expectation was missed — with an explicit same-cluster test. Four steps
(SKILL.md "Clustering: deriving the signature"), mechanized in `scripts/cluster.py`:

1. strip the leading token run **every** failure's feedback shares (scorer boilerplate);
2. reduce to content-word stems — drop quoted literals and numbers (task-specific),
   stopwords, and outcome-generic words (`failed`, `wrong`, `missing`, `expected`,
   which say *that* it failed and never *why*);
3. read the survivors as the pair (identifiers = site, verbs = expectation);
4. same cluster iff the keys **overlap** — `|A∩B| / min(|A|,|B|) ≥ 0.5` — merged
   transitively. Overlap rather than equality is the whole point.

The old key (lexical prefix hash of feedback) failed in both directions, silently.
Measured, on the exact cases the issue names:

```
one cause, three phrasings          old: 3 clusters   new: 1 cluster
three causes, one shared preamble   old: 1 cluster    new: 3 clusters
```

Both are now regression cases in `check.py`, and `--cluster first-words` keeps the old
key reachable so the comparison stays reproducible.

## 3. The deterministic work is in `scripts/`, and it goes through the adapter

`scripts/cluster.py` (new, 159 lines) holds signature extraction and clustering —
pure stdlib, no config, everything sorted, so **identical input yields byte-identical
output**. `run.py` keeps trace loading and reflective-dataset assembly. Prose is
reserved for the judgement the script cannot do: which cluster to target, what tag it
carries, what its blast radius is (the script emits `tag` and `blast_radius` as
`null` precisely to mark those as the reader's job).

**Runner-agnostic by construction** (CONTEXT.md principle 1). The rollout record — a
*core*-owned format — supplies score and feedback. The full trace belongs to the
runner, so its location comes from `adapter.trajectories(split)` and is attached as a
**path only**; nothing here parses a trace format. With no `--project`, or when the
adapter declares no native store, the pointer degrades to the rollout record's own
file. All three paths are asserted in `check.py`.

**Schema presumption flagged and fixed:** the old skill said "Reads a candidate's val
rollouts" and `run.py` populated `Generated Outputs` from `rollout["output"]` alone,
presuming the final output string carries enough trace to diagnose from. For an
agentic runner it does not — which is exactly why the failure *site*, half the cluster
key, was underivable. Each entry now carries a `Trajectory` pointer.

## 4. Removed (ownership contract)

| removed | owner |
|---|---|
| duplicate taxonomy block (SKILL.md:84-112, ~29 lines) | this file, stated once |
| `## Inputs / outputs (manifest tokens)` (5 lines) | frontmatter; read by nothing |
| analyze → ideate → edit loop incl. "ideate a DRASTIC edit" / "edit and stop" (~69 lines) | `templates/project/optimizer/INSTRUCTIONS.md` (the per-iteration prompt) |
| tools-capability levers ("a new code-bearing tool", "wrap a primitive", "remove the raw primitive") | `capabilities/tools` — a phase may not presume a capability |
| "this exact mistake sank a prior run" postmortem | dropped; the general reason (unbounded blast radius) is stated one clause earlier |
| parallel sub-agent fan-out guidance | `guidance/optimizer/<name>.md` |
| feedback specific/causal/general expanded prose | `references/concepts.md` (was duplicated against its own reference) |
| `## Dual-mode` paragraph (byte-identical across all six phase skills) | compressed to one clause in "How to run" |

No **rule** was dropped — only restatements. Ground-truth-for-understanding-only, the
no-leak rule, near-miss/partial-credit/omission failures, cost ranking, the structural
exception, the secondary-cause note and the LEDGER cross-check all survive, once each.

The **agent-mode loop** (owner `orchestrate/orchestrate`) was not present in this
skill — nothing to delete. Frontmatter `provides`/`needs`/`sources` left exactly as
they were: nothing reads them, and the contract says not to add more.

### What other skills should drop (not touched here)

- `capabilities/tools/SKILL.md:129, 266-272, 300, 386, 411` and
  `references/pitfalls.md:18` still carry BEHAVIORAL and DECISION / PERMISSION
  doctrine.
- `capabilities/system-prompt/SKILL.md:149` and `references/concepts.md:20` likewise.
- `harness.py:1240` excludes `scripts` from the `guidance/diagnose/` copy. Left alone:
  the workdir has no run-dir handle and no guaranteed importable core, so shipping the
  script there would be instruct-and-fail. SKILL.md now says plainly that `scripts/` is
  absent in the workdir and the reader clusters by hand using the same procedure — so
  no prose names an unavailable path.

## Evidence

```
SKILL.md            179 -> 169 lines   (9.0k chars, ~2.3k tokens; budget 500 / 5000)
references/concepts.md  84 -> 108      (one level deep, <300 so no TOC required)
scripts/cluster.py  new, 159           scripts/check.py  81 -> 165
```

`python skills/phases/diagnose/scripts/check.py` — `ok: true`, `problems: []`, 12 notes
including *"one cause under 3 phrasings -> 1 cluster"*, *"shared scorer preamble is
stripped -> distinct causes stay distinct"*, *"trace location comes from
adapter.trajectories(split), never a hardcoded trace schema"*, *"identical input ->
identical output"*.

`skills/algorithms/agent-optimize/scripts/check.py` (the only external caller of
`diagnose/scripts/run.py`) — `ok: true`, `problems: []`. The CLI is backward compatible.

`PYTHONPATH="$PWD/core:$PWD/dashboard/backend" python -m pytest core/tests -q` —
**789 passed, 12 skipped**, matching clean main (#349).

### Real exercise — `bash examples/toy_calc/run.sh`

Ran end to end: `baseline_val 0.0 -> test_reward 1.0`, 3 iterations. Then diagnosed the
seed's val rollouts through the adapter:

```json
{"reflective_dataset": [
   {"task_id": "a1", "Inputs": "3 + 4",
    "Generated Outputs": "I think 3 + 4 is roughly some number.",
    "Feedback": "expected '7' but agent produced 'I think 3 + 4 is roughly some number.'; the prompt likely lacks an explicit instruction to compute and output only the number",
    "Trajectory": ".../rollouts/val/a1__seed__t0.json"},
   {"task_id": "a4", "Inputs": "9 + 1", "...": "..."}],
 "clusters": [{"signature": "compute explicit instruct lack", "tasks": ["a1", "a4"],
               "score_lost": 2.0, "tag": null, "blast_radius": null}],
 "kept_good": [], "split": "val", "tag": "seed"}
```

Both failures land in one cluster under a signature that names the actual cause, and
the accepted candidate `cand_0001` diagnoses to `clusters: []`, `kept_good: [a1, a4]` —
the described procedure is demonstrably what runs.

Determinism, two separate processes over the same trace input:

```
$ diff diag-342-run1.json diag-342-run2.json && echo identical
identical
e5c2e8d2cb2e571c0fca30452a49d3711656f46a  diag-342-run1.json
e5c2e8d2cb2e571c0fca30452a49d3711656f46a  diag-342-run2.json
```

Adapter path, with an adapter that does declare a native store:

```
adapter-supplied trace dir: /native/val
entry Trajectory:           /native/val
```

One behavior change found while exercising it: prefix-stripping originally reduced
identical-wording feedback to a single token (`"number"` on toy_calc). When the shared
run covers a whole feedback the failures are not separable by prefix at all, so
stripping is now skipped and the generic-word filter does the discriminating —
signature became `compute explicit instruct lack`.
