### PR TITLE
feat(ci): let the benchmarks suite run agent-optimize, driven by a headless host

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -115,11 +115,11 @@ on:
         description: "Acceptance-gate strictness: accept a candidate iff improvement > k_se·SE (default 1.0; lower = more lenient, higher = stricter)"
         type: string
         default: "1.0"
-      algorithm_focus:
-        description: "Hill-climb focus schedule: all (whole train set each iteration) | cyclic (one task at a time) | hardest-first (lowest-scoring task first)"
+      algorithm:
+        description: "Optimization algorithm. hill-climb-* is the deterministic loop and its focus schedule: all (whole train set each iteration) | cyclic (one task at a time) | hardest-first (lowest-scoring task first). agent-optimize is the fully-agentic loop — run_suite.sh switches the run to orchestration_mode: agent and a headless agent drives the rounds itself, bounded by a stop_condition derived from `iterations`/`optimizer_*` rather than a fixed schedule."
         type: choice
-        default: all
-        options: [all, cyclic, hardest-first]
+        default: hill-climb-all
+        options: [hill-climb-all, hill-climb-cyclic, hill-climb-hardest-first, agent-optimize]
       # NB: workflow_dispatch allows at most 10 inputs and this list is full. SPLIT_SEED is
       # therefore driven by the repo variable `vars.BENCH_SPLIT_SEED` (see the job env) rather
       # than an 11th input, which would make this workflow invalid.
@@ -302,7 +302,11 @@ jobs:
       OPTIMIZER_USD_PER_ITER: ${{ github.event.inputs.optimizer_usd_per_iter || (matrix.tier == 'smoke' && '50' || '0') }}
       OPTIMIZER_MAX_TURNS: ${{ github.event.inputs.optimizer_max_turns || '80' }}
       GATE_K_SE: ${{ github.event.inputs.gate_k_se || '1.0' }}
-      ALGORITHM_FOCUS: ${{ github.event.inputs.algorithm_focus || 'all' }}
+      # Names the algorithm and (for hill-climb) its focus schedule in one token, because
+      # the 10-input cap above leaves no room for two. run_suite.sh splits it, and maps
+      # agent-optimize to orchestration_mode: agent + a derived stop_condition. A PR-label
+      # dispatch has no inputs at all, so the default keeps every existing leg unchanged.
+      ALGORITHM: ${{ github.event.inputs.algorithm || 'hill-climb-all' }}
       # Run seed. With a tier that ships a committed split_ids.json the partition is FIXED, so
       # this varies only the per-trial rollout seeding — which is what makes the independent
       # seeds a paper comparison needs (">=3 seeds") possible on one split. Set the repo
@@ -427,6 +431,7 @@ jobs:
             "agent_model": "${AGENT_MODEL:-aws/gpt-oss-120b}",
             "optimizer_model": "${OPTIMIZER_MODEL:-claude-opus-4-8}",
             "gate_k_se": ${GATE_K_SE:-1.0},
+            "algorithm": "${ALGORITHM:-hill-climb-all}",
             "warm_seed": $warm_json,
             "conclusion": "${{ job.status }}"
           }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,55 @@ All notable changes to cap-evolve are documented here. The format follows
 [0.1.0]: https://github.com/skillberry-ai/cap-evolve/releases/tag/v0.1.0
 
 ## [Unreleased]
+### Added
+- **The benchmarks suite can run `agent-optimize`.** Until now `run_suite.sh` hardcoded
+  `algorithm_skill: hill-climb`, so the fully-agentic algorithm was unreachable from CI — and
+  selecting it by hand would have failed anyway, because it refuses a deterministic invocation and
+  nothing in CI could pick up the agent-mode handoff. Three pieces close that:
+
+  - **`scripts/host.py` in the `agent-optimize` skill** — the headless host for agent mode. It
+    renders a driver briefing from the spec + handoff (absolute paths, `num_trials`, `gate_k_se`,
+    the free-text `stop_condition`, the four primitives every round must go through, and an
+    instruction not to ask questions) and delegates the CLI invocation to the existing
+    `optimizers/run-optimizer` runner, so registry rows, `{model}` substitution, budget-flag
+    mapping, cost capture and the CLI-present hard fail are the ones the deterministic path
+    already uses rather than a second copy. `--agent` takes any registry row; `--prompt-only`
+    renders the briefing free; `--seal-only` seals a run a previous host left open.
+
+    Two failure modes it exists to prevent. It raises `BASH_DEFAULT_TIMEOUT_MS` and
+    `BASH_MAX_TIMEOUT_MS` to 4h: at Claude Code's 10-minute default ceiling every full-val eval on
+    a real benchmark is killed mid-flight, and a perfectly healthy run reads as a broken runner.
+    And it **guarantees the seal** — an agent that exhausts its turns leaves no `final.json`, which
+    is both unreportable and indistinguishable from a crash, so the host runs `measure.py` itself
+    and labels the result `seal: host` so it is never mistaken for the agent's own judgement that
+    it was finished. An already-sealed run reports `seal: agent` instead of raising
+    `TestSealError`.
+
+  - **An `algorithm` dispatch input**, replacing `algorithm_focus`:
+    `hill-climb-all` (default, unchanged behaviour) | `hill-climb-cyclic` |
+    `hill-climb-hardest-first` | `agent-optimize`. One token carries both algorithm and focus
+    because `workflow_dispatch` caps a workflow at 10 inputs and that list is full. `ALGORITHM_FOCUS`
+    is still honoured when `ALGORITHM` is unset, so committed `overrides.env` files and hand-run
+    invocations keep producing the same run; `ALGORITHM` wins when both are set, so a stale alias
+    can never override a deliberate dispatch choice. `runmeta.json` now records the algorithm — a
+    hill-climb number and an agent-optimize number are not a like-for-like comparison, and the
+    history page should not present them as one.
+
+  - **A `stop_condition` derived from the same dispatch inputs**, since agent mode is bounded by
+    free-text prose rather than a round schedule: `iterations` → max rounds,
+    `optimizer_usd_per_iter` × rounds → a whole-loop $ ceiling (0 stays unlimited, as everywhere
+    else in the workflow), `gate_k_se`/`trials` → the gate. `optimizer_max_turns` becomes a
+    whole-loop turn cap the same way, because the entire search is one agent process instead of one
+    call per iteration. It is emitted through `json.dumps`: interpolated raw, a paragraph
+    containing `:` and `$` yields a spec that silently truncates at the first colon and hands the
+    agent a stopping rule nobody wrote.
+
+  `host.py` is deliberately **not** documented in `SKILL.md`. That file is the hosted agent's
+  recurring per-trigger context with ~150 characters of headroom under the 5000-token budget, and
+  the agent never invokes the host — the host invokes the agent. It is documented in
+  `docs/AGENT_ORCHESTRATION.md` and `ci/benchmarks/README.md` instead, following the same
+  convention as the skill's other non-loop scripts (`linkcheck.py`, `abstract.py`).
+
 ### Deprecated
 - **`evograph`, the fifth algorithm.** It advertised one distinctive capability — a
   collaborative weakness graph with one solver agent per weakness — and neither half survived

--- a/ci/benchmarks/README.md
+++ b/ci/benchmarks/README.md
@@ -112,10 +112,44 @@ has a **Type** column + filter.
   | `optimizer_usd_per_iter` | `0` (unlimited) | per-iteration $ cap on the optimizer — `0` disables Claude Code's native `--max-budget-usd` cap entirely; set e.g. `4.0` to bound it |
   | `optimizer_max_turns` | `80` | per-iteration turn cap on the optimizer |
   | `gate_k_se` | `1.0` | acceptance-gate strictness (accept iff Δ > k_se·SE) |
