### PR TITLE
gepa: eval-cache hits carry output/trace so reflection isn't hollow (#111)

### DIFF
--- a/core/cap_evolve/cache.py
+++ b/core/cap_evolve/cache.py
@@ -1,12 +1,15 @@
 """Eval cache — skip a rollout when the same candidate was already scored on a task.
 
-Keyed by ``(hash of the candidate's editable files, task_id) -> {reward, feedback}``
+Keyed by ``(hash of the candidate's editable files, task_id) ->
+{reward, feedback, output, trace, errored}``
 and persisted in the run dir, so re-evaluating an identical candidate (e.g. a parent
 re-sampled in GEPA, or a resumed run) costs nothing. The hash is over file CONTENTS,
 so two byte-identical candidates share cache entries even under different ids.
 
 Honesty notes:
-  * The cache stores only the SCORE (reward + feedback), never gold answers.
+  * The cache stores the SCORE (reward + feedback) plus a bounded slice of the
+    agent's OWN output/trace (truncated by the caller, ~1.5KB each) so a hit yields
+    the same reflective material as a miss. Never gold answers.
   * It is keyed on candidate-file content, so an edit (even whitespace) busts the
     key — a stale score can never be served for changed files.
   * It is an optimization, not a source of truth: ``events.jsonl`` still records
@@ -63,8 +66,8 @@ def hash_candidate_dir(candidate_dir: Path) -> str:
 class EvalCache:
     """A tiny JSON-file eval cache living in the run dir.
 
