### PR TITLE
deprecate(evograph): the fifth algorithm was agent-optimize without the val gate (#328)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,40 @@ All notable changes to cap-evolve are documented here. The format follows
 [0.1.0]: https://github.com/skillberry-ai/cap-evolve/releases/tag/v0.1.0
 
 ## [Unreleased]
+### Deprecated
+- **`evograph`, the fifth algorithm.** It advertised one distinctive capability — a
+  collaborative weakness graph with one solver agent per weakness — and neither half survived
+  comparison with its siblings. The fan-out is `agent-optimize`'s: N sibling candidates from one
+  parent, one diagnosed failure cluster each, every sibling in its own working copy (a git
+  worktree when the capability is in git), gated one at a time with a re-gate after each accept,
+  so several fixes accumulate into one lineage *honestly*. evograph instead kept a merge on a raw
+  delta over a frozen ~3-task subset of **train**, self-reported by the solver subagent that made
+  the edit — no val split, no standard error, no `Δ > k·SE`. Between `baseline` and `finalize` an
+  evograph run took **no held-out measurement at all**, so the sealed test number was the first
+  honest signal anyone saw; whole-round revert existed only as a one-round-late substitute for the
+  gate it lacked. What is genuinely unique is the run-dir `wiki/`, but the dashboard renders the
+  Weakness-graph tab from `wiki/` presence alone for any algorithm that writes the format — an
+  output contract, not a search strategy, and not a reason to make agent-mode users choose between
+  two algorithms whose difference is a file format.
+
+  The skill and its code stay in place (deprecation is reversible; removal is not). `cap-evolve
+  algorithms` lists it last and labelled `DEPRECATED`, `cap-evolve init` no longer offers it, and
+  `cap-evolve doctor` now *warns* instead of reporting `ok` for an existing evograph spec — but
+  `algorithm_skill: evograph` still resolves so an old spec and an old run dir keep working.
+  Follow-up for the maintainer: move the wiki format contract into `agent-optimize` as an optional
+  output, stop `dashboard.py` inferring `algorithm = "evograph"` from `wiki/` presence, then delete
+  the directory.
+
 ### Fixed
+- **Four of the repo's ref→ref authoring violations**, all in `evograph`: `clustering.md`,
+  `graph.md` and `dashboard.md` cross-linked each other, so an agent that loaded one file got half
+  a rule (the `affected_tasks` freeze rule was split across two files in opposite directions). The
+  schemas each file needs are now inline; references are one level deep.
+- **A root `conftest.py` excluding a path that no longer exists.** It skipped
+  `skills/algorithms/evograph/dashboard/backend/tests/test_app_security.py`, deleted with the
+  evograph dashboard in `bac04ebd` (#317). Also drops `custom_view.json` from `evograph`'s
+  `meta.yaml` summary and `"custom dashboard view"` from `branding.py` — both named the extension
+  point removed in that same commit.
 - **`agent-optimize`'s gate rejected byte-identical copies of the seed.**
   `gate_check.regressions()` vetoed on *any* strictly lower per-task reward from *any* parent
   level, while its docstring claimed to "mirror the harness's no-regression rule exactly".

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ cap-evolve dashboard                        # live, over a base dir of runs
 Every run gets the same tabs whatever algorithm produced it — Overview, Candidates, Gate,
 Tasks, Cost, Logs, Diffs, Trajectories, Memory, Files — and an algorithm that has extra signal
 gets an extra tab rather than a different dashboard. GEPA's minibatch-vs-full-val gates and
-Pareto selection, SkillOpt's epochs and edit-budget schedule, evograph's weakness graph, and
+Pareto selection, SkillOpt's epochs and edit-budget schedule, and
 `agent-optimize`'s free-form rounds are all read from events the engine already emitted.
 
 <p align="center">

--- a/conftest.py
+++ b/conftest.py
@@ -1,14 +1,8 @@
 # Root conftest.py
 #
-# The evograph dashboard backend test lives in two places:
-#   1. skills/algorithms/evograph/dashboard/backend/tests/  (source template)
-#   2. plugins/cap-evolve/skills/algorithms/evograph/dashboard/backend/tests/ (deployed copy)
-#
-# Both have an identical test_app_security.py. When pytest collects from the repo root
-# with the default prepend import mode, both files map to the same Python module name
-# (test_app_security), causing the second one's fixtures to never be registered.
-#
-# Exclude the skills/ copy so only the plugins/ (deployed) copy is collected.
-collect_ignore_glob = [
-    "skills/algorithms/evograph/dashboard/backend/tests/test_app_security.py",
-]
+# Intentionally empty. It used to exclude
+# skills/algorithms/evograph/dashboard/backend/tests/test_app_security.py from
+# collection, because that file existed twice (source template + deployed plugin copy)
+# and both mapped to the same module name under pytest's prepend import mode. The
+# evograph dashboard was deleted in bac04ebd (#317), so neither copy exists and the
+# glob matched nothing.

--- a/core/cap_evolve/branding.py
+++ b/core/cap_evolve/branding.py
@@ -225,7 +225,7 @@ COMMANDS: dict[str, dict] = {
     },
     "algorithms": {
         "group": "set up",
-        "summary": "the five optimization algorithms and how to select each",
+        "summary": "the optimization algorithms and how to select each",
         "usage": "cap-evolve algorithms [NAME] [--json]",
         "long": "What each algorithm is for, when to prefer it, and the exact spec lines.",
         "examples": ["cap-evolve algorithms", "cap-evolve algorithms gepa"],
@@ -326,7 +326,9 @@ COMMANDS: dict[str, dict] = {
 
 _GROUP_ORDER = ("set up", "optimize", "inspect")
 
-#: The five algorithms: what each is for, and the EXACT spec lines that select it.
+#: Every algorithm: what each is for, and the EXACT spec lines that select it. An entry
+#: carrying ``deprecated`` is listed last and rendered as deprecated -- it stays here so an
+#: existing spec still resolves, not because anyone should pick it.
 ALGORITHMS: dict[str, dict] = {
     "hill-climb": {
         "for": "the default. Parent is always the current best; one edit per iteration.",
@@ -355,10 +357,14 @@ ALGORITHMS: dict[str, dict] = {
     },
     "evograph": {
         "for": "collaborative weakness-graph search; one solver agent per weakness.",
-        "prefer": "failures cluster into distinct, separately fixable weaknesses.",
+        "prefer": "nothing new — use agent-optimize, which fans the same work out behind the val gate.",
         "mode": "agent",
         "spec": ["algorithm_skill: evograph", "orchestration_mode: agent"],
-        "extras": "weakness graph / round revert (custom dashboard view)",
+        "extras": "weakness-graph tab (read from the run dir), whole-round revert",
+        # Deprecated: kept so an existing spec still resolves and an old run dir still
+        # reads, but never offered as a choice. It accepted merges on a self-reported
+        # raw train delta -- no val split, no significance gate.
+        "deprecated": "use agent-optimize (agent mode), or hill-climb | gepa | skillopt",
     },
     "agent-optimize": {
         "for": "free-form: the conversational agent owns the whole search.",
@@ -481,15 +487,21 @@ def algorithms_screen(name: str | None = None, width: int = 100, *, color: bool 
     """The algorithm chooser: what each is for + the exact spec lines to select it."""
     depth = color_depth(color, env)
     p = _Pal(depth)
-    items = ([(name, ALGORITHMS[name])] if name in ALGORITHMS else list(ALGORITHMS.items()))
+    items = ([(name, ALGORITHMS[name])] if name in ALGORITHMS else
+             sorted(ALGORITHMS.items(), key=lambda kv: bool(kv[1].get("deprecated"))))
+    live = sum(1 for m in ALGORITHMS.values() if not m.get("deprecated"))
     out = [_s("cap-evolve algorithms", p.brand),
-           _s("  five ways to search; the honesty gate is the same for all of them", p.grey), ""]
+           _s(f"  {live} ways to search; the honesty gate is the same for all of them", p.grey), ""]
     if name and name not in ALGORITHMS:
         out.append(_s(f"  unknown algorithm: {name} — showing all", p.warn))
         out.append("")
     for n, m in items:
         tag = "agent-driven" if m["mode"] == "agent" else "deterministic loop"
-        out.append(f"  {_s(n.ljust(15), p.bold + p.cyan)}{_s(tag, p.grey)}")
+        if m.get("deprecated"):
+            tag = f"DEPRECATED — {m['deprecated']}"
+            out.append(f"  {_s(n.ljust(15), p.bold + p.grey)}{_s(tag, p.warn)}")
+        else:
+            out.append(f"  {_s(n.ljust(15), p.bold + p.cyan)}{_s(tag, p.grey)}")
         out.append(f"    what   {m['for']}")
         out.append(f"    prefer {m['prefer']}")
         out.append(f"    extras {_s(m['extras'], p.grey)}")

--- a/core/cap_evolve/cli.py
+++ b/core/cap_evolve/cli.py
@@ -16,7 +16,7 @@ Subcommands:
     cap-evolve help    [command]      full help + runnable examples for one command
     cap-evolve init    [--algorithm N --optimizer N]  scaffold a project + spec
     cap-evolve doctor                 readiness check: what's missing + the fix
-    cap-evolve algorithms [name]      the five algorithms and how to select each
+    cap-evolve algorithms [name]      the optimization algorithms and how to select each
     cap-evolve diff    <cand> [--vs X|--best] [--stat|--files] [--unified N]
                        what a candidate actually changed, from its snapshot
     cap-evolve version
@@ -1272,6 +1272,10 @@ def _doctor_checks(project: Path) -> list[dict]:
         add("algorithm", "fail",
             f"{algo} is agent-driven but orchestration_mode is {mode!r}",
             f"set orchestration_mode: agent in {spec_path}")
+    elif meta.get("deprecated"):
+        add("algorithm", "warn",
+            f"{algo} ({mode}) is DEPRECATED — {meta['deprecated']}",
+            f"set algorithm_skill in {spec_path}")
     else:
         add("algorithm", "ok", f"{algo} ({mode})")
 
@@ -1496,7 +1500,8 @@ def _cmd_init(argv) -> int:
             return default
         return got or default
 
-    algorithm = args.algorithm or ask("algorithm", "hill-climb", tuple(branding.ALGORITHMS))
+    offered = tuple(n for n, m in branding.ALGORITHMS.items() if not m.get("deprecated"))
+    algorithm = args.algorithm or ask("algorithm", "hill-climb", offered)
     optimizer = args.optimizer or ask("optimizer (mock = zero-API)", "mock")
     cap_path = args.capability_path or ask("capability dir (the artifact to optimize)",
                                            "seed_capability")

--- a/docs/AGENT_ORCHESTRATION.md
+++ b/docs/AGENT_ORCHESTRATION.md
@@ -32,8 +32,10 @@ stays in the loop and can steer or halt at any round. A Stop hook re-nudges the 
 driving across turns until the run is finalized.
 
 Every algorithm has an Agent-mode loop, so `hill-climb` / `gepa` / `skillopt` can all be driven
-by the agent. Two algorithms are built for this mode and run *only* here: **`agent-optimize`**
-(free-form, below) and **`evograph`** (collaborative weakness-graph search).
+by the agent. One algorithm is built for this mode and runs *only* here: **`agent-optimize`**
+(free-form, below). A second, `evograph`, is **deprecated** — it fanned the same per-cluster work
+out but accepted merges on a self-reported train delta instead of the val significance gate, so
+`agent-optimize` supersedes it.
 
 ### `agent-optimize` — the fully-agentic, free-form algorithm
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -107,7 +107,7 @@ above is checkable rather than remembered.
 | orchestrate | `orchestrate` · `using-cap-evolve` |
 | phases | `intake` · `implement-and-check` · `baseline` · `evaluate` · `diagnose` · `gate` · `finalize` · `report` |
 | capabilities | `system-prompt` · `skill-package` · `tools` · `mcp-tool` |
-| algorithms | `hill-climb` (`--focus all\|cyclic\|hardest-first`) · `gepa` · `skillopt` · `agent-optimize` (agent mode only) · `evograph` (agent mode only) |
+| algorithms | `hill-climb` (`--focus all\|cyclic\|hardest-first`) · `gepa` · `skillopt` · `agent-optimize` (agent mode only) · ~~`evograph`~~ (deprecated — use `agent-optimize`) |
 | optimizers | `run-optimizer` + `optimizers/registry.yaml` (14 backends incl. `mock`) |
 
 **Claude Code plugin:** `claude --plugin-dir ./plugins/cap-evolve` exposes every skill as

--- a/docs/OPTIMIZE_YOUR_OWN.md
+++ b/docs/OPTIMIZE_YOUR_OWN.md
@@ -142,7 +142,7 @@ resolves the name via `skills/optimizers/registry.yaml`:
 ```yaml
 capabilities:    [system-prompt, tools]   # any of: system-prompt | tools | mcp-tool | skill-package
 optimizer_skill: claude-code              # ← swap: codex | gemini-cli | opencode | cursor | droid | copilot | kimi | pi | antigravity | openclaw | ibm-bob | generic | mock
-algorithm_skill: hill-climb               # hill-climb (--focus all|cyclic|hardest-first) | gepa | skillopt | agent-optimize | evograph (last two REQUIRE orchestration_mode: agent)
+algorithm_skill: hill-climb               # hill-climb (--focus all|cyclic|hardest-first) | gepa | skillopt | agent-optimize (REQUIRES orchestration_mode: agent). evograph is deprecated.
 num_trials: 4
 store: git                                # versions every iteration
 ```

--- a/skills/_registry/manifest.json
+++ b/skills/_registry/manifest.json
@@ -29,7 +29,7 @@
     "evograph": {
       "component": "algorithm",
       "path": "algorithms/evograph",
-      "summary": "evo-graph as a cap-evolve algorithm (AGENT MODE ONLY) \u2014 a collaborative weakness-graph optimizer that clusters train failures into a shared markdown wiki, dispatches one solver per weakness in its own worktree scoped to that weakness's frozen affected_tasks, merges verified improvements, reverts a whole round on regression, and seals the test once via finalize. Writes a run-dir wiki + custom_view.json so its weakness-graph dashboard tab renders.",
+      "summary": "DEPRECATED (agent mode only) \u2014 the evo-graph weakness-graph algorithm. Do not select it for new runs: its one-solver-per-weakness fan-out is agent-optimize's sibling fan-out done behind the val significance gate evograph never applied, and its clustering, rejected-edit memory and stop-condition handling live in agent-optimize + phases/diagnose. Kept so an existing evograph run dir stays readable and the run-dir wiki/ format the dashboard's Weakness-graph tab reads still has an owner. Use agent-optimize (agent mode) or hill-climb | gepa | skillopt (deterministic).",
       "entry": "scripts/run.py",
       "abstract": "scripts/abstract.py",
       "check": "scripts/check.py",

--- a/skills/algorithms/evograph/SKILL.md
+++ b/skills/algorithms/evograph/SKILL.md
@@ -1,148 +1,82 @@
 ---
 name: evograph
 description: >-
-  evo-graph as a cap-evolve algorithm (AGENT MODE ONLY): a collaborative weakness-graph optimizer.
-  Each round re-evaluates the train split, clusters failures into a shared Obsidian-style markdown
-  "weakness graph", dispatches one solver agent per weakness in its own git worktree scoped to that
-  weakness's frozen affected_tasks, merges verified improvements, reverts a whole round on regression,
-  and repeats until the spec's stop_condition — then seals the test once via `cap-evolve finalize`.
-  Writes its wiki into the run dir; the cap-evolve dashboard reads those files directly and renders
-  the Weakness graph tab — no second server, no embedded view to launch.
-  USE when algorithm_skill: evograph and orchestration_mode: agent.
+  Deprecated agent-mode algorithm (evo-graph port): a weakness-graph search that dispatched one
+  solver agent per failure cluster and reverted a whole round on regression. Do not start new runs
+  with it — its per-weakness fan-out is already `agent-optimize`'s sibling fan-out, done behind the
+  honest val significance gate that evograph never applied, and everything else it did (failure
+  clustering, rejected-edit memory, budget-aware fan-out, free-text stop condition) lives in
+  `agent-optimize` + `phases/diagnose`. Use when reading or repairing an existing evograph run dir,
+  or when writing the run-dir `wiki/` format the dashboard's Weakness-graph tab reads — and to see
+  what to select instead: `agent-optimize` for agent-mode search, `hill-climb`, `gepa`, or
+  `skillopt` for a deterministic loop.
 component: algorithm
-argument-hint: "(agent mode) driven by the coding agent per orchestration_mode: agent"
+argument-hint: "deprecated — use agent-optimize (agent mode) or hill-climb | gepa | skillopt"
 allowed-tools: Read, Write, Edit, Bash, Task
 needs: [scores, traces, candidate]
 provides: [candidate]
 sources: [evo-graph]
 ---
 
-# evograph — collaborative weakness-graph optimizer (agent mode)
+# evograph — DEPRECATED
 
-evograph is **agent-mode only** (`orchestration_mode: agent`). There is no deterministic engine — a
-weakness-graph loop is agent-driven by nature. When a run selects `algorithm_skill: evograph`,
-cap-evolve runs intake → check → baseline and then hands **you, the coding agent in the conversation,**
-the loop (per the orchestrate skill's *Agent-mode loop*). You drive it yourself; you do not delegate
-the search to a separate optimizer agent, though you DO dispatch solver subagents for parallel work.
+**Do not select `algorithm_skill: evograph` for a new run.** Use `agent-optimize` (agent mode) or
+`hill-climb` / `gepa` / `skillopt` (deterministic). This file stays so an existing evograph run dir
+is still readable and so the wiki file-format contract has an owner until it moves.
 
-## How this differs from stock evo-graph (it fits cap-evolve)
+## Why it is deprecated
 
-evograph keeps evo-graph's *distinctive* machinery — the weakness graph, per-weakness solver
-worktrees, whole-round revert, and the wiki file formats the dashboard reads — but everything else is
-cap-evolve's:
+evograph advertised one distinctive capability — a collaborative weakness graph with one solver
+agent per weakness, merged into a shared candidate each round. Measured against its four siblings,
+that capability is not distinctive and the part that *was* distinctive was a defect:
 
-| stock evo-graph | evograph in cap-evolve |
-|---|---|
-| its own setup Q&A (`questions.md`) | **cap-evolve `intake`** — read the spec (`capevolve.yaml`); ask nothing of your own |
-| "discover & run the bench yourself" | **cap-evolve adapter + harness** — evaluate through `cap-evolve` (writes run-dir rollouts/results) |
-| its own train/test split | **cap-evolve seeded splits** (`splits.json`); train each round, **test sealed** |
-| its own final-test.json + cost prompt | **`cap-evolve finalize`** produces the sealed number; mirror it into the wiki for the view |
-| wiki under `.evograph/` | wiki under the **cap-evolve run dir** (`<run_dir>/wiki/…`) so the dashboard tab reads it |
-| primary/secondary from its own config | the spec's `metric_primary` / `metrics_display` (**#38**) — gate on the primary only |
+- **The fan-out already exists, gated properly.** `agent-optimize` fans out N sibling candidates
+  from the same parent, one diagnosed failure cluster each, every sibling in its own working copy
+  (a git worktree when the capability is in git), gated **one at a time with a re-gate after each
+  accept** so several fixes accumulate into one lineage honestly. That is evograph's round, minus
+  the flaws below. The clustering itself is `phases/diagnose`'s job in both cases.
+- **Acceptance was never held out.** evograph kept a merge on a raw delta over a frozen 3-task
+  subset of *train*, self-reported by the solver subagent that made the edit — no val split, no
+  standard error, no `Δ > k·SE`. Between `baseline` and `finalize` an evograph run took no
+  held-out measurement at all, so the sealed test number was the first honest signal anyone saw.
+  Whole-round revert existed only as a one-round-late substitute for the gate it lacked; wire the
+  real gate and there is nothing left for it to catch.
+- **What remains unique is an output format, not a search strategy.** The run-dir `wiki/` is
+  genuinely useful, but the dashboard renders the Weakness-graph tab from `wiki/` presence alone,
+  for any algorithm that writes the format (`core/cap_evolve/dashboard.py`). An output contract
+  does not earn a second agent-mode algorithm that users must choose between.
 
-Do **not** re-ask setup questions, invent a split, or run a raw bench command. Read the spec and use
-cap-evolve's primitives. This is what keeps the run honest (sealed test, val/train-gated) and the
-default dashboard tabs populated.
+## There is no deterministic engine
 
-## Vocabulary (canon — used in the wiki and the dashboard)
+There never was one, and `scripts/run.py` is a tombstone, not a stub: invoked deterministically it
+exits 2 with an `agent-mode only` payload rather than faking a loop. So evograph is also the one
+algorithm that could not be routed through the shared per-iteration record — see
+the `hill-climb` skill's `references/run-step.md`, which owns the shared iteration mechanics
+(parent selection, val gate, commit, iteration record) every other algorithm routes through. Read
+it if you are reconstructing what an evograph round *should* have done.
 
-Unchanged from evo-graph — the cap-evolve dashboard's Weakness graph tab reads these exact
-terms/formats out of the run dir:
+## Reading an existing evograph run
 
-- **Weakness** — a recurring failure pattern hurting the primary metric (incl. inconsistency). One
-  node per weakness: `<run_dir>/wiki/weaknesses/<slug>.md`.
-- **Solution** — one kept improvement, under `<run_dir>/wiki/solutions/<slug>/<sol-id>/`.
-- **Status** — `open | in-progress | completed | solved | reverted`.
-- **RSM (Rejected Store Memory)** — the dead-end log inside each weakness md; read before proposing.
+The run dir is authoritative. `<run_dir>/wiki/` holds the weakness nodes, solution cards and
+per-round results; `<run_dir>/runs/round-<N>/agents/<slug>.log` holds solver progress. The formats
+are in [references/dashboard.md](references/dashboard.md) — load it if you need to write or parse
+that wiki. Treat any per-weakness "kept / new record" number in it as a train-subset self-report,
+not a gated result; only `finalize`'s sealed test number and any `gate` decision recorded in
+`events.jsonl` are honest.
 
-## Hard rules (honesty — never violate)
+`scripts/now.py` is the one-clock timestamp stamper those formats require; it is correct and still
+used by anything writing the wiki.
 
-1. **The sealed test split is untouchable until the end.** Evaluate only on train (rounds) / the
-   affected_tasks; never score test until the final `cap-evolve finalize` (which owns the seal —
-   `RunDir.reserve_test`/`commit_test`). One test scoring, ever.
-2. **Acceptance is gated on the primary metric.** A merge/solution is kept only if it improves the
-   primary metric over its baseline on the relevant tasks; a whole round reverts if the round-start
-   train primary metric regressed. Secondary metrics (`metrics_display`) are shown, never gate.
-3. **Drive through cap-evolve primitives.** Every eval goes through the cap-evolve adapter/harness so
-   per-rollout JSON + results land in the run dir; log round boundaries via the run dir event log;
-   snapshot accepted candidates via the store. This keeps the default dashboard tabs live in addition
-   to evograph's own tab.
-4. **Isolate edits in git worktrees.** The capability under optimization is edited only inside
-   per-weakness worktrees on their own branches — never the user's checkout. (Same discipline as
-   evo-graph's Step 0; here the "capability" is cap-evolve's `capability_path` artifact.)
+## Removal is a separate decision
 
-## Step 1 — Read the spec + launch the view (no eval yet)
-
-- Read `capevolve.yaml`: `metric_primary` + `metrics_display` (#38), `stop_condition`,
-  `github_integration`, `capabilities`/`capability_path`, splits. cap-evolve intake already collected
-  these — do not re-ask.
-- Scaffold the wiki under the run dir. There is nothing to launch and nothing to register: the
-  cap-evolve dashboard reads these files itself and shows a **Weakness graph** tab whenever
-  `<run_dir>/wiki/` exists, in the live server and the static export alike.
-  - create `<run_dir>/wiki/{weaknesses,solutions,results}` and `<run_dir>/runs/`.
-  - write the formats in [references/dashboard.md](references/dashboard.md) as each round completes;
-    the tab reflects them on the next load. Give the user the cap-evolve dashboard link.
-
-## Step 2 — Round loop (you drive it, uninterrupted to stop_condition)
-
-Re-read `stop_condition` at the end of every round (free text; no built-in default).
-
-### 2.1 Eval all train tasks (via cap-evolve)
-Evaluate the current candidate on **all train tasks** through cap-evolve's eval (round 1 = the
-baseline you were handed). Tag the candidate's git state so a later round can roll back. Write
-`<run_dir>/wiki/results/round-<N>.json` (format: [references/dashboard.md](references/dashboard.md)),
-stamping `started_at` from `scripts/now.py`. Stamp all-perfect weaknesses `solved`.
-
-### 2.2 Regression check + whole-round revert (round ≥ 2)
-Compare this round's **primary metric** to `round-<N-1>.json`. If it dropped, round N−1's merges
-regressed the suite → reset the candidate to the pre-round-(N−1) tag, re-eval, overwrite the results,
-mark those weaknesses `reverted` (eligible again), demote their solutions into RSM.
-[references/graph.md](references/graph.md).
-
-### 2.3 Build / extend the weakness graph
-Dispatch builder subagents to read the round's **failed** (and contrasting **successful**)
-trajectories and write `<run_dir>/wiki/weaknesses/<slug>.md` directly — match+extend or create.
-Aim for **breadth (≥ 4 distinct weaknesses)** when the failures support it. `affected_tasks` is
-**frozen** at discovery. Do a light dedup pass. Schema + freeze rule:
-[references/clustering.md](references/clustering.md).
-
-### 2.4 Solve — one solver per weakness
-For each `open | completed | reverted` weakness, mark it `in-progress` and dispatch one solver in its
-own worktree (weakness branch → solution branch; names in [references/graph.md](references/graph.md)).
-Each solver: baseline the primary metric on its frozen `affected_tasks` (reuse round-start scores) →
-edit the capability → re-eval **only affected_tasks** via cap-evolve → keep if improved, else revert
-and try another angle → aim for ~2–3 improving iterations. Append progress to
-`<run_dir>/runs/round-<N>/agents/<slug>.log` (streamed live in the tab). Ship a real improvement →
-write `wiki/solutions/<slug>/<sol-id>/{solution.md,changes.diff}` with real before/after numbers,
-request merge, set `completed`/`solved`. Dead end → RSM, no merge.
-
-### 2.5 Merge (you)
-Trust the solver's reported result and merge into the working candidate; the round-start eval (2.1→2.2)
-is the objective backstop. If `github_integration: true`, mirror the weakness as a GitHub issue and
-ship the merge as a PR (`Closes #n`) — GitHub is **mirror-only**, the run dir stays authoritative
-(this is evograph's realization of #38's `github_integration`).
-
-### 2.6 Stop check + dashboard verify
-Stamp `completed_at`, log the round to the run dir event log, snapshot the accepted candidate via the
-store. **Verify the run dir has what both dashboards need** (round results written, weakness nodes +
-solution cards + logs present, standard events/rollouts emitted). Re-read `stop_condition`; continue
-(2.1) or halt.
-
-## Step 3 — Final test (once, after halt)
-Call `cap-evolve finalize` — it scores the best candidate on the sealed test split exactly once and
-burns the seal (unfakeable headline number). Mirror that number into `<run_dir>/wiki/results/final-test.json`
-(`"split":"test"`, `"round":"final"`) so evograph's tab shows it in its Final-test panel. Then
-`cap-evolve report`.
-
-## Cost — use cap-evolve's cost system (not a separate one)
-Do **not** run a bespoke end-of-run cost prompt. Cost is cap-evolve's job: every eval you drive
-through cap-evolve records spend in the run dir (`RunDir.update_spent`), the default dashboard **Cost**
-tab renders it, and the spec's `max_usd` / `max_optimizer_usd` caps bound it (preview with
-`cap-evolve estimate`). If you want the evograph tab's Final-test panel to show a cost number, read it
-from cap-evolve's recorded run-dir spend and mirror it into `final-test.json` as `cost_usd` — never ask
-the user to hand-total it.
+Deprecation is reversible; removal is not. Still to decide (maintainer): move the wiki format
+contract into `agent-optimize` as an optional output, stop `dashboard.py` inferring
+`algorithm = "evograph"` from `wiki/` presence, then delete this directory.
 
 ## References
-- [references/clustering.md](references/clustering.md) — weakness schema, direct-write build, freeze rule.
-- [references/graph.md](references/graph.md) — branch/PR model, solution layout, `related` edges.
-- [references/dashboard.md](references/dashboard.md) — the wiki file formats the tab reads (the contract).
+- [references/dashboard.md](references/dashboard.md) — the wiki file formats the dashboard tab
+  reads. Load it to write or parse `<run_dir>/wiki/`.
+- [references/clustering.md](references/clustering.md) — weakness-node schema and the
+  `affected_tasks` freeze rule, kept for reading historical run dirs.
+- [references/graph.md](references/graph.md) — solution-card schema, branch layout, whole-round
+  revert, kept for the same reason.

--- a/skills/algorithms/evograph/meta.yaml
+++ b/skills/algorithms/evograph/meta.yaml
@@ -1,6 +1,6 @@
 component: algorithm
 name: evograph
-summary: evo-graph as a cap-evolve algorithm (AGENT MODE ONLY) — a collaborative weakness-graph optimizer that clusters train failures into a shared markdown wiki, dispatches one solver per weakness in its own worktree scoped to that weakness's frozen affected_tasks, merges verified improvements, reverts a whole round on regression, and seals the test once via finalize. Writes a run-dir wiki + custom_view.json so its weakness-graph dashboard tab renders.
+summary: DEPRECATED (agent mode only) — the evo-graph weakness-graph algorithm. Do not select it for new runs: its one-solver-per-weakness fan-out is agent-optimize's sibling fan-out done behind the val significance gate evograph never applied, and its clustering, rejected-edit memory and stop-condition handling live in agent-optimize + phases/diagnose. Kept so an existing evograph run dir stays readable and the run-dir wiki/ format the dashboard's Weakness-graph tab reads still has an owner. Use agent-optimize (agent mode) or hill-climb | gepa | skillopt (deterministic).
 entry: scripts/run.py
 abstract: scripts/abstract.py
 check: scripts/check.py

--- a/skills/algorithms/evograph/references/clustering.md
+++ b/skills/algorithms/evograph/references/clustering.md
@@ -34,8 +34,7 @@ solutions have already been scored against that exact task set, and changing it 
 those comparisons and the "new record" signal. In later rounds you may only change `status`:
 `open`/`completed`/`reverted` → `in-progress` when re-attacked → `completed` (shipped an
 improvement, stopped) or `solved` (tasks now all ~perfect); a recurring `solved` weakness can go back
-to `in-progress`; a whole-round revert flips every weakness attacked that round to `reverted` (see
-[graph.md](graph.md)). Add each attack round to `attacked_in_rounds`.
+to `in-progress`; a whole-round revert flips every weakness attacked that round to `reverted`. Add each attack round to `attacked_in_rounds`.
 
 ## Related weaknesses
 
@@ -65,7 +64,7 @@ solved_in_round: null
 reverted_in_rounds: []         # rounds whose merged fix was rolled back by a whole-round revert
 branch: evograph/w/tool-call-arg-mismatch   # the weakness's worktree branch (set when first attacked)
 affected_tasks: [task_007, task_011, task_023]   # FROZEN after discovery round
-related:                                     # optional — graph edges; also the fix's blast-radius watchlist (see graph.md)
+related:                                     # optional — graph edges; also the fix's blast-radius watchlist
   - slug: schema-drift-after-retry
     why: both corrupt the tool-call payload; candidates to merge
 solutions:

--- a/skills/algorithms/evograph/references/dashboard.md
+++ b/skills/algorithms/evograph/references/dashboard.md
@@ -60,12 +60,15 @@ is rendered in its **own Final-test panel**, not plotted on the rounds line — 
 
 Front-matter drives the graph: `slug, status (open|in-progress|completed|solved|reverted), tags,
 discovered_in_round, attacked_in_rounds, solved_in_round, reverted_in_rounds, branch,
-affected_tasks, solutions`. Schema + example: [clustering.md](clustering.md).
+affected_tasks, solutions, related`. Each `related` entry is a `slug` + a one-line `why` — those
+are the graph's edges. `status` is one of `open | in-progress | completed | solved | reverted`, and
+`affected_tasks` is frozen after the weakness's discovery round.
 
 ### Solutions → `wiki/solutions/<weakness-slug>/<sol-id>/{solution.md,changes.diff}`
 
 Front-matter drives the solution cards (`outcome, primary_metric, secondary_metrics, new_record,
-timestamp, …`) and `changes.diff` drives the diff tabs. Schema: [graph.md](graph.md).
+timestamp, weakness, round, attempt_index, branch, tags`) and `changes.diff` drives the diff tabs.
+The `sol-id` is `r<N>-h<M>`: round N, hypothesis M for that weakness.
 
 ### Live progress → `runs/round-<N>/agents/<weakness-slug>.log`
 
@@ -89,5 +92,5 @@ same clock as `scripts/now.py`.
 ## What this buys the agents
 
 No registration, no build step, no API client. Write a markdown file or append a log line and the
-user sees it. The wiki stays the single source of truth (see
-[the SKILL.md honesty rules](../SKILL.md)).
+user sees it. The wiki stays the single source of truth for what an
+evograph run recorded — but see SKILL.md: its per-weakness numbers were never val-gated.

--- a/skills/algorithms/evograph/references/graph.md
+++ b/skills/algorithms/evograph/references/graph.md
@@ -9,8 +9,8 @@ EvoGraph keeps two mutually-linked graphs under `<run_dir>/wiki/`:
   weakness's RSM.
 
 Every solution `[[wikilink]]`s back to its weakness; every weakness lists its solutions. The
-dashboard graph shows **weaknesses only** (connected by their `related` links — see
-[clustering.md](clustering.md)); solutions appear inside a weakness's detail panel.
+dashboard graph shows **weaknesses only** (connected by their `related` links, declared in the
+weakness node's front matter); solutions appear inside a weakness's detail panel.
 
 ## Absolute wiki path (most important rule)
 
@@ -41,8 +41,7 @@ this weakness, made in round 2.
   `git diff <weakness-branch-base>..<solution-HEAD>`. Snapshotting here keeps the UI's diff stable
   even after later commits land on the weakness branch.
 
-Example `solution.md` (front-matter + body) — this is a **solution** file, not the weakness node
-(the weakness `<slug>.md` schema lives in [clustering.md](clustering.md)):
+Example `solution.md` (front-matter + body) — this is a **solution** file, not the weakness node:
 
 ```markdown
 ---
@@ -93,7 +92,7 @@ finalize `outcome` + metrics + `new_record` after the verified re-eval.
 
 The graph's **edges live on the weakness node, not on the solution.** Each
 `wiki/weaknesses/<slug>.md` lists `related:` neighbors (`slug` + `why`) — those are exactly the
-edges the dashboard draws (schema in [clustering.md](clustering.md)). A solution file only links
+edges the dashboard draws. A solution file only links
 *up* to its own weakness via `weakness: [[…]]`.
 
 A weakness's `related` neighbors are the fix's **blast radius — stay aware of them, don't re-run

--- a/skills/algorithms/evograph/scripts/check.py
+++ b/skills/algorithms/evograph/scripts/check.py
@@ -1,14 +1,14 @@
-"""Behavioral contract for evograph (AGENT MODE ONLY).
+"""Behavioral contract for evograph (DEPRECATED, agent mode only).
 
-evograph has no deterministic loop, so — unlike gepa/skillopt — there is nothing to
-run offline. Instead this check pins the contract that makes evograph safe and
-discoverable:
+evograph never had a deterministic loop, and it is now deprecated, so there is still
+nothing to run offline. This check pins what must stay true of the deprecated skill:
 
   1. its ``run.py`` REFUSES a deterministic invocation (exit 2 + an "agent-mode only"
      directive) rather than faking a deterministic loop;
-  2. the SKILL.md declares the agent-mode round loop AND the honesty rules
-     (sealed test via finalize, primary-metric gating);
-  3. every referenced doc exists (the wiki-format contract the dashboard reads).
+  2. the SKILL.md marks itself DEPRECATED and names the replacement (``agent-optimize``),
+     so nobody starts a new run on it by accident;
+  3. every referenced doc exists — above all the wiki-format contract the dashboard's
+     Weakness-graph tab reads, which is the reason this directory still exists.
 """
 
 from __future__ import annotations
@@ -45,13 +45,13 @@ def main() -> int:
             "run.py did not emit the agent-mode-only error",
             note="clear agent-mode directive emitted")
 
-    # 2: SKILL.md declares the loop + honesty contract.
+    # 2: SKILL.md is honestly marked deprecated and points somewhere better.
     skill = (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
     for needle, label in [
-        ("Round loop", "agent-mode round loop"),
-        ("finalize", "seal via cap-evolve finalize"),
-        ("primary metric", "primary-metric gating"),
-        ("orchestration_mode: agent", "agent-mode gating"),
+        ("DEPRECATED", "itself deprecated"),
+        ("agent-optimize", "the agent-mode replacement"),
+        ("hill-climb", "the deterministic replacements"),
+        ("no deterministic engine", "that it has no deterministic engine"),
     ]:
         c.check(needle in skill, f"SKILL.md missing: {label!r} ({needle!r})", note=f"SKILL.md declares {label}")
 

--- a/skills/algorithms/evograph/scripts/run.py
+++ b/skills/algorithms/evograph/scripts/run.py
@@ -1,14 +1,17 @@
-"""evograph — AGENT MODE ONLY entry.
+"""evograph — DEPRECATED, and never had a deterministic engine.
 
-evograph has no deterministic engine: its weakness-graph loop is driven by the
-coding agent (see SKILL.md). Under ``orchestration_mode: agent`` cap-evolve runs
-intake → check → baseline and then HANDS OFF to the agent (see cli.py), so this
-run.py is never invoked for a real evograph run.
+evograph is deprecated (see SKILL.md): use ``agent-optimize`` for agent-mode search,
+or ``hill-climb`` / ``gepa`` / ``skillopt`` for a deterministic loop.
+
+It also never had a deterministic engine — its weakness-graph loop was agent-driven,
+so under ``orchestration_mode: agent`` cap-evolve ran intake → check → baseline and
+then HANDED OFF to the agent (see cli.py); this run.py was never invoked for a real
+evograph run.
 
 If it IS invoked — i.e. someone selected ``algorithm_skill: evograph`` with
 ``orchestration_mode: deterministic`` — fail loudly with a clear directive rather
 than pretending to run a deterministic loop. This keeps the honesty contract
-explicit: there is no fake deterministic evograph.
+explicit: there is no fake deterministic evograph, and now no reason to want one.
 """
 
 from __future__ import annotations
@@ -38,12 +41,13 @@ def main(argv=None) -> int:
 
     print(json.dumps({
         "algorithm": ALGO,
-        "error": "evograph is agent-mode only",
+        "error": "evograph is agent-mode only, and is DEPRECATED",
         "detail": (
-            "evograph has no deterministic engine. Set `orchestration_mode: agent` in "
-            "capevolve.yaml and run it agent-driven: cap-evolve does intake/check/baseline "
-            "then hands the loop to the coding agent, which follows this skill's "
-            "'Step 2 — Round loop' and seals with `cap-evolve finalize`."
+            "evograph has no deterministic engine and is deprecated. Set "
+            "`algorithm_skill: agent-optimize` (with `orchestration_mode: agent`) for the "
+            "same per-cluster fan-out behind the val significance gate, or "
+            "`hill-climb` | `gepa` | `skillopt` for a deterministic loop. See "
+            "skills/algorithms/evograph/SKILL.md for why."
         ),
     }))
     return 2

--- a/templates/project/capevolve.yaml
+++ b/templates/project/capevolve.yaml
@@ -32,7 +32,7 @@ target_model: ""
 target_profile_file: ""
 
 # --- how to iterate ---------------------------------------------------------
-algorithm_skill: hill-climb              # algorithms/<skill>: hill-climb | gepa | skillopt | agent-optimize | evograph (agent-optimize and evograph REQUIRE orchestration_mode: agent)
+algorithm_skill: hill-climb              # algorithms/<skill>: hill-climb | gepa | skillopt | agent-optimize (REQUIRES orchestration_mode: agent). evograph is deprecated -- use agent-optimize.
 algorithm_focus: all                     # hill-climb schedule: all | cyclic | hardest-first
 orchestration_mode: deterministic        # deterministic (cap-evolve sequences the loop) | agent (the coding agent drives the loop via cap-evolve primitives, sealing with `cap-evolve finalize`)
 


### PR DESCRIPTION
Closes #328.

## Path B — deprecate

**One-sentence distinctiveness answer** (compared against all four siblings: `hill-climb` 56L, `gepa` 113L, `skillopt` 87L, `agent-optimize` 922L, plus `phases/diagnose`):

> The only thing evograph does that none of the others do is write a persistent markdown weakness wiki into the run dir — an output format the dashboard renders from `wiki/` presence alone regardless of which algorithm ran (`core/cap_evolve/dashboard.py:645-651`), not a search strategy — because its advertised distinctive claim, one solver agent per failure cluster in its own worktree merged into a shared candidate, is already `agent-optimize`'s sibling fan-out (`skills/algorithms/agent-optimize/SKILL.md:174-177, 383-391`) done behind the honest val significance gate that evograph replaced with the solver subagent's self-reported raw train delta (`SKILL.md:63-64, 120` and `references/graph.md:79-81, 106-109` before this PR).

I re-derived this rather than taking the issue's recommendation, and it lands in the same place. The three concrete reasons:

1. **The fan-out already exists, gated properly.** `agent-optimize` fans out N sibling candidates from one parent, one diagnosed failure cluster each, each `cp -r`'d to its own `$R/work/<tag>` (a git worktree when the capability is in git), and gates them **one at a time with a re-gate after every accept** — so several fixes accumulate into one lineage honestly. That *is* evograph's round, minus the flaws below. The clustering itself is `phases/diagnose`'s job in both cases, as are the rejected-edit memory (`$R/rejected.jsonl`), budget-aware fan-out (`spend.py --n-siblings`) and free-text `stop_condition` evograph also claimed.
2. **Acceptance was never held out.** `grep -n '\bval\b'` over evograph's SKILL.md + all three references returned exactly **one** hit before this PR — `SKILL.md:44`'s parenthetical "val/train-gated", which was simply false. Nothing scored val. A merge was kept on a raw delta over a frozen ~3-task subset of *train*, and `SKILL.md:120` said outright "**Trust the solver's reported result** and merge" — the subagent that made the edit graded its own homework. Between `baseline` and `finalize` an evograph run took no held-out measurement at all, so the sealed test number was the first honest signal anyone saw. Whole-round revert existed only as a one-round-late substitute for the gate it lacked; wire the real gate and it has nothing left to catch.
3. **What remains unique is an output format.** `dashboard.py:645-651` sets `has_wiki` from the directory's existence and even *infers* `algorithm = "evograph"` from it. Any algorithm that writes the format gets the tab. `references/dashboard.md:3` says so itself: "a **file-format contract**". That does not earn a second agent-mode algorithm that users must choose between.

I did not choose B to look decisive. Path A was live and I costed it: fix the gate, fix the ref→ref links, apply the ownership contract, make the body truthful. The problem is that step one of Path A *is* the deprecation argument — adding the val gate removes the reason whole-round revert exists, and what is then left over `agent-optimize` is a prescribed wiki writer. Per CONTEXT.md principle 5 (deletion beats addition) that belongs in `agent-optimize` as an optional output, not behind a fifth algorithm.

**Nothing is deleted.** Deprecation is reversible; removal deserves its own decision — see the follow-up section.

## Issue #201 — the unauditable bundle — does not apply to evograph any more

```
$ find . -name '*.js' -size +200k -not -path './node_modules/*' -not -path '*/dist/*'
./presentation/reveal/plugin/highlight/highlight.js          # vendored reveal.js
./examples/tau2_airline/run_full/ui/assets/index-CA4Zb19R.js # a static dashboard run export

$ find skills/algorithms/evograph -type d
skills/algorithms/evograph
skills/algorithms/evograph/references
skills/algorithms/evograph/scripts

$ git ls-files skills/algorithms/evograph | wc -l
10        # SKILL.md, meta.yaml, 3 references, 5 scripts — all text
```

`skills/algorithms/evograph/dashboard/` (the 1.2MB minified bundle and its server) was deleted in `bac04ebd` (#317); both dashboards now render the weakness graph from committed source (`core/cap_evolve/dashboard.py:2142`, `dashboard/frontend/src/components/AlgoPanels.tsx:224`). **evograph ships no bundle and no unauditable asset — #201 can be closed as fixed for this skill.** The one remaining committed bundle, `dashboard/frontend/dist/assets/index-C4VUMw-x.js`, *has* full source at `dashboard/frontend/src/` with `package.json` and `vite.config.ts`, so #201's "no source" complaint does not apply to it either; whether `dist/` matches `src/` is #188's question, not this PR's.

## What changed

| file | why |
|---|---|
| `skills/algorithms/evograph/SKILL.md` | **148 → 82 lines.** A deprecation notice carrying the evidence above, the replacement pointers, and how to read an existing evograph run dir. |
| `.../references/{clustering,dashboard,graph}.md` | **Clears 4 ref→ref violations — every one evograph had.** Each file now carries the schema it needs inline. |
| `.../scripts/check.py` | Pins the deprecation contract instead of the round loop. |
| `.../scripts/run.py` | The tombstone now names the replacement instead of a `Step 2 — Round loop` heading that no longer exists. |
| `.../meta.yaml`, `skills/_registry/manifest.json` | Summary marks it deprecated; drops `custom_view.json`, an extension point deleted in `bac04ebd`. Manifest regenerated by `build_manifest.py` (exit 0). |
| `core/cap_evolve/branding.py` | New `deprecated` key on an `ALGORITHMS` entry: rendered last, labelled `DEPRECATED — <what to use>`. Header count now derives from live algorithms. Also fixes `extras`, which still advertised the deleted "custom dashboard view". |
| `core/cap_evolve/cli.py` | `init` no longer *offers* it interactively (`--algorithm evograph` still accepted); `doctor` **warns** instead of reporting `ok` for an existing evograph spec. |
| docs, `templates/project/capevolve.yaml`, `README.md` | Stop advertising it as a choice. |
| `conftest.py` | Emptied. Its only job was excluding a test path deleted in `bac04ebd`; the glob matched nothing. |
| `CHANGELOG.md` | `### Deprecated` entry with the reasoning and the follow-up. |

An existing `algorithm_skill: evograph` spec still resolves and an old run dir still renders — the deprecation is a label and a warning, not a break.

## Ownership contract applied

Per `SKILL_OWNERSHIP.md`, deleted from evograph's body as restatements owned elsewhere:

- **Honesty invariants** (split seal / val-only gate / sealed test) — owned by `phases/gate`, `phases/finalize`, `phases/report`; core enforces all of it. evograph's 4 "Hard rules (honesty)" are gone.
- **The agent-mode loop** — owned by `orchestrate/orchestrate`.
- **Iteration mechanics** (parent selection, gate, commit, iteration record) — owned by `algorithms/hill-climb`. The body now points at that skill's `references/run-step.md` in prose rather than as a link, because that file lands with #330 and a dangling markdown link is worse than a named path.
- **The 18-line stock-evo-graph mapping table** — six of its seven rows described machinery that does not exist in this repo.
- **Three bare `#38` citations** an agent cannot resolve.

No rule was dropped, only restatements — with one deliberate exception, which is the point of the PR: the round-loop *instructions* are gone because the loop they instruct is deprecated. They remain in git history and in the three references, which are kept intact for exactly that reason.

**What other skills should drop** (not touched here, per the coordination rule): `capabilities/skill-package` has 2 remaining ref→ref links (`concepts.md` → `anti-patterns.md`, `description-optimization.md`) and `capabilities/tools` has 1 (`optimizer-playbook.md` → `examples.md`).

## Evidence

```
$ wc -l skills/algorithms/evograph/SKILL.md          # 82   (was 148)

$ python skills/algorithms/evograph/scripts/check.py
{"skill": "evograph", "ok": true, "problems": [], "notes": [
  "run entry exposes main()", "run.py refuses deterministic mode",
  "clear agent-mode directive emitted", "SKILL.md declares itself deprecated",
  "SKILL.md declares the agent-mode replacement",
  "SKILL.md declares the deterministic replacements",
  "SKILL.md declares that it has no deterministic engine",
  "references/clustering.md present", "references/graph.md present",
  "references/dashboard.md present"]}
exit=0
```

**Authoring lint** (`lint_skills.py` + the patched validator from #345, run against this branch): zero evograph violations — the 4 baselined ref→ref entries and the "say WHEN" advisory are all cleared. Before this PR the baseline recorded:

```
algorithms/evograph: references/clustering.md links to another reference 'graph.md'
algorithms/evograph: references/dashboard.md links to another reference 'clustering.md'
algorithms/evograph: references/dashboard.md links to another reference 'graph.md'
algorithms/evograph: references/graph.md  links to another reference 'clustering.md'
```

**Can it run deterministically? No, and this PR does not pretend otherwise.** evograph has no deterministic engine and never had one, so there is no zero-API evograph run to show. `run.py` is a tombstone that refuses rather than faking a loop:

```
$ python skills/algorithms/evograph/scripts/run.py --run-dir x --project y --optimizer mock
{"algorithm": "evograph", "error": "evograph is agent-mode only, and is DEPRECATED",
 "detail": "evograph has no deterministic engine and is deprecated. Set
 `algorithm_skill: agent-optimize` (with `orchestration_mode: agent`) for the same
 per-cluster fan-out behind the val significance gate, or `hill-climb` | `gepa` |
 `skillopt` for a deterministic loop. See skills/algorithms/evograph/SKILL.md for why."}
exit=2
```

This is also why #356 could not route it through the shared iteration-record seam: there is no engine to route.

**The replacement path does run zero-API end to end**, which is what my `templates/project/capevolve.yaml` edit had to not break:

```
$ bash examples/toy_calc/run.sh
{"run_dir": ".capevolve/run_demo", "best_id": "cand_0001",
 "baseline_val": 0.0, "test_reward": 1.0, "test_baseline_reward": 0.0,
 "test_delta": 1.0, "test_pass_k": {"1": 1.0}, "iterations": 3}
```

Baseline val 0.0 → gate-accepted candidate → sealed test 1.0, scored once.

**Deprecation is visible where a user actually meets it:**

```
$ cap-evolve algorithms
  evograph       DEPRECATED — use agent-optimize (agent mode), or hill-climb | gepa | skillopt
    what   collaborative weakness-graph search; one solver agent per weakness.
    prefer nothing new — use agent-optimize, which fans the same work out behind the val gate.

$ cap-evolve doctor --project <a project with algorithm_skill: evograph>
  warn  algorithm   evograph (agent) is DEPRECATED — use agent-optimize (agent mode), or
                    hill-climb | gepa | skillopt
                    → set algorithm_skill in .../capevolve.yaml
```

**Tests** — `PYTHONPATH="$PWD/core:$PWD/dashboard/backend" python -m pytest core/tests -q`:

```
789 passed, 12 skipped in 113.20s
```

Identical to clean main (#349), before and after. No test needed changing: `test_algorithms_cover_every_shipped_algorithm_skill` and `test_every_algorithm_prints_the_exact_spec_lines_that_select_it` both still hold because the entry stays in `ALGORITHMS` and still renders — deprecated, not hidden.

## Follow-up for the maintainer (deliberately NOT in this PR)

Removal is a separate decision and this PR does not make it. When you want it:

1. Move the wiki format contract (`references/dashboard.md`, the weakness/solution schemas, `scripts/now.py`) into `skills/algorithms/agent-optimize/` as an **optional output** — "if you want the Weakness-graph tab, write `<run_dir>/wiki/` in this format" — plus one paragraph on whole-round revert for the coarse case.
2. Stop `core/cap_evolve/dashboard.py:649-650` inferring `algorithm = "evograph"` from `wiki/` presence. The tab should key off `has_wiki`; the label should come from `run_config` only. Left alone here precisely so old run dirs keep their label while the skill is merely deprecated.
3. Then delete `skills/algorithms/evograph/`, drop the `ALGORITHMS` entry and the manifest entry, and check `grep -rn evograph core/ skills/ dashboard/frontend/src/` is clean apart from CHANGELOG history. Note `core/tests/test_cli_surface.py:229` and `core/tests/test_dashboard_status_cost_log.py:471` reference it by name and will need updating.

Also worth closing: **#201**, per the `find` output above.
