### PR TITLE
gepa: eval-cache hits carry output/trace so reflection isn't hollow (#111)

### DIFF
--- a/core/cap_evolve/cache.py
+++ b/core/cap_evolve/cache.py
@@ -1,12 +1,15 @@
 """Eval cache — skip a rollout when the same candidate was already scored on a task.
 
-Keyed by ``(hash of the candidate's editable files, task_id) -> {reward, feedback}``
+Keyed by ``(hash of the candidate's editable files, task_id) ->
+{reward, feedback, output, trace, errored}``
 and persisted in the run dir, so re-evaluating an identical candidate (e.g. a parent
 re-sampled in GEPA, or a resumed run) costs nothing. The hash is over file CONTENTS,
 so two byte-identical candidates share cache entries even under different ids.
 
 Honesty notes:
-  * The cache stores only the SCORE (reward + feedback), never gold answers.
+  * The cache stores the SCORE (reward + feedback) plus a bounded slice of the
+    agent's OWN output/trace (truncated by the caller, ~1.5KB each) so a hit yields
+    the same reflective material as a miss. Never gold answers.
   * It is keyed on candidate-file content, so an edit (even whitespace) busts the
     key — a stale score can never be served for changed files.
   * It is an optimization, not a source of truth: ``events.jsonl`` still records
@@ -61,8 +64,8 @@ def hash_candidate_dir(candidate_dir: Path) -> str:
 class EvalCache:
     """A tiny JSON-file eval cache living in the run dir.
 