-  | `algorithm_focus` | `all` | hill-climb schedule: `all` \| `cyclic` \| `hardest-first` |
+  | `algorithm` | `hill-climb-all` | which optimization algorithm — see below |
 
   Overriding `agent_model` takes precedence over any per-task `agent` a curated `tasks.json`
   entry pins — `run_suite.sh` warns (doesn't fail) on a mismatch so you know it happened.
+
+#### The `algorithm` input
+
+One token names the algorithm and, for hill-climb, its focus schedule — because
+`workflow_dispatch` caps a workflow at 10 inputs and that list is full.
+
+  | value | what runs |
+  |---|---|
+  | `hill-climb-all` (default) | deterministic loop, whole train set each iteration |
+  | `hill-climb-cyclic` | deterministic loop, one task at a time |
+  | `hill-climb-hardest-first` | deterministic loop, lowest-scoring task first |
+  | `agent-optimize` | the fully-agentic loop (see below) |
+
+`agent-optimize` is not just a fourth schedule. It has no deterministic loop at all: the run
+switches to `orchestration_mode: agent`, where `cap-evolve run` does check + baseline, prints a
+handoff and returns. There being no conversational agent in CI, `run_suite.sh` then hands the
+loop to the algorithm's own headless host
+(`skills/algorithms/agent-optimize/scripts/host.py` — see
+[`docs/AGENT_ORCHESTRATION.md`](../../docs/AGENT_ORCHESTRATION.md)), which briefs a Claude Code
+process to run the rounds itself and guarantees the run ends sealed even if that process stops
+early.
+
+Two consequences worth knowing before you compare numbers:
+
+- **Its budget is a `stop_condition`, not a schedule.** `run_suite.sh` derives free-text prose
+  from the same dispatch inputs (`iterations` → max rounds, `optimizer_usd_per_iter` × rounds →
+  a whole-loop $ ceiling, `gate_k_se`/`trials` → the gate), so a given dispatch bounds both
+  algorithms comparably. The agent may still stop earlier on its own `spend.py` reading.
+- **`optimizer_max_turns` becomes a whole-loop cap.** The entire search is one agent process
+  rather than one call per iteration, so the host multiplies the per-iteration turn cap by the
+  round count.
+
+`runmeta.json` records the `algorithm`, so the history page never compares a hill-climb number
+against an agent-optimize one as though they were the same run type.
 - **On a PR — labels:**
   - **`benchmark-smoke`** / **`benchmark-full`** → run all four benchmarks of that tier.
   - **`benchmark-smoke-<bench>`** / **`benchmark-full-<bench>`** (`tau2` · `swebench` ·

--- a/ci/benchmarks/lib/run_suite.sh
+++ b/ci/benchmarks/lib/run_suite.sh
@@ -30,7 +30,89 @@ AGENT_MODEL="${AGENT_MODEL:-aws/gpt-oss-120b}"
 NUM_TRIALS="${NUM_TRIALS:-10}"
 OPTIMIZER_MODEL="${OPTIMIZER_MODEL:-claude-opus-4-8}"
 GATE_K_SE="${GATE_K_SE:-1.0}"
-ALGORITHM_FOCUS="${ALGORITHM_FOCUS:-all}"
+
+# ---- algorithm selection ----------------------------------------------------
+# ALGORITHM is the workflow's `algorithm` input. It names the algorithm AND, for
+# hill-climb, its focus schedule in one token — because workflow_dispatch allows at most 10
+# inputs and that list is full, so a separate `algorithm` input is not available (see the
+# note in benchmarks.yml).
+#
+# agent-optimize is not just another value: it has NO deterministic loop and refuses a
+# deterministic invocation outright (skills/algorithms/agent-optimize/scripts/run.py), so
+# it must come with `orchestration_mode: agent` and a free-text `stop_condition` — the
+# stopping rule that replaces max_iterations there. Both are emitted below and consumed by
+# the capevolve.yaml heredoc further down.
+#
+# Back-compat: ALGORITHM_FOCUS was the old input name and may still be exported by hand or
+# by a committed overrides.env. It is honoured when ALGORITHM is unset, so an existing
+# invocation keeps producing the same run; ALGORITHM wins when both are set, so a stale
+# alias can never override a deliberate dispatch choice.
+ALGORITHM="${ALGORITHM:-}"
+if [ -z "$ALGORITHM" ]; then
+  case "${ALGORITHM_FOCUS:-all}" in
+    all|cyclic|hardest-first) ALGORITHM="hill-climb-${ALGORITHM_FOCUS:-all}" ;;
+    *) echo "::error:: unknown ALGORITHM_FOCUS='${ALGORITHM_FOCUS}'" >&2; exit 2 ;;
+  esac
+fi
+ALGO_FOCUS=""
+ORCH_MODE="deterministic"
+STOP_CONDITION=""
+case "$ALGORITHM" in
+  hill-climb-all|hill-climb-cyclic|hill-climb-hardest-first)
+    ALGO_SKILL="hill-climb"
+    ALGO_FOCUS="${ALGORITHM#hill-climb-}"
+    ;;
+  agent-optimize)
+    ALGO_SKILL="agent-optimize"
+    ORCH_MODE="agent"
+    # Derived from the SAME dispatch inputs that bound a deterministic run, so the two
+    # algorithms are comparable at a given dispatch. The whole loop is ONE agent process
+    # (unlike the deterministic path's one optimizer call per iteration), so a
+    # per-iteration cap becomes a whole-loop cap by multiplying it by the iteration count.
+    # OPTIMIZER_USD_PER_ITER=0 means unlimited everywhere else in this workflow; keep that
+    # meaning by omitting the dollar clause entirely rather than writing a $0 ceiling.
+    # Self-contained: fall back to the raw dispatch env so this block can be lifted and
+    # executed on its own (core/tests/test_benchmarks_agent_optimize.py does exactly that).
+    _rounds="${ITER:-${ITERATIONS:-3}}"
+    _trials="${NUM_TRIALS:-10}"
+    _k_se="${GATE_K_SE:-1.0}"
+    _stop_usd=""
+    if awk "BEGIN{exit !(${OPTIMIZER_USD_PER_ITER:-0} > 0)}" 2>/dev/null; then
+      _stop_usd="$(awk "BEGIN{printf \"%.2f\", ${OPTIMIZER_USD_PER_ITER:-0} * $_rounds}")"
+      _stop_usd=" Stop if your own (optimization) spend reaches \$${_stop_usd}."
+    fi
+    STOP_CONDITION="Spend at most ${_rounds} rounds, where a round is one candidate taken to a\
+ full-val gate decision (accepted or rejected) and booked with commit.py. Stop early when\
+ spend.py's recommendation is 'stop', or after ${_rounds} rounds, or when two consecutive\
+ rounds are rejected with no new failure cluster left to attack.${_stop_usd} Gate every\
+ candidate on FULL val at gate_k_se=${_k_se} over ${_trials} trial(s); never gate on\
+ a screen subset. Always finish by sealing test exactly once with measure.py and writing\
+ the report — a run with no finalize has no result."
+    ;;
+  *)
+    echo "::error:: unknown ALGORITHM='$ALGORITHM' (expected hill-climb-all |" \
+         "hill-climb-cyclic | hill-climb-hardest-first | agent-optimize)" >&2
+    exit 2
+    ;;
+esac
+# ---- end algorithm selection ------------------------------------------------
+
+# The algorithm block above chose the skill, the orchestration mode and (agent mode only)
+# the free-text stop_condition. Render the mode-specific lines here rather than emitting
+# empty keys: `algorithm_focus` is a hill-climb concept, and a `stop_condition` on a
+# deterministic run would be inert text that misleads whoever reads the spec back.
+ALGO_YAML="algorithm_skill:    $ALGO_SKILL"
+[ -n "$ALGO_FOCUS" ] && ALGO_YAML="$ALGO_YAML
+algorithm_focus:    $ALGO_FOCUS"
+if [ "$ORCH_MODE" = "agent" ]; then
+  # json.dumps, not bare interpolation: the derived stop_condition is a paragraph of prose
+  # containing ':', '$' and quotes, any of which makes an unquoted YAML scalar invalid or
+  # (worse) silently truncated at the colon.
+  ALGO_YAML="$ALGO_YAML
+orchestration_mode: agent
+$(STOP_CONDITION="$STOP_CONDITION" "$PY" -c 'import json,os;print("stop_condition:     " + json.dumps(os.environ["STOP_CONDITION"]))')"
+fi
+
 BASE="$REPO/ci/benchmarks/$BENCH/$TIER"
 OUT="${2:-$REPO/ci/benchmarks/.work/suite_${TIER}_${BENCH}}"
 mkdir -p "$OUT/optimized"
@@ -391,8 +473,7 @@ optimizer_usd_per_iter: ${OPTIMIZER_USD_PER_ITER:-0}
 # resolves against different cwds in check vs run and can silently fall back to the generic
 # template (issue #252), which would erase an arm's instructions with no error.
 optimizer_instructions_file: "${OPT_INSTRUCTIONS:-}"
-algorithm_skill:    hill-climb
-algorithm_focus:    $ALGORITHM_FOCUS
+$ALGO_YAML
 dataset_source:     adapter
 split_ids_file:     "inputs/split_ids.json"
 # With an explicit split_ids_file the partition is fixed, so split_seed only varies the
@@ -419,6 +500,31 @@ cd "$WORK"
       --project .capevolve/project --run-ts suite --max-iterations "$ITER" </dev/null || \
   echo "::error::suite run exited non-zero for $BENCH — see the algorithm step's returncode/stderr above"
 RUN_DIR="$WORK/.capevolve/run_suite"
+
+# ---- agent mode: drive the handed-off loop ----------------------------------
+# In agent mode `cap-evolve run` does check + baseline, prints a handoff and RETURNS — no
+# algorithm subprocess and no auto-finalize, because the loop belongs to a conversational
+# agent. CI has none, so the algorithm's own headless host drives it: it renders the driver
+# briefing from the spec + handoff and delegates the CLI invocation to the existing
+# optimizers/run-optimizer runner (registry row, model + budget flags, cost capture,
+# CLI-present hard fail). It also guarantees a seal, so a host that runs out of budget
+# mid-loop still leaves an honest final.json instead of a run dir that reads as crashed.
+#
+# Budget: the whole loop is ONE agent process, so the per-iteration caps become whole-loop
+# caps (x the round count). 0 stays unlimited, as everywhere else in this workflow.
+if [ "$ORCH_MODE" = "agent" ]; then
+  HOST_TURNS="$(( ${OPTIMIZER_MAX_TURNS:-80} * ITER ))"
+  HOST_USD_ARGS=()
+  if awk "BEGIN{exit !(${OPTIMIZER_USD_PER_ITER:-0} > 0)}"; then
+    HOST_USD_ARGS=(--usd-budget "$(awk "BEGIN{printf \"%.2f\", ${OPTIMIZER_USD_PER_ITER:-0} * $ITER}")")
+  fi
+  echo ">>> agent mode — handing the loop to the headless host (turns=$HOST_TURNS)" >&2
+  "$PY" "$REPO/skills/algorithms/agent-optimize/scripts/host.py" \
+        --run-dir "$RUN_DIR" --project "$PROJ" \
+        --agent claude-code --model "$OPTIMIZER_MODEL" \
+        --budget "$HOST_TURNS" "${HOST_USD_ARGS[@]}" </dev/null || \
+    echo "::error::agent-optimize host exited non-zero for $BENCH — see its JSON above"
+fi
 
 # ---- metrics + report (per-task base→opt from the ONE run) -----------------
 "$PY" "$LIB_DIR/metrics.py" suite "$RUN_DIR" --bench "$BENCH" --tier "$TIER" \

--- a/ci/benchmarks/lib/run_suite.sh
+++ b/ci/benchmarks/lib/run_suite.sh
@@ -161,6 +161,23 @@ case "$BENCH" in
   tau2)
     cp "$TPL/tau2_bench/adapter.py" "$PROJ/adapters/"
     cp -R "$REPO/examples/tau2_airline/seed_capability" "$PROJ/seed_capability"
+    # tau2's FULL editable surface, for every tier (smoke/full/integration all reach here):
+    # policy/policy.md (the agent's system prompt) AND tools/tools.py + reference/data_model.py
+    # (the tool code it calls). Both capability skills are declared so both sets of rules
+    # validate the candidate and both guidance docs reach the optimizer.
+    #
+    # This is the maximum that applies, not a subset. The other two capability skills are
+    # deliberately absent: `mcp-tool` is for a toolset served by an EXTERNAL MCP server and
+    # forbids editing tool code (its own SKILL.md says to use `tools` when the agent owns its
+    # tools, which here it does), and `skill-package` optimizes a SKILL.md package, which this
+    # seed is not. Adding either would narrow or invalidate the surface, not widen it.
+    #
+    # NB `capabilities` selects which capability `validate()` runs and which guidance is
+    # surfaced — it does NOT gate writes. Declaring `tools` therefore does not by itself make
+    # an optimizer USE it: on smoke run 32649063850 both candidates edited only policy.md
+    # while tools.py sat writable and unopened. What closes that gap is naming the actual
+    # files to the optimizer — the deterministic path's INSTRUCTIONS.md does, and agent mode's
+    # briefing does it in host.py's `_surface_section`.
     CAPS="[system-prompt, tools]"
     cat > "$WORK/.env" <<ENV
 MODEL=litellm_proxy/$AGENT_MODEL

--- a/core/tests/test_agent_optimize_host.py
+++ b/core/tests/test_agent_optimize_host.py
@@ -153,6 +153,71 @@ def test_prompt_only_renders_the_briefing_without_shelling_an_agent(tmp_path):
     assert "do not ask" in body.lower()
 
 
