### PR TITLE
feat(skills): make the skill authoring lint blocking — the baseline is empty (#107) [rebased, supersedes #345]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,6 +201,30 @@ jobs:
       - name: Check documented cap-evolve subcommands exist
         run: python3 ci/check_cli_subcommands.py
 
+  lint-skills:
+    name: Skill authoring lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      # Points the shipped skill-package validator at the repo's OWN skills, so the
+      # framework is held to the authoring bar it advertises in CONTRIBUTING.md.
+      #
+      # BLOCKING, with no violation baseline. It was designed report-only against a
+      # 14-violation baseline while the skills were rewritten under #322-#339; that
+      # sweep cleared all 14, so the tree is clean and the next violation is a
+      # regression to fix rather than debt to record. Advisory findings (description
+      # style, bundled-script self-check) print but never fail the step.
+      - name: Lint bundled skills against the authoring rules
+        run: python skills/_registry/lint_skills.py skills
+
   spellcheck:
     name: Spellcheck (docs)
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,11 @@ them off as clean CI runs.
 
 ## Quality bar for skills
 - SKILL.md body under ~500 lines (it is the primary doc); references one level deep with a TOC if long, and only when filled.
+- Check it yourself with `python skills/_registry/lint_skills.py skills` — the same
+  validator the `skill-package` capability applies to user skills, pointed at ours.
+  CI runs it as a **blocking** job and the tree is clean, so a violation it reports
+  is a regression in your change. Advisory lines (description style, a bundled
+  script with no `--self-check`) print but do not fail.
 - A real `check.py` smoke test (not just an import) that fails on stubs and on
   non-determinism.
 - Ground claims in cited papers/repos/docs.

--- a/core/tests/test_skill_authoring_lint.py
+++ b/core/tests/test_skill_authoring_lint.py
@@ -1,0 +1,332 @@
+"""The skill authoring lint itself is under test, not merely its verdict.
+
+Two halves:
+
+1. **Rule table.** A known-good fixture skill must pass every rule, and one
+   deliberately-broken fixture per rule must fail with a message that names the
+   problem. Without this, a reworded or accidentally-dead check turns the lint into
+   a silent no-op and nobody notices.
+2. **Lint plumbing.** Discovery must stay dynamic, the coverage-drift guard must
+   fire, every PROMOTED fragment must be reachable from a real violation, the
+   output must be byte-identical across processes, and the tree must be clean —
+   the lint is blocking, so a violation is a regression, not recorded debt.
+
+Which bucket a finding lands in (``problems`` = hard, ``warnings`` = promoted by the
+lint) is asserted per rule on purpose: the lint's promotion table is coupled to
+``abstract.py``'s wording, so a reclassification has to be a deliberate edit here
+rather than a silent hole.
+"""
+
+import importlib.util
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+SKILLS = REPO / "skills"
+LINT = SKILLS / "_registry" / "lint_skills.py"
+
+GOOD_DESC = ("Extracts tabular data from spreadsheets and writes a tidy CSV. Use when "
+             "the user has an xlsx/csv and wants columns reshaped, filtered, or joined.")
+
+
+def _lint_module():
+    spec = importlib.util.spec_from_file_location("lint_skills", LINT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def validator():
+    return _lint_module()._load_validator(SKILLS)
+
+
+def _skill(tmp: Path, *, name="fixture-skill", desc=GOOD_DESC,
+           body="# Fixture\n\nDo the thing.\n",
+           refs: dict[str, str] | None = None, frontmatter: str | None = None) -> Path:
+    """Write one skill package and return its directory."""
+    cap = tmp / "cap"
+    cap.mkdir(parents=True, exist_ok=True)
+    fm = frontmatter if frontmatter is not None else f"name: {name}\ndescription: {desc}"
+    (cap / "SKILL.md").write_text(f"---\n{fm}\n---\n\n{body}", encoding="utf-8")
+    for rel, text in (refs or {}).items():
+        target = cap / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(text, encoding="utf-8")
+    return cap
+
+
+def _lines(n: int, prefix: str = "Line") -> str:
+    return "\n".join(f"{prefix} {i} of prose that carries no real weight." for i in range(n))
+
+
+def _long_ref_without_toc(n: int = 400) -> str:
+    return "# Long reference\n\n## An ordinary first section, not a TOC\n\n" + _lines(n)
+
+
+def _long_ref_with_toc(n: int = 400) -> str:
+    toc = "\n".join(f"- [Section {i}](#section-{i})" for i in range(4))
+    return f"# Long reference\n\n{toc}\n\n## Section 0\n\n" + _lines(n)
+
+
+# (rule id, kwargs for _skill, expected fragment, bucket the finding lands in)
+BROKEN = [
+    ("name-missing", dict(frontmatter=f"description: {GOOD_DESC}"),
+     "missing 'name'", "problems"),
+    ("name-too-long", dict(name="a" * 65), "must be <=64 chars", "problems"),
+    ("name-bad-charset", dict(name="Fixture_Skill"), "lowercase [a-z0-9-]", "problems"),
+    ("name-xml", dict(frontmatter=f'name: "<x>fixture</x>"\ndescription: {GOOD_DESC}'),
+     "name must not contain XML tags", "problems"),
+    ("desc-missing", dict(frontmatter="name: fixture-skill"),
+     "missing a non-empty 'description'", "problems"),
+    ("desc-empty", dict(frontmatter='name: fixture-skill\ndescription: ""'),
+     "missing a non-empty 'description'", "problems"),
+    ("desc-too-long", dict(desc="Reshapes data. Use when asked. " + "x" * 1024),
+     "chars (>1024)", "problems"),
+    ("desc-xml", dict(desc="Routes <phase> requests. Use when the user names a phase."),
+     "description must not contain XML tags", "problems"),
+    ("desc-no-when-clause", dict(desc="Processes documents and returns extracted text."),
+     "should say WHEN to use the skill", "warnings"),
+    ("body-over-500-lines", dict(body="# Fixture\n\n" + _lines(600)),
+     "lines (>500)", "problems"),
+    ("body-over-5000-tokens", dict(body="# Fixture\n\n" + _lines(460)),
+     "tokens (>5000", "warnings"),
+    ("reference-nested-dir", dict(refs={"references/deep/inner.md": "# Inner\n"}),
+     "level deep", "warnings"),
+    ("reference-links-reference",
+     dict(refs={"references/a.md": "# A\n\nSee [b](b.md).\n", "references/b.md": "# B\n"}),
+     "keep references one level deep", "warnings"),
+    ("reference-links-reference-as-if-from-skill-md",
+     dict(refs={"references/a.md": "# A\n\nSee [b](references/b.md).\n",
+                "references/b.md": "# B\n"}),
+     "keep references one level deep", "warnings"),
+    ("long-reference-without-toc", dict(refs={"references/long.md": _long_ref_without_toc()}),
+     "table of contents", "warnings"),
+    ("broken-link-from-body", dict(body="# Fixture\n\nSee [gone](references/gone.md).\n"),
+     "'references/gone.md' which does not exist", "problems"),
+    ("broken-link-from-reference",
+     dict(refs={"references/a.md": "# A\n\nSee [script](../scripts/gone.py).\n"}),
+     "does not exist", "warnings"),
+]
+
+
+def test_a_well_formed_skill_passes_every_rule(tmp_path, validator):
+    """The known-good fixture exercises every rule's happy path: a long reference WITH
+    a TOC, references linked only from SKILL.md, a live anchored link, and a legitimate
+    ``../SKILL.md`` back-link from a reference (which must NOT read as a ref->ref hop)."""
+    cap = _skill(
+        tmp_path,
+        body=("# Fixture\n\nDo the thing.\n\n"
+              "Read [the long reference](references/long.md) for the details, and "
+              "[the short one](references/short.md#a-heading) for the summary.\n"),
+        refs={"references/long.md": _long_ref_with_toc(),
+              "references/short.md": "# Short\n\n## A heading\n\n"
+                                     "Back to [the skill](../SKILL.md).\n"},
+    )
+    v = validator.validate(cap)
+    assert v == {"ok": True, "name": "fixture-skill", "problems": [], "warnings": [],
+                 "scripts": []}
+
+
+@pytest.mark.parametrize("rule,kwargs,fragment,bucket",
+                         BROKEN, ids=[b[0] for b in BROKEN])
+def test_each_broken_fixture_fails_its_rule(tmp_path, validator, rule, kwargs, fragment, bucket):
+    v = validator.validate(_skill(tmp_path, **kwargs))
+    assert any(fragment in m for m in v[bucket]), (rule, fragment, v)
+    if bucket == "problems":
+        assert not v["ok"], (rule, v)
+    else:                      # a warning must not silently harden validate()
+        assert v["ok"], (rule, v)
+
+
+STRUCTURAL = [b for b in BROKEN if b[0] != "desc-no-when-clause"
+              and any(f in b[2] for f in ("lines (>", "tokens (>", "level deep",
+                                          "table of contents", "does not exist"))]
+
+
+@pytest.mark.parametrize("rule,kwargs,fragment,bucket", STRUCTURAL,
+                         ids=[b[0] for b in STRUCTURAL])
+def test_structural_findings_become_lint_errors(tmp_path, rule, kwargs, fragment, bucket):
+    """`validate()` keeps most structural findings as warnings so a mid-run optimizer is
+    not hard-blocked by a style budget; the repo's own lint promotes them to errors. If
+    abstract.py rewords one, PROMOTED stops matching and the lint silently goes blind —
+    so the promotion is asserted per rule, not just in aggregate. Findings abstract.py
+    already treats as hard problems reach the lint as errors directly."""
+    mod = _lint_module()
+    if bucket == "problems":
+        return                              # already an error, no promotion needed
+    assert any(frag in fragment for frag in mod.PROMOTED), (rule, fragment, mod.PROMOTED)
+
+
+def test_the_when_clause_advisory_stays_advisory():
+    """Judgement calls are reported, never failed: "say WHEN" is a heuristic on prose,
+    so it must not be promoted into a build-breaking error."""
+    mod = _lint_module()
+    assert not any(frag in "should say WHEN to use the skill" for frag in mod.PROMOTED)
+
+
+def test_the_script_advisories_stay_advisory():
+    """A bundled script with no declared '--self-check', or one importing subprocess, is
+    a judgement call the human reads in the diff — not a measurable authoring violation.
+    The repo has 130 of these today; promoting them would make the lint unusable."""
+    mod = _lint_module()
+    for advisory in ("has no declared '--self-check' entry point, so nothing verifies it",
+                     "uses subprocess — a bundled script is executable context",
+                     "has no real body (docstring/pass/... only)",
+                     "is an orphan — SKILL.md never points"):
+        assert not any(frag in advisory for frag in mod.PROMOTED), advisory
+
+
+def _repo_skills_copy(tmp_path: Path) -> Path:
+    root = tmp_path / "skills"
+    shutil.copytree(SKILLS, root, ignore=shutil.ignore_patterns("__pycache__", "*.pyc"))
+    return root
+
+
+def _run(root: Path, *args: str):
+    return subprocess.run([sys.executable, str(LINT), str(root), *args],
+                          capture_output=True, text=True)
+
+
+def test_the_repo_has_no_authoring_violations():
+    """The lint is BLOCKING with no baseline: the 14 violations it shipped against were
+    all cleared by the #322-#339 rewrites, so any violation now is a regression."""
+    out = _run(SKILLS)
+    assert out.returncode == 0, out.stdout + out.stderr
+    assert "no authoring violations" in out.stdout, out.stdout
+
+
+def test_the_violation_list_is_ordered_deterministically():
+    """The lint's output is diffed and read by humans across machines, so a wobble in
+    the order findings come out fails the build on a machine whose filesystem
+    enumerates references differently (this is what turned CI red the first time).
+    Sorted output pins it everywhere; abstract.py sorting its walks is the other belt."""
+    mod = _lint_module()
+    errors, advisories, _ = mod.lint(SKILLS)
+    for findings in (errors, advisories):
+        lines = mod._flatten(findings)
+        assert lines == sorted(lines), lines
+
+
+def test_the_output_is_byte_identical_across_processes():
+    """Sortedness inside one process is not the whole claim: two separate interpreters
+    (different hash seeds, a cold filesystem cache) must print the same bytes."""
+    first = _run(SKILLS)
+    second = _run(SKILLS)
+    assert first.stdout == second.stdout, "lint output differs between processes"
+    assert first.stdout.strip(), first.stdout
+
+
+def test_a_new_violation_fails_the_lint(tmp_path):
+    root = _repo_skills_copy(tmp_path)
+    (root / "phases" / "gate" / "SKILL.md").write_text(
+        f"---\nname: gate\ndescription: {GOOD_DESC}\n---\n\n# Gate\n\n" + _lines(600),
+        encoding="utf-8")
+    out = _run(root)
+    assert out.returncode == 1, out.stdout
+    assert "phases/gate" in out.stdout and "lines (>500)" in out.stdout, out.stdout
+
+
+def test_discovery_is_dynamic_and_sees_every_skill():
+    """The lint globs; it never reads a committed list that could go stale."""
+    mod = _lint_module()
+    on_disk = {p.parent.relative_to(SKILLS).as_posix() for p in SKILLS.glob("*/*/SKILL.md")}
+    _, _, n = mod.lint(SKILLS)
+    assert n == len(on_disk), (n, sorted(on_disk))
+    assert not mod._manifest_drift(SKILLS)
+
+
+def test_coverage_drift_fires_on_rename_away_plus_add_new(tmp_path):
+    """Non-vacuity: removing one skill and adding another in the same commit nets to the
+    same count, so a `n < MIN_SKILLS` floor would miss it. Comparing PATH SETS against
+    the committed manifest catches it, and needs no magic number."""
+    root = _repo_skills_copy(tmp_path)
+    shutil.rmtree(root / "phases" / "gate")
+    replacement = root / "phases" / "newskill"
+    replacement.mkdir()
+    (replacement / "SKILL.md").write_text(
+        f"---\nname: newskill\ndescription: {GOOD_DESC}\n---\n\n# New\n\nBody.\n",
+        encoding="utf-8")
+    out = _run(root)
+    assert out.returncode == 1, out.stdout
+    assert "renamed/moved/removed" in out.stdout, out.stdout
+    assert "phases/gate" in out.stdout, out.stdout
+
+
+def test_block_scalar_descriptions_are_actually_parsed(tmp_path, validator):
+    """`description: >-` used to parse as the literal '>-' (len 2), so EVERY description
+    check — including the XML-tag hard problem — passed vacuously on it. The parser must
+    read the folded value, and the checks must then fire on it."""
+    for mark, joined in ((">-", "first line second line"), ("|", "first line\nsecond line")):
+        fm, body = validator._parse_frontmatter(
+            f"---\nname: fixture\ndescription: {mark}\n  first line\n"
+            f"  second line\ncomponent: phase\n---\n\nBody.\n")
+        assert fm["description"] == joined, (mark, fm)
+        assert fm["component"] == "phase", fm     # keys AFTER the block still parse
+        assert body.strip() == "Body."
+
+    cap = _skill(tmp_path, frontmatter=("name: fixture\ndescription: >-\n"
+                                        "  Does a thing. Use when proving the parser reads a\n"
+                                        "  folded scalar. Wrap it in <X> tags."))
+    assert any("XML tags" in p for p in validator.validate(cap)["problems"])
+
+    # every shipped description is really parsed, not silently truncated to a marker
+    for skill_md in sorted(SKILLS.glob("*/*/SKILL.md")):
+        fm, _ = validator._parse_frontmatter(skill_md.read_text(encoding="utf-8"))
+        assert len(fm.get("description", "")) > 100, (skill_md, fm.get("description"))
+
+
+def test_an_anchor_in_a_link_is_not_part_of_the_path(tmp_path, validator):
+    """`references/x.md#a-heading` used to be existence-checked verbatim, so every deep
+    link read as broken — a false positive on a correct skill."""
+    cap = _skill(tmp_path, body="# F\n\nSee [detail](references/x.md#deep-heading).\n",
+                 refs={"references/x.md": "# X\n\n## Deep heading\n\nDetail.\n"})
+    v = validator.validate(cap)
+    assert v["problems"] == [] and v["warnings"] == [], v
+
+
+def test_a_back_link_to_skill_md_is_not_a_reference_hop(tmp_path, validator):
+    """`../SKILL.md` resolves *through* references/, so testing `refs / link` for
+    existence read a legitimate back-link as a sibling reference — a live false positive
+    on `capabilities/tools` before the target was judged on its RESOLVED path."""
+    cap = _skill(tmp_path, body="# F\n\nSee [x](references/x.md).\n",
+                 refs={"references/x.md": "# X\n\nBack to [the skill](../SKILL.md).\n"})
+    assert validator.validate(cap)["warnings"] == []
+
+
+def test_say_when_advisory_accepts_positional_when_phrasing(validator):
+    """The advisory demanded the literal bigram 'use when', so descriptions that state
+    WHEN positionally ('Use after intake') were false positives. Rewording good prose to
+    green a regex would be a downgrade; the check accepts both forms instead."""
+    for desc in ("Scores a candidate. Use when you need a number.",
+                 "Establishes the starting point. Use after implement-and-check.",
+                 "Applies the acceptance decision. Use to inspect one decision.",
+                 "Extracts the learning signal. Use between evaluation and edits."):
+        assert validator.SAYS_WHEN_RE.search(desc), desc
+    assert not validator.SAYS_WHEN_RE.search("Processes documents and returns text.")
+
+
+def test_promoted_fragments_still_match_the_validators_wording(tmp_path, validator):
+    """Each PROMOTED fragment must be reachable from a real violation. If abstract.py
+    rewords a finding, this fails loudly rather than the lint quietly going blind."""
+    mod = _lint_module()
+    cap = _skill(
+        tmp_path,
+        body="# F\n\n" + _lines(1400) + "\n\nSee [gone](references/gone.md).\n",
+        refs={"references/long.md": _long_ref_without_toc(),
+              "references/a.md": "# A\n\nSee [long](long.md) and [x](../scripts/gone.py).\n",
+              "references/nested/deep.md": "# Deep\n"},
+    )
+    v = validator.validate(cap)
+    findings = v["problems"] + v["warnings"]
+    for frag in mod.PROMOTED:
+        assert any(frag in m for m in findings), (frag, findings)
+    # …and each of them actually reaches the lint as an ERROR, not an advisory.
+    errs = [m for m in v["problems"]] + [
+        w for w in v["warnings"] if any(f in w for f in mod.PROMOTED)]
+    for frag in mod.PROMOTED:
+        assert any(frag in m for m in errs), (frag, errs)

--- a/skills/_registry/lint_skills.py
+++ b/skills/_registry/lint_skills.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Dogfood the skill-package authoring lint on cap-evolve's OWN bundled skills.
+
+The framework ships `skills/capabilities/skill-package/scripts/abstract.py` to
+enforce the Agent-Skills authoring rules (skill-creator's progressive-disclosure
+budget, frontmatter shape, one-level references) on *user* skills. This script
+points that same validator at `skills/*/*/SKILL.md`, so the framework is held to
+the bar it advertises in CONTRIBUTING.md instead of only selling it.
+
+Structural authoring warnings are ERRORS here. `validate()` reports body size /
+reference depth / missing-TOC / broken links as *warnings* because an optimizer
+mid-run should not be hard-blocked by a style budget. For the repo's own skills
+there is no such excuse, so `PROMOTED` turns them into failures. Description
+*style* heuristics (POV, all-caps, "say WHEN", truncation risk) and bundled-script
+advisories (no declared `--self-check`, a risky import) stay advisory — they are
+judgement calls, not measurable violations.
+
+Discovery is a glob, never a committed list, so a NEW skill is linted the day it
+lands. The anti-vacuity guard cross-checks that glob against the committed
+`manifest.json` — two independent views of one tree that must agree — so a
+rename/move/deletion fails loudly even when an addition in the same commit keeps
+the count unchanged.
+
+The lint is BLOCKING and there is no violation baseline. It shipped report-only
+against a 14-violation baseline while the skills were rewritten under #322-#339;
+that rewrite sweep cleared every one, so the baseline is empty and deleted, and the
+next violation is a regression to fix rather than debt to record. (The baseline
+machinery is in `git log -- skills/_registry/` if the tree ever needs it again.)
+
+Usage: python skills/_registry/lint_skills.py [skills_root]
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+# `validate()` findings that are objectively measurable authoring violations, keyed by
+# a stable fragment of the message. A warning matching one of these is promoted to an
+# error; anything unmatched stays advisory. Coupled to abstract.py's wording on
+# purpose: test_skill_authoring_lint.py proves each fragment is still reachable from a
+# real violation, so a reworded message breaks the test instead of blinding the lint.
+PROMOTED = (
+    "lines (>",              # body over MAX_BODY_LINES
+    "tokens (>",             # body over MAX_BODY_TOKENS
+    "level deep",            # references nested, or a reference linking a reference
+    "table of contents",     # long reference with no early TOC
+    "does not exist",        # a relative link pointing at a missing file
+)
+
+
+def _load_validator(skills_root: Path):
+    path = skills_root / "capabilities" / "skill-package" / "scripts" / "abstract.py"
+    if not path.is_file():
+        raise SystemExit(f"lint_skills: cannot find the validator at {path}")
+    spec = importlib.util.spec_from_file_location("skill_package_abstract", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _manifest_drift(skills_root: Path) -> str:
+    """Anti-vacuity: the glob and the committed manifest are two independent views of
+    the same tree and must agree. A floor (`n < 20`) misses rename-away + add-new in
+    one commit; comparing the PATH SETS catches it, and needs no magic number."""
+    manifest = skills_root / "_registry" / "manifest.json"
+    if not manifest.is_file():
+        return f"the committed manifest is missing at {manifest}"
+    listed = {s["path"] for s in
+              json.loads(manifest.read_text(encoding="utf-8"))["skills"].values()}
+    found = {p.parent.relative_to(skills_root).as_posix()
+             for p in skills_root.glob("*/*/SKILL.md")}
+    if found == listed:
+        return ""
+    return (f"{len(found)} skill package(s) on disk do not match the {len(listed)} in "
+            f"manifest.json — on disk only: {sorted(found - listed) or 'none'}; in "
+            f"manifest only: {sorted(listed - found) or 'none'}. A skill was "
+            f"renamed/moved/removed; rebuild the manifest and re-review coverage")
+
+
+def lint(skills_root: Path) -> tuple[dict[str, list[str]], dict[str, list[str]], int]:
+    """Return (per-skill errors, per-skill advisories, number of skills linted)."""
+    validator = _load_validator(skills_root)
+    errors: dict[str, list[str]] = {}
+    advisories: dict[str, list[str]] = {}
+    skills = sorted(skills_root.glob("*/*/SKILL.md"))
+    for skill_md in skills:
+        skill_dir = skill_md.parent
+        key = skill_dir.relative_to(skills_root).as_posix()
+        v = validator.validate(skill_dir)
+        errs = list(v["problems"])
+        advs: list[str] = []
+        for w in v["warnings"]:
+            (errs if any(frag in w for frag in PROMOTED) else advs).append(w)
+        if errs:
+            errors[key] = errs
+        if advs:
+            advisories[key] = advs
+    return errors, advisories, len(skills)
+
+
+def _flatten(findings: dict[str, list[str]]) -> list[str]:
+    """One stable `<skill>: <message>` line per finding.
+
+    Fully sorted, not just by skill: two runs in different processes must print
+    byte-identical output, so no wobble in the order findings are produced may leak
+    through. (`abstract.py` also sorts its reference iteration — this is the second
+    belt, because output that depends on filesystem order fails on one machine only.)
+    """
+    return sorted(f"{key}: {m}" for key in findings for m in findings[key])
+
+
+def main(argv: list[str]) -> int:
+    positional = [a for a in argv[1:] if not a.startswith("--")]
+    root = Path(positional[0] if positional else "skills").resolve()
+    errors, advisories, n = lint(root)
+    lines = _flatten(errors)
+
+    print(f"skill authoring lint — {n} skill package(s) under {root}")
+    for ln in lines:
+        print(f"  ERROR  {ln}")
+    for ln in _flatten(advisories):
+        print(f"  advise {ln}")
+
+    drift = _manifest_drift(root)
+    if drift:
+        print(f"  ERROR  discovery: {drift}")
+        return 1
+    if lines:
+        print(f"FAIL — {len(lines)} authoring violation(s) "
+              f"({len(advisories)} skill(s) with advisories)")
+        return 1
+    print(f"OK — {n} skill packages, no authoring violations "
+          f"({len(advisories)} skill(s) with advisories)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/skills/capabilities/skill-package/scripts/abstract.py
+++ b/skills/capabilities/skill-package/scripts/abstract.py
@@ -49,6 +49,13 @@ from pathlib import Path
 NAME_RE = re.compile(r"^[a-z0-9-]{1,64}$")
 FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---", re.S)
 XML_TAG_RE = re.compile(r"</?[a-zA-Z][^>]*>")  # an actual tag, not a stray "<"
+REL_LINK_RE = re.compile(r"\]\(([^)\s]+)\)")  # any Markdown link target
+# A description states WHEN either conditionally ("Use when the user asks") or
+# POSITIONALLY ("Use after intake", "Use as the last evaluation step") — both are real
+# triggering signals, so demanding the literal "use when" bigram flags good prose.
+SAYS_WHEN_RE = re.compile(
+    r"\bwhen\b|\buse (after|before|as|at|to|between|right|during|only|this|the moment)\b",
+    re.I)
 MAX_BODY_LINES = 500              # skill-creator's Level-2 budget (hard here)
 MAX_BODY_TOKENS = 5000            # cap-evolve heuristic (~chars/4), advisory only
 CHARS_PER_TOKEN = 4
@@ -96,7 +103,11 @@ def _parse_frontmatter(text: str) -> tuple[dict, str]:
     for line in m.group(1).splitlines():
         stripped = line.strip()
         indented = line[:1] in (" ", "\t")
-        if key and (indented or (fold and stripped)):
+        # A block scalar continues while lines are INDENTED; a blank line inside it
+        # is not a terminator. An unindented `next-key:` ends it — treating that as
+        # continuation swallowed every key after a `>`/`|` description (6 of them on
+        # algorithms/evograph) and inflated the measured description past its cap.
+        if key and (indented or (fold and not stripped)):
             if not stripped:
                 continue
             sep = "\n" if fold == "|" else " "
@@ -115,6 +126,25 @@ def _parse_frontmatter(text: str) -> tuple[dict, str]:
         else:
             key, fold = None, ""
     return fm, text[m.end():]
+
+
+def _relative_links(text: str) -> list[str]:
+    """Local relative link targets in Markdown, anchors stripped.
+
+    A Markdown link may carry an anchor (``references/x.md#a-heading``); the anchor is
+    not part of the path, so existence-checking the raw target reads every deep link as
+    broken. Absolute URLs, bare in-document anchors and mailto:/rooted paths are skipped
+    — only targets that must resolve to a file next to the linking document come back,
+    de-duplicated (the same file linked five times is one problem, not five findings).
+    """
+    out = []
+    for raw in REL_LINK_RE.findall(text):
+        if raw.startswith(("#", "/", "mailto:")) or "://" in raw:
+            continue
+        target = raw.split("#", 1)[0].strip()
+        if target:
+            out.append(target)
+    return list(dict.fromkeys(out))
 
 
 def _subpackages(capability_dir: Path) -> list[Path]:
@@ -326,7 +356,7 @@ def _validate_frontmatter(fm: dict, problems: list, warnings: list) -> str:
         problems.append(f"description is {len(desc)} chars (>{LONG_DESC_CHARS})")
     if XML_TAG_RE.search(desc):
         problems.append("description must not contain XML tags")
-    if not re.search(r"\b(use when|when )\b", desc, re.I):
+    if not SAYS_WHEN_RE.search(desc):
         warnings.append("description should say WHEN to use the skill "
                         "('Use when …') — it is the primary triggering signal")
     # point-of-view drift: descriptions must be third person.
@@ -346,15 +376,20 @@ def _validate_frontmatter(fm: dict, problems: list, warnings: list) -> str:
 
 
 def _validate_references(pkg: Path, body: str, problems: list, warnings: list) -> None:
-    # broken links the body points at
-    for rel in re.findall(r"\(((?:references|scripts|assets)/[^)\s]+)\)", body):
-        if not (pkg / rel).exists():
+    # Relative links the body points at must resolve. Anchors are stripped first
+    # (_relative_links), or every deep link like "references/x.md#heading" reads as broken.
+    for rel in _relative_links(body):
+        if rel.split("/", 1)[0] in ("references", "scripts", "assets") \
+                and not (pkg / rel).exists():
             problems.append(f"SKILL.md links '{rel}' which does not exist")
 
     refs = pkg / "references"
     if not refs.is_dir():
         return
-    for sub in refs.iterdir():
+    # sorted(): filesystem iteration order differs between machines, and callers (the
+    # repo's own blocking authoring lint, and the optimizer's warning list) need the
+    # findings to come out in the same order everywhere.
+    for sub in sorted(refs.iterdir()):
         if sub.is_dir():
             warnings.append(f"references/{sub.name}/ is nested >1 level deep; "
                             "keep references one level deep")
@@ -372,15 +407,23 @@ def _validate_references(pkg: Path, body: str, problems: list, warnings: list) -
                             f"contents in its first {TOC_SCAN_CHARS} chars: put "
                             f"{MIN_TOC_LINKS}+ anchor links ('- [Section](#section)') "
                             "at the very TOP, above any orientation prose")
-        # One level deep is about POINTERS, not directories: a reference that points
-        # at another reference can be missed when the agent reads only part of it.
-        for link in re.findall(r"\]\(([^)\s]+)\)", text):
-            if re.match(r"(\./)?(\.\./)?references/", link) or (
-                    link.endswith(".md") and (refs / link).exists() and link != f.name):
+        # One level deep is about POINTERS, not directories: a reference that points at
+        # another reference can be missed when the agent reads only part of it. Judged
+        # on the RESOLVED target — a substring/`refs / link` test reads a legitimate
+        # "../SKILL.md" back-link as a sibling reference (it resolves through refs/).
+        for target in _relative_links(text):
+            # A reference written as if it were SKILL.md ("references/b.md") still MEANS
+            # the sibling, so resolve that form against references/ — otherwise the
+            # commonest ref->ref shape reads as a mere broken link.
+            rel = re.sub(r"^(\./)?references/", "", target)
+            hop = ((refs if rel != target else f.parent) / rel).resolve()
+            if hop.suffix == ".md" and hop.parent == refs.resolve() and hop != f.resolve():
                 warnings.append(f"references/{f.name} points at another reference "
-                                f"('{link}') — keep references one level deep, linked "
+                                f"('{target}') — keep references one level deep, linked "
                                 "directly from SKILL.md")
-                break
+            elif not hop.exists():
+                warnings.append(f"references/{f.name} links '{target}' "
+                                "which does not exist")
         if f.name not in body and f"references/{f.name}" not in body:
             warnings.append(f"references/{f.name} is an orphan — SKILL.md never points "
                             "at it, so the agent will not know to load it")


### PR DESCRIPTION
Closes #107. **Supersedes #345** (rebased onto current main; #345's branch is not force-pushed).

#345 was deliberately held to last in the 25-PR sweep because its baseline recorded **14
violations across 5 skills**, and the concurrent skill rewrites (#322-#339) were targeting
every one of them. That sweep is done. The lint now reports **zero** violations across all
20 skill packages, so the baseline file is deleted and the CI job is **BLOCKING** — which is
exactly what #345's own comment said should happen once the list was clear.

## Not a cherry-pick: #392/#394 got there first

#345's branch predates #392 and #394, which had already landed most of its validator work.
Its `abstract.py` is 315 lines; main's is 528. Porting it wholesale would have reverted
their work, so **main's version is the base** and only the deltas it was still missing are
ported. Already on main, left alone:

| #345's claimed fix | Status on main |
|---|---|
| `description: >-` block scalars parsed | already landed (#392) |
| ref→ref "one level deep" rule | already landed, different wording |
| "say WHEN" accepts positional phrasing | already landed (`when `) — tightened here |
| TOC check is a real check, not `"## " in text[:1500]` | already landed; main accepts ≥3 anchor links **or** ≥3 `## ` headings |
| body length promoted to an error | already a hard `problems` entry on main |

I kept main's more lenient TOC form (anchor links *or* section headings) rather than #345's
anchor-links-only rule. #345 itself flagged that tightening as wanting explicit sign-off, and
main's version is already far from the tautology #345 was complaining about. Say the word and
I'll tighten it in a follow-up.

## Validator deltas actually ported

- **`_relative_links()` strips a link's `#anchor`** before the existence test, so
  `references/x.md#heading` no longer reads as broken.
- **ref→ref is judged on the RESOLVED target**, not `refs / link`. The old test read a
  legitimate `../SKILL.md` back-link as a sibling reference — a *live false positive on
  `capabilities/tools`* that this PR's before-run reproduces. It also stopped at the first
  finding per file, so a reference with two bad hops only ever reported one.
- **broken relative links are now checked from inside each reference too**, not only from
  SKILL.md (a rule in #345's table that main did not implement).
- **`sorted(refs.iterdir())`** — see the determinism section.

## One bug this rebase surfaced, live on main today

A `>`/`|` block scalar in the frontmatter **swallowed every key after it**, because an
unindented `next-key:` was treated as a scalar continuation. On `algorithms/evograph` that
lost 6 keys (`component`, `argument-hint`, `allowed-tools`, `needs`, `provides`, `sources`)
and glued them onto the description, which then measured **1032 chars** and presented as a
hard `>1024` cap violation. Its real description is **794 chars**.

I nearly "fixed" this by trimming evograph's description — the phantom violation is
convincing. Fixed at the root instead: a block scalar now ends at the first unindented
non-blank line, and **no shipped skill loses a frontmatter key**. `_parse_frontmatter` is
the wrong place for a heuristic, so this is the one-condition fix, not a per-skill patch.

**No `SKILL.md` is touched by this PR** — same scope discipline #345 held to.

## Before / after violation counts

"Before" = main's validator + #345's lint, i.e. what the tree really looked like today:

| Rule | #345's baseline (14) | Before, on main (2) | After (0) |
|---|---|---|---|
| body ≤500 lines | 2 | 0 | 0 |
| body ≤5000 tokens | 2 | 0 | 0 |
| references one level deep | 7 | 1 | 0 |
| long-reference TOC | 2 | 0 | 0 |
| description no XML | 1 | 0 | 0 |
| description ≤1024 chars | 0 | 1 | 0 |

Per skill, and why each "before" line is gone:

| Skill | Before | Why it is gone |
|---|---|---|
| `capabilities/tools` | `references/optimizer-playbook.md` points at another reference `'../SKILL.md'` | **False positive.** `../SKILL.md` resolves *through* `references/`, so `(refs / link).exists()` was true. Judged on the resolved path now; `test_a_back_link_to_skill_md_is_not_a_reference_hop` pins it. |
| `algorithms/evograph` | description is 1032 chars (>1024) | **Phantom.** The block-scalar parser bug above. Real length 794. |

All 12 of #345's original body-length / token / ref→ref / TOC / description-XML violations
were genuinely fixed by the rewrite sweep — none of them was masked, and the lint re-derives
them from the tree rather than trusting the old list.

### Full lint output, before

```
skill authoring lint — 20 skill package(s) under <repo>/skills
  ERROR  algorithms/evograph: description is 1032 chars (>1024)
  ERROR  capabilities/tools: references/optimizer-playbook.md points at another reference ('../SKILL.md') — keep references one level deep, linked directly from SKILL.md
  [130 advisory lines]
FAIL — 2 authoring violation(s) not in the baseline (0 known, 20 skill(s) with advisories)
```

### Full lint output, after

```
$ python skills/_registry/lint_skills.py skills
skill authoring lint — 20 skill package(s) under <repo>/skills
  [130 advisory lines]
OK — 20 skill packages, no authoring violations (20 skill(s) with advisories)
$ echo $?
0
```

The 130 advisory lines are all `--self-check`-absent / `uses subprocess` / orphan-reference
findings from #392's script validation. They print and never fail;
`test_the_script_advisories_stay_advisory` pins that promoting them would be wrong.

## CI: flipped to BLOCKING

`lint-skills` in `.github/workflows/ci.yml`, running `python skills/_registry/lint_skills.py
skills`. No `--baseline`, no `continue-on-error`, and `skills/_registry/authoring-baseline.txt`
is deleted. #345's instructions for flipping it were literally "delete
authoring-baseline.txt, drop `--baseline`, drop `continue-on-error`" — done.

The `--baseline` / `--write-baseline` machinery is removed along with the file. With a clean
tree and a blocking job, the next violation is a regression to fix, not debt to record; a
baseline that exists to hold zero lines is the thing that rots. It is in
`git log -- skills/_registry/` if it is ever needed again.

Non-vacuity is unchanged: discovery is a glob (never a committed list), cross-checked against
`manifest.json`'s path sets, so a rename-away plus add-new in one commit fails loudly even
though the count stays at 20 — which an `n < 20` floor cannot see.

## Determinism — #345's original CI failure

The earlier bug was `refs.iterdir()` / `glob` returning filesystem order, so per-skill
findings came out differently on the runner than locally. `glob` was already sorted on main;
`iterdir()` was not, and is now.

```
$ python skills/_registry/lint_skills.py skills > a.txt
$ PYTHONHASHSEED=random python skills/_registry/lint_skills.py skills > b.txt
ea62cc986b6b85e518bdd463a55b2197f39ec9f8ed552e4b47ee7967ff3f25f1  a.txt
ea62cc986b6b85e518bdd463a55b2197f39ec9f8ed552e4b47ee7967ff3f25f1  b.txt
BYTE-IDENTICAL
```

Also byte-identical under `PYTHONHASHSEED=1` and `PYTHONHASHSEED=99999`.
`test_the_violation_list_is_ordered_deterministically` still guards it (and now checks the
advisory list too, which is also printed sorted), and
`test_the_output_is_byte_identical_across_processes` guards it across process boundaries —
sortedness inside one interpreter was never the whole claim.

## The validator still catches a real violation

Planted in a scratch copy of `skills/`, then reverted:

```
$ python skills/_registry/lint_skills.py /tmp/iss107-scratch/skills
  ERROR  algorithms/evograph: references/clustering.md points at another reference ('dashboard.md') — keep references one level deep, linked directly from SKILL.md
  ERROR  phases/gate: SKILL.md body is 624 lines (>500); the body is a recurring per-session cost — split detail into references/
  ERROR  phases/gate: SKILL.md body is ~9894 tokens (>5000, this repo's heuristic) — move detail into references/
  ERROR  phases/report: SKILL.md links 'references/nope.md' which does not exist
FAIL — 4 authoring violation(s) (20 skill(s) with advisories)
$ echo $?
1
```

A >500-line body, a ref→ref link, and a broken body link: all three reported, exit 1. Scratch
copy deleted; the real tree re-lints clean.

## Tests — 39 in this file, 875 in the suite

```
$ PYTHONPATH="$PWD/core:$PWD/dashboard/backend" python -m pytest core/tests -q
875 passed, 12 skipped in 148.95s (0:02:28)
```

Main is `836 passed, 12 skipped`. **Delta +39, exactly this PR's test file** — nothing else
moved. Never unpinned (#349), and no `pip install ./core` into the repo-root venv.

The test file is adapted from #345's to main's `problems`/`warnings` split (main hardens body
length and body links; #345's base had them as warnings) and to its `scripts` key. Which
bucket each finding lands in is now asserted per rule, so a future reclassification has to be
a deliberate edit rather than a silent hole in the promotion table.
`test_promoted_fragments_still_match_the_validators_wording` is the anti-rot test: every
`PROMOTED` fragment must be reachable from a real violation *and* actually reach the lint as
an error, so rewording a message in `abstract.py` breaks the test instead of blinding the lint.

Also green: `python -m compileall core skills`, and `scripts/check.py` for `skill-package`,
`evograph`, `tools`, `agent-optimize`, `using-cap-evolve` (all `"ok": true`).

## toy_calc

```
$ bash examples/toy_calc/run.sh
{"run_dir": ".capevolve/run_demo", "best_id": "cand_0001", "finalized": true,
 "baseline_val": 0.0, "best_val": 1.0, "test_reward": 1.0, "test_delta": 1.0,
 "test_pass_k": {"1": 1.0}, "iterations": 3}
```

Completes, sealed once. **Honest reading:** `toy_calc` runs at `n_trials=1`, where the paired
SE collapses to 0 and `gate.py:171-180` applies its documented STRICT fallback (accept any
Δ > 0). So this "gate-accepted" result evidences the **plumbing, the split and the seal** —
it is *not* evidence that the gate discriminates signal from noise. Nothing here should be
read as a gate-quality claim.

## Deliberately out of scope

- Tightening the TOC rule to anchor-links-only (#345 flagged it for sign-off; main's form is
  already non-tautological).
- The 130 script advisories. Adding `--self-check` to ~65 bundled scripts is its own PR, and
  promoting them without doing that work would just make the blocking lint unusable.
