### PR TITLE
fix: docs, skills and code invoked cap-evolve subcommands that do not exist (#203)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,8 @@
 #                        runs pytest on core/tests/ and dashboard/backend/tests/
 #   2. build-dashboard — installs dashboard/frontend dependencies, runs npm build + vitest
 #   3. toy-example     — runs the zero-API toy_calc example and asserts test_reward 1.0
-#   4. docs-links      — checks relative links/images in Markdown resolve (offline)
+#   4. docs-links      — checks relative links/images in Markdown resolve (offline), and
+#                        that every documented `cap-evolve <sub>` exists in the CLI (#203)
 #   5. spellcheck      — codespell over README + docs
 #
 # No shared-workflow delegation needed: this is repo-specific CI.
@@ -193,6 +194,12 @@ jobs:
             --exclude-path examples/skillsbench/run_full
             "README.md" "docs/**/*.md" "examples/**/*.md" "*.md"
           fail: true
+
+      # Docs/skills/code must not instruct agents to run a `cap-evolve <sub>` that does
+      # not exist (issue #203). The valid set is parsed out of core/cap_evolve/cli.py, so
+      # no install is needed and the check cannot drift from the CLI.
+      - name: Check documented cap-evolve subcommands exist
+        run: python3 ci/check_cli_subcommands.py
 
   spellcheck:
     name: Spellcheck (docs)

--- a/ci/check_cli_subcommands.py
+++ b/ci/check_cli_subcommands.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Fail if a doc or skill invokes a `cap-evolve <subcommand>` the CLI does not implement.
+
+Docs and several algorithm skills used to instruct agents to invoke the finalize and
+report PHASES as if they were subcommands. Neither is (both are scripts, invoked by
+`cap-evolve run` via `skill_run(step)`), so an agent following them ran a command that
+fails at the end of a run that may have cost real money (issue #203).
+
+This file names no phantom command itself -- on purpose: the check scans `ci/` too, so a
+worked example here would need an exception mechanism, and an exception mechanism is the
+hole every future phantom slips through.
+
+The valid set is READ OUT OF THE CODE -- the `COMMANDS` dict in `core/cap_evolve/cli.py`,
+parsed with `ast` so nothing needs installing -- not hardcoded here, so it stays correct
+as commands are added or removed.
+
+Only backticked/fenced invocations are checked; prose like "cap-evolve optimizes any
+capability" is not a command. Usage: `python ci/check_cli_subcommands.py [root ...]`.
+"""
+from __future__ import annotations
+
+import ast
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+CLI = ROOT / "core" / "cap_evolve" / "cli.py"
+# .py/.sh are in here because the two worst #203 sites were CODE, not prose: the
+# agent-mode handoff JSON printed by cli.py and the Stop-hook nudge in plugins/.
+SUFFIXES = {".md", ".yaml", ".yml", ".txt", ".py", ".sh"}
+DEFAULT_ROOTS = ("skills", "docs", "templates", "plugins", "ci", "site", "examples",
+                 "core", "README.md", "RUN.md", "llms.txt")
+# CHANGELOG records what past releases claimed; built run artifacts are generated.
+SKIP = ("CHANGELOG.md", "core/build/", "node_modules/", "/run_full/", "/dist/")
+
+# The two forms a real invocation takes: a backticked span and a line
+# inside a ``` fence. Unfenced prose ("cap-evolve runs intake ...") is not a command and is
+# deliberately not matched. ponytail: no shell parsing -- a fence line must be the command
+# at column 0 (indented fence lines are prose notes); widen if a phantom hides mid-pipeline.
+INLINE = re.compile(r"`+cap-evolve\s+([a-z][a-z0-9-]*)")
+FENCED = re.compile(r"^\$? ?cap-evolve\s+([a-z][a-z0-9-]*)")
+# ...and an unfenced line that is plainly a copy-pasteable command (carries a `--flag`).
+BARE = re.compile(r"^\$? ?cap-evolve\s+([a-z][a-z0-9-]*)(?=.*\s--)")
+
+
+def invocations(text):
+    """Yield (subcommand, line_no) for every real `cap-evolve <sub>` invocation."""
+    fenced = False
+    for n, line in enumerate(text.split("\n"), 1):
+        if line.lstrip().startswith("```"):
+            fenced = not fenced
+            continue
+        pats = (FENCED,) if fenced else (INLINE, BARE)
+        for m in (m for pat in pats for m in pat.finditer(line)):
+            yield m.group(1), n
+
+
+def cli_commands() -> set[str]:
+    """The subcommand names `cap-evolve` actually dispatches, straight from cli.py."""
+    tree = ast.parse(CLI.read_text(encoding="utf-8"))
+    names: set[str] = set()
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and any(
+            isinstance(t, ast.Name) and t.id == "COMMANDS" for t in node.targets
+        ):
+            names |= {k.value for k in node.value.keys if isinstance(k, ast.Constant)}
+    if not names:
+        sys.exit(f"error: no COMMANDS table found in {CLI} -- update this check")
+    return names | {"help", "version"}  # -h/--help/-V/--version aliases
+
+
+def files(roots):
+    for r in roots:
+        p = ROOT / r
+        for f in ([p] if p.is_file() else sorted(p.rglob("*"))):
+            rel = f.relative_to(ROOT).as_posix()
+            if f.is_file() and f.suffix in SUFFIXES and not any(s in rel for s in SKIP):
+                yield f, rel
+
+
+def main(argv) -> int:
+    valid = cli_commands()
+    bad = []
+    for f, rel in files(argv or list(DEFAULT_ROOTS)):
+        for sub, line in invocations(f.read_text(encoding="utf-8", errors="replace")):
+            if sub not in valid:
+                bad.append(f"{rel}:{line}: `cap-evolve {sub}` is not a subcommand")
+    if bad:
+        print("\n".join(bad))
+        print(f"\n{len(bad)} phantom cap-evolve subcommand reference(s).")
+        print(f"Valid: {' '.join(sorted(valid))}")
+        print("Phases (finalize/report/baseline/...) are SCRIPTS: run "
+              "`python skills/phases/<phase>/scripts/run.py`, or `/cap-evolve:<phase>`, "
+              "or let `cap-evolve run` sequence them.")
+        return 1
+    print(f"ok: no phantom cap-evolve subcommands (valid: {' '.join(sorted(valid))})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/core/README.md
+++ b/core/README.md
@@ -25,8 +25,8 @@ cap-evolve run   --spec .capevolve/project/capevolve.yaml \
             --project .capevolve/project
 cap-evolve run   --spec .capevolve/project/capevolve.yaml \
             --project .capevolve/project --run-ts full --resume  # continue an interrupted run
-cap-evolve check --spec .capevolve/project/capevolve.yaml   # validate adapter
-cap-evolve report                                        # regenerate dashboard
+cap-evolve check --project .capevolve/project             # validate adapter
+cap-evolve dashboard --base .capevolve                   # serve the live dashboard
 ```
 
 See the [cap-evolve repository](https://github.com/skillberry-ai/cap-evolve) for full

--- a/core/cap_evolve/cli.py
+++ b/core/cap_evolve/cli.py
@@ -703,7 +703,7 @@ def _cmd_run(argv):
     # coding agent, so the plan reflects only what this process actually runs.
     if orchestration_mode == "agent":
         sequence = ["intake", "implement-and-check", "baseline",
-                    "<handoff: agent drives the loop, then `cap-evolve finalize`>"]
+                    "<handoff: agent drives the loop, then runs the finalize phase script>"]
     else:
         sequence = ["intake", "implement-and-check", "baseline", algorithm_name, "finalize", "report"]
 
@@ -834,14 +834,14 @@ def _cmd_run(argv):
 
     # Agent mode: the coding agent drives the optimization loop itself (reading the
     # algorithm's "Agent-mode loop"), writing run-dir artifacts via cap-evolve
-    # primitives, and sealing with `cap-evolve finalize`. cap-evolve run does
+    # primitives, and sealing by running the finalize phase script. cap-evolve run does
     # setup+baseline, then hands off here — no algorithm subprocess, no auto-finalize.
     if orchestration_mode == "agent":
         print(json.dumps({"mode": "agent", "run_dir": run_dir, "algorithm": algorithm_name,
                           "spec_path": str(spec_path), "dashboard": dash_url or "off",
                           "stop_condition": str(spec.get("stop_condition", "")),
-                          "next": "drive via the orchestrate Agent-mode loop; "
-                                  "seal with `cap-evolve finalize`"}))
+                          "next": "drive via the orchestrate Agent-mode loop; seal by "
+                                  "running skills/phases/finalize/scripts/run.py"}))
         return done(0)
 
     # 2) algorithm (hill-climb variants select their schedule via --focus)

--- a/core/cap_evolve/dashboard.py
+++ b/core/cap_evolve/dashboard.py
@@ -486,7 +486,8 @@ def _derive_status(*, events: list, now: float, budget, spent, agent_mode: bool,
         # about it is the exact class of wrong status the old logic produced.
         return "awaiting_agent", (
             "baseline is done and `cap-evolve run` handed off — the agent has not "
-            "committed a candidate yet (agent-mode runs end with `cap-evolve finalize`)")
+            "committed a candidate yet (agent-mode runs end by running the finalize "
+            "phase script)")
 
     last_t = 0.0
     for e in reversed(events):

--- a/core/tests/test_stop_hook_agent_mode.py
+++ b/core/tests/test_stop_hook_agent_mode.py
@@ -1,8 +1,8 @@
 """require_green_check Stop hook: agent-mode continuation nudge.
 
 The hook blocks a Stop (exit 2) once per chain when an agent-mode run is not yet
-finalized, so the coding agent keeps driving its loop until it seals with
-`cap-evolve finalize`. Deterministic runs, finalized runs, and a relenting chain
+finalized, so the coding agent keeps driving its loop until it seals with the
+finalize phase script. Deterministic runs, finalized runs, and a relenting chain
 (`stop_hook_active`) are all unaffected.
 
 We unit-test `decide()` directly. The green-check itself (`_check_failed_reason`)

--- a/docs/AGENT_ORCHESTRATION.md
+++ b/docs/AGENT_ORCHESTRATION.md
@@ -98,10 +98,10 @@ python "$S/phases/finalize/scripts/run.py" --run-dir "$R" --project "$P" --n-tri
 python "$S/phases/report/scripts/run.py"   --run-dir "$R"
 ```
 
-> **Note — there is no `cap-evolve finalize` subcommand.** The orchestrate/host prose uses
-> `cap-evolve finalize` as shorthand; sealing is done by the finalize *phase script* above
-> (`skills/phases/finalize/scripts/run.py`), which scores the best candidate on test once and
-> burns the seal. A second finalize raises `TestSealError`.
+> **Note — finalize is not a `cap-evolve` subcommand.** Where prose says "finalize", it means
+> the finalize *phase script* above (`skills/phases/finalize/scripts/run.py`), which scores the
+> best candidate on test once and burns the seal. A second finalize raises `TestSealError`.
+> `cap-evolve --help` lists the real subcommands.
 
 ## Honesty invariants (both modes)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -26,7 +26,8 @@ prioritizes what makes cap-evolve best-in-class and widely adopted.
   obra/superpowers) — verified headless commands; adding one is a single YAML row.
 - Honest-eval upgrades: paired significance gate (default), seal-on-success test,
   structured `Rollout.error` infra signal, per-trial seed for real pass^k variance.
-- Rich **self-contained** `dashboard.html` + `cap-evolve report --terminal` ANSI report.
+- Rich **self-contained** `dashboard.html` + an ANSI terminal report (`--terminal` on
+  the report phase script).
 - Host-agnostic installer + Claude Code plugin (honesty hooks in core-owned scripts,
   diagnoser/proposer subagents, router) — `claude --plugin-dir ./plugins/cap-evolve`.
 - Real proof: tau2-bench airline (gpt-oss-120b agent + user simulator) optimized

--- a/plugins/cap-evolve/hooks/inject_router.py
+++ b/plugins/cap-evolve/hooks/inject_router.py
@@ -41,7 +41,7 @@ _CONTEXT = (
     "capevolve.yaml`, which presumes intake already happened and enforces the check "
     "gate before spending budget; or, with `orchestration_mode: agent` in the spec, "
     "`cap-evolve run` stops after baseline and hands the loop back to the agent, with "
-    "no sealed-test number until `cap-evolve finalize` is called. Honesty discipline "
+    "no sealed-test number until the finalize phase script seals it. Honesty discipline "
     "(sealed test, val-only gate) is enforced by core and by this plugin's hooks — do "
     "not edit the test split, test rollouts, or gold files, and do not finish an "
     "iteration while `cap-evolve check` is red."

--- a/plugins/cap-evolve/hooks/require_green_check.py
+++ b/plugins/cap-evolve/hooks/require_green_check.py
@@ -163,7 +163,8 @@ def decide(payload: dict) -> int:
             "cap-evolve (agent mode): the run is not finalized. Re-read your "
             "stop_condition — if it isn't met and budget remains, keep driving the "
             "algorithm's Agent-mode loop (evaluate->gate->accept/revert), verifying each "
-            "round wrote its run-dir artifacts. When done, seal with `cap-evolve finalize`."
+            "round wrote its run-dir artifacts. When done, seal by running the finalize "
+            "phase script (skills/phases/finalize/scripts/run.py)."
         )
     return 0
 

--- a/skills/algorithms/agent-optimize/SKILL.md
+++ b/skills/algorithms/agent-optimize/SKILL.md
@@ -289,7 +289,7 @@ that bought it.
 
 ## Stop & seal, then MEASURE (exactly once)
 
-There is no `cap-evolve status` command: **every 2–3 rounds** (and always before a fan-out) run
+Spend is not a CLI subcommand: **every 2–3 rounds** (and always before a fan-out) run
 `spend.py`. Everything it reports is re-read from the run dir, never from a total you carry in your head
 — which is what keeps a `$6.00` cap from becoming `$6.01`. (The Stop hook re-nudges you across turns
 until the run is finalized.) Stop when `recommendation` is `stop`, then produce the run's one honest
@@ -306,8 +306,9 @@ information, and seals test through the same `harness.finalize` the finalize pha
 interchangeable with `phases/finalize/scripts/run.py`. It refuses to flatter the run: an **empty** split
 says `empty`, not 0.0; a **no-holdout** spec is a **FIT metric, not generalisation**, with the overlap
 counted; a negative `screen_ledger.net_rollouts` says screening was pure overhead; and
-`best_id == "seed"` is a **null result with a diagnosed cause**, never a 0.000 gain. (There is **no
-`cap-evolve finalize` subcommand** — a second finalize raises `TestSealError`.) No finalize, no result.
+`best_id == "seed"` is a **null result with a diagnosed cause**, never a 0.000 gain. (Sealing is that
+phase script, **not a CLI subcommand** — and a second finalize raises `TestSealError`.) No finalize,
+no result.
 
 ## Honesty invariants specific to driving this by hand
 

--- a/skills/algorithms/hill-climb/SKILL.md
+++ b/skills/algorithms/hill-climb/SKILL.md
@@ -132,8 +132,9 @@ class of tasks, which is what the loop is asking for anyway.
 
 When `orchestration_mode: agent`, drive the loop yourself with the same mechanism as
 above: parent = current best, one edit per iteration, evaluate on **val**, gate,
-accept → snapshot / reject → revert, seal once with `cap-evolve finalize`, then
-`report`. `orchestrate` owns the agent-mode rules; the hill-climb-specific obligation
+accept → snapshot / reject → revert, seal once with the finalize phase script
+(`skills/phases/finalize/scripts/run.py`), then report. `orchestrate` owns the
+agent-mode rules; the hill-climb-specific obligation
 is that you must reproduce the handover surface `run_step` normally builds —
 `LEDGER.md`, `JOURNAL.md`, `PROCESS.md`, `RUNMAP.md` + `prior_iterations/` — and carry
 rejected edits into the next iteration's prompt. Skip it and the dashboard goes dark

--- a/skills/orchestrate/orchestrate/SKILL.md
+++ b/skills/orchestrate/orchestrate/SKILL.md
@@ -52,7 +52,7 @@ Rules:
 2. **Honesty is self-policed:** never touch the sealed test split until the end; revert on regression; acceptance is val-only.
 3. **Between rounds, verify the run dir has what the dashboard needs** before continuing: the round's events are logged, results/rollouts are written, and each accepted candidate is snapshotted. If a round produced no run-dir artifacts, the dashboard will be blank — fix that before proceeding.
 4. **Re-read `stop_condition` each round.** Stop when it is met, or budget/stall hits.
-5. **Seal once, at the end:** call `cap-evolve finalize` (scores the best candidate on the sealed test split exactly once) then `cap-evolve report`. A run with no finalize has no result.
+5. **Seal once, at the end:** run the finalize phase script `skills/phases/finalize/scripts/run.py` (scores the best candidate on the sealed test split exactly once), then the report phase script `skills/phases/report/scripts/run.py` — see `docs/AGENT_ORCHESTRATION.md` for the exact invocations. Neither is a `cap-evolve` subcommand; both are scripts. A run with no finalize has no result.
 
 ## How to run
 ```

--- a/skills/phases/intake/inputs/INPUTS.md
+++ b/skills/phases/intake/inputs/INPUTS.md
@@ -158,7 +158,7 @@ path, how to obtain it, and the alternatives. Never invent a NEEDED input.
   - `metric_primary`: the single metric that decides accept/reject (= the scalar reward). Blank = use the reward directly.
   - `metrics_display` + `metric_directions`: extra SHOWN-ONLY metrics and each one's direction (`higher`|`lower`). These never affect the gate — display only.
 - **github_integration** (default `false`): if `true`, intake runs `gh auth status`; when authed, cap-evolve may mirror the algorithm's work items as issues and ship the winner as a PR (`Closes #n`). WHAT gets mirrored is algorithm-specific — the chosen `algorithm_skill` defines it (e.g. evograph mirrors *weaknesses*; a candidate-based algorithm might mirror candidates/iterations). GitHub is NEVER the source of truth — the run dir is. If unauthed, intake offers `gh auth login` or skip.
-- **orchestration_mode** (default `deterministic`): `deterministic` = cap-evolve sequences the loop (code-enforced honesty). `agent` = the coding agent drives the loop via cap-evolve primitives and seals with `cap-evolve finalize`. Agent mode also uses `stop_condition`.
+- **orchestration_mode** (default `deterministic`): `deterministic` = cap-evolve sequences the loop (code-enforced honesty). `agent` = the coding agent drives the loop via cap-evolve primitives and seals with the finalize phase script (`skills/phases/finalize/scripts/run.py`). Agent mode also uses `stop_condition`.
 - **stop_condition** (default empty): agent-mode free-text halt rule, re-read each round. Deterministic mode ignores it and uses the budget knobs.
 
 - **baseline traces** (optional): prior rollouts to seed diagnosis. Default: none

--- a/skills/phases/report/SKILL.md
+++ b/skills/phases/report/SKILL.md
@@ -17,8 +17,8 @@ seed started (val), where the best candidate landed (val), and the single **held
 test** number that counts. It is what a human reads to decide whether to ship.
 
 Runs standalone as `/cap-evolve:report`, or headlessly as the last step of
-`cap-evolve run` — same `scripts/run.py` either way. There is no `cap-evolve report`
-subcommand; invoke the script.
+`cap-evolve run` — same `scripts/run.py` either way. report is a phase SCRIPT, not a
+`cap-evolve` subcommand; invoke the script.
 
 ## How to read the three numbers
 The honest reading is always **test vs baseline**, with val as a sanity check in

--- a/templates/project/capevolve.yaml
+++ b/templates/project/capevolve.yaml
@@ -34,7 +34,7 @@ target_profile_file: ""
 # --- how to iterate ---------------------------------------------------------
 algorithm_skill: hill-climb              # algorithms/<skill>: hill-climb | gepa | skillopt | agent-optimize (REQUIRES orchestration_mode: agent). evograph is deprecated -- use agent-optimize.
 algorithm_focus: all                     # hill-climb schedule: all | cyclic | hardest-first
-orchestration_mode: deterministic        # deterministic (cap-evolve sequences the loop) | agent (the coding agent drives the loop via cap-evolve primitives, sealing with `cap-evolve finalize`)
+orchestration_mode: deterministic        # deterministic (cap-evolve sequences the loop) | agent (the coding agent drives the loop via cap-evolve primitives, sealing with the finalize phase script)
 
 # --- what context the optimizer gets (hill-climb | gepa | skillopt) ---------
 # The per-iteration optimizer prompt is RENDERED from this template (intake authors it,


### PR DESCRIPTION
Supersedes #367 (do not merge that one — it was written against a `main` that has since
been rewritten underneath it by 17 PRs; ~half its 16 files no longer exist in the shape it
patched). Fresh branch, violation list **re-derived from scratch** against `af7cf9d6`.