+def test_the_briefing_enumerates_every_editable_file_not_just_the_capability_names(tmp_path):
+    """Naming capabilities is not enough — name the FILES, or only the prompt gets edited.
+
+    Measured on tau2 smoke run 32649063850: the spec declared
+    `capabilities: [system-prompt, tools]`, and both candidates the agent produced touched
+    only `policy/policy.md`. `tools/tools.py` and `reference/data_model.py` were in the
+    candidate dir, writable, and never opened. `capabilities` gates which capability
+    `validate()` runs, not what may be written, so nothing was blocking the agent; it simply
+    had no reason to know the other files were fair game.
+
+    This repo already paid for that lesson once — see the "NAME THE ARTIFACTS" note in
+    run_suite.sh's spreadsheetbench arm, where an optimizer handed two editable files
+    reported "all in prompt.md" and left the second surface inert. The briefing must
+    therefore list the real files, so the fix is generic rather than per-benchmark.
+    """
+    project = _project(tmp_path)
+    run_dir = _run_dir(tmp_path)
+
+    # A multi-file capability, like tau2's: a prompt AND code, plus a nested reference.
+    seed = run_dir.root / "candidates" / "seed"
+    (seed / "tools").mkdir(parents=True, exist_ok=True)
+    (seed / "tools" / "tools.py").write_text("def get_details():\n    ...\n", encoding="utf-8")
+    (seed / "reference").mkdir(parents=True, exist_ok=True)
+    (seed / "reference" / "data_model.py").write_text("SCHEMA = {}\n", encoding="utf-8")
+
+    out = _host("--run-dir", str(run_dir.root), "--project", str(project), "--prompt-only")
+    body = Path(out["prompt_path"]).read_text(encoding="utf-8")
+
+    assert "tools/tools.py" in body, (
+        "the briefing does not name the editable tool code, so an agent reasonably edits "
+        "only the obvious prompt file")
+    assert "reference/data_model.py" in body, (
+        "nested files under the capability are editable too and must be listed")
+
+    # And it must say so, not merely list paths: a bare file list reads as inventory.
+    low = body.lower()
+    assert "only the prompt" in low or "only the obvious" in low, (
+        "the briefing lists the files but never says that touching only the prompt leaves "
+        f"the rest of the surface unexercised: {body}")
+
+
+def test_the_briefing_does_not_invent_files_for_a_prompt_only_capability(tmp_path):
+    """A single-file capability must not be described as if it had more surface.
+
+    Overcorrecting is its own failure: telling an agent to "also edit the tool code" when
+    there is none sends it hunting for code to change, which is exactly how a prompt-only
+    run once ended up editing adapter.py (see run_suite.sh's spreadsheetbench note).
+    """
+    project = _project(tmp_path)
+    run_dir = _run_dir(tmp_path)
+    seed = run_dir.root / "candidates" / "seed"
+    for extra in seed.rglob("*"):
+        if extra.is_file() and extra.name != "prompt.md":
+            extra.unlink()
+    (seed / "prompt.md").write_text("You are a helpful agent.\n", encoding="utf-8")
+
+    out = _host("--run-dir", str(run_dir.root), "--project", str(project), "--prompt-only")
+    body = Path(out["prompt_path"]).read_text(encoding="utf-8")
+
+    assert "prompt.md" in body
+    assert "tools.py" not in body, (
+        "the briefing named tool code for a capability that has none — that sends the agent "
+        "looking for code outside its capability to edit")
+
+
 def test_unknown_host_agent_is_refused_before_any_spend(tmp_path):
     project = _project(tmp_path)
     run_dir = _run_dir(tmp_path)

--- a/core/tests/test_agent_optimize_host.py
+++ b/core/tests/test_agent_optimize_host.py
@@ -1,0 +1,249 @@
+"""``host.py`` — the headless host that lets a NON-INTERACTIVE caller drive agent mode.
+
+agent-optimize's loop is prose in SKILL.md, executed by a conversational agent. CI has no
+conversational agent, so before this script the algorithm was simply unavailable there:
+``cap-evolve run`` prints a handoff and returns, and nothing drives the loop.
+
+``host.py`` closes that gap without duplicating anything: it renders the driver briefing
+from the spec + handoff and delegates the actual CLI invocation to the existing
+``optimizers/run-optimizer`` runner (registry rows, model/budget flag mapping, cost
+capture, CLI-present hard fail). What is tested here is everything that does NOT need a
+model:
+
+  * the briefing carries the handoff facts and the loop's own commands (a briefing that
+    omits ``measure.py`` produces a run with no sealed number — the failure mode that
+    makes an unattended run worthless);
+  * an unknown host agent is refused BEFORE any spend;
+  * ``--seal-only`` seals a run the agent left unfinalized, so a host that dies mid-loop
+    still yields an honest result rather than a run dir CI reads as "crashed";
+  * the Bash-tool timeout is raised — at the 10-minute default ceiling every full-val
+    eval on a real benchmark is killed mid-flight and reads as a broken runner.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+SKILL = REPO / "skills" / "algorithms" / "agent-optimize"
+HOST = SKILL / "scripts" / "host.py"
+
+
+def _env() -> dict:
+    return dict(os.environ, CAPEVOLVE_CORE=str(REPO / "core"),
+                CAPEVOLVE_SKILLS_DIR=str(REPO / "skills"))
+
+
+def _host(*argv: str, expect_rc: int = 0) -> dict:
+    p = subprocess.run([sys.executable, str(HOST), *argv],
+                       capture_output=True, text=True, env=_env())
+    assert p.returncode == expect_rc, (
+        f"host.py rc={p.returncode} (expected {expect_rc})\n"
+        f"stdout: {p.stdout[:2000]}\nstderr: {p.stderr[:2000]}")
+    try:
+        return json.loads(p.stdout)
+    except Exception as exc:  # noqa: BLE001
+        raise AssertionError(f"host.py did not emit JSON: {p.stdout[:500]}") from exc
+
+
+def _project(tmp: Path, *, n: int = 20, stop: str = "") -> Path:
+    """A real project dir the subprocess can load — same shape the skill's check uses."""
+    project = tmp / "project"
+    (project / "adapters").mkdir(parents=True, exist_ok=True)
+    (project / "adapters" / "adapter.py").write_text(
+        "from cap_evolve.skillcheck import SyntheticAdapter\n\n\n"
+        "class Adapter(SyntheticAdapter):\n"
+        f"    def __init__(self):\n        super().__init__(n={n})\n",
+        encoding="utf-8")
+    stop = stop or "reach val mean >= 0.9, or stop after $5 or 30 minutes"
+    (project / "capevolve.yaml").write_text(
+        "num_trials: 1\ngate_mode: paired\ngate_k_se: 1.0\n"
+        "capabilities: [system-prompt]\ncapability_path: seed_capability\n"
+        f'stop_condition: "{stop}"\n',
+        encoding="utf-8")
+    return project
+
+
+def _run_dir(tmp: Path, *, n: int = 20):
+    """A baselined run dir — exactly what the agent-mode handoff points at."""
+    from cap_evolve import Budget, RunDir, harness
+    from cap_evolve.skillcheck import SyntheticAdapter, seed_capability_dir
+
+    adapter = SyntheticAdapter(n=n)
+    seed = seed_capability_dir(tmp, level=3)
+    run_dir = RunDir.create(tmp / ".capevolve", ts="host", budget=Budget(max_iterations=5))
+    harness.ensure_splits(adapter, run_dir, seed=0)
+    harness.baseline(adapter, seed, run_dir=run_dir)
+    return run_dir
+
+
+def test_host_script_exists_and_is_documented_where_it_belongs():
+    """Documented for operators, NOT inside the agent's per-trigger context.
+
+    SKILL.md is what the hosted agent re-reads on every trigger, and it is capped at ~5000
+    tokens with about 150 characters of headroom. host.py is not part of the loop the agent
+    executes — the host invokes the agent, never the other way round — so spending that
+    budget on it would push out guidance the agent does need. The skill's own scripts/
+    already sets this precedent: `linkcheck.py` and `abstract.py` are likewise absent from
+    SKILL.md, while every genuine loop helper is named there.
+
+    So the contract is: host.py carries its own reasoning in its docstring, and the
+    operator-facing docs explain when to reach for it.
+    """
+    assert HOST.is_file(), "skills/algorithms/agent-optimize/scripts/host.py is missing"
+
+    skill_body = (SKILL / "SKILL.md").read_text(encoding="utf-8").split("---", 2)[-1]
+    assert len(skill_body) // 4 <= 5000, (
+        "SKILL.md is over the repo's 5000-token body budget — whatever was added to it "
+        "belongs in references/ or the operator docs")
+
+    agent_orch = (REPO / "docs" / "AGENT_ORCHESTRATION.md").read_text(encoding="utf-8")
+    assert "host.py" in agent_orch, (
+        "agent mode's own doc never mentions the headless host, so nobody looking for "
+        "'how do I run this unattended' will find it")
+
+    bench_readme = (REPO / "ci" / "benchmarks" / "README.md").read_text(encoding="utf-8")
+    assert "agent-optimize" in bench_readme, (
+        "the benchmarks README does not document the agent-optimize dispatch option")
+
+    doc = HOST.read_text(encoding="utf-8")
+    assert "run-optimizer" in doc, (
+        "host.py must say that it delegates the CLI invocation rather than shelling agents "
+        "itself — otherwise the next reader adds a second copy of that logic")
+
+
+def test_prompt_only_renders_the_briefing_without_shelling_an_agent(tmp_path):
+    """--prompt-only is the offline seam: render the briefing, spend nothing."""
+    project = _project(tmp_path, stop="reach val mean >= 0.75, or stop after $3")
+    run_dir = _run_dir(tmp_path)
+
+    out = _host("--run-dir", str(run_dir.root), "--project", str(project),
+                "--agent", "claude-code", "--prompt-only")
+
+    assert out["prompt_only"] is True
+    assert out.get("returncode") is None, "a --prompt-only run must not invoke the agent"
+
+    prompt_path = Path(out["prompt_path"])
+    assert prompt_path.is_file(), "the briefing was not written to disk"
+    assert prompt_path.parent == run_dir.root / "host", (
+        "the briefing belongs in the run dir, so an audit of the run can read what the "
+        f"host actually asked for; got {prompt_path}")
+    body = prompt_path.read_text(encoding="utf-8")
+
+    # The handoff facts. Absolute paths: the host's cwd and the agent's cwd need not agree.
+    assert str(run_dir.root) in body
+    assert str(project) in body
+    assert str(REPO / "skills") in body
+
+    # The spec values the loop's own gate needs, restated so the agent does not guess.
+    assert "reach val mean >= 0.75" in body, "the stop_condition was not handed over"
+    assert "1.0" in body and "num_trials" in body
+
+    # The loop's commands. measure.py is the load-bearing one: no seal, no result.
+    for helper in ("spend.py", "gate_check.py", "commit.py", "measure.py"):
+        assert helper in body, f"the briefing never names {helper}"
+
+    # Unattended means unattended — a briefing that invites questions stalls in CI.
+    assert "do not ask" in body.lower()
+
+
+def test_unknown_host_agent_is_refused_before_any_spend(tmp_path):
+    project = _project(tmp_path)
+    run_dir = _run_dir(tmp_path)
+
+    out = _host("--run-dir", str(run_dir.root), "--project", str(project),
+                "--agent", "no-such-agent-cli", expect_rc=2)
+
+    assert "no-such-agent-cli" in json.dumps(out)
+    assert "registry" in json.dumps(out).lower(), (
+        "the refusal should point at optimizers/registry.yaml, which is where a host "
+        f"agent is actually added: {out}")
+    assert not (run_dir.root / "final.json").exists(), "a refused host must not seal"
+
+
+def test_seal_only_finalizes_a_run_the_agent_left_open(tmp_path):
+    """The guarantee that makes an unattended run reportable.
+
+    An agent that runs out of turns mid-loop leaves no final.json. CI then cannot tell
+    "the agent stopped early" from "a step crashed", and there is no honest number at
+    all. --seal-only produces one from whatever the run already established.
+    """
+    project = _project(tmp_path)
+    run_dir = _run_dir(tmp_path)
+    assert not (run_dir.root / "final.json").exists()
+
+    out = _host("--run-dir", str(run_dir.root), "--project", str(project), "--seal-only")
+
+    assert out["sealed"] is True, out
+    assert out["seal"] == "host", (
+        "a seal the host had to perform must be labelled as such, not presented as the "
+        f"agent's own: {out}")
+    final = run_dir.root / "final.json"
+    assert final.is_file(), "--seal-only did not produce final.json"
+    payload = json.loads(final.read_text(encoding="utf-8"))
+    assert "test" in payload and "reward" in payload["test"]
+
+
+def test_seal_only_is_idempotent_and_never_double_seals(tmp_path):
+    """A second seal must not raise TestSealError out of the host.
+
+    The host runs after an agent that may itself have sealed. Blowing up there would
+    fail a run that is actually complete.
+    """
+    project = _project(tmp_path)
+    run_dir = _run_dir(tmp_path)
+    first = _host("--run-dir", str(run_dir.root), "--project", str(project), "--seal-only")
+    assert first["sealed"] is True
+
+    second = _host("--run-dir", str(run_dir.root), "--project", str(project), "--seal-only")
+    assert second["sealed"] is True
+    assert second["seal"] == "agent", (
+        "an already-sealed run must be reported as already sealed, not re-sealed: "
+        f"{second}")
+
+
+def test_bash_timeout_is_raised_far_past_the_ten_minute_default(tmp_path):
+    """A full-val eval on a real benchmark runs for hours inside one Bash call.
+
+    Claude Code caps a Bash call at BASH_MAX_TIMEOUT_MS (default 600000 = 10 min). Left
+    at the default, every eval the driver launches is killed mid-flight and the whole run
+    reads as a broken runner rather than a slow one.
+    """
+    project = _project(tmp_path)
+    run_dir = _run_dir(tmp_path)
+
+    out = _host("--run-dir", str(run_dir.root), "--project", str(project), "--prompt-only")
+
+    env = out["agent_env"]
+    assert int(env["BASH_MAX_TIMEOUT_MS"]) >= 3_600_000, env
+    assert int(env["BASH_DEFAULT_TIMEOUT_MS"]) >= 3_600_000, env
+    # The docs are explicit that the effective ceiling is max(default, max) — so both
+    # have to move, and the default must never exceed the max.
+    assert int(env["BASH_DEFAULT_TIMEOUT_MS"]) <= int(env["BASH_MAX_TIMEOUT_MS"]), env
+
+
+def test_skills_dir_and_core_reach_the_agent(tmp_path):
+    """Every loop command is `python $A/<helper>.py`, which imports cap_evolve."""
+    project = _project(tmp_path)
+    run_dir = _run_dir(tmp_path)
+    out = _host("--run-dir", str(run_dir.root), "--project", str(project), "--prompt-only")
+    env = out["agent_env"]
+    assert env["CAPEVOLVE_SKILLS_DIR"] == str(REPO / "skills")
+
+
+@pytest.mark.parametrize("missing", ["--run-dir", "--project"])
+def test_required_handoff_arguments(tmp_path, missing):
+    project = _project(tmp_path)
+    run_dir = _run_dir(tmp_path)
+    argv = ["--run-dir", str(run_dir.root), "--project", str(project), "--prompt-only"]
+    i = argv.index(missing)
+    del argv[i:i + 2]
+    p = subprocess.run([sys.executable, str(HOST), *argv],
+                       capture_output=True, text=True, env=_env())
+    assert p.returncode != 0, f"{missing} must be required"