-    ``get(candidate_hash, task_id)`` -> ``{"reward", "feedback"}`` or ``None``;
-    ``put(candidate_hash, task_id, reward, feedback)`` persists. Persistence is a
+    ``get(candidate_hash, task_id)`` -> the stored entry or ``None``;
+    ``put(...)`` persists. Persistence is a
     single JSON object ``{ "<hash>::<task_id>": {...} }`` rewritten on each put — fine
     for the run sizes here (a few thousand entries) and trivially portable.
     """
@@ -85,9 +88,15 @@ class EvalCache:
     def get(self, candidate_hash: str, task_id: str) -> dict | None:
         return self._data.get(self._key(candidate_hash, task_id))
 
-    def put(self, candidate_hash: str, task_id: str, reward: float, feedback: str = "") -> None:
+    def put(self, candidate_hash: str, task_id: str, reward: float, feedback: str = "",
+            output: str = "", trace: str = "", errored: bool = False) -> None:
+        # ponytail: callers pass output/trace ALREADY truncated (gepa._short, 1500 chars),
+        # so an entry stays ~3KB; _flush rewrites the whole file per put, which is fine at
+        # these run sizes. Add eviction only if a run's cache file ever gets unwieldy.
         self._data[self._key(candidate_hash, task_id)] = {
-            "reward": float(reward), "feedback": str(feedback or "")}
+            "reward": float(reward), "feedback": str(feedback or ""),
+            "output": str(output or ""), "trace": str(trace or ""),
+            "errored": bool(errored)}
         self._flush()
 
     def _flush(self) -> None:

--- a/core/cap_evolve/gepa.py
+++ b/core/cap_evolve/gepa.py
@@ -162,9 +162,15 @@ def _eval_minibatch(
             if cached is not None:
                 reward = float(cached.get("reward", 0.0))
                 fb = str(cached.get("feedback", ""))
+                # Replay the reflective payload: without it a hit feeds
+                # _write_reflection an empty output/trace and misclassifies a cached
+                # infra failure as an actionable capability defect.
                 scores.append(Score(task_id=task.id, reward=reward, feedback=fb,
                                     n=1, stderr=0.0, trial_rewards=[reward],
-                                    raw={"cached": True}))
+                                    raw={"cached": True,
+                                         "errored": bool(cached.get("errored")),
+                                         "output": str(cached.get("output", "")),
+                                         "trace": str(cached.get("trace", ""))}))
                 continue
             rollout = (pooled.get(task.id) if pooled is not None
                        else adapter.run_target(task, ctx, seed=seed))
@@ -175,12 +181,12 @@ def _eval_minibatch(
             run_tokens += int(getattr(rollout, "tokens", 0) or 0)
             sc = adapter.score(task, rollout)
             n_called += 1
+            out_s = _short(getattr(rollout, "output", None))
+            trace_s = _short(getattr(rollout, "trace", None))
             scores.append(Score(
                 task_id=task.id, reward=sc.reward, feedback=sc.feedback or "",
                 n=1, stderr=0.0, trial_rewards=[sc.reward],
-                raw={"errored": errored,
-                     "output": _short(getattr(rollout, "output", None)),
-                     "trace": _short(getattr(rollout, "trace", None))},
+                raw={"errored": errored, "output": out_s, "trace": trace_s},
             ))
             (out_dir / f"{task.id}__{tag}__t0.json").write_text(
                 json.dumps({"input": task.input, "rollout": rollout.to_dict(),
@@ -188,7 +194,8 @@ def _eval_minibatch(
                 encoding="utf-8",
             )
             if cache is not None:
-                cache.put(chash, task.id, sc.reward, sc.feedback or "")
+                cache.put(chash, task.id, sc.reward, sc.feedback or "",
+                          output=out_s, trace=trace_s, errored=errored)
 
     elapsed = time.time() - t0
     # Count ONLY rollouts actually fired (cache hits cost nothing) toward budget.

--- a/core/tests/test_gepa.py
+++ b/core/tests/test_gepa.py
@@ -299,3 +299,68 @@ def test_accepted_candidate_snapshot_is_capability_only(tmp_path):
         names = {p.name for p in cand.iterdir()}
         assert not names & set(harness._SNAPSHOT_IGNORE), f"{cand.name} dirty: {sorted(names)}"
         assert "PROCESS.md" in names, f"{cand.name} lost its explainability record"
+
+
+def test_cache_hit_carries_output_trace_for_reflection(tmp_path):
+    """issue #111 — a cache HIT must yield the same reflective material as a MISS.
+
+    Populates the eval cache with a first (all-miss) minibatch, then re-runs the
+    identical candidate so every task is served from cache, and asserts the replayed
+    ``raw`` still carries output/trace — and that ``REFLECTION.md`` built from it is
+    not hollow. Also pins the second symptom: a cached infra-errored failure must stay
+    in the "Ignore — infra errors" bucket, not become an actionable capability defect.
+    """
+    from cap_evolve import Budget, CapabilityAdapter, EvalCache, Rollout, RunDir, Score, Task
+    from cap_evolve import gepa, harness
+
+    class _A(CapabilityAdapter):
+        def tasks(self, split):  # noqa: ARG002
+            return [Task(id=f"t{i}", input=f"in{i}", target="ok") for i in range(3)] + [
+                Task(id="boom", input="in3", target="ok")]
+
+        def run_target(self, task, ctx, *, seed=0):  # noqa: ARG002
+            if task.id == "boom":
+                return Rollout(task_id=task.id, error="runner exploded")
+            return Rollout(task_id=task.id, output=f"WRONG-{task.id}",
+                           trace=f"step1 read {task.input}; step2 guessed")
+
+        def score(self, task, rollout):
+            return Score(task_id=task.id, reward=0.0, feedback=f"expected ok for {task.id}",
+                         trial_rewards=[0.0])
+
+        def materialize(self, candidate_dir, edits=None):  # noqa: ARG002
+            return None
+
+    adapter = _A()
+    cand = tmp_path / "cand"
+    cand.mkdir()
+    (cand / "prompt.txt").write_text("v1", encoding="utf-8")
+    run_dir = RunDir.create(tmp_path / ".capevolve", ts="c1", budget=Budget(max_iterations=2))
+    harness.ensure_splits(adapter, run_dir, seed=0)
+    cache = EvalCache(run_dir.root / "eval_cache.json")
+    ids = [t.id for t in adapter.tasks("all")]
+
+    gepa._eval_minibatch(adapter, cand, ids, run_dir=run_dir, cache=cache,
+                         tag="mb_miss", seed=0, workers=1)
+    assert len(cache) == len(ids)
+
+    hit = gepa._eval_minibatch(adapter, cand, ids, run_dir=run_dir, cache=cache,
+                               tag="mb_hit", seed=0, workers=1)
+    hit_raw = {pt["task_id"]: (pt.get("raw") or {}) for pt in hit.per_task}
+    assert all(r.get("cached") for r in hit_raw.values()), "expected an all-hit minibatch"
+    for tid in ("t0", "t1", "t2"):
+        assert hit_raw[tid].get("output"), f"cache hit for {tid} lost the agent output"
+        assert hit_raw[tid].get("trace"), f"cache hit for {tid} lost the trace"
+        assert hit_raw[tid]["output"] == f"WRONG-{tid}"
+    # infra failures stay classified as infra failures across a hit
+    assert hit_raw["boom"].get("errored") is True
+
+    workdir = tmp_path / "wd"
+    workdir.mkdir()
+    gepa._write_reflection(workdir, hit)
+    md = (workdir / "REFLECTION.md").read_text(encoding="utf-8")
+    assert "- Agent output: WRONG-t0" in md, "reflective dataset is hollow on a cache hit"
+    assert "- Trajectory: step1 read in0" in md
+    assert "3 actionable failing task(s)" in md          # boom excluded
+    assert "failed with run/infra errors" in md and "boom" in md
+    assert "- Agent output: \n" not in md               # no empty output lines

--- a/core/tests/test_w1_engine.py
+++ b/core/tests/test_w1_engine.py
@@ -468,7 +468,8 @@ def test_cache_get_put_roundtrip(tmp_path):
     c = EvalCache(tmp_path / "cache.json")
     assert c.get("h", "t0") is None
     c.put("h", "t0", reward=0.7, feedback="ok")
-    assert c.get("h", "t0") == {"reward": 0.7, "feedback": "ok"}
+    assert c.get("h", "t0") == {"reward": 0.7, "feedback": "ok", "output": "",
+                                "trace": "", "errored": False}
     # persisted: a fresh instance reads it back
     c2 = EvalCache(tmp_path / "cache.json")
     assert c2.get("h", "t0")["reward"] == 0.7


### PR DESCRIPTION
Fixes #111. **Supersedes #385** (same fix, rebased onto current `main` `af7cf9d6`; #385 went CONFLICTING after today's 17 merges). #385 itself supersedes #210.

## Root cause

`EvalCache.put` persisted only the score, so the cache-HIT branch of `gepa._eval_minibatch` could
only rebuild `raw={"cached": True}` — while the MISS branch stores `{"errored", "output", "trace"}`
and `_write_reflection` reads exactly those three keys.

Two silent consequences:

1. Every cache-served failing task landed in `REFLECTION.md` as a bare `- Agent output:`. GEPA's
   whole advantage over hill-climb is reflection quality (arXiv:2507.19457), so the expensive
   optimizer call was asked to diagnose a common root cause from nothing.
2. `errored` was also absent on a hit, so `actionable = [pt for pt in failing if not
   raw.get("errored")]` classified every cached **infra** failure as an actionable **capability**
   defect — environment noise injected into the reflective dataset.

Not a rare path: this run's own gepa trace shows **4 of 6 minibatches served entirely from cache**
(`fired=0 cached=4`), because parents are re-sampled from the Pareto frontier every iteration.

## The fix — 2 source files

* `cache.py` — `put(..., output="", trace="", errored=False)` also stores the bounded reflective
  payload. Callers pass output/trace **already truncated** by the miss path's existing
  `_short(..., 1500)`, so an entry stays ~3KB.
* `gepa.py` — the hit branch replays `errored`/`output`/`trace` into `raw`; the miss branch reuses
  its two computed `_short` values for both `raw` and `put` (no double truncation).

`put` is called from exactly one site, so the fix is at the single place all callers route through.
The hit/miss decision stays where it was (`cache.get(...) is None`), so main's parallel `misses`
pre-pass + `run_trials_pool` path is untouched.

## Rebase notes

`cache.py` / `gepa.py` merged cleanly onto post-#346/#350/#386 `main` — #346 removed the dead
optimizer-memory API but left `put`/`get` shape untouched, and #386's `OptimizerContext` restructuring
did not move `_eval_minibatch` or `_write_reflection`. The only conflict was in `core/tests/test_gepa.py`,
where #350 appended `test_accepted_candidate_snapshot_is_capability_only` at the same spot; **both**
tests are kept.

## Evidence

### Regression test fails on current `main`, passes with the fix

Source files reverted to `af7cf9d6`, new test kept:

```
>           assert hit_raw[tid].get("output"), f"cache hit for {tid} lost the agent output"
E           AssertionError: cache hit for t0 lost the agent output
E           assert None
E            +    where <built-in method get of dict object at 0x11111a840> = {'cached': True}.get
FAILED core/tests/test_gepa.py::test_cache_hit_carries_output_trace_for_reflection
1 failed in 1.07s
```

`raw` on a hit is literally `{'cached': True}` — the bug in one line of output. With the fix:

```
$ python -m pytest core/tests/test_gepa.py::test_cache_hit_carries_output_trace_for_reflection \
                  core/tests/test_w1_engine.py::test_cache_get_put_roundtrip -q
2 passed in 1.20s
```

### Cache-hit reflective dataset is non-empty (both symptoms)

All four minibatch tasks served from cache; `boom` is an infra failure:

```
all cache hits: True
summary: 3 actionable failing minibatch task(s); full reflective dataset in REFLECTION.md
======================================================================
# Reflective dataset (GEPA)

Parent minibatch reward: 0.000 (0/4 sampled tasks pass). ...

## Ignore — 1 task(s) failed with run/infra errors
Environment noise (a flaky/aborted run), not a capability problem: boom

## 3 actionable failing task(s)
### task t0
- Agent output: WRONG-t0
- Trajectory: step1 read in0; step2 guessed
- Feedback: expected ok for t0

### task t1
- Agent output: WRONG-t1
- Trajectory: step1 read in1; step2 guessed
- Feedback: expected ok for t1

### task t2
- Agent output: WRONG-t2
- Trajectory: step1 read in2; step2 guessed
- Feedback: expected ok for t2
```

Symptom 1 fixed (output + trajectory present). Symptom 2 fixed: the cached infra failure sits in the
run/infra-errors bucket and is excluded from the 3 actionable capability defects — on `main` it would
be a 4th actionable task.

### Full suite (imports pinned — see #349)

```
$ PYTHONPATH="$PWD/core:$PWD/dashboard/backend" python -m pytest core/tests -q
806 passed, 12 skipped in 127.02s (0:02:07)
```

805 on `af7cf9d6` + this PR's one new test = **806**. No failures. `ruff` error count unchanged
(11 pre-existing, identical before and after).

### Zero-API runs reach a gate-accepted sealed test score

Pinned `toy_calc` (hill-climb), unchanged from main's baseline:

```
$ bash examples/toy_calc/run.sh
"best_id": "cand_0001", "baseline_val": 0.0, "test_reward": 1.0,
"test_baseline_reward": 0.0, "test_delta": 1.0
```

Same example under **gepa** (the path this PR changes):

```
"best_id": "gepa_0001", "baseline_val": 0.0, "test_reward": 1.0,
"test_baseline_reward": 0.0, "test_delta": 1.0, "iterations": 3
```

That run's cache entries carry the payload, and most minibatches were cache-served:

```
cache entries: 8
entry keys: ['errored', 'feedback', 'output', 'reward', 'trace']

mb_p_0000 fired=4 cached=0
mb_c_0000 fired=4 cached=0
mb_p_0001 fired=0 cached=4     <- all-hit
mb_c_0001 fired=0 cached=4     <- all-hit
mb_p_0002 fired=0 cached=4     <- all-hit
mb_c_0002 fired=0 cached=4     <- all-hit
```

## Test-file note

`core/tests/test_w1_engine.py` is touched for one reason: `test_cache_get_put_roundtrip` asserts the
stored cache entry by **exact dict equality**, so widening the entry necessarily moves that assertion.
One line (two after wrapping). Not scope creep.

No cache eviction policy added: `_flush` already rewrites the whole JSON per put, puts only happen on
real rollouts, and entries are bounded by `_short`. The ceiling is noted in a `ponytail:` comment on `put`.
