### PR TITLE
feat(skill-package): optimize the whole package, and gate on validity (#322) — supersedes #360

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,27 @@ All notable changes to cap-evolve are documented here. The format follows
   `2,000 USD` into `$0.00`.
 
 ### Added
+- **`skill-package` optimizes the WHOLE package, and its rules are now enforced by the loop.**
+  `materialize()` exposed only `SKILL.md` + `references/*.md`, so `scripts/` and `assets/` were
+  not components of the artifact the capability claimed to own, and `validate()` — the entire
+  "edits stay valid skills" story — was never called from `harness`/`gepa`/`skillopt`. Now:
+  every file in the package is a component (binary assets as inventory stubs); `apply()` can
+  create or rewrite any of them (a NEW bundled script included), refuses writes escaping the
+  package, and honors an action policy (`policy.json`:
+  `frontmatter|body|reference|script|asset|add|remove`) so a run can allow prose but forbid new
+  code; `validate()` `ast.parse()`s every bundled script, rejects a stub body, and RUNS a
+  declared `--self-check` with a timeout and a stripped env. `harness.run_step` calls each
+  capability's own `validate()` after the optimizer returns and **before any rollout is paid
+  for** (generic per-capability hook, no capability special-cased): hard problems make the step
+  **indecisive** — no reward, stall counter untouched, best unchanged — with the reason filed in
+  the rejected memory and the LEDGER's new "Not scored" section, and warnings carried into the
+  optimizer's feedback. Problems the parent already had are excluded, so a pre-existing
+  violation cannot wedge a run. Also: block-scalar (`description: >`) frontmatter is parsed
+  instead of silently bypassing every description lint; body >500 lines is a hard problem;
+  nested/orphan references and fake TOCs warn; `scripts/trigger_eval.py` makes held-out
+  trigger-rate selection a deterministic script instead of prose; `examples/toy_skill/` is a
+  zero-API run whose capability IS a skill package and whose score can only rise by adding
+  bundled code. `skill-package/SKILL.md` shrank 122 → 100 lines while gaining the script lever.
 - **Four real τ²-bench airline runs** on `aws/gpt-oss-120b` (agent + user simulator) with
   `aws/claude-opus-5` proposing edits, committed with `events.jsonl` at
   `examples/tau2_airline/run_agentopt_v{2,3,4}/`. **All four are null results** — `best_id =

--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import contextlib
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -906,10 +907,17 @@ def _build_ledger(workdir: Path, run_dir: RunDir, rejected, history) -> None:
 
     table = ["| iter | candidate | parent | outcome | val | Δ vs parent | broke (were passing) | fixed |",
              "| --- | --- | --- | --- | --- | --- | --- | --- |"]
+    void: list[str] = []
     for i, rec in enumerate(rows, 1):
         cid = str(rec.get("candidate"))
         par = str(rec.get("parent") or "seed")
         outcome = "ACCEPT" if rec.get("accept") else "reject"
+        # A step with no val was never measured (an invalid candidate, or an edit to a
+        # sealed file). Calling that "reject" teaches the wrong lesson — the edit's IDEA
+        # was never tested, only its execution was broken — so name it and say why.
+        if rec.get("val") is None and str(rec.get("reason", "")).startswith("indecisive"):
+            outcome = "not scored"
+            void.append(f"- **{cid}**: {str(rec.get('reason'))[:600]}")
         val = rec.get("val")
         pval = rec.get("parent_val")
         d = (f"{val - pval:+.3f}" if isinstance(val, (int, float))
@@ -931,7 +939,11 @@ def _build_ledger(workdir: Path, run_dir: RunDir, rejected, history) -> None:
         "this to never re-introduce a change that broke a task, and to see which approaches "
         "the gate accepted vs rejected.\n\n"
         "## Iterations\n" + "\n".join(table) + "\n\n"
-        f"## Current best: {best}\n"
+        + ("## Not scored — fix the execution, keep the idea\n"
+           "These candidates were never measured, so their reward says nothing. Correct the "
+           "stated fault and retry the same idea; do not abandon it, and do not resubmit it "
+           "unchanged.\n" + "\n".join(void) + "\n\n" if void else "")
+        + f"## Current best: {best}\n"
     )
     (workdir / "LEDGER.md").write_text(text, encoding="utf-8")
 
@@ -1369,17 +1381,27 @@ def _write_instructions_pointer(path: Path, skills_dir: str) -> None:
 
 def _tamper_step(run_dir: RunDir, *, cid: str, parent_id, workdir: Path,
                  report, current_val: SplitResult, optimizer_seconds: float,
-                 opt_cost_usd: float, opt_tokens: int, optimizer_error) -> dict:
-    """An INDECISIVE step for a candidate that edited a protected file.
+                 opt_cost_usd: float, opt_tokens: int, optimizer_error,
+                 kind: str = "integrity", event: str = "tamper_detected",
+                 detail_key: str = "tamper", rejected=None) -> dict:
+    """An INDECISIVE step for a candidate that was never validly measurable.
 
-    Not a rejection at 0.0: the candidate was never validly measured, so recording a
-    reward would poison the split mean and the paired gate. ``accepted=None`` leaves
-    the stall counter alone, ``set_best`` is never called, and the workdir is
-    snapshotted for forensics so an operator can see exactly what was edited.
+    Two causes share this path: the candidate edited a protected file (integrity),
+    or it is invalid by its own capability's rules (validation). Neither is a
+    rejection at 0.0: the candidate was never validly measured, so recording a
+    reward would poison the split mean and the paired gate. ``accepted=None``
+    leaves the stall counter alone, ``set_best`` is never called, and the workdir
+    is snapshotted for forensics so an operator can see exactly what was edited.
+
+    Unlike an infrastructure outage, an invalid edit IS the optimizer's doing — so
+    when ``rejected`` memory is supplied the reason is filed there, and the next
+    iteration is told what it broke instead of repeating it.
     """
-    reason = "indecisive (integrity): " + report.reason
-    run_dir.log_event("tamper_detected", candidate=cid, parent=parent_id,
+    reason = f"indecisive ({kind}): " + report.reason
+    run_dir.log_event(event, candidate=cid, parent=parent_id,
                       report=report.to_dict(), reason=report.reason)
+    if rejected is not None:
+        rejected.add(cid, f"candidate {cid} (not scored: invalid)", reason, None)
     run_dir.snapshot(cid, workdir, ignore=_SNAPSHOT_IGNORE)  # forensics only — never best
     run_dir.update_spent(iterations=1, accepted=None)
     run_dir.log_event("step", candidate=cid, accept=False, reason=reason, val=None,
@@ -1394,9 +1416,9 @@ def _tamper_step(run_dir: RunDir, *, cid: str, parent_id, workdir: Path,
         # delta 0.0 keeps the GateDecision shape; there is no measurement to report.
         "decision": {"accept": False, "reason": reason, "delta": 0.0, "threshold": 0.0,
                      "indecisive": True},
-        "candidate_val": None,      # NO reward — a tampered run is missing data
+        "candidate_val": None,      # NO reward — an unmeasurable run is missing data
         "parent_val": current_val.to_dict(),
-        "tamper": report.to_dict(),
+        detail_key: report.to_dict(),
         "regressions": [],
         "optimizer_seconds": optimizer_seconds,
         "optimizer_usd": opt_cost_usd,
@@ -1513,6 +1535,24 @@ def run_step(
                                 opt_cost_usd=opt_cost_usd, opt_tokens=opt_tokens,
                                 optimizer_error=optimizer_error)
 
+    # The capability's OWN validity rules, checked here (still before the gate, and
+    # before any rollout is paid for) rather than left to prose the optimizer may skip.
+    # An invalid artifact's score measures a broken candidate, not the edit, so the
+    # step is INDECISIVE — same discipline as the tamper path.
+    validation = _capability_validate(capabilities, workdir, parent_dir=parent_dir)
+    if validation is not None:
+        if validation.warnings:
+            run_dir.log_event("capability_validation_warnings", candidate=cid,
+                              warnings=validation.warnings)
+        if validation.problems:
+            return _tamper_step(run_dir, cid=cid, parent_id=parent_id, workdir=workdir,
+                                report=validation, current_val=current_val,
+                                optimizer_seconds=optimizer_seconds,
+                                opt_cost_usd=opt_cost_usd, opt_tokens=opt_tokens,
+                                optimizer_error=optimizer_error, kind="validation",
+                                event="capability_invalid", detail_key="validation",
+                                rejected=rejected)
+
     cand_val = evaluate_candidate(adapter, workdir, run_dir=run_dir, split="val",
                                   n_trials=n_trials, tag=cid)
 
@@ -1605,7 +1645,12 @@ def run_step(
                           n_tasks=cand_val.n_tasks)
     else:
         if rejected is not None:
-            rejected.add(cid, summary, decision.reason, cand_val.reward, note=note, impact=impact)
+            reason = decision.reason
+            if validation is not None and validation.warnings:
+                # Authoring smells the candidate carries are part of why it is worth
+                # revisiting — the next iteration should see them, not rediscover them.
+                reason += " | validation warnings: " + "; ".join(validation.warnings[:5])
+            rejected.add(cid, summary, reason, cand_val.reward, note=note, impact=impact)
     if store is not None:
         store.commit(f"iter {run_dir.spent.iterations}: "
                      f"{'ACCEPT' if accepted else 'reject'} {summary}",
@@ -1714,9 +1759,24 @@ _CAP_EDIT_SPACE = {
     "system-prompt": "Edit the prompt/policy text: instructions, decision policy, and the "
                      "output contract. Prefer sharpening rules the traces show the agent "
                      "breaking; do not just append more preamble.",
-    "skill-package": "Edit the SKILL.md (frontmatter + body), its references, and bundled "
-                     "scripts, staying within skill-creator rules (valid frontmatter, "
-                     "progressive disclosure, one-level references, concise body).",
+    "skill-package": "Edit ANY part of the package: the SKILL.md frontmatter (the "
+                     "`description` decides whether the skill fires at all — the "
+                     "highest-leverage text), the body, `references/*.md`, and the "
+                     "bundled `scripts/`. HIGHEST-LEVERAGE EDIT: TURN A SKIPPED PROSE "
+                     "STEP INTO A BUNDLED SCRIPT the body invokes by command line — a "
+                     "step the agent runs can't be 'forgotten' the way a body rule can, "
+                     "and a script's source never enters the agent's context (only its "
+                     "output), so it is cheaper than the prose it replaces. Two patterns "
+                     "to prefer: (1) the traces show the agent re-deriving the same "
+                     "helper or doing a deterministic transform by hand — write it once "
+                     "into scripts/ and say EXECUTE it, don't read it; (2) a check the "
+                     "agent keeps skipping — make it a script that exits non-zero. The "
+                     "script must be real working code (never '...' or docstring-only) "
+                     "with a `--self-check` entry point, because validation RUNS it "
+                     "before any rollout is paid for. Keep the body lean (<=500 lines) "
+                     "and push depth into one-level references with explicit pointers; "
+                     "the frontmatter/body/reference/script split is validated, so an "
+                     "invalid package is not scored at all.",
     "mcp-tool": "ONLY safe edits: tool/parameter documentation, in-description examples, and "
                 "adding/removing tools from the exposed set. The wire schema and tool code "
                 "are owned by the external server and are NOT editable here.",
@@ -1913,6 +1973,100 @@ def _parallel_note(parallel: bool, optimizer_name: str | None) -> str:
     return ("Your agent runs single-threaded (no subagents). Still address as MANY clusters as you "
             "can in this ONE candidate — work through them in turn, drafting and keeping every "
             "real, safe fix, not just the biggest one.")
+
+
+def _load_capability_abstract(name: str, tag: str):
+    """Import ``skills/capabilities/<name>/scripts/abstract.py``, or None."""
+    import importlib.util
+
+    skills_root = Path(__file__).resolve().parents[2] / "skills" / "capabilities"
+    abstract_path = skills_root / name / "scripts" / "abstract.py"
+    if not abstract_path.exists():
+        return None
+    try:
+        spec = importlib.util.spec_from_file_location(f"capevolve_cap_{name}_{tag}",
+                                                     abstract_path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)  # type: ignore[union-attr]
+        return mod
+    except Exception:  # noqa: BLE001 — a capability we can't import contributes nothing
+        return None
+
+
+class _ValidationReport:
+    """The {problems, warnings} a capability's ``validate()`` reported for a candidate."""
+
+    def __init__(self, problems, warnings, by_capability):
+        self.problems = list(problems)
+        self.warnings = list(warnings)
+        self.by_capability = dict(by_capability)
+
+    @property
+    def reason(self) -> str:
+        shown = "; ".join(self.problems[:5])
+        more = f" (+{len(self.problems) - 5} more)" if len(self.problems) > 5 else ""
+        return f"candidate is not a valid {'/'.join(self.by_capability)}: {shown}{more}"
+
+    def to_dict(self) -> dict:
+        return {"problems": self.problems, "warnings": self.warnings,
+                "by_capability": self.by_capability}
+
+
+def _capability_validate(capabilities, cand_dir: Path,
+                         parent_dir: Path | None = None) -> _ValidationReport | None:
+    """Validate a candidate against each capability's OWN rules (generic, per-capability).
+
+    Calls ``validate(cand_dir)`` on every ``skills/capabilities/<name>/scripts/abstract.py``
+    that defines it. Returns None when no capability offered a usable signal, so
+    callers behave exactly as before for capabilities without the handler.
+
+    Problems the PARENT already had are dropped: a pre-existing violation (a seed
+    skill whose body is already over budget, say) is not something one edit can be
+    blamed for, and voiding every step over it would wedge the run. What is
+    reported is what this edit INTRODUCED. Numbers are normalized when comparing so
+    "612 lines" → "615 lines" still counts as pre-existing.
+    """
+    caps = [c for c in (capabilities or []) if c]
+    if not caps:
+        return None
+
+    def _run(name, mod, d):
+        try:
+            v = mod.validate(Path(d))
+        except Exception:  # noqa: BLE001 — never let a handler abort the loop
+            return None
+        return v if isinstance(v, dict) else None
+
+    problems: list[str] = []
+    warnings: list[str] = []
+    by_cap: dict[str, dict] = {}
+    got_signal = False
+    for name in caps:
+        mod = _load_capability_abstract(name, "validate")
+        if mod is None or not hasattr(mod, "validate"):
+            continue
+        v = _run(name, mod, cand_dir)
+        if v is None:
+            continue
+        got_signal = True
+        pre = set()
+        if parent_dir is not None:
+            pv = _run(name, mod, parent_dir)
+            if pv:
+                pre = {_norm_problem(p) for p in pv.get("problems", [])}
+        new = [p for p in v.get("problems", []) if _norm_problem(p) not in pre]
+        problems += [f"{name}: {p}" for p in new]
+        warnings += [f"{name}: {w}" for w in v.get("warnings", [])]
+        by_cap[name] = {"ok": bool(v.get("ok")), "problems": new,
+                        "warnings": v.get("warnings", []),
+                        "pre_existing": sorted(pre)}
+    if not got_signal:
+        return None
+    return _ValidationReport(problems, warnings, by_cap)
+
+
+def _norm_problem(text: str) -> str:
+    return re.sub(r"\d+", "N", str(text))
 
 
 def _capability_is_empty(capabilities, cand_dir: Path) -> bool | None:

--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -1205,7 +1205,7 @@ def _inject_optimizer_context(adapter, run_dir: RunDir, workdir: Path, *, split:
     # 2) capability skills as local guidance
     caps = [c for c in (capabilities or []) if c]
     if caps:
-        skills_root = Path(__file__).resolve().parents[2] / "skills" / "capabilities"
+        skills_root = _capabilities_root()
         for c in caps:
             src = skills_root / c
             if not src.is_dir():
@@ -1539,7 +1539,8 @@ def run_step(
     # before any rollout is paid for) rather than left to prose the optimizer may skip.
     # An invalid artifact's score measures a broken candidate, not the edit, so the
     # step is INDECISIVE — same discipline as the tamper path.
-    validation = _capability_validate(capabilities, workdir, parent_dir=parent_dir)
+    validation = _capability_validate(capabilities, workdir, parent_dir=parent_dir,
+                                      run_dir=run_dir)
     if validation is not None:
         if validation.warnings:
             run_dir.log_event("capability_validation_warnings", candidate=cid,
@@ -1795,7 +1796,7 @@ def _capability_brief(capabilities) -> str:
     caps = [c for c in (capabilities or []) if c]
     if not caps:
         return ""
-    skills_root = Path(__file__).resolve().parents[2] / "skills" / "capabilities"
+    skills_root = _capabilities_root()
     lines = ["## What you are editing (the allowed edit space)",
              "The capability under optimization is composed of these editable artifact(s). "
              "Use the FULL edit space below — do not limit yourself to trivial wording tweaks."]
@@ -1975,22 +1976,38 @@ def _parallel_note(parallel: bool, optimizer_name: str | None) -> str:
             "real, safe fix, not just the biggest one.")
 
 
-def _load_capability_abstract(name: str, tag: str):
-    """Import ``skills/capabilities/<name>/scripts/abstract.py``, or None."""
+def _capabilities_root() -> Path:
+    """Where the capability skills live: ``CAPEVOLVE_SKILLS_DIR`` if set, else the
+    repo's own ``skills/`` (running from source). An installed tree does not sit next
+    to this module, so resolving only relative to ``__file__`` silently finds nothing —
+    and a capability we cannot find is a capability whose rules go unenforced."""
+    env = os.environ.get("CAPEVOLVE_SKILLS_DIR")
+    if env and (Path(env) / "capabilities").is_dir():
+        return Path(env) / "capabilities"
+    return Path(__file__).resolve().parents[2] / "skills" / "capabilities"
+
+
+def _load_capability_abstract(name: str, tag: str) -> tuple:
+    """Import ``skills/capabilities/<name>/scripts/abstract.py``.
+
+    Returns ``(module, None)`` or ``(None, why)``. The ``why`` exists because the
+    failure mode here is SILENT-OFF: a moved skills tree or an import regression would
+    otherwise disable enforcement with no trace, and the loop would go back to scoring
+    invalid candidates while every test still passed. The caller logs it.
+    """
     import importlib.util
 
-    skills_root = Path(__file__).resolve().parents[2] / "skills" / "capabilities"
-    abstract_path = skills_root / name / "scripts" / "abstract.py"
+    abstract_path = _capabilities_root() / name / "scripts" / "abstract.py"
     if not abstract_path.exists():
-        return None
+        return None, f"no abstract.py at {abstract_path}"
     try:
         spec = importlib.util.spec_from_file_location(f"capevolve_cap_{name}_{tag}",
                                                      abstract_path)
         mod = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(mod)  # type: ignore[union-attr]
-        return mod
-    except Exception:  # noqa: BLE001 — a capability we can't import contributes nothing
-        return None
+    except Exception as e:  # noqa: BLE001 — never abort the loop over an import
+        return None, f"import failed: {type(e).__name__}: {e}"[:300]
+    return mod, None
 
 
 class _ValidationReport:
@@ -2013,7 +2030,8 @@ class _ValidationReport:
 
 
 def _capability_validate(capabilities, cand_dir: Path,
-                         parent_dir: Path | None = None) -> _ValidationReport | None:
+                         parent_dir: Path | None = None,
+                         run_dir: RunDir | None = None) -> _ValidationReport | None:
     """Validate a candidate against each capability's OWN rules (generic, per-capability).
 
     Calls ``validate(cand_dir)`` on every ``skills/capabilities/<name>/scripts/abstract.py``
@@ -2030,20 +2048,34 @@ def _capability_validate(capabilities, cand_dir: Path,
     if not caps:
         return None
 
+    def unavailable(name, why):
+        # Enforcement that turns itself off quietly is the defect this hook exists to
+        # remove, so say so in the run record rather than leaving it to be inferred.
+        if run_dir is not None:
+            run_dir.log_event("capability_validate_unavailable", capability=name, reason=why)
+
     def _run(name, mod, d):
         try:
             v = mod.validate(Path(d))
-        except Exception:  # noqa: BLE001 — never let a handler abort the loop
+        except Exception as e:  # noqa: BLE001 — never let a handler abort the loop
+            unavailable(name, f"validate() raised: {type(e).__name__}: {e}"[:300])
             return None
-        return v if isinstance(v, dict) else None
+        if not isinstance(v, dict):
+            unavailable(name, f"validate() returned {type(v).__name__}, expected dict")
+            return None
+        return v
 
     problems: list[str] = []
     warnings: list[str] = []
     by_cap: dict[str, dict] = {}
     got_signal = False
     for name in caps:
-        mod = _load_capability_abstract(name, "validate")
-        if mod is None or not hasattr(mod, "validate"):
+        mod, why = _load_capability_abstract(name, "validate")
+        if mod is None:
+            unavailable(name, why)
+            continue
+        if not hasattr(mod, "validate"):
+            unavailable(name, "abstract.py defines no validate()")
             continue
         v = _run(name, mod, cand_dir)
         if v is None:
@@ -2083,7 +2115,7 @@ def _capability_is_empty(capabilities, cand_dir: Path) -> bool | None:
         return None
     import importlib.util
 
-    skills_root = Path(__file__).resolve().parents[2] / "skills" / "capabilities"
+    skills_root = _capabilities_root()
     complete = True  # did we get a usable is_empty() from EVERY requested capability?
     for name in caps:
         abstract_path = skills_root / name / "scripts" / "abstract.py"
@@ -2091,10 +2123,10 @@ def _capability_is_empty(capabilities, cand_dir: Path) -> bool | None:
             complete = False
             continue
         try:
-            spec = importlib.util.spec_from_file_location(
-                f"capevolve_cap_{name}_isempty", abstract_path)
-            mod = importlib.util.module_from_spec(spec)
-            spec.loader.exec_module(mod)  # type: ignore[union-attr]
+            mod, _why = _load_capability_abstract(name, "isempty")
+            if mod is None:
+                complete = False
+                continue
             is_empty = getattr(mod, "is_empty", None)
             if is_empty is None:
                 complete = False

--- a/core/tests/test_capability_validation_wiring.py
+++ b/core/tests/test_capability_validation_wiring.py
@@ -1,0 +1,202 @@
+"""Wiring proofs for the per-capability ``validate()`` hook in ``run_step``.
+
+The capability handlers are unit-tested by each skill's own ``scripts/check.py``. What is
+proved HERE is the wiring into the optimization loop, because the failure mode is
+**silent-off** — if the hook stops firing, the loop happily scores invalid candidates again
+and nothing else in the suite notices:
+
+* a candidate the capability calls invalid is INDECISIVE, not rejected at 0.0: no reward,
+  best_id and the stall counter untouched, and **no rollouts paid for** (validation runs
+  before ``evaluate_candidate``);
+* a clean candidate under the same wiring still accepts;
+* a problem the PARENT already had does not void the step (a pre-existing violation must
+  not wedge a run);
+* no ``capabilities`` ⇒ no validation, i.e. the old behavior is unchanged;
+* a capability that cannot be loaded or whose ``validate()`` raises is REPORTED
+  (``capability_validate_unavailable``) instead of quietly disabling enforcement.
+
+Mirrors ``test_integrity_wiring.py``, which proves the same discipline for the tamper path.
+"""
+
+import importlib.util
+import json
+import os
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+CORE = REPO / "core"
+EXAMPLE = REPO / "examples" / "toy_skill"
+
+sys.path.insert(0, str(CORE))
+
+CAPS = ["skill-package"]
+
+
+@pytest.fixture(autouse=True)
+def _env():
+    old = dict(os.environ)
+    os.environ["CAPEVOLVE_CORE"] = str(CORE)
+    os.environ["CAPEVOLVE_TOY_DATA"] = str(EXAMPLE)
+    os.environ["CAPEVOLVE_SKILLS_DIR"] = str(REPO / "skills")
+    yield
+    os.environ.clear()
+    os.environ.update(old)
+
+
+def _adapter():
+    spec = importlib.util.spec_from_file_location("toy_skill_adapter", EXAMPLE / "adapter.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.Adapter()
+
+
+class CountingAdapter:
+    """Counts rollouts, so a test can prove an invalid candidate cost nothing."""
+
+    def __init__(self, inner):
+        self._inner = inner
+        self.rollouts = 0
+
+    def __getattr__(self, name):
+        return getattr(self._inner, name)
+
+    def run_target(self, task, ctx, *, seed: int = 0):
+        self.rollouts += 1
+        return self._inner.run_target(task, ctx, seed=seed)
+
+
+def _fresh_run(tmp_path: Path, adapter, ts: str, seed_extra=None):
+    from cap_evolve import Budget, RunDir, harness
+    seed = tmp_path / ts / "seed_capability"
+    shutil.copytree(EXAMPLE / "seed_capability", seed)
+    if seed_extra:
+        seed_extra(seed)
+    rd = RunDir.create(tmp_path / ts / ".capevolve", ts=ts,
+                       budget=Budget(max_iterations=5, stall=2))
+    # 4 val tasks (3 of them messy) so a real gain clears the significance bar; the
+    # default 0.25 ratio leaves 2, where k=1·SE swallows any delta.
+    harness.ensure_splits(adapter, rd, seed=0, ratios=(0.2, 0.4, 0.4))
+    return rd, harness.baseline(adapter, seed, run_dir=rd)
+
+
+# The good edit is the example's own mock script, so the test cannot drift from the
+# edit the shipped example claims works.
+_GOOD_EDITS = json.loads((EXAMPLE / "mock_script.json").read_text(encoding="utf-8"))["edits"]
+
+
+def _good_edit(workdir: Path, instructions: str):
+    """A working bundled script + the SKILL.md pointer that tells the agent to run it."""
+    for e in _GOOD_EDITS:
+        target = workdir / e["file"]
+        target.parent.mkdir(parents=True, exist_ok=True)
+        cur = target.read_text(encoding="utf-8") if target.exists() else ""
+        target.write_text(e["text"] if e["op"] == "set" else cur + e["text"], encoding="utf-8")
+
+
+def _broken_script(workdir: Path, instructions: str):
+    """Ships a bundled script that does not compile — deterministic code that isn't."""
+    (workdir / "scripts").mkdir(exist_ok=True)
+    (workdir / "scripts" / "helper.py").write_text("def broken(:\n", encoding="utf-8")
+
+
+def _events(run_dir, kind: str) -> list[dict]:
+    out = []
+    for line in (run_dir.root / "events.jsonl").read_text(encoding="utf-8").splitlines():
+        if line.strip():
+            e = json.loads(line)
+            if e.get("kind") == kind:
+                out.append(e)
+    return out
+
+
+def _step(rd, adapter, base, optimizer, **kw):
+    from cap_evolve import harness
+    return harness.run_step(adapter, run_dir=rd, parent_dir=rd.candidate_dir("seed"),
+                            optimizer=optimizer, instructions="improve val",
+                            current_val=base,
+                            gate_kwargs={"mode": "significant", "k_se": 1.0}, **kw)
+
+
+# --- the catch ---------------------------------------------------------------
+
+def test_invalid_candidate_is_indecisive_and_costs_nothing(tmp_path):
+    adapter = CountingAdapter(_adapter())
+    rd, base = _fresh_run(tmp_path, adapter, "invalid")
+    best_before, stall_before, rollouts_before = rd.best_id, rd.spent.stall, adapter.rollouts
+
+    step = _step(rd, adapter, base, _broken_script, capabilities=CAPS)
+
+    # 1. indecisive, NOT a rejection at 0.0 — the candidate was never measured.
+    assert step["candidate_val"] is None
+    assert step["decision"]["indecisive"] is True
+    assert step["accepted"] is False
+    assert "does not compile" in json.dumps(step["validation"]["problems"])
+    # 2/3. best and the stall counter are untouched (an unjudged candidate is not a reject).
+    assert rd.best_id == best_before
+    assert rd.spent.stall == stall_before
+    # 4. the iteration is still counted as spent.
+    assert rd.spent.iterations == 1
+    # 5. NO rollouts were paid for: validation runs before evaluate_candidate.
+    assert adapter.rollouts == rollouts_before
+    assert not list((rd.root / "rollouts" / "val").glob(f"{step['candidate_id']}*"))
+    # 6. auditable.
+    ev = _events(rd, "capability_invalid")
+    assert len(ev) == 1 and "skill-package" in json.dumps(ev[0]["report"])
+    assert len(_events(rd, "step_indecisive")) == 1
+
+
+def test_valid_candidate_under_the_same_wiring_still_accepts(tmp_path):
+    adapter = _adapter()
+    rd, base = _fresh_run(tmp_path, adapter, "valid")
+    step = _step(rd, adapter, base, _good_edit, capabilities=CAPS)
+
+    assert step["candidate_val"] is not None
+    assert step["accepted"] is True
+    assert step["candidate_val"]["reward"] > base.reward
+    assert rd.best_id == step["candidate_id"]
+    assert _events(rd, "capability_invalid") == []
+
+
+def test_pre_existing_problem_does_not_void_the_step(tmp_path):
+    """A seed that is ALREADY invalid must not make every future step indecisive."""
+    def overlong_body(seed: Path):
+        p = seed / "SKILL.md"
+        p.write_text(p.read_text(encoding="utf-8") + "filler\n" * 600, encoding="utf-8")
+
+    adapter = _adapter()
+    rd, base = _fresh_run(tmp_path, adapter, "preexisting", seed_extra=overlong_body)
+    # the seed really is invalid on the rule we rely on
+    from cap_evolve import harness
+    seed_report = harness._capability_validate(CAPS, rd.candidate_dir("seed"))
+    assert any("lines" in p for p in seed_report.problems)
+
+    step = _step(rd, adapter, base, _good_edit, capabilities=CAPS)
+    assert step["candidate_val"] is not None      # measured, not voided
+    assert step["decision"]["indecisive"] is False
+
+
+def test_no_capabilities_means_no_validation(tmp_path):
+    """Back-compat: a caller that passes no capabilities behaves exactly as before."""
+    adapter = _adapter()
+    rd, base = _fresh_run(tmp_path, adapter, "off")
+    step = _step(rd, adapter, base, _broken_script)      # same broken edit, no capabilities
+
+    assert step["candidate_val"] is not None              # it WAS measured
+    assert "validation" not in step
+    assert _events(rd, "capability_invalid") == []
+
+
+def test_unloadable_capability_is_reported_not_silently_ignored(tmp_path):
+    """Enforcement that turns itself off must say so — silent-off is the defect."""
+    adapter = _adapter()
+    rd, base = _fresh_run(tmp_path, adapter, "missing")
+    step = _step(rd, adapter, base, _good_edit, capabilities=["no-such-capability"])
+
+    assert step["candidate_val"] is not None              # no signal ⇒ no gating
+    ev = _events(rd, "capability_validate_unavailable")
+    assert len(ev) == 1
+    assert ev[0]["capability"] == "no-such-capability" and "no abstract.py" in ev[0]["reason"]

--- a/examples/skillsbench/optimizer/INSTRUCTIONS.md
+++ b/examples/skillsbench/optimizer/INSTRUCTIONS.md
@@ -167,8 +167,11 @@ general fix. A fiddly task-specific rule hurts the held-out tasks.
   blast-radius line in PROCESS.md. Drop any that doesn't.
 - You shipped several such edits across the top-ranked clusters you could fix SAFELY, and
   did NOT pad with speculative/cosmetic edits or re-add anything already rejected.
-- Every edit keeps its skill a VALID package (frontmatter, body budget, one-level
-  references, no broken links) — re-validate each touched skill.
+- Every edit keeps its skill a VALID package. The framework re-validates it for you
+  BEFORE any rollout is paid for (frontmatter, body budget, one-level references, no
+  broken links, and every bundled script compiles + its `--self-check` passes); a
+  candidate that fails is NOT SCORED AT ALL, so a broken script wastes the whole
+  iteration. Run `python <skill>/scripts/<file> --self-check` yourself before you stop.
 - No edit hardcodes a task-specific filename/value/marker/answer — every edit GENERALIZES.
 - PLACEMENT: every skill file you created/edited lives INSIDE a skill dir (docx/pptx/xlsx/pdf,
   e.g. `pdf/scripts/x.py`). You did NOT create any new skill file at the candidate ROOT — only

--- a/examples/toy_skill/README.md
+++ b/examples/toy_skill/README.md
@@ -1,0 +1,39 @@
+# Example: toy_skill (zero-API, deterministic, capability = a skill package)
+
+`toy_calc` proves the pipeline on a system prompt. This one proves it on a **skill
+package**, and specifically on the part of a package prose cannot fix: the tasks are
+arithmetic written the way people write it (`3 plus 4`, `1,200 + 5`), the seed skill
+only *asks* for normalization in its body, and the deterministic stand-in agent gets
+those wrong until a bundled `scripts/normalize.py` exists for it to run.
+
+So the score can only rise by adding **code** to the package — the determinism lever
+the `skill-package` capability pushes — and the accepted candidate's diff contains a
+script, not just SKILL.md prose.
+
+## Files
+- `adapter.py` — a `CapabilityAdapter`: 10 arithmetic tasks, a stand-in agent that
+  runs `scripts/normalize.py` when the SKILL.md points at it, and an exact-match scorer.
+- `seed_capability/SKILL.md` — a valid seed skill with no bundled scripts.
+- `mock_script.json` — the deterministic edit the `mock` optimizer applies: it CREATES
+  `scripts/normalize.py` (with a `--self-check`) and adds the pointer line to SKILL.md.
+
+## Run it
+```bash
+REPO=$PWD                       # cap-evolve repo root
+export CAPEVOLVE_CORE=$REPO/core PYTHONPATH=$REPO/core CAPEVOLVE_SKILLS_DIR=$REPO/skills
+export CAPEVOLVE_TOY_DATA=$REPO/examples/toy_skill
+export CAPEVOLVE_MOCK_SCRIPT=$REPO/examples/toy_skill/mock_script.json
+
+D=/tmp/toyskill; mkdir -p $D/.capevolve/project/adapters
+cp $REPO/examples/toy_skill/adapter.py $D/.capevolve/project/adapters/
+cp -R $REPO/examples/toy_skill/seed_capability $D/seed_capability
+cp $REPO/examples/toy_skill/capevolve.yaml $D/.capevolve/project/capevolve.yaml
+
+python3 -m cap_evolve.cli run --spec $D/.capevolve/project/capevolve.yaml \
+    --project $D/.capevolve/project --run-ts demo
+cap-evolve diff --best --run $D/.capevolve/runs/demo     # shows scripts/normalize.py
+```
+
+The candidate is validated by `skills/capabilities/skill-package/scripts/abstract.py`
+before any rollout is paid for — including running the new script's `--self-check` —
+so a candidate that ships broken code is never scored.

--- a/examples/toy_skill/adapter.py
+++ b/examples/toy_skill/adapter.py
@@ -1,0 +1,88 @@
+"""Toy-skill adapter — a zero-API, deterministic run whose capability IS a skill package.
+
+The `toy_calc` example proves the pipeline on a prompt. This one proves it on the
+part of a skill package that prose cannot fix: the tasks are arithmetic written
+the way people write it ("two thousand", "3 plus 4", "1,200 + 5"), and the
+deterministic stand-in agent can only get those right by RUNNING a bundled
+`scripts/normalize.py` that the SKILL.md points it at. Following the seed skill's
+prose alone fails every messy task — so the score can only rise when the
+optimizer writes bundled CODE, which is exactly the determinism lever the
+`skill-package` capability is supposed to push.
+
+Set ``CAPEVOLVE_TOY_DATA`` to this example dir (or leave it — it defaults here).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+from cap_evolve import CapabilityAdapter, Rollout, Score, Task
+
+_DATA = Path(os.environ.get("CAPEVOLVE_TOY_DATA", Path(__file__).resolve().parent))
+
+# (expression as a user writes it, exact answer)
+TASKS = [
+    ("2 + 3", "5"),
+    ("10 - 4", "6"),
+    ("6 * 7", "42"),
+    ("3 plus 4", "7"),
+    ("9 minus 5", "4"),
+    ("8 times 3", "24"),
+    ("1,200 + 5", "1205"),
+    ("2,000 minus 1,000", "1000"),
+    ("12 plus 1,000", "1012"),
+    ("4 times 1,100", "4400"),
+]
+
+_SAFE = set("0123456789 +-*")
+
+
+def _eval(expr: str) -> str:
+    if not set(expr) <= _SAFE:
+        raise ValueError(f"cannot parse {expr!r}")
+    return str(int(eval(expr, {"__builtins__": {}}, {})))  # noqa: S307 (charset-limited)
+
+
+class Adapter(CapabilityAdapter):
+
+    def tasks(self, split: str) -> list[Task]:
+        return [Task(id=f"t{i:02d}", input=x, target=y) for i, (x, y) in enumerate(TASKS)]
+
+    def run_target(self, task: Task, ctx, *, seed: int = 0) -> Rollout:
+        pkg = Path(ctx)
+        body = (pkg / "SKILL.md").read_text(encoding="utf-8") if (pkg / "SKILL.md").exists() else ""
+        expr = str(task.input)
+        # The agent runs a bundled script only when the skill TELLS it to (by naming a
+        # `scripts/<file>` command in the body) AND the script is there — the same
+        # contract a real agent follows. Any filename works; the pointer is what matters.
+        helper = next((pkg / m for m in re.findall(r"(scripts/[\w./-]+\.py)", body)
+                       if (pkg / m).exists()), None)
+        if helper is not None:
+            p = subprocess.run([sys.executable, str(helper), expr],
+                               capture_output=True, text=True, timeout=30)
+            out = (p.stdout or "").strip() or f"error: {(p.stderr or '').strip()[:120]}"
+            return Rollout(task_id=task.id, output=out, trace=f"ran {helper.name}")
+        # Prose-only path: it handles the tidy cases and fumbles the rest.
+        try:
+            out = _eval(re.sub(r"\s+", " ", expr).strip())
+        except Exception as e:  # noqa: BLE001
+            out = f"error: {e}"
+        return Rollout(task_id=task.id, output=out, trace="followed the SKILL.md body only")
+
+    def score(self, task: Task, rollout: Rollout) -> Score:
+        got = (rollout.output or "").strip()
+        ok = got == str(task.target).strip()
+        fb = ("correct" if ok else
+              f"expected '{task.target}' but got '{got}': the input is not plain "
+              "arithmetic (number words, thousands separators), and the skill gives no "
+              "deterministic way to normalize it before computing")
+        return Score(task_id=task.id, reward=1.0 if ok else 0.0, feedback=fb,
+                     trial_rewards=[1.0 if ok else 0.0])
+
+    def apply(self, candidate_dir: Path, edits: dict | None = None) -> None:
+        # The stand-in reads the candidate package directly, so going "live" is a no-op.
+        return None

--- a/examples/toy_skill/capevolve.yaml
+++ b/examples/toy_skill/capevolve.yaml
@@ -1,0 +1,25 @@
+# toy_skill run spec — capability = a skill package, optimizer = mock (zero-API).
+capabilities: [skill-package]
+capability_path: seed_capability
+actions: [edit]
+
+optimizer_skill: mock
+optimizer_model: ""
+
+algorithm_skill: hill-climb
+algorithm_focus: all
+orchestration_mode: deterministic
+
+dataset_source: adapter
+split_seed: 0
+split_train: 0.4
+split_val: 0.3
+split_test: 0.3
+
+num_trials: 1
+gate_mode: paired
+gate_k_se: 1.0
+
+max_iterations: 2
+stall: 2
+store: git

--- a/examples/toy_skill/mock_script.json
+++ b/examples/toy_skill/mock_script.json
@@ -1,0 +1,14 @@
+{
+  "edits": [
+    {
+      "file": "scripts/normalize.py",
+      "op": "set",
+      "text": "\"\"\"Normalize a messy arithmetic expression to plain digits/operators, then compute it.\n\nBundled because the SKILL.md body asking for normalization \"before computing\" is a\nstep the agent skips: number words and thousands separators need the same handful of\nsubstitutions every time, which is code, not judgment.\n\n    python scripts/normalize.py '2,000 minus 1,000'   ->  1000\n    python scripts/normalize.py --self-check          ->  ok\n\"\"\"\n\nimport re\nimport sys\n\nWORDS = {\"plus\": \"+\", \"and\": \"+\", \"minus\": \"-\", \"less\": \"-\",\n         \"times\": \"*\", \"multiplied by\": \"*\"}\nSAFE = set(\"0123456789 +-*\")\n\n\ndef normalize(expr):\n    s = str(expr).lower()\n    s = re.sub(r\"(\\d),(\\d\\d\\d)\", r\"\\1\\2\", s)          # 1,200 -> 1200\n    for word, op in WORDS.items():\n        s = re.sub(rf\"\\b{re.escape(word)}\\b\", op, s)\n    return re.sub(r\"\\s+\", \" \", s).strip()\n\n\ndef compute(expr):\n    s = normalize(expr)\n    if not set(s) <= SAFE:\n        raise ValueError(f\"cannot normalize {expr!r} -> {s!r}\")\n    return str(int(eval(s, {\"__builtins__\": {}}, {})))\n\n\ndef _self_check():\n    for raw, want in ((\"2 + 3\", \"5\"), (\"3 plus 4\", \"7\"), (\"8 times 3\", \"24\"),\n                      (\"1,200 + 5\", \"1205\"), (\"2,000 minus 1,000\", \"1000\")):\n        got = compute(raw)\n        assert got == want, f\"{raw!r}: expected {want}, got {got}\"\n    print(\"ok\")\n\n\nif __name__ == \"__main__\":\n    if \"--self-check\" in sys.argv:\n        _self_check()\n    else:\n        print(compute(sys.argv[1]))\n"
+    },
+    {
+      "file": "SKILL.md",
+      "op": "ensure_contains",
+      "text": "\nDo the normalization by running the bundled helper instead of by hand \u2014 it is the\nsame substitution table every time, and skipping it is what produces wrong answers:\n\n```\npython scripts/normalize.py '<the expression>'    # prints the answer alone\n```\n"
+    }
+  ]
+}

--- a/examples/toy_skill/seed_capability/SKILL.md
+++ b/examples/toy_skill/seed_capability/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: arithmetic-answers
+description: Answers a short arithmetic question with just the number. Use when the user asks to compute a sum, difference, or product and wants only the result back.
+---
+
+# Arithmetic answers
+
+Read the expression, compute it, and reply with the number alone — no units, no
+working, no trailing punctuation.
+
+Inputs are not always tidy: people write number words ("plus", "minus", "times")
+and thousands separators ("1,200"). Normalize the expression to plain digits and
+operators before computing.

--- a/skills/_registry/manifest.json
+++ b/skills/_registry/manifest.json
@@ -156,7 +156,7 @@
     "skill-package": {
       "component": "capability",
       "path": "capabilities/skill-package",
-      "summary": "Optimize an Agent Skill package (SKILL.md + references + scripts) under skill-creator authoring rules.",
+      "summary": "Optimize a WHOLE Agent Skill package \u2014 SKILL.md, references, and bundled scripts \u2014 under the skill-creator authoring rules.",
       "entry": "scripts/run.py",
       "abstract": "scripts/abstract.py",
       "check": "scripts/check.py",

--- a/skills/capabilities/skill-package/SKILL.md
+++ b/skills/capabilities/skill-package/SKILL.md
@@ -1,122 +1,98 @@
 ---
 name: skill-package
-description: Optimize an Agent Skill package itself — its SKILL.md (frontmatter + body), references, and bundled scripts. Use when the capability under optimization IS a skill, you want the downstream agent to trigger it correctly and follow it without wasted steps. Enforces the skill-creator authoring rules (progressive disclosure, valid frontmatter, body budget, one-level references) so edits stay valid skills.
+description: Optimize an Agent Skill package itself — its SKILL.md (frontmatter + body), its references, and its bundled scripts. Use when the capability under optimization IS a skill, you want the downstream agent to trigger it correctly and follow it without wasted steps, or you want a step the agent keeps skipping turned into deterministic bundled code. Checks every edit against the skill-creator authoring rules (valid frontmatter, progressive disclosure, one-level references, body budget, scripts that compile and self-check) so a candidate stays a valid, runnable skill.
 component: capability
 argument-hint: "--path DIR"
 allowed-tools: Read, Write, Edit, Bash
 provides: [candidate]
 needs: []
-sources: [agentskills, skillgrad, trace2skill, skillopt]
+sources: [agentskills, skillgrad, trace2skill]
 ---
 
 # Capability: skill package
 
-The thing being optimized is a skill directory (a `SKILL.md` plus `references/`,
-`scripts/`, `assets/`). This capability treats that whole package as the editable
-artifact and bakes in the **skill-creator** authoring rules (sourced to first-party
-Anthropic docs — see [`references/concepts.md`](references/concepts.md)) so the
-optimizer improves the skill without breaking it.
+The artifact is a whole skill directory — `SKILL.md` plus `references/`, `scripts/`
+and `assets/` — and **all of it is editable**: `materialize()` exposes every file as
+a component, `apply()` can rewrite or CREATE one (a new bundled script included), and
+`validate()` checks the result against the **skill-creator** authoring rules
+(first-party sources in [`references/concepts.md`](references/concepts.md)).
 
 ## What you can change (highest leverage first)
 
-Each lever is an edit class; pick the one that fixes the biggest failure cluster.
-One-line examples here; depth in the referenced files.
+Pick the lever that fixes the biggest failure cluster; depth is in the references.
 
-1. **The `description` / trigger** — the decision boundary that makes the skill
-   fire, and the single highest-leverage edit. Write it **third person**, state
-   **what** it does AND **when** to use it, and use the **keywords a user would
-   actually say**. Lean slightly pushy for under-trigger; tighten the boundary and
-   name near-miss cases for over-trigger. **Front-load the key use case** — the
-   listing truncates `description + when_to_use` at 1,536 chars. *Ex:* "Formats
-   data" → "Exports records to CSV. Use when the user asks to export or download a
-   table." Full playbook: [`references/description-optimization.md`](references/description-optimization.md).
-2. **The body** — improve clarity / altitude, remove dead weight, fix the step the
-   agent keeps skipping. The body is loaded on every trigger and **stays in context
-   all session — a recurring token cost**, so keep it **<500 lines AND ~5k tokens**
-   and **state what to do, don't narrate why at length**. Imperative voice; explain
-   the *why* of a rule briefly instead of piling on ALL-CAPS MUSTs.
-3. **References** — factor mutually-exclusive or rarely-co-used detail into
-   `references/*.md` as the body grows. Keep them **one level deep**, link each
-   **directly from SKILL.md with an explicit pointer saying what it contains and
-   when to load it**, and give long refs (>300 lines) a table of contents. Don't
-   nest (a ref pointing to another ref) — the agent may only partially read it.
-4. **Scripts** — when traces show the agent re-implementing the same helper, or a
-   step is deterministic/repeatable, **bundle it in `scripts/`** and **state
-   execute-vs-read intent**. A script runs via bash without its code entering
-   context (output-only token cost); prose is only *likely* and costs context.
-   Reserve prose for steps that need judgment.
+1. **The `description` / trigger** — the only text loaded before the skill fires, so
+   the single highest-leverage edit. Third person; state **what** it does AND **when**
+   to use it; use the **keywords a user would actually say**. Lean slightly pushy for
+   under-trigger, tighten the boundary and name near-miss cases for over-trigger, and
+   **front-load the key use case** (hosts truncate the listing — 1,536 chars on Claude
+   Code by default). *Ex:* "Formats data" → "Exports records to CSV. Use when the user
+   asks to export or download a table." Playbook + the measurable loop:
+   [`references/description-optimization.md`](references/description-optimization.md).
+2. **A skipped step → a bundled script** (the determinism lever). Prose is only
+   *likely* to be followed; code that runs is repeatable. When the traces show the
+   agent skipping a step, re-deriving the same helper, or doing a deterministic
+   transform by hand, **write it into `scripts/` and make the body invoke it** by
+   command line. Write real, working code — never `...` or a docstring-only stub —
+   give it a `--self-check` entry point (`validate()` runs it, so a broken script is
+   caught before any rollout is paid for), and say **execute, don't read**: a script's
+   source never enters the agent's context, only its output.
+3. **The body** — improve clarity and altitude, delete dead weight, fix the
+   instruction the agent misreads. The body loads on every trigger and stays in
+   context all session — a recurring cost — so keep it **≤500 lines** (enforced),
+   imperative, and explain a rule's *why* briefly instead of piling on ALL-CAPS MUSTs.
+4. **References** — move mutually-exclusive or rarely-co-used detail into
+   `references/*.md`. Keep them **one level deep** (a ref must not point at another
+   ref — the agent may read only part of it), link each **directly from SKILL.md with
+   a pointer saying what it holds and when to load it**, and give a long ref (>300
+   lines) a table of contents **at the very top, above any orientation prose** — the
+   check is positional because a TOC the head-reader never reaches is not a TOC.
+   Multiple variants/domains → one ref per variant (`references/aws.md`, `gcp.md`, …)
+   plus a selection body, so only one is read.
+5. **Assets** — `assets/` holds files the skill *emits* (templates, icons, fonts),
+   not context the agent reads. Edit one only when the skill's output depends on it.
 
-> **Keep edits valid skills:** valid frontmatter (`name` ≤64/[a-z0-9-]/no XML;
-> `description` non-empty ≤1024/no XML, with a "use when" clause), body within
-> budget, references one level deep, no broken links. Don't introduce
-> unaudited/exfiltrating content — a skill body is executable context.
-
-## How agents use a skill (progressive disclosure)
-Three loading levels — optimize for the cheapest that still works:
-1. **Metadata** (`name` + `description`) — always in context (~100 tokens). The
-   description is the *only* thing that decides whether the skill fires.
-2. **SKILL.md body** — loaded when the skill triggers (recurring session cost).
-3. **References / scripts** — loaded or executed only as needed.
-
-So a vague description → the skill never triggers; a bloated body → wasted context
-and worse behavior; detail that belongs in a reference → paid for on every trigger.
+> **Every edit must leave a valid skill.** `validate()` fails a candidate on: no
+> `SKILL.md`; `name` missing/>64 chars/not `[a-z0-9-]`/containing an XML tag;
+> `description` empty/>1024 chars/containing an XML tag; a body over 500 lines; a
+> broken `references|scripts|assets/…` link; a bundled script that does not compile or
+> whose `--self-check` fails. It *warns* on the softer authoring smells (POV drift,
+> ALL-CAPS in the description, orphan or nested references, a missing TOC, a stub
+> script, a script with no self-check, network/subprocess use in new code). A skill is
+> executable context: keep bundled code auditable and free of surprises.
 
 ## Adapting to the reader's capability tier
-Scale the SKILL.md body density to WHO follows it at runtime (see the `THE READER` block
-in your instructions, if present). A **mid/weak** reader needs more worked steps, explicit
-ordering, and examples in the body — it infers less, so a compact principle-first body
-leaves it guessing. A **frontier** reader follows a compact, principle-first body and is
-slowed by over-specification. Keep the progressive-disclosure structure and body budget
-either way (push detail into `references/`); the tier changes how *explicit* the retained
-body is, not how *long* it may be.
+Scale body density to WHO follows it at runtime (see the `THE READER` block in your
+instructions, if present). A **mid/weak** reader needs more worked steps, explicit
+ordering, and examples in the body — and benefits most from lever 2, since code it
+executes cannot be skipped the way a rule can. A **frontier** reader follows a
+compact, principle-first body and is slowed by over-specification. The tier changes
+how *explicit* the retained body is, not how *long* it may be.
 
-## The description is the trigger — optimize it as a separable step
-Most triggering failures are fixed by editing the *description*, not the body.
-
-- **Under-trigger** → enumerate the phrasings and contexts that should fire it,
-  including when the user doesn't name the skill.
-- **Over-trigger** → tighten the boundary and state the near-miss cases it does NOT
-  cover. `CRITICAL`/`ALWAYS`/`MUST` in a description over-triggers current models —
-  prefer plain "Use when …"; reserve pushy phrasing for genuine under-triggering.
-- **Trivial single-step tasks** may not trigger any skill regardless of wording.
-
-## Measure every edit against the objective
-A skill edit is only an improvement if it raises the number we are optimizing.
-
-- **The acceptance signal is the intake benchmark score** on the held-out **val**
-  split, via cap-evolve `evaluate` → `gate`. Keep only gated wins; reject edits
-  that don't clear the significance bar. **Never overfit the handful of iteration
-  examples** — a skill is used many times; fiddly task-specific rules hurt.
-- **For triggering**, also track trigger-rate on a held-out set of should-trigger /
-  should-NOT-trigger prompts (with **near-miss negatives**), and pick the
-  description that scores best on the held-out set — the skill-creator loop's own
-  select-by-held-out discipline, which is exactly cap-evolve's train/val/test split.
-
-## Handlers (scripts/abstract.py)
-`materialize(dir)` → {SKILL.md, references/*} · `apply(dir, edits)` ·
-`validate(dir)` → frontmatter (`name` ≤64/[a-z0-9-]/no XML; `description` ≤1024/no
-XML with a "use when" clause; POV + all-caps + 1,536-listing lints), body ≤500
-lines / ~5k tokens, references one level deep + TOC for long ones, links exist.
-
-## Optimizing it each iteration (analyze → ideate → edit)
-**Analyze before editing** (treat the skill like an evolving playbook you curate):
-from the traces + the current skill, identify (a) recurring failures clustered by
-root cause (the step the agent skips, the wrong trigger, the misread instruction)
-and (b) good behavior seen only on some trials that should be made consistent. Then
-make **ONE** targeted edit that fixes the biggest cluster and reinforces (b),
-staying within the skill-creator rules. Be economical: one good edit, then stop.
+## Trigger rate is a second objective
+Task reward is the gate signal, and cap-evolve owns that machinery — do not add a
+private eval loop here. But triggering is invisible to task reward when the skill never
+fires, so measure it separately with `scripts/trigger_eval.py` on a held-out set of
+should-trigger / should-NOT-trigger prompts (with near-miss negatives) and keep the
+description that wins on the **held-out** half.
 
 ## How to run
 ```
-python scripts/check.py                                  # self-test (must pass)
-python scripts/run.py --path <skill_dir>                 # candidate + validity report
-python scripts/token_report.py --path <skill_dir>        # progressive-disclosure budget
+python scripts/check.py                            # self-test (must pass)
+python scripts/run.py --path <skill_dir>           # candidate + validity report
+python scripts/token_report.py --path <skill_dir>  # budget + script inventory
+python scripts/trigger_eval.py --eval-set <json> --skill <dir> --judge-cmd '<cmd>'
 ```
+Handlers in `scripts/abstract.py`: `materialize(dir)` → every file as a component ·
+`apply(dir, edits)` → `{changed, refused}`, contained to the package and gated by the
+action policy (`policy.json`: `frontmatter|body|reference|script|asset|add|remove`,
+so a run can allow prose but forbid new code) · `validate(dir)` → `{ok, problems,
+warnings, scripts}`.
 
 ## References
 - [`references/concepts.md`](references/concepts.md) — the authoring model and the
   validity rules, with first-party sources. Load for grounding.
 - [`references/description-optimization.md`](references/description-optimization.md)
   — the trigger-tuning playbook. Load when fixing under/over-trigger.
-- [`references/anti-patterns.md`](references/anti-patterns.md) — common bad smells
-  and the why. Load when a draft "feels off" or to review an edit.
+- [`references/anti-patterns.md`](references/anti-patterns.md) — skill smells and the
+  why. Load when a draft "feels off" or to review an edit.

--- a/skills/capabilities/skill-package/meta.yaml
+++ b/skills/capabilities/skill-package/meta.yaml
@@ -1,6 +1,6 @@
 component: capability
 name: skill-package
-summary: Optimize an Agent Skill package (SKILL.md + references + scripts) under skill-creator authoring rules.
+summary: Optimize a WHOLE Agent Skill package — SKILL.md, references, and bundled scripts — under the skill-creator authoring rules.
 entry: scripts/run.py
 abstract: scripts/abstract.py
 check: scripts/check.py

--- a/skills/capabilities/skill-package/references/anti-patterns.md
+++ b/skills/capabilities/skill-package/references/anti-patterns.md
@@ -44,9 +44,6 @@
   the skill executes; code is repeatable where prose is only likely.
 - **Not stating execute-vs-read intent.** → The agent doesn't know whether to run
   the script (output-only token cost) or read it as reference. Say which.
-
-## Process
-- **Selecting an edit on the iteration examples.** → That is overfitting. Keep an
-  edit only if it raises the objective on a held-out split and clears the gate.
-- **Multiple edits at once.** → You can't attribute the score change. Make ONE
-  targeted edit per iteration, then re-measure.
+- **A stub script** (docstring / `...` / `pass` only) or one with no `--self-check`.
+  → Nothing proves it runs, so the "deterministic" step silently isn't. Write real
+  code with a self-check `validate()` can execute.

--- a/skills/capabilities/skill-package/references/concepts.md
+++ b/skills/capabilities/skill-package/references/concepts.md
@@ -3,17 +3,15 @@
 > The authoring model below is first-party (Anthropic Agent Skills docs +
 > skill-creator + the engineering blog; see Sources). When the optimizer edits a
 > skill package, these are the rules that make the edit a *better skill*, not just
-> different text. Sibling references:
-> [`description-optimization.md`](description-optimization.md) (the trigger lever)
-> and [`anti-patterns.md`](anti-patterns.md) (what not to do).
+> different text. Load it for grounding; `SKILL.md` links the sibling references.
 
 ## What a skill package is
 ```
 skill-name/
 ├── SKILL.md          (required: YAML frontmatter + Markdown body)
 ├── references/*.md   (docs loaded on demand)
-├── scripts/          (executables; code never enters context, only output)
-└── assets/           (templates/icons used in output)
+├── scripts/          (code the agent EXECUTES; source never enters context)
+└── assets/           (templates/icons/fonts used in the skill's OUTPUT)
 ```
 
 ## Progressive disclosure (the core idea)
@@ -23,63 +21,57 @@ Skills use a **three-level loading model**; optimize for the cheapest that works
    system prompt, ~100 tokens per skill. The `description` is the **primary
    triggering mechanism**: it must say WHAT the skill does AND WHEN to use it.
 2. **SKILL.md body** — loaded **when the skill triggers**, then it **stays in
-   context for the rest of the session** (a recurring cost). Target **<500 lines /
-   under ~5k tokens**. When it grows, move detail into `references/` and point to it.
-3. **Bundled resources** — references and scripts, loaded/executed **only as
-   needed**, effectively unlimited. A script runs via bash **without its code
-   entering context** — only its *output* costs tokens. A reference file costs
-   **zero** context until actually read.
+   context for the rest of the session** (a recurring cost). Keep it **≤500 lines**
+   (skill-creator's guidance, enforced by `validate`). When it grows, move detail
+   into `references/` and add an explicit pointer.
+3. **Bundled resources** — references, scripts and assets, loaded/executed **only as
+   needed**, effectively unlimited. A reference costs **zero** context until read; a
+   script runs via bash **without its code entering context at all** — only its
+   *output* costs tokens.
 
 ## Frontmatter rules (hard invariants)
-Two required fields, both validated:
 - **`name`**: ≤64 chars, lowercase `[a-z0-9-]` only, **no XML tags**, no reserved
   words (`anthropic`, `claude`).
 - **`description`**: non-empty, ≤1024 chars, **no XML tags**. Should contain a
-  "use when" clause (the triggering signal).
+  "use when" clause (the triggering signal). A block scalar (`description: >`) is
+  fine — the validator reads it.
 
-**Listing truncation.** In the Claude Code skill listing the combined
-`description + when_to_use` text is truncated (default 1,536 chars, configurable via
-`maxSkillDescriptionChars`). This is tighter in practice than the 1024-char
-validation limit, so **front-load the key use case** — put the most important
-trigger words first, before they can be cut.
+**Listing truncation (host-specific).** The Claude Code skill listing truncates the
+combined `description + when_to_use` text at 1,536 chars by default (configurable via
+`maxSkillDescriptionChars`); another host may differ. That is tighter in practice than
+the 1024-char validation limit, so **front-load the key use case**.
 
-## Description-as-trigger optimization (a separable, measurable step)
-See [`description-optimization.md`](description-optimization.md) for the full
-playbook. In short: write **third person**, include the **keywords users actually
-say**, lean slightly pushy (Claude tends to *under*-trigger); fix over-triggering
-by making the description **more specific**, not by adding ALL-CAPS. Select the
-description by **held-out** trigger score, not the iteration examples.
+## Deterministic code beats prose
+A body rule is *likely* to be followed; a script that runs is repeatable. The strong
+signals to convert a step into `scripts/`: traces where the agent **skips the step**,
+**re-implements the same helper**, or hand-executes a deterministic transform. Write
+working code (not a stub), give it a `--self-check` so an edit that breaks it is
+caught before rollouts are paid for, and **state execute-vs-read intent** in the body
+so the agent runs it instead of reading it. Reserve prose for judgment.
 
-## What the optimizer should change (and how)
-- **Sharpen the `description`** for triggering — the highest-leverage edit.
-- **Tighten the body**: imperative voice; **state what to do, don't narrate** the
-  why at length (every body line is a recurring token cost). Explain a rule's
-  reasoning briefly rather than piling on ALL-CAPS MUSTs — today's models follow
-  reasoning better than rigid rules.
-- **Generalize, don't overfit** to the eval tasks — a skill is used many times.
-- **Factor repeated work into `scripts/`**: a strong signal is traces where the
-  agent independently **re-implements the same helper**, or a deterministic step.
-  Code is repeatable where prose is only *likely*; **state execute-vs-read intent**.
-- **Organize by domain** when multi-framework: a selection body + one reference file
-  per variant linked **directly** from SKILL.md, so only the relevant one is read.
-  Keep references **one level deep** with an explicit "what/when to load" pointer.
+## Organize by variant when the skill spans domains
+A selection body plus one reference per variant (`references/aws.md`, `gcp.md`, …),
+each linked **directly** from SKILL.md with a what/when pointer, so only the relevant
+one is ever read. Keep references **one level deep**: a reference that points at
+another reference can be missed when the agent reads only part of the first.
 
-## How to optimize honestly (the loop)
-Skill optimization is **empirical**: observe how Claude actually triggers and
-follows the skill, cluster the failures, make one targeted edit, and **keep it only
-if it raises the objective score on a held-out split**. This mirrors ACE's
-generation → reflection → curation of an evolving playbook, and it is exactly the
-cap-evolve discipline: propose → `evaluate` on val → `gate` on significance →
-`finalize` once on sealed test. Never select on the training/iteration examples.
+## Measurement is core-owned — do not re-implement it
+cap-evolve already owns evaluation and acceptance, so this capability deliberately does
+**not** carry skill-creator's own eval harness (`evals.json`, assertions, graders): a
+second private eval loop would duplicate — and could contradict — the framework's own.
+The one skill-specific measurement it adds is trigger rate
+(`scripts/trigger_eval.py`), because a skill that never fires is invisible to task
+reward.
 
-## Validity rules enforced by `validate`
-- `name`: ≤64 chars, `[a-z0-9-]`, no XML tags, no "anthropic"/"claude".
-- `description`: non-empty, ≤1024 chars, no XML tags, ideally a "use when" clause.
-  Warns on first-person POV, all-caps CRITICAL/ALWAYS/MUST/NEVER, and length near
-  the 1,536 listing cap.
-- body ≤ ~500 lines AND ~5k tokens (else: split into references).
-- references one level deep; long references (>300 lines) start with a TOC.
-- files the body links to (`references/…`, `scripts/…`) must exist.
+## What `validate` decides
+- **Fails** (hard problem): no `SKILL.md`; bad/missing `name`; empty/oversize/XML
+  `description`; body >500 lines; a broken `references|scripts|assets/…` link; a
+  bundled script that does not compile or whose declared `--self-check` fails.
+- **Warns**: first-person POV, ALL-CAPS `CRITICAL/ALWAYS/MUST/NEVER`, a description
+  near the host listing cap, a body over ~5k tokens (this repo's own heuristic, not a
+  skill-creator rule), a nested or orphan reference, a long reference with no real
+  table of contents, a stub script, a script with no `--self-check`, and
+  network/subprocess/`eval` use in bundled code.
 
 ## Sources
 - Anthropic Agent Skills docs — overview & best-practices:

--- a/skills/capabilities/skill-package/references/description-optimization.md
+++ b/skills/capabilities/skill-package/references/description-optimization.md
@@ -29,16 +29,30 @@ applies to the current task. It must:
   for ALL-CAPS — `CRITICAL`/`ALWAYS`/`MUST` *increase* over-triggering on current
   models.
 
-## Selecting a description honestly (don't overfit)
-1. Assemble a held-out set: **should-trigger** prompts and **should-NOT-trigger**
-   prompts, the latter including **near-miss negatives** (prompts that look close
-   but must not fire).
-2. Propose candidate descriptions.
-3. Measure trigger-rate on the held-out set (and downstream task success on the
-   objective).
-4. **Keep the candidate that scores best on the held-out set**, not on the
-   iteration examples. (skill-creator splits its eval queries and selects by the
-   held-out/test score — the same train/val/test discipline cap-evolve enforces.)
+## Selecting a description honestly — run the loop, don't eyeball it
+A trigger decision is stochastic, so one sample per query is noise and hand-judging
+drifts between candidates. `scripts/trigger_eval.py` makes it deterministic:
+
+```bash
+python scripts/trigger_eval.py --eval-set trigger_eval.json --skill <skill_dir> \
+    --judge-cmd '<a shell command that answers YES/NO on stdout>' \
+    --description "<candidate description>" --trials 3
+# -> {"train_score": .., "heldout_score": .., "per_query": [..], "select_on": "heldout_score"}
+```
+
+1. Write ~20 realistic queries — 8-10 **should-trigger** (varied phrasing, including
+   cases where the user never names the skill) and 8-10 **should-NOT-trigger**, whose
+   value is in the **near-misses**: same keywords, different actual need. An obviously
+   irrelevant negative tests nothing. Save as
+   `[{"query": "...", "should_trigger": true}, ...]`.
+2. The script splits 60/40 by seed and runs each query `--trials 3` times, so the
+   score is a rate rather than a coin flip.
+3. Propose candidate descriptions and re-score each one with `--description`.
+4. **Keep the candidate with the best `heldout_score`** — never the train score. Same
+   discipline as cap-evolve's val/test seal, for the same reason.
+
+Queries must be substantive: a trivial one-step request ("read file X") won't trigger
+any skill regardless of description quality, so it measures nothing.
 
 Caveat: **trivial single-step tasks may not trigger any skill** regardless of
 wording — don't chase those as triggering failures.

--- a/skills/capabilities/skill-package/scripts/abstract.py
+++ b/skills/capabilities/skill-package/scripts/abstract.py
@@ -1,56 +1,120 @@
-"""skill-package capability — optimize an Agent Skill package (SKILL.md + refs + scripts).
+"""skill-package capability — optimize a WHOLE Agent Skill package.
 
 A skill package is a directory: a required ``SKILL.md`` (YAML frontmatter
 ``name``/``description`` + a Markdown body) plus optional ``references/`` (docs
-loaded on demand), ``scripts/`` (executables), and ``assets/``. Optimizing a skill
-means editing that text to improve how a downstream agent uses it.
+loaded on demand), ``scripts/`` (code the agent EXECUTES — its source never
+enters context), and ``assets/`` (files used in output). Every one of those is an
+editable component here: ``materialize`` exposes them, ``apply`` can create or
+rewrite them (including a NEW bundled script), and ``validate`` checks them.
 
-``validate`` here encodes the skill-creator / Agent-Skills authoring rules so the
-optimizer can't drift into an invalid package (all rules sourced to first-party
+``validate`` encodes the skill-creator / Agent-Skills authoring rules so the
+optimizer cannot drift into an invalid package (rules sourced to first-party
 Anthropic docs — see references/concepts.md):
   - frontmatter has ``name`` (<=64 chars, [a-z0-9-], no "anthropic"/"claude",
     no XML tags) and a non-empty ``description`` (<=1024 chars, no XML tags) that
     says WHAT + WHEN ("use when").
-  - SKILL.md body stays under ~500 lines AND ~5k tokens (progressive disclosure
-    budget; the body is a recurring per-session token cost).
-  - references are one level deep and any long reference (>300 lines) has a TOC.
-  - referenced files that the body points at actually exist.
+  - the SKILL.md body stays within the Level-2 budget (<=500 lines): it is a
+    recurring per-session token cost.
+  - references are one level deep (no nested pointers), each is linked from
+    SKILL.md, and a long one (>300 lines) opens with a table of contents.
+  - files the body links to exist.
+  - bundled scripts COMPILE (``ast.parse``), are not stub-only, and — when they
+    declare a ``--self-check`` entry point — that self-check actually passes.
+    Deterministic code the agent runs is only deterministic if it runs.
 
-Soft authoring lints (warnings, not failures): a first-person description
-(point-of-view drift hurts discovery), all-caps CRITICAL/ALWAYS/MUST/NEVER in the
-description (over-triggers current models), and a long description that risks the
-1,536-char listing truncation (description + when_to_use) — front-load the use case.
+Soft authoring lints (warnings, not failures): first-person description (POV
+drift hurts discovery), all-caps CRITICAL/ALWAYS/MUST/NEVER in the description
+(over-triggers current models), a description long enough to risk the host's
+listing truncation, a script with no declared self-check, and a script reaching
+for network/subprocess/``eval`` (a bundled script is executable context — the
+human must see that in the diff).
 
-Edit ops (mirrored by the mock optimizer): {"file","op":"set|append|ensure_contains","text"}.
+Edit ops (mirrored by the mock optimizer):
+``{"file", "op": set|append|ensure_contains|remove, "text", "kind"?}``. ``kind``
+defaults to the file's location (frontmatter/body/reference/script/asset) and is
+checked against the action policy (``inputs/policy.json`` overrides
+``DEFAULT_POLICY``), so a run can allow prose edits while forbidding new code.
 """
 
 from __future__ import annotations
 
+import ast
+import json
+import os
 import re
+import subprocess
+import sys
 from pathlib import Path
 
 NAME_RE = re.compile(r"^[a-z0-9-]{1,64}$")
 FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---", re.S)
 XML_TAG_RE = re.compile(r"</?[a-zA-Z][^>]*>")  # an actual tag, not a stray "<"
-MAX_BODY_LINES = 500
-MAX_BODY_TOKENS = 5000            # ~chars/4; Level-2 body budget
+MAX_BODY_LINES = 500              # skill-creator's Level-2 budget (hard here)
+MAX_BODY_TOKENS = 5000            # cap-evolve heuristic (~chars/4), advisory only
 CHARS_PER_TOKEN = 4
 LONG_REF_LINES = 300
-LISTING_CAP_CHARS = 1536          # description + when_to_use truncation in the listing
+MIN_TOC_LINKS = 3                 # anchor links a long reference's TOC must show...
+TOC_SCAN_CHARS = 1500             # ...within this leading window, so put the TOC FIRST
+LISTING_CAP_CHARS = 1536          # Claude Code host default (maxSkillDescriptionChars)
 LONG_DESC_CHARS = 1024            # hard cap; also the front-load advisory threshold
+MAX_COMPONENT_CHARS = 40000       # per-component cap so one big file can't blow the prompt
+SELF_CHECK_TIMEOUT = 30           # seconds per bundled-script self-check
+TEXT_SUFFIXES = {".py", ".sh", ".md", ".txt", ".json", ".yaml", ".yml", ".toml",
+                 ".js", ".ts", ".csv", ".cfg", ".ini", ""}
+RISKY_IMPORTS = {"subprocess", "socket", "urllib", "http", "requests", "httpx", "ftplib",
+                 "telnetlib", "smtplib", "ctypes"}
+RISKY_BUILTINS = {"eval", "exec", "compile", "__import__"}
+
+# The whole package is editable, so every kind is allowed by default. A run that
+# must not gain new executable code drops "script" (and "add") in policy.json —
+# the same knob shape the tool capabilities use (cap_evolve.tool_surface).
+DEFAULT_POLICY = {"allow": ["frontmatter", "body", "reference", "script", "asset",
+                            "add", "remove"]}
+
+
+def load_policy(capability_dir: Path) -> dict:
+    """``policy.json`` in the capability dir if present (it overrides), else the default."""
+    f = Path(capability_dir) / "policy.json"
+    return json.loads(f.read_text(encoding="utf-8")) if f.exists() else dict(DEFAULT_POLICY)
 
 
 def _parse_frontmatter(text: str) -> tuple[dict, str]:
+    """Parse the YAML frontmatter enough for the authoring lints.
+
+    Handles what a description realistically uses: a one-line value, a quoted
+    value, a ``>``/``|`` block scalar, and an indented continuation. A block
+    scalar is ordinary YAML for a long description — the highest-leverage field
+    this capability edits — so a parser that returned the literal ``'>'`` would
+    silently bypass every description lint.
+    """
     m = FRONTMATTER_RE.match(text)
     if not m:
         return {}, text
-    fm = {}
+    fm: dict[str, str] = {}
+    key: str | None = None
+    fold = ""                     # ">" (fold to spaces), "|" (keep newlines), or ""
     for line in m.group(1).splitlines():
-        if ":" in line and not line.startswith(" "):
-            k, _, v = line.partition(":")
-            fm[k.strip()] = v.strip().strip('"').strip("'")
-    body = text[m.end():]
-    return fm, body
+        stripped = line.strip()
+        indented = line[:1] in (" ", "\t")
+        if key and (indented or (fold and stripped)):
+            if not stripped:
+                continue
+            sep = "\n" if fold == "|" else " "
+            fm[key] = (fm[key] + sep + stripped).strip() if fm[key] else stripped
+            continue
+        if ":" in line and not indented:
+            key, _, v = line.partition(":")
+            key = key.strip()
+            v = v.strip()
+            if v in (">", "|", ">-", "|-", ">+", "|+"):
+                fold, v = v[0], ""
+            else:
+                fold = ""
+                v = v.strip('"').strip("'")
+            fm[key] = v
+        else:
+            key, fold = None, ""
+    return fm, text[m.end():]
 
 
 def _subpackages(capability_dir: Path) -> list[Path]:
@@ -70,21 +134,46 @@ def _subpackages(capability_dir: Path) -> list[Path]:
     )
 
 
+def _read_component(f: Path) -> str:
+    """Component text for one bundled file; binaries become an inventory stub.
+
+    An asset (icon/font/template) is part of the package the optimizer must SEE,
+    but its bytes are worthless in a text prompt — so list it, don't inline it.
+    """
+    if f.suffix.lower() not in TEXT_SUFFIXES:
+        return f"<binary asset, {f.stat().st_size} bytes>"
+    try:
+        text = f.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        return f"<binary asset, {f.stat().st_size} bytes>"
+    if len(text) > MAX_COMPONENT_CHARS:
+        return text[:MAX_COMPONENT_CHARS] + f"\n<truncated at {MAX_COMPONENT_CHARS} chars>"
+    return text
+
+
 def _materialize_one(skill_dir: Path, prefix: str = "") -> dict:
-    """Flatten ONE skill package's SKILL.md + references into named components."""
+    """Flatten ONE skill package — SKILL.md, references, scripts, assets — into components."""
     parts = {}
     skill_md = skill_dir / "SKILL.md"
     if skill_md.exists():
         parts[f"{prefix}SKILL.md"] = skill_md.read_text(encoding="utf-8")
-    refs = skill_dir / "references"
-    if refs.is_dir():
-        for f in sorted(refs.glob("*.md")):
-            parts[f"{prefix}references/{f.name}"] = f.read_text(encoding="utf-8")
+    for sub in ("references", "scripts", "assets"):
+        d = skill_dir / sub
+        if not d.is_dir():
+            continue
+        for f in sorted(d.rglob("*")):
+            if f.is_file() and "__pycache__" not in f.parts:
+                rel = f.relative_to(skill_dir).as_posix()
+                parts[f"{prefix}{rel}"] = _read_component(f)
     return parts
 
 
 def materialize(capability_dir: Path) -> dict:
-    """Flatten SKILL.md + references into named text components.
+    """Flatten the whole package into named components (SKILL.md + refs + scripts + assets).
+
+    ``scripts/<name>`` is code the downstream agent EXECUTES: its source costs the
+    agent no context, only its output — which is why converting a skipped prose
+    step into a script is the determinism lever.
 
     Supports BOTH a single-skill capability_path (SKILL.md at the top) and a
     MULTI-skill root holding several immediate sub-packages: components from each
@@ -100,15 +189,65 @@ def materialize(capability_dir: Path) -> dict:
     return _materialize_one(capability_dir)
 
 
+def _kind_of(rel: str) -> str:
+    """The action kind implied by a component's location in the package."""
+    head = rel.split("/", 1)[0]
+    if head == "references":
+        return "reference"
+    if head == "scripts":
+        return "script"
+    if head == "assets":
+        return "asset"
+    return "body"          # SKILL.md — "frontmatter" is the same file, callers may say so
+
+
 def apply(capability_dir: Path, edits: list[dict] | None = None) -> dict:
+    """Apply edits to any part of the package. Returns {changed, refused}.
+
+    Every write is contained to the capability dir (a ``../`` target is refused,
+    not raised — the same {changed, refused} contract the tool capabilities use)
+    and checked against the action policy, so a run can permit prose edits while
+    forbidding new executable code.
+    """
     capability_dir = Path(capability_dir)
-    report = {"changed": []}
+    root = capability_dir.resolve()
+    allow = set(load_policy(capability_dir).get("allow", []))
+    report: dict = {"changed": [], "refused": []}
+
+    def refuse(edit, reason):
+        report["refused"].append({"edit": edit, "reason": reason})
+
     for e in edits or []:
-        target = capability_dir / e["file"]
+        rel = str(e.get("file", ""))
         op = e.get("op", "set")
         text = e.get("text", "")
-        target.parent.mkdir(parents=True, exist_ok=True)
-        cur = target.read_text(encoding="utf-8") if target.exists() else ""
+        target = capability_dir / rel
+        try:
+            resolved = target.resolve()
+        except OSError as exc:                       # pragma: no cover — exotic paths
+            refuse(e, f"unresolvable path: {exc}")
+            continue
+        if resolved != root and root not in resolved.parents:
+            refuse(e, f"path '{rel}' escapes the capability dir")
+            continue
+        kind = e.get("kind") or _kind_of(rel)
+        if kind == "frontmatter":
+            kind = "frontmatter" if "frontmatter" in allow else "body"
+        if kind not in allow:
+            refuse(e, f"action '{kind}' not allowed by policy")
+            continue
+        exists = target.exists()
+        if op == "remove":
+            if "remove" not in allow:
+                refuse(e, "action 'remove' not allowed by policy")
+            elif exists:
+                target.unlink()
+                report["changed"].append(rel)
+            continue
+        if not exists and "add" not in allow:
+            refuse(e, f"creating '{rel}' needs the 'add' action")
+            continue
+        cur = target.read_text(encoding="utf-8") if exists else ""
         if op == "set":
             new = text
         elif op == "append":
@@ -116,10 +255,12 @@ def apply(capability_dir: Path, edits: list[dict] | None = None) -> dict:
         elif op == "ensure_contains":
             new = cur if (text.strip() and text.strip() in cur) else cur + text
         else:
-            raise ValueError(f"unknown op {op!r}")
+            refuse(e, f"unknown op {op!r}")
+            continue
         if new != cur:
+            target.parent.mkdir(parents=True, exist_ok=True)
             target.write_text(new, encoding="utf-8")
-            report["changed"].append(e["file"])
+            report["changed"].append(rel)
     return report
 
 
@@ -136,7 +277,7 @@ def is_empty(capability_dir: Path) -> bool:
 
 
 def validate(capability_dir: Path) -> dict:
-    """Enforce the Agent-Skills authoring rules. Returns {ok, problems, warnings}.
+    """Enforce the Agent-Skills authoring rules. Returns {ok, problems, warnings, scripts}.
 
     An empty capability (no SKILL.md, no sub-packages) is accepted as a valid
     starting state so the optimizer can create the initial skill from failing
@@ -147,35 +288,26 @@ def validate(capability_dir: Path) -> dict:
     ``ok`` is True only if every sub-package is valid."""
     capability_dir = Path(capability_dir)
     if is_empty(capability_dir):
-        return {"ok": True, "empty": True, "name": "", "problems": [], "warnings": []}
+        return {"ok": True, "empty": True, "name": "", "problems": [], "warnings": [],
+                "scripts": []}
     subs = _subpackages(capability_dir)
     if subs:
         problems: list[str] = []
         warnings: list[str] = []
         names: list[str] = []
+        scripts: list[dict] = []
         for sub in subs:
             v = _validate_one(sub)
             names.append(v.get("name", sub.name))
             problems += [f"{sub.name}: {p}" for p in v["problems"]]
             warnings += [f"{sub.name}: {w}" for w in v["warnings"]]
+            scripts += [{**s, "skill": sub.name} for s in v.get("scripts", [])]
         return {"ok": not problems, "name": ",".join(names),
-                "problems": problems, "warnings": warnings}
+                "problems": problems, "warnings": warnings, "scripts": scripts}
     return _validate_one(capability_dir)
 
 
-def _validate_one(capability_dir: Path) -> dict:
-    """Enforce the Agent-Skills authoring rules on ONE skill package."""
-    capability_dir = Path(capability_dir)
-    problems: list[str] = []
-    warnings: list[str] = []
-
-    skill_md = capability_dir / "SKILL.md"
-    if not skill_md.exists():
-        return {"ok": False, "problems": ["no SKILL.md in the package"], "warnings": []}
-
-    text = skill_md.read_text(encoding="utf-8")
-    fm, body = _parse_frontmatter(text)
-
+def _validate_frontmatter(fm: dict, problems: list, warnings: list) -> str:
     name = fm.get("name", "")
     if not name:
         problems.append("frontmatter missing 'name'")
@@ -189,52 +321,208 @@ def _validate_one(capability_dir: Path) -> dict:
     desc = fm.get("description", "")
     if not desc.strip():
         problems.append("frontmatter missing a non-empty 'description'")
-    else:
-        if len(desc) > LONG_DESC_CHARS:
-            problems.append(f"description is {len(desc)} chars (>{LONG_DESC_CHARS})")
-        if XML_TAG_RE.search(desc):
-            problems.append("description must not contain XML tags")
-        if not re.search(r"\b(use when|when )\b", desc, re.I):
-            warnings.append("description should say WHEN to use the skill "
-                            "('Use when …') — it is the primary triggering signal")
-        # point-of-view drift: descriptions must be third person.
-        if re.search(r"(?<![A-Za-z])I(?![A-Za-z])|I'?m\b|I can\b|you can help", desc):
-            warnings.append("description should be third person (e.g. 'Processes X "
-                            "…'), not first person ('I can …') — POV drift hurts discovery")
-        # all-caps imperatives over-trigger current models.
-        if re.search(r"\b(CRITICAL|ALWAYS|MUST|NEVER)\b", desc):
-            warnings.append("avoid all-caps CRITICAL/ALWAYS/MUST/NEVER in the "
-                            "description — it over-triggers; say plainly 'Use when …'")
-        # the listing shows description + when_to_use truncated at 1,536 chars.
-        if len(desc) > LISTING_CAP_CHARS - 256:
-            warnings.append(f"description is {len(desc)} chars; the listing truncates "
-                            f"description + when_to_use at {LISTING_CAP_CHARS} — "
-                            "front-load the key use case so it survives truncation")
+        return name
+    if len(desc) > LONG_DESC_CHARS:
+        problems.append(f"description is {len(desc)} chars (>{LONG_DESC_CHARS})")
+    if XML_TAG_RE.search(desc):
+        problems.append("description must not contain XML tags")
+    if not re.search(r"\b(use when|when )\b", desc, re.I):
+        warnings.append("description should say WHEN to use the skill "
+                        "('Use when …') — it is the primary triggering signal")
+    # point-of-view drift: descriptions must be third person.
+    if re.search(r"(?<![A-Za-z])I(?![A-Za-z])|I'?m\b|I can\b|you can help", desc):
+        warnings.append("description should be third person (e.g. 'Processes X "
+                        "…'), not first person ('I can …') — POV drift hurts discovery")
+    # all-caps imperatives over-trigger current models.
+    if re.search(r"\b(CRITICAL|ALWAYS|MUST|NEVER)\b", desc):
+        warnings.append("avoid all-caps CRITICAL/ALWAYS/MUST/NEVER in the "
+                        "description — it over-triggers; say plainly 'Use when …'")
+    # host listing truncation (Claude Code default; configurable per host).
+    if len(desc) > LISTING_CAP_CHARS - 256:
+        warnings.append(f"description is {len(desc)} chars; the Claude Code host "
+                        f"truncates description + when_to_use at {LISTING_CAP_CHARS} "
+                        "by default (configurable) — front-load the key use case")
+    return name
+
+
+def _validate_references(pkg: Path, body: str, problems: list, warnings: list) -> None:
+    # broken links the body points at
+    for rel in re.findall(r"\(((?:references|scripts|assets)/[^)\s]+)\)", body):
+        if not (pkg / rel).exists():
+            problems.append(f"SKILL.md links '{rel}' which does not exist")
+
+    refs = pkg / "references"
+    if not refs.is_dir():
+        return
+    for sub in refs.iterdir():
+        if sub.is_dir():
+            warnings.append(f"references/{sub.name}/ is nested >1 level deep; "
+                            "keep references one level deep")
+    for f in sorted(refs.glob("*.md")):
+        text = f.read_text(encoding="utf-8")
+        head = text[:TOC_SCAN_CHARS]
+        n = text.count("\n") + 1
+        # A long reference needs a real table of contents, and the check is POSITIONAL:
+        # the agent may read only the head, so a perfect TOC sitting behind a preamble
+        # is a TOC the reader never sees. Anchor links preferred, section headings
+        # accepted as the weaker form.
+        if n > LONG_REF_LINES and not (head.count("](#") >= MIN_TOC_LINKS
+                                       or head.count("\n## ") >= MIN_TOC_LINKS):
+            warnings.append(f"references/{f.name} is {n} lines and shows no table of "
+                            f"contents in its first {TOC_SCAN_CHARS} chars: put "
+                            f"{MIN_TOC_LINKS}+ anchor links ('- [Section](#section)') "
+                            "at the very TOP, above any orientation prose")
+        # One level deep is about POINTERS, not directories: a reference that points
+        # at another reference can be missed when the agent reads only part of it.
+        for link in re.findall(r"\]\(([^)\s]+)\)", text):
+            if re.match(r"(\./)?(\.\./)?references/", link) or (
+                    link.endswith(".md") and (refs / link).exists() and link != f.name):
+                warnings.append(f"references/{f.name} points at another reference "
+                                f"('{link}') — keep references one level deep, linked "
+                                "directly from SKILL.md")
+                break
+        if f.name not in body and f"references/{f.name}" not in body:
+            warnings.append(f"references/{f.name} is an orphan — SKILL.md never points "
+                            "at it, so the agent will not know to load it")
+
+
+def _script_self_check(f: Path, pkg: Path) -> dict:
+    """Run a bundled script's declared ``--self-check`` and report the outcome.
+
+    Only a script that DECLARES a self-check is executed — an entry point that
+    needs real arguments would otherwise "fail" for the wrong reason. Runs with a
+    timeout, in the package dir, with no inherited proxy/API env, so validation
+    cannot quietly reach the network on the optimizer's behalf.
+    """
+    src = f.read_text(encoding="utf-8", errors="replace")
+    rel = f.relative_to(pkg).as_posix()
+    if "--self-check" not in src:
+        return {"file": rel, "self_check": "absent"}
+    if os.environ.get("CAPEVOLVE_NO_SCRIPT_EXEC"):
+        return {"file": rel, "self_check": "skipped (CAPEVOLVE_NO_SCRIPT_EXEC)"}
+    # PATH/HOME/PYTHONPATH pass through (a bundled script may import its own package);
+    # nothing else does — no API keys — and the proxy vars are blanked so a self-check
+    # cannot quietly reach the network on the optimizer's behalf.
+    env = {"PATH": os.environ.get("PATH", ""), "HOME": os.environ.get("HOME", ""),
+           "PYTHONPATH": os.environ.get("PYTHONPATH", ""),
+           "PYTHONDONTWRITEBYTECODE": "1", "NO_NETWORK": "1",
+           "http_proxy": "", "https_proxy": "", "HTTP_PROXY": "", "HTTPS_PROXY": ""}
+    try:
+        p = subprocess.run([sys.executable, str(f.resolve()), "--self-check"],
+                           cwd=str(pkg.resolve()),
+                           capture_output=True, text=True, timeout=SELF_CHECK_TIMEOUT,
+                           env=env)
+    except subprocess.TimeoutExpired:
+        return {"file": rel, "self_check": "timeout", "ok": False,
+                "exit_code": None, "stderr_tail": f"timed out after {SELF_CHECK_TIMEOUT}s"}
+    except OSError as exc:                                # pragma: no cover
+        return {"file": rel, "self_check": "error", "ok": False,
+                "exit_code": None, "stderr_tail": str(exc)[-400:]}
+    # A failing self-check often reports on stdout (an assertion printer, a FAIL
+    # line), so carry both tails — the optimizer can only fix what it is shown.
+    return {"file": rel, "self_check": "ran", "ok": p.returncode == 0,
+            "exit_code": p.returncode, "stderr_tail": (p.stderr or "")[-400:],
+            "stdout_tail": (p.stdout or "")[-400:]}
+
+
+def _is_stub(tree: ast.Module) -> bool:
+    """True when a module has no real body — only a docstring / pass / ``...``."""
+    for node in tree.body:
+        if isinstance(node, ast.Expr) and isinstance(node.value, ast.Constant):
+            continue                                      # docstring or bare ``...``
+        if isinstance(node, ast.Pass):
+            continue
+        return False
+    return True
+
+
+def _risky(tree: ast.Module) -> list[str]:
+    """Network / subprocess / dynamic-exec surface a human should see in the diff.
+
+    Judged from the AST (imports and calls), not substrings, so a script that
+    merely mentions the word is not flagged.
+    """
+    found: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            found |= {a.name.split(".")[0] for a in node.names} & RISKY_IMPORTS
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            found |= {node.module.split(".")[0]} & RISKY_IMPORTS
+        elif isinstance(node, ast.Call) and isinstance(node.func, ast.Name) \
+                and node.func.id in RISKY_BUILTINS:
+            found.add(node.func.id + "()")
+    return sorted(found)
+
+
+def _validate_scripts(pkg: Path, problems: list, warnings: list) -> list[dict]:
+    """Check bundled code the way the downstream agent will meet it: as something run.
+
+    Deterministic code is the point of ``scripts/`` — a script that does not
+    compile, or whose declared self-check fails, is not determinism, it is a file.
+    """
+    d = pkg / "scripts"
+    if not d.is_dir():
+        return []
+    reports: list[dict] = []
+    for f in sorted(d.rglob("*.py")):
+        if "__pycache__" in f.parts:
+            continue
+        rel = f.relative_to(pkg).as_posix()
+        src = f.read_text(encoding="utf-8", errors="replace")
+        try:
+            tree = ast.parse(src, filename=str(f))
+        except SyntaxError as exc:
+            problems.append(f"{rel} does not compile: {exc.msg} (line {exc.lineno})")
+            reports.append({"file": rel, "compiles": False, "error": exc.msg})
+            continue
+        rep: dict = {"file": rel, "compiles": True}
+        if _is_stub(tree):
+            warnings.append(f"{rel} has no real body (docstring/pass/... only) — a "
+                            "bundled script must be working code, not a placeholder")
+            rep["stub"] = True
+        risky = _risky(tree)
+        if risky:
+            warnings.append(f"{rel} uses {', '.join(risky)} — a bundled script is "
+                            "executable context; confirm this is intended in the diff")
+            rep["risky"] = risky
+        rep.update(_script_self_check(f, pkg))
+        if rep.get("self_check") == "absent":
+            warnings.append(f"{rel} has no declared '--self-check' entry point, so "
+                            "nothing verifies it still runs after an edit — add one")
+        elif rep.get("ok") is False:
+            detail = (rep.get("stderr_tail") or "").strip() or (rep.get("stdout_tail") or "").strip()
+            problems.append(f"{rel} --self-check failed (exit {rep.get('exit_code')}): "
+                            f"{detail[-300:]}")
+        reports.append(rep)
+    return reports
+
+
+def _validate_one(capability_dir: Path) -> dict:
+    """Enforce the Agent-Skills authoring rules on ONE skill package."""
+    capability_dir = Path(capability_dir)
+    problems: list[str] = []
+    warnings: list[str] = []
+
+    skill_md = capability_dir / "SKILL.md"
+    if not skill_md.exists():
+        return {"ok": False, "name": "", "problems": ["no SKILL.md in the package"],
+                "warnings": [], "scripts": []}
+
+    text = skill_md.read_text(encoding="utf-8")
+    fm, body = _parse_frontmatter(text)
+    name = _validate_frontmatter(fm, problems, warnings)
 
     n_body = body.count("\n") + 1
     if n_body > MAX_BODY_LINES:
-        warnings.append(f"SKILL.md body is {n_body} lines (>{MAX_BODY_LINES}); "
-                        "split detail into references/ (progressive disclosure)")
+        problems.append(f"SKILL.md body is {n_body} lines (>{MAX_BODY_LINES}); the body "
+                        "is a recurring per-session cost — split detail into references/")
     body_tokens = len(body) // CHARS_PER_TOKEN
     if body_tokens > MAX_BODY_TOKENS:
-        warnings.append(f"SKILL.md body is ~{body_tokens} tokens (>{MAX_BODY_TOKENS}); "
-                        "it is a recurring per-session cost — move detail into references/")
+        warnings.append(f"SKILL.md body is ~{body_tokens} tokens (>{MAX_BODY_TOKENS}, this "
+                        "repo's heuristic) — move detail into references/")
 
-    refs = capability_dir / "references"
-    if refs.is_dir():
-        for sub in refs.iterdir():
-            if sub.is_dir():
-                warnings.append(f"references/{sub.name}/ is nested >1 level deep; "
-                                "keep references one level deep")
-        for f in refs.glob("*.md"):
-            ln = f.read_text(encoding="utf-8").count("\n") + 1
-            if ln > LONG_REF_LINES and "## " not in f.read_text(encoding="utf-8")[:1500]:
-                warnings.append(f"references/{f.name} is {ln} lines without an early "
-                                "table of contents")
+    _validate_references(capability_dir, body, problems, warnings)
+    scripts = _validate_scripts(capability_dir, problems, warnings)
 
-    # broken reference links the body points at
-    for rel in re.findall(r"\(((?:references|scripts|assets)/[^)\s]+)\)", body):
-        if not (capability_dir / rel).exists():
-            warnings.append(f"SKILL.md references '{rel}' which does not exist")
-
-    return {"ok": not problems, "name": name, "problems": problems, "warnings": warnings}
+    return {"ok": not problems, "name": name, "problems": problems,
+            "warnings": warnings, "scripts": scripts}

--- a/skills/capabilities/skill-package/scripts/check.py
+++ b/skills/capabilities/skill-package/scripts/check.py
@@ -1,5 +1,10 @@
-"""Round-trip materialize -> apply -> validate on a sample skill package, and
-assert the authoring-rule checks fire."""
+"""Self-test: round-trip the WHOLE package through materialize -> apply -> validate.
+
+One case per rule, each with a deliberately broken fixture, so every authoring
+rule is a checked property instead of a claim. The end-to-end case is the point
+of the capability: apply() CREATES a new bundled script, materialize() shows it as
+a component, and validate() runs its self-check.
+"""
 
 from __future__ import annotations
 
@@ -12,56 +17,172 @@ import _bootstrap  # noqa: F401
 
 import abstract
 import token_report
+import trigger_eval
+
+GOOD = ("---\nname: demo-skill\n"
+        "description: Do a thing. Use when the user wants the thing done.\n---\n"
+        "# Demo\nBody.\n")
+
+
+def _pkg(d: Path, skill_md: str = GOOD) -> Path:
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "SKILL.md").write_text(skill_md, encoding="utf-8")
+    return d
 
 
 def main() -> int:
     report = {"skill": "skill-package", "ok": False, "problems": [], "notes": []}
-    with tempfile.TemporaryDirectory() as d:
-        cap = Path(d)
-        (cap / "SKILL.md").write_text(
-            "---\nname: demo-skill\n"
-            "description: Do a thing. Use when the user wants the thing done.\n---\n"
-            "# Demo\nBody.\n", encoding="utf-8")
+    fail = report["problems"].append
+    note = report["notes"].append
+
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+
+        # --- the whole package is materialized (SKILL.md + refs + scripts + assets)
+        cap = _pkg(root / "full")
+        (cap / "references").mkdir()
+        (cap / "references" / "deep.md").write_text("# Deep\n", encoding="utf-8")
+        (cap / "scripts").mkdir()
+        (cap / "scripts" / "helper.py").write_text("print(1)\n", encoding="utf-8")
+        (cap / "assets").mkdir()
+        (cap / "assets" / "tpl.html").write_text("<p>x</p>\n", encoding="utf-8")
+        (cap / "assets" / "logo.png").write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 40)
         parts = abstract.materialize(cap)
-        if "SKILL.md" not in parts:
-            report["problems"].append("materialize missed SKILL.md")
-        v = abstract.validate(cap)
+        missing = [k for k in ("SKILL.md", "references/deep.md", "scripts/helper.py",
+                               "assets/tpl.html", "assets/logo.png") if k not in parts]
+        if missing:
+            fail(f"materialize missed package components: {missing}")
+        if "binary asset" not in parts.get("assets/logo.png", ""):
+            fail("a binary asset must be inventoried as a stub, not inlined")
+        note("materialize exposes SKILL.md + references + scripts + assets")
+
+        # --- a valid package passes
+        v = abstract.validate(_pkg(root / "ok"))
         if not v["ok"]:
-            report["problems"].append(f"valid skill rejected: {v['problems']}")
+            fail(f"valid skill rejected: {v['problems']}")
 
-        # an invalid name must be caught
-        (cap / "SKILL.md").write_text(
-            "---\nname: Bad_Name_With_Caps\ndescription: x\n---\n# x\n", encoding="utf-8")
-        v2 = abstract.validate(cap)
-        if v2["ok"]:
-            report["problems"].append("invalid name not rejected")
+        # --- frontmatter: bad name / XML tag in name
+        if abstract.validate(_pkg(root / "n1", "---\nname: Bad_Name\ndescription: x\n---\n#x\n"))["ok"]:
+            fail("invalid name not rejected")
+        if abstract.validate(_pkg(root / "n2", "---\nname: bad-<tag>\n"
+                                  "description: Do it. Use when needed.\n---\n#x\n"))["ok"]:
+            fail("XML tag in name not rejected")
 
-        # an XML tag in the name is an Anthropic invariant -> hard problem
-        (cap / "SKILL.md").write_text(
-            "---\nname: bad-<tag>\ndescription: Do a thing. Use when needed.\n---\n# x\n",
-            encoding="utf-8")
-        if abstract.validate(cap)["ok"]:
-            report["problems"].append("XML tag in name not rejected")
-
-        # soft lints must fire as warnings: first person + all-caps imperative
-        (cap / "SKILL.md").write_text(
-            "---\nname: lint-demo\n"
-            "description: I can help. ALWAYS use when the user wants it.\n---\n# x\n",
-            encoding="utf-8")
-        w = " ".join(abstract.validate(cap)["warnings"])
+        # --- soft lints fire on a ONE-LINE description
+        w = " ".join(abstract.validate(_pkg(
+            root / "l1", "---\nname: lint-demo\n"
+            "description: I can help. ALWAYS use when the user wants it.\n---\n#x\n"))["warnings"])
         if "third person" not in w or "over-triggers" not in w:
-            report["problems"].append(f"POV/all-caps lints did not fire: {w!r}")
+            fail(f"POV/all-caps lints did not fire: {w!r}")
 
-        # apply edit works
-        abstract.apply(cap, [{"file": "references/extra.md", "op": "set", "text": "# Extra\n"}])
-        if not (cap / "references" / "extra.md").exists():
-            report["problems"].append("apply did not write a reference file")
+        # --- ... and on a FOLDED (block scalar) description, which used to bypass them
+        folded = abstract.validate(_pkg(
+            root / "l2", "---\nname: lint-folded\ndescription: >\n"
+            "  I can help with things.\n  ALWAYS use when the user wants it.\n---\n#x\n"))
+        wf = " ".join(folded["warnings"])
+        if "third person" not in wf or "over-triggers" not in wf:
+            fail(f"block-scalar description bypassed the lints: {folded}")
+        note("block-scalar (`description: >`) frontmatter is parsed and linted")
 
-        # token_report runs and reports a body budget
+        # --- body budget is enforced, not merely advised
+        big = abstract.validate(_pkg(root / "big", GOOD + "line\n" * 600))
+        if big["ok"] or not any("lines" in p for p in big["problems"]):
+            fail(f"a 600-line body must be a hard problem: {big}")
+
+        # --- references: nested pointer, orphan, fake TOC
+        cap = _pkg(root / "refs", GOOD + "See [a](references/a.md).\n")
+        (cap / "references").mkdir()
+        (cap / "references" / "a.md").write_text("# A\nSee [b](references/b.md)\n", encoding="utf-8")
+        (cap / "references" / "b.md").write_text("# B\n", encoding="utf-8")
+        (cap / "references" / "long.md").write_text(
+            "# L\n" + "orientation prose that pushes the TOC out of the window\n" * 30 +
+            "## Contents\n- [A](#a)\n- [B](#b)\n- [C](#c)\n" + "x\n" * 400,
+            encoding="utf-8")   # a real TOC, but behind a preamble -> still warns
+        w = " ".join(abstract.validate(cap)["warnings"])
+        for want, label in (("one level deep", "nested reference pointer"),
+                            ("orphan", "orphan reference"),
+                            ("table of contents", "missing TOC in a long reference")):
+            if want not in w:
+                fail(f"{label} not warned: {w!r}")
+        note("reference structure: nested pointers, orphans, missing TOC all warn")
+
+        # --- broken link the body points at
+        if abstract.validate(_pkg(root / "bl", GOOD + "See [x](references/gone.md).\n"))["ok"]:
+            fail("a broken reference link must be a hard problem")
+
+        # --- scripts: a syntax error is a hard problem
+        cap = _pkg(root / "badpy")
+        (cap / "scripts").mkdir()
+        (cap / "scripts" / "x.py").write_text("def broken(:\n", encoding="utf-8")
+        v = abstract.validate(cap)
+        if v["ok"] or not any("does not compile" in p for p in v["problems"]):
+            fail(f"a bundled script that does not compile must fail validation: {v}")
+
+        # --- scripts: stub body + missing self-check warn
+        cap = _pkg(root / "stub")
+        (cap / "scripts").mkdir()
+        (cap / "scripts" / "s.py").write_text('"""todo."""\n...\n', encoding="utf-8")
+        w = " ".join(abstract.validate(cap)["warnings"])
+        if "no real body" not in w or "--self-check" not in w:
+            fail(f"stub/self-check warnings did not fire: {w!r}")
+
+        # --- scripts: a FAILING declared self-check is a hard problem
+        cap = _pkg(root / "failing")
+        (cap / "scripts").mkdir()
+        (cap / "scripts" / "f.py").write_text(
+            "import sys\nif '--self-check' in sys.argv:\n"
+            "    print('boom', file=sys.stderr); sys.exit(1)\n", encoding="utf-8")
+        v = abstract.validate(cap)
+        if v["ok"] or not any("--self-check failed" in p for p in v["problems"]):
+            fail(f"a failing script self-check must fail validation: {v}")
+
+        # --- apply(): path traversal is refused, not written
+        cap = _pkg(root / "esc")
+        r = abstract.apply(cap, [{"file": "../escaped.txt", "op": "set", "text": "pwned"}])
+        if r["changed"] or not r["refused"] or (root / "escaped.txt").exists():
+            fail(f"apply must refuse an edit escaping the capability dir: {r}")
+
+        # --- apply(): the action policy gates a script edit
+        cap = _pkg(root / "policy")
+        (cap / "policy.json").write_text(json.dumps({"allow": ["body", "reference", "add"]}),
+                                        encoding="utf-8")
+        r = abstract.apply(cap, [{"file": "scripts/no.py", "op": "set", "text": "x=1\n"}])
+        if r["changed"] or "not allowed by policy" not in json.dumps(r["refused"]):
+            fail(f"a script edit must be refusable by policy: {r}")
+        note("apply() contains writes to the package and honors the action policy")
+
+        # --- END TO END: apply() CREATES a bundled script, it materializes as a
+        #     component, and validate() runs its self-check.
+        cap = _pkg(root / "e2e", GOOD + "Run [the helper](scripts/helper.py).\n")
+        script = ("import sys\n\n"
+                  "def normalize(s):\n    return ' '.join(str(s).split()).lower()\n\n"
+                  'if __name__ == "__main__":\n'
+                  "    if '--self-check' in sys.argv:\n"
+                  "        assert normalize('  A  B ') == 'a b'\n"
+                  "        print('ok')\n")
+        r = abstract.apply(cap, [{"file": "scripts/helper.py", "op": "set", "text": script}])
+        if "scripts/helper.py" not in r["changed"]:
+            fail(f"apply did not create the new bundled script: {r}")
+        if "scripts/helper.py" not in abstract.materialize(cap):
+            fail("a newly created script must appear as a component")
+        v = abstract.validate(cap)
+        checked = [s for s in v["scripts"] if s["file"] == "scripts/helper.py"]
+        if not v["ok"]:
+            fail(f"the created script package must validate: {v['problems']}")
+        if not checked or checked[0].get("self_check") != "ran" or not checked[0].get("ok"):
+            fail(f"the created script's self-check did not run and pass: {v['scripts']}")
+        note("end-to-end: optimizer-created script -> component -> self-check ran and passed")
+
+        # --- reporters
         tr = token_report.report(cap)
         if "body_tokens" not in tr or "over_budget" not in tr:
-            report["problems"].append(f"token_report missing budget fields: {tr}")
-        report["notes"].append("materialize/apply/validate + rule checks + token_report ok")
+            fail(f"token_report missing budget fields: {tr}")
+        if not tr.get("scripts") or tr.get("scripts_context_cost") != 0:
+            fail(f"token_report must inventory scripts with context_cost 0: {tr}")
+        if trigger_eval.main(["--self-check"]) != 0:
+            fail("trigger_eval --self-check failed")
+        note("token_report inventories scripts; trigger_eval self-check passes")
+
     report["ok"] = not report["problems"]
     print(json.dumps(report, indent=2))
     return 0 if report["ok"] else 1

--- a/skills/capabilities/skill-package/scripts/token_report.py
+++ b/skills/capabilities/skill-package/scripts/token_report.py
@@ -1,14 +1,17 @@
 """Report the progressive-disclosure token budget of a skill package.
 
 Level 2 (the SKILL.md body) is loaded on every trigger and stays in context for
-the whole session — a *recurring* token cost — so it has a soft budget
-(<500 lines / ~5k tokens). Level 3 references cost zero context until actually
-read. This reporter estimates those costs (~chars/4) and flags body overruns, so
-the optimizer can SEE the budget instead of guessing.
+the whole session — a *recurring* token cost — so it has a budget (<=500 lines;
+~5k tokens is this repo's own heuristic). Level 3 costs **zero** context until
+used: a reference until it is read, a script until it is run (and a script's
+source is never loaded at all — only its output). So the report states
+``context_cost: 0`` for both, and inventories ``scripts/`` — the deterministic
+surface — instead of only sizing the cheap thing.
 
 Deterministic, dependency-free (no cap-evolve bootstrap) — run it directly:
 
     python scripts/token_report.py --path <skill_dir>
+    python scripts/token_report.py --self-check
 
 Exit code is 0 always (advisory); the JSON `over_budget` flag carries the signal.
 """
@@ -49,13 +52,61 @@ def report(skill_dir: Path) -> dict:
         for f in sorted(refs.glob("*.md")):
             out["references"][f.name] = _tokens(f.read_text(encoding="utf-8"))
     out["reference_tokens_total"] = sum(out["references"].values())
+    # Level 3 is free until used — say so, so a big reference is not mistaken for
+    # an expensive one and the optimizer reads the budget correctly.
+    out["references_context_cost"] = 0
+    out["scripts"] = _scripts(skill_dir)
+    out["scripts_context_cost"] = 0        # source never loads; only the output costs
     return out
+
+
+def _scripts(skill_dir: Path) -> list[dict]:
+    """Inventory the deterministic surface: size, entry point, declared self-check."""
+    d = skill_dir / "scripts"
+    if not d.is_dir():
+        return []
+    rows = []
+    for f in sorted(d.rglob("*")):
+        if not f.is_file() or "__pycache__" in f.parts:
+            continue
+        try:
+            src = f.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            src = ""
+        rows.append({"file": f.relative_to(skill_dir).as_posix(),
+                     "bytes": f.stat().st_size,
+                     "entry_point": '__main__' in src or f.suffix == ".sh",
+                     "self_check": "--self-check" in src})
+    return rows
+
+
+def _self_check() -> int:
+    import tempfile
+    with tempfile.TemporaryDirectory() as d:
+        pkg = Path(d)
+        (pkg / "SKILL.md").write_text("---\nname: t\ndescription: d\n---\n# t\nbody\n",
+                                      encoding="utf-8")
+        (pkg / "scripts").mkdir()
+        (pkg / "scripts" / "h.py").write_text(
+            'if __name__ == "__main__":\n    pass  # --self-check\n', encoding="utf-8")
+        r = report(pkg)
+    assert r["scripts"] and r["scripts"][0]["file"] == "scripts/h.py", r
+    assert r["scripts"][0]["entry_point"] and r["scripts"][0]["self_check"], r
+    assert r["scripts_context_cost"] == 0 and r["references_context_cost"] == 0, r
+    assert r["body_lines"] > 0 and r["over_budget"] is False, r
+    print(json.dumps({"self_check": "ok"}))
+    return 0
 
 
 def main(argv=None) -> int:
     p = argparse.ArgumentParser(prog="token-report")
-    p.add_argument("--path", required=True, help="skill package dir (contains SKILL.md)")
+    p.add_argument("--path", help="skill package dir (contains SKILL.md)")
+    p.add_argument("--self-check", action="store_true")
     args = p.parse_args(argv)
+    if args.self_check:
+        return _self_check()
+    if not args.path:
+        p.error("--path is required (or use --self-check)")
     print(json.dumps(report(Path(args.path)), indent=2))
     return 0
 

--- a/skills/capabilities/skill-package/scripts/trigger_eval.py
+++ b/skills/capabilities/skill-package/scripts/trigger_eval.py
@@ -1,0 +1,177 @@
+"""Measure a candidate `description`'s trigger rate on a held-out split.
+
+The `description` is the only text loaded before a skill fires, so triggering is
+its own measurable objective. Doing this by hand costs a decision per query and
+drifts run to run; this script makes it deterministic: it splits the eval set by
+seed, asks a judge the same question N times per query (a trigger decision is
+stochastic — one sample is noise), scores both halves, and prints JSON. Select
+the description by the HELD-OUT score, never the train score.
+
+Eval set (JSON list, the shape skill-creator uses):
+
+    [{"query": "the user prompt", "should_trigger": true}, ...]
+
+The judge is whatever the host has, so this stays model-agnostic: `--judge-cmd`
+is shelled once per (query, trial) with the prompt on stdin and must print a
+verdict containing `yes`/`trigger` or `no`. Example:
+
+    python trigger_eval.py --eval-set eval.json --skill ../my-skill \
+        --judge-cmd 'llm -m gpt-4o-mini' --trials 3
+
+    {"train_score": 0.83, "heldout_score": 0.75, "per_query": [...]}
+
+`--self-check` runs the whole pipeline against a built-in keyword judge (no
+model, no network) and asserts the scoring is right, so the plumbing is verified
+without spending anything.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+PROMPT = """You decide whether one skill should be consulted for a user request.
+
+Skill name: {name}
+Skill description: {description}
+
+User request: {query}
+
+Answer with one word: YES if the skill should be consulted, NO if it should not."""
+
+
+def _description(skill_dir: Path) -> tuple[str, str]:
+    """(name, description) from a skill package's frontmatter."""
+    text = (Path(skill_dir) / "SKILL.md").read_text(encoding="utf-8")
+    m = re.match(r"^---\s*\n(.*?)\n---", text, re.S)
+    fm = {}
+    if m:
+        key = None
+        for line in m.group(1).splitlines():
+            if ":" in line and not line[:1].isspace():
+                key, _, v = line.partition(":")
+                key = key.strip()
+                fm[key] = v.strip().strip('"').strip("'")
+            elif key and line.strip():
+                fm[key] = (fm[key] + " " + line.strip()).strip()
+    return fm.get("name", ""), fm.get("description", "")
+
+
+def _keyword_judge(prompt: str) -> str:
+    """Offline stand-in used by --self-check: does the request share the description's words?"""
+    desc = re.search(r"Skill description: (.*)", prompt).group(1).lower()
+    query = re.search(r"User request: (.*)", prompt, re.S).group(1).lower()
+    words = {w for w in re.findall(r"[a-z]{4,}", desc)}
+    hits = sum(1 for w in re.findall(r"[a-z]{4,}", query) if w in words)
+    return "YES" if hits >= 2 else "NO"
+
+
+def _ask(judge_cmd: str | None, prompt: str) -> bool:
+    if judge_cmd is None:
+        verdict = _keyword_judge(prompt)
+    else:
+        p = subprocess.run(judge_cmd, shell=True, input=prompt, text=True,
+                           capture_output=True, timeout=120)
+        verdict = (p.stdout or "").strip()
+    low = verdict.lower()
+    return ("yes" in low or "trigger" in low) and "no" != low[:2]
+
+
+def evaluate(items: list[dict], name: str, description: str, *, trials: int = 3,
+             judge_cmd: str | None = None) -> list[dict]:
+    """Per-query trigger rate over `trials` samples, plus whether it matches expectation."""
+    out = []
+    for it in items:
+        prompt = PROMPT.format(name=name, description=description, query=it["query"])
+        fired = [_ask(judge_cmd, prompt) for _ in range(trials)]
+        rate = sum(fired) / len(fired)
+        want = bool(it["should_trigger"])
+        out.append({"query": it["query"], "should_trigger": want,
+                    "trigger_rate": rate,
+                    "score": rate if want else 1.0 - rate})
+        out[-1]["correct"] = out[-1]["score"] > 0.5
+    return out
+
+
+def _mean(rows: list[dict]) -> float:
+    return round(sum(r["score"] for r in rows) / len(rows), 4) if rows else 0.0
+
+
+def split(items: list[dict], *, seed: int = 0, train_frac: float = 0.6) -> tuple[list, list]:
+    """Deterministic train/held-out split (skill-creator uses 60/40)."""
+    idx = list(range(len(items)))
+    random.Random(seed).shuffle(idx)
+    cut = max(1, int(round(len(items) * train_frac)))
+    return [items[i] for i in idx[:cut]], [items[i] for i in idx[cut:]]
+
+
+def run(eval_set: list[dict], skill_dir: Path, *, trials: int = 3, seed: int = 0,
+        train_frac: float = 0.6, judge_cmd: str | None = None,
+        description: str | None = None) -> dict:
+    name, current = _description(skill_dir)
+    desc = description if description is not None else current
+    train, heldout = split(eval_set, seed=seed, train_frac=train_frac)
+    tr = evaluate(train, name, desc, trials=trials, judge_cmd=judge_cmd)
+    ho = evaluate(heldout, name, desc, trials=trials, judge_cmd=judge_cmd)
+    return {"skill": name, "trials": trials, "seed": seed,
+            "n_train": len(tr), "n_heldout": len(ho),
+            "train_score": _mean(tr), "heldout_score": _mean(ho),
+            "per_query": tr + ho,
+            "select_on": "heldout_score"}
+
+
+def _self_check() -> int:
+    """Prove the split + scoring + judge plumbing with no model and no network."""
+    items = [{"query": f"please export the sales table to csv {i}", "should_trigger": True}
+             for i in range(5)]
+    items += [{"query": f"write a haiku about rain {i}", "should_trigger": False}
+              for i in range(5)]
+    with tempfile.TemporaryDirectory() as d:
+        pkg = Path(d)
+        (pkg / "SKILL.md").write_text(
+            "---\nname: csv-export\ndescription: Exports records to csv table files. "
+            "Use when the user asks to export or download a sales table.\n---\n# x\n",
+            encoding="utf-8")
+        out = run(items, pkg, trials=3, seed=0)
+    a, b = split(items, seed=0), split(items, seed=0)
+    assert [i["query"] for i in a[0]] == [i["query"] for i in b[0]], "split is not deterministic"
+    assert out["n_train"] == 6 and out["n_heldout"] == 4, out
+    assert out["heldout_score"] > 0.5, f"keyword judge should mostly agree: {out}"
+    assert all(0.0 <= r["trigger_rate"] <= 1.0 for r in out["per_query"])
+    print(json.dumps({"self_check": "ok", "train_score": out["train_score"],
+                      "heldout_score": out["heldout_score"]}))
+    return 0
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(prog="trigger-eval")
+    p.add_argument("--self-check", action="store_true", help="offline pipeline check")
+    p.add_argument("--eval-set", help="JSON [{query, should_trigger}]")
+    p.add_argument("--skill", help="skill package dir (contains SKILL.md)")
+    p.add_argument("--description", default=None, help="candidate description to test "
+                                                       "instead of the one in SKILL.md")
+    p.add_argument("--judge-cmd", default=None, help="shell command; prompt on stdin, "
+                                                     "YES/NO on stdout")
+    p.add_argument("--trials", type=int, default=3)
+    p.add_argument("--seed", type=int, default=0)
+    p.add_argument("--train-frac", type=float, default=0.6)
+    args = p.parse_args(argv)
+    if args.self_check:
+        return _self_check()
+    if not (args.eval_set and args.skill):
+        p.error("--eval-set and --skill are required (or use --self-check)")
+    items = json.loads(Path(args.eval_set).read_text(encoding="utf-8"))
+    print(json.dumps(run(items, Path(args.skill), trials=args.trials, seed=args.seed,
+                         train_frac=args.train_frac, judge_cmd=args.judge_cmd,
+                         description=args.description), indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
**Supersedes #360** (rebased onto `main` @ `2a4c3bf9`; #360's branch is left untouched — close it in favour of this one).

Closes #322.

## What this does

The `skill-package` capability optimizes the **whole package** — SKILL.md frontmatter + body, `references/*.md`, bundled `scripts/`, assets — not just SKILL.md. And the loop now **gates on validity**: `harness.run_step` calls each capability's own `validate()` after the optimizer returns and **before any rollout is paid for**. A candidate with a hard problem becomes **indecisive** — `candidate_val is None`, best/stall untouched, **zero rollouts written** — with the reason filed in the rejected memory and the LEDGER's new "Not scored — fix the execution, keep the idea" section. So a bundled script that fails its own `--self-check` never spends evaluation budget.

`validate()` `ast.parse()`s every bundled script, rejects a stub body, and RUNS a declared `--self-check` with a timeout and a stripped env. Problems the **parent** already had are excluded (numbers normalized when comparing), so a pre-existing violation cannot wedge a run. A capability whose `validate()` cannot be loaded or raises logs `capability_validate_unavailable` rather than silently disabling enforcement.

## Rebase resolutions against current `main`

- **#386 / #355** moved `capabilities` off `run_step`'s signature into the shared `OptimizerContext`. The validation hook reads `ctx.capabilities`, and `ctx` is bound once (`ctx = ctx or OptimizerContext()`) instead of constructed inline for `inject()`. The wiring tests build a ctx the same way.
- **#346** dropped `note`/`impact` from `RejectedMemory.add`. The validation-warning augmentation of the reject reason is re-applied on main's 4-arg signature.
- **`_capabilities_root()` is substituted at FIVE sites, not the four #360 knew about**: `_inject_optimizer_context`, `_capability_brief`, `_capability_is_empty`, the new validation hook, and **`_inject_native_skills`** — a `parents[2]` skills path `main` grew after #360 forked, which would otherwise keep ignoring `CAPEVOLVE_SKILLS_DIR` exactly like the others did.
- **#387** (cache carries output/trace) and **#370** (train→val focus) auto-merged with no interaction.

## Evidence

**Full suite, pinned PYTHONPATH** (never unpinned — issue #349):

```
$ PYTHONPATH="$PWD/core:$PWD/dashboard/backend" python -m pytest core/tests -q
811 passed, 12 skipped in 132.98s
```

`main` is `806 passed, 12 skipped`. Delta `+5` = exactly the 5 new tests in `core/tests/test_capability_validation_wiring.py`. No pre-existing test changed behaviour.

**The wiring tests are genuinely RED-able.** The original review's blocker was that a wiring test which passes with the wiring removed is worthless. With `_capability_validate` made to `return None` unconditionally:

```
FAILED test_invalid_candidate_is_indecisive_and_costs_nothing
    assert step["candidate_val"] is None
E   AssertionError: assert {'split': 'val', 'reward': 0.25, ...} is None
FAILED test_pre_existing_problem_does_not_void_the_step
E   AttributeError: 'NoneType' object has no attribute 'problems'
FAILED test_unloadable_capability_is_reported_not_silently_ignored
    assert len(ev) == 1
E   assert 0 == 1  +  where 0 = len([])
3 failed, 2 passed
```

The 3 catch-tests fail and each names the fault (the invalid candidate got scored / no report / nothing logged). The 2 that still pass are the deliberate **negative controls** — `test_valid_candidate_under_the_same_wiring_still_accepts` and `test_no_capabilities_means_no_validation` — which assert the hook does *not* fire; they are supposed to pass with the wiring off.

**Capability check:**

```
$ python skills/capabilities/skill-package/scripts/check.py
{"self_check": "ok", "train_score": 1.0, "heldout_score": 1.0}
{"skill": "skill-package", "ok": true, "problems": [], "notes": [
  "materialize exposes SKILL.md + references + scripts + assets",
  "block-scalar (`description: >`) frontmatter is parsed and linted",
  "reference structure: nested pointers, orphans, missing TOC all warn",
  "apply() contains writes to the package and honors the action policy",
  "end-to-end: optimizer-created script -> component -> self-check ran and passed",
  "token_report inventories scripts; trigger_eval self-check passes"]}
```

**A real run where an invalid candidate is refused as indecisive at zero rollouts** — `examples/toy_skill/` (zero-API, deterministic) with a `mock` script that ships `scripts/normalize.py` = `def broken(:`:

```
capability_invalid  cand_0001
  problems: ["skill-package: scripts/normalize.py does not compile: invalid syntax (line 1)"]
  by_capability.skill-package.pre_existing: []
step                cand_0001  val: null
  reason: "indecisive (validation): candidate is not a valid skill-package: ..."
step_indecisive     cand_0001

rollouts written for cand_0001:  NONE
evaluate events in the whole run: 2   (baseline val + sealed test — none for the candidate)
best_id: seed        iterations: 1
```

And the next iteration's LEDGER tells the optimizer to keep the idea:

```
| iter | candidate | parent | outcome    | val | Δ vs parent |
| 1    | cand_0001 | seed   | not scored |     |             |

## Not scored — fix the execution, keep the idea
These candidates were never measured, so their reward says nothing. Correct the
stated fault and retry the same idea; do not abandon it, and do not resubmit it
unchanged.
- **cand_0001**: indecisive (validation): candidate is not a valid skill-package:
  skill-package: scripts/normalize.py does not compile: invalid syntax (line 1)
```

**The happy path on the same example** (score can only rise by adding working bundled code):

```
best_id: cand_0001   baseline_val 0.333 -> best_val 1.0   test_delta +0.666667
```

**`bash examples/toy_calc/run.sh`** — gate-accepted sealed test score, unchanged from `main`:

```
best_id: cand_0001   baseline_val 0.0 -> best_val 1.0
test_reward 1.0   test_delta 1.0   pass^1 1.0   iterations 3
```
