### PR TITLE
implement-and-check: stop claiming the standalone chain is ungated (#374 closed it)

### DIFF
--- a/skills/phases/evaluate/SKILL.md
+++ b/skills/phases/evaluate/SKILL.md
@@ -103,7 +103,8 @@ Two axes, and the trials axis is the one people get wrong.
   different seeds and warns if they are byte-identical
   (`core/cap_evolve/check.py:169-190`). It is opt-in because the probe costs real
   rollouts — run it once per adapter, and treat the warning as "every variance number
-  here is fiction".
+  here is fiction". Trials cost budget linearly, so spend them where variance actually
+  threatens a decision — the val split the gate reads — not on every exploratory probe.
 - **Tasks.** `stats.stderr` returns 0.0 below 2 tasks and `combined_stderr`'s
   between-task term is 0 below 2 (`stats.py:28-30, 47-50`), so a 1-task val gives
   `stderr = 0`, a bar of 0, and the gate degenerates to strict ("any Δ>0 wins") with

--- a/skills/phases/implement-and-check/SKILL.md
+++ b/skills/phases/implement-and-check/SKILL.md
@@ -106,10 +106,12 @@ than that. Measured on this checkout (issue #358):
 - `materialize()` is a **probe, not an assertion**: a raise is a note and does not fail
   the check (`check.py:166-167`), because a real adapter may need its full environment.
   Green means "callable or explained", not "edit path verified".
-- `cap-evolve run` fails closed: `cli.py:721-726` returns 1 before creating a run dir, so
-  no split and no spend. The **standalone** `/cap-evolve:*` chain does not —
-  `baseline/scripts/run.py` contains no check, and `provides: checked` is a static
-  ordering token, not a runtime precondition.
+- Both entry paths fail closed, so a red check never freezes a split: `cap-evolve run`
+  returns 1 before creating a run dir (`cli.py:721-726`), and the **standalone**
+  `/cap-evolve:baseline` re-runs the core check itself and exits non-zero before the run
+  dir exists (`baseline/scripts/run.py`). What is *not* a runtime precondition is the
+  `provides: checked` token — it declares ordering only, so a phase that skips baseline
+  gets no gate from the DAG.
 
 If your scorer calls a judge, say so in `PROJECT.md` along with how its decoding is
 pinned — the gate cannot see it. The one failure mode nothing here can catch: feedback
@@ -121,8 +123,8 @@ Standalone as `/cap-evolve:implement-and-check`; orchestrator-callable — but u
 this phase, `cap-evolve run` does **not** invoke `scripts/run.py`. It calls the core check
 inline and shells straight to `baseline`, so `--skill-check` and the pipeline self-test run
 in standalone mode only. Run this phase yourself before either `cap-evolve run` or
-`/cap-evolve:baseline` if you want them — and, per the previous section, the standalone
-chain has no gate of its own.
+`/cap-evolve:baseline` if you want them: both of those re-run the *core* check, but
+neither runs `--skill-check` or the pipeline self-test.
 
 ## References
 - `references/concepts.md` — why each check exists, the

--- a/skills/phases/implement-and-check/scripts/check.py
+++ b/skills/phases/implement-and-check/scripts/check.py
@@ -82,6 +82,21 @@ def main() -> int:
                 f"RNG scorer passed the determinism probe (problems={rep.problems})",
                 note="detects a non-deterministic score()")
 
+    # 4. SKILL.md's account of WHERE the gate is enforced must match the code. PR #374
+    #    added run_check() to baseline/scripts/run.py after this SKILL.md was written,
+    #    so the "the standalone chain is ungated" paragraph went stale and told the
+    #    reader a closed hole was still open.
+    skill = (Path(__file__).resolve().parents[1] / "SKILL.md").read_text(encoding="utf-8")
+    gated = "run_check(" in (Path(__file__).resolve().parents[2] / "baseline"
+                             / "scripts" / "run.py").read_text(encoding="utf-8")
+    claims_ungated = ("contains no check" in skill
+                      or "has no gate of its own" in skill)
+    c.check(gated != claims_ungated,
+            "SKILL.md and baseline/scripts/run.py disagree about whether the standalone "
+            f"chain is gated (baseline calls run_check={gated}, "
+            f"SKILL.md says ungated={claims_ungated})",
+            note="SKILL.md's standalone-gate claim matches baseline/scripts/run.py")
+
     return c.emit()
 
 


### PR DESCRIPTION
Post-merge review of the seven PHASE-skill PRs (#362 #363 #364 #366 #374 #379 #381), none independently reviewed.

## The regression

`#363` shipped, under "What the gate does and does not guarantee":

> `cap-evolve run` fails closed … The **standalone** `/cap-evolve:*` chain does not — `baseline/scripts/run.py` contains no check

and again under Dual-mode: "the standalone chain has no gate of its own."

That was true when #363 was written. `#374` then landed *after* it and added `run_check(project)` to `baseline/scripts/run.py`, gated **before** `RunDir.create`, closing the #358 standalone hole — and `baseline/scripts/check.py` asserts it ("red adapter refused: baseline exits non-zero before freezing a split"; "baseline created a run dir despite a red check"). `#363`'s prose was never updated.

Reader consequence: the hard-gate skill tells the agent a closed hole is still open, and cites issue #358 as live. An agent following it either bolts on a redundant manual gate or, worse, distrusts the standalone path it is being told to use.

## The fix

Both sentences corrected. The genuinely-not-a-runtime-precondition part (`provides: checked` is a static ordering token) is kept, because that half is still true.

Failing-first test in `implement-and-check/scripts/check.py`: it reads both files and fails when SKILL.md's standalone-gate claim and `baseline/scripts/run.py` disagree. Verified red before the prose fix:

```
"problems": ["SKILL.md and baseline/scripts/run.py disagree about whether the standalone
  chain is gated (baseline calls run_check=True, SKILL.md says ungated=True)"]
exit=1
```

and green after. The drift was *cross-skill*, so neither skill's own tests could ever see it — hence the pairing rather than a doc assertion inside one file.

## Also: one genuine instruction restored

`#364` deleted from `evaluate` as restatement:

> Trials cost budget linearly. Spend them where variance actually threatens the decision — usually on the val split the gate reads, not on every probe.

Nothing else owns trial-budget allocation (`finalize` covers only its own 2x test cost), so that was a loss, not a duplicate. Restored as one clause in "How much measurement do you need".

## Verification

- all 8 `skills/phases/*/scripts/check.py` green
- `PYTHONPATH="$PWD/core:$PWD/dashboard/backend" python -m pytest core/tests -q` → `805 passed, 12 skipped`
- `bash examples/toy_calc/run.sh` green
- both edited bodies well under 500 lines / 5000 tokens