Closes #203.

## The bug

Docs and skills instructed agents to run `cap-evolve finalize`, `cap-evolve report` and
`cap-evolve status`. None of them is a subcommand. The real table is the `COMMANDS` dict in
`core/cap_evolve/cli.py`; finalize/report are phase **scripts** that `cap-evolve run`
invokes via `skill_run(step)`. An agent following the prose ran a command that fails at the
end of a run that may have cost real money.

## What re-deriving found: 22 references in 15 files (vs #367's 16 files)

The delta from #367, both directions:

**Already fixed by the skill rewrites that landed today** — #362 (report), #379 (intake),
#369 (gepa), #380 (skillopt), #366 (finalize), #364 (evaluate), #374 (baseline), #381
(diagnose), #373 (mcp-tool), #348 (tools), #359 (using-cap-evolve), #377 (system-prompt)
each corrected their own skill while rewriting it, and #384 deprecated evograph entirely.
So `skills/algorithms/{gepa,skillopt,evograph}/**` — four of #367's files — needed nothing
here. `README.md`, `RUN.md`, `llms.txt` and `site/` are clean on current main.

**New, not in #367:**
- `skills/algorithms/agent-optimize/SKILL.md:292` — a **third** phantom, `cap-evolve status`,
  introduced by #368 after #367 was opened.
