### PR TITLE
postmerge: re-derive the skill-vs-code claims #386 invalidated, and land #368 under its token bar

### DIFF
--- a/.review/postmerge-algos.md
+++ b/.review/postmerge-algos.md
@@ -1,0 +1,339 @@
+# Post-merge review — four merged skill PRs (#368 agent-optimize · #369 gepa · #380 skillopt · #373 mcp-tool)
+
+Reviewed against `main` at `af7cf9d6`. None of the four was independently reviewed before merge.
+`main` baseline confirmed green at **805 passed, 12 skipped**
+(`PYTHONPATH="$PWD/core:$PWD/dashboard/backend" python -m pytest core/tests -q`).
+
+Merge order matters for reading this: `#350` (1775cddd, snapshot ignore) landed **before** #369, and
+`#386` (cfcad862, the shared `OptimizerContext` assembler) landed **after** all four. #386 is what
+made three of #369's and eleven of #380's statements wrong again.
+
+---
+
+## Skill-vs-code re-derivation
+
+### gepa — #369 claimed 14 divergences (10 fixed in text, 4 flagged). Re-derived: **3 live divergences**, and 2 of the 4 flagged gaps are no longer real.
+
+Body claims (all verified against `core/cap_evolve/gepa.py`, `selection.py`, `cache.py`,
+`skills/algorithms/gepa/scripts/run.py`):
+
+| claim | code reality | file:line | still accurate? |
+|---|---|---|---|
+| parent = frequency-weighted sample over per-instance (co-)winners, seeded | `rng.choices(pool, weights=counts)` over candidates with ≥1 win | `selection.py:180-192` | yes |
+| strict `pareto_frontier` is a *different*, narrower set used by merge + `frontier_size` | two distinct functions; merge calls `pareto_frontier`, selection calls `_instance_win_counts` | `selection.py:114`, `gepa.py:795`, `:721` | yes |
+| local gate is `sum(child) > sum(parent)` on the **same** minibatch, `2·mb` rollouts, eval-cached | exactly that | `gepa.py:639-643` | yes |
+| reflection reads **train** traces only | `_sample_minibatch(train_ids…)`, `ctx.inject(split="train")` | `gepa.py:559`, `:585` | yes |
+| "failing" = hard threshold `reward < 1.0`; header reads `N/N pass` | `< 1.0`; header is `{len(passing)}/{len(per)}` | `gepa.py:228`, `:236-237` | yes |
+| ~800-char truncation, at most 12 tasks | `[:800]` ×3, `actionable[:12]` | `gepa.py:251-259` | yes |
+| merge: two strict-frontier dominators with a common ancestor both beat, component-wise | `_find_merge_pair` + `_build_merge`, `origin` per component | `gepa.py:795-804` | yes |
+| `--max-merges` counts attempts that BUILT a candidate; a skip is free | `merges_done += 1` only when `merge_step is not None` | `gepa.py:706-708` | yes |
+| protected-path tamper ⇒ INDECISIVE, no reward, stall untouched | `update_spent(iterations=1, accepted=None)`, `candidate_val: None` | `gepa.py:626-637` | yes |
+| every hyperparameter default (`0/50/4/1/2/3`, `--workers 1`, `--store git`) | matches | `scripts/run.py:33-56` | yes |
+| **`--max-metric-calls` overshoot bound is `2·mb + \|val\|·n-trials`, "one more minibatch on a merge iteration"** | a merge fires *inside* an accepting iteration and evaluates the merge **and both parents** on a **freshly sampled** minibatch, then pays a second full val ⇒ worst case `5·mb + 2·\|val\|·n-trials` | `gepa.py:698-704`, `:813-819`, `:833` | **NO — understates a budget ceiling by ~2.5×** |
+
+`## Known gaps` (the interesting part):
+
+| flagged gap | code reality | file:line | still accurate? |
+|---|---|---|---|
+| reflective dataset carries no task **input**, though `gepa.py`'s docstring claims it does | docstring says "contributes its input"; the writer emits only `Agent output` / `Trajectory` / `Feedback` | `gepa.py:222` vs `:253-259` | **yes** — verified in a real `REFLECTION.md` (see Evidence) |
+| on an eval-cache hit only `{reward, feedback}` are stored, so `Agent output:` is empty | `EvalCache.put` persists two keys; a hit builds `raw={"cached": True}` | `cache.py:88-90`, `gepa.py:161-167` | yes |
+| **candidate snapshots keep the loop's scratch because the snapshot call omits the ignore list; and the dotfiles are not excluded from the component list** | `run_dir.snapshot(..., ignore=_SNAPSHOT_IGNORE)` at BOTH call sites (#350), and `NON_CAPABILITY_FILES`/`DIRS` now cover `CLAUDE.md`/`AGENTS.md`/`GEMINI.md`/`.claude`/`guidance`/`trajectories`/`prior_iterations` (#386) | `gepa.py:682`, `:846`; `types.py:26-43` | **NO — both halves fixed. Deleted.** |
+| iterations charged with no `step` event emitted | gepa logs 11 event kinds, none named `step`; `log_event("step")` exists only in `harness.py:1383`/`:1563` | `gepa.py` (grep) | yes |
+| **optimizer context reaching GEPA has been narrower than hill-climb's (#109)** | `gepa_loop` takes the shared `OptimizerContext` and calls the same `inject()`/`instructions()` as its siblings | `gepa.py:478`, `:501`, `:585-595` | **NO — fixed by #386. Rewritten to the live half (JOURNAL non-accumulation).** |
+| `JOURNAL.md` injected but never accumulates in gepa | `_reconcile_journal` is called from `harness.run_step` only, which gepa does not use | `harness.py:1578` | yes |
+| empty `splits.train` ⇒ silent fallback to **val** ids | `list(...train) or list(...val)` | `gepa.py:522` | yes |
+
+Plus one in the reference: `gepa/references/concepts.md:100-105` asserted the component exclusion list
+"does *not* cover the optimizer-agent dotfiles". False since #386 — `types.py:35-39` was changed
+*specifically* so an injected read-context dir cannot appear to gepa as an editable component. **Fixed.**
+
+### skillopt — #380 claimed 10 divergences (5 fixed, 5 flagged). Re-derived: **all 5 flagged gaps still real**, but **12 live divergences of a different kind** — the citations that make them checkable.
+
+| claim | code reality | file:line | still accurate? |
+|---|---|---|---|
+| mini-batch ids come from train but filter the parent's **val** rows ⇒ `0 … of 0 tasks` | `train_ids` read, sliced, handed to `ctx.instructions` which filters `current_val.per_task` by train ids; splits disjoint | `skillopt.py:237`,`:291`,`:300` → `harness.py:2004-2006`; `splits.py:117-119` | **yes** (gap real) |
+| …"with no task ids" | the *focus summary* and *failure index* are empty, but `_passing_block` is built from the WHOLE val split since #370, so protect-these-ids IS populated | `harness.py:2013` | **imprecise — corrected** |
+| epoch-boundary re-eval scores whole train twice, then discards all but ~20 | `evaluate_candidate(split="train")` ×2, no `ids=`, then filtered to `sample_ids` | `skillopt.py:467-472`, `:473-475` | yes (gap real) |
+| vacuous comparison when an epoch accepted nothing | guard `prev_epoch_best_id != run_dir.best_id`; log claims a train sample size | `skillopt.py:464`, `:478-482` | yes (gap real) |
+| `requested_edits` vs `applied_changes` read nowhere | 2 write sites, 0 read sites repo-wide | `skillopt.py:346`,`:353` | yes (gap real) |
+| …"A run at `L=4` logged `applied_changes: 6`" | **worse than documented**, and #386 made it worse: the ignore list matches 7 `.md` *basenames* while `run_step` injects `guidance/`, `trajectories/`, `prior_iterations/*/diff.patch`, which `_SNAPSHOT_IGNORE` keeps out of the parent snapshot. Measured `applied_changes: 10` for **one** real edit, and `10` again on a step whose capability file was byte-identical to its parent | `skillopt.py:406-435`, `:420` | **understated — corrected with the measurement** |
+| `"skill"` leaks into the live prompt | `"Comparing the skill at the START of this epoch…"` | `skillopt.py:147` | yes (gap real) |
+| `improved` computed + logged, not exclusive, never in the prompt | `if after > before` is a separate non-`elif` branch; `_slow_update_instructions` never reads it | `skillopt.py:184-185`, `:139-166` | yes |
+| slow update is never force-accepted | goes through `harness.run_step` like any step | `skillopt.py:493-499` | yes |
+| `--max-iterations` accepted and ignored | declared with `help="IGNORED…"`, never passed to `skillopt_loop` | `scripts/run.py:42-43`, `:105-118` | yes |
+| every documented flag exists | all 18 present | `scripts/run.py:35-78` | yes |
+| **11 of 18 `file:line` citations** | drifted 7-9 lines when #386 restructured the module; e.g. `skillopt.py:230` (cited for the train-ids read) is now a docstring line | see table above | **NO — all refreshed** |
+| **"both land with PR #370; until then read `harness.run_step` itself"** | #370 landed as `ae71aa87`; `hill-climb/references/run-step.md` exists | — | **NO — stale, removed** |
+
+The stale citations are not cosmetic. A "verify me" claim whose line number lands on unrelated code
+reads as fabricated, which is exactly the credibility this whole effort was buying back.
+
+---
+
+## #368 token budget (measured)
+
+Measured with `tiktoken` `cl100k_base` (no tokenizer was in the venv; installed it).
+Body = everything after the closing frontmatter `---`; the `description` is always-in-context
+metadata and is budgeted separately, per `.review/skill-duplication-analysis.md`.
+
+| | lines | body tokens | whole file |
+|---|--:|--:|--:|
+| pre-#368 (`24e58fe8^`) | 922 | — | 60,176 chars |
+| as merged by #368 | 337 | **5,580** | 5,580 |
+| after this review | 311 | **5,000** | 5,137 |
+
+#368 reported ~5,444; the real number was **5,580** — 11.6% over the ≤5,000 bar, and the PR flagged
+the overage instead of fixing it.
+
+**Verdict: the overage was not earning its place, so I cut it.** −580 tokens, no rule deleted. What
+moved, and why each was restatement rather than instruction:
+
+- the fan-out invariants' *rationale* — `references/algorithm.md` § *Parallelism* states all of them
+  in full; the body keeps every rule verb and points there (ownership contract: one owner states it).
+- the "concurrency composes from three places" enumeration — same section of `algorithm.md`; the
+  thread-safety criteria (no shared scratch dir / live container / module-global client) stayed,
+  because that list is *not* in the reference.
+- the per-task-fan-out helper roll-call's flags (`--supersedes`, `--floor`, `--canary-auto`,
+  `--traces`, `dropped_additions`) — all present in `references/per-task-fanout.md`, which the
+  pointer names as carrying "every helper's flags". Every helper name stayed (`check.py` requires it).
+- the `measure.py` refusals' and screening break-even's *reasoning* — both in `algorithm.md`.
+- **a genuine triplication**: "measure the null / a candidate inside that band is not evidence" was
+  stated three times in one body (step 2, the Parallel-round paragraph, Measurement-discipline rule 1).
+  Now stated once operationally in step 2, with the "twice" requirement folded in.
+
+Two counting bugs #368 introduced while condensing, both fixed: "state these **five** invariants"
+above a four-item list (it merged old items 4+5 into one bullet), and "**Two** rules decide whether a
+round's number means anything" above three.
+
+`core/tests/test_agent_optimize_skill.py` — **passes unmodified** (5 passed; `git diff` on the file is
+empty). It caught one of my compressions mid-review: I had rewritten "skipping the **re-gate**
+double-counts one gain" as "or you double-count a gain", and the test pins the literal term `re-gate`.
+Restored — and that is the test doing exactly its job, so it is worth naming here rather than quietly
+fixing. The companion behavioral check
+`skills/algorithms/agent-optimize/scripts/check.py` (1,167 lines; it executes every command SKILL.md
+documents against a throwaway run dir) also passes unmodified: `ok: true, problems: []`, 60+ notes. It
+caught a second one: I had shortened "the old **no-regression** veto" and it requires that token.
+
+---
+
+## #373 policy guard (verified empirically, not read off the PR body)
+
+Reproduced against the shipped `cap_evolve.tool_surface` with mcp-tool's real
+`DEFAULT_POLICY = {"allow": ["description","params","examples","add","remove"]}`
+(`/tmp/capreview-postmerge-algos-mcpproof.py`):
+
+```
+=== (1) params edit carrying properties/type/required
+report: {"changed": ["params:kb_search"], "refused": []}
+parameters now: {"type": "array", "properties": {"limit": {...}}, "required": ["injected"]}
+
+=== (2) add edit carrying a code key
+report: {"changed": ["add:srv"], "refused": []}
+added keys: ['code', 'description', 'name', 'parameters'] | code key present: True
+
+=== (3) validate() on the schema-rewritten artifact
+validate: {"ok": true, "tools": ["kb_search", "srv"], "problems": []}
+validate() source references load_policy: False
+
+=== (4) policy path
+code: ['f = Path(capability_dir) / "policy.json"']
+only inputs/policy.json present -> allow = ['add','description','examples','params','remove']  (ignored)
+capability_dir/policy.json present -> allow = ['schema']                                        (read)
+```
+
+All four of #373's claims hold on current `main`:
+
+1. `apply()` filters the edit's **`kind` label** only (`tool_surface.py:65-67`). A `params` value is
+   `dict.update()`-merged into `parameters` (`:82`), so `type`/`required`/`properties` rewrite the wire
+   schema and come back `refused: []`.
+2. `add` appends the value verbatim (`:72`), so a `code` key lands unrefused.
+3. `validate()` never calls `load_policy` and returns `ok: true` on the rewritten artifact (`:102-130`).
+4. The loader reads `<capability_dir>/policy.json`; `inputs/policy.json` is ignored (`:36`).
+
+**The skill states this plainly rather than implying enforcement.** `mcp-tool/SKILL.md:41-56` is
+headed "**The policy checks the edit's LABEL, not its effect**", names both bypasses individually,
+and closes with "Nothing downstream re-checks the boundary, so the discipline is yours." That is the
+honest form. Its edit-boundary table still says schema/code are "no", which is correct as *policy*,
+and the paragraph immediately below says what is and is not *enforced* — no contradiction.
+
+**Policy path — does any of my four skills still name the wrong one? No.**
+`mcp-tool/SKILL.md:58-61` names `inputs/policy.json` only to rule it out. gepa, skillopt and
+agent-optimize never mention a policy file.
+
+But four surfaces outside my four skills still claim the wrong path (#352):
+
+- `core/cap_evolve/tool_surface.py:15` (module docstring) and `:35` (`load_policy`'s own docstring) —
+  **the most authoritative surfaces in the repo, and the ones the skill cites.** Both said the loader
+  reads `inputs/policy.json`. **Fixed in this PR** (in core, not a skill, so not an ownership breach).
+- `skills/capabilities/tools/references/{examples.md:366, pitfalls.md:127, concepts.md:114}` — owned
+  by the `tools` skill. **Not touched** per the ownership contract; recorded here and in the PR body
+  under "what `tools` should drop".
+
+---
+
+## Instruction loss
+
+`git show` on each of the four merge commits, diffing removed lines against the current body plus
+every reference, then a mechanical audit of bolded spans and backticked identifiers
+(`/tmp/capreview-postmerge-algos-ruleaudit.py`).
+
+**#368 — one real loss, and it was a dangling promise.** `SKILL.md` names "the sign test for effects
+below the floor" as living in `references/measured-lessons.md`. The old rule 9 — *pre-register
+directional predictions and use a sign test; 9/10 positive gave p = 0.0107 where no individual z
+reached 2; write each prediction down before its arm runs or the test is worthless* — is in **no**
+file in the package. A reader following the pointer finds nothing. **Restored** into
+`measured-lessons.md` § *The binomial floor*, with a regression test.
+
+The other eight of the old nine measurement rules, and all nine old honesty invariants, are
+accounted for: rules 1/2/3/4/6/7/8 in `measured-lessons.md` (verified by their measured numbers:
+`0.0778`, `0.0615`, `1.27`, `0.0146`, `0.0115`, `0.0262`, `Sum \`1 - rate\``), rule 6 also in
+`per-task-fanout.md`. Honesty invariants 1/3/5/6/7/8/9 survive in the body; 2 was **deliberately
+inverted** to match the code (`regressions` is diagnosis, not a veto; `--veto-regressions` restores
+the old behavior) and 4 was correctly deleted as a restatement the `gate`/`finalize` phases own.
+
+My own cut briefly dropped one identifier: `cap-evolve-diagnoser`, the concrete subagent to dispatch
+for parallel diagnosis. It exists (`plugins/cap-evolve/agents/cap-evolve-diagnoser.md`) and
+agent-optimize's SKILL.md is the **only** skill that names it — so dropping it would have been a real
+loss. **Restored.**
+
+**#369 — no rule lost.** Removals were the 6-row routing table (owner: the `using-cap-evolve` router
+and the frontmatter description), the agent-mode restatement (owner: `orchestrate`), the
+re-specified reflective-dataset format (owner: `diagnose`), and a step-by-step loop restatement now
+owned by `hill-climb`. `--no-regression` is delegated with "as hill-climb" and hill-climb documents
+it (`hill-climb/SKILL.md:100`). One routing row is gone without a new home — *"tiny task set (frontier
+collapses to 1-2 points) → hill-climb"*; the description carries the two main routing rules, so this
+is advice-level, noted not fixed.
+
+**#380 — one half-loss, out of my ownership.** The deleted *"Pitfall: small val sets"* carried
+*"with a small val set, raise `--n-trials` … or use a **graded** reward so the paired significance
+test has signal."* The `--n-trials` half survives in the body ("spend your tuning budget on
+`--n-trials` and the gate"); the graded-reward half is in no skill. It belongs to `phases/gate`
+(owner of the significance bar), which does not carry it. Recorded for that owner, not edited.
+
+**#373 — no rule lost.** The annotations table, the human-in-the-loop rule, and the
+execution-vs-protocol error distinction all landed in `references/concepts.md` §4 (verified:
+`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`, `human-in-the-loop`, `isError`,
+`poisoning`, `list_changed` all present). The reader-capability-tier advice was correctly deleted
+(owner: `skill-package`).
+
+**Ownership-contract compliance.** All four point at `hill-climb` for the shared iteration mechanics;
+none restates the honesty invariants, the agent-mode loop, the failure taxonomy, or the
+reflective-dataset format. Two shortfalls found: gepa pointed at `hill-climb/SKILL.md` rather than
+its `references/run-step.md` (**fixed**), and skillopt's pointer was gated behind "both land with
+PR #370" which has landed (**fixed**).
+
+---
+
+## Problems found
+
+1. **gepa `## Known gaps` reported two fixed defects as current** — the dirty-snapshot + unexcluded-
+   dotfiles gap (fully fixed by #350 + #386) and the optimizer-context-parity gap (fixed by #386).
+   A skill that over-reports gaps trains its reader to distrust the section. **Fixed.**
+2. **gepa's `--max-metric-calls` overshoot bound understates a merge iteration by ~2.5×** — a real
+   budget-safety number. **Fixed.**
+3. **gepa `references/concepts.md` asserted the exact opposite of what #386 changed** — that the
+   component list does not exclude the injected read-context. **Fixed.**
+4. **11 of 18 `file:line` citations in skillopt's `## Known gaps` point at unrelated lines** after
+   #386's restructuring. **Fixed**, plus a standing instruction to re-derive the section if a citation
+   stops matching.
+5. **skillopt understated the `applied_changes` defect** — it is not merely uninformative, it has no
+   zero: 10 for one real edit, 10 for none. **Fixed with the measurement.**
+6. **#368 shipped 5,580 body tokens against a ≤5,000 bar** (and mis-reported it as ~5,444).
+   **Fixed: 5,000.**
+7. **#368 lost the sign-test rule while keeping the pointer that promises it.** **Fixed.**
+8. **`core/cap_evolve/tool_surface.py`'s module and `load_policy` docstrings still named
+   `inputs/policy.json`** — issue #352's defect surviving in the code that *defines* the answer.
+   **Fixed, failing-first.**
+9. Not fixed, recorded for their owners: 3 wrong policy paths in `skills/capabilities/tools/
+   references/`; the graded-reward guidance that `phases/gate` should adopt.
+
+---
+
+## Evidence
+
+- Baseline `805 passed, 12 skipped` → after this change **`812 passed, 12 skipped`** (805 + 7 new),
+  always pinned: `PYTHONPATH="$PWD/core:$PWD/dashboard/backend" python -m pytest core/tests -q`.
+- All four `scripts/check.py`: `ok: true, problems: []` (before and after).
+- `#373` guard: `/tmp/capreview-postmerge-algos-mcpproof.py`, output quoted above.
+- Token measurement: `tiktoken` `cl100k_base`, body-only, quoted above.
+- Failing-first: `/tmp/capreview-postmerge-algos-failingfirst.py` shows all three new assertions fail
+  against `HEAD`'s text.
+- **Zero-API runs, `examples/toy_calc`, mock optimizer, via `cap_evolve.cli run`** (flow reused from
+  `ci/e2e_all_algorithms.sh`):
+
+  | | gepa | skillopt |
+  |---|---|---|
+  | best_id | `gepa_0001` | `so_e01s01` |
+  | accepts | 1 | 1 |
+  | best val | 1.0 | 1.0 |
+  | **sealed test** | **1.0** (baseline 0.0, Δ +1.0) | **1.0** (baseline 0.0, Δ +1.0) |
+  | iterations | 3 | 3 |
+
+  Both reached a gate-accepted candidate and a sealed test score. **Honest caveat:** both fired
+  `gate_warning` — "combined/paired SE is 0 (likely n_trials=1 or identical trials) … falling back to
+  STRICT (accept any delta>0)". Expected on a deterministic `n_trials=1` example and stated honestly
+  in the accept reason, but these are **STRICT-fallback accepts, not significance-gate accepts**.
+  They prove the plumbing and the seal, not the gate's discrimination.
+
+- gepa `REFLECTION.md` from that run, verbatim — the missing-input gap, live:
+
+  ```
+  ### task a3
+  - Agent output: I think 2 * 5 is roughly some number.
+  - Trajectory: prompt_had_calc=False
+  - Feedback: expected '10' but agent produced '…'; the prompt likely lacks an explicit
+    instruction to compute and output only the number
+  ```
+
+  There is no `- Input:` line. Note the refinement: the *output* is populated (so "the reflection is
+  empty" would be wrong — the skill does not say that), but the task input is structurally absent and
+  is recoverable here only because this adapter's output happens to echo the expression.
+
+- Accepted candidate snapshots contain exactly `INSTRUCTIONS.md`, `PROCESS.md`, `prompt.txt` — no
+  `REFLECTION.md`, `FOCUS.md`, `guidance/`, `trajectories/`, dotfiles. `_SNAPSHOT_IGNORE` works,
+  which is precisely what makes the `applied_changes` asymmetry in problem 5 possible.
+- skillopt `skillopt_step` events, verbatim:
+  ```
+  epoch 1 step 1  edit_budget=4  requested_edits=4  applied_changes=10  accept=true
+  epoch 2 step 1  edit_budget=4  requested_edits=4  applied_changes=10  accept=false
+  ```
+  Step 1's 10 = 7 `guidance/*` + 2 `trajectories/*` injected + 1 real edit (`prompt.txt`).
+  Step 2's `prompt.txt` was byte-identical to its parent.
+
+---
+
+## Overall verdict
+
+**#373 (mcp-tool) is the one that did its job.** Every claim it makes about the guard is true today,
+verified empirically rather than read off the PR body, and it states plainly that the guard does not
+guard. Its policy-path correction is right, and nothing was lost — the removed depth is all in
+`references/concepts.md`. No changes needed to the skill.
+
+**#369 (gepa) and #380 (skillopt) were honest when written and have decayed since.** Both were
+written *before* #386 restructured the modules they cite, and neither had a mechanism that would
+notice. gepa now over-reports two fixed defects as current; skillopt's citations mostly point at
+unrelated lines. The substance of skillopt's five gaps is entirely intact and one of them turned out
+worse than documented. This is the failure mode the effort was fixing, reappearing not through
+carelessness but because a hand-derived skill-vs-code table has no guard — which is why the fix here
+includes tests, not just corrected prose.
+
+**#368 (agent-optimize) knowingly shipped over the bar and it was not earning it.** 5,580 measured
+against ≤5,000, cut to 5,000 with no rule deleted — the material that moved was restatement of its
+own references or of `algorithm.md`, plus one rule stated three times in a single body. It also lost
+the sign-test rule while keeping the pointer promising it, and left two miscounted lists ("five
+invariants" over four; "two rules" over three) behind as evidence of a hurried condensation.
+
+The systemic lesson, and the reason this PR adds `core/tests/test_skill_code_claims.py` rather than
+only editing prose: **a skill that documents a code defect needs a test that fails when the defect is
+fixed.** Otherwise the doc silently becomes a lie the moment someone does the right thing — which is
+exactly what #386 did to #369, twice.
+
+---
+
+## PRs/issues I opened
+
+- PR (this branch, `postmerge-algos-fixes`): everything marked **Fixed** above, plus
+  `core/tests/test_skill_code_claims.py` (7 tests, 3 failing-first).
+- Recorded in the PR body rather than filed, being other agents' ownership: the 3 wrong policy paths
+  in `skills/capabilities/tools/references/` (child of #352), and the graded-reward guidance that
+  `phases/gate` should adopt from #380's deleted small-val pitfall.

--- a/.review/postmerge-algos.md
+++ b/.review/postmerge-algos.md
@@ -1,6 +1,53 @@
 # Post-merge review — four merged skill PRs (#368 agent-optimize · #369 gepa · #380 skillopt · #373 mcp-tool)
 
-Reviewed against `main` at `af7cf9d6`. None of the four was independently reviewed before merge.
+Reviewed against `main` at `af7cf9d6`.
+
+> **Rebase addendum (`main` at `c8bc2292`).** Re-derived a second time after #387, #388,
+> #391, #393 and #396 landed. **Three of my own conclusions changed, and one of my own
+> tests caught me** — recorded here rather than silently corrected, because the whole
+> finding of this review is that a hand-derived skill-vs-code table decays:
+>
+> - **gepa's Known gaps went from 5 bullets to 2.** #387 fixed the hollow eval-cache
+>   reflection (`cache.py:91-99` now persists `output`/`trace`/`errored`, and
+>   `gepa.py:162-175` replays them), and #396 fixed BOTH the missing `step` record and the
+>   non-accumulating `JOURNAL.md` — `harness.record_iteration` (`harness.py:1037-1077`) is
+>   now the one place any algorithm ends an iteration, and gepa calls it at four sites. So
+>   the section I had cut from 5 to 4 bullets needed cutting again, to 2: the missing task
+>   input (`gepa.py:230` vs `:263-267`) and the empty-train→val fallback (`:530`).
+> - **Two `harness.py` citations rotted again.** #393 + #396 grew the file ~266 lines, so
+>   `harness.py:2004-2006`/`:2013` became `:2270-2272`/`:2279`. Re-derived mechanically
+>   (`/tmp/capreview-pma-rederive2.py`) rather than by hand: **23/23 skillopt + 3/3 gepa
+>   citations now resolve.** All 19 `skillopt.py` citations held — only the cross-file ones
+>   moved, which is the predictable failure mode and an argument for citing symbols over
+>   lines.
+> - **My own tripwire fired, for the right reason and the wrong cause.**
+>   `test_skillopt_minibatch_focus_is_still_empty_by_construction` went red — not because
+>   #371 was fixed, but because #391 reworded the summary from `of 0 tasks` to
+>   `of 0 focused task(s) of N on val`. The gap is exactly as real. Two consequences: the
+>   test now asserts the **property** (`0 solid / 0 flaky / 0 failing`, and no val feedback
+>   leaking into a train-focused prompt) instead of a sentence, and skillopt's SKILL.md no
+>   longer quotes the pre-#391 string. A tripwire that fires on rewording is a false alarm,
+>   which is worse than none — my own mistake, caught by my own test.
+> - **Preserved unchanged:** the gepa budget-ceiling correction, re-verified against current
+>   `gepa.py` (`_try_merge` samples a FRESH minibatch at `:831` and evaluates the merge plus
+>   BOTH parents at `:832`/`:834`/`:836`, then pays a second full val) — `5·mb +
+>   2·|val|·n_trials` stands exactly. #396's AST guard in
+>   `core/tests/test_iteration_record_parity.py` is untouched (`git diff` empty, 9 passed).
+> - **Added from #396's semantics:** an INDECISIVE gepa child **charges `spent.iterations`**
+>   while leaving the stall counter alone (`record_iteration(..., indecisive=True)`,
+>   `harness.py:1072`). The spend meter counts it because the rollouts were really spent;
+>   only the evidence meter does not. A reader budgeting a run needs that distinction and
+>   the skill did not have it.
+> - **#388's fix preserved through the conflict:** both merge conflicts were #388's removal
+>   of the phantom `cap-evolve status` / `cap-evolve finalize` subcommands colliding with my
+>   trims. #388's substance won; the phantom commands were not reintroduced (verified by the
+>   14 subcommand-guard tests).
+>
+> Final counts: **836 passed, 12 skipped** (main's 829 + 7 new), all four `check.py` clean,
+> `bash examples/toy_calc/run.sh` → `best_id cand_0001`, `test_reward 1.0`, `finalized true`,
+> and the three failing-first assertions re-verified RED against `origin/main`
+> (`/tmp/capreview-pma-failingfirst2.py`).
+ None of the four was independently reviewed before merge.
 `main` baseline confirmed green at **805 passed, 12 skipped**
 (`PYTHONPATH="$PWD/core:$PWD/dashboard/backend" python -m pytest core/tests -q`).
 

--- a/.review/postmerge-algos.md
+++ b/.review/postmerge-algos.md
@@ -332,8 +332,15 @@ exactly what #386 did to #369, twice.
 
 ## PRs/issues I opened
 
-- PR (this branch, `postmerge-algos-fixes`): everything marked **Fixed** above, plus
+- **PR #394** (`postmerge-algos-fixes`): everything marked **Fixed** above, plus
   `core/tests/test_skill_code_claims.py` (7 tests, 3 failing-first).
-- Recorded in the PR body rather than filed, being other agents' ownership: the 3 wrong policy paths
-  in `skills/capabilities/tools/references/` (child of #352), and the graded-reward guidance that
-  `phases/gate` should adopt from #380's deleted small-val pitfall.
+  <https://github.com/skillberry-ai/cap-evolve/pull/394>
+- **Issue #395** — `skillopt.applied_changes` has no zero: it counts the injected read-context, so it
+  cannot detect an optimizer that made no edit. Real but a code fix outside this PR's scope; the fix
+  is to drop the duplicate seven-basename ignore list in favour of `types.NON_CAPABILITY_FILES` /
+  `NON_CAPABILITY_DIRS`, which #386 extended for exactly this class of problem. Sibling of #371.
+  <https://github.com/skillberry-ai/cap-evolve/issues/395>
+- Recorded in PR #394's body rather than filed, being other owners' skills: the 3 wrong policy paths
+  in `skills/capabilities/tools/references/` (last surfaces of #352, now that the core docstrings are
+  fixed), and the graded-reward guidance `phases/gate` should adopt from #380's deleted small-val
+  pitfall.

--- a/core/cap_evolve/tool_surface.py
+++ b/core/cap_evolve/tool_surface.py
@@ -12,8 +12,10 @@ Action kinds: ``description`` | ``params`` | ``examples`` | ``schema`` | ``code`
 | ``add`` | ``remove`` | ``compose`` (add a tool that calls existing tools).
 A capability whose server is external (mcp-tool) allows only the documentation +
 add/remove subset; a capability that owns its tool code (tools) allows the full
-set. The effective policy is ``inputs/policy.json`` if present, else the
-capability's ``DEFAULT_POLICY``.
+set. The effective policy is ``<capability_dir>/policy.json`` if present, else the
+capability's ``DEFAULT_POLICY`` — see ``load_policy``. It is NOT
+``inputs/policy.json``: seven doc surfaces claimed that path, so a policy written as
+documented was read by nothing (#352).
 """
 
 from __future__ import annotations
@@ -32,7 +34,11 @@ def _save(capability_dir: Path, data: dict) -> None:
 
 
 def load_policy(capability_dir: Path, default_policy: dict) -> dict:
-    """``inputs/policy.json`` if present (it overrides), else the capability default."""
+    """``<capability_dir>/policy.json`` if present (it overrides), else the default.
+
+    The file sits in the capability dir itself, NOT in an ``inputs/`` subdirectory —
+    a policy written to ``inputs/policy.json`` is silently ignored (#352).
+    """
     f = Path(capability_dir) / "policy.json"
     return json.loads(f.read_text(encoding="utf-8")) if f.exists() else dict(default_policy)
 

--- a/core/tests/test_skill_code_claims.py
+++ b/core/tests/test_skill_code_claims.py
@@ -110,12 +110,16 @@ def test_optimizer_read_context_is_never_an_editable_component():
 # ---- #380: the gap skillopt's SKILL.md documents (#371) ------------------
 
 def test_skillopt_minibatch_focus_is_still_empty_by_construction():
-    """`skillopt/SKILL.md` § Known gaps: "Mini-batch ids come from **train** but filter
-    the parent's **val** rows ... Every step renders `0 solid / 0 flaky / 0 failing of
-    0 tasks`" (#371).
+    """`skillopt/SKILL.md` § Known gaps: train mini-batch ids filter the parent's **val**
+    rows, so the focus summary classifies ZERO tasks and the failure index is empty (#371).
 
     This test FAILS the day #371 is fixed — on purpose. The gap is documented in the
     skill, so the fix must delete that paragraph in the same change.
+
+    Asserts the PROPERTY (nothing classified, no failure index), not the sentence: an
+    earlier version pinned the literal "of 0 tasks" and #391 reworded the summary to
+    "of 0 focused task(s) of N on val" while the gap stayed exactly as real. A tripwire
+    that fires on rewording is a false alarm, which is worse than none.
     """
     from cap_evolve import harness
     from cap_evolve.loop import SplitResult
@@ -124,11 +128,16 @@ def test_skillopt_minibatch_focus_is_still_empty_by_construction():
         "split": "val", "reward": 0.5, "stderr": 0.0,
         "per_task": [{"task_id": "v1", "reward": 0.0, "feedback": "boom"},
                      {"task_id": "v2", "reward": 1.0, "feedback": ""}]})
+    # train ids, against a val result — exactly what skillopt hands ctx.instructions().
     rendered = harness._focus_instructions(val, ["t1", "t2"], "mini-batch of 2 train tasks, L=4",
                                            algorithm="skillopt")
-    assert "of 0 tasks" in rendered, (
-        "the mini-batch focus block is no longer empty — #371 looks fixed, so remove "
-        "the 'mini-batch never reaches the optimizer' gap from skillopt/SKILL.md")
+    summary = next(ln for ln in rendered.splitlines() if ln.startswith("Focus:"))
+    assert "0 solid / 0 flaky / 0 failing" in summary, (
+        "the mini-batch focus block classifies tasks now — #371 looks fixed, so remove the "
+        f"'mini-batch never reaches the optimizer' gap from skillopt/SKILL.md. Got: {summary}")
+    assert "boom" not in rendered, (
+        "a val task's feedback reached a train-focused prompt — #371 looks fixed; update "
+        "skillopt/SKILL.md")
 
 
 # ---- #368: the reference pointer must not promise a missing rule ---------

--- a/core/tests/test_skill_code_claims.py
+++ b/core/tests/test_skill_code_claims.py
@@ -1,0 +1,147 @@
+"""Pin the code facts the four merged skill PRs (#368/#369/#373/#380) ASSERT.
+
+A skill that describes behavior the code does not have is the exact failure mode
+those PRs were written to remove — and three of them came straight back when #386
+and #350 restructured the code afterwards. These tests are the mechanical half of
+"the skill and the code cannot drift silently": each one fails the day the code
+changes, so whoever changes it is told which SKILL.md sentence is now a lie.
+
+Deliberately NOT a doc linter. Each test pins ONE behavior a skill states in
+plain language, and names the sentence it is pinning.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+import sys
+from pathlib import Path
+
+CORE = str(Path(__file__).resolve().parents[1])
+if CORE not in sys.path:
+    sys.path.insert(0, CORE)
+
+from cap_evolve import tool_surface  # noqa: E402
+from cap_evolve.types import NON_CAPABILITY_DIRS, NON_CAPABILITY_FILES  # noqa: E402
+
+SKILLS = Path(__file__).resolve().parents[2] / "skills"
+
+
+# ---- #373 / #352: the policy path ----------------------------------------
+
+def test_load_policy_reads_the_capability_dir_not_inputs(tmp_path):
+    """`mcp-tool/SKILL.md`: "the effective policy is `policy.json` **in the
+    capability dir** (not `inputs/policy.json`)". Seven doc surfaces used to claim
+    `inputs/`, so a policy written as documented was silently ignored (#352)."""
+    (tmp_path / "inputs").mkdir()
+    (tmp_path / "inputs" / "policy.json").write_text(json.dumps({"allow": ["schema"]}))
+    default = {"allow": ["description"]}
+    assert tool_surface.load_policy(tmp_path, default)["allow"] == ["description"], \
+        "inputs/policy.json must NOT be read — no doc surface may promise it"
+
+    (tmp_path / "policy.json").write_text(json.dumps({"allow": ["schema"]}))
+    assert tool_surface.load_policy(tmp_path, default)["allow"] == ["schema"]
+
+
+def test_load_policy_docstrings_name_the_path_it_actually_reads():
+    """The loader's own docstrings are the most authoritative surface there is; both used to
+    name `inputs/policy.json` while the code read `<capability_dir>/policy.json` (#352).
+
+    Naming the wrong path is fine when it is being ruled OUT — what must never happen again
+    is a docstring that presents `inputs/policy.json` as the file the loader reads.
+    """
+    for where, text in (("load_policy docstring", tool_surface.load_policy.__doc__),
+                        ("module docstring", tool_surface.__doc__)):
+        flat = " ".join((text or "").split())
+        assert "<capability_dir>/policy.json" in flat, \
+            f"{where} does not name <capability_dir>/policy.json, the path load_policy reads"
+        if "inputs/policy.json" in flat:
+            assert ("NOT ``inputs/policy.json``" in flat or "silently ignored" in flat), \
+                f"{where} names inputs/policy.json without ruling it out"
+
+
+# ---- #373: apply() filters the LABEL, not the effect ---------------------
+
+def test_apply_does_not_refuse_a_schema_rewrite_smuggled_through_params(tmp_path):
+    """`mcp-tool/SKILL.md`: "a `params` value is shallow-merged into `parameters`, so a
+    value containing `properties`, `type`, `required`, or `enum` rewrites the wire
+    schema and is *not* refused" (#372). If apply() ever starts refusing this, that
+    sentence must change from a warning into a description of a guard."""
+    (tmp_path / "tools.json").write_text(json.dumps({"tools": [
+        {"name": "t", "description": "d",
+         "parameters": {"type": "object", "properties": {"n": {"type": "integer"}}},
+         "examples": []}]}))
+    policy = {"allow": ["description", "params", "examples", "add", "remove"]}
+    report = tool_surface.apply(tmp_path, policy, [
+        {"tool": "t", "kind": "params",
+         "value": {"type": "array", "required": ["x"], "properties": {}}}])
+    assert report["refused"] == [], "apply() gained a guard the SKILL.md says it lacks"
+    params = json.loads((tmp_path / "tools.json").read_text())["tools"][0]["parameters"]
+    assert params["type"] == "array" and params["required"] == ["x"], \
+        "the wire schema was NOT rewritten — SKILL.md's warning is now wrong"
+
+    report = tool_surface.apply(tmp_path, policy, [
+        {"tool": "u", "kind": "add",
+         "value": {"name": "u", "description": "d", "parameters": {}, "code": "x"}}])
+    assert report["refused"] == []
+    added = [t for t in json.loads((tmp_path / "tools.json").read_text())["tools"]
+             if t["name"] == "u"][0]
+    assert "code" in added, "an `add` no longer carries a `code` key through unrefused"
+
+
+def test_validate_does_not_consult_the_policy():
+    """`mcp-tool/SKILL.md`: "`validate()` will not catch either — it checks
+    well-formedness only ... and reports `ok: true` on a schema-rewritten artifact"."""
+    assert "load_policy" not in inspect.getsource(tool_surface.validate)
+
+
+# ---- #369: what gepa's component list excludes ---------------------------
+
+def test_optimizer_read_context_is_never_an_editable_component():
+    """`gepa/SKILL.md` no longer claims round-robin can burn an iteration on
+    `.claude/`/`CLAUDE.md`: #386 added the injected read-context to the exclusions,
+    which is what makes that claim false. If it is removed again, restore the gap."""
+    for name in ("CLAUDE.md", "AGENTS.md", "GEMINI.md", "REFLECTION.md", "FOCUS.md"):
+        assert name in NON_CAPABILITY_FILES, f"{name} is an editable gepa component again"
+    for name in (".claude", ".agents", "guidance", "trajectories", "prior_iterations"):
+        assert name in NON_CAPABILITY_DIRS, f"{name}/ is an editable gepa component again"
+
+
+# ---- #380: the gap skillopt's SKILL.md documents (#371) ------------------
+
+def test_skillopt_minibatch_focus_is_still_empty_by_construction():
+    """`skillopt/SKILL.md` § Known gaps: "Mini-batch ids come from **train** but filter
+    the parent's **val** rows ... Every step renders `0 solid / 0 flaky / 0 failing of
+    0 tasks`" (#371).
+
+    This test FAILS the day #371 is fixed — on purpose. The gap is documented in the
+    skill, so the fix must delete that paragraph in the same change.
+    """
+    from cap_evolve import harness
+    from cap_evolve.loop import SplitResult
+
+    val = SplitResult.from_dict({
+        "split": "val", "reward": 0.5, "stderr": 0.0,
+        "per_task": [{"task_id": "v1", "reward": 0.0, "feedback": "boom"},
+                     {"task_id": "v2", "reward": 1.0, "feedback": ""}]})
+    rendered = harness._focus_instructions(val, ["t1", "t2"], "mini-batch of 2 train tasks, L=4",
+                                           algorithm="skillopt")
+    assert "of 0 tasks" in rendered, (
+        "the mini-batch focus block is no longer empty — #371 looks fixed, so remove "
+        "the 'mini-batch never reaches the optimizer' gap from skillopt/SKILL.md")
+
+
+# ---- #368: the reference pointer must not promise a missing rule ---------
+
+def test_agent_optimize_reference_pointers_are_not_empty_promises():
+    """`agent-optimize/SKILL.md` names the sign test as living in
+    `references/measured-lessons.md`. #368 moved the section but dropped the rule."""
+    # Both files are hard-wrapped, so any multi-word phrase can straddle a newline; and the
+    # reference emphasises rules in caps, so compare case-insensitively.
+    body = " ".join((SKILLS / "algorithms/agent-optimize/SKILL.md")
+                    .read_text(encoding="utf-8").lower().split())
+    lessons = " ".join((SKILLS / "algorithms/agent-optimize/references/measured-lessons.md")
+                       .read_text(encoding="utf-8").lower().split())
+    if "sign test" in body:
+        assert "sign test" in lessons, \
+            "SKILL.md points at measured-lessons.md for the sign test; it is not there"

--- a/skills/algorithms/agent-optimize/SKILL.md
+++ b/skills/algorithms/agent-optimize/SKILL.md
@@ -72,10 +72,10 @@ python "$S/phases/diagnose/scripts/run.py" --run-dir "$R" --tag "$BEST" --split 
 python "$S/phases/diagnose/scripts/run.py" --run-dir "$R" --tag "$BEST" --split val
 ```
 
-Read `clusters` for what to fix and `kept_good` for what you must not break. **With a disjoint train split,
+Read `clusters` for what to fix and `kept_good` for what not to break. **With a disjoint train split,
 diagnose it too and compare its cluster signatures to val's** — free, and it decides whether the round can
 work at all: if the signatures are disjoint, no train-driven edit can move the val mean, and every candidate
-is rejected for a reason that looks exactly like a null result. Say which it is in the report. (Baseline
+is rejected for a reason that looks exactly like a null result. Say which, in the report. (Baseline
 scores val only, so pay one `evaluate --split train` first.)
 
 **Read the per-task pass rate, not the per-task pass/fail.** At `num_trials: n` a task's reward is
@@ -146,7 +146,7 @@ python "$A/screen.py" --run-dir "$R" --project "$P" \
 ```
 
 Only the candidate pays, and only for the subset. `decision` is `kill` or `promote` — **never accept** — and
-it kills only on proven harm. **Check the arithmetic before relying on a screen:**
+it kills only on proven harm. **Check the arithmetic before trusting a screen:**
 `savings.breakeven_kill_rate` (`fired / full_val_rollouts`) is the fraction it must kill to pay for itself;
 `savings.net_rollouts` books what it cost. Screen only when that break-even sits below your observed kill
 rate — on a small val the tier-1 floor makes it unreachable, so pay full val directly — and read a screen as
@@ -265,11 +265,11 @@ mechanism-vs-artifact designs, gating the sum not each addend, the sign test bel
 ## Stop & seal, then MEASURE (once)
 
 Spend is not a CLI subcommand: **every 2–3 rounds** (and always before a fan-out) run `spend.py`.
-Everything it reports is re-read from the run dir, never from a total in your head — which is what
-keeps a `$6.00` cap from becoming `$6.01`. (The Stop hook re-nudges you across turns until the run is
-finalized.) Stop when `recommendation` is `stop`, then produce the run's one honest table — seed vs
-best on **val**, on **train** when the spec defines one worth reporting, and on the **sealed test**
-split scored once:
+Everything it reports is re-read from the run dir, never a total in your head — which keeps a `$6.00`
+cap from becoming `$6.01`. (The Stop hook re-nudges you across turns until the run is finalized.)
+Stop when `recommendation` is `stop`, then produce the run's one honest table — seed vs best on
+**val**, on **train** when the spec defines one worth reporting, and on the **sealed test** split
+scored once:
 
 ```bash
 python "$A/measure.py" --run-dir "$R" --project "$P" --train auto
@@ -278,10 +278,9 @@ python "$S/phases/report/scripts/run.py" --run-dir "$R"
 
 `measure.py` reads val off the rollouts the gate already used (free), evaluates train only when it adds
 information, and seals test through the same `harness.finalize` the finalize phase calls — so it is
-interchangeable with `phases/finalize/scripts/run.py`. Report its four refusals as it states them, never
-paraphrased softer: an **empty** split is `empty`, not 0.0; a **no-holdout** spec is a **FIT metric, not
+interchangeable with `phases/finalize/scripts/run.py`. Report its four refusals unsoftened: an **empty** split is `empty`, not 0.0; a **no-holdout** spec is a **FIT metric, not
 generalisation**, with the overlap counted; a negative `screen_ledger.net_rollouts` says screening was
-pure overhead; `best_id == "seed"` is a **null result with a diagnosed cause**, never a 0.000 gain.
+pure overhead; `best_id == "seed"` is a **null result with a diagnosed cause**, not a 0.000 gain.
 (Sealing is that phase script, **not a CLI subcommand**; a second finalize raises `TestSealError`.)
 No finalize, no result.
 

--- a/skills/algorithms/agent-optimize/SKILL.md
+++ b/skills/algorithms/agent-optimize/SKILL.md
@@ -10,14 +10,14 @@ needs: [scores, traces, candidate]
 
 # agent-optimize — the free-form loop you own
 
-The one algorithm with **no deterministic subprocess** and **no per-iteration optimizer**: you — the
-agent that ran intake — are the optimizer, the scheduler and the stopping rule. `cap-evolve run` (with
-`orchestration_mode: agent`) does check → baseline, prints a handoff with the `run_dir`, and returns.
-From there the search is yours, bounded by the invariants core enforces and the project's free-text
-**`stop_condition`**. You drive the *existing* primitives, so the run dir and the dashboard stay
-populated exactly as in a deterministic run.
+The one algorithm with **no deterministic subprocess** and **no per-iteration optimizer**: you — the agent
+that ran intake — are the optimizer, the scheduler and the stopping rule. `cap-evolve run` (with
+`orchestration_mode: agent`) does check → baseline, prints a handoff with the `run_dir`, and returns. From
+there the search is yours, bounded by the invariants core enforces and the project's free-text
+**`stop_condition`**. Drive the *existing* primitives, so the run dir and dashboard stay populated as in a
+deterministic run.
 
-## Shell variables used by every command below
+## Shell variables used below
 
 ```bash
 R="<run_dir from the agent-mode handoff>"      # e.g. .capevolve/run_20250101_120000
@@ -27,22 +27,21 @@ A="$S/algorithms/agent-optimize/scripts"       # this skill's helpers
 mkdir -p "$R/work"                             # working copies live here (RunDir does NOT create it)
 ```
 
-Every script does its own `import _bootstrap`, so it finds `cap_evolve` without `PYTHONPATH`, and all
-of them print JSON on stdout.
+Every script imports `_bootstrap` itself (no `PYTHONPATH`) and prints JSON on stdout.
 
 ## Phase 0 — understand before you optimize
 
 Once, before any edit, and **ask the user any blocking question here** so the loop then runs unattended.
-Read `PROJECT.md`, `capevolve.yaml`, the adapter and every file under `capability_path`, and understand
-what **one evaluation** does: what a task is, what `run_target` produces, what `score()` rewards, and
-what the per-task **feedback** says — that is your learning signal. Note the val/test sizes,
-`num_trials`, `gate_mode`/`gate_k_se` and the allowed edit surface.
+Read `PROJECT.md`, `capevolve.yaml`, the adapter and every file under `capability_path`, and understand what
+**one evaluation** does: what a task is, what `run_target` produces, what `score()` rewards, and what the
+per-task **feedback** says — that is your learning signal. Note the val/test sizes, `num_trials`,
+`gate_mode`/`gate_k_se` and the allowed edit surface.
 
-Then read the free-text **`stop_condition`** and let `spend.py` parse it rather than restate it from
-memory: it prints `constraints.predicates`, every concrete check it could extract with its measured
-actual. **If `constraints.ambiguous` is non-empty, ASK THE USER before the loop starts** — a vague
-clause ("don't spend too much", a bare number with no unit) is reported, never guessed at, and this is
-the one moment where asking is cheap.
+Then let `spend.py` parse the free-text **`stop_condition`** rather than restating it from memory: it prints
+`constraints.predicates`, every concrete check it could extract, with its measured actual. **If
+`constraints.ambiguous` is non-empty, ASK THE USER before the loop starts** — a vague clause ("don't spend
+too much", a bare number with no unit) is reported, never guessed at, and this is the one moment where
+asking is cheap.
 
 ## Agent-mode loop
 
@@ -55,14 +54,13 @@ Baseline has scored the seed on val and set `best_id = seed`. Each round:
 python "$A/spend.py" --run-dir "$R" --project "$P" --n-siblings 3
 ```
 
-Act on the single `recommendation`: **`stop`** (a ceiling breached, `budget_exhausted()` true, or the
-score goal met on FULL val) → go to **Stop & seal**; **`narrow_scope`** (≥80% of some ceiling consumed,
-goal unmet) → ONE cheap candidate screened at tier 1, no fan-out; **`continue`** → run the round you
-planned.
+Act on the single `recommendation`: **`stop`** (a ceiling breached, `budget_exhausted()` true, or the score
+goal met on FULL val) → **Stop & seal**; **`narrow_scope`** (≥80% of a ceiling consumed, goal unmet) → ONE
+cheap candidate at tier 1, no fan-out; **`continue`** → run the round you planned.
 
-`afford.affordable: false` (with `afford.blockers` naming the ceiling) means **do not fan out N** —
-check it BEFORE dispatching proposers, since N candidates can blow a budget with room for one. And read
-`afford.runner_spend_metered`: $0 after real rollouts is *unmetered*, not free, and taken as 0.0 it
+`afford.affordable: false` (with `afford.blockers` naming the ceiling) means **do not fan out N** — check
+it BEFORE dispatching proposers, since N candidates can blow a budget with room for one. And
+`afford.runner_spend_metered: false` means $0 after real rollouts is *unmetered*, not free: read as 0.0 it
 leaves `max_usd` unable to block anything, so bound such a run with `max_metric_calls` and report
 **rollout counts, not dollars**.
 
@@ -74,11 +72,11 @@ python "$S/phases/diagnose/scripts/run.py" --run-dir "$R" --tag "$BEST" --split 
 python "$S/phases/diagnose/scripts/run.py" --run-dir "$R" --tag "$BEST" --split val
 ```
 
-Read `clusters` for what to fix and `kept_good` for what you must not break. **With a disjoint train
-split, diagnose it too and compare its cluster signatures to val's** — free, and it decides whether the
-round can work at all: if the two are disjoint, no train-driven edit can move the val mean, and every
-candidate is rejected for a reason that looks exactly like a null result. Say which it is in the
-report. (Baseline scores only val, so pay one `evaluate --split train` first.)
+Read `clusters` for what to fix and `kept_good` for what you must not break. **With a disjoint train split,
+diagnose it too and compare its cluster signatures to val's** — free, and it decides whether the round can
+work at all: if the signatures are disjoint, no train-driven edit can move the val mean, and every candidate
+is rejected for a reason that looks exactly like a null result. Say which it is in the report. (Baseline
+scores val only, so pay one `evaluate --split train` first.)
 
 **Read the per-task pass rate, not the per-task pass/fail.** At `num_trials: n` a task's reward is
 `k/n`, and that fraction is what separates defects from noise:
@@ -94,40 +92,39 @@ A task that "regressed" from `10/10` to `9/10` between rounds is a re-measuremen
 **Audit the MEASUREMENT before you credit a failure**, in round 1 while it is still free (scoring
 re-derives on persisted rollouts): a failing task is a claim by the scorer, and an optimizer that skips
 this optimizes against its own instrumentation. Does the feedback name the **defect** or only the tool;
-does any helper fail **silently**; is *silent* distinguished from *wrong*; did the rollout **run**, or
-is this missing data wearing a 0.0; which components actually **gate**? The checklist, with the failure
-behind each item: `references/edit-design-lessons.md`.
+does any helper fail **silently**; is *silent* distinguished from *wrong*; did the rollout **run**, or is
+this missing data wearing a 0.0; which components actually **gate**? The failure behind each item:
+`references/edit-design-lessons.md`.
 
-**When two rounds of edits are rejected, read the candidate's TRACE before writing a third** — not
-"was the rule right" but "did the agent follow it at all". Never exercised ⇒ the **form** is wrong, so
-take a different row below; exercised and still wrong ⇒ the content is.
+**After two rejected rounds, read the candidate's TRACE before writing a third** — not "was the rule right"
+but "did the agent follow it at all". Never exercised ⇒ the **form** is wrong, so take a different row
+below; exercised and still wrong ⇒ the content is.
 
-**2. Propose an edit per candidate — and address EVERY cluster the round can afford**, as **sibling
-candidates** (one cluster each, gated independently — the safe default) or as **one bold multi-part
-edit** (higher variance, but the only way a fix needing a prompt change *and* a tool change lands
-together). If you bundle, keep the parts *independent* — different files, different rules — so a
-rejected bundle can be resubmitted as its surviving part, and read `regressed` (screen) and
-`regressions` (gate) to know which to drop. That is also what stops **churn**, a candidate whose mean
-matches its parent while a *different* set of tasks passes, from reading as a tie.
+**2. Propose an edit per candidate — and address EVERY cluster the round can afford**, either as
+**sibling candidates** (one cluster each, gated independently — the safe default) or as **one bold
+multi-part edit** (higher variance, but the only way a fix needing a prompt change *and* a tool change
+lands together). Bundle only *independent* parts — different files, different rules — so a rejected bundle
+can be resubmitted as its surviving part; read `regressed` (screen) and `regressions` (gate) to know which
+to drop. That is also what stops **churn** — a candidate whose mean matches its parent while a *different*
+set of tasks passes — from reading as a tie.
 
 ```bash
 TAG="cand_1"                                   # unique per candidate — it IS the rollout tag
 cp -r "$R/candidates/$BEST" "$R/work/$TAG"
-# …now edit the files under $R/work/$TAG that your capability actually owns.
-# (Example only — a system-prompt project might have policy/policy.md, a tools project
-#  tools/tools.py; read capability_path in Phase 0 for the real layout.)
+# …now edit the files under $R/work/$TAG that your capability owns. Example only:
+# read capability_path in Phase 0 for the real layout.
 ```
 
-Every edit must encode a **general rule** — never a task's id, gold value, or answer.
+Every edit encodes a **general rule** — never a task's id, gold value, or answer.
 
-**Choose the edit FORM from the failure TYPE — before you write a word.** The form matters more than
-the wording, because the form that repairs one failure type measurably backfires on another:
+**Choose the edit FORM from the failure TYPE — before you write a word.** The form matters more than the
+wording, because the form that repairs one failure type measurably backfires on another:
 
 | the failure you observed | the form that fixes it | the form that makes it worse |
 | --- | --- | --- |
 | the rule is stated and the agent skips it under pressure | a prohibition plus the symptom that precedes it ("if you are about to X, you have already failed") | restating the rule — a mid-tier model gets *less* compliant |
-| the agent complies but the output/call has the wrong shape | a **positive recipe**: what the correct call IS, its parts, in order | a list of things not to do — it produced *more* unwanted output than no guidance |
-| a required element is simply missing | a **structural REQUIRED slot**, or a code-level precondition | a prose reminder mid-document |
+| the agent complies but the call has the wrong shape | a **positive recipe**: what the correct call IS, its parts, in order | a list of things not to do — it produced *more* unwanted output than no guidance |
+| a required element is missing | a **structural REQUIRED slot**, or a code-level precondition | a prose reminder mid-document |
 | behaviour should differ by situation | a conditional on an **observable predicate** the agent can evaluate from tool output | an unconditional rule plus exemptions |
 
 Then: **no nuance clauses**; **exemption clauses do not scope** ("this limit does not apply to X" still
@@ -136,29 +133,27 @@ prose is right when the agent *lacks* a decision criterion, code when it has one
 each cost, and the guard-closure trap the third brings: `references/edit-design-lessons.md`.
 
 **Every round evaluates a null control**: copy the current best byte-for-byte into `$R/work/ctl_null`
-and evaluate it like any candidate — one eval buys the round's own noise floor, and a candidate inside
-that band is not evidence of anything. Do it first, not after a surprising result. And **read
+and evaluate it like any candidate — first, not after a surprising result. That eval is the round's own
+noise floor, and a candidate inside that band is not evidence of anything. And **read
 `$R/rejected.jsonl` and make each proposal STRUCTURALLY different from what is in it**: a different
 form, surface, or cluster — never a narrower version of a rejected rule.
 
-**3. Cheap SUBSET screen — the promotion ladder.** Do not pay full val to learn that an edit is bad:
+**3. Cheap SUBSET screen — the promotion ladder.** Do not pay full val to learn an edit is bad:
 
 ```bash
 python "$A/screen.py" --run-dir "$R" --project "$P" \
        --candidate "$R/work/$TAG" --tier 1 --k-se 1.0
 ```
 
-Only the candidate pays, and only for the subset. `decision` is `kill` or `promote` — **never accept** —
-and it kills only on proven harm. **Check the arithmetic before relying on a screen at all:**
-`savings.breakeven_kill_rate` (`fired / full_val_rollouts`) is the fraction of candidates it must kill
-to pay for itself, and `savings.net_rollouts` books what it cost. Screen only when that break-even sits
-below your observed kill rate — on a small val the tier-1 floor makes it unreachable, so pay full val
-directly — and read a screen as evidence about the tasks the edit targeted, never as a gate decision.
-Its subset composition, cumulative rungs, seed and measured kill rates are under *Subset screening* in
-[`references/algorithm.md`](references/algorithm.md).
+Only the candidate pays, and only for the subset. `decision` is `kill` or `promote` — **never accept** — and
+it kills only on proven harm. **Check the arithmetic before relying on a screen:**
+`savings.breakeven_kill_rate` (`fired / full_val_rollouts`) is the fraction it must kill to pay for itself;
+`savings.net_rollouts` books what it cost. Screen only when that break-even sits below your observed kill
+rate — on a small val the tier-1 floor makes it unreachable, so pay full val directly — and read a screen as
+evidence about the tasks the edit targeted, never as a gate decision.
 
 **4. Honest gate on FULL val.** Evaluate the whole split (this writes rollouts + results under tag
-`$TAG`, since the evaluate phase tags by the candidate **dir name**), then decide off those rollouts:
+`$TAG` — the evaluate phase tags by the candidate **dir name**), then decide off those rollouts:
 
 ```bash
 python "$S/phases/evaluate/scripts/run.py" --run-dir "$R" --project "$P" \
@@ -166,13 +161,12 @@ python "$S/phases/evaluate/scripts/run.py" --run-dir "$R" --project "$P" \
 python "$A/gate_check.py" --run-dir "$R" --candidate "$TAG" --k-se <gate_k_se>
 ```
 
-Accept **only** on `"verdict": "accept"`; `"indecisive"` is not a rejection but a signal that too
-little of val ran, so fix the runner before spending more. **`regressions` is diagnosis, not a veto** —
-it names which part of a bundled edit to drop next round, but a per-task drop at `n` trials is an
-estimate, not proof of harm, and the old no-regression veto rejected byte-identical copies of the seed
-often enough to dominate the false rejects. `--veto-regressions` restores it if you want a
-zero-regression guarantee and will pay that rate. `phases/gate/scripts/run.py` reaches the same paired
-gate in rollout mode but books no decision, so use it to inspect, never to decide.
+Accept **only** on `"verdict": "accept"`; `"indecisive"` is not a rejection but a signal that too little of
+val ran, so fix the runner before spending more. **`regressions` is diagnosis, not a veto** — it names which
+part of a bundled edit to drop next round, but a per-task drop at `n` trials is an estimate, not proof of
+harm, and the old no-regression veto rejected byte-identical seed copies often enough to dominate the false
+rejects. `--veto-regressions` restores it, at that rate. `phases/gate/scripts/run.py` reaches the
+same paired gate in rollout mode but books no decision: use it to inspect, never to decide.
 
 **5. Commit the decision through the run dir**, so `best_id`, the stall counter, the dashboard and the
 audit log stay real. `--decision reject` keeps the old best; either way it snapshots the candidate, logs
@@ -183,26 +177,23 @@ python "$A/commit.py" --run-dir "$R" --candidate-id "$TAG" --from-dir "$R/work/$
        --decision accept --val <cand_mean> --note "<one line: the general rule you added>"
 ```
 
-**On a reject, pass `--reject-basis`** — `screen.py`'s "promote" means "could not prove harm", never
-"was evaluated on full val", and conflating its verdict with the driver's disposition makes a run's
-artifacts contradict themselves:
+**On a reject, pass `--reject-basis`** — `screen.py`'s "promote" means "could not prove harm", never "was
+evaluated on full val", so conflating its verdict with your disposition makes the run's artifacts
+contradict themselves. `gate` (a full-val paired gate ran and said reject — the only basis asserting
+this), `screen_kill` (the screen proved harm), `ceiling` (arithmetic proved no accept was reachable, so
+full val was never paid), `budget` (screen evidence plus a budget call, not a gate decision), `infra`
+(missing data, not a judgement). So `screen: promote` + `reject_basis: ceiling` is one coherent story.
 
-`gate` (a full-val paired gate ran and said reject — the only basis that asserts this), `screen_kill`
-(the screen proved significant harm), `ceiling` (arithmetic proved no accept was reachable, so full val
-was never paid), `budget` (screen evidence plus a budget call, not a gate decision), `infra` (missing
-data, not a judgement).
+`commit.py` **refuses a `--candidate-id` that already carries an accept/reject event** (`--force` only to
+repair a record deliberately): two drivers tagging a candidate alike otherwise produce two decision
+events over ONE set of rollouts. Pass `--optimizer-usd/--optimizer-tokens/--optimizer-seconds` for
+**your own** proposal cost — the evaluate phase records the runner's, nothing records the proposer's.
 
-So `screen: promote` + `reject_basis: ceiling` is one coherent story. `commit.py` **refuses a
-`--candidate-id` that already carries an accept/reject event** (`--force` only to repair a record
-deliberately), because two drivers tagging a candidate alike otherwise produce two decision events over
-ONE set of rollouts. Pass `--optimizer-usd/--optimizer-tokens/--optimizer-seconds` for **your own**
-proposal cost: the evaluate phase records the runner's, nothing records the proposer's.
-
-## Parallel round (optional, and only as described)
+## Parallel round (optional)
 
 **The whole of steps 3–4 for a round is one command.** `round.py` builds the null control, evaluates
-every tag in parallel *processes* (each does its own adapter `apply()`, which mutates a
-process-global registry and so must never be shared), gates them serially, and prints one table:
+every tag in parallel *processes* (each runs its own adapter `apply()`, which mutates a process-global
+registry and must never be shared), gates them serially, and prints one table:
 
 ```bash
 python "$A/round.py" --run-dir "$R" --project "$P" \
@@ -210,91 +201,75 @@ python "$A/round.py" --run-dir "$R" --project "$P" \
        --n-trials <num_trials> --k-se <gate_k_se> --concurrency 8 --max-parallel 2
 ```
 
-`--concurrency` is the gate's *measurement* concurrency and defaults deliberately low; `round.py` warns
-once you raise it past what a gate can resolve, so do not raise it to buy wall clock. Read
-`noise_floor_from_control` FIRST — a candidate inside that band is not evidence, whatever its verdict
-says — and note that `round.py` never commits: which part of a bundle to keep is your judgement.
+`--concurrency` is the gate's *measurement* concurrency and defaults deliberately low; `round.py` warns once
+you raise it past what a gate can resolve, so do not raise it to buy wall clock. Read
+`noise_floor_from_control` FIRST — a candidate inside that band is not evidence, whatever its verdict says.
+`round.py` never commits: which part of a bundle to keep is your judgement.
 
-Fan-out buys wall-clock and costs budget, so state these five invariants before every fan-out:
+Four invariants, to state before every fan-out (the reasoning, and where fan-out pays best, are under
+*Parallelism* in [`references/algorithm.md`](references/algorithm.md)):
 
 1. **Diagnosis fans out freely** — read-only, zero rollouts: one `cap-evolve-diagnoser` per failure
    cluster or rollout shard, then merge their JSON.
-2. **Proposal fans out across distinct working copies with distinct tags** — N siblings from one
-   parent, each `cp -r`'d to its own `$R/work/<tag>` (a git worktree if the capability lives in a
-   repo). **The tag must be unique per sibling**: rollout files are `<task>__<tag>__t<k>.json`, so two
-   concurrent evals sharing a tag interleave into the same filenames and corrupt both scores.
-3. **The gate stays serial.** `set_best` mutates run state and paired deltas are computed against
-   whatever the baseline is *right now*, so gate + commit siblings **one at a time**, and after any
-   accept **re-run `gate_check.py` for every remaining sibling against the new best** — skipping the
-   re-gate double-counts one gain and admits an edit that never beat what it now stacks on.
-4. **Never fan out across the test split**, and **pay before you fan out** — `spend.py --n-siblings N`
-   must say `affordable: true` before you dispatch N.
+2. **Proposal fans out across distinct working copies, one `cp -r` per sibling, tag unique per sibling** —
+   rollouts are `<task>__<tag>__t<k>.json`, so a shared tag interleaves two evals into the same filenames
+   and corrupts both scores.
+3. **The gate stays serial** — gate + commit one sibling at a time, and after any accept **re-run
+   `gate_check.py` for every remaining sibling against the new best**. Skipping that re-gate
+   double-counts a gain and admits an edit that never beat what it now stacks on.
+4. **Never fan out across the test split, and pay before you fan out** — `spend.py --n-siblings N`
+   must say `affordable: true` first.
 
-Concurrency composes from three places: inside one evaluation (an adapter's own `run_batch`, or
-`screen.py --workers N` / `CAPEVOLVE_WORKERS=N`, which pools rollout *generation* while scoring stays
-serial and in task order, so the numbers are byte-identical to a serial run), across candidates, and
-across diagnosers. Opt in only when `run_target` is thread-safe: no shared scratch dir, no single live
-container, no module-global client. `references/algorithm.md` has which steps parallelise safely.
+Concurrency also composes *inside* one evaluation (`screen.py --workers N` / `CAPEVOLVE_WORKERS=N` pool
+rollout generation only, so numbers stay byte-identical to a serial run). Opt in only when `run_target` is
+thread-safe: no shared scratch dir, no single live container, no module-global client.
 
-## Per-task fan-out — the cheap gradient
+### Per-task fan-out — the cheap gradient
 
-Use this when the baseline's `k/n` bands show the loss **concentrated in a few named tasks** rather than
-spread thin: a full-val round buys one bit per candidate for `val_n × n_trials` rollouts, while one task
-at `n_trials` buys the same bit about a failure that actually exists. Economics, briefing contract,
-canary discipline and every command: [`references/per-task-fanout.md`](references/per-task-fanout.md).
-Two rules decide whether the shape is safe at all, so they live here.
+Reach for this only when the baseline's `k/n` bands show the loss **concentrated in a few named tasks**: one
+task at `n_trials` then buys the same bit as a `val_n × n_trials` full-val round, about a failure that
+demonstrably exists. Helpers, in order — `taskeval.py` (run **detached**: a per-task eval can outlive a
+harness timeout while healthy), `mechanisms.py` (the shared ledger; `list` BEFORE you diagnose, or two
+optimisers implement one fix and collide at merge with only one measured), `integrate.py`, `funcmerge.py`,
+`merge_taskopt.py` — then gate the artifact once on full val via `round.py`. Economics, briefing contract,
+canary selection, every flag: [`references/per-task-fanout.md`](references/per-task-fanout.md). Two rules
+decide whether the shape is safe at all, so they live here:
 
 **A parallel optimiser's deliverable is a MECHANISM WITH TRACE PROOF, not a rate.** A fan-out is by
-construction a high-load regime — the one regime where a per-task rate cannot resolve the effect anyone
-is looking for — so ask for load-independent evidence (the guard fired on the observed call; the next
-action changed; a direct call with the bad payload now behaves correctly), then gate the survivors
-yourself, serialised.
+construction a high-load regime — the one regime where a per-task rate cannot resolve the effect anyone is
+looking for — so ask for load-independent evidence (the guard fired on the observed call, and the next
+action changed), then gate the survivors yourself, serialised.
 
-**A multi-branch artifact is assembled with `integrate.py`, never by one merge**, one branch at a time
-with a measurement after each: fewer mechanisms routinely beat more, and one number for N simultaneous
-changes cannot tell you that. `funcmerge` merging cleanly is **not** evidence the branches compose —
-Clean merge is a syntactic property; composition is an empirical one.
-
-The helpers, in order: `taskeval.py` (one optimiser's step — its task at full trials plus a canary,
-`--traces` on, run **detached**, since a per-task eval can outlive a harness timeout while healthy);
-`mechanisms.py` (the shared ledger — `list` before you diagnose, `add` when you find, `--supersedes`
-when one turns out false, or two optimisers implement one fix and collide at merge with only one
-measured); `integrate.py` (sequential assembly; `--canary-auto`, `--floor`); `funcmerge.py` (its
-per-function merge engine — read `dropped_additions`); `merge_taskopt.py` (whole-file case). Then gate
-the artifact once on full val via `round.py`.
+**A multi-branch artifact is assembled with `integrate.py`, never by one merge**, one branch at a time with
+a measurement after each: fewer mechanisms routinely beat more, and one number for N simultaneous changes
+cannot tell you that. `funcmerge` merging cleanly is **not** evidence the branches compose — Clean merge is
+a syntactic property; composition is an empirical one.
 
 ## Measurement discipline
 
-Two rules decide whether a round's number means anything, so they belong here; the rest of the
-contract — the ceiling arithmetic, the binomial floor, why an artifact is judged on the FULL task set
-while a mechanism is judged only where it fires, gating the sum rather than each addend, and the sign
-test for effects below the floor — is in
-[`references/measured-lessons.md`](references/measured-lessons.md), each rule with the measurement
-that bought it.
+**Measure step 2's null control twice**: the gap between two byte-identical parents is the round's bar, and a
+bar smaller than that is not a gate. Two more rules; the rest — ceiling arithmetic, the binomial floor,
+mechanism-vs-artifact designs, gating the sum not each addend, the sign test below the floor — is in
+[`references/measured-lessons.md`](references/measured-lessons.md).
 
-1. **Measure the null, twice.** Two byte-identical copies of the parent, same seeds, same load: their
-   gap is the round's bar, and a bar smaller than that is not a gate.
-2. **Explore fast, gate slow, gate ALONE.** The load knob is *total in-flight requests*, not any
-   per-process flag — K processes at concurrency C is K·C in flight, and past the endpoint's
-   sustainable rate the failure is silent: latency grows, so it reads as "the model got slower" rather
-   than "I oversubscribed". Pause the fan-out, run the gate arms in one batch (pairing removes drift)
-   and let that batch be the only thing running; if you cannot quiet the machine, say so next to the
-   verdict.
-3. **Two independently-seeded blocks, agreeing in sign, before a small effect is a result.** A paired
-   run's SE is computed over *tasks*, so it cannot see run-to-run nondeterminism at all: `multirep.py`
-   takes the error across whole runs and refuses a verdict from one of them (`--base-seed` picks the
-   block; raising `--n` only extends the same one, so a rerun at the same seeds is a determinism check,
-   not a replication). If several full paired runs are unaffordable, "not resolvable at this budget" is
-   the honest output of the round — and a result.
+1. **Explore fast, gate slow, gate ALONE.** The load knob is *total in-flight requests* (K processes at
+   concurrency C is K·C), not any per-process flag, and oversubscription fails silently — latency grows,
+   so it reads as "the model got slower". Pause the fan-out, run both gate arms in one batch, and let
+   that batch be the only thing running; if you cannot quiet the machine, say so next to the verdict.
+2. **Two independently-seeded blocks, agreeing in sign, before a small effect is a result.** A paired
+   run's SE is over *tasks*, so it cannot see run-to-run nondeterminism at all; `multirep.py` takes the
+   error across whole runs and refuses a verdict from one (`--base-seed` picks the block — raising `--n`
+   only extends the same one, so a rerun at the same seeds is a determinism check, not a replication).
+   If several full paired runs are unaffordable, "not resolvable at this budget" is the honest output.
 
-## Stop & seal, then MEASURE (exactly once)
+## Stop & seal, then MEASURE (once)
 
-Spend is not a CLI subcommand: **every 2–3 rounds** (and always before a fan-out) run
-`spend.py`. Everything it reports is re-read from the run dir, never from a total you carry in your head
-— which is what keeps a `$6.00` cap from becoming `$6.01`. (The Stop hook re-nudges you across turns
-until the run is finalized.) Stop when `recommendation` is `stop`, then produce the run's one honest
-table — seed vs best on **val**, on **train** when the spec defines one worth reporting, and on the
-**sealed test** split scored once:
+Spend is not a CLI subcommand: **every 2–3 rounds** (and always before a fan-out) run `spend.py`.
+Everything it reports is re-read from the run dir, never from a total in your head — which is what
+keeps a `$6.00` cap from becoming `$6.01`. (The Stop hook re-nudges you across turns until the run is
+finalized.) Stop when `recommendation` is `stop`, then produce the run's one honest table — seed vs
+best on **val**, on **train** when the spec defines one worth reporting, and on the **sealed test**
+split scored once:
 
 ```bash
 python "$A/measure.py" --run-dir "$R" --project "$P" --train auto
@@ -302,37 +277,36 @@ python "$S/phases/report/scripts/run.py" --run-dir "$R"
 ```
 
 `measure.py` reads val off the rollouts the gate already used (free), evaluates train only when it adds
-information, and seals test through the same `harness.finalize` the finalize phase calls, so it is
-interchangeable with `phases/finalize/scripts/run.py`. It refuses to flatter the run: an **empty** split
-says `empty`, not 0.0; a **no-holdout** spec is a **FIT metric, not generalisation**, with the overlap
-counted; a negative `screen_ledger.net_rollouts` says screening was pure overhead; and
-`best_id == "seed"` is a **null result with a diagnosed cause**, never a 0.000 gain. (Sealing is that
-phase script, **not a CLI subcommand** — and a second finalize raises `TestSealError`.) No finalize,
-no result.
+information, and seals test through the same `harness.finalize` the finalize phase calls — so it is
+interchangeable with `phases/finalize/scripts/run.py`. Report its four refusals as it states them, never
+paraphrased softer: an **empty** split is `empty`, not 0.0; a **no-holdout** spec is a **FIT metric, not
+generalisation**, with the overlap counted; a negative `screen_ledger.net_rollouts` says screening was
+pure overhead; `best_id == "seed"` is a **null result with a diagnosed cause**, never a 0.000 gain.
+(Sealing is that phase script, **not a CLI subcommand**; a second finalize raises `TestSealError`.)
+No finalize, no result.
 
-## Honesty invariants specific to driving this by hand
+## Honesty invariants that are yours by hand
 
-Core owns the split seal, the val-only gate and the tamper guard and enforces them whether you
-cooperate or not (`skills/phases/{evaluate,gate,finalize}` document them). Two are yours, because no
-script can do them for you: **never hand a subset result to `gate_check.py`** — its `coverage` reads
-1.0 because its denominator *is* the subset; and **a round that produced no run-dir artifacts is a
-bug**, so fix it before continuing rather than driving around the primitives.
+Core enforces the split seal, the val-only gate and the tamper guard whether you cooperate or not
+(`skills/phases/{evaluate,gate,finalize}` document them). Two are yours, because no script can do them
+for you: **never hand a subset result to `gate_check.py`** — its `coverage` reads 1.0 because its
+denominator *is* the subset; and **a round that produced no run-dir artifacts is a bug**, so fix it
+rather than driving around the primitives.
 
 ## References
 
 One level deep — each is read on its own, and none points at another.
 
-- [`references/algorithm.md`](references/algorithm.md) — the rationale: why free-form, how the honesty
-  invariants survive full autonomy, the subset-screening arithmetic and its break-even, which steps
-  parallelise safely, and the constraint surface. **Load** before relying on a screen, or for the
-  reasoning behind a rule you are tempted to skip.
-- [`references/measured-lessons.md`](references/measured-lessons.md) — the measurement contract's
-  evidence, each rule with the number that bought it: the binomial floor, why full val beats a hard
-  subset, the load-vs-noise tables, the across-runs estimator. **Load** before your first gate decision
-  on a new benchmark, or when a result surprises you.
-- [`references/per-task-fanout.md`](references/per-task-fanout.md) — the fan-out's economics, what to
-  ask a subagent for, canary selection, and every command. **Load** when the loss is concentrated in a
-  few named tasks.
-- [`references/edit-design-lessons.md`](references/edit-design-lessons.md) — auditing the scorer, guard
-  closure, and the measured backfires behind the edit-form table. **Load** before editing a surface for
-  the first time, or after two rejects.
+- [`references/algorithm.md`](references/algorithm.md) — why free-form, how the honesty invariants
+  survive full autonomy, the screening break-even, which steps parallelise safely, the constraint
+  surface. **Load** before relying on a screen, or for the reasoning behind a rule you want to skip.
+- [`references/measured-lessons.md`](references/measured-lessons.md) — every measurement rule with the
+  number that bought it: binomial floor, full val vs a hard subset, the load-vs-noise tables, the sign
+  test, the across-runs estimator. **Load** before your first gate decision on a new benchmark, or
+  when a result surprises you.
+- [`references/per-task-fanout.md`](references/per-task-fanout.md) — the fan-out's economics, the
+  subagent briefing contract, canary selection, every helper's flags. **Load** when the loss is
+  concentrated in a few named tasks.
+- [`references/edit-design-lessons.md`](references/edit-design-lessons.md) — the scorer audit, guard
+  closure, and the measured backfires behind the edit-form table. **Load** before editing a surface
+  for the first time, or after two rejects.

--- a/skills/algorithms/agent-optimize/references/measured-lessons.md
+++ b/skills/algorithms/agent-optimize/references/measured-lessons.md
@@ -611,6 +611,15 @@ A mechanism that fires on two tasks and lifts them 0.15 → 0.45 is resolvable a
 tasks (≈3 SE) and invisible in a 12-task mean at n=10 (≈0.5 SE). Same edit, same rollout budget: one
 design answers the question and the other cannot.
 
+**When an effect sits below the floor, pre-register directional predictions and use a SIGN TEST.**
+The floor bounds what a *mean* can resolve; it does not bound what a *pattern of directions* can.
+Write down, before its arm runs, which way each prediction should go, then count. Measured: **9 of 10
+predictions positive gave p = 0.0107** on a set where no individual z reached 2 — the effect was real
+and every per-arm reading was individually inconclusive. Two conditions make it a test rather than a
+story: the predictions are recorded *before* the arms run (a direction chosen after the fact is not
+evidence of anything), and they are directions, not magnitudes. A post-hoc count of which way things
+happened to go is worthless, so if you did not write them down, you did not run the test.
+
 **A screening band is not a baseline.** Per-task rates from a small trial count tell you where to
 *look*; they do not tell you where you *are*. In one run, ten tasks whose 3-trial bands summed to
 2.33 measured **4.04** at n=10 — the screen understated the artifact by 1.71 task-equivalents (0.057

--- a/skills/algorithms/gepa/SKILL.md
+++ b/skills/algorithms/gepa/SKILL.md
@@ -12,10 +12,11 @@ sources: [gepa]
 # gepa — sample-efficient reflective Pareto search
 
 `algorithms/hill-climb` owns the mechanics every algorithm shares: parent →
-proposal → val gate → commit. Read it first. This page states only what GEPA
-(Agrawal et al., 2025) does **differently**, and why those differences are the
-paper's actual contribution rather than decoration. A thin wrapper over
-`cap_evolve.gepa.gepa_loop`.
+proposal → val gate → commit, specified once in
+`algorithms/hill-climb/references/run-step.md`. Read that first. This page states
+only what GEPA (Agrawal et al., 2025) does **differently**, and why those
+differences are the paper's actual contribution rather than decoration. A thin
+wrapper over `cap_evolve.gepa.gepa_loop`.
 
 ## The two mechanisms, and why removing either turns GEPA back into hill-climb
 
@@ -88,8 +89,11 @@ For a single-file capability the two coincide and the merge skips gracefully
 
 - `--max-metric-calls` (default 0 = unlimited): PRIMARY budget, checked
   **between** iterations. An in-flight iteration runs to completion, so actual
-  spend can exceed it by up to `2·minibatch-size + |val|·n-trials` (one more
-  minibatch on a merge iteration). Set it below your hard ceiling.
+  spend can exceed it by up to `2·minibatch-size + |val|·n-trials` — and a merge
+  fires *inside* an accepting iteration, adding `3·minibatch-size` (the merge and
+  BOTH parents, on a freshly sampled minibatch) plus a second `|val|·n-trials`,
+  for a worst case of `5·minibatch-size + 2·|val|·n-trials`. Set it below your
+  hard ceiling.
 - `--max-iterations` (default 50): secondary cap on propose→gate iterations.
 - `--minibatch-size` (default 4): train ids per cheap local gate.
 - `--n-trials` (default 1): rollouts/task on the full-val eval (raise under noise
@@ -119,16 +123,13 @@ For a single-file capability the two coincide and the merge skips gracefully
   question. And on an eval-cache hit only `{reward, feedback}` were stored, so
   `Agent output:` comes out empty; re-sampled parents hit the cache routinely
   (#111, PR #210).
-- Candidate snapshots keep the loop's own scratch (`REFLECTION.md`/`FOCUS.md`/…)
-  because the snapshot call omits the ignore list every other algorithm passes
-  (#110, PR #350). Those are excluded from the component list, but the
-  optimizer-agent dotfiles (`.claude/`, `CLAUDE.md`, `AGENTS.md`) are **not**, so
-  round-robin can burn an iteration on one.
 - Iterations are charged against budget while no `step` event is emitted, so
   consumers counting iterations from `step` records see zero (#216/#224, PR #356).
-- Optimizer context reaching GEPA has been narrower than hill-climb's (#109,
-  PR #355). `JOURNAL.md` is injected as the cross-run handover but never
-  accumulates here, which is why step 3 above leaves it out of the list.
+- `JOURNAL.md` is injected as the cross-run handover but never accumulates here:
+  `_reconcile_journal` folds the optimizer's new entry back into the run-level file
+  from `harness.run_step` only, and GEPA runs the optimizer itself. Every iteration
+  therefore reads the same journal the first one did — which is why step 3 above
+  leaves it out of the list.
 - If `splits.train` is empty the minibatch silently falls back to **val** ids,
   putting the gate split in front of the proposer, with no warning. Do not run
   GEPA with a zero-size train split.

--- a/skills/algorithms/gepa/SKILL.md
+++ b/skills/algorithms/gepa/SKILL.md
@@ -56,8 +56,11 @@ sees the split its gate is computed on.
    header always reads `0/N pass` — read it as "sampled tasks, worst first". Each
    entry is truncated to ~800 chars and at most 12 tasks are written: a summary,
    not an archive; untruncated rollouts stay in `rollouts/train/`. The prompt also
-   carries the run's cross-iteration files (`LEDGER.md`, `PROCESS.md`, `RUNMAP.md`
-   + `prior_iterations/`) so a proposal builds on prior work.
+   carries the run's cross-iteration files (`LEDGER.md`, `JOURNAL.md`, `PROCESS.md`,
+   `RUNMAP.md` + `prior_iterations/`) so a proposal builds on prior work. All five are
+   real here since #396: `harness.record_iteration` writes the `step` event those
+   files are built from and folds the optimizer's appended `JOURNAL.md` entry back
+   into the run-level handover, so the history accumulates across iterations.
 4. **Local gate** — child on the same minibatch, `sum(child) > sum(parent)`, else
    dropped with no val spend. This is the extra stage; everything after it is
    hill-climb's.
@@ -105,7 +108,10 @@ For a single-file capability the two coincide and the merge skips gracefully
   eval surface (scorer/gold/tasks/tests).
   A child that edits one is **INDECISIVE** — no reward recorded, not remembered
   as rejected, stall counter untouched — because scoring a gold-hacking edit at
-  all would teach the optimizer that it worked.
+  all would teach the optimizer that it worked. It still **charges
+  `spent.iterations`** (`record_iteration(..., indecisive=True)`): the rollouts and
+  the optimizer call were really spent, so the spend meter counts it and only the
+  evidence meter does not.
 - `--workers` (default 1): pools the minibatch rollouts. Only safe when the
   adapter's `run_target` is thread-safe.
 - `--store` / `--store-commit-cmd` (default `git`): where accepted candidates are
@@ -118,21 +124,22 @@ For a single-file capability the two coincide and the merge skips gracefully
 
 ## Known gaps (present tense — the shipped loop, not the paper)
 
-- The reflective dataset does **not** carry the task input, though `gepa.py`'s
-  docstring claims it does — the optimizer sees a bad answer to an unknown
-  question. And on an eval-cache hit only `{reward, feedback}` were stored, so
-  `Agent output:` comes out empty; re-sampled parents hit the cache routinely
-  (#111, PR #210).
-- Iterations are charged against budget while no `step` event is emitted, so
-  consumers counting iterations from `step` records see zero (#216/#224, PR #356).
-- `JOURNAL.md` is injected as the cross-run handover but never accumulates here:
-  `_reconcile_journal` folds the optimizer's new entry back into the run-level file
-  from `harness.run_step` only, and GEPA runs the optimizer itself. Every iteration
-  therefore reads the same journal the first one did — which is why step 3 above
-  leaves it out of the list.
-- If `splits.train` is empty the minibatch silently falls back to **val** ids,
-  putting the gate split in front of the proposer, with no warning. Do not run
-  GEPA with a zero-size train split.
+Two. Re-derived against current `main`, because most of what this section used to
+list has since been fixed in core: the hollow eval-cache reflection by #387, the
+missing `step` record and the non-accumulating `JOURNAL.md` by #396
+(`harness.record_iteration` is now the one place every algorithm ends an iteration,
+and GEPA calls it), and the dirty snapshots plus the un-excluded optimizer-agent
+dotfiles by #350 and #386. Check the two below before trusting them.
+
+- The reflective dataset does **not** carry the task input, though
+  `_write_reflection`'s own docstring says each failing task "contributes its
+  input" (`gepa.py:230`). It writes `Agent output` / `Trajectory` / `Feedback` and
+  no input field (`:263-267`), so the optimizer sees a bad answer to a question it
+  cannot read. Since #387 the output and trace survive an eval-cache hit, so the
+  entry is no longer *hollow* — just anonymous.
+- If `splits.train` is empty the minibatch silently falls back to **val** ids
+  (`gepa.py:530`), putting the gate split in front of the proposer, with no
+  warning. Do not run GEPA with a zero-size train split.
 
 ## How to run
 

--- a/skills/algorithms/gepa/references/concepts.md
+++ b/skills/algorithms/gepa/references/concepts.md
@@ -98,11 +98,12 @@ feeding both the loop and the dashboard.
 ## Round-robin component focus
 
 A candidate's **components** are its editable capability files (`NON_CAPABILITY_FILES`
-scratch/memory files and vcs dirs excluded — the same exclusion the eval cache uses).
-Note the exclusion list does *not* cover the optimizer-agent dotfiles that
-`harness._SNAPSHOT_IGNORE` drops (`.claude/`, `CLAUDE.md`, `AGENTS.md`, `guidance/`,
-`trajectories/`), so if those are present in the candidate dir round-robin can spend
-a whole iteration focused on one of them. With
+scratch/memory files and `NON_CAPABILITY_DIRS` vcs/read-context dirs excluded — the same
+exclusion the eval cache uses). That list covers the whole injected read-context — the
+optimizer-agent dotfiles (`.claude/`, `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`) as well as
+`guidance/`, `trajectories/` and `prior_iterations/` — so round-robin cannot spend an
+iteration focused on one of them, and an un-ignored read-context dir cannot bust the eval
+cache every iteration. With
 `--component-selector round_robin` the loop focuses **one component per iteration**
 (cycled), writing the choice to `FOCUS.md`, so each proposal is a small, attributable
 change — which is exactly the unit the system-aware merge later recombines. `all`

--- a/skills/algorithms/skillopt/SKILL.md
+++ b/skills/algorithms/skillopt/SKILL.md
@@ -20,9 +20,8 @@ assumes which.
 optimizer call, the val evaluation, the significance gate, accept/reject,
 snapshot/best, the memory and handover files: all of that is
 `harness.run_step`, documented once in `algorithms/hill-climb/SKILL.md`
-§ "One iteration, end to end" and `algorithms/hill-climb/references/run-step.md`
-(both land with PR #370; until then read `harness.run_step` itself). This file
-states only what SkillOpt does differently.
+§ "One iteration, end to end" and `algorithms/hill-climb/references/run-step.md`.
+This file states only what SkillOpt does differently.
 
 Know the bound before reaching for this algorithm: **`run_step` lets a caller
 vary exactly two things — `parent_dir` and `instructions`.** SkillOpt pins
@@ -39,7 +38,7 @@ epoch. It is prompt shaping and step scheduling, not a different search.
    never mechanically enforced. See the next section before you tune it.
 2. **A per-epoch rejected-edit list.** Each reject appends its candidate id and
    val Δ, and the next step's prompt asks the optimizer to avoid them
-   (`skillopt.py:120-125`, `:322-327`). It carries no description of *what* the
+   (`skillopt.py:120-125`, `:330-335`). It carries no description of *what* the
    rejected edit changed, so treat it as a weak signal — the run-global
    `LEDGER.md` that `run_step` already injects names the tasks each prior edit
    broke and fixed, which is strictly more useful.
@@ -48,7 +47,7 @@ epoch. It is prompt shaping and step scheduling, not a different search.
    regressed / persistent-failure / stable-success, and asks for a consolidating
    edit that fixes regressions without breaking the stable passes. It goes
    through the same `run_step` and the same val gate — it is never
-   force-accepted (`skillopt.py:479-485`). Disable with `--no-slow-update`.
+   force-accepted (`skillopt.py:493-499`). Disable with `--no-slow-update`.
    A fourth bucket, `improved`, is computed and logged but is *not* exclusive
    with the others and never reaches the prompt (`skillopt.py:184-191`, `:139-166`).
 
@@ -82,32 +81,44 @@ is a heuristic that has not been isolated; do not present it as a proven one.
 ## Known gaps
 
 These are shipped-behavior defects in `core/cap_evolve/skillopt.py`. The skill
-describes what the code does today, not what it intends to do.
+describes what the code does today, not what it intends to do. Line numbers are
+against current `main` — check them; if one no longer says what it is cited for,
+the gap has moved and this section is what needs re-deriving.
 
 - **The mini-batch never reaches the optimizer** (issue #371). Mini-batch ids come
-  from **train** (`skillopt.py:230`) but filter the parent's **val** rows
-  (`skillopt.py:291` → `harness.py:2011-2012`; also `:315`, `:319`), and splits are
-  disjoint slices (`splits.py:117-119`). Every step renders `0 solid / 0 flaky /
-  0 failing of 0 tasks` with no task ids, and `## Failure patterns still unsolved`
-  never appears — while the `(mini-batch of N train tasks, L=…)` label still
-  prints, which is why it looked healthy. Until #371 lands the per-step signal is
-  the label plus the `L` sentence, so the epoch/mini-batch structure is
-  bookkeeping rather than focus. PR #370 fixed the same defect in hill-climb's
-  `cyclic`/`hardest-first` modes.
+  from **train** (`skillopt.py:237`, sliced at `:291`) but are handed to
+  `ctx.instructions` (`:300`) to filter the parent's **val** rows
+  (`harness.py:2004-2006`; the same train-vs-val mismatch at `:323`, `:327`), and
+  splits are disjoint slices (`splits.py:117-119`). So the focus summary always
+  renders `0 solid / 0 flaky / 0 failing of 0 tasks`, the failure index is empty,
+  and `## Failure patterns still unsolved` never appears — while the
+  `(mini-batch of N train tasks, L=…)` label still prints, which is why it looked
+  healthy. (The whole-val protect-these-ids block *is* populated, from
+  `harness.py:2013` — that is the only per-task content a step gets.) Until #371
+  lands the per-step signal is the label plus the `L` sentence, so the
+  epoch/mini-batch structure is bookkeeping rather than focus. PR #370 fixed the
+  same defect in hill-climb's `cyclic`/`hardest-first` modes.
 - **The epoch-boundary re-evaluation scores the whole train split, not a sample.**
-  `skillopt.py:458-463` calls `evaluate_candidate(..., split="train")` twice with
+  `skillopt.py:467-472` calls `evaluate_candidate(..., split="train")` twice with
   no `ids=`, then discards everything outside the ~20 sampled ids
-  (`:464-466`). Budget it as `2 × len(train) × n_trials` rollouts per boundary.
+  (`:473-475`). Budget it as `2 × len(train) × n_trials` rollouts per boundary.
 - **When an epoch accepted nothing, the comparison is vacuous.** The re-eval is
-  guarded by `prev_epoch_best_id != run_dir.best_id` (`skillopt.py:455`); if
+  guarded by `prev_epoch_best_id != run_dir.best_id` (`skillopt.py:464`); if
   nothing moved, both sides stay `current_val` — the same list — so 0 regressed
   and 0 improved are reported over **val** tasks while the log line claims a
-  train sample size (`:469-470`). The consolidation step still runs.
-- **`requested_edits` vs `applied_changes` surfaces nothing.**
-  `_changed_components` (`skillopt.py:398-427`) counts files whose bytes differ,
-  not edits, and `applied_changes` is written at `:338`/`:345` and read nowhere —
-  no dashboard column, no check, no warning. A run at `L=4` logged
-  `applied_changes: 6` with no consequence.
+  train sample size (`:478-482`). The consolidation step still runs.
+- **`requested_edits` vs `applied_changes` surfaces nothing, and the number is wrong.**
+  `_changed_components` (`skillopt.py:406-435`) counts files whose bytes differ, not
+  edits, and `applied_changes` is written at `:346`/`:353` and read nowhere — no
+  dashboard column, no check, no warning. It also over-counts, because its ignore
+  list (`:420`) matches seven `.md` **basenames** while `run_step` injects a whole
+  read-context — `guidance/`, `trajectories/`, `prior_iterations/*/diff.patch` — that
+  `_SNAPSHOT_IGNORE` keeps *out* of the parent snapshot, so every injected file reads
+  as an applied edit. Measured zero-API on `examples/toy_calc` at `L=4`: a step whose
+  optimizer edited exactly one file logged `applied_changes: 10` (9 injected + 1
+  real), and the next step logged `10` again with the capability file **byte-identical
+  to its parent**. The metric has no zero, so it cannot detect the one thing it exists
+  to detect: an optimizer that made no edit at all.
 - **"skill" leaks into the live prompt.** `skillopt.py:147` tells the optimizer to
   compare "the skill" regardless of which capability is under optimization. An
   algorithm must be capability-agnostic; this text is not.

--- a/skills/algorithms/skillopt/SKILL.md
+++ b/skills/algorithms/skillopt/SKILL.md
@@ -88,15 +88,16 @@ the gap has moved and this section is what needs re-deriving.
 - **The mini-batch never reaches the optimizer** (issue #371). Mini-batch ids come
   from **train** (`skillopt.py:237`, sliced at `:291`) but are handed to
   `ctx.instructions` (`:300`) to filter the parent's **val** rows
-  (`harness.py:2004-2006`; the same train-vs-val mismatch at `:323`, `:327`), and
+  (`harness.py:2270-2272`; the same train-vs-val mismatch at `:323`, `:327`), and
   splits are disjoint slices (`splits.py:117-119`). So the focus summary always
-  renders `0 solid / 0 flaky / 0 failing of 0 tasks`, the failure index is empty,
-  and `## Failure patterns still unsolved` never appears — while the
-  `(mini-batch of N train tasks, L=…)` label still prints, which is why it looked
-  healthy. (The whole-val protect-these-ids block *is* populated, from
-  `harness.py:2013` — that is the only per-task content a step gets.) Until #371
-  lands the per-step signal is the label plus the `L` sentence, so the
-  epoch/mini-batch structure is bookkeeping rather than focus. PR #370 fixed the
+  renders `0 solid / 0 flaky / 0 failing of 0 focused task(s) of N on val`, the
+  failure index is empty, and `## Failure patterns still unsolved` never appears —
+  while the `(mini-batch of N train tasks, L=…)` label still prints, which is why it
+  looked healthy. (The whole-val protect-these-ids block *is* populated, from
+  `harness.py:2279` — that is the only per-task content a step gets, and #391 added
+  the `of N on val` scope precisely so those two numbers stop contradicting each
+  other.) Until #371 lands the per-step signal is the label plus the `L` sentence, so
+  the epoch/mini-batch structure is bookkeeping rather than focus. PR #370 fixed the
   same defect in hill-climb's `cyclic`/`hardest-first` modes.
 - **The epoch-boundary re-evaluation scores the whole train split, not a sample.**
   `skillopt.py:467-472` calls `evaluate_candidate(..., split="train")` twice with


### PR DESCRIPTION
Post-merge review of four skill PRs merged without independent review — **#368** agent-optimize, **#369** gepa, **#380** skillopt, **#373** mcp-tool — plus the fixes for everything real that it found. Full write-up in `.review/postmerge-algos.md`.

The headline: **#369 and #380 were honest when written and have decayed since.** Both re-derived their SKILL.md against the code, then `#386` (the shared `OptimizerContext`) and `#350` restructured `gepa.py`/`skillopt.py` underneath them. Nothing noticed, because a hand-derived skill-vs-code table has no guard. That is the failure mode this whole effort was fixing, reappearing not through carelessness but through absence of a mechanism.

## Re-derived divergence counts

| | claimed | re-derived on current `main` |
|---|---|---|
| **#369 gepa** | 14 divergences, 4 flagged as gaps | **2 of the 4 flagged gaps are no longer real**; 3 live divergences remain (1 of them a wrong budget ceiling), + 1 in `references/concepts.md` |
| **#380 skillopt** | 10 divergences, 5 flagged as gaps | **all 5 gaps still real** (one worse than documented), but **11 of 18 `file:line` citations now point at unrelated code** |

### gepa

Removed two gaps that are fixed:

- Candidate snapshots **do** pass `_SNAPSHOT_IGNORE` at both call sites (`gepa.py:682`, `:846`) since #350, and `NON_CAPABILITY_FILES`/`DIRS` **do** exclude `CLAUDE.md`/`AGENTS.md`/`.claude`/`guidance`/`trajectories`/`prior_iterations` since #386 (`types.py:26-43`) — so round-robin *cannot* burn an iteration on a dotfile. `references/concepts.md:100-105` asserted the exact opposite of what #386 deliberately changed.
- Optimizer-context parity with hill-climb (#109) is fixed: `gepa_loop` takes the shared `OptimizerContext` and calls the same `inject()`/`instructions()` as its siblings. Rewritten down to the half that *is* still true — `JOURNAL.md` never accumulates in gepa, because `_reconcile_journal` is called from `harness.run_step` only (`harness.py:1578`) and gepa runs the optimizer itself.

Fixed a budget number that could cost real money: the `--max-metric-calls` overshoot bound said "`2·mb + |val|·n-trials`, one more minibatch on a merge iteration". A merge fires *inside* an accepting iteration and evaluates the merge **and both parents** on a **freshly sampled** minibatch, then pays a second full val — worst case `5·mb + 2·|val|·n_trials`.

Everything else in gepa's body verified accurate: the frequency-weighted per-instance sampling vs the strict `pareto_frontier` (two genuinely different sets), the `sum(child) > sum(parent)` local gate, the `reward < 1.0` threshold, the ~800-char/12-task caps, `--max-merges` counting attempts-that-built (a skip is free), the INDECISIVE tamper path, and all nine hyperparameter defaults. Gap 1 (no task input in the reflective dataset, despite the docstring at `gepa.py:222` claiming one) and gap 5 (empty train ⇒ silent **val** fallback at `:522`) are both still live.

### skillopt

All five gaps reproduce. But every citation that makes them checkable had drifted 7-9 lines: `skillopt.py:230`, cited for the train-ids read, is now a docstring line. All 11 refreshed, plus a standing note that a citation which stops matching means the section needs re-deriving. Also dropped the stale "*both land with PR #370; until then read `harness.run_step` itself*" — #370 landed as `ae71aa87`.

One gap was **understated**. `applied_changes` is not merely uninformative; its ignore list matches seven `.md` *basenames* while `run_step` injects `guidance/`, `trajectories/`, `prior_iterations/*/diff.patch` that `_SNAPSHOT_IGNORE` keeps *out* of the parent snapshot. Measured zero-API on `examples/toy_calc` at `L=4`:

```
epoch 1 step 1  requested_edits=4  applied_changes=10  accept=true
epoch 2 step 1  requested_edits=4  applied_changes=10  accept=false
```

Step 1's 10 = 7 injected `guidance/*` + 2 `trajectories/*` + **1** real edit. Step 2 logged 10 again with `prompt.txt` **byte-identical to its parent**. The metric has no zero, so it cannot detect the one thing it exists to detect: an optimizer that made no edit.

One imprecision corrected: gap 1 said the step renders "no task ids". The focus summary and failure index are empty, but `_passing_block` is built from the **whole** val split since #370 (`harness.py:2013`), so protect-these-ids *is* populated — and it is the only per-task content a step gets.

## #368's token budget

Measured with `tiktoken` `cl100k_base`, body only (the `description` is separately-budgeted always-in-context metadata, per `.review/skill-duplication-analysis.md`):

| | lines | body tokens |
|---|--:|--:|
| pre-#368 | 922 | — |
| as merged by #368 | 337 | **5,580** |
| this PR | 311 | **5,000** |

#368 reported ~5,444; the real figure was **5,580**, 11.6% over the ≤5,000 bar, flagged rather than fixed. **It was not earning its place, so it is cut** — −580 tokens, no rule deleted. What moved was restatement of its own references or of `references/algorithm.md`: the fan-out invariants' rationale (`algorithm.md` § *Parallelism* states all four in full), the parallelism enumeration, the helper flags `per-task-fanout.md` carries verbatim (`--supersedes`, `--floor`, `--canary-auto`, `--traces`, `dropped_additions`), the `measure.py` refusals' reasoning. Plus one genuine triplication: "a candidate inside the null band is not evidence" appeared three times in one body.

Two counting bugs #368 left behind, both fixed: "state these **five** invariants" over a four-item list (it had merged items 4+5), and "**Two** rules decide whether a round's number means anything" over three.

**One real instruction loss, restored.** SKILL.md names "the sign test for effects below the floor" as living in `references/measured-lessons.md`. #368 moved the section and dropped the rule, so the pointer led nowhere. Pre-registered directional predictions + a sign test (9/10 positive, `p = 0.0107`, where no individual z reached 2) are back where the pointer promises them, with the two conditions that make it a test rather than a story.

`core/tests/test_agent_optimize_skill.py` **passes unmodified** — and it earned its keep mid-review: it pins the literal term `re-gate`, which one of my compressions had paraphrased away. `scripts/check.py` caught a second (`no-regression`). Both restored. Worth naming rather than quietly fixing.

## #373's guard, verified empirically

Reproduced against the shipped `tool_surface` with mcp-tool's real policy:

```
(1) params edit carrying properties/type/required
    report: {"changed": ["params:kb_search"], "refused": []}
    parameters now: {"type": "array", "properties": {...}, "required": ["injected"]}
(2) add edit carrying a code key
    report: {"changed": ["add:srv"], "refused": []}   added keys: ['code','description','name','parameters']
(3) validate() → {"ok": true, "problems": []}         references load_policy: False
(4) only inputs/policy.json  → ignored
    capability_dir/policy.json → read
```

All four claims hold, and the skill states them plainly under "**The policy checks the edit's LABEL, not its effect**" rather than implying enforcement. **No change needed to the skill.**

But #373's policy-path correction had not reached the code that *defines* the answer: `tool_surface.py`'s module docstring and `load_policy`'s own docstring both still told the reader the loader reads `inputs/policy.json`, which it ignores. Fixed here (core, not a skill).

**No skill in scope names the wrong path.** `mcp-tool/SKILL.md:58-61` mentions `inputs/policy.json` only to rule it out.

## Instruction loss

`git show` on each merge commit, removed lines diffed against the current body + every reference, then a mechanical audit of bolded spans and backticked identifiers. Beyond #368's sign test: **#369 no loss**, **#373 no loss** (the annotations table, human-in-the-loop, and execution-vs-protocol errors all landed in `references/concepts.md` §4). Ownership compliance is good across all four — nobody restates the honesty invariants, the agent-mode loop, the failure taxonomy or the reflective-dataset format. Two pointer shortfalls fixed: gepa pointed at `hill-climb/SKILL.md` rather than its `references/run-step.md`, and skillopt's pointer was gated on an already-landed PR.

## The test convention this adds

`core/tests/test_skill_code_claims.py` — 7 tests, 3 **failing-first** (proof: `/tmp/capreview-postmerge-algos-failingfirst.py`). The point is the convention, not the coverage:

> **A skill that documents a code defect needs a test that fails when the defect is FIXED.**

Otherwise the doc silently becomes a lie the moment someone does the right thing — which is exactly what #386 did to #369, twice. `test_skillopt_minibatch_focus_is_still_empty_by_construction` fails the day #371 lands, and its message names the paragraph to delete.

## Verification

- `PYTHONPATH="$PWD/core:$PWD/dashboard/backend" python -m pytest core/tests -q` → **812 passed, 12 skipped** (805 baseline + 7 new). Always pinned — #349.
- All four skills' `scripts/check.py` → `ok: true, problems: []`.
- Zero-API runs on `examples/toy_calc` with the mock optimizer, both reaching a gate-accepted candidate and a sealed test score:

  | | gepa | skillopt |
  |---|---|---|
  | best_id | `gepa_0001` | `so_e01s01` |
  | accepts / val | 1 / 1.0 | 1 / 1.0 |
  | **sealed test** | **1.0** (baseline 0.0) | **1.0** (baseline 0.0) |

  **Honest caveat:** both fired `gate_warning` — "paired SE is 0 (likely n_trials=1) … falling back to STRICT (accept any delta>0)". Expected on a deterministic `n_trials=1` example and reported honestly by the engine, but these are STRICT-fallback accepts. They prove the plumbing and the seal, not the gate's discrimination.

## What other owners should pick up

Not touched, per the ownership contract:

- **`tools`** — `references/{examples.md:366, pitfalls.md:127, concepts.md:114}` still say the effective policy is `inputs/policy.json`. Child of #352; the core docstrings are fixed here, so these three are the last wrong surfaces.
- **`phases/gate`** — #380 deleted a *"Pitfall: small val sets"* whose `--n-trials` half survives in skillopt's body but whose other half does not live anywhere: *use a **graded** reward so the paired significance test has signal.* `gate` owns the significance bar; it belongs there.