--- a/core/tests/test_benchmarks_agent_optimize.py
+++ b/core/tests/test_benchmarks_agent_optimize.py
@@ -1,0 +1,273 @@
+"""The benchmarks suite can run `agent-optimize`, not only the hill-climb variants.
+
+Three things had to change and each is pinned here:
+
+  1. **run_suite.sh's algorithm selection.** It hardcoded `algorithm_skill: hill-climb`,
+     so agent-optimize was unreachable — and selecting it without
+     `orchestration_mode: agent` is refused outright by the algorithm itself. The block is
+     executed as real bash (same approach as test_run_suite_split_hook.py) rather than
+     grepped, because the thing that breaks is shell behaviour, not text.
+  2. **Back-compat.** The dispatch input was renamed `algorithm_focus` -> `algorithm`, but
+     committed `overrides.env` files and hand-run operators still export ALGORITHM_FOCUS.
+     A silent change of focus would quietly alter what a published number means.
+  3. **The CI report still renders.** metrics.py builds its iteration timeline from `step`
+     events, which agent mode only produces because `commit.py` books each decision through
+     `harness.record_iteration`. That coupling is load-bearing and untested, so it is
+     pinned here: without it an agent-mode run reports zero iterations and an empty
+     timeline while still exiting 0.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+RUN_SUITE = REPO / "ci" / "benchmarks" / "lib" / "run_suite.sh"
+WORKFLOW = REPO / ".github" / "workflows" / "benchmarks.yml"
+sys.path.insert(0, str(REPO / "ci" / "benchmarks" / "lib"))
+
+MARK_START = "# ---- algorithm selection"
+MARK_END = "# ---- end algorithm selection"
+
+
+def _algorithm_block() -> str:
+    """Lift the algorithm-selection block verbatim out of run_suite.sh."""
+    src = RUN_SUITE.read_text(encoding="utf-8")
+    start = src.index(MARK_START)
+    end = src.index(MARK_END, start)
+    return src[start:end]
+
+
+def _select(**env: str) -> dict:
+    """Run the real block with the given environment; return the variables it set."""
+    script = _algorithm_block() + (
+        '\nprintf "%s\\n%s\\n%s\\n%s\\n" '
+        '"$ALGO_SKILL" "$ALGO_FOCUS" "$ORCH_MODE" "$STOP_CONDITION"\n')
+    p = subprocess.run(["bash", "-c", script], capture_output=True, text=True,
+                       env={"PATH": "/usr/bin:/bin", **env})
+    assert p.returncode == 0, f"block failed: {p.stderr}"
+    skill, focus, mode, stop = (p.stdout.split("\n") + ["", "", "", ""])[:4]
+    return {"skill": skill, "focus": focus, "mode": mode, "stop": stop,
+            "stderr": p.stderr}
+
+
+# --------------------------------------------------------------------------- 1
+
+
+@pytest.mark.parametrize("value,focus", [
+    ("hill-climb-all", "all"),
+    ("hill-climb-cyclic", "cyclic"),
+    ("hill-climb-hardest-first", "hardest-first"),
+])
+def test_hill_climb_variants_stay_deterministic(value, focus):
+    got = _select(ALGORITHM=value)
+    assert got["skill"] == "hill-climb"
+    assert got["focus"] == focus
+    assert got["mode"] == "deterministic", (
+        "a hill-climb dispatch must not be switched into agent mode")
+    assert got["stop"] == "", (
+        "stop_condition is agent-mode's stopping rule; a deterministic run is bounded by "
+        "max_iterations and must not carry one")
+
+
+def test_default_is_the_previous_behaviour():
+    """No ALGORITHM set at all == what every existing dispatch already did."""
+    got = _select()
+    assert (got["skill"], got["focus"], got["mode"]) == ("hill-climb", "all", "deterministic")
+
+
+def test_agent_optimize_selects_agent_mode():
+    got = _select(ALGORITHM="agent-optimize")
+    assert got["skill"] == "agent-optimize"
+    assert got["mode"] == "agent", (
+        "agent-optimize refuses a deterministic invocation — selecting it without "
+        "orchestration_mode: agent would fail the run outright")
+    assert got["focus"] == "", "focus is a hill-climb concept and must not be emitted"
+    assert got["stop"], "agent mode without a stop_condition has no stopping rule"
+
+
+def test_agent_optimize_stop_condition_is_derived_from_the_dispatch_inputs():
+    """The same inputs must bound both algorithms, or the two are not comparable."""
+    got = _select(ALGORITHM="agent-optimize", ITERATIONS="7",
+                  OPTIMIZER_USD_PER_ITER="4.0", GATE_K_SE="0.2")
+    stop = got["stop"]
+    assert "7" in stop, f"ITERATIONS did not reach the stop_condition: {stop}"
+    assert "28" in stop, (
+        "the USD ceiling should be the per-iteration cap x iterations (4.0 x 7 = 28), "
+        f"since the whole loop is one process: {stop}")
+    assert "finalize" in stop or "measure" in stop, (
+        f"the stop_condition must require a seal — no finalize, no result: {stop}")
+
+
+def test_unlimited_optimizer_budget_yields_no_dollar_ceiling():
+    """0 means unlimited everywhere else in this workflow; keep that meaning."""
+    got = _select(ALGORITHM="agent-optimize", ITERATIONS="10", OPTIMIZER_USD_PER_ITER="0")
+    assert "$0" not in got["stop"], (
+        f"a 0 (unlimited) cap must not become a $0 ceiling: {got['stop']}")
+
+
+def test_unknown_algorithm_fails_loudly():
+    script = _algorithm_block()
+    p = subprocess.run(["bash", "-c", script], capture_output=True, text=True,
+                       env={"PATH": "/usr/bin:/bin", "ALGORITHM": "gepa-typo"})
+    assert p.returncode != 0, (
+        "an unrecognised algorithm must abort — silently falling back to hill-climb "
+        "publishes a number under the wrong algorithm's name")
+    assert "gepa-typo" in (p.stderr + p.stdout)
+
+
+def _yaml_block() -> str:
+    """Lift the spec-rendering block too — it turns those variables into capevolve.yaml."""
+    src = RUN_SUITE.read_text(encoding="utf-8")
+    start = src.index("# The algorithm block above chose the skill")
+    end = src.index('BASE="$REPO/ci/benchmarks/$BENCH/$TIER"', start)
+    return src[start:end]
+
+
+def _rendered_spec(**env: str) -> dict:
+    """Run selection + rendering, then parse the emitted YAML the way core does."""
+    from cap_evolve.specfile import read_yaml
+
+    script = _algorithm_block() + _yaml_block() + '\nprintf "%s\\n" "$ALGO_YAML"\n'
+    p = subprocess.run(["bash", "-c", script], capture_output=True, text=True,
+                       env={"PATH": "/usr/bin:/bin", "PY": sys.executable, **env})
+    assert p.returncode == 0, f"render failed: {p.stderr}"
+    return read_yaml(p.stdout) or {}
+
+
+def test_the_agent_mode_spec_it_writes_is_valid_yaml():
+    """The stop_condition is a paragraph containing ':' and '$'.
+
+    Interpolated raw it produces a spec that either fails to parse or — far worse — parses
+    with the prose silently truncated at the first colon, leaving the agent with a stopping
+    rule nobody wrote. Hence json.dumps; hence this test parses the real output.
+    """
+    spec = _rendered_spec(ALGORITHM="agent-optimize", ITERATIONS="4",
+                          OPTIMIZER_USD_PER_ITER="2.5", GATE_K_SE="0.2", NUM_TRIALS="3")
+
+    assert spec.get("algorithm_skill") == "agent-optimize"
+    assert spec.get("orchestration_mode") == "agent"
+    assert "algorithm_focus" not in spec
+
+    stop = spec.get("stop_condition") or ""
+    # Round-trip intact: the whole paragraph, not a fragment ending at a colon.
+    assert stop.endswith("a run with no finalize has no result."), (
+        f"the stop_condition was truncated in the emitted YAML: {stop!r}")
+    assert "$10.00" in stop, f"2.5 x 4 rounds should give a $10.00 ceiling: {stop!r}"
+    assert "gate_k_se=0.2" in stop and "3 trial(s)" in stop
+
+
+def test_the_deterministic_spec_it_writes_is_unchanged_in_shape():
+    spec = _rendered_spec(ALGORITHM="hill-climb-hardest-first")
+    assert spec.get("algorithm_skill") == "hill-climb"
+    assert spec.get("algorithm_focus") == "hardest-first"
+    assert "orchestration_mode" not in spec, (
+        "a deterministic run must not carry an orchestration_mode key at all — core's "
+        "default is what every existing run used")
+    assert "stop_condition" not in spec
+
+
+# --------------------------------------------------------------------------- 2
+
+
+@pytest.mark.parametrize("focus", ["all", "cyclic", "hardest-first"])
+def test_legacy_algorithm_focus_is_still_honoured(focus):
+    got = _select(ALGORITHM_FOCUS=focus)
+    assert (got["skill"], got["focus"], got["mode"]) == ("hill-climb", focus, "deterministic")
+
+
+def test_algorithm_wins_over_the_legacy_alias():
+    got = _select(ALGORITHM="hill-climb-cyclic", ALGORITHM_FOCUS="hardest-first")
+    assert got["focus"] == "cyclic", (
+        "the explicit new input must win; otherwise a stale exported alias silently "
+        "overrides a deliberate dispatch choice")
+
+
+# --------------------------------------------------------------------------- 3
+
+
+def test_agent_mode_rounds_render_in_the_ci_iteration_timeline(tmp_path):
+    """metrics.py's timeline is built from `step` events, and agent mode must emit them.
+
+    This is a coupling, not a coincidence: `commit.py` books a decision through
+    `harness.record_iteration`, which writes the canonical `step` record every consumer
+    reads. Nothing in the agent's own prose obliges it to — so if commit.py ever stopped
+    routing through record_iteration, an agent-mode CI run would still succeed while its
+    report rendered "(no iteration events found)" and its iteration count stayed 0,
+    which `assert_run.py --min-iterations 1` reads as a run that never optimized.
+
+    Executed for real (commit.py against a live run dir), because the point is the
+    integration, and a hand-written events.jsonl would pin only this test's assumptions.
+    """
+    import metrics
+    from cap_evolve import Budget, RunDir, harness
+    from cap_evolve.skillcheck import SyntheticAdapter, seed_capability_dir
+
+    adapter = SyntheticAdapter(n=20)
+    seed = seed_capability_dir(tmp_path, level=3)
+    run_dir = RunDir.create(tmp_path / ".capevolve", ts="ci", budget=Budget(max_iterations=5))
+    harness.ensure_splits(adapter, run_dir, seed=0)
+    harness.baseline(adapter, seed, run_dir=run_dir)
+
+    work = run_dir.root / "work" / "cand_1"
+    work.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(run_dir.root / "candidates" / "seed", work)
+
+    commit = REPO / "skills" / "algorithms" / "agent-optimize" / "scripts" / "commit.py"
+    p = subprocess.run(
+        [sys.executable, str(commit), "--run-dir", str(run_dir.root),
+         "--candidate-id", "cand_1", "--from-dir", str(work),
+         "--decision", "accept", "--val", "0.61", "--note", "a general rule"],
+        capture_output=True, text=True,
+        env={**os.environ, "CAPEVOLVE_CORE": str(REPO / "core")})
+    assert p.returncode == 0, f"commit.py failed: {p.stdout}\n{p.stderr}"
+
+    rows = [r for r in metrics.iteration_rows(str(run_dir.root), best_id="cand_1")
+            if r["phase"] == "iterate"]
+    assert len(rows) == 1, f"an agent-mode round produced no timeline row: {rows}"
+    assert rows[0]["candidate"] == "cand_1"
+    assert rows[0]["accepted"] is True
+    assert rows[0]["reward"] == 0.61
+    assert run_dir.spent.iterations == 1, (
+        "the round did not charge an iteration — assert_run.py --min-iterations 1 would "
+        "fail a run that really did optimize")
+
+
+# --------------------------------------------------------------------------- workflow
+
+
+def test_workflow_exposes_the_algorithm_input_within_githubs_ten_input_cap():
+    src = WORKFLOW.read_text(encoding="utf-8")
+    inputs = src[src.index("  workflow_dispatch:"):src.index("  pull_request:")]
+    # Top-level input keys are indented exactly 6 spaces under `inputs:`.
+    names = [ln.strip().rstrip(":") for ln in inputs.splitlines()
+             if len(ln) - len(ln.lstrip()) == 6 and ln.rstrip().endswith(":")
+             and not ln.strip().startswith("#")]
+    assert "algorithm" in names, f"no `algorithm` dispatch input: {names}"
+    assert "algorithm_focus" not in names, (
+        "algorithm_focus was replaced by algorithm; keeping both would exceed the cap")
+    assert len(names) <= 10, (
+        f"workflow_dispatch allows at most 10 inputs; this file declares {len(names)}: "
+        f"{names} — GitHub rejects the whole workflow as invalid")
+
+
+def test_workflow_offers_every_algorithm_the_suite_can_run():
+    src = WORKFLOW.read_text(encoding="utf-8")
+    block = src[src.index("      algorithm:"):]
+    block = block[:block.index("\n      #") if "\n      #" in block[:2000] else 2000]
+    for opt in ("hill-climb-all", "hill-climb-cyclic", "hill-climb-hardest-first",
+                "agent-optimize"):
+        assert opt in block, f"the algorithm input does not offer {opt}: {block[:500]}"
+
+
+def test_runmeta_records_which_algorithm_produced_the_number():
+    src = WORKFLOW.read_text(encoding="utf-8")
+    assert '"algorithm"' in src, (
+        "runmeta.json must record the algorithm — benchmark-history compares numbers "
+        "across runs, and hill-climb vs agent-optimize is not a like-for-like comparison")

--- a/core/tests/test_site_live_panel_tiers.py
+++ b/core/tests/test_site_live_panel_tiers.py
@@ -87,3 +87,48 @@ def test_tier_filter_offers_every_tier():
         'site/benchmarks.js must call hydrateFilter("#f-tier", …) to populate the tier '
         "dropdown from records; a static option list silently hides tiers not in the markup"
     )
+
+
+def test_history_table_shows_which_algorithm_produced_the_number():
+    """A hill-climb number and an agent-optimize number are not a like-for-like comparison.
+
+    The benchmarks page is where numbers get compared across runs, so `runmeta.json` records
+    the `algorithm` and the table has to surface it. Without the column the field exists in
+    every record and is invisible exactly where the false comparison would be made.
+
+    Column count matters too: the expandable detail row spans the whole table, so a header
+    added without bumping its colspan leaves the per-task/per-step tables misaligned.
+    """
+    html = HTML.read_text(encoding="utf-8")
+    js = JS.read_text(encoding="utf-8")
+
+    assert re.search(r'<th data-k="algorithm">', html), (
+        "the history table has no Algorithm column — the algorithm that produced a number "
+        "would be invisible on the page where numbers are compared"
+    )
+    assert "r.algorithm" in js, "benchmarks.js never renders the record's algorithm field"
+
+    header_block = html[html.index("<thead><tr>"):html.index("</thead>")]
+    n_cols = len(re.findall(r"<th\b", header_block))
+    spans = {int(m) for m in re.findall(r'colspan="(\d+)"', js)}
+    assert spans == {n_cols}, (
+        f"the table has {n_cols} columns but the detail row spans {sorted(spans)} — the "
+        "expanded per-task table would not line up with the header"
+    )
+
+
+def test_a_record_without_an_algorithm_is_not_given_one():
+    """Every record written before the field existed must render as unknown, not guessed.
+
+    `algorithm_focus` was already dispatchable then, so an old run's schedule is genuinely
+    unrecoverable. Defaulting the column to "hill-climb-all" would fabricate precisely the
+    provenance the column exists to establish.
+    """
+    js = JS.read_text(encoding="utf-8")
+    m = re.search(r"const algo = ([^;]+);", js)
+    assert m, "the algorithm cell is not rendered through a reviewable expression"
+    expr = m.group(1)
+    assert '"—"' in expr or "'—'" in expr, (
+        f"a missing algorithm must render as an em dash: {expr}")
+    assert "hill-climb" not in expr, (
+        f"a missing algorithm must not be back-filled with a guessed default: {expr}")

--- a/docs/AGENT_ORCHESTRATION.md
+++ b/docs/AGENT_ORCHESTRATION.md
@@ -103,6 +103,48 @@ python "$S/phases/report/scripts/run.py"   --run-dir "$R"
 > best candidate on test once and burns the seal. A second finalize raises `TestSealError`.
 > `cap-evolve --help` lists the real subcommands.
 
+## Unattended agent mode — the headless host
+
+Agent mode assumes a conversational agent is present to pick up the handoff. Where none is —
+CI, cron, a script — the handoff would simply go unread: `cap-evolve run` prints it, returns 0,
+and nothing drives the loop. `skills/algorithms/agent-optimize/scripts/host.py` is the host for
+that case:
+
+```bash
+S="$CAPEVOLVE_SKILLS_DIR"
+python "$S/algorithms/agent-optimize/scripts/host.py" \
+       --run-dir "$R" --project "$P" \
+       --agent claude-code --model claude-opus-4-8 \
+       --budget 240 --usd-budget 30
+```
+
+It renders a driver briefing from the spec + handoff (paths, `num_trials`, `gate_k_se`, the
+`stop_condition`, and an instruction not to ask questions), then hands it to the named agent CLI
+through the existing **`optimizers/run-optimizer`** runner — so the registry row, `{model}`
+substitution, budget-flag mapping, cost capture and CLI-present hard-fail are the same ones the
+deterministic path uses, not a second copy. `--agent` accepts any row in
+`skills/optimizers/registry.yaml`.
+
+Three things are the host's own:
+
+- **Whole-loop budgets.** Agent mode runs the entire search in ONE agent process, so `--budget`
+  (turns) and `--usd-budget` bound the whole loop, not one round. CI derives them by multiplying
+  the per-iteration caps by the round count.
+- **A raised Bash-tool ceiling.** Claude Code caps one Bash call at `BASH_MAX_TIMEOUT_MS`
+  (default 10 min). A full-val eval on a real benchmark runs far longer, so the host raises both
+  `BASH_DEFAULT_TIMEOUT_MS` and `BASH_MAX_TIMEOUT_MS` — the effective ceiling is the larger of
+  the two. Left at the default, every eval is killed mid-flight and a healthy run reads as a
+  broken runner.
+- **A guaranteed seal.** An agent that exhausts its turns leaves no `final.json`, and there is
+  then no honest number and no way to tell "stopped early" from "crashed". If the agent did not
+  seal, the host does — through the same `measure.py` — and reports `seal: host` so it is never
+  mistaken for the agent's own judgement that it was finished. Already-sealed runs report
+  `seal: agent` rather than raising `TestSealError`.
+
+`--prompt-only` renders the briefing and spends nothing (it lands at `$R/host/driver_prompt.md`,
+so a finished run carries a record of exactly what the host asked for). `--seal-only` seals a run
+a previous host left open.
+
 ## Honesty invariants (both modes)
 
 - Acceptance and the score-goal check are always on **full val** through the gate; cheap subset

--- a/site/benchmarks.html
+++ b/site/benchmarks.html
@@ -114,6 +114,7 @@
       <th data-k="source">Source</th>
       <th data-k="bench">Bench</th>
       <th data-k="tier">Type</th>
+      <th data-k="algorithm">Algorithm</th>
       <th data-k="iterations">Iters</th>
       <th data-k="trials">Trials</th>
       <th data-k="reward">Reward base→opt</th>

--- a/site/benchmarks.js
+++ b/site/benchmarks.js
@@ -237,8 +237,14 @@ function render() {
     const badge = `<span class="badge ${esc(r.conclusion)}">${esc(r.conclusion)}</span>`;
     const date = esc(fmtLocal(r.date));
     const tier = esc(r.tier || "smoke");
+    // Which algorithm produced the number. Records written before the `algorithm` field
+    // existed render "—" rather than a guessed "hill-climb-all": the focus schedule was
+    // already dispatchable then, so the algorithm of an old run is genuinely unknown, and
+    // labelling it would fabricate the very provenance this column exists to establish.
+    const algo = esc(r.algorithm || "—");
     tr.innerHTML = `<td><a href="${esc(r.run_url)}">${date}</a></td>
-      <td>${src}</td><td>${esc(r.bench)}</td><td>${tier}</td><td>${r.iterations ?? "—"}</td>
+      <td>${src}</td><td>${esc(r.bench)}</td><td>${tier}</td><td><code>${algo}</code></td>
+      <td>${r.iterations ?? "—"}</td>
       <td>${r.trials ?? "—"}</td>
       <td>${reward}</td><td>${evalUsd}</td><td>${optUsd}</td><td>${latency}</td>
       <td><code>${esc(r.agent_model || "—")}</code></td><td><code>${esc(r.optimizer_model || "—")}</code></td>
@@ -248,7 +254,7 @@ function render() {
     const detail = document.createElement("tr");
     detail.className = "detail-row";
     detail.hidden = true;
-    detail.innerHTML = `<td colspan="14">${taskTable(r.tasks || [])}${stepsTable(r.steps || [])}</td>`;
+    detail.innerHTML = `<td colspan="15">${taskTable(r.tasks || [])}${stepsTable(r.steps || [])}</td>`;
     tb.appendChild(detail);
 
     tr.addEventListener("click", (e) => {

--- a/skills/algorithms/agent-optimize/scripts/check.py
+++ b/skills/algorithms/agent-optimize/scripts/check.py
@@ -1138,6 +1138,74 @@ def _benchmark_agnostic(c: Checker) -> None:
             note="no benchmark, optimizer or agent identity leaks into the skill's own text")
 
 
+def _host(c: Checker, tmp: Path) -> None:
+    """The headless host: a briefing that carries the loop, and a guaranteed seal.
+
+    This is the seam that makes the algorithm usable with no human in the loop, so both of
+    its own guarantees are executed here — offline, no agent CLI involved:
+
+      * ``--prompt-only`` renders the briefing (the run's audit trail of what the host
+        actually asked for) and spends nothing;
+      * ``--seal-only`` seals a run the agent left open, and is idempotent — a host that
+        raised ``TestSealError`` on an already-sealed run would fail runs that are complete.
+    """
+    from cap_evolve import Budget, RunDir, harness
+    from cap_evolve.skillcheck import SyntheticAdapter
+
+    host = HERE / "host.py"
+    if not c.check(host.is_file(), "missing scripts/host.py (the headless host)"):
+        return
+
+    adapter = SyntheticAdapter(n=20)
+    seed = seed_capability_dir(tmp / "host", level=3)
+    project = _project(tmp / "host", n=20)
+    run_dir = RunDir.create(tmp / "host" / ".capevolve", ts="host",
+                            budget=Budget(max_iterations=3))
+    harness.ensure_splits(adapter, run_dir, seed=0)
+    harness.baseline(adapter, seed, run_dir=run_dir)
+    R, P = str(run_dir.root), str(project)
+
+    rendered = _run(c, "host.py --prompt-only",
+                    [str(host), "--run-dir", R, "--project", P, "--prompt-only"])
+    if rendered:
+        body = Path(rendered["prompt_path"]).read_text(encoding="utf-8")
+        for needle in ("spend.py", "gate_check.py", "commit.py", "measure.py"):
+            c.check(needle in body, f"the host briefing never names {needle}")
+        c.check(R in body and P in body,
+                "the host briefing does not carry the handoff paths")
+        c.check("do not ask" in body.lower(),
+                "the host briefing must tell the agent not to ask questions — an "
+                "unattended run that waits for a reply stalls until it is killed")
+        env = rendered.get("agent_env") or {}
+        c.check(int(env.get("BASH_MAX_TIMEOUT_MS", 0)) >= 3_600_000
+                and int(env.get("BASH_DEFAULT_TIMEOUT_MS", 0)) >= 3_600_000,
+                f"the host left the Bash-tool timeout at its 10-minute default: {env} — "
+                "every full-val eval would be killed mid-flight and read as a broken runner",
+                note="the host raises the Bash-tool ceiling past a full-val eval")
+
+    c.check(not (run_dir.root / "final.json").exists(),
+            "--prompt-only must not seal anything")
+    sealed = _run(c, "host.py --seal-only",
+                  [str(host), "--run-dir", R, "--project", P, "--seal-only"])
+    if sealed:
+        c.check(sealed.get("sealed") is True and sealed.get("seal") == "host",
+                f"--seal-only did not seal, or did not label the seal as the host's: {sealed}")
+    again = _run(c, "host.py --seal-only (idempotent)",
+                 [str(host), "--run-dir", R, "--project", P, "--seal-only"])
+    if again:
+        c.check(again.get("seal") == "agent",
+                f"a second seal must report the run as already sealed, not re-seal: {again}",
+                note="the host's seal is idempotent — a complete run is never failed for it")
+
+    unknown = _run(c, "host.py --agent <unknown>",
+                   [str(host), "--run-dir", R, "--project", P,
+                    "--agent", "definitely-not-a-registry-row"], expect_rc=2)
+    if unknown:
+        c.check("registry" in json.dumps(unknown).lower(),
+                f"an unknown host agent must be refused with a pointer at the registry, "
+                f"before any spend: {unknown}")
+
+
 def main() -> int:
     c = Checker("agent-optimize")
     _guard(c)
@@ -1161,6 +1229,7 @@ def main() -> int:
         _integrate(c, tmp)
         _mechanisms(c, tmp)
         _measure(c, tmp)
+        _host(c, tmp)
     finally:
         shutil.rmtree(tmp, ignore_errors=True)
     _benchmark_agnostic(c)

--- a/skills/algorithms/agent-optimize/scripts/host.py
+++ b/skills/algorithms/agent-optimize/scripts/host.py
@@ -1,0 +1,382 @@
+"""host.py — drive this skill's loop from a NON-INTERACTIVE caller (CI, cron, a script).
+
+agent-optimize's loop is prose in ``SKILL.md``, executed by the conversational agent that
+ran intake. ``cap-evolve run`` (agent mode) does check + baseline, prints a handoff, and
+returns: no algorithm subprocess, no auto-finalize. That is exactly right with a human in
+the loop and leaves the algorithm *unavailable* anywhere without one — a CI job gets the
+handoff and then nothing happens.
+
+This script is the missing host, and deliberately owns as little as possible:
+
+  * the **loop** stays in ``SKILL.md`` + this dir's helpers. The briefing points at them; it
+    does not restate the algorithm, because a second copy of the loop would drift from the
+    first and there would be no way to tell which one ran.
+  * the **CLI invocation** is delegated to ``optimizers/run-optimizer``, which already
+    resolves a registry row, substitutes ``{model}``, maps ``--budget``/``--usd-budget`` to
+    that CLI's own flags, captures cost from its JSON output, and hard-fails when the CLI
+    is absent. Re-implementing any of that here would be a second, worse copy.
+
+What is genuinely this script's own:
+
+**A raised Bash-tool ceiling.** Every loop command is a shell call, and a full-val eval on
+a real benchmark runs for hours. Claude Code caps one Bash call at ``BASH_MAX_TIMEOUT_MS``
+(default 600000 = 10 min) and the effective ceiling is ``max(default, max)``, so both are
+raised. Left alone, every eval is killed mid-flight and an entirely healthy run reads as a
+broken runner.
+
+**A guaranteed seal.** An agent that exhausts its turns or dies mid-loop leaves no
+``final.json``. CI then cannot distinguish "stopped early" from "a step crashed", and there
+is no honest number at all. So if the agent did not seal, the host does — through the same
+``measure.py`` the skill documents, labelled ``seal: host`` so nobody mistakes it for the
+agent's own judgement that it was finished.
+
+The seal is idempotent: an already-sealed run reports ``seal: agent`` rather than raising
+``TestSealError`` out of the host and failing a run that is actually complete.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import _bootstrap  # noqa: F401
+
+HERE = Path(__file__).resolve().parent
+SKILL_DIR = HERE.parent
+SKILLS = SKILL_DIR.parents[1]
+RUN_OPTIMIZER = SKILLS / "optimizers" / "run-optimizer" / "scripts" / "run.py"
+REGISTRY = SKILLS / "optimizers" / "registry.yaml"
+
+# 4h. Long enough for a full-val eval on the slowest benchmark in this repo
+# (spreadsheetbench full: one Docker container per task x trials), while still bounding a
+# genuinely hung command instead of waiting forever.
+BASH_TIMEOUT_MS = 4 * 60 * 60 * 1000
+
+
+def _spec(project: Path, spec_path: Path | None) -> dict:
+    from cap_evolve.specfile import read_yaml
+
+    path = spec_path or (project / "capevolve.yaml")
+    if not path.exists():
+        return {}
+    return read_yaml(path.read_text(encoding="utf-8")) or {}
+
+
+def _known_agents() -> list[str]:
+    from cap_evolve.specfile import read_yaml
+
+    try:
+        return sorted((read_yaml(REGISTRY.read_text(encoding="utf-8")) or {}).keys())
+    except Exception:  # noqa: BLE001 — a missing registry is reported by the caller below
+        return []
+
+
+def _briefing(*, run_dir: Path, project: Path, spec: dict, skills: Path,
+              rounds: int) -> str:
+    """The driver briefing: the handoff facts, then a pointer to the loop itself.
+
+    Deliberately NOT a restatement of the algorithm. SKILL.md is the implementation and the
+    agent reads it; what it cannot know are the paths, the spec values and the fact that
+    nobody is available to answer a question.
+    """
+    stop = str(spec.get("stop_condition") or "").strip()
+    n_trials = spec.get("num_trials", 1)
+    k_se = spec.get("gate_k_se", 1.0)
+    gate_mode = spec.get("gate_mode", "paired")
+    caps = spec.get("capabilities") or []
+    cap_path = spec.get("capability_path") or "seed_capability"
+    skill_md = SKILL_DIR / "SKILL.md"
+    helpers = HERE
+
+    if not stop:
+        stop = (f"Spend at most {rounds} rounds, gate every candidate on FULL val, and "
+                "finish by sealing test exactly once with measure.py.")
+
+    return f"""# Drive the agent-optimize loop on an existing run — unattended
+
+You are the optimizer for a cap-evolve run that is ALREADY set up and baselined.
+`cap-evolve run` finished check + baseline and handed the loop over. Your job is to run the
+`agent-optimize` loop against it and finish with one honest sealed measurement.
+
+## Read this first
+
+`{skill_md}`
+
+That file IS the algorithm — its "Agent-mode loop" section is what you execute, step by
+step, including Phase 0. Its helper scripts are in `{helpers}`. Do not re-derive the loop
+from this briefing; this briefing only gives you the facts SKILL.md cannot know.
+
+## The handoff
+
+```bash
+R="{run_dir}"      # the run dir: splits, baseline, candidates, rollouts, events
+P="{project}"      # the project: capevolve.yaml, adapters/, {cap_path}
+S="{skills}"       # the skills dir (CAPEVOLVE_SKILLS_DIR is already set to it)
+A="$S/algorithms/agent-optimize/scripts"
+mkdir -p "$R/work"
+```
+
+Paths are absolute; use them as given rather than relative paths, because your working
+directory is not necessarily either of theirs.
+
+## The spec values your gate needs
+
+| key | value |
+| --- | --- |
+| `num_trials` | {n_trials} |
+| `gate_k_se` | {k_se} |
+| `gate_mode` | {gate_mode} |
+| `capabilities` (your editable surface) | {caps} |
+| `capability_path` | {cap_path} |
+
+Pass these explicitly — `--n-trials {n_trials}` on every evaluate, `--k-se {k_se}` on every
+gate — rather than relying on a default that may not match this spec.
+
+## The primitives every round must go through
+
+SKILL.md says why; this is the checklist, because nobody is watching and a round that
+skipped one leaves artifacts that cannot be audited afterwards:
+
+| helper | per round | what it is for |
+| --- | --- | --- |
+| `$A/spend.py` | before | affordability + your stop condition as checkable predicates |
+| `$A/gate_check.py` | after the full-val eval | the paired significance gate — the accept decision |
+| `$A/commit.py` | always, accept or reject | books the decision: snapshot, best_id, iteration, event |
+| `$A/measure.py` | once, at the end | seals test exactly once and prints the honest table |
+
+`commit.py` is the one most easily skipped on a reject, and skipping it is what makes a run
+report zero iterations having done real work. `screen.py` and `round.py` are optional
+accelerators; the four above are not.
+
+## Your stop condition
+
+{stop}
+
+`spend.py` parses that text into checkable predicates; run it before each round and act on
+its single `recommendation` (`stop` | `narrow_scope` | `continue`), as SKILL.md describes.
+
+## Unattended — this is the one real difference from an interactive run
+
+**Nobody is available to answer a question. Do not ask any; do not wait for input.** Where
+SKILL.md's Phase 0 says to ask the user about a blocking ambiguity (including
+`constraints.ambiguous` from `spend.py`), instead: pick the most conservative reading, state
+the assumption in one line in your final summary, and proceed. A round spent on a
+conservative assumption is worth far more than a run that stalls waiting for a reply.
+
+Two consequences worth being explicit about:
+
+1. **Never leave the run unsealed.** Finish with `measure.py` (which seals test exactly
+   once) and the report phase, as SKILL.md's "Stop & seal" section shows. A run with no
+   finalize has no result. If you are running out of budget, stop optimizing and seal —
+   sealing what you have beats one more candidate.
+2. **A null result is a valid outcome, honestly reported.** If nothing beat the baseline
+   through the gate, say so and seal anyway. Do not lower the gate, gate on a screen
+   subset, or present a screen `promote` as an accept to manufacture a gain.
+
+## When you are done
+
+Finish your final message with the run's honest table: seed vs best on val, on train if it
+adds information, and on the sealed test split — plus the accepted candidate id, the number
+of rounds, and any assumption you had to make on your own.
+"""
+
+
+def _seal(run_dir: Path, project: Path, spec: dict, *, timeout: float | None) -> dict:
+    """Ensure the run has a sealed test number. Idempotent.
+
+    Returns ``{"sealed": bool, "seal": "agent"|"host"|"failed", ...}``. ``agent`` means
+    final.json was already there when the host looked — the normal, desired outcome.
+    """
+    final = run_dir / "final.json"
+    if final.exists():
+        return {"sealed": True, "seal": "agent"}
+
+    n_trials = int(spec.get("num_trials", 1) or 1)
+    cmd = [sys.executable, str(HERE / "measure.py"), "--run-dir", str(run_dir),
+           "--project", str(project), "--n-trials", str(n_trials), "--train", "auto"]
+    p = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout,
+                       env=_child_env())
+    if final.exists():
+        return {"sealed": True, "seal": "host", "measure_rc": p.returncode}
+    return {"sealed": False, "seal": "failed", "measure_rc": p.returncode,
+            "measure_error": (p.stderr or p.stdout)[-1200:]}
+
+
+def _child_env() -> dict:
+    env = dict(os.environ)
+    env.setdefault("CAPEVOLVE_SKILLS_DIR", str(SKILLS))
+    return env
+
+
+def _agent_env(model: str | None) -> dict:
+    """The environment the hosted agent runs in — reported so a test can assert it."""
+    env = {
+        "CAPEVOLVE_SKILLS_DIR": str(SKILLS),
+        # Both, because the effective ceiling is max(default, max): raising only one leaves
+        # the other as the real limit.
+        "BASH_DEFAULT_TIMEOUT_MS": str(BASH_TIMEOUT_MS),
+        "BASH_MAX_TIMEOUT_MS": str(BASH_TIMEOUT_MS),
+    }
+    if model:
+        env["CAPEVOLVE_OPTIMIZER_MODEL"] = model
+    return env
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(
+        prog="host.py",
+        description="Drive the agent-optimize loop headlessly against a baselined run dir.")
+    p.add_argument("--run-dir", required=True, help="run dir from the agent-mode handoff")
+    p.add_argument("--project", required=True, help="project dir (capevolve.yaml, adapters/)")
+    p.add_argument("--spec", default=None,
+                   help="spec file; defaults to <project>/capevolve.yaml")
+    p.add_argument("--agent", default="claude-code",
+                   help="host agent: a row in optimizers/registry.yaml (default claude-code)")
+    p.add_argument("--model", default=None, help="model for the host agent")
+    p.add_argument("--budget", type=int, default=None,
+                   help="whole-loop turn cap, mapped to the CLI's own budget flag")
+    p.add_argument("--usd-budget", type=float, default=None,
+                   help="whole-loop $ cap, mapped to the CLI's native flag where it has one")
+    p.add_argument("--timeout", type=float, default=None,
+                   help="wall-clock seconds for the hosted agent (default: none)")
+    p.add_argument("--prompt-only", action="store_true",
+                   help="render the briefing and exit without invoking the agent")
+    p.add_argument("--seal-only", action="store_true",
+                   help="skip the agent; only ensure the run has a sealed test number")
+    args = p.parse_args(argv)
+
+    run_dir = Path(args.run_dir).resolve()
+    project = Path(args.project).resolve()
+    if not run_dir.is_dir():
+        print(json.dumps({"error": f"run dir not found: {run_dir}",
+                          "fix": "pass the run_dir from the agent-mode handoff printed by "
+                                 "`cap-evolve run`"}, indent=2))
+        return 2
+    if not project.is_dir():
+        print(json.dumps({"error": f"project dir not found: {project}"}, indent=2))
+        return 2
+
+    spec = _spec(project, Path(args.spec).resolve() if args.spec else None)
+    rounds = int(spec.get("max_iterations", 0) or 0) or 10
+
+    if args.seal_only:
+        out = _seal(run_dir, project, spec, timeout=args.timeout)
+        print(json.dumps({"run_dir": str(run_dir), "seal_only": True, **out}, indent=2))
+        return 0 if out["sealed"] else 1
+
+    # Refuse an unknown host agent BEFORE anything is spent. The registry is where a host
+    # agent is actually added, so name it in the fix.
+    known = _known_agents()
+    if known and args.agent not in known:
+        print(json.dumps({
+            "error": f"unknown host agent: {args.agent!r}",
+            "known": known,
+            "fix": f"pass --agent with one of the rows in {REGISTRY}, or add a row there "
+                   "(one row per shell-invokable agent CLI — no new code needed)",
+        }, indent=2))
+        return 2
+
+    prompt_dir = run_dir / "host"
+    prompt_dir.mkdir(parents=True, exist_ok=True)
+    prompt_path = prompt_dir / "driver_prompt.md"
+    prompt_path.write_text(
+        _briefing(run_dir=run_dir, project=project, spec=spec, skills=SKILLS, rounds=rounds),
+        encoding="utf-8")
+
+    agent_env = _agent_env(args.model)
+    if args.prompt_only:
+        print(json.dumps({"run_dir": str(run_dir), "agent": args.agent,
+                          "model": args.model, "prompt_only": True,
+                          "prompt_path": str(prompt_path), "returncode": None,
+                          "agent_env": agent_env, "budget": args.budget,
+                          "usd_budget": args.usd_budget}, indent=2))
+        return 0
+
+    # Delegate the invocation. --json switches on run-optimizer's cost capture, which is how
+    # the host's own spend reaches the run dir at all: the evaluate phase records the
+    # runner's cost, and nothing records the proposer's.
+    cmd = [sys.executable, str(RUN_OPTIMIZER), "--name", args.agent, "--json",
+           # The agent needs write access to BOTH the run dir and the project; their common
+           # parent is the natural workdir. Every path in the briefing is absolute anyway.
+           "--workdir", str(_common_parent(run_dir, project)),
+           "--prompt", str(prompt_path)]
+    if args.model:
+        cmd += ["--model", args.model]
+    if args.budget:
+        cmd += ["--budget", str(int(args.budget))]
+    if args.usd_budget:
+        cmd += ["--usd-budget", str(float(args.usd_budget))]
+
+    started = time.time()
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=args.timeout,
+                              env={**_child_env(), **agent_env})
+        timed_out = False
+    except subprocess.TimeoutExpired:
+        proc = None
+        timed_out = True
+    seconds = time.time() - started
+
+    payload: dict = {}
+    if proc is not None:
+        try:
+            payload = json.loads(proc.stdout)
+        except Exception:  # noqa: BLE001 — a non-JSON tail is reported, not fatal
+            payload = {"stdout_tail": (proc.stdout or "")[-1200:]}
+
+    usd = float(payload.get("cost_usd") or payload.get("usd") or 0.0)
+    tokens = int(payload.get("tokens") or 0)
+
+    # Book the host's own spend. The agent books per-round costs it knows about through
+    # commit.py --optimizer-usd; it cannot know its own process cost, and the host can.
+    try:
+        from cap_evolve import RunDir
+
+        rd = RunDir.open(run_dir)
+        rd.log_event("host", agent=args.agent, model=args.model or "",
+                     usd=usd, tokens=tokens, seconds=round(seconds, 3),
+                     returncode=(None if proc is None else proc.returncode),
+                     timed_out=timed_out)
+        if usd or tokens:
+            rd.update_spent(optimizer_usd=usd, optimizer_tokens=tokens)
+    except Exception as exc:  # noqa: BLE001 — spend accounting must not lose the run
+        payload.setdefault("warnings", []).append(f"could not book host spend: {exc}")
+
+    seal = _seal(run_dir, project, spec, timeout=args.timeout)
+
+    out = {
+        "run_dir": str(run_dir),
+        "agent": args.agent,
+        "model": args.model,
+        "prompt_path": str(prompt_path),
+        "returncode": None if proc is None else proc.returncode,
+        "timed_out": timed_out,
+        "seconds": round(seconds, 3),
+        "usd": usd,
+        "agent_env": agent_env,
+        "optimizer": payload,
+        **seal,
+    }
+    if proc is not None and proc.returncode != 0:
+        out["agent_error"] = (proc.stderr or "")[-1200:]
+    print(json.dumps(out, indent=2))
+    # The run's worth is its sealed number, so that — not the agent's exit code — decides
+    # ours. An agent that ran out of turns after three honest rounds produced a result; one
+    # that exited 0 without sealing did not.
+    return 0 if seal["sealed"] else 1
+
+
+def _common_parent(a: Path, b: Path) -> Path:
+    try:
+        return Path(os.path.commonpath([str(a), str(b)]))
+    except ValueError:
+        return a.parent
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/algorithms/agent-optimize/scripts/host.py
+++ b/skills/algorithms/agent-optimize/scripts/host.py
@@ -76,6 +76,61 @@ def _known_agents() -> list[str]:
         return []
 
 