-    ``get(candidate_hash, task_id)`` -> ``{"reward", "feedback"}`` or ``None``;
-    ``put(candidate_hash, task_id, reward, feedback)`` persists. Persistence is a
+    ``get(candidate_hash, task_id)`` -> the stored entry or ``None``;
+    ``put(...)`` persists. Persistence is a
     single JSON object ``{ "<hash>::<task_id>": {...} }`` rewritten on each put — fine
     for the run sizes here (a few thousand entries) and trivially portable.
     """
@@ -83,9 +86,15 @@ class EvalCache:
     def get(self, candidate_hash: str, task_id: str) -> dict | None:
         return self._data.get(self._key(candidate_hash, task_id))
 
-    def put(self, candidate_hash: str, task_id: str, reward: float, feedback: str = "") -> None:
+    def put(self, candidate_hash: str, task_id: str, reward: float, feedback: str = "",
+            output: str = "", trace: str = "", errored: bool = False) -> None:
+        # ponytail: callers pass output/trace ALREADY truncated (gepa._short, 1500 chars),
+        # so an entry stays ~3KB; _flush rewrites the whole file per put, which is fine at
+        # these run sizes. Add eviction only if a run's cache file ever gets unwieldy.
         self._data[self._key(candidate_hash, task_id)] = {
-            "reward": float(reward), "feedback": str(feedback or "")}
+            "reward": float(reward), "feedback": str(feedback or ""),
+            "output": str(output or ""), "trace": str(trace or ""),
+            "errored": bool(errored)}
         self._flush()
 
     def _flush(self) -> None:

--- a/core/cap_evolve/gepa.py
+++ b/core/cap_evolve/gepa.py
@@ -160,9 +160,15 @@ def _eval_minibatch(
             if cached is not None:
                 reward = float(cached.get("reward", 0.0))
                 fb = str(cached.get("feedback", ""))
+                # Replay the reflective payload: without it a hit feeds
+                # _write_reflection an empty output/trace and misclassifies a cached
+                # infra failure as an actionable capability defect.
                 scores.append(Score(task_id=task.id, reward=reward, feedback=fb,
                                     n=1, stderr=0.0, trial_rewards=[reward],
-                                    raw={"cached": True}))
+                                    raw={"cached": True,
+                                         "errored": bool(cached.get("errored")),
+                                         "output": str(cached.get("output", "")),
+                                         "trace": str(cached.get("trace", ""))}))
                 continue
             rollout = (pooled.get(task.id) if pooled is not None
                        else adapter.run_target(task, ctx, seed=seed))
@@ -173,12 +179,12 @@ def _eval_minibatch(
             run_tokens += int(getattr(rollout, "tokens", 0) or 0)
             sc = adapter.score(task, rollout)
             n_called += 1
+            out_s = _short(getattr(rollout, "output", None))
+            trace_s = _short(getattr(rollout, "trace", None))
             scores.append(Score(
                 task_id=task.id, reward=sc.reward, feedback=sc.feedback or "",
                 n=1, stderr=0.0, trial_rewards=[sc.reward],
-                raw={"errored": errored,
-                     "output": _short(getattr(rollout, "output", None)),
-                     "trace": _short(getattr(rollout, "trace", None))},
+                raw={"errored": errored, "output": out_s, "trace": trace_s},
             ))
             (out_dir / f"{task.id}__{tag}__t0.json").write_text(
                 json.dumps({"input": task.input, "rollout": rollout.to_dict(),
@@ -186,7 +192,8 @@ def _eval_minibatch(
                 encoding="utf-8",
             )
             if cache is not None:
-                cache.put(chash, task.id, sc.reward, sc.feedback or "")
+                cache.put(chash, task.id, sc.reward, sc.feedback or "",
+                          output=out_s, trace=trace_s, errored=errored)
 
     elapsed = time.time() - t0
     # Count ONLY rollouts actually fired (cache hits cost nothing) toward budget.

--- a/core/tests/test_gepa.py
+++ b/core/tests/test_gepa.py
@@ -274,3 +274,68 @@ def test_merge_skips_gracefully_monolith(tmp_path):
         if "merge_of" in s:
             assert "accepted" in s and "local_gate" in s
     assert res["best_val"] == 1.0
+
+
+def test_cache_hit_carries_output_trace_for_reflection(tmp_path):
+    """issue #111 — a cache HIT must yield the same reflective material as a MISS.
+
+    Populates the eval cache with a first (all-miss) minibatch, then re-runs the
+    identical candidate so every task is served from cache, and asserts the replayed
+    ``raw`` still carries output/trace — and that ``REFLECTION.md`` built from it is
+    not hollow. Also pins the second symptom: a cached infra-errored failure must stay
+    in the "Ignore — infra errors" bucket, not become an actionable capability defect.
+    """
+    from cap_evolve import Budget, CapabilityAdapter, EvalCache, Rollout, RunDir, Score, Task
+    from cap_evolve import gepa, harness
+
+    class _A(CapabilityAdapter):
+        def tasks(self, split):  # noqa: ARG002
+            return [Task(id=f"t{i}", input=f"in{i}", target="ok") for i in range(3)] + [
+                Task(id="boom", input="in3", target="ok")]
+
+        def run_target(self, task, ctx, *, seed=0):  # noqa: ARG002
+            if task.id == "boom":
+                return Rollout(task_id=task.id, error="runner exploded")
+            return Rollout(task_id=task.id, output=f"WRONG-{task.id}",
+                           trace=f"step1 read {task.input}; step2 guessed")
+
+        def score(self, task, rollout):
+            return Score(task_id=task.id, reward=0.0, feedback=f"expected ok for {task.id}",
+                         trial_rewards=[0.0])
+
+        def materialize(self, candidate_dir, edits=None):  # noqa: ARG002
+            return None
+
+    adapter = _A()
+    cand = tmp_path / "cand"
+    cand.mkdir()
+    (cand / "prompt.txt").write_text("v1", encoding="utf-8")
+    run_dir = RunDir.create(tmp_path / ".capevolve", ts="c1", budget=Budget(max_iterations=2))
+    harness.ensure_splits(adapter, run_dir, seed=0)
+    cache = EvalCache(run_dir.root / "eval_cache.json")
+    ids = [t.id for t in adapter.tasks("all")]
+
+    miss = gepa._eval_minibatch(adapter, cand, ids, run_dir=run_dir, cache=cache,
+                                tag="mb_miss", seed=0, workers=1)
+    assert len(cache) == len(ids)
+
+    hit = gepa._eval_minibatch(adapter, cand, ids, run_dir=run_dir, cache=cache,
+                               tag="mb_hit", seed=0, workers=1)
+    hit_raw = {pt["task_id"]: (pt.get("raw") or {}) for pt in hit.per_task}
+    assert all(r.get("cached") for r in hit_raw.values()), "expected an all-hit minibatch"
+    for tid in ("t0", "t1", "t2"):
+        assert hit_raw[tid].get("output"), f"cache hit for {tid} lost the agent output"
+        assert hit_raw[tid].get("trace"), f"cache hit for {tid} lost the trace"
+        assert hit_raw[tid]["output"] == f"WRONG-{tid}"
+    # infra failures stay classified as infra failures across a hit
+    assert hit_raw["boom"].get("errored") is True
+
+    workdir = tmp_path / "wd"
+    workdir.mkdir()
+    gepa._write_reflection(workdir, hit)
+    md = (workdir / "REFLECTION.md").read_text(encoding="utf-8")
+    assert "- Agent output: WRONG-t0" in md, "reflective dataset is hollow on a cache hit"
+    assert "- Trajectory: step1 read in0" in md
+    assert "3 actionable failing task(s)" in md          # boom excluded
+    assert "failed with run/infra errors" in md and "boom" in md
+    assert "- Agent output: \n" not in md               # no empty output lines

--- a/core/tests/test_w1_engine.py
+++ b/core/tests/test_w1_engine.py
@@ -468,7 +468,8 @@ def test_cache_get_put_roundtrip(tmp_path):
     c = EvalCache(tmp_path / "cache.json")
     assert c.get("h", "t0") is None
     c.put("h", "t0", reward=0.7, feedback="ok")
-    assert c.get("h", "t0") == {"reward": 0.7, "feedback": "ok"}
+    assert c.get("h", "t0") == {"reward": 0.7, "feedback": "ok", "output": "",
+                                "trace": "", "errored": False}
     # persisted: a fresh instance reads it back
     c2 = EvalCache(tmp_path / "cache.json")
     assert c2.get("h", "t0")["reward"] == 0.7


### PR DESCRIPTION
Fixes #111. Supersedes #210 (same bug, much smaller mechanism — see "What I deliberately dropped").

## Root cause

`EvalCache.put` persisted only the score — `core/cap_evolve/cache.py:86-89` (pre-fix):

```python
def put(self, candidate_hash, task_id, reward, feedback="") -> None:
    self._data[self._key(candidate_hash, task_id)] = {
        "reward": float(reward), "feedback": str(feedback or "")}
```

So the cache-HIT branch of `_eval_minibatch` (`core/cap_evolve/gepa.py:159-166`) could only
rebuild `raw={"cached": True}`, while the MISS branch stores
`{"errored", "output", "trace"}` (`gepa.py:179-181`) — and `_write_reflection`
(`gepa.py:252-260`) reads exactly those three keys.

Consequences, both silent:

1. Every cache-served failing task lands in `REFLECTION.md` as a bare `- Agent output:`.
   GEPA's whole advantage over hill-climb is reflection quality (arXiv:2507.19457), so the
   expensive optimizer call was being asked to diagnose a common root cause from nothing.
2. `errored` was also absent on a hit, so `actionable = [pt for pt in failing if not
   raw.get("errored")]` (`gepa.py:231-232`) classified every cached **infra** failure as an
   actionable **capability** defect — environment noise injected into the reflective dataset.

This is not a rare path: `cache.py`'s own docstring names "a parent re-sampled in GEPA" as the
target use case, and parents *are* re-sampled from the per-instance Pareto frontier every
iteration with minibatch ids redrawn from the same `train_ids`. The cache is designed to serve
precisely the eval that feeds reflection.

## The fix — 27 insertions / 11 deletions in 2 files

Fixed once at the single place all callers route through (`put` is called from exactly one
site; `get` from two, both in `_eval_minibatch`):

* `cache.py` — `put(..., output="", trace="", errored=False)` also stores the bounded
  reflective payload. Callers pass `output`/`trace` **already truncated** by the miss path's
  existing `_short(..., 1500)`, so an entry stays ~3KB. Docstring honesty note updated: the
  cache now stores the score plus a bounded slice of the agent's *own* output/trace — never
  gold answers, still busted by any file edit.
* `gepa.py` — the hit branch replays `errored`/`output`/`trace` into `raw`; the miss branch
  reuses its two computed `_short` values for both `raw` and `put` (no double truncation).

`git diff --numstat` for the source change:

```
15	6	core/cap_evolve/cache.py
12	5	core/cap_evolve/gepa.py
```

The hit/miss decision stays exactly where it was (`cache.get(...) is None`), so main's
parallel `misses` pre-pass + `run_trials_pool` path is untouched and still correct.

## Regression test — fails before, passes after

One test appended to `core/tests/test_gepa.py` (65 lines incl. its synthetic adapter):
populate the cache with an all-miss minibatch, re-run the identical candidate so every task
is a HIT, then assert the replayed rollout carries output + trace and that `REFLECTION.md`
built from it is not hollow. It also pins symptom 2 (cached infra failure stays in the
"Ignore — infra errors" bucket).

**BEFORE the fix:**

```
$ python -m pytest core/tests/test_gepa.py::test_cache_hit_carries_output_trace_for_reflection -q
        for tid in ("t0", "t1", "t2"):
>           assert hit_raw[tid].get("output"), f"cache hit for {tid} lost the agent output"
E           AssertionError: cache hit for t0 lost the agent output
E           assert None
E            +  where None = <built-in method get of dict object at 0x105b06300>('output')
E            +    where <built-in method get of dict object at 0x105b06300> = {'cached': True}.get

core/tests/test_gepa.py:327: AssertionError
=========================== short test summary info ============================
FAILED core/tests/test_gepa.py::test_cache_hit_carries_output_trace_for_reflection
1 failed in 1.14s
```

Note `raw` on a hit is literally `{'cached': True}` — that is the bug in one line of output.

**AFTER the fix:**

```
$ python -m pytest core/tests/test_gepa.py::test_cache_hit_carries_output_trace_for_reflection \
                  core/tests/test_w1_engine.py::test_cache_get_put_roundtrip -q
..                                                                       [100%]
2 passed in 0.08s
```

`core/tests/test_w1_engine.py` is touched for one reason only, and it is not scope creep:
`test_cache_get_put_roundtrip` asserts the stored cache entry by **exact dict equality**, so
widening the entry necessarily moves that assertion. It is a 1-line change (2 lines after
wrapping) and the only other test touched.

## Full suite

Green, with imports pinned to one `cap_evolve` tree (see #349 — mixing a venv-installed copy
with `core/tests`' own `sys.path.insert` makes the process import two module trees and any
identity/monkeypatch assertion fail spuriously):

```
$ PYTHONPATH="$PWD/core:$PWD/dashboard/backend" python -m pytest core/tests -q
790 passed, 12 skipped in 111.97s (0:01:51)
```

789 on clean main + this PR's one new test = 790. No failures.

## toy_calc still reaches a gate-accepted test score

```
$ bash examples/toy_calc/run.sh 2>&1 | tail -15
{"baseline_val":0.0,"best_id":"cand_0001","dashboard":".capevolve/run_demo/dashboard.html",
 "dashboard_server":"http://127.0.0.1:7878","iterations":3,"run_dir":".capevolve/run_demo",
 "test_baseline_reward":0.0,"test_delta":1.0,"test_pass_k":{"1":1.0},"test_reward":1.0}
```

## What I deliberately dropped from #210, and why

#210 fixed the same real bug but at +503/-0 across 4 files. Dropped:

* **The `rollout_file` pointer indirection.** The miss path *already* truncates output/trace
  via `_short(..., 1500)`, so storing those two bounded strings directly in the cache entry
  is exactly the "bounded, redacted slice" #111 Option A asks for. No re-reading a rollout
  json on every hit.
* **The hardlink re-materialization** that the pointer required, and therefore
* **the `harness.py` `write_text` → `_atomic_write` change** — collateral damage from
  creating shared inodes across tags, not from the bug, and
* **the ~20 lines of path-traversal / symlink validation** that only existed because
  `rollout_file` had to be treated as untrusted input.
* **The 364-line new test file** (~3x the fix it guarded) → one 65-line test appended to the
  existing `core/tests/test_gepa.py`.

Two behavioural reasons the payload approach is not merely smaller but *more correct*:

* **Pointerless entries stayed cache misses.** #210's `_replay_cached` returns `None` for a
  pre-#111 or pruned entry, so a resumed run silently re-pays rollouts the cache was supposed
  to save. Payload storage has no unresolvable pointer.
* **It no longer composes with main's parallel minibatch path.** Main computes `misses`
  *before* the per-task loop and pools only those rollouts (`gepa.py:152-157`). Under #210 a
  hit whose pointer fails to resolve becomes a miss *after* pooling, so `pooled.get(task.id)`
  is `None` → `Rollout(task_id=..., error="no rollout")` → a fabricated infra error and a 0.0
  reward instead of the re-run the docstring promises.

Kept from #210: the `errored` replay, which fixes the second symptom neither #210's
description nor #111 mentioned. Credit to #210 for finding the bug.

I also deliberately did **not** add a cache eviction policy: `_flush` already rewrites the
whole JSON per put and puts only happen on real rollouts, so entries are bounded by `_short`.
The ceiling is noted in a `ponytail:` comment on `put`.