- `plugins/cap-evolve/hooks/inject_router.py:44` — the router context injected into every
  session, so this one was teaching the phantom to the agent on turn one.
- `core/tests/test_stop_hook_agent_mode.py` and `core/cap_evolve/cli.py` line numbers all
  moved (#357 and others touched `cli.py`), which is why replaying the diff was not an option.

## Judgement calls kept from #367

- **Negative-disclaimer sites are rewritten to state the fact without printing the phantom
  string.** "There is no `cap-evolve finalize` subcommand" → "finalize is not a `cap-evolve`
  subcommand". Same information, and the guard needs no exception mechanism — which is the
  hole every future phantom would slip through. The guard's own docstring follows the same
  rule, since it scans `ci/` too.
- **Left alone:** CHANGELOG history (records what a past release claimed) and the ANSI panel
  *title* `cap-evolve report · <run_id>` in `dashboard.py` + its assertion in
  `test_dashboard.py`. Neither tells anyone to type anything, and neither is backticked or at
  column 0, so the guard does not flag them.

## Also fixed

`core/README.md` documented `cap-evolve check --spec …`; `_cmd_check` takes `--project` (or
the dir positionally) and rejects `--spec` with exit 2. Its `cap-evolve report # regenerate
dashboard` line is now `cap-evolve dashboard --base .capevolve`, which is real.

## The durable half: `ci/check_cli_subcommands.py`

**Code-derived, no hardcoded list.** It `ast`-parses the `COMMANDS` dict out of
`core/cap_evolve/cli.py` (no import, so nothing needs installing) and errors out loudly if
that table ever moves. Adding or removing a subcommand updates the check for free.

Extended past #367's version to scan `.py`/`.sh` as well as `.md`/`.yaml`/`.txt`, and to
include `core/` — because the three worst sites this fixes were **code**, not prose, and
#367's suffix set would not have caught a regression in any of them. Skips `CHANGELOG.md`,
`node_modules/`, `*/dist/` and `*/run_full/` (frozen run artifacts). Only backticked spans,
fenced command lines and unfenced lines carrying a `--flag` count, so prose like "cap-evolve
optimizes any capability" is not mistaken for an invocation.

Wired into the `docs-links` CI job.

### Guard: fails on a planted bad reference, then passes

```
$ printf '\n<!-- planted: run `cap-evolve finalize` to seal -->\n' >> docs/ROADMAP.md
$ python ci/check_cli_subcommands.py; echo "exit code: $?"
docs/ROADMAP.md:69: `cap-evolve finalize` is not a subcommand

1 phantom cap-evolve subcommand reference(s).
Valid: algorithms check dashboard diff doctor estimate help init replay run splits tail version watch
Phases (finalize/report/baseline/...) are SCRIPTS: run `python skills/phases/<phase>/scripts/run.py`, or `/cap-evolve:<phase>`, or let `cap-evolve run` sequence them.
exit code: 1

$ # planted line removed
$ python ci/check_cli_subcommands.py; echo "exit code: $?"
ok: no phantom cap-evolve subcommands (valid: algorithms check dashboard diff doctor estimate help init replay run splits tail version watch)
exit code: 0
```

## Evidence

Grep before (`cap-evolve\s+(finalize|report|status)` across `skills/ docs/ README.md RUN.md
llms.txt templates/ examples/ site/ plugins/ ci/ core/`) — 15 files:

```
skills/algorithms/agent-optimize/SKILL.md:2      docs/ROADMAP.md:1
skills/algorithms/hill-climb/SKILL.md:1          templates/project/capevolve.yaml:1
skills/phases/intake/inputs/INPUTS.md:1          plugins/cap-evolve/hooks/inject_router.py:1
skills/phases/report/SKILL.md:1                  plugins/cap-evolve/hooks/require_green_check.py:1
skills/orchestrate/orchestrate/SKILL.md:1        core/README.md:1
docs/AGENT_ORCHESTRATION.md:2                    core/cap_evolve/dashboard.py:2
                                                 core/cap_evolve/cli.py:3
                                                 core/tests/test_stop_hook_agent_mode.py:1
                                                 core/tests/test_dashboard.py:1
```

After — only the two deliberately-exempt ANSI-panel-title sites:

```
core/cap_evolve/dashboard.py:1        # f-string panel title
core/tests/test_dashboard.py:1        # the assertion on that title
```

Tests, pinned (issue #349), unchanged from `main`:

```
$ PYTHONPATH="$PWD/core:$PWD/dashboard/backend" python -m pytest core/tests -q
805 passed, 12 skipped in 120.76s
```

Toy example reaches a gate-accepted sealed score:

```
$ bash examples/toy_calc/run.sh
"baseline_val": 0.0, "best_val": 1.0, "test_reward": 1.0, "test_delta": 1.0, "finalized": true, "iterations": 3
```

## Out of scope, filed as a follow-up finding

`dashboard/frontend/src/components/KpiStrip.tsx:136` and `AlgoPanels.tsx:371` also render
the phantom `cap-evolve finalize` to users. `dashboard/` is outside this issue's path list,
and touching it forces a `dist/` rebuild (the committed-bundle staleness gate, #188), so it
is left for a separate PR. The guard's roots are one line away from covering it once that
rebuild is acceptable.