+def _editable_files(run_dir: Path, project: Path, spec: dict) -> list[str]:
+    """The capability's real files, relative — the surface the agent may actually edit.
+
+    ``capabilities`` names which capability skills' ``validate()`` runs; it does NOT restrict
+    what may be written. Handing the agent only those names is what leaves most of the
+    surface untouched: in one measured run a spec declaring both a prompt capability and a
+    tool-code capability produced 2 of 2 candidates that edited only the prompt file, while
+    the tool code sat writable and unopened in the same candidate dir.
+
+    Read from the materialized seed candidate (what the agent copies and edits) rather than
+    from the project's capability_path, so this is the same file set it will really see.
+    """
+    root = run_dir / "candidates" / "seed"
+    if not root.is_dir():
+        cap = str(spec.get("capability_path") or "seed_capability")
+        root = (project / cap).resolve()
+    if not root.is_dir():
+        return []
+    skip_dirs = {"__pycache__", ".git"}
+    files = [
+        p.relative_to(root).as_posix()
+        for p in sorted(root.rglob("*"))
+        if p.is_file()
+        and not any(part in skip_dirs for part in p.parts)
+        and p.suffix not in {".pyc", ".pyo"}
+    ]
+    return files
+
+
+def _surface_section(files: list[str]) -> str:
+    """Render the editable-file list, and say what a prompt-only edit leaves undone.
+
+    Scaled to what is actually there: naming tool code for a capability that has none sends
+    the agent hunting outside its capability for code to change.
+    """
+    if not files:
+        return ""
+    listing = "\n".join(f"- `{f}`" for f in files)
+    if len(files) == 1:
+        return (f"## Your editable surface — one file\n\n{listing}\n\n"
+                "That file is the whole capability. There is no tool code and no second "
+                "surface, so do not go looking for one outside it.\n")
+    return (
+        f"## Your editable surface — ALL {len(files)} of these files\n\n{listing}\n\n"
+        "Every one of them is in your candidate copy and every one is fair game — prose, "
+        "code, data, nested files alike. A round that changes **only the obvious prompt "
+        "file** leaves the rest of the agent's instruction and behaviour surface exactly as "
+        "it was, and that is the most common way a run produces nothing: the fix that was "
+        "needed lived in a file nobody opened.\n\n"
+        "So before you write an edit, decide *which file* is the right place for it — a rule "
+        "the agent already has and violates usually belongs in code as a guard, while a "
+        "missing decision criterion belongs in prose. Say which file you chose, and why that "
+        "one, when you commit the round.\n")
+
+
 def _briefing(*, run_dir: Path, project: Path, spec: dict, skills: Path,
               rounds: int) -> str:
     """The driver briefing: the handoff facts, then a pointer to the loop itself.
@@ -90,6 +145,7 @@ def _briefing(*, run_dir: Path, project: Path, spec: dict, skills: Path,
     gate_mode = spec.get("gate_mode", "paired")
     caps = spec.get("capabilities") or []
     cap_path = spec.get("capability_path") or "seed_capability"
+    surface = _surface_section(_editable_files(run_dir, project, spec))
     skill_md = SKILL_DIR / "SKILL.md"
     helpers = HERE
 
@@ -131,11 +187,13 @@ directory is not necessarily either of theirs.
 | `num_trials` | {n_trials} |
 | `gate_k_se` | {k_se} |
 | `gate_mode` | {gate_mode} |
-| `capabilities` (your editable surface) | {caps} |
+| `capabilities` (which capability rules validate your edits) | {caps} |
 | `capability_path` | {cap_path} |
 
 Pass these explicitly — `--n-trials {n_trials}` on every evaluate, `--k-se {k_se}` on every
 gate — rather than relying on a default that may not match this spec.
+
+{surface}
 
 ## The primitives every round must go through
 


### PR DESCRIPTION
## The gap

`agent-optimize` — the fully-agentic algorithm — could not be run from the benchmarks suite at all.

- [`run_suite.sh`](ci/benchmarks/lib/run_suite.sh) hardcoded `algorithm_skill: hill-climb`.
- Selecting the agentic algorithm by hand would have failed anyway: it [refuses a deterministic invocation](skills/algorithms/agent-optimize/scripts/run.py), and in agent mode `cap-evolve run` does check + baseline, [prints a handoff and returns](core/cap_evolve/cli.py) — leaving the loop to a conversational agent CI does not have. The handoff would have gone unread and the job would have exited 0 having optimized nothing.
- `workflow_dispatch` is at GitHub's hard 10-input cap, so an 11th `algorithm` input would have made the whole workflow invalid.

## Approach

The loop stays owned by the algorithm skill; the CLI invocation stays owned by `run-optimizer`. This adds only the host that connects them — no agent-driving logic lands in `ci/benchmarks/`, and the same host works locally and for any benchmark.

### `skills/algorithms/agent-optimize/scripts/host.py`

Renders the driver briefing from the spec + handoff (absolute paths, `num_trials`, `gate_k_se`, the free-text `stop_condition`, the four primitives every round must go through, and an instruction not to ask questions), then delegates the invocation to the existing [`optimizers/run-optimizer`](skills/optimizers/run-optimizer/scripts/run.py) runner — so registry rows, `{model}` substitution, budget-flag mapping, cost capture and the CLI-present hard fail are the ones the deterministic path already uses rather than a second copy. `--agent` takes any registry row.

Two failure modes it exists to prevent:

- **It raises `BASH_DEFAULT_TIMEOUT_MS` / `BASH_MAX_TIMEOUT_MS` to 4h.** At Claude Code's 10-minute default ceiling every full-val eval on a real benchmark is killed mid-flight, and a perfectly healthy run reads as a broken runner.
- **It guarantees the seal.** An agent that exhausts its turns leaves no `final.json` — unreportable *and* indistinguishable from a crash. The host then runs `measure.py` itself and labels the result `seal: host`, so it is never mistaken for the agent's own judgement that it was finished. An already-sealed run reports `seal: agent` rather than raising `TestSealError` and failing a run that is actually complete.

`--prompt-only` renders the briefing free (it lands at `$R/host/driver_prompt.md`, so a finished run records exactly what the host asked for); `--seal-only` seals a run a previous host left open.

### The `algorithm` dispatch input

`algorithm_focus` → `algorithm`: `hill-climb-all` (default, unchanged behaviour) | `hill-climb-cyclic` | `hill-climb-hardest-first` | `agent-optimize`. One token carries both algorithm and focus, because of the 10-input cap. `runmeta.json` now records it — a hill-climb number and an agent-optimize number are not a like-for-like comparison, and the history page should not present them as one.

`ALGORITHM_FOCUS` is still honoured when `ALGORITHM` is unset, so committed `overrides.env` files and hand-run invocations keep producing the same run; `ALGORITHM` wins when both are set, so a stale exported alias can never override a deliberate dispatch choice.

### A derived `stop_condition`

Agent mode is bounded by free-text prose, not a round schedule, so `run_suite.sh` derives it from the **same** dispatch inputs that bound a deterministic run: `iterations` → max rounds, `optimizer_usd_per_iter` × rounds → a whole-loop `$` ceiling (`0` stays unlimited, as everywhere else in the workflow), `gate_k_se`/`trials` → the gate. `optimizer_max_turns` becomes a whole-loop turn cap the same way, because the entire search is one agent process rather than one call per iteration.

It is emitted through `json.dumps`: interpolated raw, a paragraph containing `:` and `$` yields a spec that silently truncates at the first colon and hands the agent a stopping rule nobody wrote.

## A note on where `host.py` is documented

Deliberately **not** in `SKILL.md`. That file is the hosted agent's recurring per-trigger context, and it has ~150 characters of headroom under the repo's 5000-token body budget — while the agent never invokes the host; the host invokes the agent. Spending that budget on it would push out guidance the agent does need. Same convention as the skill's other non-loop scripts (`linkcheck.py`, `abstract.py`), which SKILL.md also does not name. It is documented in `docs/AGENT_ORCHESTRATION.md` and `ci/benchmarks/README.md`.

## Testing

- Shell blocks are **executed as real bash** rather than grepped (following `test_run_suite_split_hook.py`), since what breaks is shell behaviour: all four algorithm values, the legacy alias and its precedence, an unknown value aborting loudly, and the emitted YAML **parsed back** to prove the `stop_condition` survives round-trip intact.
- `host.py`'s offline guarantees are executed: briefing contents, unknown-agent refusal *before* any spend, the seal fallback and its idempotence, the raised Bash ceiling. The skill's own `check.py` now covers them too, so they cannot drift.
- One test pins the coupling that makes the CI report render at all: `commit.py` books decisions through `harness.record_iteration`, which writes the canonical `step` event `metrics.py` builds its timeline from. Without it an agent-mode run reports zero iterations and an empty timeline while still exiting 0.
- Full suite: **943 passed**. One pre-existing failure (`test_cli_surface.py::test_spec_defaults_relative_to_project_not_the_cwd`, a manifest lookup for `run-optimizer`) reproduces unchanged on `main` and is untouched by this branch.
- `actionlint` clean on the workflow; end-to-end agent-mode chain verified offline against the `toy_calc` example with the `mock` registry row (handoff → host → run-optimizer → seal fallback → `final.json`).

A tau2 smoke run with `algorithm: agent-optimize` is being dispatched against this branch to verify it end to end on real models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)