### PR TITLE
fix(core): scope the narrow-focus count so the prompt stops contradicting its own protect block

### DIFF
--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -2012,10 +2012,14 @@ def _focus_instructions(current_val: SplitResult, focus_ids, label: str,
     # narrow focus, silently dropping the only explicit protect-these-ids instruction.
     protect = solid if focus_ids is None else _classify(per_all)[3]
 
+    # The counts are over the FOCUS SET; ``_passing_block`` below counts the whole val
+    # split. Say which, or a narrow focus renders "0 solid" one line above
+    # "Currently PASSING (1 task(s))" and the prompt contradicts itself.
+    scope = "tasks" if focus_ids is None else f"focused task(s) of {len(per_all)} on val"
     focus_summary = (
         f"Focus: {label}. Current val reward {current_val.reward:.3f}: "
         f"{len(solid)} solid / {len(flaky)} flaky / {len(always_fail)} failing"
-        + (f" / {len(errored)} infra-errored" if errored else "") + f" of {n} tasks."
+        + (f" / {len(errored)} infra-errored" if errored else "") + f" of {n} {scope}."
     )
     failures = _failures_block(always_fail, flaky, errored)
     passing = _passing_block(protect)

--- a/core/tests/test_w1_engine.py
+++ b/core/tests/test_w1_engine.py
@@ -286,6 +286,32 @@ def test_infra_classified_by_rollout_error(tmp_path):
     assert "good" in instr
 
 
+def test_narrow_focus_summary_scopes_its_counts():
+    """A narrow focus must not report a focus-scoped count as if it were val-wide.
+
+    ``_passing_block`` is classified over the WHOLE val split (so narrowing attention
+    never narrows the non-regression constraint), while the summary line counts only
+    the focus set. Unscoped, a one-task focus rendered "0 solid ... of 1 tasks" one
+    line above "Currently PASSING (1 task(s))" — the prompt contradicting itself about
+    whether a passing task exists.
+    """
+    from cap_evolve import harness
+    from cap_evolve.loop import SplitResult
+    per = [{"task_id": "v1", "reward": 1.0, "feedback": "passed", "raw": {}},
+           {"task_id": "v2", "reward": 0.0, "feedback": "wrong result", "raw": {}}]
+    val = SplitResult(split="val", reward=0.5, stderr=0.5, per_task=per,
+                      n_tasks=2, n_scored=2)
+
+    narrow = harness._focus_instructions(val, ["v2"], "task v2")
+    assert "0 solid / 0 flaky / 1 failing of 1 focused task(s) of 2 on val." in narrow
+    assert "## Currently PASSING (1 task(s))" in narrow, \
+        "the whole-val protect block is what the scoped count must not contradict"
+
+    # 'all' is unchanged: the focus set IS the val split, so "tasks" needs no scoping.
+    assert "1 solid / 0 flaky / 1 failing of 2 tasks." in \
+        harness._focus_instructions(val, None, "all")
+
+
 # ---- atomic state write ---------------------------------------------------
 
 def test_state_write_is_atomic_no_partial(tmp_path, monkeypatch):


### PR DESCRIPTION
Found in a post-merge review of #370.

#370 correctly made `_passing_block` classify over the **whole** val split, so narrowing
attention no longer narrows the non-regression constraint. But the summary line one
paragraph above it still counts only the **focus set**, and nothing in the rendered prompt
said which was which. Under `--focus cyclic` / `--focus hardest-first` the optimizer reads:

```
Focus: task t3. Current val reward 0.333: 0 solid / 0 flaky / 1 failing of 1 tasks.
...
## Currently PASSING (1 task(s)) — your edit MUST NOT regress these
```

Two lines apart, the prompt asserts both "0 solid" and "1 currently passing". That ships on
every iteration of every narrow-focus run.

## The change

Name the scope when the focus is narrow — `of 1 focused task(s) of 2 on val`. `--focus all`
is untouched: there the focus set *is* the val split, so `tasks` needs no qualifier.

One line in `core/cap_evolve/harness.py` plus the comment explaining why the asymmetry
exists (so the next reader does not "fix" it by narrowing the protect block again).

## Why the existing guards could not see it

#370 added exactly the right *kind* of check — assertions on the rendered prompt, because
the `mock` optimizer never reads it. But `test_narrow_focus_renders_the_focused_tasks_failures`
asserts the failure index is non-empty, and `check.py` asserts both blocks are *present*.
Neither can see the two blocks disagreeing with each other about the same split.

`test_narrow_focus_summary_scopes_its_counts` pins the exact rendered counts under a narrow
focus alongside the whole-val protect block, and asserts `--focus all` is unchanged.

## Verification

```
$ git checkout HEAD -- core/cap_evolve/harness.py     # test only, no fix
$ python -m pytest core/tests/test_w1_engine.py -k narrow_focus_summary -q
E  assert '0 solid / 0 flaky / 1 failing of 1 focused task(s) of 2 on val.' in "..."
1 failed

$ git apply <the fix>
$ python -m pytest core/tests/test_w1_engine.py -k narrow_focus_summary -q
1 passed

$ PYTHONPATH="$PWD/core:$PWD/dashboard/backend" python -m pytest core/tests -q
806 passed, 12 skipped          # 805 on main + this test

$ bash examples/toy_calc/run.sh
"baseline_val": 0.0, "best_val": 1.0, "test_reward": 1.0, "iterations": 3

$ python skills/algorithms/hill-climb/scripts/check.py     # ok, exit 0
```

## Not in this PR

The rest of the #370 review came out clean — its headline focus fix is **confirmed by
capturing and inspecting the rendered prompt under all three schedules**, with real
per-task failure content from the parent's val rows and a non-empty protect block in each,
and the deleted pre-loop train evaluation is genuinely gone (`grep -rn 'seed_train' .` is
empty; `split="train"` no longer appears in `harness.py`).

Two things I deliberately did not touch:

- `references/focus-schedules.md` cites `harness.py:2183` / `:2011-2013`; #386 landed after
  #370 and shifted those to `:2308` / `:2004-2006`. Doc rot, not worth its own PR.
- `--focus cyclic` round-robins over **all** val ids, so an iteration landing on a passing
  task renders "No actionable failures in focus" — the majority case once val is high. It
  matches the documented round-robin contract, so it is a design question (narrow `cyclic`
  to failing ids? re-derive the order after each accept?), not a bug to sneak into a fix.
- The same train-ids/val-rows defect is alive in `skillopt` in three places. #371 already
  tracks it accurately; I added the two sites its body was missing as a comment there.