### PR TITLE
fix(agent-optimize): give the hosted agent the full capability surface, and keep the host benchmark-agnostic

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -36,9 +36,9 @@ on:
         default: smoke
         options: [all, smoke, pilot, full]
       iterations:
-        description: "Optimizer iterations per task for the FULL tier (default 10; raise to give the optimizer more budget). Smoke always runs 3, regardless of this input."
+        description: "Optimizer iterations. LEAVE BLANK for the tier default (smoke 3, everything else 10). Set a value to override deliberately — including on smoke, where more rounds are how you watch a per-iteration curve rather than a single step."
         type: string
-        default: "10"
+        default: ""
       trials:
         description: "Trials per task per eval. LEAVE BLANK for the tier default (smoke 3, everything else 10). Set a value only to override deliberately — on a 5-task binary tier, 1 trial cannot separate signal from noise, which is why blank does not mean 1."
         type: string
@@ -275,10 +275,14 @@ jobs:
     env:
       ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
       ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
-      # Smoke always runs a fixed 3 iterations (cheap, fast regression) — decoupled
-      # from the `iterations` input, which only controls the (expensive) full tier
-      # (default 10 there — see the `iterations` input above).
-      ITERATIONS: ${{ matrix.tier == 'smoke' && '3' || github.event.inputs.iterations || '10' }}
+      # Smoke DEFAULTS to 3 iterations (cheap, fast regression) but an explicit dispatch value
+      # now wins, exactly as it does for NUM_TRIALS below and for the same reason: the input's
+      # own default is "" so "user asked for 10" is distinguishable from "user asked for
+      # nothing". Before this, `matrix.tier == 'smoke' && '3'` came FIRST and short-circuited,
+      # so a dispatch of iterations=5 on smoke was silently ignored and the operator learned it
+      # only by reading ITERATIONS in the job log. Smoke is the tier you iterate the algorithm
+      # on, so pinning it was the wrong knob to make unreachable.
+      ITERATIONS: ${{ github.event.inputs.iterations || (matrix.tier == 'smoke' && '3') || '10' }}
       # Smoke pins 3 trials, same as it pins iterations, and for a measurable reason.
       # Run 31183768756 was dispatched with trials=1 and re-scored the SAME seed capability at
       # 0.400 (baseline) then 0.200 (finalize) — pytest-dev__pytest-7432 flipped 1.000 -> 0.000

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ All notable changes to cap-evolve are documented here. The format follows
 
 ## [Unreleased]
 ### Fixed
+- **The end_turn diagnosis accused a complete run of abandoning work.** Run 32871360361 booked 4
+  of 10 rounds, investigated a round-5 lever, judged the residual failure unfixable by the
+  surfaces it owned, **sealed test itself**, wrote its report and stopped at 121 of 1650 turns.
+  The host told the operator it had "stopped of its own accord … which is what a turn ending on
+  outstanding work looks like … a backgrounded job … cannot resume a non-interactive run" —
+  the exact defect the warning was written for, on a run that was complete and honest. Two facts
+  already in the payload disprove it: `seal == "agent"` (a loop that dies mid-turn leaves the
+  host to seal, as run 32814848187 did) and an empty `unbooked_rounds`. The diagnosis now
+  branches on both and reports unspent rounds as **under-use** — "it stopped when it ran out of
+  edits it trusted, not when it ran out of rounds" — while the foreground explanation is kept for
+  the case that actually produced it. The "a candidate may never have been committed" hedge no
+  longer fires when the backstop came back clean, since it sent readers hunting for a candidate
+  that provably did not exist.
+
 - **A parent-gated round discarded the drift-free comparison it had already paid to measure.**
   Run 32871360361 round 4 gated in `parent` mode: `cand4` at 0.53 against the seed's *stored* 0.38
   = +0.15, bar 0.11 (drift), so 1.4x — marginal. The same round's two concurrent controls both

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ All notable changes to cap-evolve are documented here. The format follows
 
 ## [Unreleased]
 ### Fixed
+- **A parent-gated round discarded the drift-free comparison it had already paid to measure.**
+  Run 32871360361 round 4 gated in `parent` mode: `cand4` at 0.53 against the seed's *stored* 0.38
+  = +0.15, bar 0.11 (drift), so 1.4x — marginal. The same round's two concurrent controls both
+  read **exactly 0.27**, so the drift-free answer from the identical rollouts is **+0.26 against a
+  bar of 0.00**. The 0.11 belongs to *when* the seed was measured, not to `cand4`; parent-mode
+  gating understated the effect and inflated the bar simultaneously. Each candidate now also
+  carries `control_relative` — the same gate re-run against the concurrently-measured control,
+  costing no rollouts since the controls are already evaluated — so where the two comparisons
+  disagree, the difference is visibly drift rather than the edit. Reported rather than made the
+  default: changing the default gate mode on one benchmark's drift would be a guess about every
+  other workload, while an extra comparison is strictly more information and agrees with the
+  primary one wherever there is no drift.
+
 - **A reject that overrode the gate was recorded as the gate's own verdict.** `--reject-basis
   gate` is documented as "full-val paired gate ran", and run 32871360361 booked it for `cand2` —
   which `round_i1.json` recorded as `verdict: accept` at +0.19 against a concurrent control. So

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,36 @@ All notable changes to cap-evolve are documented here. The format follows
 
 ## [Unreleased]
 ### Fixed
+- **The hosted agent ended its turn to wait for a notification, and the process exited under
+  it.** With the turn budget raised to 600, run 32814848187 no longer ran out of turns — it
+  used 78 and stopped anyway, on `subtype: success` / `stop_reason: end_turn`, rc 0. It had
+  launched round 2's full-val gate in the background and ended its turn to await word back.
+  In a non-interactive run there is nothing to come back to: ending a turn ends the process
+  and orphans its children. The gate finished **14 minutes after the agent was gone**, wrote a
+  real verdict (`r2_comm_search` val 0.44 vs parent 0.58 → reject) that nobody read, and left
+  2 of 3 rounds unspent — while the orphaned evals were still hitting the runner as
+  `measure.py` measured the seal. Three changes, none of which restricts concurrency: the
+  briefing now states that the *main loop* runs in the foreground and that the turn which
+  launched work is the turn that collects it — fanning out subagents or a whole round's evals
+  stays encouraged, since delegating the work is not the same as detaching the wait; `round.py`
+  persists its gate table under `$R/work/` instead of leaving stdout the only copy, so an
+  abandoned round's verdict is evidence rather than a redirect the driver may have skipped; and
+  the host reports `unbooked_rounds` — candidates a round gated to a verdict that no
+  `commit.py` ever booked — which `spent.iterations` cannot distinguish from a round never
+  attempted. It reports rather than books: which decision a verdict deserves is the driver's
+  judgement, and booking an accept after `measure.py` had sealed against the old `best_id`
+  would turn a visible gap into a wrong headline number.
+
+- **`incomplete` gave turn-budget advice to an agent that was not turn-starved.** One message
+  served both stop causes and fit only the first. Run 32733635494 died on `error_max_turns`,
+  where "raise `optimizer_max_turns` or lower the round count" was exactly right; run
+  32814848187 stopped at 78 of 600 turns, and the same sentence pointed the operator at a knob
+  already 7× larger than what the agent used. The diagnosis now splits on the stop cause, and
+  reads the agent's own `stop_reason` alongside the harness's `subtype` — the discriminator is
+  the former (`end_turn`), while the latter says only `success`, which is why a voluntary stop
+  was indistinguishable from a clean finish. `--seal-only`, the path an operator reaches for on
+  a run that died mid-loop, reports abandoned rounds too.
+
 - **Agent-mode optimizer cost was reported as $0.00 on every run.** `run-optimizer` nests the
   figure under `cost.total_cost_usd`; the host read a flat `cost_usd`/`usd` and booked `0.0`.
   Smoke run 32733635494 spent **$8.37** (68,432 tokens) and recorded nothing — and because that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ All notable changes to cap-evolve are documented here. The format follows
 
 ## [Unreleased]
 ### Fixed
+- **A round's verdict could be decided by which control replicate happened to be the
+  reference.** On run 32871360361 round 3, two byte-identical control replicates measured two
+  minutes apart read **0.32 and 0.20** — a 0.12 gap. The gate reference was whichever carried the
+  round-scoped tag (0.20), so `cand3` at 0.37 scored +0.17 and **accepted**; against the other
+  replicate it is +0.05 and rejects. Nothing in the table said the verdict rested on that coin
+  flip. Each candidate is now re-gated against *every* control replicate — which costs no new
+  rollouts, since `gate_check.py` reads what is already stored — and the table reports
+  `verdict_by_reference` plus `verdict_stable`. A verdict that flips is downgraded to
+  `inconclusive`, because a round that cannot tell an edit from re-measurement has not measured
+  anything, whatever the delta looked like against the replicate that happened to be picked.
+
+  For context on why this matters at this scale, the same run's replicate gaps were 0.00, 0.01
+  and 0.12 across three rounds: with two replicates the gap is itself a poor estimate of the
+  noise, so the stability check — a direct observation rather than an estimate — is the more
+  reliable signal.
+
 - **The round table gave the driver two incompatible noise bars, and it rejected the run's best
   candidate on the wrong one.** On run 32871360361 round 2, `cand2` was gated against a control
   measured in that same round (0.24, its replicate 0.25 — agreeing to 0.01) and beat it by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,36 @@ All notable changes to cap-evolve are documented here. The format follows
 [0.1.0]: https://github.com/skillberry-ai/cap-evolve/releases/tag/v0.1.0
 
 ## [Unreleased]
+### Added
+- **The run now keeps the agent's own transcript.** Four hours of run 32814848187 were
+  unaccounted for *and unaccountable*: its 900 metric calls account for every evaluation in
+  `events.jsonl` and none fall in the gap, so nothing was being measured — but the only record
+  of what the agent itself did was an 800-char `stdout_tail`, which narrows the cause to
+  "something hit the 4-hour Bash ceiling" and no further. `--output-format json` cannot close
+  that: it returns one result object with the final text and the totals, never the turns. So
+  `run-optimizer` takes `--transcript <path>`, and the registry carries a separate
+  `transcript_flag` (`--output-format stream-json --verbose`, verified against Claude Code
+  2.1.241) used *instead of* `json_flag` only when a transcript is requested — its last line is
+  the same result object, so cost and stop parsing are unchanged and the deterministic
+  per-iteration path is untouched. `host.py` points it at `$R/host/transcript.jsonl`, beside
+  the `driver_prompt.md` it already writes, so the run dir holds both what was asked for and
+  what was done. Secret values are scrubbed before the file is written: a transcript records
+  tool results verbatim and the run dir is a published artifact, so one `env` the agent
+  happened to run would otherwise leak the gateway token. `terminal_reason` and
+  `permission_denials` join the captured stop fields — the latter distinguishes "blocked by the
+  tool allowlist" from "chose to stop", which were previously the same observation.
+
 ### Fixed
+- **An explicit `iterations` dispatch was silently ignored on the smoke tier.**
+  `ITERATIONS: ${{ matrix.tier == 'smoke' && '3' || inputs.iterations || '10' }}` put the tier
+  pin first, and GitHub's `||` yields the first truthy operand — so dispatching smoke with
+  `iterations: 10` ran 3, discoverable only by reading `ITERATIONS` in the job log after the
+  budget had been spent on the wrong round count. Smoke is the tier the algorithm itself gets
+  iterated on, which makes it the worst one to pin unreachably. `NUM_TRIALS` already had this
+  right, including why its input default is `""` (with a non-empty default there is no way to
+  tell "asked for 10" from "asked for nothing"); `iterations` now has the same shape, and a
+  test asserts the two agree so the next edit to either notices.
+
 - **The hosted agent ended its turn to wait for a notification, and the process exited under
   it.** With the turn budget raised to 600, run 32814848187 no longer ran out of turns — it
   used 78 and stopped anyway, on `subtype: success` / `stop_reason: end_turn`, rc 0. It had

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ All notable changes to cap-evolve are documented here. The format follows
 
 ## [Unreleased]
 ### Fixed
+- **Review follow-ups (PR #399).** Three findings from code review, all in the agent-optimize
+  host: (1) `_CODE_SUFFIXES` was a 14-entry allowlist, so a capability whose code is C, C++, C#,
+  PHP, Swift, Kotlin or Objective-C was treated as prose and never got the "the form that works
+  is a guard in the code" advice — the same silent miss this host was fixed for on `.py`/`.js`,
+  relocated to whichever language nobody listed. The set is broadened across scripting, shell,
+  compiled, functional and query languages and is now documented as **known-good, not
+  exhaustive**, so absence reads as a gap to fill rather than a decision that the language is
+  prose. (2) A *declared* capability with no matching skill package was skipped by
+  `harness._stage_context` while the payload still said `staged: True`, making
+  some-capabilities-missing indistinguishable from everything-staged — while the all-missing case
+  had always been loud. The context now carries `guidance_missing` and emits a `::warning::`
+  naming the capability, since silently optimizing a surface with no allowed-edit-space brief is
+  the exact defect this host was opened to fix. (3) A stray blank line after the concurrency
+  guard's `return 2`.
+
 - **The end_turn diagnosis accused a complete run of abandoning work.** Run 32871360361 booked 4
   of 10 rounds, investigated a round-5 lever, judged the residual failure unfixable by the
   surfaces it owned, **sealed test itself**, wrote its report and stopped at 121 of 1650 turns.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,36 @@ All notable changes to cap-evolve are documented here. The format follows
 
 ## [Unreleased]
 ### Fixed
+- **Three ways the agent-mode host was accidentally shaped around one benchmark.** Found by
+  auditing it against the repo's other workloads rather than by a failing run:
+
+  - **A project's `optimizer_instructions_file` was silently dropped.** `cli.py` applies that key
+    only for `algorithm_name in OPTIMIZER_CONTEXT_ALGORITHMS` (hill-climb / gepa / skillopt), so
+    agent mode ignored it. That is dangerous, not merely lossy: one arm uses that file to state
+    that the `{placeholders}` in its second editable file are load-bearing and that breaking one
+    makes EVERY task score 0 (the agent is never told where to write its answer). An agent that
+    never saw the warning could wipe the run's whole signal with an edit that looks harmless. The
+    host now reads and includes it — and reports a spec-named path that does not exist instead of
+    silently downgrading to generic guidance (the #252 failure mode).
+
+    Included with its **scope stated**, not pasted in: that file is written for the deterministic
+    per-iteration optimizer and tells the agent to stop after editing and not to evaluate, because
+    there the harness re-scores the candidate. In agent mode the agent owns the evaluation and the
+    gate, so an agent obeying that line would never gate anything. Benchmark facts bind; the
+    process half is explicitly superseded. Its unrendered `{{SLOT}}` template markers are stripped
+    too — the parity test already treats those as a defect on the deterministic side.
+
+  - **Code-vs-prose advice was offered to capabilities with no code.** The briefing told every
+    multi-file capability that "a rule the agent violates usually belongs in code as a guard".
+    For a two-prose-file capability (a system prompt plus a task template) that sends the agent
+    looking for code it does not own — how a prompt-only run once ended up editing `adapter.py`.
+    Now conditional on the surface actually containing code.
+
+  - **A large capability would have had every file listed.** A skill-package capability runs to
+    dozens of files; enumerating them crowded out the rest of the briefing. Now grouped by
+    directory above 20 files, stating the true total and how many are not listed individually,
+    and telling the agent to enumerate the rest itself — a bounded listing that never reads as
+    the complete surface.
 - **The hosted agent now gets the same optimizer read-context as every other algorithm.** Two
   agent-optimize CI runs on a `[system-prompt, tools]` capability edited **only the prompt file**
   across 4 of 4 candidates; the tool code sat writable and unopened in the same candidate dir. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ All notable changes to cap-evolve are documented here. The format follows
 [0.1.0]: https://github.com/skillberry-ai/cap-evolve/releases/tag/v0.1.0
 
 ## [Unreleased]
+### Fixed
+- **The hosted agent now gets the same optimizer read-context as every other algorithm.** Two
+  agent-optimize CI runs on a `[system-prompt, tools]` capability edited **only the prompt file**
+  across 4 of 4 candidates; the tool code sat writable and unopened in the same candidate dir. The
+  cause was not the spec and not the file list. `harness.OptimizerContext` exists so "an algorithm
+  cannot silently run on a thinner prompt than its siblings" — it stages each declared
+  capability's skill as `./guidance/<cap>/` *and* where the agent natively discovers skills, plus
+  the diagnose method, `capability_sources`, and the agent's features reference. The host never
+  called it, so the agent had guidance for prose and **none at all** for the tool code beside it,
+  and did what it had guidance for.
+
+  `test_optimizer_context_parity.py` had already named this hole in its own docstring:
+  agent-optimize "declares none of the context flags and drives its own loop… an algorithm absent
+  from [ALGORITHMS] is NOT covered — it can still run blind while this file stays green." It ran
+  blind. `host.py` now calls `inject()` with the agent as the optimizer row, and reports whether
+  staging succeeded — silently-off is indistinguishable from working while quietly optimizing less
+  surface, which is exactly how this went unnoticed.
+
+  Two consequences of reusing that path, both handled: the briefing points at the staged guidance
+  (unread guidance is not guidance), and the always-on `CLAUDE.md` it writes opens with "read
+  `./INSTRUCTIONS.md` FIRST" — true for the deterministic optimizer, which has one, so the host
+  writes the briefing there too (same bytes as the run-dir audit copy) and states that
+  `LEDGER.md` / `RUNMAP.md` / `prior_iterations/` belong to the other loop and are legitimately
+  absent.
+
 ### Added
 - **The benchmarks suite can run `agent-optimize`.** Until now `run_suite.sh` hardcoded
   `algorithm_skill: hill-climb`, so the fully-agentic algorithm was unreachable from CI — and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,11 @@ All notable changes to cap-evolve are documented here. The format follows
   the `driver_prompt.md` it already writes, so the run dir holds both what was asked for and
   what was done. Secret values are scrubbed before the file is written: a transcript records
   tool results verbatim and the run dir is a published artifact, so one `env` the agent
-  happened to run would otherwise leak the gateway token. `terminal_reason` and
+  happened to run would otherwise leak the gateway token. It is published into the uploaded
+  dir directly (gzipped), *not* through the UI export: the artifact path is `$OUT/**` while the
+  run dir sits elsewhere, and `export_static` caps every file at 256 KiB keeping the FIRST
+  chunk — one turn of stream-json is already 17 KB, so the cap would have discarded exactly the
+  end-of-run evidence the transcript exists to provide. `terminal_reason` and
   `permission_denials` join the captured stop fields — the latter distinguishes "blocked by the
   tool allowlist" from "chose to stop", which were previously the same observation.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ All notable changes to cap-evolve are documented here. The format follows
 
 ## [Unreleased]
 ### Fixed
+- **The round table gave the driver two incompatible noise bars, and it rejected the run's best
+  candidate on the wrong one.** On run 32871360361 round 2, `cand2` was gated against a control
+  measured in that same round (0.24, its replicate 0.25 — agreeing to 0.01) and beat it by
+  **+0.19**, three times the `k_se=1.0` threshold. The table also reported
+  `noise_floor_from_control = 0.14`, which is the control-vs-**stored**-parent gap — temporal
+  drift — and its `reading` said to treat any candidate at or below the floor as no evidence.
+  Those are different baselines, so the driver resolved the contradiction conservatively:
+  re-derived `+0.05` against the stored best and booked a **reject**, with the note *"round noise
+  floor 0.14 > margin"*. A real improvement was discarded because the instrument asked it to
+  compare a control-relative delta against a drift-derived floor. The table now reports a single
+  `evidence_bar` matched to how the round actually gated — the replicate gap under
+  `--gate-against control`, where drift is already cancelled; the larger of the replicate gap and
+  the drift under `--gate-against parent`, where every delta carries it — and the `reading` says
+  that drift bounds how far the **absolute** rewards can be trusted rather than being a bar a
+  concurrently-gated candidate must clear, and explicitly tells the driver not to re-derive a
+  delta against the stored parent and reject on that.
+
 - **`round.py` reported the control's reward under the parent's tag, hiding the round's own
   drift.** Line 214 loaded `parent` from `gate_ref` — which under `--gate-against control` is
   the concurrently-measured control — while the output block emitted it with `"tag": best`. On

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ All notable changes to cap-evolve are documented here. The format follows
 
 ## [Unreleased]
 ### Fixed
+- **A reject that overrode the gate was recorded as the gate's own verdict.** `--reject-basis
+  gate` is documented as "full-val paired gate ran", and run 32871360361 booked it for `cand2` —
+  which `round_i1.json` recorded as `verdict: accept` at +0.19 against a concurrent control. So
+  `events.jsonl`, the run's audit record, said the gate had rejected the best candidate of the
+  run when the driver had in fact overridden it. Overriding is legitimate — `round.py` leaves the
+  decision to the driver deliberately — but misattributing it is not, and provenance is the one
+  thing that log exists to get right. `commit.py` now reads the candidate's verdict from the
+  persisted round table (possible only because `round.py` stopped leaving stdout the sole copy),
+  refuses `--reject-basis gate` when the gate accepted, and offers `driver_judgement` as the
+  truthful basis for an override. Every booked decision now carries `gate_verdict` and
+  `overrode_gate`, so a divergence is visible rather than lost.
+
 - **A round's verdict could be decided by which control replicate happened to be the
   reference.** On run 32871360361 round 3, two byte-identical control replicates measured two
   minutes apart read **0.32 and 0.20** — a 0.12 gap. The gate reference was whichever carried the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ All notable changes to cap-evolve are documented here. The format follows
 [0.1.0]: https://github.com/skillberry-ai/cap-evolve/releases/tag/v0.1.0
 
 ## [Unreleased]
+### Fixed
+- **Every candidate eval in agent mode could die `ModuleNotFoundError`, and did.** An arm's
+  adapter deps are installed into exactly one venv, and `run_suite.sh` runs `cap-evolve run`
+  with that interpreter — so on run 32861747778 the baseline scored 0.44 while *every* round-1
+  eval (candidate and control alike) crashed importing the adapter, scoring `null` rather than
+  zero. CI's `PATH` never contains that venv's bin, and SKILL.md tells the agent to run
+  `python "$A/round.py"`, so bare `python` could never resolve to the interpreter that works;
+  the run before it had survived on luck, and with no transcript kept not even the luck was
+  inspectable. Fixed as a guard rather than as prose — the interpreter that launched the host
+  *is* the correct one (`run_suite.sh` invokes `"$PY" host.py`), so its bin dir now goes first
+  on the agent's `PATH` and every existing `python …` command in the skill becomes correct by
+  construction. The briefing also names it as `$PY` and says not to substitute another
+  interpreter, `uv run`, or a fresh venv.
+
+- **A gate too coarse to resolve its own verdict is now refused, not warned about.** The same
+  run gated at `--concurrency 100` *after* SKILL.md had told it "do not raise it to buy wall
+  clock", and `round.py`'s own table then carried "a verdict from this round can therefore not
+  resolve an effect smaller than roughly 0.08" while the run continued and booked decisions
+  regardless. This skill's own edit-form rule applies to the skill itself: where the agent has
+  the criterion and violates it anyway, the form that works is a guard in code, not a further
+  restatement in prose. `round.py` now exits 2 above concurrency 25 — where the measured
+  degradation is established — naming the value to use instead, with
+  `--allow-high-concurrency` to record the trade deliberately. Refusal, not a silent clamp, is
+  already this script's idiom for an incoherent request. The briefing states the concurrency
+  alongside `num_trials` and `gate_k_se`, because a number it never states is a number the
+  agent picks.
+
 ### Added
 - **The run now keeps the agent's own transcript.** Four hours of run 32814848187 were
   unaccounted for *and unaccountable*: its 900 metric calls account for every evaluation in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,38 @@ All notable changes to cap-evolve are documented here. The format follows
 [0.1.0]: https://github.com/skillberry-ai/cap-evolve/releases/tag/v0.1.0
 
 ## [Unreleased]
+### Changed
+- **`OptimizerContext` gained a public seam, and the agent-mode host now reuses it instead of
+  hand-rolling equivalents.** The class docstring already said it exists so "an algorithm cannot
+  silently run on a thinner prompt than its siblings"; the host was the one caller that
+  re-authored the blocks, and the measured consequence was an optimizer that only ever edited
+  prose. Two of those blocks turn out to be exactly the guidance it was missing:
+  `harness._CAP_EDIT_SPACE["tools"]` ("HIGHEST-LEVERAGE EDIT: WRITE A NEW CODE-BEARING TOOL …
+  a deterministic tool can't be 'forgotten' the way a prompt rule can") and the target-reader
+  block ("when the reader is weaker than you, prefer explicit rules, worked examples, and code
+  enforcement over terse prose") — the CI agent under test being `aws/gpt-oss-120b`, precisely
+  that weak reader.
+
+  New public surface, all additive: `OptimizerContext.from_spec()` (construct from a
+  `capevolve.yaml` dict rather than argparse args, resolving the target profile the same way),
+  `capability_brief()`, `reader_brief()`, `empty_seed_brief()`, and `render_template()` (fills a
+  template's slots for a caller that is not a per-iteration one, blanking only the four
+  genuinely per-iteration slots). Plus `specfile.resolve_instructions_file()`, now the single
+  resolver for `optimizer_instructions_file` — `cli.py` calls it too, so the rule and its #252
+  warning exist once.
+
+  What the host deliberately does **not** reuse is `instructions()`: it renders the
+  per-iteration contract ("fix many root causes in this ONE candidate and STOP; the harness
+  re-scores you"), which is false where the agent owns the search, the evaluation and the gate.
+  The blocks are composed instead. Recorded on the class so the next reader does not "fix" it.
+
+  Net: three hand-rolled duplicates deleted from `host.py` (`_guidance_section`,
+  `_arm_instructions`, `_strip_template_slots`), its registry lookup delegated to
+  run-optimizer's own `load_registry`, and its code-vs-prose advice removed in favour of the
+  shared block that states it better. `empty_seed_brief` also closes a real gap: a no-skill
+  control arm (one that blanks the seed to measure "author from nothing") previously got no
+  author-from-scratch guidance in agent mode at all.
+
 ### Fixed
 - **Three ways the agent-mode host was accidentally shaped around one benchmark.** Found by
   auditing it against the repo's other workloads rather than by a failing run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ All notable changes to cap-evolve are documented here. The format follows
 
 ## [Unreleased]
 ### Fixed
+- **`round.py` reported the control's reward under the parent's tag, hiding the round's own
+  drift.** Line 214 loaded `parent` from `gate_ref` — which under `--gate-against control` is
+  the concurrently-measured control — while the output block emitted it with `"tag": best`. On
+  run 32871360361 that printed `parent: {tag: "seed", reward: 0.34}` while `baseline.json`
+  recorded the seed at 0.38, a discrepancy no reader could reconcile. Not cosmetic: the gap
+  between the parent's stored reward and a byte-identical control measured *now* IS the round's
+  temporal drift, and on this benchmark the same seed bytes scored 0.24 / 0.44 / 0.38 across
+  three runs the same day (sd 0.103, ~3.7x the acceptance bar) — so collapsing the two erased
+  the one number that says whether any delta in the table means anything. The table now carries
+  `parent` (the candidate being climbed from, read from `best`), `gate_reference` (what deltas
+  and thresholds are actually measured against), and `parent_vs_gate_ref_drift` with a reading
+  that names it as re-measurement, not progress. `delta_vs_parent` is renamed
+  `delta_vs_gate_ref`, because under control-mode gating it never was a delta against the
+  parent.
+
 - **Every candidate eval in agent mode could die `ModuleNotFoundError`, and did.** An arm's
   adapter deps are installed into exactly one venv, and `run_suite.sh` runs `cap-evolve run`
   with that interpreter — so on run 32861747778 the baseline scored 0.44 while *every* round-1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,35 @@ All notable changes to cap-evolve are documented here. The format follows
 [0.1.0]: https://github.com/skillberry-ai/cap-evolve/releases/tag/v0.1.0
 
 ## [Unreleased]
+### Fixed
+- **Agent-mode optimizer cost was reported as $0.00 on every run.** `run-optimizer` nests the
+  figure under `cost.total_cost_usd`; the host read a flat `cost_usd`/`usd` and booked `0.0`.
+  Smoke run 32733635494 spent **$8.37** (68,432 tokens) and recorded nothing — and because that
+  is indistinguishable from the genuinely-unmetered gateway the skill warns about, the wrong
+  conclusion was drawn from it twice. A dollar ceiling cannot bind what it cannot see: with 0.0
+  booked, `max_usd` and `spend.py`'s dollar predicates were inert for the whole run.
+
+- **The host now says WHY the agent stopped, and refuses to let an unfinished run look
+  finished.** `run-optimizer` passes through the agent CLI's termination fields (`subtype`,
+  `num_turns`, `is_error`, …) — vendor-neutral, like its cost parsing, and useful to the
+  deterministic path too, where an exit code of 0 also covers both "finished" and "hit
+  `--max-turns` with work outstanding". The host reports `stop_reason` / `num_turns` /
+  `rounds_booked` / `rounds_budget`, and emits an `incomplete` field plus a `::warning::` when
+  rounds were left unspent. On the run that prompted this, that state had to be reconstructed
+  from a truncated stdout tail.
+
+- **Agent mode was starved of turns.** `optimizer_max_turns` (default 80) is a
+  *deterministic-path* unit: there one optimizer invocation means "propose one edit and stop",
+  and the harness owns diagnosis, evaluation and gating. In agent mode the same allowance must
+  also cover Phase 0, diagnose, the null-control replicates, `round.py` orchestration,
+  `gate_check` and `commit.py` — per round. At 240 turns (80 × 3) run 32733635494 bought **1.9
+  rounds**: the agent stopped on `error_max_turns` having just evaluated a candidate at val
+  **0.530**, the best of the run, and never reached the `commit.py` that would have booked it.
+  So it reported 1 of 3 rounds and discarded its best result. The host budget is now
+  `max(optimizer_max_turns, 150) × (rounds + 1)` — a floor of 150/round against the ~126
+  measured, with the `+1` paying for the work that is not a round (Phase 0 and the seal). A
+  raised `optimizer_max_turns` still wins, so the floor is not a clamp.
+
 ### Changed
 - **`OptimizerContext` gained a public seam, and the agent-mode host now reuses it instead of
   hand-rolling equivalents.** The class docstring already said it exists so "an algorithm cannot

--- a/ci/benchmarks/lib/run_suite.sh
+++ b/ci/benchmarks/lib/run_suite.sh
@@ -589,5 +589,24 @@ else
   [ -d "$opt_dir" ] && cp -R "$opt_dir"/. "$dst/optimized_capability/" 2>/dev/null || true
 fi
 
+# The agent's own record, into the dir that actually gets uploaded. The artifact path is
+# $OUT/**, while the run dir lives under suite_<tier>_<bench>_proj/ — run-dir files reach the
+# artifact ONLY through the UI export, which caps every file at 256 KiB and keeps the FIRST
+# chunk (dashboard/backend/capevolve_dashboard/files.py). A stream-json transcript runs to
+# megabytes and the part that shows where a run stalled is the END, so the cap would discard
+# exactly the evidence this was added to capture. Gzipped: ~10x on JSON, so full fidelity
+# costs the artifact very little.
+if [ -d "$RUN_DIR/host" ]; then
+  mkdir -p "$OUT/host"
+  for f in "$RUN_DIR/host"/*; do
+    [ -f "$f" ] || continue
+    case "$f" in
+      *.jsonl|*.jsonl.stderr) gzip -c "$f" > "$OUT/host/$(basename "$f").gz" 2>/dev/null || true ;;
+      *) cp "$f" "$OUT/host/" 2>/dev/null || true ;;
+    esac
+  done
+  echo ">>> host record -> $OUT/host ($(du -sh "$OUT/host" 2>/dev/null | cut -f1))" >&2
+fi
+
 cat "$OUT/report.md"
 echo "RUN_DIR=$RUN_DIR"

--- a/ci/benchmarks/lib/run_suite.sh
+++ b/ci/benchmarks/lib/run_suite.sh
@@ -81,13 +81,23 @@ case "$ALGORITHM" in
       _stop_usd="$(awk "BEGIN{printf \"%.2f\", ${OPTIMIZER_USD_PER_ITER:-0} * $_rounds}")"
       _stop_usd=" Stop if your own (optimization) spend reaches \$${_stop_usd}."
     fi
+    # NB the stopping rule deliberately does NOT stop on consecutive rejections. It used to
+    # ("stop when two consecutive rounds are rejected"), and that clause fired exactly where
+    # the algorithm prescribes ESCALATION instead: SKILL.md says "after two rejected rounds,
+    # read the candidate's TRACE before writing a third", because a reject usually means the
+    # edit FORM was wrong, not that the search is done. On smoke run 32701056043 the agent
+    # rejected two prose candidates and stopped — never reaching the round where it would have
+    # tried a code-level guard, which its own reject note ("require calculate tool for all
+    # money") had already identified as the right form. Rejections bound nothing; rounds and
+    # spend do.
     STOP_CONDITION="Spend at most ${_rounds} rounds, where a round is one candidate taken to a\
- full-val gate decision (accepted or rejected) and booked with commit.py. Stop early when\
- spend.py's recommendation is 'stop', or after ${_rounds} rounds, or when two consecutive\
- rounds are rejected with no new failure cluster left to attack.${_stop_usd} Gate every\
- candidate on FULL val at gate_k_se=${_k_se} over ${_trials} trial(s); never gate on\
- a screen subset. Always finish by sealing test exactly once with measure.py and writing\
- the report — a run with no finalize has no result."
+ full-val gate decision (accepted or rejected) and booked with commit.py. Stop when spend.py's\
+ recommendation is 'stop', or after ${_rounds} rounds.${_stop_usd} Do NOT stop early merely\
+ because rounds were rejected: a rejection is the signal to change the edit FORM or the SURFACE\
+ on the next round, not to finish. Use every round the budget allows. Gate every candidate on\
+ FULL val at gate_k_se=${_k_se} over ${_trials} trial(s); never gate on a screen subset. Always\
+ finish by sealing test exactly once with measure.py and writing the report — a run with no\
+ finalize has no result."
     ;;
   *)
     echo "::error:: unknown ALGORITHM='$ALGORITHM' (expected hill-climb-all |" \

--- a/ci/benchmarks/lib/run_suite.sh
+++ b/ci/benchmarks/lib/run_suite.sh
@@ -540,7 +540,23 @@ RUN_DIR="$WORK/.capevolve/run_suite"
 # Budget: the whole loop is ONE agent process, so the per-iteration caps become whole-loop
 # caps (x the round count). 0 stays unlimited, as everywhere else in this workflow.
 if [ "$ORCH_MODE" = "agent" ]; then
-  HOST_TURNS="$(( ${OPTIMIZER_MAX_TURNS:-80} * ITER ))"
+  # TURN BUDGET. `optimizer_max_turns` (default 80) is a DETERMINISTIC-path unit: there one
+  # optimizer invocation means "propose one edit and stop", and the harness does the diagnosis,
+  # the evaluation and the gate. In agent mode that same allowance must additionally cover
+  # Phase 0 reading, diagnose, the null-control replicates, round.py orchestration, gate_check
+  # and commit.py — every round.
+  #
+  # Measured on smoke run 32733635494 (trials=10): 240 turns (80 x 3) bought 1.9 rounds. The
+  # agent stopped on error_max_turns having just evaluated a candidate at val 0.530 — the best
+  # of the run — and never reached the commit.py that would have booked it. So the run reported
+  # 1 of 3 rounds and discarded its best result.
+  #
+  # ~126 turns/round were actually consumed there, so the floor is 150/round, and the round
+  # count is +1 to pay for the work that is not a round: Phase 0 and the final seal. An
+  # operator who raises optimizer_max_turns above the floor still wins — the max() keeps this a
+  # floor, not a clamp.
+  HOST_TURNS_PER_ROUND=$(( ${OPTIMIZER_MAX_TURNS:-80} > 150 ? ${OPTIMIZER_MAX_TURNS:-80} : 150 ))
+  HOST_TURNS="$(( HOST_TURNS_PER_ROUND * (ITER + 1) ))"
   HOST_USD_ARGS=()
   if awk "BEGIN{exit !(${OPTIMIZER_USD_PER_ITER:-0} > 0)}"; then
     HOST_USD_ARGS=(--usd-budget "$(awk "BEGIN{printf \"%.2f\", ${OPTIMIZER_USD_PER_ITER:-0} * $ITER}")")

--- a/core/cap_evolve/cli.py
+++ b/core/cap_evolve/cli.py
@@ -884,26 +884,21 @@ def _cmd_run(argv):
     # as read-only optimizer context. Both are resolved project-relative if not absolute.
     # The instructions file defaults to the scaffolded project/optimizer/INSTRUCTIONS.md.
     if algorithm_name in OPTIMIZER_CONTEXT_ALGORITHMS:
-        from .specfile import resolve_project_path
-        instr = spec.get("optimizer_instructions_file") or "optimizer/INSTRUCTIONS.md"
-        # ONE resolution rule, shared with implement-and-check's pipeline_selftest:
-        # a relative spec path is PROJECT-relative. It used to be probed against the
-        # caller's cwd first, so the same key resolved to a different file depending on
-        # where `cap-evolve run` was invoked from — and on a miss the flag was silently
-        # dropped and the optimizer got the generic template instead of the
+        from .specfile import resolve_instructions_file, resolve_project_path
+        # ONE resolution rule, shared with implement-and-check's pipeline_selftest AND the
+        # agent-mode host: a relative spec path is PROJECT-relative. It used to be probed
+        # against the caller's cwd first, so the same key resolved to a different file
+        # depending on where `cap-evolve run` was invoked from — and on a miss the flag was
+        # silently dropped and the optimizer got the generic template instead of the
         # capability-scoped one intake authored (#252).
-        # proj_abs, not the relative `project`: resolving against a relative project
-        # dir is still cwd-dependent, which is the bug (#252). An absolute path is also
-        # safer for the subprocess, which runs with cwd=workdir.
-        instr_p = resolve_project_path(proj_abs, instr)
-        if instr_p.exists():
+        # proj_abs, not the relative `project`: resolving against a relative project dir is
+        # still cwd-dependent, which is the bug (#252). An absolute path is also safer for
+        # the subprocess, which runs with cwd=workdir.
+        instr_p, instr_exists, instr_warning = resolve_instructions_file(spec, proj_abs)
+        if instr_exists:
             alg_cmd += ["--instructions-file", str(instr_p)]
-        elif _stderr_is_usable():
-            print(f"warning: optimizer_instructions_file {instr!r} does not exist "
-                  f"(resolved project-relative to {instr_p}) — the optimizer will get "
-                  f"cap-evolve's GENERIC template, not your capability-scoped one; "
-                  f"`cap-evolve check` and the implement-and-check self-test catch this",
-                  file=sys.stderr, flush=True)
+        elif instr_warning and _stderr_is_usable():
+            print(f"warning: {instr_warning}", file=sys.stderr, flush=True)
         repo = spec.get("runner_repo_path")
         if repo:
             alg_cmd += ["--bench-repo", str(resolve_project_path(proj_abs, str(repo)))]

--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -2384,6 +2384,16 @@ class OptimizerContext:
     genuinely per-algorithm inputs are parameters — ``algorithm`` (selects the algorithm
     brief) and ``extra`` (the caller's own block, e.g. gepa's reflective-dataset
     pointer).
+
+    **Agent mode composes the blocks instead of the whole prompt.** ``instructions()``
+    renders the per-iteration contract — "fix many root causes in this ONE candidate and
+    STOP; the harness re-scores you" — which is false for an agent that owns the whole
+    search, evaluates, and gates. So an agent-mode host must NOT call ``instructions()``;
+    it calls ``inject()`` plus the ``*_brief()`` accessors below and frames its own loop.
+    Those accessors exist because a host that hand-wrote equivalents ran without the
+    measured guidance the deterministic path has always had — ``_CAP_EDIT_SPACE``'s
+    "write a code-bearing tool" block and the target-reader block — and its optimizer
+    correspondingly only ever edited prose.
     """
 
     capabilities: tuple = ()
@@ -2456,6 +2466,106 @@ class OptimizerContext:
             bench_repo=getattr(args, "bench_repo", None),
             target_reader=_tp.reader_block(profile),
         )
+
+    @classmethod
+    def from_spec(cls, spec: dict, *, project_dir: Path | None = None,
+                  optimizer_name: str | None = None) -> OptimizerContext:
+        """Build a context from a ``capevolve.yaml`` dict rather than argparse args.
+
+        The sibling of ``from_args`` for callers that hold a spec — an agent-mode host has
+        one and no argparse namespace. Same fields, same target-profile resolution, so the
+        two construction paths cannot drift into handing out different context.
+        """
+        from . import target_profile as _tp
+
+        profile = _tp.resolve(str(spec.get("target_model") or ""), None,
+                             project_dir=project_dir)
+        return cls(
+            capabilities=tuple(c for c in (spec.get("capabilities") or []) if c),
+            optimizer_name=optimizer_name,
+            capability_sources=tuple(s for s in (spec.get("capability_sources") or []) if s),
+            project_dir=Path(project_dir) if project_dir else None,
+            instructions_file=(str(spec.get("optimizer_instructions_file") or "") or None),
+            bench_repo=(str(spec.get("bench_repo") or "") or None),
+            target_reader=_tp.reader_block(profile),
+        )
+
+    # ---- reusable prompt blocks ----------------------------------------------
+    # Public because agent mode needs the same measured guidance without the
+    # per-iteration contract that instructions() wraps around it. Each returns "" when it
+    # has nothing to say, so a caller can concatenate unconditionally.
+
+    def capability_brief(self) -> str:
+        """What the capability is and the FULL allowed edit space, per declared capability.
+
+        Carries ``_CAP_EDIT_SPACE`` — including the measured "highest-leverage edit is a new
+        code-bearing tool, because a deterministic tool can't be forgotten the way a prompt
+        rule can" guidance. A prompt that omits this is how an optimizer with tool code in
+        scope spends every round rewording prose.
+        """
+        return _capability_brief(list(self.capabilities))
+
+    def reader_brief(self) -> str:
+        """Who consumes the capability at runtime, and what that implies for the edit.
+
+        Resolved from ``target_model``: when the reader is weaker than the optimizer, prefer
+        explicit rules, worked examples and code enforcement over terse prose. Empty for an
+        agnostic profile.
+        """
+        return self.target_reader or ""
+
+    def empty_seed_brief(self, parent_dir: Path | None,
+                         current_val: SplitResult | None = None) -> str:
+        """Guidance for a capability that starts EMPTY (author it, don't refine it).
+
+        Uses the capability's own ``is_empty()`` when available and falls back to the reward
+        heuristic only without it — the same precedence ``instructions()`` applies. Needed by
+        any no-skill control (an arm that blanks the seed to measure "author from nothing").
+        """
+        seed_empty = (_capability_is_empty(list(self.capabilities), parent_dir)
+                      if parent_dir is not None else None)
+        if current_val is None:
+            if seed_empty is not True:
+                return ""
+            return _empty_seed_note(SplitResult(split="val", reward=0.0, stderr=0.0,
+                                                per_task=[]), seed_empty=True)
+        return _empty_seed_note(current_val, seed_empty=seed_empty)
+
+    def render_template(self, text: str, *, parent_dir: Path | None = None,
+                        current_val: SplitResult | None = None) -> str:
+        """Fill an instructions template's slots with what a NON-per-iteration caller knows.
+
+        The per-iteration slots (``FOCUS_SUMMARY`` / ``FAILURES`` / ``PASSING`` /
+        ``ALGO_BRIEF``) describe one scored step and one gate the caller does not own, so they
+        render empty here — an agent-mode driver diagnoses and gates for itself and would be
+        reading a stale snapshot of someone else's iteration. Everything else is filled from
+        the same functions ``_focus_instructions`` uses.
+
+        The alternative — passing the template through raw — reaches the agent as literal
+        ``{{TARGET_READER}}`` braces, which the parity test already treats as a defect on the
+        deterministic side.
+        """
+        repl = {
+            "{{TARGET_READER}}": self.reader_brief(),
+            "{{CAP_BRIEF}}": self.capability_brief(),
+            "{{EMPTY_SEED}}": self.empty_seed_brief(parent_dir, current_val),
+            "{{BENCH_REPO}}": (
+                f"- The benchmark / runner source is at `{self.bench_repo}` — read-only "
+                "context you may consult to understand tools, scoring, or task structure."
+                if self.bench_repo else ""),
+            "{{PARALLEL_NOTE}}": _parallel_note(_optimizer_parallel(self.optimizer_name),
+                                                self.optimizer_name),
+            # Per-iteration, deliberately blank — see the docstring.
+            "{{FOCUS_SUMMARY}}": "",
+            "{{FAILURES}}": "",
+            "{{PASSING}}": "",
+            "{{ALGO_BRIEF}}": "",
+        }
+        for k, v in repl.items():
+            text = text.replace(k, v)
+        # Any slot the template carries that this method does not know about would otherwise
+        # reach the reader as literal braces. Drop them rather than ship a broken document.
+        return re.sub(r"\{\{[A-Z0-9_]+\}\}", "", text)
 
     # ---- the two things every algorithm needs --------------------------------
 

--- a/core/cap_evolve/specfile.py
+++ b/core/cap_evolve/specfile.py
@@ -120,6 +120,37 @@ def resolve_project_path(project, value) -> Path:
     return v if v.is_absolute() else Path(project) / v
 
 
+#: Where a project's optimizer-instructions template lives when the spec does not name one.
+DEFAULT_INSTRUCTIONS_REL = "optimizer/INSTRUCTIONS.md"
+
+
+def resolve_instructions_file(spec: dict, project) -> tuple[Path, bool, str]:
+    """Resolve ``optimizer_instructions_file`` — ONE rule, for every consumer.
+
+    Returns ``(path, exists, warning)``. ``warning`` is non-empty only when the spec
+    NAMED a file that is not there: falling back then means the optimizer reads
+    cap-evolve's generic template instead of the capability-scoped one, and a step that
+    did not get what it needed must not look like a step that had nothing to propose
+    (#252). An absent default path is normal and silent.
+
+    Shared because it was resolved in two places — ``cli.py`` for the deterministic
+    algorithms, and an agent-mode host — and the second copy also had to re-derive the
+    default and the warning text. Two copies of a resolution rule is exactly how #252
+    happened the first time.
+    """
+    named = str(spec.get("optimizer_instructions_file") or "").strip()
+    path = resolve_project_path(project, named or DEFAULT_INSTRUCTIONS_REL)
+    if path.exists():
+        return path, True, ""
+    warning = ""
+    if named:
+        warning = (f"optimizer_instructions_file {named!r} does not exist (resolved "
+                   f"project-relative to {path}) — the optimizer will get cap-evolve's "
+                   f"GENERIC template, not your capability-scoped one; `cap-evolve check` "
+                   f"and the implement-and-check self-test catch this")
+    return path, False, warning
+
+
 def spec_for_run(run_dir, project: Path | None = None) -> dict:
     """The spec THIS run was started with, read from the run dir first.
 

--- a/core/tests/test_agent_optimize_constraints.py
+++ b/core/tests/test_agent_optimize_constraints.py
@@ -488,3 +488,31 @@ def test_a_verdict_that_flips_with_the_choice_of_control_replicate_is_marked_uns
         "close the call was")
     assert "unstable" in src.lower(), (
         "the reading must tell the driver an unstable verdict is not evidence")
+
+
+def test_rejecting_a_candidate_the_gate_ACCEPTED_cannot_claim_the_gate_as_its_basis():
+    """Run 32871360361's audit log says cand2 was rejected on basis `gate`. The gate accepted it.
+
+    `--reject-basis gate` is documented as "full-val paired gate ran", so anyone reading
+    events.jsonl concludes the gate rejected the candidate. In fact round_i1.json recorded
+    `verdict: accept` at +0.19 against a concurrent control, and the driver overrode it on its own
+    reading of the drift. Overriding is legitimate — round.py explicitly leaves the decision to
+    the driver — but recording it as the gate's own verdict makes the run's history wrong about
+    the one thing it exists to preserve.
+
+    commit.py already refuses an incoherent basis ("--reject-basis is meaningless on an accept"),
+    so the idiom exists; it just could not see the gate's verdict until round.py started
+    persisting its table.
+    """
+    import pathlib  # noqa: PLC0415
+    src = (pathlib.Path(__file__).resolve().parents[2]
+           / "skills/algorithms/agent-optimize/scripts/commit.py").read_text(encoding="utf-8")
+
+    assert "driver_judgement" in src, (
+        "there is no truthful basis for an override, so a driver that disagrees with the gate has "
+        "no honest option but to misattribute the reject to the gate")
+    assert "gate_verdict" in src, (
+        "the booked event must carry the gate's own verdict, so a divergence between what the "
+        "gate said and what was booked is visible in events.jsonl rather than lost")
+    assert "overrode_gate" in src, (
+        "an override must be marked as one in the audit record")

--- a/core/tests/test_agent_optimize_constraints.py
+++ b/core/tests/test_agent_optimize_constraints.py
@@ -342,3 +342,56 @@ def test_full_val_ceiling_is_not_computable_without_coverage():
 
     assert "status" in full_val_ceiling([], [], [], [])
     assert "accept_possible" not in full_val_ceiling([_pt("a", 1.0)], [], ["a"], ["a"])
+
+
+# --- run 32861747778: a gate at concurrency 100 -------------------------------
+
+def _round_rc(*extra, run_dir="/nonexistent", concurrency="100"):
+    """Invoke round.py's guard. Dummy paths: the refusal must precede any run-dir access."""
+    import json as _json
+    import subprocess as _sp
+    import sys as _sys
+    from pathlib import Path as _P
+    here = _P(__file__).resolve().parents[2] / "skills/algorithms/agent-optimize/scripts"
+    p = _sp.run([_sys.executable, str(here / "round.py"), "--run-dir", run_dir,
+                 "--project", run_dir, "--candidates", "c1", "--n-trials", "1",
+                 "--concurrency", concurrency, *extra],
+                capture_output=True, text=True)
+    try:
+        return p.returncode, _json.loads(p.stdout or "{}")
+    except Exception:
+        return p.returncode, {"stdout": p.stdout, "stderr": p.stderr}
+
+
+def test_a_gate_too_coarse_to_resolve_its_own_verdict_is_refused_not_warned():
+    """Measured: the agent set --concurrency 100 after SKILL.md told it not to.
+
+    round.py already warned in its own output ("cannot resolve an effect smaller than roughly
+    0.08") and the run continued regardless, producing verdicts nobody should believe. This
+    skill's own edit-form rule applies to the skill: where the agent has the criterion and
+    violates it anyway, the form that works is a guard in the code, not another restatement in
+    prose. `--gate-against control --no-control` is already refused this way, so refusal — not
+    a silent clamp — is the established idiom here.
+    """
+    rc, out = _round_rc()
+    assert rc == 2, f"concurrency 100 was accepted: rc={rc} {out}"
+    blob = json.dumps(out).lower()
+    assert "concurrency" in blob, f"the refusal does not name the offending knob: {out}"
+    assert "8" in json.dumps(out), f"the refusal should name the value to use instead: {out}"
+
+
+def test_the_high_concurrency_refusal_has_a_deliberate_escape_hatch():
+    """A hard wall would break any tier that legitimately needs throughput; the point is that
+    raising it must be an explicit, recorded choice rather than a default someone drifts into.
+    """
+    rc, out = _round_rc("--allow-high-concurrency")
+    assert rc != 2 or "concurrency" not in json.dumps(out).lower(), (
+        f"the escape hatch does not bypass the concurrency guard: rc={rc} {out}")
+
+
+def test_the_default_concurrency_is_not_refused():
+    """The guard must be silent on the value the skill actually documents."""
+    rc, out = _round_rc(concurrency="8")
+    blob = json.dumps(out).lower()
+    assert not (rc == 2 and "concurrency" in blob), (
+        f"the documented default was refused by its own guard: rc={rc} {out}")

--- a/core/tests/test_agent_optimize_constraints.py
+++ b/core/tests/test_agent_optimize_constraints.py
@@ -516,3 +516,26 @@ def test_rejecting_a_candidate_the_gate_ACCEPTED_cannot_claim_the_gate_as_its_ba
         "gate said and what was booked is visible in events.jsonl rather than lost")
     assert "overrode_gate" in src, (
         "an override must be marked as one in the audit record")
+
+
+def test_a_parent_gated_round_still_reports_the_drift_free_comparison_it_measured():
+    """Run 32871360361 round 4 held both answers in one table and printed only the weaker one.
+
+    It gated in `parent` mode: `cand4` 0.53 against the seed's STORED 0.38 = +0.15, bar 0.11
+    (drift), so 1.4x — marginal. But the round also measured two concurrent controls that read
+    **exactly 0.27 both times**, so the drift-free comparison from the very same rollouts is +0.26
+    against a bar of 0.00. The 0.11 is a property of *when* the seed was measured, not of `cand4`;
+    parent-mode gating both understated the effect and inflated the bar.
+
+    Rather than change the default gate mode on one benchmark's evidence, report both: the
+    control-relative comparison costs no rollouts (the controls are already evaluated and
+    `gate_check.py` reads stored data), and on a benchmark without drift the two simply agree.
+    """
+    import pathlib  # noqa: PLC0415
+    src = (pathlib.Path(__file__).resolve().parents[2]
+           / "skills/algorithms/agent-optimize/scripts/round.py").read_text(encoding="utf-8")
+
+    assert '"control_relative"' in src, (
+        "a parent-gated round throws away the drift-free comparison it already paid to measure, "
+        "so a real improvement can read as marginal with no way to see why")
+    assert "drift" in src.lower(), "the report must name what separates the two comparisons"

--- a/core/tests/test_agent_optimize_constraints.py
+++ b/core/tests/test_agent_optimize_constraints.py
@@ -426,3 +426,38 @@ def test_the_round_table_does_not_report_the_controls_reward_under_the_parents_t
     # The true parent must be read from `best`, never from gate_ref.
     assert "split_result_from_rollouts(run_dir, best," in src, (
         "the parent block still sources its reward from gate_ref rather than from `best`")
+
+
+def test_the_round_states_ONE_evidence_bar_matched_to_how_it_gated():
+    """Measured on run 32871360361 round 2: the table handed the driver two incompatible bars
+    and it took the wrong one.
+
+    `cand2` was gated against a CONCURRENT control (0.24, replicate 0.25 — agreeing to 0.01) and
+    beat it by +0.19, three times the k_se threshold. But the table also reported
+    `noise_floor_from_control = 0.14`, which is the control-vs-STORED-parent gap, i.e. temporal
+    drift — and its `reading` said "treat any candidate whose |delta| is at or below that as no
+    evidence". Comparing a control-relative delta against a drift-derived floor is apples to
+    oranges, and the driver resolved the ambiguity conservatively: it re-derived +0.05 against
+    the stored best and booked a REJECT on a candidate that had cleared its concurrent control
+    nineteen times over.
+
+    Drift is exactly what control-mode gating removes, so under that mode the bar is the
+    replicate null delta. Under parent-mode gating the delta IS against a stored reward, so
+    drift belongs in the bar. One number, named, matched to the mode.
+    """
+    import pathlib  # noqa: PLC0415
+    src = (pathlib.Path(__file__).resolve().parents[2]
+           / "skills/algorithms/agent-optimize/scripts/round.py").read_text(encoding="utf-8")
+
+    assert '"evidence_bar"' in src, (
+        "the round must state ONE bar the candidate delta is judged against, or the driver "
+        "picks between the several numbers reported and may pick the wrong one")
+    # It must be mode-aware: the replicate gap under control gating, drift-inclusive otherwise.
+    bar = src[src.index('"evidence_bar"'):]
+    bar = bar[:bar.index("\n\n")] if "\n\n" in bar[:1500] else bar[:1500]
+    assert "gate_against" in bar or "control" in bar, (
+        f"evidence_bar is not matched to the gate mode: {bar[:400]}")
+    # And the drift must be described as affecting the absolute number, not as a bar to clear.
+    assert "absolute" in src.lower(), (
+        "nothing tells the reader that drift bounds the trustworthiness of the ABSOLUTE reward "
+        "rather than the candidate-vs-control comparison")

--- a/core/tests/test_agent_optimize_constraints.py
+++ b/core/tests/test_agent_optimize_constraints.py
@@ -395,3 +395,34 @@ def test_the_default_concurrency_is_not_refused():
     blob = json.dumps(out).lower()
     assert not (rc == 2 and "concurrency" in blob), (
         f"the documented default was refused by its own guard: rc={rc} {out}")
+
+
+def test_the_round_table_does_not_report_the_controls_reward_under_the_parents_tag():
+    """Measured on run 32871360361: `parent: {tag: 'seed', reward: 0.34}` while
+    `baseline.json` said the seed scored 0.38 — because line 214 loads `parent` from
+    `gate_ref` (the CONTROL under --gate-against control) and line 266 emits it with
+    `"tag": best`. Two different objects in one block, irreconcilable for anyone reading it.
+
+    This is not cosmetic. The true parent vs the concurrently-measured control IS the round's
+    temporal drift — the quantity that decides whether any delta means anything, measured at
+    0.24/0.44/0.38 on identical seed bytes across three runs — and conflating them erases it.
+    So the table must carry both, and the delta key must name what it is really measured
+    against.
+    """
+    import pathlib  # noqa: PLC0415
+    src = (pathlib.Path(__file__).resolve().parents[2]
+           / "skills/algorithms/agent-optimize/scripts/round.py").read_text(encoding="utf-8")
+
+    assert '"delta_vs_parent"' not in src, (
+        "delta_vs_parent is computed against gate_ref, which under --gate-against control is "
+        "the control, not the parent — the key name lies")
+    assert '"delta_vs_gate_ref"' in src, "the delta key must name its actual reference"
+    assert '"gate_reference"' in src, (
+        "the table must report the object deltas were computed against, separately from the "
+        "parent it is climbing from")
+    assert '"parent_vs_gate_ref_drift"' in src, (
+        "the parent-vs-control gap is the round's own drift measurement and must be reported, "
+        "not left for a reader to reconstruct from baseline.json")
+    # The true parent must be read from `best`, never from gate_ref.
+    assert "split_result_from_rollouts(run_dir, best," in src, (
+        "the parent block still sources its reward from gate_ref rather than from `best`")

--- a/core/tests/test_agent_optimize_constraints.py
+++ b/core/tests/test_agent_optimize_constraints.py
@@ -461,3 +461,30 @@ def test_the_round_states_ONE_evidence_bar_matched_to_how_it_gated():
     assert "absolute" in src.lower(), (
         "nothing tells the reader that drift bounds the trustworthiness of the ABSOLUTE reward "
         "rather than the candidate-vs-control comparison")
+
+
+def test_a_verdict_that_flips_with_the_choice_of_control_replicate_is_marked_unstable():
+    """Measured on run 32871360361 round 3: the verdict was decided by a coin flip.
+
+    Two byte-identical control replicates, measured two minutes apart, read 0.32 and 0.20 — a
+    0.12 gap. The gate reference was whichever one carried the round-scoped tag (0.20), so
+    `cand3` at 0.37 scored +0.17 and ACCEPTED. Against the other replicate it is +0.05 and
+    rejects. Nothing in the table said the verdict rested on that choice.
+
+    Re-gating against each replicate costs no new rollouts — they are already stored — so the
+    round can simply report whether its verdict survives every reference it could have used. One
+    that does not is not evidence, however large the delta looks against the replicate that
+    happened to be picked.
+    """
+    import pathlib  # noqa: PLC0415
+    src = (pathlib.Path(__file__).resolve().parents[2]
+           / "skills/algorithms/agent-optimize/scripts/round.py").read_text(encoding="utf-8")
+
+    assert '"verdict_stable"' in src, (
+        "the table does not say whether the verdict survives the choice of control replicate, "
+        "so a coin-flip accept is indistinguishable from a real one")
+    assert '"verdict_by_reference"' in src, (
+        "the per-replicate verdicts must be shown, not just a boolean, or nobody can see how "
+        "close the call was")
+    assert "unstable" in src.lower(), (
+        "the reading must tell the driver an unstable verdict is not evidence")

--- a/core/tests/test_agent_optimize_host.py
+++ b/core/tests/test_agent_optimize_host.py
@@ -194,6 +194,39 @@ def test_the_briefing_enumerates_every_editable_file_not_just_the_capability_nam
         f"the rest of the surface unexercised: {body}")
 
 
+def test_two_rejections_escalate_the_form_rather_than_ending_the_run(tmp_path):
+    """Measured: the agent chose prose twice, was rejected twice, and stopped.
+
+    Its own reject notes named the surface each time ("System-prompt surface") and round 1's
+    note — "require calculate tool for all money" — is precisely the case where SKILL.md says
+    code beats prose: the agent HAS the criterion and violates it. The prescribed third round
+    was a guard in the tool code. It never happened.
+
+    So the briefing states this as a precondition on the round, not as encouragement: after two
+    rejects, the same surface-and-form is off the table.
+    """
+    project = _project(tmp_path)
+    run_dir = _run_dir(tmp_path)
+    seed = run_dir.root / "candidates" / "seed"
+    (seed / "policy").mkdir(parents=True, exist_ok=True)
+    (seed / "policy" / "policy.md").write_text("Be helpful.\n", encoding="utf-8")
+    (seed / "tools").mkdir(parents=True, exist_ok=True)
+    (seed / "tools" / "tools.py").write_text("def calculate():\n    ...\n", encoding="utf-8")
+
+    out = _host("--run-dir", str(run_dir.root), "--project", str(project), "--prompt-only")
+    body = Path(out["prompt_path"]).read_text(encoding="utf-8")
+    low = body.lower()
+
+    assert "may not reuse the surface" in low, (
+        "the briefing does not forbid a third round on the same surface and form")
+    assert "not a reason to stop" in low, (
+        "the briefing does not say that two rejections are not a reason to stop")
+    # With code in the surface, the escalation must name the code form specifically —
+    # a generic "try something else" is what produced three prose candidates.
+    assert "guard in the code" in low, (
+        f"the escalation never names the code form for a capability that owns tool code: {body}")
+
+
 def test_the_briefing_does_not_invent_files_for_a_prompt_only_capability(tmp_path):
     """A single-file capability must not be described as if it had more surface.
 

--- a/core/tests/test_agent_optimize_host.py
+++ b/core/tests/test_agent_optimize_host.py
@@ -716,3 +716,220 @@ def test_required_handoff_arguments(tmp_path, missing):
     p = subprocess.run([sys.executable, str(HOST), *argv],
                        capture_output=True, text=True, env=_env())
     assert p.returncode != 0, f"{missing} must be required"
+
+
+# --- the end_turn defect: run 32814848187 ------------------------------------
+# The turn budget raised to 600 in this branch worked: that run used 78 of 600 and stopped
+# on subtype=success / stop_reason=end_turn, rc=0. It had backgrounded round 2's full-val
+# gate and ended its turn to await a notification, which a `claude -p` process can never
+# receive — end_turn IS process exit. The gate finished 14 minutes after the agent was gone,
+# with a real verdict (r2_comm_search 0.44 vs parent 0.58 -> reject) that nobody read, so
+# rounds_booked stayed 1 of 3 and round 3 never started. Three holes, one per test below.
+
+
+def test_the_briefing_forbids_ending_a_turn_on_outstanding_work_without_banning_delegation(
+        tmp_path):
+    """The rule has to be about WHERE the main loop lives, not about avoiding concurrency.
+
+    The briefing's "Unattended" section covered only asking questions ("Do not ask any; do
+    not wait for input"). Backgrounding a job and ending the turn to await a notification
+    breaks neither clause, and that is exactly what happened. But the fix must not read as
+    "never delegate": fanning out subagents or several evals at once is the intended way to
+    use this host, and `round.py` exists to do precisely that. What is fatal is the *main
+    loop* leaving the foreground — delegation is fine as long as the driving turn stays
+    blocked on the result and reads it itself.
+    """
+    project = _project(tmp_path)
+    run_dir = _run_dir(tmp_path)
+
+    out = _host("--run-dir", str(run_dir.root), "--project", str(project), "--prompt-only")
+    brief = Path(out["prompt_path"]).read_text(encoding="utf-8").lower()
+
+    assert "foreground" in brief, (
+        "the briefing never tells the agent its main loop must stay in the foreground, so "
+        "backgrounding the gate and ending the turn breaks no stated rule")
+    assert "orphan" in brief or "exits" in brief, (
+        "the briefing must state the CONSEQUENCE — ending a turn with no pending tool call "
+        "ends the process and orphans its children — or the rule reads as mere style")
+
+    # Generic, not a ban on concurrency: subagents and parallel work must stay permitted,
+    # since round.py's whole point is evaluating a round's candidates at once.
+    assert ("subagent" in brief or "delegat" in brief or "parallel" in brief), (
+        "the rule must say delegation stays allowed; a blanket 'do everything yourself, "
+        "serially' would forbid round.py's parallel evals and the subagent fan-out the "
+        "claude-code registry row advertises")
+
+    # And it must not name one tool or one mechanism — any later-reporting mechanism is
+    # equally fatal, so the rule is phrased on the outcome.
+    assert "notif" in brief or "wake" in brief or "report back" in brief, (
+        "the rule should generalise to anything that reports back after the turn ends, "
+        "not just to the one mechanism this run happened to use")
+
+
+def test_an_agent_that_ENDED_ITS_TURN_is_not_told_to_raise_the_turn_budget(tmp_path):
+    """Two different stop causes had one message, and it fit only the older one.
+
+    Run 32733635494 really did die on error_max_turns, and "raise optimizer_max_turns or
+    lower the round count" was the right advice. Run 32814848187 stopped at 78 of 600 turns
+    on end_turn; the same sentence sent the operator to a knob that was already 7x larger
+    than what the agent used. The host has the stop reason in hand and must split on it.
+    """
+    project = _project(tmp_path)
+    run_dir = _run_dir(tmp_path)
+
+    stub = tmp_path / "fake_run_optimizer.py"
+    stub.write_text(
+        "import json\n"
+        "print(json.dumps({'optimizer': 'claude-code', 'cli_present': True,\n"
+        "                  'returncode': 0, 'auth_present': [],\n"
+        "                  'stop': {'subtype': 'success', 'num_turns': 78,\n"
+        "                           'is_error': False, 'stop_reason': 'end_turn'}}))\n",
+        encoding="utf-8")
+
+    out = _host("--run-dir", str(run_dir.root), "--project", str(project),
+                "--agent", "claude-code", "--run-optimizer", str(stub))
+
+    assert out.get("incomplete"), f"stopping with rounds left must not read as done: {out}"
+    msg = str(out["incomplete"]).lower()
+    assert "optimizer_max_turns" not in msg, (
+        "an agent that used 78 of its turns and ended its turn voluntarily is not "
+        f"turn-starved; pointing the operator at the turn budget misdiagnoses it: {msg}")
+    assert "turn" in msg and ("outstanding" in msg or "background" in msg
+                              or "chose" in msg or "voluntar" in msg), (
+        f"the end_turn case needs its own diagnosis, not a generic one: {msg}")
+    # The inner stop_reason is the discriminator and must survive into the payload; reading
+    # only `subtype` sees "success" and cannot tell this from a clean finish.
+    assert "end_turn" in json.dumps(out), (
+        f"the agent's stop_reason never reaches the host's output: {out}")
+
+
+def test_a_turn_starved_agent_still_gets_the_turn_budget_advice(tmp_path):
+    """The split must not lose the advice that was right for the original defect."""
+    project = _project(tmp_path)
+    run_dir = _run_dir(tmp_path)
+
+    stub = tmp_path / "fake_run_optimizer.py"
+    stub.write_text(
+        "import json\n"
+        "print(json.dumps({'optimizer': 'claude-code', 'cli_present': True,\n"
+        "                  'returncode': 0, 'auth_present': [],\n"
+        "                  'stop': {'subtype': 'error_max_turns', 'num_turns': 240}}))\n",
+        encoding="utf-8")
+
+    out = _host("--run-dir", str(run_dir.root), "--project", str(project),
+                "--agent", "claude-code", "--run-optimizer", str(stub))
+
+    assert "optimizer_max_turns" in str(out.get("incomplete", "")), (
+        f"the turn-exhausted case lost its own advice in the split: {out}")
+
+
+def test_a_round_that_was_gated_but_never_booked_is_reported(tmp_path):
+    """The work was done and the verdict was on disk; only commit.py was missing.
+
+    round2.log held `r2_comm_search reward 0.44, verdict reject` against parent r1_ops_bag.
+    Nothing read it. The host's own accounting could not see it either — `spent.iterations`
+    counts commit.py calls, so an un-booked round is indistinguishable from a round that was
+    never attempted, and the operator is left to diff candidate dirs by hand.
+
+    The host reports it rather than booking it: which decision a round's verdict deserves is
+    the driver's judgement, and a host that booked accepts would silently move `best_id`
+    after `measure.py` had already sealed against the old one.
+    """
+    project = _project(tmp_path)
+    run_dir = _run_dir(tmp_path)
+
+    work = run_dir.root / "work"
+    work.mkdir(parents=True, exist_ok=True)
+    (work / "round2.log").write_text(json.dumps({
+        "parent": {"tag": "r1_ops_bag", "reward": 0.58},
+        "candidates": [{"tag": "r2_comm_search", "reward": 0.44,
+                        "delta_vs_parent": -0.14, "verdict": "reject", "eval_rc": 0}],
+        "control": {"tag": "ctl_null_i1", "reward": 0.5, "verdict": "reject"},
+    }), encoding="utf-8")
+
+    stub = tmp_path / "fake_run_optimizer.py"
+    stub.write_text(
+        "import json\n"
+        "print(json.dumps({'optimizer': 'claude-code', 'cli_present': True,\n"
+        "                  'returncode': 0, 'auth_present': [],\n"
+        "                  'stop': {'subtype': 'success', 'num_turns': 78,\n"
+        "                           'stop_reason': 'end_turn'}}))\n",
+        encoding="utf-8")
+
+    out = _host("--run-dir", str(run_dir.root), "--project", str(project),
+                "--agent", "claude-code", "--run-optimizer", str(stub))
+
+    unbooked = out.get("unbooked_rounds")
+    assert unbooked, (
+        "a fully-gated round with no commit.py decision is invisible in the host's "
+        f"output, so the run reads as if that round never happened: {out}")
+    blob = json.dumps(unbooked)
+    assert "r2_comm_search" in blob, f"the candidate is not named: {blob}"
+    assert "reject" in blob, f"the verdict that was computed is not carried: {blob}"
+    assert "round2.log" in blob, f"the log to look in is not named: {blob}"
+    assert "r2_comm_search" in str(out.get("incomplete", "")), (
+        "the un-booked candidate must surface in the operator-facing warning too, not "
+        f"only in a nested key nobody greps: {out.get('incomplete')}")
+    # The control is round.py's noise floor, never committed by design — reporting it as
+    # un-booked would cry wolf on every single round.
+    assert "ctl_null" not in blob, (
+        f"the null control is not a bookable candidate and must not be flagged: {blob}")
+
+
+def test_a_booked_round_is_not_reported_as_unbooked(tmp_path):
+    """The backstop must be silent on the healthy path, or it is noise.
+
+    Asserted on the full host path, not ``--seal-only``: a negative assertion is only worth
+    anything on the code path that also produces the positive, and the key would otherwise be
+    trivially absent.
+    """
+    project = _project(tmp_path)
+    run_dir = _run_dir(tmp_path)
+
+    work = run_dir.root / "work"
+    work.mkdir(parents=True, exist_ok=True)
+    (work / "round1.log").write_text(json.dumps({
+        "parent": {"tag": "seed", "reward": 0.24},
+        "candidates": [{"tag": "r1_ops_bag", "reward": 0.58, "verdict": "accept"}],
+    }), encoding="utf-8")
+    # What commit.py leaves behind for that candidate.
+    run_dir.log_event("accept", candidate="r1_ops_bag", val=0.58)
+
+    stub = tmp_path / "fake_run_optimizer.py"
+    stub.write_text(
+        "import json\n"
+        "print(json.dumps({'optimizer': 'claude-code', 'cli_present': True,\n"
+        "                  'returncode': 0, 'auth_present': [],\n"
+        "                  'stop': {'subtype': 'success', 'num_turns': 78,\n"
+        "                           'stop_reason': 'end_turn'}}))\n",
+        encoding="utf-8")
+
+    out = _host("--run-dir", str(run_dir.root), "--project", str(project),
+                "--agent", "claude-code", "--run-optimizer", str(stub))
+
+    assert out["unbooked_rounds"] == [], (
+        f"a candidate with an accept event on record was flagged as un-booked: {out}")
+    assert "r1_ops_bag" not in str(out.get("incomplete", "")), (
+        f"a booked candidate leaked into the warning: {out.get('incomplete')}")
+
+
+def test_seal_only_also_reports_an_abandoned_round(tmp_path):
+    """--seal-only is what an operator runs on a run that died; it must say what was left.
+
+    Reporting the abandoned round only on the full host path hides it from the one reader who
+    went looking for why the run is short.
+    """
+    project = _project(tmp_path)
+    run_dir = _run_dir(tmp_path)
+
+    work = run_dir.root / "work"
+    work.mkdir(parents=True, exist_ok=True)
+    (work / "round2.log").write_text(json.dumps({
+        "parent": {"tag": "r1_ops_bag", "reward": 0.58},
+        "candidates": [{"tag": "r2_comm_search", "reward": 0.44, "verdict": "reject"}],
+    }), encoding="utf-8")
+
+    out = _host("--run-dir", str(run_dir.root), "--project", str(project), "--seal-only")
+
+    assert "r2_comm_search" in json.dumps(out.get("unbooked_rounds")), (
+        f"--seal-only sealed the run and said nothing about the abandoned round: {out}")

--- a/core/tests/test_agent_optimize_host.py
+++ b/core/tests/test_agent_optimize_host.py
@@ -1060,3 +1060,115 @@ def test_an_agent_that_died_without_sealing_still_gets_the_foreground_diagnosis(
     msg = str(out.get("incomplete") or "")
     assert "foreground" in msg or "background" in msg, (
         f"the foreground diagnosis was lost for the case it exists for: {msg}")
+
+
+# --- review follow-ups (PR #399 review by OsherElhadad) -----------------------
+
+
+def test_code_advice_fires_for_languages_beyond_the_first_handful(tmp_path):
+    """`_CODE_SUFFIXES` was a 14-entry allowlist, so C/C++/C#/PHP/Swift/Kotlin got prose advice.
+
+    The briefing offers "the form that works is a guard in the code" only when the editable
+    surface actually contains code — correct, because a two-prose-file capability told to prefer
+    an in-code guard goes hunting for code it does not own. But gating that on a short suffix
+    list reintroduced the same silent-miss for every language not named, which is the failure
+    class this PR exists to remove rather than relocate.
+
+    Asserted on the module's set rather than through a rendered briefing, because the point is
+    coverage of the vocabulary, not one file's rendering.
+    """
+    # Parsed statically rather than imported: host.py's `import _bootstrap` needs its own
+    # scripts dir on sys.path, and this assertion is about the vocabulary, not the runtime.
+    import ast  # noqa: PLC0415
+
+    tree = ast.parse(HOST.read_text(encoding="utf-8"))
+    suffixes = next(
+        ast.literal_eval(n.value) for n in ast.walk(tree)
+        if isinstance(n, ast.Assign)
+        and any(getattr(t, "id", "") == "_CODE_SUFFIXES" for t in n.targets))
+
+    class _M:  # tiny shim so the assertions below read the same either way
+        _CODE_SUFFIXES = suffixes
+    mod = _M
+
+    for suffix in (".c", ".h", ".cc", ".cpp", ".hpp", ".cs", ".php", ".swift", ".kt", ".m",
+                   ".scala", ".ex", ".erl", ".hs", ".ml", ".r", ".jl", ".dart", ".zig"):
+        assert suffix in mod._CODE_SUFFIXES, (
+            f"{suffix} is not recognised as code, so a capability whose only code is {suffix} "
+            "silently gets prose-only advice — the bug this PR fixed for .py, relocated")
+    # Prose must stay prose, or the original defect comes back from the other side.
+    for suffix in (".md", ".txt", ".rst"):
+        assert suffix not in mod._CODE_SUFFIXES, f"{suffix} must not count as code"
+    # And the list must be documented as non-exhaustive, so the next reader broadens it rather
+    # than assuming absence means "deliberately prose".
+    src = HOST.read_text(encoding="utf-8")
+    head = src[:src.index("_CODE_SUFFIXES")]
+    assert "not exhaustive" in head.lower() or "non-exhaustive" in head.lower(), (
+        "the set must say it is known-good rather than complete, or its gaps read as decisions")
+
+
+def test_a_capability_with_no_guidance_skill_is_reported_not_silently_skipped(tmp_path):
+    """`harness._stage_context` skips a capability with no matching skill dir and still says
+    `staged: True`, so some-capabilities-missing was indistinguishable from all-staged.
+
+    The whole-staging failure was already loud (`staged: False` + a `::warning::`). The
+    per-capability miss was not — and "quietly optimizing less surface" is the exact defect
+    this PR was opened to fix, so leaving one half of it silent is inconsistent.
+
+    The staged guidance list was already in the payload; what was missing was comparing it
+    against what the spec asked for and saying so.
+    """
+    project = _project(tmp_path)
+    # A capability that has no skill package anywhere under skills/.
+    (project / "capevolve.yaml").write_text(
+        "num_trials: 1\ngate_mode: paired\ngate_k_se: 1.0\n"
+        "capabilities: [system-prompt, no-such-capability]\n"
+        "capability_path: seed_capability\nstop_condition: \"stop after 1 round\"\n",
+        encoding="utf-8")
+    run_dir = _run_dir(tmp_path)
+
+    out = _host("--run-dir", str(run_dir.root), "--project", str(project), "--prompt-only")
+    ctx = out["context"]
+
+    assert "no-such-capability" in ctx.get("capabilities", []), ctx
+    assert "no-such-capability" not in ctx.get("guidance", []), (
+        "fixture is wrong: the capability must genuinely have no guidance dir")
+    assert ctx.get("guidance_missing") == ["no-such-capability"], (
+        "a declared capability that got NO guidance is not reported, so the agent optimizes "
+        f"that surface blind and the JSON looks fully staged: {ctx}")
+
+
+def test_the_guidance_gap_is_warned_about_not_only_recorded(tmp_path):
+    """A field nobody greps is not a report. The all-missing case already warns; match it."""
+    project = _project(tmp_path)
+    (project / "capevolve.yaml").write_text(
+        "num_trials: 1\ngate_mode: paired\ngate_k_se: 1.0\n"
+        "capabilities: [system-prompt, no-such-capability]\n"
+        "capability_path: seed_capability\nstop_condition: \"stop after 1 round\"\n",
+        encoding="utf-8")
+    run_dir = _run_dir(tmp_path)
+
+    stub = tmp_path / "fake_run_optimizer.py"
+    stub.write_text(
+        "import json\n"
+        "print(json.dumps({'optimizer': 'claude-code', 'cli_present': True,\n"
+        "                  'returncode': 0, 'auth_present': []}))\n",
+        encoding="utf-8")
+    p = subprocess.run(
+        [sys.executable, str(HOST), "--run-dir", str(run_dir.root), "--project", str(project),
+         "--agent", "claude-code", "--run-optimizer", str(stub)],
+        capture_output=True, text=True, env=_env())
+
+    assert "::warning::" in p.stderr and "no-such-capability" in p.stderr, (
+        f"the guidance gap was recorded but never surfaced as a warning: {p.stderr[-600:]}")
+
+
+def test_a_fully_staged_run_reports_no_guidance_gap(tmp_path):
+    """The gap report must be silent on the healthy path, or it is noise."""
+    project = _project(tmp_path)
+    run_dir = _run_dir(tmp_path)
+
+    out = _host("--run-dir", str(run_dir.root), "--project", str(project), "--prompt-only")
+
+    assert out["context"].get("guidance_missing") == [], (
+        f"a fully-staged run reports a phantom gap: {out['context']}")

--- a/core/tests/test_agent_optimize_host.py
+++ b/core/tests/test_agent_optimize_host.py
@@ -523,6 +523,105 @@ def test_a_large_capability_is_summarised_without_pretending_to_be_complete(tmp_
         assert pack in surface, f"group {pack} vanished from the summarised listing"
 
 
+def test_the_agents_real_cost_is_booked_not_silently_zeroed(tmp_path):
+    """run-optimizer nests cost under ``cost.total_cost_usd``; the host read the wrong key.
+
+    Measured on run 32733635494: the payload carried ``cost.total_cost_usd: 8.370`` and
+    68,432 tokens, and the host booked ``usd: 0.0``. Every agent-mode run therefore reported
+    $0.00 optimizer spend while really spending money — and it looked exactly like the
+    "unmetered gateway" case the skill warns about, so the wrong conclusion was drawn twice.
+
+    A cost ceiling cannot bind what it cannot see: with 0.0 booked, ``max_usd`` and spend.py's
+    dollar predicates are inert.
+    """
+    from cap_evolve import RunDir
+
+    project = _project(tmp_path)
+    run_dir = _run_dir(tmp_path)
+
+    # A stub agent that emits exactly run-optimizer's real result shape.
+    stub = tmp_path / "fake_run_optimizer.py"
+    stub.write_text(
+        "import json, sys\n"
+        "print(json.dumps({'optimizer': 'claude-code', 'cli_present': True,\n"
+        "                  'returncode': 0, 'auth_present': [],\n"
+        "                  'cost': {'total_cost_usd': 8.37, 'tokens': 68432}}))\n",
+        encoding="utf-8")
+
+    out = _host("--run-dir", str(run_dir.root), "--project", str(project),
+                "--agent", "claude-code", "--run-optimizer", str(stub))
+
+    assert out["usd"] == pytest.approx(8.37), (
+        f"the host did not read cost.total_cost_usd from the payload: {out}")
+
+    rd = RunDir.open(run_dir.root)
+    assert rd.spent.optimizer_usd == pytest.approx(8.37), (
+        "the cost never reached the run's spend ledger, so no dollar ceiling can bind it")
+    events = (run_dir.root / "events.jsonl").read_text(encoding="utf-8")
+    host_ev = [json.loads(ln) for ln in events.splitlines()
+               if ln.strip() and json.loads(ln).get("kind") == "host"]
+    assert host_ev and host_ev[-1]["usd"] == pytest.approx(8.37), (
+        f"the host event under-reports the round's cost: {host_ev}")
+
+
+def test_the_host_reports_why_the_agent_stopped(tmp_path):
+    """The diagnosis that had to be reconstructed by hand.
+
+    Run 32733635494's agent stopped mid-round-2 with its highest-scoring candidate
+    (val 0.530) evaluated but never committed, and the host's output said only
+    ``returncode: 0, timed_out: false``. Whether it ran out of turns, hit an error, or chose
+    to stop was invisible; the stop reason was inferred from a truncated stdout tail.
+    """
+    project = _project(tmp_path)
+    run_dir = _run_dir(tmp_path)
+
+    stub = tmp_path / "fake_run_optimizer.py"
+    stub.write_text(
+        "import json\n"
+        "print(json.dumps({'optimizer': 'claude-code', 'cli_present': True,\n"
+        "                  'returncode': 0, 'auth_present': [],\n"
+        "                  'cost': {'total_cost_usd': 1.0, 'tokens': 10},\n"
+        "                  'stop': {'subtype': 'error_max_turns', 'num_turns': 240,\n"
+        "                           'is_error': False}}))\n",
+        encoding="utf-8")
+
+    out = _host("--run-dir", str(run_dir.root), "--project", str(project),
+                "--agent", "claude-code", "--run-optimizer", str(stub))
+
+    assert out.get("stop_reason") == "error_max_turns", (
+        f"the host does not surface the agent's stop reason: {out}")
+    assert out.get("num_turns") == 240, f"turns used not reported: {out}"
+    assert "turn" in json.dumps(out).lower()
+
+
+def test_an_agent_that_stopped_with_rounds_left_is_called_out(tmp_path):
+    """Stopping early with budget remaining is a defect, and must not read as completion.
+
+    The run that prompted this booked 1 of 3 rounds, had a better candidate sitting
+    un-committed, and still reported success. The host cannot un-spend that, but it can refuse
+    to let it look finished.
+    """
+    project = _project(tmp_path)
+    run_dir = _run_dir(tmp_path)
+
+    stub = tmp_path / "fake_run_optimizer.py"
+    stub.write_text(
+        "import json\n"
+        "print(json.dumps({'optimizer': 'claude-code', 'cli_present': True,\n"
+        "                  'returncode': 0, 'auth_present': [],\n"
+        "                  'stop': {'subtype': 'error_max_turns', 'num_turns': 240}}))\n",
+        encoding="utf-8")
+
+    out = _host("--run-dir", str(run_dir.root), "--project", str(project),
+                "--agent", "claude-code", "--run-optimizer", str(stub))
+
+    # Zero rounds were committed against a budget of 5 (see _run_dir).
+    assert out.get("incomplete"), (
+        f"an agent that booked 0 of its rounds is reported as if it finished: {out}")
+    assert "0" in str(out["incomplete"]) or "round" in str(out["incomplete"]).lower()
+    assert out["seal"] == "host", "the seal fallback should have been what produced a result"
+
+
 def test_unknown_host_agent_is_refused_before_any_spend(tmp_path):
     project = _project(tmp_path)
     run_dir = _run_dir(tmp_path)

--- a/core/tests/test_agent_optimize_host.py
+++ b/core/tests/test_agent_optimize_host.py
@@ -218,6 +218,89 @@ def test_the_briefing_does_not_invent_files_for_a_prompt_only_capability(tmp_pat
         "looking for code outside its capability to edit")
 
 
+def test_the_hosted_agent_gets_the_same_optimizer_context_as_every_other_algorithm(tmp_path):
+    """The structural reason a hosted run edited only prose — and the fix.
+
+    `harness.OptimizerContext` exists so "an algorithm cannot silently run on a thinner
+    prompt than its siblings": it stages the declared capability skills as `./guidance/<cap>/`
+    AND natively where the agent auto-discovers them, plus the diagnose method, the
+    capability_sources, and the agent's own features reference. Every deterministic algorithm
+    calls `inject()`.
+
+    The host did not, and `test_optimizer_context_parity.py` says so in its own docstring:
+    agent-optimize "declares none of the context flags and drives its own loop… an algorithm
+    absent from [ALGORITHMS] is NOT covered — it can still run blind while this file stays
+    green." It ran blind. Two consecutive CI runs edited only the prompt file across 4 of 4
+    candidates, having been handed no guidance whatsoever on how to edit tool code — naming
+    the files in prose did not change that, because the missing thing was never the file list.
+    """
+    project = _project(tmp_path)
+    (project / "capevolve.yaml").write_text(
+        "num_trials: 1\ngate_mode: paired\ngate_k_se: 1.0\n"
+        "capabilities: [system-prompt, tools]\ncapability_path: seed_capability\n"
+        'stop_condition: "at most 2 rounds; seal with measure.py"\n',
+        encoding="utf-8")
+    run_dir = _run_dir(tmp_path)
+
+    out = _host("--run-dir", str(run_dir.root), "--project", str(project), "--prompt-only")
+
+    workdir = Path(out["workdir"])
+    assert out["context"]["staged"] is True, (
+        f"the optimizer context was not staged for the hosted agent: {out['context']}")
+
+    # Both declared capabilities, as readable guidance AND natively discoverable.
+    for cap in ("system-prompt", "tools"):
+        assert (workdir / "guidance" / cap / "SKILL.md").is_file(), (
+            f"no ./guidance/{cap}/ — the agent has no guidance on editing this surface")
+        assert (workdir / ".claude" / "skills" / cap / "SKILL.md").is_file(), (
+            f"{cap} not placed where claude-code natively discovers skills")
+
+    # The failure-clustering method the loop's step 1 depends on.
+    assert (workdir / "guidance" / "diagnose" / "SKILL.md").is_file(), (
+        "no ./guidance/diagnose/ — the agent is told to read clusters with no method for it")
+
+    # And the briefing must point at what was staged, or it goes unread.
+    body = Path(out["prompt_path"]).read_text(encoding="utf-8")
+    assert "guidance/" in body, "the briefing never points at the staged guidance"
+
+    # Staging writes an always-on CLAUDE.md whose first instruction is "read
+    # ./INSTRUCTIONS.md FIRST" — written for the deterministic optimizer, which has one.
+    # Agent mode passes its briefing as the prompt, so without this the agent's always-on
+    # context opens by pointing at a file that does not exist.
+    instructions = workdir / "INSTRUCTIONS.md"
+    assert instructions.is_file(), (
+        "the staged CLAUDE.md points at ./INSTRUCTIONS.md and nothing wrote one")
+    assert instructions.read_text(encoding="utf-8") == body, (
+        "INSTRUCTIONS.md and the run-dir briefing differ — two versions of the brief means "
+        "no way to tell which one the agent followed")
+
+    # That same pointer names deterministic-loop artifacts this loop never builds.
+    assert "LEDGER.md" in body and "will not exist here" in body, (
+        "the briefing does not tell the agent that LEDGER.md/RUNMAP.md belong to the other "
+        "loop, so it will hunt for files that are legitimately absent")
+
+
+def test_a_context_staging_failure_is_loud_not_silently_off(tmp_path):
+    """Silent-off is the failure mode this repo warns about everywhere.
+
+    A run whose guidance never got staged looks exactly like one where it did — the agent
+    just quietly optimizes less surface, which is the defect that produced this fix. So a
+    staging failure must be reported in the host's own output rather than swallowed.
+    """
+    project = _project(tmp_path)
+    run_dir = _run_dir(tmp_path)
+    # Break adapter import: inject() needs the adapter for the trajectories copy.
+    (project / "adapters" / "adapter.py").write_text("raise RuntimeError('boom')\n",
+                                                     encoding="utf-8")
+
+    out = _host("--run-dir", str(run_dir.root), "--project", str(project), "--prompt-only")
+
+    assert out["context"]["staged"] is False
+    assert out["context"].get("error"), (
+        f"a staging failure must say why, not just that it happened: {out['context']}")
+    assert "boom" in json.dumps(out["context"]) or "RuntimeError" in json.dumps(out["context"])
+
+
 def test_unknown_host_agent_is_refused_before_any_spend(tmp_path):
     project = _project(tmp_path)
     run_dir = _run_dir(tmp_path)

--- a/core/tests/test_agent_optimize_host.py
+++ b/core/tests/test_agent_optimize_host.py
@@ -843,7 +843,7 @@ def test_a_round_that_was_gated_but_never_booked_is_reported(tmp_path):
     (work / "round2.log").write_text(json.dumps({
         "parent": {"tag": "r1_ops_bag", "reward": 0.58},
         "candidates": [{"tag": "r2_comm_search", "reward": 0.44,
-                        "delta_vs_parent": -0.14, "verdict": "reject", "eval_rc": 0}],
+                        "delta_vs_gate_ref": -0.14, "verdict": "reject", "eval_rc": 0}],
         "control": {"tag": "ctl_null_i1", "reward": 0.5, "verdict": "reject"},
     }), encoding="utf-8")
 

--- a/core/tests/test_agent_optimize_host.py
+++ b/core/tests/test_agent_optimize_host.py
@@ -301,6 +301,151 @@ def test_a_context_staging_failure_is_loud_not_silently_off(tmp_path):
     assert "boom" in json.dumps(out["context"]) or "RuntimeError" in json.dumps(out["context"])
 
 
+def test_benchmark_specific_optimizer_instructions_reach_the_agent(tmp_path):
+    """`optimizer_instructions_file` must not be silently dropped in agent mode.
+
+    cli.py applies that key only for `algorithm_name in OPTIMIZER_CONTEXT_ALGORITHMS`
+    (hill-climb / gepa / skillopt) — agent-optimize is not in that set, so a spec naming
+    arm-specific instructions had them ignored entirely.
+
+    That is not cosmetic for every benchmark. The spreadsheetbench arm writes instructions
+    whose appended note states that the `{placeholders}` in its second editable file are
+    LOAD-BEARING and that breaking one makes EVERY task score 0 — the agent is never told
+    where to write its answer. Dropping that text in agent mode means the agent can destroy
+    the run's entire signal with an edit it had no way to know was fatal.
+    """
+    project = _project(tmp_path)
+    (project / "capevolve.yaml").write_text(
+        "num_trials: 1\ngate_mode: paired\ngate_k_se: 1.0\n"
+        "capabilities: [system-prompt]\ncapability_path: seed_capability\n"
+        'optimizer_instructions_file: "optimizer/INSTRUCTIONS.md"\n'
+        'stop_condition: "at most 2 rounds; seal with measure.py"\n',
+        encoding="utf-8")
+    (project / "optimizer").mkdir(exist_ok=True)
+    (project / "optimizer" / "INSTRUCTIONS.md").write_text(
+        "# Arm-specific rules\n\nKeep every {placeholder} in task_template.md — break one "
+        "and EVERY task scores 0.\n", encoding="utf-8")
+    run_dir = _run_dir(tmp_path)
+
+    out = _host("--run-dir", str(run_dir.root), "--project", str(project), "--prompt-only")
+    body = Path(out["prompt_path"]).read_text(encoding="utf-8")
+
+    assert "{placeholder}" in body and "EVERY task scores 0" in body, (
+        "the arm's own optimizer instructions never reached the briefing")
+    assert out["instructions_file"], "the host did not report which instructions it used"
+
+
+def test_arm_instructions_are_scoped_and_their_template_slots_stripped(tmp_path):
+    """Pasting the arm's file verbatim injects a CONTRADICTING contract, and raw templating.
+
+    That file is written for the deterministic per-iteration optimizer: it says to stop after
+    editing and not to evaluate, because there the harness re-scores the candidate. In agent
+    mode the agent owns the evaluation and the gate — an agent that obeyed that line would
+    never gate anything. And it is a template, whose `{{SLOT}}` markers the deterministic path
+    renders from per-iteration state the host does not have.
+
+    So: slots stripped, and the precedence between the two contracts stated rather than left
+    for the agent to guess.
+    """
+    project = _project(tmp_path)
+    (project / "capevolve.yaml").write_text(
+        "num_trials: 1\ncapabilities: [system-prompt]\ncapability_path: seed_capability\n"
+        'optimizer_instructions_file: "optimizer/INSTRUCTIONS.md"\n'
+        'stop_condition: "at most 2 rounds"\n', encoding="utf-8")
+    (project / "optimizer").mkdir(exist_ok=True)
+    (project / "optimizer" / "INSTRUCTIONS.md").write_text(
+        "# Fix the prompt\n\n{{TARGET_READER}}\n\n{{FOCUS_SUMMARY}}\n\n"
+        "Then STOP — the harness re-scores you, don't run evaluation yourself.\n"
+        "Keep every {placeholder}: breaking one zeroes every task.\n", encoding="utf-8")
+    run_dir = _run_dir(tmp_path)
+
+    out = _host("--run-dir", str(run_dir.root), "--project", str(project), "--prompt-only")
+    body = Path(out["prompt_path"]).read_text(encoding="utf-8")
+
+    assert "{{" not in body, (
+        f"unrendered template slot reached the agent: "
+        f"{[l for l in body.splitlines() if '{{' in l]}")
+    # The benchmark fact survives.
+    assert "zeroes every task" in body
+    # And the conflicting process half is explicitly scoped out.
+    assert "does NOT apply" in body, (
+        "the briefing includes instructions telling the agent not to evaluate, without saying "
+        "they do not apply here — the agent would never gate a candidate")
+
+
+def test_a_named_instructions_file_that_is_missing_is_reported_not_ignored(tmp_path):
+    """Issue #252's failure mode: a bad path silently yields the generic guidance."""
+    project = _project(tmp_path)
+    (project / "capevolve.yaml").write_text(
+        "num_trials: 1\ncapabilities: [system-prompt]\ncapability_path: seed_capability\n"
+        'optimizer_instructions_file: "optimizer/NOPE.md"\n'
+        'stop_condition: "at most 2 rounds"\n', encoding="utf-8")
+    run_dir = _run_dir(tmp_path)
+
+    out = _host("--run-dir", str(run_dir.root), "--project", str(project), "--prompt-only")
+    assert out["instructions_warning"], (
+        f"a named-but-missing instructions file must be reported: {out}")
+    assert "NOPE.md" in out["instructions_warning"]
+
+
+def test_code_vs_prose_advice_only_appears_when_the_surface_HAS_code(tmp_path):
+    """A two-prose-file capability must not be told to write a code guard.
+
+    spreadsheetbench's capability is `prompt.md` + `task_template.md` — both prose, no tool
+    code. Advice to "prefer an in-code guard" there sends the agent looking for code it does
+    not own, which is how a prompt-only run once went and edited `adapter.py`.
+    """
+    project = _project(tmp_path)
+    run_dir = _run_dir(tmp_path)
+    seed = run_dir.root / "candidates" / "seed"
+    for f in list(seed.rglob("*")):
+        if f.is_file():
+            f.unlink()
+    (seed / "prompt.md").write_text("You are an expert.\n", encoding="utf-8")
+    (seed / "task_template.md").write_text("Do {instruction}.\n", encoding="utf-8")
+
+    out = _host("--run-dir", str(run_dir.root), "--project", str(project), "--prompt-only")
+    body = Path(out["prompt_path"]).read_text(encoding="utf-8")
+
+    assert "task_template.md" in body, "the second prose file must still be named"
+    assert "in code as a guard" not in body and "code-level" not in body, (
+        f"code advice offered to a capability with no code: {body}")
+
+
+def test_a_large_capability_is_summarised_without_pretending_to_be_complete(tmp_path):
+    """A skill-package capability can be dozens of files; a full list would swamp the brief.
+
+    Bounding it is fine. Bounding it silently is not — this repo's own rule is that a
+    coverage cap must say what it dropped, or the reader takes the list as exhaustive.
+    """
+    project = _project(tmp_path)
+    run_dir = _run_dir(tmp_path)
+    seed = run_dir.root / "candidates" / "seed"
+    for pack in ("docx", "pptx", "xlsx"):
+        d = seed / pack
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "SKILL.md").write_text("# skill\n", encoding="utf-8")
+        for i in range(12):
+            (d / f"ref_{i}.md").write_text("x\n", encoding="utf-8")
+
+    out = _host("--run-dir", str(run_dir.root), "--project", str(project), "--prompt-only")
+    body = Path(out["prompt_path"]).read_text(encoding="utf-8")
+
+    total = sum(1 for p in seed.rglob("*") if p.is_file())
+    surface = body[body.index("editable surface"):body.index("## How to edit each surface")]
+
+    assert str(total) in surface, (
+        f"the briefing does not state the real file count ({total}): {surface}")
+    bullets = [ln for ln in surface.splitlines() if ln.startswith("- ")]
+    assert len(bullets) < total, (
+        f"{total} files were listed one per line; the briefing should summarise instead")
+    assert "not listed" in surface or "more" in surface, (
+        "a truncated listing must say files were left out, or it reads as the whole set")
+    # The top-level groups must survive truncation — that is what makes it navigable.
+    for pack in ("docx", "pptx", "xlsx"):
+        assert pack in surface, f"group {pack} vanished from the summarised listing"
+
+
 def test_unknown_host_agent_is_refused_before_any_spend(tmp_path):
     project = _project(tmp_path)
     run_dir = _run_dir(tmp_path)

--- a/core/tests/test_agent_optimize_host.py
+++ b/core/tests/test_agent_optimize_host.py
@@ -988,3 +988,75 @@ def test_the_briefing_states_the_measurement_concurrency_the_gate_can_resolve(tm
     assert "concurrency" in body.lower(), (
         "the briefing hands over trials and k_se but not the measurement concurrency, the one "
         "knob whose misuse silently widens the noise floor past the gate")
+
+
+def test_an_agent_that_SEALED_the_run_itself_is_not_accused_of_abandoning_work(tmp_path):
+    """My own end_turn diagnosis fired falsely on run 32871360361.
+
+    That agent booked 4 of 10 rounds, then investigated a round-5 lever, judged the residual
+    failure unfixable by the surfaces it owned, sealed test itself, wrote its report and stopped
+    at 121 of 1650 turns. The host told the operator it had "stopped of its own accord with
+    rounds still to spend, which is what a turn ending on outstanding work looks like … a
+    backgrounded job … cannot resume a non-interactive run" — accusing it of the exact defect
+    4016ed0a was written for, when the run was complete and honest.
+
+    Two facts already in the payload disprove it: `seal == "agent"` (it finalized itself; an
+    agent that died mid-turn leaves the host to seal, which is what run 32814848187 did) and
+    `unbooked_rounds == []` (the backstop found no gated-but-unbooked candidate). Unspent budget
+    is worth reporting, but as under-use — not as a lost loop.
+    """
+    project = _project(tmp_path)
+    run_dir = _run_dir(tmp_path)
+    # Seal it first, so the host sees an already-sealed run: seal == "agent".
+    _host("--run-dir", str(run_dir.root), "--project", str(project), "--seal-only")
+
+    stub = tmp_path / "fake_run_optimizer.py"
+    stub.write_text(
+        "import json\n"
+        "print(json.dumps({'optimizer': 'claude-code', 'cli_present': True,\n"
+        "                  'returncode': 0, 'auth_present': [],\n"
+        "                  'stop': {'subtype': 'success', 'num_turns': 121,\n"
+        "                           'stop_reason': 'end_turn'}}))\n",
+        encoding="utf-8")
+
+    out = _host("--run-dir", str(run_dir.root), "--project", str(project),
+                "--agent", "claude-code", "--run-optimizer", str(stub))
+
+    assert out["seal"] == "agent", f"fixture did not produce an agent-sealed run: {out}"
+    assert out["unbooked_rounds"] == [], out
+    msg = str(out.get("incomplete") or "")
+    assert msg, "unspent rounds should still be reported, as under-use"
+    assert "background" not in msg and "file watcher" not in msg, (
+        f"the foreground-defect diagnosis fired on a run the agent sealed itself: {msg}")
+    assert "may never have been committed" not in msg, (
+        "unbooked_rounds is empty and the agent sealed, so nothing was lost — saying otherwise "
+        f"sends the operator hunting for a candidate that does not exist: {msg}")
+    assert "budget" in msg.lower() or "unspent" in msg.lower() or "under-use" in msg.lower(), (
+        f"the real finding — rounds left unspent — is not stated: {msg}")
+
+
+def test_an_agent_that_died_without_sealing_still_gets_the_foreground_diagnosis(tmp_path):
+    """The discriminator must not disarm the diagnosis it was built for.
+
+    Run 32814848187 ended its turn with round 2's gate still running and left the host to seal
+    (`seal: "host"`). That case must keep the foreground explanation.
+    """
+    project = _project(tmp_path)
+    run_dir = _run_dir(tmp_path)
+
+    stub = tmp_path / "fake_run_optimizer.py"
+    stub.write_text(
+        "import json\n"
+        "print(json.dumps({'optimizer': 'claude-code', 'cli_present': True,\n"
+        "                  'returncode': 0, 'auth_present': [],\n"
+        "                  'stop': {'subtype': 'success', 'num_turns': 78,\n"
+        "                           'stop_reason': 'end_turn'}}))\n",
+        encoding="utf-8")
+
+    out = _host("--run-dir", str(run_dir.root), "--project", str(project),
+                "--agent", "claude-code", "--run-optimizer", str(stub))
+
+    assert out["seal"] == "host", f"fixture should leave the seal to the host: {out}"
+    msg = str(out.get("incomplete") or "")
+    assert "foreground" in msg or "background" in msg, (
+        f"the foreground diagnosis was lost for the case it exists for: {msg}")

--- a/core/tests/test_agent_optimize_host.py
+++ b/core/tests/test_agent_optimize_host.py
@@ -933,3 +933,58 @@ def test_seal_only_also_reports_an_abandoned_round(tmp_path):
 
     assert "r2_comm_search" in json.dumps(out.get("unbooked_rounds")), (
         f"--seal-only sealed the run and said nothing about the abandoned round: {out}")
+
+
+# --- run 32861747778: round 1 died on the interpreter, then on concurrency ----
+
+
+def test_the_agent_inherits_the_interpreter_that_can_actually_import_the_adapter(tmp_path):
+    """Round 1's every eval died `ModuleNotFoundError: No module named 'tau2'`.
+
+    The benchmark's deps live in ONE interpreter: ci_setup.sh does
+    `uv pip install -p "$CAPEVOLVE_PY" -e tau2-bench`, and run_suite.sh runs `cap-evolve run`
+    with it — which is why the baseline scored 0.44 while every candidate eval crashed. But
+    ci_setup exports `PATH="$HOME/.local/bin:$PATH"` and never puts that venv's bin on PATH,
+    while SKILL.md tells the agent to run `python "$A/round.py"`. Bare `python` therefore CANNOT
+    resolve to the interpreter that works, and the run before this one only survived by luck —
+    with no transcript kept, not even the luck is inspectable.
+
+    Prose is the wrong fix here (SKILL.md's commands would all have to change and be obeyed).
+    The interpreter that launched the host is by construction the right one, so put its bin dir
+    first on the agent's PATH and every existing `python ...` command becomes correct.
+    """
+    project = _project(tmp_path)
+    run_dir = _run_dir(tmp_path)
+
+    out = _host("--run-dir", str(run_dir.root), "--project", str(project), "--prompt-only")
+
+    path = out["agent_env"].get("PATH", "")
+    assert path, f"the agent is handed no PATH at all, so it inherits whatever CI had: {out['agent_env']}"
+    want = str(Path(sys.executable).parent)
+    assert path.split(os.pathsep)[0] == want, (
+        f"the host's own interpreter dir is not FIRST on the agent's PATH, so bare `python` "
+        f"still resolves elsewhere: want {want}, got {path.split(os.pathsep)[:3]}")
+
+    # And named explicitly in the handoff, so the agent can be unambiguous when it wants to be.
+    body = Path(out["prompt_path"]).read_text(encoding="utf-8")
+    assert sys.executable in body, (
+        "the briefing never names the interpreter, so an agent that shells a different one has "
+        "no way to know which is right")
+
+
+def test_the_briefing_states_the_measurement_concurrency_the_gate_can_resolve(tmp_path):
+    """The agent gated at --concurrency 100, which round.py itself calls unresolvable.
+
+    SKILL.md already says "do not raise it to buy wall clock" and the agent raised it to 100
+    anyway — the run's own table then carried "a verdict from this round can therefore not
+    resolve an effect smaller than roughly 0.08". A number the briefing never states is a
+    number the agent picks, so state it.
+    """
+    project = _project(tmp_path)
+    run_dir = _run_dir(tmp_path)
+    out = _host("--run-dir", str(run_dir.root), "--project", str(project), "--prompt-only")
+    body = Path(out["prompt_path"]).read_text(encoding="utf-8")
+
+    assert "concurrency" in body.lower(), (
+        "the briefing hands over trials and k_se but not the measurement concurrency, the one "
+        "knob whose misuse silently widens the noise floor past the gate")

--- a/core/tests/test_agent_optimize_host.py
+++ b/core/tests/test_agent_optimize_host.py
@@ -313,6 +313,47 @@ def test_the_hosted_agent_gets_the_same_optimizer_context_as_every_other_algorit
         "loop, so it will hunt for files that are legitimately absent")
 
 
+def test_the_briefing_carries_the_same_measured_blocks_the_deterministic_prompt_does(tmp_path):
+    """Prompt-content parity, from the shared seam rather than re-authored here.
+
+    The host used to hand-roll thinner equivalents of two blocks the deterministic path has
+    always had, and the measured consequence was an optimizer that only ever edited prose:
+
+      * `harness._CAP_EDIT_SPACE["tools"]` — "HIGHEST-LEVERAGE EDIT: WRITE A NEW CODE-BEARING
+        TOOL … a deterministic tool can't be 'forgotten' the way a prompt rule can".
+      * the target-reader block — "when the reader is weaker than you, prefer explicit rules,
+        worked examples, and code enforcement over terse prose".
+
+    Both now come from `OptimizerContext`, so the two paths cannot drift. Asserted against
+    harness's own strings, not against a copy pasted into this test.
+    """
+    from cap_evolve import harness
+
+    project = _project(tmp_path)
+    (project / "capevolve.yaml").write_text(
+        "num_trials: 1\ngate_mode: paired\ngate_k_se: 1.0\n"
+        "capabilities: [system-prompt, tools]\ncapability_path: seed_capability\n"
+        "target_model: aws/gpt-oss-120b\n"
+        'stop_condition: "at most 2 rounds; seal with measure.py"\n', encoding="utf-8")
+    run_dir = _run_dir(tmp_path)
+
+    out = _host("--run-dir", str(run_dir.root), "--project", str(project), "--prompt-only")
+    body = Path(out["prompt_path"]).read_text(encoding="utf-8")
+
+    # The capability brief, verbatim from the shared source.
+    expected = harness.OptimizerContext(capabilities=("system-prompt", "tools")).capability_brief()
+    assert expected.strip() and expected.strip() in body, (
+        "the briefing does not carry harness's capability brief — the block that names tool "
+        "code as the highest-leverage surface")
+    assert "CODE-BEARING TOOL" in body, (
+        "the measured 'write a code-bearing tool' guidance did not reach the agent")
+
+    # The reader block, for a weak target model.
+    assert "THE READER" in body and "aws/gpt-oss-120b" in body, (
+        "the briefing never tells the agent who consumes the capability at runtime, so it "
+        "cannot know the reader is weaker than itself")
+
+
 def test_a_context_staging_failure_is_loud_not_silently_off(tmp_path):
     """Silent-off is the failure mode this repo warns about everywhere.
 
@@ -465,7 +506,10 @@ def test_a_large_capability_is_summarised_without_pretending_to_be_complete(tmp_
     body = Path(out["prompt_path"]).read_text(encoding="utf-8")
 
     total = sum(1 for p in seed.rglob("*") if p.is_file())
-    surface = body[body.index("editable surface"):body.index("## How to edit each surface")]
+    # Just the editable-surface section: from its heading to whatever heading follows it.
+    start = body.index("## Your editable surface")
+    nxt = body.find("\n## ", start + 1)
+    surface = body[start:nxt if nxt != -1 else len(body)]
 
     assert str(total) in surface, (
         f"the briefing does not state the real file count ({total}): {surface}")

--- a/core/tests/test_benchmarks_agent_optimize.py
+++ b/core/tests/test_benchmarks_agent_optimize.py
@@ -105,6 +105,33 @@ def test_agent_optimize_stop_condition_is_derived_from_the_dispatch_inputs():
         f"the stop_condition must require a seal — no finalize, no result: {stop}")
 
 
+def test_rejections_are_not_a_stopping_condition():
+    """The clause that ended a run exactly where the algorithm prescribes escalation.
+
+    The derived stop_condition used to say "stop when two consecutive rounds are rejected".
+    SKILL.md says the opposite: "after two rejected rounds, read the candidate's TRACE before
+    writing a third" — a reject usually means the edit FORM was wrong, not that the search is
+    done. On smoke run 32701056043 the agent rejected two prose candidates and stopped, never
+    reaching the round where it would have tried a code-level guard, which its own reject note
+    ("require calculate tool for all money") had already identified as the right form.
+
+    Rounds and spend bound a run. Rejections bound nothing.
+    """
+    got = _select(ALGORITHM="agent-optimize", ITERATIONS="5")
+    stop = got["stop"].lower()
+
+    assert "two consecutive" not in stop, (
+        f"rejections are still a stopping condition: {got['stop']}")
+    assert "do not stop early merely because rounds were rejected" in stop, (
+        f"the stop_condition does not say that a rejection is not a reason to stop: "
+        f"{got['stop']}")
+    assert "change the edit form" in stop or "change the edit" in stop, (
+        f"the stop_condition does not point at escalation as the response to a reject: "
+        f"{got['stop']}")
+    # The real ceilings must survive.
+    assert "5" in stop and "spend.py" in stop
+
+
 def test_unlimited_optimizer_budget_yields_no_dollar_ceiling():
     """0 means unlimited everywhere else in this workflow; keep that meaning."""
     got = _select(ALGORITHM="agent-optimize", ITERATIONS="10", OPTIMIZER_USD_PER_ITER="0")

--- a/core/tests/test_benchmarks_agent_optimize.py
+++ b/core/tests/test_benchmarks_agent_optimize.py
@@ -132,6 +132,71 @@ def test_rejections_are_not_a_stopping_condition():
     assert "5" in stop and "spend.py" in stop
 
 
+MARK_HOST_START = "# ---- agent mode: drive the handed-off loop"
+MARK_HOST_END = "# ---- metrics + report"
+
+
+def _host_budget(**env: str) -> dict:
+    """Run the agent-mode host-invocation block and report the budget it computes."""
+    src = RUN_SUITE.read_text(encoding="utf-8")
+    block = src[src.index(MARK_HOST_START):src.index(MARK_HOST_END)]
+    # Stub the host call itself: this test is about the arithmetic, not the subprocess.
+    block = block.replace('"$PY" "$REPO/skills/algorithms/agent-optimize/scripts/host.py" \\',
+                          'echo HOSTCALL \\')
+    script = ('ORCH_MODE=agent\nITER="${ITERATIONS:-3}"\nPY=python3\nREPO=.\nBENCH=tau2\n'
+              'RUN_DIR=/tmp/x\nPROJ=/tmp/y\nOPTIMIZER_MODEL=m\n' + block +
+              '\nprintf "TURNS=%s\\nUSD=%s\\n" "$HOST_TURNS" "${HOST_USD_ARGS[*]-}"\n')
+    p = subprocess.run(["bash", "-c", script], capture_output=True, text=True,
+                       env={"PATH": "/usr/bin:/bin", **env})
+    assert p.returncode == 0, f"block failed: {p.stderr}"
+    out = {}
+    for ln in p.stdout.splitlines():
+        if "=" in ln and ln.split("=", 1)[0] in ("TURNS", "USD"):
+            k, v = ln.split("=", 1)
+            out[k] = v.strip()
+    return out
+
+
+def test_agent_mode_gets_its_own_turn_allowance_not_the_per_iteration_one():
+    """80 turns/iteration is a DETERMINISTIC-path unit and starves the agent loop.
+
+    There, one optimizer invocation means "propose one edit and stop" — the harness does the
+    diagnosis, evaluation and gating. In agent mode the same allowance must also cover Phase 0
+    reading, diagnose, null-control replicates, round.py orchestration, gate_check and
+    commit.py, per round.
+
+    Measured on run 32733635494: 240 turns (80 x 3) bought 1.9 rounds. The agent stopped on
+    error_max_turns having evaluated a candidate at val 0.530 — the best of the run — and never
+    reached the commit.py that would have booked it. So the run reported 1 of 3 rounds and
+    discarded its best result.
+    """
+    got = _host_budget(ITERATIONS="3", OPTIMIZER_MAX_TURNS="80")
+    turns = int(got["TURNS"])
+
+    assert turns > 240, (
+        f"agent mode still gets the per-iteration allowance ({turns}) — the budget that was "
+        "measured to buy 1.9 of 3 rounds")
+    # Per round it must clear the ~126 turns/round that run actually consumed, with the
+    # non-round work (Phase 0, the seal) paid for on top.
+    assert turns / 3 >= 150, (
+        f"{turns} turns over 3 rounds is {turns / 3:.0f}/round; the measured requirement is "
+        "~126/round before Phase 0 and finalize")
+
+
+def test_a_raised_optimizer_max_turns_is_still_honoured():
+    """The dispatch input must remain the operator's lever, not be clamped by the floor."""
+    low = int(_host_budget(ITERATIONS="3", OPTIMIZER_MAX_TURNS="80")["TURNS"])
+    high = int(_host_budget(ITERATIONS="3", OPTIMIZER_MAX_TURNS="400")["TURNS"])
+    assert high > low, (
+        f"raising optimizer_max_turns 80 -> 400 did not raise the host budget ({low} -> {high})")
+
+
+def test_more_rounds_buy_more_turns():
+    three = int(_host_budget(ITERATIONS="3", OPTIMIZER_MAX_TURNS="80")["TURNS"])
+    ten = int(_host_budget(ITERATIONS="10", OPTIMIZER_MAX_TURNS="80")["TURNS"])
+    assert ten > three, f"the turn budget does not scale with the round count ({three}, {ten})"
+
+
 def test_unlimited_optimizer_budget_yields_no_dollar_ceiling():
     """0 means unlimited everywhere else in this workflow; keep that meaning."""
     got = _select(ALGORITHM="agent-optimize", ITERATIONS="10", OPTIMIZER_USD_PER_ITER="0")

--- a/core/tests/test_benchmarks_agent_optimize.py
+++ b/core/tests/test_benchmarks_agent_optimize.py
@@ -363,3 +363,53 @@ def test_runmeta_records_which_algorithm_produced_the_number():
     assert '"algorithm"' in src, (
         "runmeta.json must record the algorithm — benchmark-history compares numbers "
         "across runs, and hill-climb vs agent-optimize is not a like-for-like comparison")
+
+
+# --- the iterations input was unreachable on smoke ---------------------------
+
+
+def _env_expr(key: str) -> str:
+    """The workflow's `env:` expression for one key, verbatim."""
+    src = WORKFLOW.read_text(encoding="utf-8")
+    for ln in src.splitlines():
+        if ln.strip().startswith(f"{key}:") and "${{" in ln:
+            return ln.split(":", 1)[1].strip()
+    raise AssertionError(f"no env expression for {key} in {WORKFLOW}")
+
+
+def test_an_explicit_iterations_dispatch_reaches_smoke():
+    """`matrix.tier == 'smoke' && '3'` came FIRST, so it short-circuited the input.
+
+    GitHub's `||` yields the first truthy operand, so with the tier pin leading, a dispatch of
+    `iterations: 10` on smoke silently produced 3 — discoverable only by reading ITERATIONS in
+    the job log, after the run had already spent its budget on the wrong round count. Smoke is
+    the tier the algorithm itself gets iterated on, so it is the worst one to make unreachable.
+
+    NUM_TRIALS already had this right, including the reason its input default is `""` (with a
+    non-empty default, "asked for 10" and "asked for nothing" are indistinguishable). The two
+    knobs must therefore have the SAME shape: input first, tier default second.
+    """
+    iters, trials = _env_expr("ITERATIONS"), _env_expr("NUM_TRIALS")
+
+    assert iters.index("inputs.iterations") < iters.index("matrix.tier"), (
+        "the tier pin still precedes the dispatch input, so an explicit `iterations` on smoke "
+        f"is short-circuited away: {iters}")
+    # Parity with the knob that already solved this, so the next edit to either notices.
+    shape = lambda e: (e.index("inputs.") < e.index("matrix.tier"),  # noqa: E731
+                       "'3'" in e, "'10'" in e)
+    assert shape(iters) == shape(trials), (
+        f"ITERATIONS and NUM_TRIALS disagree on precedence/defaults:\n  {iters}\n  {trials}")
+    # Smoke's default must survive a blank dispatch: 3, not 10.
+    assert "'3'" in iters and "smoke" in iters, (
+        f"smoke's 3-iteration default was dropped rather than made overridable: {iters}")
+
+
+def test_the_iterations_input_defaults_to_blank_so_the_tier_default_can_win():
+    """A non-empty input default re-breaks the fix, silently, for every tier."""
+    src = WORKFLOW.read_text(encoding="utf-8")
+    block = src[src.index("      iterations:"):src.index("      trials:")]
+    assert 'default: ""' in block, (
+        "the `iterations` input must default to blank so a tier default is distinguishable "
+        f"from a deliberate choice — otherwise smoke silently gets the input's number: {block}")
+    assert "BLANK" in block or "blank" in block, (
+        f"the input description must tell the operator blank means the tier default: {block}")

--- a/core/tests/test_optimizer_transcript.py
+++ b/core/tests/test_optimizer_transcript.py
@@ -168,3 +168,63 @@ def test_the_claude_code_row_declares_a_transcript_flag():
     assert "stream-json" in flag, f"claude-code cannot produce a real transcript: {row}"
     assert "--verbose" in flag, (
         f"headless stream-json requires --verbose or the CLI refuses the combination: {flag}")
+
+
+# --- the transcript has to survive INTO the artifact -------------------------
+
+RUN_SUITE = REPO / "ci" / "benchmarks" / "lib" / "run_suite.sh"
+
+
+def _host_publish_block() -> str:
+    """The host-record copy block, lifted verbatim out of run_suite.sh."""
+    src = RUN_SUITE.read_text(encoding="utf-8")
+    start = src.index("# The agent's own record, into the dir that actually gets uploaded")
+    return src[start:src.index('cat "$OUT/report.md"', start)]
+
+
+def test_the_transcript_reaches_the_uploaded_artifact_not_just_the_run_dir(tmp_path):
+    """Writing it to the run dir is not enough, and the gap is silent.
+
+    The artifact path is `$OUT/**`; the run dir lives under `suite_<tier>_<bench>_proj/`. Run-dir
+    files reach the artifact only through the UI export, which caps EVERY file at 256 KiB and
+    keeps `raw[:_MAX_FILE_BYTES]` — the FIRST chunk. Measured: one turn of stream-json with no
+    tool results is already 17 KB, so a multi-round transcript is megabytes and the cap would
+    keep only its opening — while the part that shows where a run stalled is the END. That is
+    the precise evidence the transcript was added to capture, so it must bypass the export.
+
+    Executed as real bash, like the algorithm-selection block: what breaks here is shell
+    behaviour, not text.
+    """
+    run_dir = tmp_path / "run"; (run_dir / "host").mkdir(parents=True)
+    out = tmp_path / "out"; out.mkdir()
+    # Bigger than the export's 256 KiB cap, so a truncating path is visibly wrong.
+    big = "\n".join(json.dumps({"type": "assistant", "i": i, "pad": "x" * 400})
+                    for i in range(2000))
+    (run_dir / "host" / "transcript.jsonl").write_text(big, encoding="utf-8")
+    (run_dir / "host" / "driver_prompt.md").write_text("# briefing", encoding="utf-8")
+
+    script = f'RUN_DIR={run_dir}\nOUT={out}\n' + _host_publish_block()
+    p = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+    assert p.returncode == 0, f"{p.stdout}\n{p.stderr}"
+
+    gz = out / "host" / "transcript.jsonl.gz"
+    assert gz.is_file(), f"the transcript never reached $OUT: {list((out).rglob('*'))}"
+    assert (out / "host" / "driver_prompt.md").is_file(), "the briefing stopped being published"
+
+    import gzip  # noqa: PLC0415
+    body = gzip.decompress(gz.read_bytes()).decode("utf-8")
+    assert body == big, "the published transcript is not byte-identical to the run's"
+    assert len(body) > 256 * 1024, "the fixture no longer exceeds the cap it exists to defeat"
+    # And the whole point of gzipping: full fidelity for a fraction of the artifact.
+    assert gz.stat().st_size < len(big) / 4, (
+        f"gzip bought nothing: {gz.stat().st_size} vs {len(big)} raw")
+
+
+def test_publishing_the_host_record_is_skipped_cleanly_when_there_is_none(tmp_path):
+    """Every deterministic-path run has no host/ dir; the block must not fail the suite."""
+    run_dir = tmp_path / "run"; run_dir.mkdir()
+    out = tmp_path / "out"; out.mkdir()
+    script = f'RUN_DIR={run_dir}\nOUT={out}\n' + _host_publish_block()
+    p = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+    assert p.returncode == 0, f"a run with no host/ dir broke the publish step: {p.stderr}"
+    assert not (out / "host").exists(), f"an empty host/ dir was published: {out}"

--- a/core/tests/test_optimizer_transcript.py
+++ b/core/tests/test_optimizer_transcript.py
@@ -1,0 +1,170 @@
+"""``run-optimizer --transcript`` — the run's own record of what the agent did.
+
+Run 32814848187 spent four hours doing nothing measurable (its 900 metric calls account for
+every evaluation in ``events.jsonl``, and none fall in the gap), and the only trace kept of
+the agent's own actions was an 800-char ``stdout_tail``. So "what was it blocked on" could be
+narrowed to "something that ran into the 4-hour Bash ceiling" and no further — the next
+identical stall would have been equally undiagnosable.
+
+``--output-format json`` cannot fix that: it returns ONE result object with the final text and
+the totals, never the turns. The registry therefore carries a separate ``transcript_flag``
+(``--output-format stream-json --verbose``, verified against Claude Code 2.1.241) used only
+when a transcript is asked for, whose last line is the same result object — so cost and stop
+parsing are unchanged and the deterministic per-iteration path is untouched.
+
+What is pinned here: the transcript lands, the streaming flag REPLACES ``json_flag`` rather
+than joining it (two ``--output-format`` flags is an error), cost/stop still parse out of a
+streamed run, and secret values never reach the file.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+RUN_OPT = REPO / "skills" / "optimizers" / "run-optimizer" / "scripts" / "run.py"
+
+
+def _fake_registry(tmp: Path, *, transcript_flag: str | None) -> Path:
+    """A registry whose one row is a python script we control, plus a fake CLI."""
+    cli = tmp / "fakecli.py"
+    cli.write_text(
+        "import json, sys\n"
+        "streaming = '--output-format' in sys.argv and 'stream-json' in sys.argv\n"
+        "assert sys.argv.count('--output-format') <= 1, f'duplicate flag: {sys.argv}'\n"
+        "if streaming:\n"
+        "    print(json.dumps({'type': 'system', 'subtype': 'init'}))\n"
+        "    print(json.dumps({'type': 'assistant', 'message': 'editing'}))\n"
+        "    print(json.dumps({'type': 'tool_use', 'name': 'Bash',\n"
+        "                      'input': {'command': 'echo $ANTHROPIC_AUTH_TOKEN'}}))\n"
+        "    print(json.dumps({'type': 'tool_result', 'content': 'sk-secret-value-1234567890'}))\n"
+        "print(json.dumps({'type': 'result', 'subtype': 'success', 'num_turns': 42,\n"
+        "                  'stop_reason': 'end_turn', 'terminal_reason': 'end_turn',\n"
+        "                  'is_error': False, 'total_cost_usd': 1.25,\n"
+        "                  'usage': {'input_tokens': 100, 'output_tokens': 20}}))\n",
+        encoding="utf-8")
+    row = [
+        "faker:",
+        f'  command_template: "{sys.executable} {cli} --prompt {{prompt}}"',
+        '  env_keys: "ANTHROPIC_AUTH_TOKEN"',
+        '  install_url: ""',
+        '  auth_notes: ""',
+        '  json_flag: "--output-format json"',
+        '  budget_flag: ""',
+        '  usd_budget_flag: ""',
+        '  offline: "false"',
+    ]
+    if transcript_flag:
+        row.append(f'  transcript_flag: "{transcript_flag}"')
+    reg = tmp / "registry.yaml"
+    reg.write_text("\n".join(row) + "\n", encoding="utf-8")
+    return reg
+
+
+def _run(tmp: Path, *, transcript: Path | None, transcript_flag="--output-format stream-json "
+                                                                "--verbose", secret="") -> dict:
+    reg = _fake_registry(tmp, transcript_flag=transcript_flag)
+    workdir = tmp / "wd"; workdir.mkdir(exist_ok=True)
+    prompt = tmp / "INSTRUCTIONS.md"; prompt.write_text("edit something", encoding="utf-8")
+    argv = [sys.executable, str(RUN_OPT), "--name", "faker", "--json",
+            "--workdir", str(workdir), "--prompt", str(prompt)]
+    if transcript:
+        argv += ["--transcript", str(transcript)]
+    env = dict(os.environ, CAPEVOLVE_OPTIMIZER_REGISTRY=str(reg),
+               CAPEVOLVE_CORE=str(REPO / "core"))
+    if secret:
+        env["ANTHROPIC_AUTH_TOKEN"] = secret
+    p = subprocess.run(argv, capture_output=True, text=True, env=env)
+    assert p.returncode == 0, f"rc={p.returncode}\n{p.stdout}\n{p.stderr}"
+    return json.loads(p.stdout)
+
+
+def test_the_full_transcript_is_persisted_not_just_an_800_char_tail(tmp_path):
+    dest = tmp_path / "host" / "transcript.jsonl"
+    out = _run(tmp_path, transcript=dest)
+
+    assert dest.is_file(), f"--transcript wrote nothing to {dest}: {out}"
+    assert out["transcript"]["path"] == str(dest), out
+    lines = [json.loads(x) for x in dest.read_text(encoding="utf-8").splitlines() if x.strip()]
+    kinds = [x.get("type") for x in lines]
+    assert "tool_use" in kinds, (
+        "the transcript holds no tool calls, so it still cannot show what a stalled agent was "
+        f"doing: {kinds}")
+    assert kinds[-1] == "result", f"the result object must remain the last line: {kinds}"
+    # Parent dirs are created: the host points this at $R/host/, which need not exist yet.
+    assert out["transcript"]["lines"] >= 5, out["transcript"]
+
+
+def test_the_streaming_flag_replaces_json_flag_rather_than_joining_it(tmp_path):
+    """Two --output-format flags is an error, so this must substitute, not append.
+
+    The fake CLI asserts on it, so an append would surface as a non-zero exit here.
+    """
+    out = _run(tmp_path, transcript=tmp_path / "t.jsonl")
+    assert out["returncode"] == 0, out
+    # And the streamed shape really was requested (the fake only emits turns when it is).
+    body = (tmp_path / "t.jsonl").read_text(encoding="utf-8")
+    assert '"type": "assistant"' in body, f"the CLI was not asked for the stream: {body[:300]}"
+
+
+def test_cost_and_stop_still_parse_from_a_STREAMED_run(tmp_path):
+    """The whole point of reusing the result object: nothing downstream changes.
+
+    host.py books spend from `cost.total_cost_usd` and diagnoses from `stop`; if either went
+    missing under streaming, the transcript would have been bought with the run's accounting.
+    """
+    out = _run(tmp_path, transcript=tmp_path / "t.jsonl")
+
+    assert out["cost"]["total_cost_usd"] == 1.25, out["cost"]
+    assert out["cost"]["tokens"] == 120, out["cost"]
+    stop = out["stop"]
+    assert stop["subtype"] == "success" and stop["num_turns"] == 42, stop
+    assert stop["stop_reason"] == "end_turn", stop
+    assert stop["terminal_reason"] == "end_turn", (
+        f"terminal_reason names the terminating condition outright and is dropped: {stop}")
+
+
+def test_a_row_with_no_transcript_flag_still_records_what_it_printed(tmp_path):
+    """Graceful for every other CLI: --transcript must not require a streaming mode."""
+    dest = tmp_path / "t.jsonl"
+    out = _run(tmp_path, transcript=dest, transcript_flag=None)
+
+    assert dest.is_file(), f"a row without transcript_flag lost its transcript: {out}"
+    body = dest.read_text(encoding="utf-8")
+    assert '"type": "result"' in body, body
+    assert '"type": "assistant"' not in body, (
+        "no transcript_flag means no stream was requested; inventing one would pass a flag "
+        f"the CLI may not support: {body[:200]}")
+
+
+def test_secret_values_never_reach_the_transcript(tmp_path):
+    """A transcript records tool results verbatim, and the run dir is a CI artifact.
+
+    One `env` the agent happened to run would otherwise publish the gateway token. The fake CLI
+    echoes a secret-shaped value in a tool result precisely to prove the scrub runs.
+    """
+    dest = tmp_path / "t.jsonl"
+    out = _run(tmp_path, transcript=dest, secret="sk-secret-value-1234567890")
+
+    body = dest.read_text(encoding="utf-8")
+    assert "sk-secret-value-1234567890" not in body, (
+        f"the auth token was written to the transcript verbatim: {body[:400]}")
+    assert "ANTHROPIC_AUTH_TOKEN" in body, (
+        f"the redaction should leave a marker so the reader knows what was removed: {body[:400]}")
+    assert out["transcript"].get("error") is None, out
+
+
+def test_the_claude_code_row_declares_a_transcript_flag():
+    """The row the host actually uses, and the streamed shape verified on CLI 2.1.241."""
+    sys.path.insert(0, str(RUN_OPT.parent))
+    import run as run_optimizer  # noqa: PLC0415
+
+    row = run_optimizer.load_registry()["claude-code"]
+    flag = str(row.get("transcript_flag", ""))
+    assert "stream-json" in flag, f"claude-code cannot produce a real transcript: {row}"
+    assert "--verbose" in flag, (
+        f"headless stream-json requires --verbose or the CLI refuses the combination: {flag}")

--- a/docs/AGENT_ORCHESTRATION.md
+++ b/docs/AGENT_ORCHESTRATION.md
@@ -125,7 +125,18 @@ substitution, budget-flag mapping, cost capture and CLI-present hard-fail are th
 deterministic path uses, not a second copy. `--agent` accepts any row in
 `skills/optimizers/registry.yaml`.
 
-Three things are the host's own:
+It also stages the **same optimizer read-context every deterministic algorithm receives**, via
+`harness.OptimizerContext.inject()`: each declared capability's skill as `./guidance/<cap>/` *and*
+placed where the agent natively discovers skills, plus the diagnose method, `capability_sources`,
+and the agent's own features reference. That class exists so "an algorithm cannot silently run on
+a thinner prompt than its siblings", and agent mode used to bypass it — which is not cosmetic. In
+two measured CI runs, 4 of 4 candidates edited only the prompt file of a `[system-prompt, tools]`
+capability, because the agent had guidance for prose and none at all for the tool code beside it.
+`capabilities` gates which capability `validate()` runs, never what may be written, so nothing was
+blocking those edits; the guidance for that surface simply was not there. The briefing also
+enumerates the capability's real files, since naming capabilities is not the same as naming files.
+
+Four things are the host's own:
 
 - **Whole-loop budgets.** Agent mode runs the entire search in ONE agent process, so `--budget`
   (turns) and `--usd-budget` bound the whole loop, not one round. CI derives them by multiplying
@@ -135,6 +146,11 @@ Three things are the host's own:
   `BASH_DEFAULT_TIMEOUT_MS` and `BASH_MAX_TIMEOUT_MS` — the effective ceiling is the larger of
   the two. Left at the default, every eval is killed mid-flight and a healthy run reads as a
   broken runner.
+- **A truthful `INSTRUCTIONS.md`.** The staged always-on `CLAUDE.md` opens with "read
+  `./INSTRUCTIONS.md` FIRST" — written for the deterministic optimizer, which has one. The host
+  writes the briefing there too (same bytes as the run-dir copy), so that pointer resolves, and
+  the briefing states that `LEDGER.md` / `RUNMAP.md` / `prior_iterations/` belong to the
+  deterministic loop and are legitimately absent here.
 - **A guaranteed seal.** An agent that exhausts its turns leaves no `final.json`, and there is
   then no honest number and no way to tell "stopped early" from "crashed". If the agent did not
   seal, the host does — through the same `measure.py` — and reports `seal: host` so it is never

--- a/skills/algorithms/agent-optimize/scripts/check.py
+++ b/skills/algorithms/agent-optimize/scripts/check.py
@@ -1035,10 +1035,25 @@ def _gate_concurrency(c: Checker, tmp: Path) -> None:
     """
     src = (HERE / "round.py").read_text(encoding="utf-8")
     m = re.search(r'"--concurrency",\s*type=int,\s*default=(\w+)', src)
-    c.check(bool(m) and m.group(1).isdigit() and int(m.group(1)) <= 12,
-            f"round.py --concurrency default is {m.group(1) if m else 'missing'}: a gate above "
+    # The default may be a literal or a named constant; resolve a name to its assignment so the
+    # check follows the value rather than the spelling (a name-only assertion would pass for
+    # DEFAULT_CONCURRENCY = 100).
+    got = m.group(1) if m else ""
+    if got and not got.isdigit():
+        nm = re.search(rf'^{re.escape(got)}\s*=\s*(\d+)', src, re.M)
+        got = nm.group(1) if nm else got
+    c.check(bool(m) and got.isdigit() and int(got) <= 12,
+            f"round.py --concurrency default is {got or 'missing'}: a gate above "
             "~12 cannot resolve an effect smaller than the 0.08 a null control moves there",
             note="the gate's measurement concurrency defaults to a LOW value")
+    # …and the refusal bound above it must exist and be a real bound, or the default is only a
+    # suggestion the driver can step over — which is what it did.
+    mb = re.search(r'^MAX_RESOLVING_CONCURRENCY\s*=\s*(\d+)', src, re.M)
+    c.check(bool(mb) and int(mb.group(1)) >= int(got or 0)
+            and "allow-high-concurrency" in src and "return 2" in src,
+            "round.py must REFUSE a concurrency too coarse to resolve its own verdict, with a "
+            "deliberate escape hatch — warning about it in the output was not enough",
+            note="a gate the driver set too hot is refused, not warned about")
     c.check("concurrency_warning" in src and "measurement_concurrency" in src,
             "round.py must report measurement_concurrency and a concurrency_warning, so a "
             "verdict that cannot resolve the effect is not read as a clean one",

--- a/skills/algorithms/agent-optimize/scripts/check.py
+++ b/skills/algorithms/agent-optimize/scripts/check.py
@@ -607,6 +607,17 @@ def _round_control(c: Checker, tmp: Path) -> None:
         c.check("commit" in (r.get("next") or ""),
                 "round.py must hand the accept/reject decision back to the driver",
                 note="round.py never commits: which part of a bundle to keep is a judgement")
+        # The table must survive on disk, not only on stdout. A driver that forgot to redirect
+        # left the round's gate verdict nowhere: on run 32814848187 the abandoned round was
+        # reconstructible only because the driver happened to have redirected it somewhere
+        # someone guessed. host.py's un-booked-round backstop reads these files.
+        table = r.get("table_path") or ""
+        c.check(bool(table) and Path(table).is_file()
+                and Path(table).parent == work
+                and json.loads(Path(table).read_text(encoding="utf-8")).get("candidates"),
+                f"round.py did not persist its gate table under $R/work/ (got {table!r})",
+                note="the round's verdict is the run's evidence; it must not depend on the "
+                     "driver remembering to redirect stdout")
 
     # A round whose --n-trials differs from the parent's must be able to pair against the
     # control instead, or every delta silently carries a precision mismatch.

--- a/skills/algorithms/agent-optimize/scripts/commit.py
+++ b/skills/algorithms/agent-optimize/scripts/commit.py
@@ -59,6 +59,34 @@ def _prior_decision(run_dir: RunDir, candidate_id: str) -> dict | None:
     return None
 
 
+def _gate_verdict(run_dir: RunDir, candidate_id: str) -> str | None:
+    """The verdict ``round.py`` recorded for this candidate, from its persisted table.
+
+    Readable only because ``round.py`` now writes its table to ``work/`` instead of leaving
+    stdout the sole copy — before that, ``commit.py`` had no way to know what the gate had said
+    and could not tell an agreeing reject from an override.
+
+    Newest table wins: a same-iteration re-gate is written alongside the first (``.r1.json``),
+    and the later measurement is the one being booked against.
+    """
+    work = run_dir.root / "work"
+    if not work.is_dir():
+        return None
+    for log in sorted(work.iterdir(), key=lambda p: p.stat().st_mtime, reverse=True):
+        if not log.is_file() or log.suffix != ".json":
+            continue
+        try:
+            payload = json.loads(log.read_text(encoding="utf-8"))
+        except Exception:  # noqa: BLE001 — not a round table
+            continue
+        if not isinstance(payload, dict):
+            continue
+        for row in payload.get("candidates") or []:
+            if isinstance(row, dict) and str(row.get("tag")) == str(candidate_id):
+                return row.get("verdict")
+    return None
+
+
 def main(argv=None) -> int:
     p = argparse.ArgumentParser(prog="commit")
     p.add_argument("--run-dir", required=True)
@@ -76,11 +104,14 @@ def main(argv=None) -> int:
     # with it, "promote" + basis=ceiling is one coherent story. `gate` is the only basis
     # that asserts a full-val paired gate actually ran.
     p.add_argument("--reject-basis", default=None,
-                   choices=["gate", "screen_kill", "ceiling", "budget", "infra"],
-                   help="what evidence the reject rests on: gate=full-val paired gate ran; "
-                        "screen_kill=screen proved harm; ceiling=arithmetic proof no accept "
-                        "was reachable, so full val was never paid; budget=screen evidence "
-                        "plus a budget call; infra=missing data, not a judgement")
+                   choices=["gate", "screen_kill", "ceiling", "budget", "infra",
+                            "driver_judgement"],
+                   help="what evidence the reject rests on: gate=full-val paired gate ran AND "
+                        "rejected; screen_kill=screen proved harm; ceiling=arithmetic proof no "
+                        "accept was reachable, so full val was never paid; budget=screen "
+                        "evidence plus a budget call; infra=missing data, not a judgement; "
+                        "driver_judgement=the gate ACCEPTED and you are overriding it (say why "
+                        "in --note)")
     p.add_argument("--optimizer-usd", type=float, default=0.0)
     p.add_argument("--optimizer-tokens", type=int, default=0)
     p.add_argument("--optimizer-seconds", type=float, default=0.0)
@@ -117,6 +148,24 @@ def main(argv=None) -> int:
         print(json.dumps({"error": "--reject-basis is meaningless on an accept",
                           "fix": "drop it, or pass --decision reject"}, indent=2))
         return 2
+    # `--reject-basis gate` asserts the gate rejected this candidate. On run 32871360361 it was
+    # booked for cand2, which round_i1.json recorded as `verdict: accept` at +0.19 against a
+    # concurrent control — so events.jsonl, the run's audit record, said the gate had rejected the
+    # best candidate of the run when in fact the driver had overridden it. Overriding is
+    # legitimate (round.py leaves the decision to the driver on purpose); misattributing it is
+    # not, and it is the one thing this log exists to get right.
+    gate_verdict = _gate_verdict(run_dir, args.candidate_id)
+    overrode_gate = bool(not accepted and gate_verdict == "accept")
+    if overrode_gate and args.reject_basis == "gate":
+        print(json.dumps({
+            "error": f"--reject-basis gate, but the gate ACCEPTED {args.candidate_id} "
+                     "(see its row in work/round_*.json)",
+            "fix": "pass --reject-basis driver_judgement and say in --note why you are "
+                   "overriding the gate — e.g. the verdict was unstable across control "
+                   "replicates, or a task you care about regressed",
+        }, indent=2))
+        return 2
+
     # The parent this candidate was gated against — ``gate_check --current`` defaults to
     # ``best_id``, so read it BEFORE ``set_best`` moves it.
     parent_id = run_dir.best_id or "seed"
@@ -129,6 +178,7 @@ def main(argv=None) -> int:
     # 100% of its optimizer spend as unattributed. opt_cost_usd/opt_tokens are the field
     # names the ledger already reads from headless optimizer backends.
     run_dir.log_event(args.decision, candidate=args.candidate_id, val=args.val,
+                      gate_verdict=gate_verdict, overrode_gate=overrode_gate,
                       note=args.note,
                       reject_basis=args.reject_basis,
                       opt_cost_usd=args.optimizer_usd or None,
@@ -151,6 +201,8 @@ def main(argv=None) -> int:
     stop, reason = run_dir.budget_exhausted()
     print(json.dumps({"decision": args.decision, "candidate": args.candidate_id,
                       "reject_basis": args.reject_basis,
+                      "gate_verdict": gate_verdict,
+                      "overrode_gate": overrode_gate,
                       "best_id": run_dir.best_id, "spent": spent.to_dict(),
                       "stop": stop, "stop_reason": reason}, indent=2))
     return 0

--- a/skills/algorithms/agent-optimize/scripts/host.py
+++ b/skills/algorithms/agent-optimize/scripts/host.py
@@ -169,7 +169,21 @@ def _surface_section(files: list[str]) -> str:
     if has_code:
         body += (" — a rule the agent already has and violates usually belongs in code as a "
                  "guard, while a missing decision criterion belongs in prose")
-    body += (". Say which file you chose, and why that one, when you commit the round.\n")
+    body += (". Name the file you chose in the `commit.py --note` for the round, so the run "
+             "records which surface each decision was made on.\n\n"
+             "### Precondition on round 3 and later\n\n"
+             "**If your last two rounds were both rejected, the next round may not reuse the "
+             "surface *and* form those two used.** Read the rejected candidate's trace first "
+             "and ask whether the agent ever exercised your rule at all: never exercised means "
+             "the FORM was wrong, so a third variation of the same wording will be rejected "
+             "too. Change the form, or change the surface")
+    if has_code:
+        body += (" — and where the failing behaviour is one the agent has a criterion for and "
+                 "violates anyway (it *should* call a tool and does not, it *should* validate "
+                 "and does not), the form that works is a guard in the code, not a third "
+                 "restatement in prose")
+    body += (".\n\nTwo rejections are not a reason to stop — they are the signal to escalate. "
+             "Spend every round the budget allows.\n")
     return head + body
 
 

--- a/skills/algorithms/agent-optimize/scripts/host.py
+++ b/skills/algorithms/agent-optimize/scripts/host.py
@@ -131,8 +131,27 @@ def _surface_section(files: list[str]) -> str:
         "one, when you commit the round.\n")
 
 
+def _guidance_section(workdir: Path, context: dict) -> str:
+    """Point at the staged capability guidance — unread guidance is not guidance."""
+    if not context.get("staged"):
+        return ("## Capability guidance\n\nNot available for this run (staging failed). Work "
+                "from the capability files themselves and be conservative.\n")
+    caps = context.get("capabilities") or []
+    lines = "\n".join(f"- `{workdir}/guidance/{c}/SKILL.md` — how to edit the **{c}** surface"
+                      for c in caps)
+    return (
+        "## How to edit each surface — READ THESE BEFORE YOUR FIRST EDIT\n\n"
+        f"{lines}\n"
+        f"- `{workdir}/guidance/diagnose/SKILL.md` — the failure-clustering method step 1 uses\n\n"
+        "One guidance doc per declared capability, and there is one for every surface you may "
+        "edit — not just the prose one. Each states what is safely editable there, the edit "
+        "forms that work, and the failure modes. **Read the guidance for the surface you are "
+        "about to change**: an edit made without it is a guess, and the surface you have no "
+        "guidance for is the one you will avoid by default.\n")
+
+
 def _briefing(*, run_dir: Path, project: Path, spec: dict, skills: Path,
-              rounds: int) -> str:
+              rounds: int, workdir: Path, context: dict) -> str:
     """The driver briefing: the handoff facts, then a pointer to the loop itself.
 
     Deliberately NOT a restatement of the algorithm. SKILL.md is the implementation and the
@@ -146,6 +165,7 @@ def _briefing(*, run_dir: Path, project: Path, spec: dict, skills: Path,
     caps = spec.get("capabilities") or []
     cap_path = spec.get("capability_path") or "seed_capability"
     surface = _surface_section(_editable_files(run_dir, project, spec))
+    guidance = _guidance_section(workdir, context)
     skill_md = SKILL_DIR / "SKILL.md"
     helpers = HERE
 
@@ -194,6 +214,7 @@ Pass these explicitly — `--n-trials {n_trials}` on every evaluate, `--k-se {k_
 gate — rather than relying on a default that may not match this spec.
 
 {surface}
+{guidance}
 
 ## The primitives every round must go through
 
@@ -217,6 +238,14 @@ accelerators; the four above are not.
 
 `spend.py` parses that text into checkable predicates; run it before each round and act on
 its single `recommendation` (`stop` | `narrow_scope` | `continue`), as SKILL.md describes.
+
+## Files in your working directory that belong to the OTHER loop
+
+Your always-on instructions mention `LEDGER.md`, `RUNMAP.md` and `prior_iterations/`. Those are
+built by the *deterministic* loop, which calls one optimizer per iteration; you are driving the
+whole search yourself, so they will not exist here and their absence is not a problem — do not
+go looking for them or try to recreate them. `JOURNAL.md` is different: `commit.py` reconciles
+it as you book rounds, so it accrues your own history and is worth reading from round 2 on.
 
 ## Unattended — this is the one real difference from an interactive run
 
@@ -263,6 +292,54 @@ def _seal(run_dir: Path, project: Path, spec: dict, *, timeout: float | None) ->
         return {"sealed": True, "seal": "host", "measure_rc": p.returncode}
     return {"sealed": False, "seal": "failed", "measure_rc": p.returncode,
             "measure_error": (p.stderr or p.stdout)[-1200:]}
+
+
+def _stage_context(*, run_dir: Path, project: Path, workdir: Path, spec: dict,
+                   agent: str) -> dict:
+    """Stage the SAME optimizer read-context every deterministic algorithm receives.
+
+    ``harness.OptimizerContext`` exists so "an algorithm cannot silently run on a thinner
+    prompt than its siblings": it places the declared capability skills as
+    ``./guidance/<cap>/`` *and* where the agent natively discovers skills, plus the diagnose
+    method, any ``capability_sources``, and the agent's own features reference.
+
+    Agent mode never called it. ``test_optimizer_context_parity.py`` names that gap in its own
+    docstring — this algorithm "declares none of the context flags and drives its own loop", so
+    it "can still run blind while this file stays green". It did: measured across two runs, 4
+    of 4 candidates edited only the prompt file, because the agent had guidance for prose and
+    none at all for the tool code sitting beside it. Naming the files in the briefing did not
+    move it, since the file list was never the missing piece.
+
+    Reported rather than swallowed: a run that silently skipped staging is indistinguishable
+    from one that staged fine, and simply optimizes less surface.
+    """
+    caps = tuple(c for c in (spec.get("capabilities") or []) if c)
+    try:
+        from cap_evolve import RunDir, harness
+        from cap_evolve.check import load_adapter
+
+        rd = RunDir.open(run_dir)
+        adapter = load_adapter(project)
+        ctx = harness.OptimizerContext(
+            capabilities=caps,
+            optimizer_name=agent,
+            capability_sources=tuple(spec.get("capability_sources") or []),
+            project_dir=project,
+        )
+        # split="val" + the current best's tag: the parent step the agent builds on, which is
+        # the same choice the deterministic loop makes.
+        ctx.inject(adapter, rd, workdir, split="val", tag=rd.best_id or "seed")
+        staged = {"staged": True, "capabilities": list(caps),
+                  "guidance": sorted(p.name for p in (workdir / "guidance").iterdir())
+                  if (workdir / "guidance").is_dir() else []}
+        try:
+            rd.log_event("host_context", capabilities=list(caps), agent=agent, staged=True)
+        except Exception:  # noqa: BLE001 — the event is a nicety, the staging is the point
+            pass
+        return staged
+    except Exception as exc:  # noqa: BLE001
+        return {"staged": False, "capabilities": list(caps),
+                "error": f"{type(exc).__name__}: {exc}"[:400]}
 
 
 def _child_env() -> dict:
@@ -339,12 +416,28 @@ def main(argv=None) -> int:
         }, indent=2))
         return 2
 
+    # The agent needs write access to BOTH the run dir and the project; their common parent
+    # is the natural workdir, and it is where the staged guidance + native skills land.
+    workdir = _common_parent(run_dir, project)
+    context = _stage_context(run_dir=run_dir, project=project, workdir=workdir,
+                             spec=spec, agent=args.agent)
+
     prompt_dir = run_dir / "host"
     prompt_dir.mkdir(parents=True, exist_ok=True)
     prompt_path = prompt_dir / "driver_prompt.md"
-    prompt_path.write_text(
-        _briefing(run_dir=run_dir, project=project, spec=spec, skills=SKILLS, rounds=rounds),
-        encoding="utf-8")
+    briefing = _briefing(run_dir=run_dir, project=project, spec=spec, skills=SKILLS,
+                         rounds=rounds, workdir=workdir, context=context)
+    prompt_path.write_text(briefing, encoding="utf-8")
+    # Also as <workdir>/INSTRUCTIONS.md. Staging writes an always-on CLAUDE.md pointer whose
+    # first instruction is "read ./INSTRUCTIONS.md FIRST" — written for the deterministic
+    # per-iteration optimizer, which has one. Agent mode passes its briefing as the prompt, so
+    # without this the agent's always-on context opens by pointing at a file that is not there.
+    # Same bytes, so the two can never disagree; the run-dir copy stays the audit record.
+    if context.get("staged"):
+        try:
+            (workdir / "INSTRUCTIONS.md").write_text(briefing, encoding="utf-8")
+        except OSError as exc:
+            context.setdefault("warnings", []).append(f"INSTRUCTIONS.md: {exc}")
 
     agent_env = _agent_env(args.model)
     if args.prompt_only:
@@ -352,16 +445,21 @@ def main(argv=None) -> int:
                           "model": args.model, "prompt_only": True,
                           "prompt_path": str(prompt_path), "returncode": None,
                           "agent_env": agent_env, "budget": args.budget,
-                          "usd_budget": args.usd_budget}, indent=2))
+                          "usd_budget": args.usd_budget,
+                          "workdir": str(workdir), "context": context}, indent=2))
         return 0
+    if not context["staged"]:
+        print(f"::warning::optimizer context not staged for the hosted agent "
+              f"({context.get('error')}) — it will optimize with no capability guidance",
+              file=sys.stderr)
 
     # Delegate the invocation. --json switches on run-optimizer's cost capture, which is how
     # the host's own spend reaches the run dir at all: the evaluate phase records the
     # runner's cost, and nothing records the proposer's.
     cmd = [sys.executable, str(RUN_OPTIMIZER), "--name", args.agent, "--json",
-           # The agent needs write access to BOTH the run dir and the project; their common
-           # parent is the natural workdir. Every path in the briefing is absolute anyway.
-           "--workdir", str(_common_parent(run_dir, project)),
+           # Same workdir the guidance was staged into, so the agent's cwd is where its
+           # native skills dir and ./guidance/ live.
+           "--workdir", str(workdir),
            "--prompt", str(prompt_path)]
     if args.model:
         cmd += ["--model", args.model]

--- a/skills/algorithms/agent-optimize/scripts/host.py
+++ b/skills/algorithms/agent-optimize/scripts/host.py
@@ -842,8 +842,23 @@ def main(argv=None) -> int:
         # Ran to a clean stop of its own accord, with rounds and turns still to spend.
         voluntary = not turn_limited and ("end_turn" in reasons or "success" in reasons)
 
+        # An agent that SEALED THE RUN ITSELF did not lose its loop — it finished it early. Both
+        # facts needed to tell the two apart are already here: `seal == "agent"` (run 32814848187,
+        # which really did end its turn on a running gate, left the host to seal) and an empty
+        # `unbooked_rounds`. Without this branch the diagnosis fired on run 32871360361 — 4 of 10
+        # rounds, test sealed, report written, 121 of 1650 turns — and told the operator it had
+        # abandoned a backgrounded job. Accusing a complete run of the defect this warning exists
+        # for is how a warning stops being read.
+        finished_itself = (seal.get("seal") == "agent" and not unbooked)
+
         if turn_limited:
             fix = ("raise the turn budget (optimizer_max_turns) or lower the round count")
+        elif finished_itself:
+            fix = ("it sealed the run itself and left nothing unbooked, so this is UNSPENT "
+                   "BUDGET, not a loop that died: it stopped when it ran out of edits it "
+                   "trusted, not when it ran out of rounds. Read its final message for the "
+                   "reason — if the honest answer is 'no further lever found', the lever is the "
+                   "stop condition or the briefing, not the host")
         elif voluntary:
             fix = ("it stopped of its own accord with rounds still to spend, which is what a "
                    "turn ending on outstanding work looks like from here: a backgrounded job, "
@@ -860,6 +875,11 @@ def main(argv=None) -> int:
             evidence = "; gated but never booked with commit.py: " + ", ".join(
                 f"{u['candidate']} (verdict {u['verdict']}, val {u['reward']}, in "
                 f"work/{u['log']})" for u in unbooked)
+        elif finished_itself:
+            # Both checks came back clean, so say so. Hedging here sent a reader hunting for a
+            # candidate that provably does not exist.
+            evidence = ("; every round it ran was booked and it sealed the run itself, so no "
+                        "measured candidate was lost")
         else:
             evidence = ("; a candidate it evaluated may never have been committed")
 

--- a/skills/algorithms/agent-optimize/scripts/host.py
+++ b/skills/algorithms/agent-optimize/scripts/host.py
@@ -143,8 +143,33 @@ def _editable_files(run_dir: Path, project: Path, spec: dict) -> list[str]:
 
 #: Suffixes that make a capability file CODE rather than prose. Drives whether the briefing
 #: offers code-vs-prose advice at all — see _surface_section.
-_CODE_SUFFIXES = {".py", ".js", ".mjs", ".ts", ".tsx", ".sh", ".bash", ".rb", ".go", ".rs",
-                  ".java", ".pl", ".lua", ".sql"}
+#:
+#: KNOWN-GOOD, NOT EXHAUSTIVE. A missing suffix means the code-guard advice silently does not
+#: fire, which is the same silent-miss this host was fixed for on ``.py``/``.js`` — just
+#: relocated to whichever language nobody listed. It started at 14 entries and therefore
+#: treated C, C++, C#, PHP, Swift, Kotlin and Objective-C surfaces as prose. So: ADD to this
+#: set freely when a workload brings a new language; absence here is a gap, never a decision
+#: that the language is prose.
+#:
+#: A suffix list is deliberately kept as the test rather than the capability's declared kind.
+#: Kind is only a proxy — a ``tools`` capability can be schema-only and a ``system-prompt`` one
+#: can ship a helper script — whereas the question the briefing actually asks is "does the
+#: surface I am handing you contain code you could put a guard in".
+_CODE_SUFFIXES = {
+    # scripting / dynamic
+    ".py", ".js", ".mjs", ".cjs", ".ts", ".tsx", ".jsx", ".rb", ".pl", ".lua", ".php",
+    ".r", ".jl", ".dart", ".groovy", ".tcl",
+    # shell
+    ".sh", ".bash", ".zsh", ".fish", ".ps1",
+    # compiled / systems
+    ".c", ".h", ".cc", ".cpp", ".cxx", ".hpp", ".hh", ".cs", ".go", ".rs", ".java", ".kt",
+    ".kts", ".swift", ".m", ".mm", ".scala", ".zig", ".nim", ".d", ".f90", ".vb",
+    # functional
+    ".ex", ".exs", ".erl", ".hs", ".ml", ".mli", ".clj", ".cljs", ".fs", ".fsx", ".rkt",
+    ".scm", ".lisp", ".el",
+    # query / template languages that carry real logic
+    ".sql", ".vim",
+}
 #: Above this, the listing is grouped instead of enumerated. A skill-package capability can
 #: be dozens of files, and a wall of paths crowds out the rest of the briefing.
 _MAX_LISTED = 20
@@ -574,9 +599,17 @@ def _stage_context(*, run_dir: Path, project: Path, workdir: Path, spec: dict,
         # split="val" + the current best's tag: the parent step the agent builds on, which is
         # the same choice the deterministic loop makes.
         ctx.inject(adapter, rd, workdir, split="val", tag=rd.best_id or "seed")
-        staged = {"staged": True, "capabilities": list(caps),
-                  "guidance": sorted(g.name for g in (workdir / "guidance").iterdir())
-                  if (workdir / "guidance").is_dir() else []}
+        guidance = (sorted(g.name for g in (workdir / "guidance").iterdir())
+                    if (workdir / "guidance").is_dir() else [])
+        # A DECLARED capability that got no guidance dir. `harness._stage_context` skips a
+        # capability with no matching skill package (`if not src.is_dir(): continue`) and still
+        # reports staged, so "some capabilities missing" was indistinguishable from "everything
+        # staged" — while the all-missing case has always been loud. Silently optimizing a
+        # surface with no guidance is the exact defect this host was fixed for; leaving half of
+        # it quiet just moves the blind spot. The staged list was already reported; what was
+        # missing is the comparison against what the spec asked for.
+        staged = {"staged": True, "capabilities": list(caps), "guidance": guidance,
+                  "guidance_missing": [c for c in caps if c not in guidance]}
         try:
             rd.log_event("host_context", capabilities=list(caps), agent=agent, staged=True)
         except Exception:  # noqa: BLE001 — the event is a nicety, the staging is the point
@@ -736,6 +769,15 @@ def main(argv=None) -> int:
     if not context["staged"]:
         print(f"::warning::optimizer context not staged for the hosted agent "
               f"({context.get('error')}) — it will optimize with no capability guidance",
+              file=sys.stderr)
+    elif context.get("guidance_missing"):
+        # Warned, not merely recorded: a field nobody greps is not a report, and this is the
+        # partial case of the failure the branch above already shouts about.
+        missing = ", ".join(context["guidance_missing"])
+        print(f"::warning::agent-optimize: no guidance staged for declared capability/ies "
+              f"[{missing}] — no skill package of that name exists under the capabilities "
+              f"root, so the agent will edit that surface with no allowed-edit-space brief. "
+              f"Check the spelling in capevolve.yaml `capabilities`, or add the skill.",
               file=sys.stderr)
 
     # Delegate the invocation. --json switches on run-optimizer's cost capture, which is how

--- a/skills/algorithms/agent-optimize/scripts/host.py
+++ b/skills/algorithms/agent-optimize/scripts/host.py
@@ -87,6 +87,9 @@ REGISTRY = SKILLS / "optimizers" / "registry.yaml"
 # (spreadsheetbench full: one Docker container per task x trials), while still bounding a
 # genuinely hung command instead of waiting forever.
 BASH_TIMEOUT_MS = 4 * 60 * 60 * 1000
+#: Measurement concurrency handed to the agent when the spec names none. Matches ``round.py``'s
+#: own default and its refusal bound; see the concurrency note in the briefing.
+GATE_CONCURRENCY = 8
 
 
 def _spec(project: Path, spec_path: Path | None) -> dict:
@@ -299,6 +302,9 @@ def _briefing(*, run_dir: Path, project: Path, spec: dict, skills: Path,
     # cannot promise a ceiling the env does not grant.
     hours = round(BASH_TIMEOUT_MS / 3_600_000, 1)
     hours = int(hours) if hours == int(hours) else hours
+    # The interpreter that launched us — see _agent_env for why this is the authority.
+    interpreter = sys.executable
+    gate_conc = int(spec.get("measure_concurrency") or GATE_CONCURRENCY)
 
     if not stop:
         stop = (f"Spend at most {rounds} rounds, gate every candidate on FULL val, and "
@@ -325,11 +331,18 @@ R="{run_dir}"      # the run dir: splits, baseline, candidates, rollouts, events
 P="{project}"      # the project: capevolve.yaml, adapters/, {cap_path}
 S="{skills}"       # the skills dir (CAPEVOLVE_SKILLS_DIR is already set to it)
 A="$S/algorithms/agent-optimize/scripts"
+PY="{interpreter}"      # the ONLY interpreter that can import this benchmark's adapter deps
 mkdir -p "$R/work"
 ```
 
 Paths are absolute; use them as given rather than relative paths, because your working
 directory is not necessarily either of theirs.
+
+`$PY` is already first on your `PATH`, so plain `python` resolves to it and SKILL.md's commands
+work as written. Use `"$PY"` explicitly anywhere you build a command yourself. Do **not**
+substitute another interpreter, `uv run`, or a fresh venv: the adapter's packages are
+installed into this one only, and an eval run under any other dies with `ModuleNotFoundError`
+on the adapter's imports — which scores the candidate `null`, not zero, and wastes the round.
 
 ## The spec values your gate needs
 
@@ -340,9 +353,16 @@ directory is not necessarily either of theirs.
 | `gate_mode` | {gate_mode} |
 | `capabilities` (which capability rules validate your edits) | {caps} |
 | `capability_path` | {cap_path} |
+| `--concurrency` for every gate | {gate_conc} |
 
 Pass these explicitly — `--n-trials {n_trials}` on every evaluate, `--k-se {k_se}` on every
 gate — rather than relying on a default that may not match this spec.
+
+**The concurrency is a measurement parameter, not a speed dial.** Measured on this benchmark,
+byte-identical code at identical seeds moves ~0.03 at concurrency 8 and ~0.08 above 25 — so a
+gate run hot cannot resolve the effect you are looking for, and `round.py` now refuses a value
+that coarse rather than warning about it. Buy wall clock with fewer candidates per round, never
+with concurrency.
 
 {surface}
 {guidance}
@@ -581,6 +601,19 @@ def _agent_env(model: str | None) -> dict:
         # the other as the real limit.
         "BASH_DEFAULT_TIMEOUT_MS": str(BASH_TIMEOUT_MS),
         "BASH_MAX_TIMEOUT_MS": str(BASH_TIMEOUT_MS),
+        # THE interpreter, first. An arm's adapter deps are installed into exactly one venv, and
+        # `cap-evolve run` uses it — which is why on run 32861747778 the baseline scored 0.44
+        # while every candidate eval died `ModuleNotFoundError` on the adapter's own imports:
+        # CI's PATH never contains that venv's bin, and SKILL.md tells the agent to run
+        # `python "$A/round.py"`. Bare `python` could therefore never resolve to the one that
+        # works, and the run before it had survived on luck.
+        #
+        # Fixed here rather than by rewriting SKILL.md's commands: the interpreter that launched
+        # this host IS the correct one (run_suite.sh invokes `"$PY" host.py`), so putting its bin
+        # dir first makes every existing `python ...` line correct by construction. Prose the
+        # agent must remember is the form that already failed.
+        "PATH": os.pathsep.join([str(Path(sys.executable).parent),
+                                 os.environ.get("PATH", "")]).rstrip(os.pathsep),
     }
     if model:
         env["CAPEVOLVE_OPTIMIZER_MODEL"] = model

--- a/skills/algorithms/agent-optimize/scripts/host.py
+++ b/skills/algorithms/agent-optimize/scripts/host.py
@@ -496,6 +496,9 @@ def main(argv=None) -> int:
                    help="render the briefing and exit without invoking the agent")
     p.add_argument("--seal-only", action="store_true",
                    help="skip the agent; only ensure the run has a sealed test number")
+    p.add_argument("--run-optimizer", default=None,
+                   help="path to the run-optimizer script (test seam; defaults to the "
+                        "sibling optimizers/run-optimizer)")
     args = p.parse_args(argv)
 
     run_dir = Path(args.run_dir).resolve()
@@ -589,7 +592,8 @@ def main(argv=None) -> int:
     # Delegate the invocation. --json switches on run-optimizer's cost capture, which is how
     # the host's own spend reaches the run dir at all: the evaluate phase records the
     # runner's cost, and nothing records the proposer's.
-    cmd = [sys.executable, str(RUN_OPTIMIZER), "--name", args.agent, "--json",
+    runner = Path(args.run_optimizer).resolve() if args.run_optimizer else RUN_OPTIMIZER
+    cmd = [sys.executable, str(runner), "--name", args.agent, "--json",
            # Same workdir the guidance was staged into, so the agent's cwd is where its
            # native skills dir and ./guidance/ live.
            "--workdir", str(workdir),
@@ -618,8 +622,21 @@ def main(argv=None) -> int:
         except Exception:  # noqa: BLE001 — a non-JSON tail is reported, not fatal
             payload = {"stdout_tail": (proc.stdout or "")[-1200:]}
 
-    usd = float(payload.get("cost_usd") or payload.get("usd") or 0.0)
-    tokens = int(payload.get("tokens") or 0)
+    # run-optimizer nests the figure under `cost.total_cost_usd` (see its `result["cost"]`).
+    # Reading a flat `cost_usd`/`usd` booked 0.0 for every run: on run 32733635494 the payload
+    # carried 8.370 USD / 68,432 tokens and the run recorded $0.00, which is indistinguishable
+    # from the genuinely-unmetered case the skill warns about — so the wrong conclusion was
+    # drawn twice. The flat keys stay as fallbacks for any optimizer row that reports that way.
+    cost = payload.get("cost") or {}
+    usd = float(cost.get("total_cost_usd") or payload.get("cost_usd")
+                or payload.get("usd") or 0.0)
+    tokens = int(cost.get("tokens") or payload.get("tokens") or 0)
+    # Why the agent stopped. Reconstructing this from a truncated stdout tail is what the
+    # previous version forced, and the answer (turns exhausted mid-round, with a better
+    # candidate evaluated but never committed) mattered more than anything else in the payload.
+    stop = payload.get("stop") or {}
+    stop_reason = str(stop.get("subtype") or "") or None
+    num_turns = stop.get("num_turns")
 
     # Book the host's own spend. The agent books per-round costs it knows about through
     # commit.py --optimizer-usd; it cannot know its own process cost, and the host can.
@@ -630,13 +647,30 @@ def main(argv=None) -> int:
         rd.log_event("host", agent=args.agent, model=args.model or "",
                      usd=usd, tokens=tokens, seconds=round(seconds, 3),
                      returncode=(None if proc is None else proc.returncode),
-                     timed_out=timed_out)
+                     timed_out=timed_out, stop_reason=stop_reason, num_turns=num_turns)
         if usd or tokens:
             rd.update_spent(optimizer_usd=usd, optimizer_tokens=tokens)
+        # The run dir's budget, not the spec's: baseline freezes it there, `--resume` can
+        # extend it, and it is what `budget_exhausted()` actually judges against.
+        rounds_done = int(rd.spent.iterations or 0)
+        rounds_budget = int(rd.budget.max_iterations or 0)
     except Exception as exc:  # noqa: BLE001 — spend accounting must not lose the run
         payload.setdefault("warnings", []).append(f"could not book host spend: {exc}")
+        rounds_done, rounds_budget = -1, 0
 
     seal = _seal(run_dir, project, spec, timeout=args.timeout)
+
+    # An agent that stopped with rounds left is a DEFECT, not a finished run — and it must not
+    # read as completion. Measured: one run booked 1 of 3 rounds with a higher-scoring
+    # candidate already evaluated but never committed, and reported success. The host cannot
+    # un-spend that, but it can refuse to let it look finished.
+    incomplete = ""
+    if 0 <= rounds_done < rounds_budget:
+        incomplete = (f"the agent booked {rounds_done} of {rounds_budget} rounds"
+                      + (f" and stopped on {stop_reason}" if stop_reason else "")
+                      + (f" after {num_turns} turns" if num_turns else "")
+                      + " — a candidate it evaluated may never have been committed; raise the "
+                        "turn budget (optimizer_max_turns) or lower the round count")
 
     out = {
         "run_dir": str(run_dir),
@@ -645,8 +679,14 @@ def main(argv=None) -> int:
         "prompt_path": str(prompt_path),
         "returncode": None if proc is None else proc.returncode,
         "timed_out": timed_out,
+        "stop_reason": stop_reason,
+        "num_turns": num_turns,
+        "rounds_booked": rounds_done,
+        "rounds_budget": rounds_budget,
+        "incomplete": incomplete,
         "seconds": round(seconds, 3),
         "usd": usd,
+        "tokens": tokens,
         "agent_env": agent_env,
         "instructions_file": arm_path,
         "instructions_warning": arm_warning,
@@ -657,6 +697,8 @@ def main(argv=None) -> int:
     if proc is not None and proc.returncode != 0:
         out["agent_error"] = (proc.stderr or "")[-1200:]
     print(json.dumps(out, indent=2))
+    if incomplete:
+        print(f"::warning::agent-optimize: {incomplete}", file=sys.stderr)
     # The run's worth is its sealed number, so that — not the agent's exit code — decides
     # ours. An agent that ran out of turns after three honest rounds produced a result; one
     # that exited 0 without sealing did not.

--- a/skills/algorithms/agent-optimize/scripts/host.py
+++ b/skills/algorithms/agent-optimize/scripts/host.py
@@ -713,7 +713,13 @@ def main(argv=None) -> int:
            # Same workdir the guidance was staged into, so the agent's cwd is where its
            # native skills dir and ./guidance/ live.
            "--workdir", str(workdir),
-           "--prompt", str(prompt_path)]
+           "--prompt", str(prompt_path),
+           # The loop's own record. Four hours of run 32814848187 were unaccounted for and
+           # unaccountable: the only trace kept was an 800-char stdout tail, so what the agent
+           # was blocked on could be narrowed to "something that hit the Bash ceiling" and no
+           # further. This lands beside driver_prompt.md, so the run dir holds both what the
+           # host asked for and what the agent actually did.
+           "--transcript", str(prompt_path.parent / "transcript.jsonl")]
     if args.model:
         cmd += ["--model", args.model]
     if args.budget:
@@ -848,6 +854,7 @@ def main(argv=None) -> int:
         "usd": usd,
         "tokens": tokens,
         "agent_env": agent_env,
+        "transcript": (payload.get("transcript") or {}).get("path", ""),
         "instructions_file": arm_path,
         "instructions_warning": arm_warning,
         "context": context,

--- a/skills/algorithms/agent-optimize/scripts/host.py
+++ b/skills/algorithms/agent-optimize/scripts/host.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
 import time
@@ -105,30 +106,152 @@ def _editable_files(run_dir: Path, project: Path, spec: dict) -> list[str]:
     return files
 
 
+#: Suffixes that make a capability file CODE rather than prose. Drives whether the briefing
+#: offers code-vs-prose advice at all — see _surface_section.
+_CODE_SUFFIXES = {".py", ".js", ".mjs", ".ts", ".tsx", ".sh", ".bash", ".rb", ".go", ".rs",
+                  ".java", ".pl", ".lua", ".sql"}
+#: Above this, the listing is grouped instead of enumerated. A skill-package capability can
+#: be dozens of files, and a wall of paths crowds out the rest of the briefing.
+_MAX_LISTED = 20
+
+
 def _surface_section(files: list[str]) -> str:
     """Render the editable-file list, and say what a prompt-only edit leaves undone.
 
-    Scaled to what is actually there: naming tool code for a capability that has none sends
-    the agent hunting outside its capability for code to change.
+    Scaled to what is actually there, in two ways that matter for genericity:
+
+    * **Code advice only when there is code.** A capability of two prose files (a system
+      prompt plus a task template) told to "prefer an in-code guard" goes looking for code it
+      does not own — the failure that once had a prompt-only optimizer editing ``adapter.py``.
+    * **Grouped, never silently truncated, when large.** A skill-package capability can run to
+      dozens of files. Bounding the list is fine; bounding it without saying so is not, since
+      the reader then takes it as the complete surface.
     """
     if not files:
         return ""
-    listing = "\n".join(f"- `{f}`" for f in files)
     if len(files) == 1:
-        return (f"## Your editable surface — one file\n\n{listing}\n\n"
-                "That file is the whole capability. There is no tool code and no second "
-                "surface, so do not go looking for one outside it.\n")
-    return (
-        f"## Your editable surface — ALL {len(files)} of these files\n\n{listing}\n\n"
-        "Every one of them is in your candidate copy and every one is fair game — prose, "
+        return (f"## Your editable surface — one file\n\n- `{files[0]}`\n\n"
+                "That file is the whole capability. There is no second surface, so do not go "
+                "looking for one outside it.\n")
+
+    has_code = any(Path(f).suffix in _CODE_SUFFIXES for f in files)
+
+    if len(files) <= _MAX_LISTED:
+        listing = "\n".join(f"- `{f}`" for f in files)
+        head = f"## Your editable surface — ALL {len(files)} of these files\n\n{listing}\n"
+    else:
+        groups: dict[str, list[str]] = {}
+        for f in files:
+            parts = f.split("/")
+            groups.setdefault(parts[0] if len(parts) > 1 else ".", []).append(f)
+        rows = []
+        shown = 0
+        for g, gf in sorted(groups.items()):
+            examples = ", ".join(f"`{x}`" for x in gf[:3])
+            more = f", +{len(gf) - 3} more" if len(gf) > 3 else ""
+            shown += min(len(gf), 3)
+            label = f"`{g}/`" if g != "." else "top level"
+            rows.append(f"- {label} — {len(gf)} file(s): {examples}{more}")
+        head = (
+            f"## Your editable surface — {len(files)} files\n\n" + "\n".join(rows) + "\n\n"
+            f"Grouped because there are {len(files)}; {len(files) - shown} are not listed "
+            f"individually above. **Enumerate the full set yourself** (`find` the candidate "
+            f"dir) before deciding a file is out of scope — everything under it is editable, "
+            f"not only the files named here.\n")
+
+    body = (
+        "\nEvery one of them is in your candidate copy and every one is fair game — prose, "
         "code, data, nested files alike. A round that changes **only the obvious prompt "
         "file** leaves the rest of the agent's instruction and behaviour surface exactly as "
         "it was, and that is the most common way a run produces nothing: the fix that was "
         "needed lived in a file nobody opened.\n\n"
-        "So before you write an edit, decide *which file* is the right place for it — a rule "
-        "the agent already has and violates usually belongs in code as a guard, while a "
-        "missing decision criterion belongs in prose. Say which file you chose, and why that "
-        "one, when you commit the round.\n")
+        "So before you write an edit, decide *which file* is the right place for it")
+    if has_code:
+        body += (" — a rule the agent already has and violates usually belongs in code as a "
+                 "guard, while a missing decision criterion belongs in prose")
+    body += (". Say which file you chose, and why that one, when you commit the round.\n")
+    return head + body
+
+
+def _arm_instructions(project: Path, spec: dict) -> tuple[str, str, str]:
+    """The project's own ``optimizer_instructions_file``, which agent mode used to drop.
+
+    ``cli.py`` applies that key only for ``algorithm_name in OPTIMIZER_CONTEXT_ALGORITHMS``
+    (hill-climb / gepa / skillopt). agent-optimize is not in that set, so a project shipping
+    capability-scoped instructions had them ignored in agent mode.
+
+    That is dangerous, not merely lossy. One benchmark arm in this repo uses that file to say
+    that the ``{placeholders}`` in its second editable file are LOAD-BEARING and that breaking
+    one makes EVERY task score 0 — the agent is never told where to write its answer. An agent
+    that never sees the warning can wipe out the run's whole signal with an edit that looks
+    harmless.
+
+    Returns ``(text, resolved_path, warning)``. The default path being absent is normal and
+    silent; a path the spec NAMED being absent is reported, which is the #252 failure mode
+    (a bad path silently downgrading to generic guidance).
+    """
+    from cap_evolve.specfile import resolve_project_path
+
+    named = str(spec.get("optimizer_instructions_file") or "").strip()
+    rel = named or "optimizer/INSTRUCTIONS.md"
+    path = resolve_project_path(project, rel)
+    if path.is_file():
+        try:
+            return path.read_text(encoding="utf-8"), str(path), ""
+        except OSError as exc:
+            return "", str(path), f"could not read {path}: {exc}"
+    if named:
+        return "", "", (f"optimizer_instructions_file {named!r} does not exist (resolved "
+                        f"project-relative to {path}) — the agent gets no capability-scoped "
+                        f"instructions for this benchmark")
+    return "", "", ""
+
+
+def _strip_template_slots(text: str) -> tuple[str, int]:
+    """Drop unrendered ``{{SLOT}}`` markers from an instructions template.
+
+    That file is a TEMPLATE: the deterministic path renders ``{{TARGET_READER}}`` /
+    ``{{FOCUS_SUMMARY}}`` / ``{{EMPTY_SEED}}`` per iteration from state the host does not have.
+    Passed through raw they reach the agent as literal braces — which the parity test already
+    treats as a defect for the deterministic path ("unrendered placeholder in the prompt").
+    """
+    slot = re.compile(r"\{\{[A-Z0-9_]+\}\}")
+    n = len(slot.findall(text))
+    kept = [ln for ln in text.splitlines() if not slot.fullmatch(ln.strip())]
+    return slot.sub("", "\n".join(kept)), n
+
+
+def _arm_section(text: str) -> str:
+    """Include the arm's own instructions — with their scope stated, not silently merged.
+
+    Two things make a verbatim paste wrong, and both are generic rather than per-benchmark:
+
+    * It is a template (see ``_strip_template_slots``).
+    * It was authored for the DETERMINISTIC per-iteration optimizer, so its process half
+      actively contradicts this loop — it says to stop after editing and not to evaluate,
+      because there the harness re-scores the candidate. Here the agent owns the evaluation
+      and the gate, and an agent that obeyed that line would never gate anything.
+
+    What is uniquely valuable in it is the benchmark's own constraints — which files are
+    editable, which tokens are load-bearing, what silently zeroes a score. So the precedence
+    is stated explicitly instead of leaving the agent to guess which half to follow.
+    """
+    body, stripped = _strip_template_slots(text)
+    if not body.strip():
+        return ""
+    note = (f" ({stripped} unrendered template slot(s) removed)" if stripped else "")
+    return (
+        "## Benchmark-specific instructions for THIS capability\n\n"
+        f"Authored for this project{note}. Read them for the **benchmark's own facts and "
+        "constraints** — which files are editable, which tokens are load-bearing, what "
+        "silently zeroes a score. Those are measured on this benchmark, are repeated nowhere "
+        "else in this briefing, and are binding.\n\n"
+        "**Scope, because they were written for the other loop:** they address a per-iteration "
+        "optimizer that proposes one edit and stops while the harness scores it. You own the "
+        "whole search, so anything in them about stopping after an edit, not evaluating, or "
+        "iteration budget does NOT apply — the loop in SKILL.md and this briefing wins there. "
+        "On benchmark facts, they win.\n\n"
+        "<arm_instructions>\n" + body.strip() + "\n</arm_instructions>\n")
 
 
 def _guidance_section(workdir: Path, context: dict) -> str:
@@ -151,7 +274,7 @@ def _guidance_section(workdir: Path, context: dict) -> str:
 
 
 def _briefing(*, run_dir: Path, project: Path, spec: dict, skills: Path,
-              rounds: int, workdir: Path, context: dict) -> str:
+              rounds: int, workdir: Path, context: dict, arm: str = "") -> str:
     """The driver briefing: the handoff facts, then a pointer to the loop itself.
 
     Deliberately NOT a restatement of the algorithm. SKILL.md is the implementation and the
@@ -166,6 +289,7 @@ def _briefing(*, run_dir: Path, project: Path, spec: dict, skills: Path,
     cap_path = spec.get("capability_path") or "seed_capability"
     surface = _surface_section(_editable_files(run_dir, project, spec))
     guidance = _guidance_section(workdir, context)
+    arm_block = _arm_section(arm)
     skill_md = SKILL_DIR / "SKILL.md"
     helpers = HERE
 
@@ -215,6 +339,7 @@ gate — rather than relying on a default that may not match this spec.
 
 {surface}
 {guidance}
+{arm_block}
 
 ## The primitives every round must go through
 
@@ -425,8 +550,9 @@ def main(argv=None) -> int:
     prompt_dir = run_dir / "host"
     prompt_dir.mkdir(parents=True, exist_ok=True)
     prompt_path = prompt_dir / "driver_prompt.md"
+    arm_text, arm_path, arm_warning = _arm_instructions(project, spec)
     briefing = _briefing(run_dir=run_dir, project=project, spec=spec, skills=SKILLS,
-                         rounds=rounds, workdir=workdir, context=context)
+                         rounds=rounds, workdir=workdir, context=context, arm=arm_text)
     prompt_path.write_text(briefing, encoding="utf-8")
     # Also as <workdir>/INSTRUCTIONS.md. Staging writes an always-on CLAUDE.md pointer whose
     # first instruction is "read ./INSTRUCTIONS.md FIRST" — written for the deterministic
@@ -446,7 +572,9 @@ def main(argv=None) -> int:
                           "prompt_path": str(prompt_path), "returncode": None,
                           "agent_env": agent_env, "budget": args.budget,
                           "usd_budget": args.usd_budget,
-                          "workdir": str(workdir), "context": context}, indent=2))
+                          "workdir": str(workdir), "context": context,
+                          "instructions_file": arm_path,
+                          "instructions_warning": arm_warning}, indent=2))
         return 0
     if not context["staged"]:
         print(f"::warning::optimizer context not staged for the hosted agent "
@@ -515,6 +643,9 @@ def main(argv=None) -> int:
         "seconds": round(seconds, 3),
         "usd": usd,
         "agent_env": agent_env,
+        "instructions_file": arm_path,
+        "instructions_warning": arm_warning,
+        "context": context,
         "optimizer": payload,
         **seal,
     }

--- a/skills/algorithms/agent-optimize/scripts/host.py
+++ b/skills/algorithms/agent-optimize/scripts/host.py
@@ -6,15 +6,32 @@ returns: no algorithm subprocess, no auto-finalize. That is exactly right with a
 the loop and leaves the algorithm *unavailable* anywhere without one — a CI job gets the
 handoff and then nothing happens.
 
-This script is the missing host, and deliberately owns as little as possible:
+This script is the missing host, and deliberately owns as little as possible. Everything it
+borrows, and from where:
 
   * the **loop** stays in ``SKILL.md`` + this dir's helpers. The briefing points at them; it
     does not restate the algorithm, because a second copy of the loop would drift from the
     first and there would be no way to tell which one ran.
-  * the **CLI invocation** is delegated to ``optimizers/run-optimizer``, which already
-    resolves a registry row, substitutes ``{model}``, maps ``--budget``/``--usd-budget`` to
-    that CLI's own flags, captures cost from its JSON output, and hard-fails when the CLI
-    is absent. Re-implementing any of that here would be a second, worse copy.
+  * the **CLI invocation** goes through ``optimizers/run-optimizer``, which already resolves a
+    registry row, substitutes ``{model}``, maps ``--budget``/``--usd-budget`` to that CLI's own
+    flags, captures cost from its JSON output, and hard-fails when the CLI is absent — and
+    whose ``load_registry`` also answers "is this a known agent?".
+  * the **read-context** is ``harness.OptimizerContext``: ``inject()`` stages the capability
+    skills, the diagnose method, the sources and the trajectories exactly as every
+    deterministic algorithm gets them, and ``capability_brief()`` / ``reader_brief()`` /
+    ``empty_seed_brief()`` supply the measured prompt blocks. This script previously
+    hand-rolled thinner equivalents, and the consequence was measurable: with
+    ``_CAP_EDIT_SPACE``'s "the highest-leverage edit is a new code-bearing tool" and the
+    target-reader block both absent, the hosted optimizer only ever edited prose.
+  * the **spec resolution** for ``optimizer_instructions_file`` is
+    ``specfile.resolve_instructions_file``, shared with ``cli.py``. Two copies of a path
+    resolution rule is how #252 happened.
+  * the **seal** is ``measure.py``, the same script the skill documents.
+
+What it does NOT borrow: ``OptimizerContext.instructions()``. That renders the per-iteration
+contract — "fix many root causes in this ONE candidate and STOP; the harness re-scores you" —
+which is false here, where the agent owns the search, the evaluation and the gate. The blocks
+are composed instead, and an arm's own instructions template is included with its scope stated.
 
 What is genuinely this script's own:
 
@@ -39,7 +56,6 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import re
 import subprocess
 import sys
 import time
@@ -69,10 +85,12 @@ def _spec(project: Path, spec_path: Path | None) -> dict:
 
 
 def _known_agents() -> list[str]:
-    from cap_evolve.specfile import read_yaml
-
+    """Registry rows, read by run-optimizer's own loader rather than a second parser."""
     try:
-        return sorted((read_yaml(REGISTRY.read_text(encoding="utf-8")) or {}).keys())
+        sys.path.insert(0, str(RUN_OPTIMIZER.parent))
+        import run as _run_optimizer  # run-optimizer/scripts/run.py
+
+        return sorted((_run_optimizer.load_registry() or {}).keys())
     except Exception:  # noqa: BLE001 — a missing registry is reported by the caller below
         return []
 
@@ -165,12 +183,11 @@ def _surface_section(files: list[str]) -> str:
         "file** leaves the rest of the agent's instruction and behaviour surface exactly as "
         "it was, and that is the most common way a run produces nothing: the fix that was "
         "needed lived in a file nobody opened.\n\n"
-        "So before you write an edit, decide *which file* is the right place for it")
-    if has_code:
-        body += (" — a rule the agent already has and violates usually belongs in code as a "
-                 "guard, while a missing decision criterion belongs in prose")
-    body += (". Name the file you chose in the `commit.py --note` for the round, so the run "
-             "records which surface each decision was made on.\n\n"
+        "So before you write an edit, decide *which file* is the right place for it — the "
+        "allowed edit space per capability, and which form has the most leverage on each, is "
+        "in the capability brief below rather than restated here. Name the file you chose in "
+        "the `commit.py --note` for the round, so the run records which surface each decision "
+        "was made on.\n\n"
              "### Precondition on round 3 and later\n\n"
              "**If your last two rounds were both rejected, the next round may not reuse the "
              "surface *and* form those two used.** Read the rejected candidate's trace first "
@@ -187,76 +204,23 @@ def _surface_section(files: list[str]) -> str:
     return head + body
 
 
-def _arm_instructions(project: Path, spec: dict) -> tuple[str, str, str]:
-    """The project's own ``optimizer_instructions_file``, which agent mode used to drop.
-
-    ``cli.py`` applies that key only for ``algorithm_name in OPTIMIZER_CONTEXT_ALGORITHMS``
-    (hill-climb / gepa / skillopt). agent-optimize is not in that set, so a project shipping
-    capability-scoped instructions had them ignored in agent mode.
-
-    That is dangerous, not merely lossy. One benchmark arm in this repo uses that file to say
-    that the ``{placeholders}`` in its second editable file are LOAD-BEARING and that breaking
-    one makes EVERY task score 0 — the agent is never told where to write its answer. An agent
-    that never sees the warning can wipe out the run's whole signal with an edit that looks
-    harmless.
-
-    Returns ``(text, resolved_path, warning)``. The default path being absent is normal and
-    silent; a path the spec NAMED being absent is reported, which is the #252 failure mode
-    (a bad path silently downgrading to generic guidance).
-    """
-    from cap_evolve.specfile import resolve_project_path
-
-    named = str(spec.get("optimizer_instructions_file") or "").strip()
-    rel = named or "optimizer/INSTRUCTIONS.md"
-    path = resolve_project_path(project, rel)
-    if path.is_file():
-        try:
-            return path.read_text(encoding="utf-8"), str(path), ""
-        except OSError as exc:
-            return "", str(path), f"could not read {path}: {exc}"
-    if named:
-        return "", "", (f"optimizer_instructions_file {named!r} does not exist (resolved "
-                        f"project-relative to {path}) — the agent gets no capability-scoped "
-                        f"instructions for this benchmark")
-    return "", "", ""
-
-
-def _strip_template_slots(text: str) -> tuple[str, int]:
-    """Drop unrendered ``{{SLOT}}`` markers from an instructions template.
-
-    That file is a TEMPLATE: the deterministic path renders ``{{TARGET_READER}}`` /
-    ``{{FOCUS_SUMMARY}}`` / ``{{EMPTY_SEED}}`` per iteration from state the host does not have.
-    Passed through raw they reach the agent as literal braces — which the parity test already
-    treats as a defect for the deterministic path ("unrendered placeholder in the prompt").
-    """
-    slot = re.compile(r"\{\{[A-Z0-9_]+\}\}")
-    n = len(slot.findall(text))
-    kept = [ln for ln in text.splitlines() if not slot.fullmatch(ln.strip())]
-    return slot.sub("", "\n".join(kept)), n
-
-
 def _arm_section(text: str) -> str:
     """Include the arm's own instructions — with their scope stated, not silently merged.
 
-    Two things make a verbatim paste wrong, and both are generic rather than per-benchmark:
-
-    * It is a template (see ``_strip_template_slots``).
-    * It was authored for the DETERMINISTIC per-iteration optimizer, so its process half
-      actively contradicts this loop — it says to stop after editing and not to evaluate,
-      because there the harness re-scores the candidate. Here the agent owns the evaluation
-      and the gate, and an agent that obeyed that line would never gate anything.
+    That file was authored for the DETERMINISTIC per-iteration optimizer, so its process half
+    actively contradicts this loop: it says to stop after editing and not to evaluate, because
+    there the harness re-scores the candidate. Here the agent owns the evaluation and the gate,
+    and an agent obeying that line would never gate anything.
 
     What is uniquely valuable in it is the benchmark's own constraints — which files are
-    editable, which tokens are load-bearing, what silently zeroes a score. So the precedence
-    is stated explicitly instead of leaving the agent to guess which half to follow.
+    editable, which tokens are load-bearing, what silently zeroes a score. So the precedence is
+    stated explicitly instead of leaving the agent to guess which half to follow.
     """
-    body, stripped = _strip_template_slots(text)
-    if not body.strip():
+    if not text.strip():
         return ""
-    note = (f" ({stripped} unrendered template slot(s) removed)" if stripped else "")
     return (
         "## Benchmark-specific instructions for THIS capability\n\n"
-        f"Authored for this project{note}. Read them for the **benchmark's own facts and "
+        "Authored for this project. Read them for the **benchmark's own facts and "
         "constraints** — which files are editable, which tokens are load-bearing, what "
         "silently zeroes a score. Those are measured on this benchmark, are repeated nowhere "
         "else in this briefing, and are binding.\n\n"
@@ -265,35 +229,46 @@ def _arm_section(text: str) -> str:
         "whole search, so anything in them about stopping after an edit, not evaluating, or "
         "iteration budget does NOT apply — the loop in SKILL.md and this briefing wins there. "
         "On benchmark facts, they win.\n\n"
-        "<arm_instructions>\n" + body.strip() + "\n</arm_instructions>\n")
+        "<arm_instructions>\n" + text.strip() + "\n</arm_instructions>\n")
 
 
-def _guidance_section(workdir: Path, context: dict) -> str:
-    """Point at the staged capability guidance — unread guidance is not guidance."""
-    if not context.get("staged"):
-        return ("## Capability guidance\n\nNot available for this run (staging failed). Work "
-                "from the capability files themselves and be conservative.\n")
-    caps = context.get("capabilities") or []
-    lines = "\n".join(f"- `{workdir}/guidance/{c}/SKILL.md` — how to edit the **{c}** surface"
-                      for c in caps)
-    return (
-        "## How to edit each surface — READ THESE BEFORE YOUR FIRST EDIT\n\n"
-        f"{lines}\n"
-        f"- `{workdir}/guidance/diagnose/SKILL.md` — the failure-clustering method step 1 uses\n\n"
-        "One guidance doc per declared capability, and there is one for every surface you may "
-        "edit — not just the prose one. Each states what is safely editable there, the edit "
-        "forms that work, and the failure modes. **Read the guidance for the surface you are "
-        "about to change**: an edit made without it is a guess, and the surface you have no "
-        "guidance for is the one you will avoid by default.\n")
+def _shared_blocks(ctx, run_dir: Path, context: dict) -> str:
+    """The prompt blocks the DETERMINISTIC path has always had, from the same source.
+
+    Not re-authored here. Every deterministic algorithm gets these through
+    ``OptimizerContext``; agent mode used to hand-roll thinner equivalents, and the measured
+    consequence was an optimizer that only ever edited prose — because the block naming tool
+    code as the highest-leverage surface (``harness._CAP_EDIT_SPACE``) and the block saying a
+    weak reader needs code enforcement over terse prose (the target-reader profile) were both
+    absent. Reusing them is the fix; writing better prose here would not have been.
+    """
+    parts = []
+    brief = ctx.capability_brief()
+    if brief:
+        parts.append(brief)
+        if context.get("staged"):
+            parts.append("Each `./guidance/<cap>/SKILL.md` above is staged in your working "
+                         "directory and also under the native skills dir. **Read the one for "
+                         "the surface you are about to edit** — an edit made without it is a "
+                         "guess, and the surface you have no guidance for is the one you will "
+                         "avoid by default.")
+    reader = ctx.reader_brief()
+    if reader:
+        parts.append(reader)
+    empty = ctx.empty_seed_brief(run_dir / "candidates" / "seed")
+    if empty:
+        parts.append(empty)
+    return "\n\n".join(p.strip() for p in parts if p and p.strip())
 
 
 def _briefing(*, run_dir: Path, project: Path, spec: dict, skills: Path,
-              rounds: int, workdir: Path, context: dict, arm: str = "") -> str:
+              rounds: int, workdir: Path, context: dict, arm: str = "",
+              ctx=None) -> str:
     """The driver briefing: the handoff facts, then a pointer to the loop itself.
 
     Deliberately NOT a restatement of the algorithm. SKILL.md is the implementation and the
-    agent reads it; what it cannot know are the paths, the spec values and the fact that
-    nobody is available to answer a question.
+    agent reads it; what it cannot know are the paths, the spec values, the shared prompt
+    blocks, and the fact that nobody is available to answer a question.
     """
     stop = str(spec.get("stop_condition") or "").strip()
     n_trials = spec.get("num_trials", 1)
@@ -302,7 +277,7 @@ def _briefing(*, run_dir: Path, project: Path, spec: dict, skills: Path,
     caps = spec.get("capabilities") or []
     cap_path = spec.get("capability_path") or "seed_capability"
     surface = _surface_section(_editable_files(run_dir, project, spec))
-    guidance = _guidance_section(workdir, context)
+    guidance = _shared_blocks(ctx, run_dir, context) if ctx is not None else ""
     arm_block = _arm_section(arm)
     skill_md = SKILL_DIR / "SKILL.md"
     helpers = HERE
@@ -434,7 +409,7 @@ def _seal(run_dir: Path, project: Path, spec: dict, *, timeout: float | None) ->
 
 
 def _stage_context(*, run_dir: Path, project: Path, workdir: Path, spec: dict,
-                   agent: str) -> dict:
+                   agent: str) -> tuple:
     """Stage the SAME optimizer read-context every deterministic algorithm receives.
 
     ``harness.OptimizerContext`` exists so "an algorithm cannot silently run on a thinner
@@ -453,32 +428,31 @@ def _stage_context(*, run_dir: Path, project: Path, workdir: Path, spec: dict,
     from one that staged fine, and simply optimizes less surface.
     """
     caps = tuple(c for c in (spec.get("capabilities") or []) if c)
+    from cap_evolve import harness
+
+    # from_spec, not the field-by-field constructor: it also resolves the target profile, so
+    # reader_brief() is populated exactly the way the deterministic path's from_args does it.
+    ctx = harness.OptimizerContext.from_spec(spec, project_dir=project, optimizer_name=agent)
     try:
-        from cap_evolve import RunDir, harness
+        from cap_evolve import RunDir
         from cap_evolve.check import load_adapter
 
         rd = RunDir.open(run_dir)
         adapter = load_adapter(project)
-        ctx = harness.OptimizerContext(
-            capabilities=caps,
-            optimizer_name=agent,
-            capability_sources=tuple(spec.get("capability_sources") or []),
-            project_dir=project,
-        )
         # split="val" + the current best's tag: the parent step the agent builds on, which is
         # the same choice the deterministic loop makes.
         ctx.inject(adapter, rd, workdir, split="val", tag=rd.best_id or "seed")
         staged = {"staged": True, "capabilities": list(caps),
-                  "guidance": sorted(p.name for p in (workdir / "guidance").iterdir())
+                  "guidance": sorted(g.name for g in (workdir / "guidance").iterdir())
                   if (workdir / "guidance").is_dir() else []}
         try:
             rd.log_event("host_context", capabilities=list(caps), agent=agent, staged=True)
         except Exception:  # noqa: BLE001 — the event is a nicety, the staging is the point
             pass
-        return staged
+        return ctx, staged
     except Exception as exc:  # noqa: BLE001
-        return {"staged": False, "capabilities": list(caps),
-                "error": f"{type(exc).__name__}: {exc}"[:400]}
+        return ctx, {"staged": False, "capabilities": list(caps),
+                     "error": f"{type(exc).__name__}: {exc}"[:400]}
 
 
 def _child_env() -> dict:
@@ -558,15 +532,32 @@ def main(argv=None) -> int:
     # The agent needs write access to BOTH the run dir and the project; their common parent
     # is the natural workdir, and it is where the staged guidance + native skills land.
     workdir = _common_parent(run_dir, project)
-    context = _stage_context(run_dir=run_dir, project=project, workdir=workdir,
-                             spec=spec, agent=args.agent)
+    ctx, context = _stage_context(run_dir=run_dir, project=project, workdir=workdir,
+                                  spec=spec, agent=args.agent)
 
     prompt_dir = run_dir / "host"
     prompt_dir.mkdir(parents=True, exist_ok=True)
     prompt_path = prompt_dir / "driver_prompt.md"
-    arm_text, arm_path, arm_warning = _arm_instructions(project, spec)
+    # ONE resolution rule, shared with cli.py's deterministic path (specfile). Two copies of
+    # it is how #252 happened: a relative key resolved against different cwds, and a miss
+    # silently downgraded the optimizer to the generic template.
+    from cap_evolve.specfile import resolve_instructions_file
+
+    arm_p, arm_exists, arm_warning = resolve_instructions_file(spec, project)
+    arm_path = str(arm_p) if arm_exists else ""
+    arm_text = ""
+    if arm_exists:
+        try:
+            # Rendered through the shared renderer, not stripped by hand: the arm's template
+            # arrives with its blocks filled from the same functions the deterministic path
+            # uses, instead of as literal {{SLOT}} braces.
+            arm_text = ctx.render_template(arm_p.read_text(encoding="utf-8"),
+                                           parent_dir=run_dir / "candidates" / "seed")
+        except OSError as exc:
+            arm_warning = f"could not read {arm_p}: {exc}"
     briefing = _briefing(run_dir=run_dir, project=project, spec=spec, skills=SKILLS,
-                         rounds=rounds, workdir=workdir, context=context, arm=arm_text)
+                         rounds=rounds, workdir=workdir, context=context, arm=arm_text,
+                         ctx=ctx)
     prompt_path.write_text(briefing, encoding="utf-8")
     # Also as <workdir>/INSTRUCTIONS.md. Staging writes an always-on CLAUDE.md pointer whose
     # first instruction is "read ./INSTRUCTIONS.md FIRST" — written for the deterministic

--- a/skills/algorithms/agent-optimize/scripts/host.py
+++ b/skills/algorithms/agent-optimize/scripts/host.py
@@ -49,6 +49,20 @@ agent's own judgement that it was finished.
 
 The seal is idempotent: an already-sealed run reports ``seal: agent`` rather than raising
 ``TestSealError`` out of the host and failing a run that is actually complete.
+
+**A foreground contract, and a backstop for when it is broken.** The turn budget is not the
+only way an unattended loop stops short. On run 32814848187 the agent used 78 of 600 turns and
+stopped on ``subtype: success`` / ``stop_reason: end_turn``: it had backgrounded round 2's gate
+and ended its turn to await a notification, which ends the process here — there is no
+conversation to resume it. So the briefing states the invariant (the turn that launches work is
+the turn that collects it; delegate the work, never the waiting — subagents and parallel evals
+stay encouraged), and ``unbooked_rounds`` reports candidates a round gated to a verdict that no
+``commit.py`` booked, since ``spent.iterations`` cannot tell that from a round never attempted.
+It reports rather than books: booking an accept after ``measure.py`` sealed against the old
+``best_id`` would convert a visible gap into a wrong headline number.
+
+That check runs AFTER the seal on purpose — the abandoned round's evals outlived the agent by
+14 minutes, so a pre-seal check would have found an empty ``work/``.
 """
 
 from __future__ import annotations
@@ -281,6 +295,10 @@ def _briefing(*, run_dir: Path, project: Path, spec: dict, skills: Path,
     arm_block = _arm_section(arm)
     skill_md = SKILL_DIR / "SKILL.md"
     helpers = HERE
+    # Quoted from the constant that actually sets BASH_*_TIMEOUT_MS below, so the briefing
+    # cannot promise a ceiling the env does not grant.
+    hours = round(BASH_TIMEOUT_MS / 3_600_000, 1)
+    hours = int(hours) if hours == int(hours) else hours
 
     if not stop:
         stop = (f"Spend at most {rounds} rounds, gate every candidate on FULL val, and "
@@ -369,7 +387,7 @@ SKILL.md's Phase 0 says to ask the user about a blocking ambiguity (including
 the assumption in one line in your final summary, and proceed. A round spent on a
 conservative assumption is worth far more than a run that stalls waiting for a reply.
 
-Two consequences worth being explicit about:
+Three consequences worth being explicit about:
 
 1. **Never leave the run unsealed.** Finish with `measure.py` (which seals test exactly
    once) and the report phase, as SKILL.md's "Stop & seal" section shows. A run with no
@@ -378,6 +396,28 @@ Two consequences worth being explicit about:
 2. **A null result is a valid outcome, honestly reported.** If nothing beat the baseline
    through the gate, say so and seal anyway. Do not lower the gate, gate on a screen
    subset, or present a screen `promote` as an accept to manufacture a gain.
+3. **Drive the loop from the foreground, and never end a turn with work outstanding.**
+   There is no conversation to come back to. When you end a turn with no tool call pending,
+   this process exits and everything it started is orphaned — so anything that would report
+   back *later* never reports at all: a job left running in the background, a watcher on a
+   file, a completion notice, a wake-up you scheduled. There is nobody to wake.
+
+   This is not a rule against doing several things at once. Fan out as widely as the work
+   deserves — subagents, parallel diagnosers, a whole round's candidates evaluated
+   concurrently (that is exactly what `round.py` is for). The one invariant is that **the
+   turn that launched the work is still the turn that collects it**: stay blocked until the
+   result is in your hands, read it, and act on it before that turn ends. Delegate the work,
+   never the waiting.
+
+   Waiting is safe: one Bash call may run for {hours} hours, a ceiling raised for precisely
+   this reason, so a long eval does not need backgrounding to survive. If something really
+   would outlast that, make it smaller — fewer trials, fewer candidates per round — rather
+   than detaching it.
+
+   Measured on run 32814848187: the driver backgrounded round 2's full-val gate and ended
+   its turn to await a notification. The process exited; the gate finished 14 minutes later
+   and wrote a real verdict that nobody was left to read. Two of three rounds went unspent,
+   and the orphaned evals were still hitting the runner while the seal was being measured.
 
 ## When you are done
 
@@ -385,6 +425,78 @@ Finish your final message with the run's honest table: seed vs best on val, on t
 adds information, and on the sealed test split — plus the accepted candidate id, the number
 of rounds, and any assumption you had to make on your own.
 """
+
+
+def _decided_candidates(run_dir: Path) -> set[str]:
+    """Candidate tags that already carry an accept/reject decision in ``events.jsonl``.
+
+    Same source and same event names ``commit.py`` writes and re-reads for its own
+    double-booking guard — the audit log rather than in-process memory, because the driver
+    that booked the decision is a different process that has already exited.
+    """
+    decided: set[str] = set()
+    try:
+        with (run_dir / "events.jsonl").open(encoding="utf-8") as f:
+            for line in f:
+                try:
+                    ev = json.loads(line)
+                except Exception:  # noqa: BLE001 — a torn line is not a decision
+                    continue
+                if ev.get("kind") in ("accept", "reject") and ev.get("candidate"):
+                    decided.add(str(ev["candidate"]))
+    except OSError:
+        return decided
+    return decided
+
+
+def _unbooked_rounds(run_dir: Path) -> list[dict]:
+    """Candidates a round GATED but nobody booked with ``commit.py``.
+
+    ``spent.iterations`` counts ``commit.py`` calls, so a round whose full-val gate ran to a
+    verdict and was then abandoned is indistinguishable from a round never attempted — the
+    operator is left diffing candidate dirs by hand to find out which. Measured on run
+    32814848187: ``r2_comm_search`` was gated to ``reject`` at val 0.44 against parent 0.58,
+    the table was on disk, and the run reported 1 of 3 rounds with no hint the second existed.
+
+    Recognised by SHAPE, not by filename: ``round.py`` prints its table to stdout and the
+    driver chooses where to redirect it, so matching ``round*.log`` would only ever catch the
+    one name that happened to be used. Any file under ``work/`` that parses as a round table
+    counts.
+
+    Deliberately reports rather than books. Which decision a verdict deserves is the driver's
+    judgement — ``round.py``'s own docstring says so — and a host that booked accepts on its
+    behalf would move ``best_id`` after ``measure.py`` had already sealed against the old one,
+    turning a visible gap into a wrong headline number.
+    """
+    work = run_dir / "work"
+    if not work.is_dir():
+        return []
+    decided = _decided_candidates(run_dir)
+    seen: set[str] = set()
+    found: list[dict] = []
+    for log in sorted(work.iterdir()):
+        if not log.is_file() or log.suffix not in (".log", ".json", ".txt"):
+            continue
+        try:
+            payload = json.loads(log.read_text(encoding="utf-8"))
+        except Exception:  # noqa: BLE001 — not a round table; nothing to say about it
+            continue
+        if not isinstance(payload, dict) or not isinstance(payload.get("candidates"), list):
+            continue
+        for cand in payload["candidates"]:
+            if not isinstance(cand, dict):
+                continue
+            tag = str(cand.get("tag") or "")
+            # A row with no verdict never reached a decision anyone could have skipped
+            # (a crashed eval, or a table written before the gate ran).
+            if not tag or tag in decided or tag in seen or not cand.get("verdict"):
+                continue
+            seen.add(tag)
+            found.append({"candidate": tag, "verdict": cand.get("verdict"),
+                          "reward": cand.get("reward"),
+                          "parent": (payload.get("parent") or {}).get("tag"),
+                          "log": log.name})
+    return found
 
 
 def _seal(run_dir: Path, project: Path, spec: dict, *, timeout: float | None) -> dict:
@@ -517,6 +629,10 @@ def main(argv=None) -> int:
 
     if args.seal_only:
         out = _seal(run_dir, project, spec, timeout=args.timeout)
+        # This is the rescue path an operator reaches for on a run that died mid-loop, so it
+        # is the path most likely to be sitting on an abandoned round. Reporting it only on
+        # the full host path would hide it from exactly the reader who came looking.
+        out["unbooked_rounds"] = _unbooked_rounds(run_dir)
         print(json.dumps({"run_dir": str(run_dir), "seal_only": True, **out}, indent=2))
         return 0 if out["sealed"] else 1
 
@@ -636,6 +752,11 @@ def main(argv=None) -> int:
     # candidate evaluated but never committed) mattered more than anything else in the payload.
     stop = payload.get("stop") or {}
     stop_reason = str(stop.get("subtype") or "") or None
+    # Two different fields, and the discriminator is the SECOND one. Claude Code reports the
+    # harness-level outcome in `subtype` and the model's own reason in `stop_reason`; on run
+    # 32814848187 those were "success" and "end_turn". Reading only `subtype` sees a clean
+    # finish and cannot tell a voluntary stop from a completed run.
+    agent_stop = str(stop.get("stop_reason") or "") or None
     num_turns = stop.get("num_turns")
 
     # Book the host's own spend. The agent books per-round costs it knows about through
@@ -660,17 +781,54 @@ def main(argv=None) -> int:
 
     seal = _seal(run_dir, project, spec, timeout=args.timeout)
 
+    # AFTER the seal on purpose. The abandoned round's evals were still running when the agent
+    # exited — on run 32814848187 its table landed 14 minutes later, during measure.py — so a
+    # check made before sealing would have found an empty work/ and reported nothing.
+    unbooked = _unbooked_rounds(run_dir)
+
     # An agent that stopped with rounds left is a DEFECT, not a finished run — and it must not
     # read as completion. Measured: one run booked 1 of 3 rounds with a higher-scoring
     # candidate already evaluated but never committed, and reported success. The host cannot
     # un-spend that, but it can refuse to let it look finished.
+    #
+    # The advice has to be per-cause. One message served both stop causes and fit only the
+    # first: run 32733635494 died on error_max_turns, where "raise optimizer_max_turns" was
+    # exactly right, and run 32814848187 stopped at 78 of 600 turns on end_turn, where the same
+    # sentence pointed at a knob already 7x larger than what the agent used — and sent the next
+    # operator to raise it again.
     incomplete = ""
     if 0 <= rounds_done < rounds_budget:
+        reasons = f"{stop_reason or ''} {agent_stop or ''}"
+        turn_limited = "max_turns" in reasons
+        # Ran to a clean stop of its own accord, with rounds and turns still to spend.
+        voluntary = not turn_limited and ("end_turn" in reasons or "success" in reasons)
+
+        if turn_limited:
+            fix = ("raise the turn budget (optimizer_max_turns) or lower the round count")
+        elif voluntary:
+            fix = ("it stopped of its own accord with rounds still to spend, which is what a "
+                   "turn ending on outstanding work looks like from here: a backgrounded job, "
+                   "a file watcher, or anything else that reports back later cannot resume a "
+                   "non-interactive run, because ending a turn ends the process. The loop must "
+                   "be driven from the foreground — see the briefing's Unattended section. "
+                   "Delegation is fine; detaching the wait is not")
+        else:
+            fix = ("the agent did not finish and did not run out of turns — read agent_error "
+                   "and the optimizer payload for what killed it")
+
+        evidence = ""
+        if unbooked:
+            evidence = "; gated but never booked with commit.py: " + ", ".join(
+                f"{u['candidate']} (verdict {u['verdict']}, val {u['reward']}, in "
+                f"work/{u['log']})" for u in unbooked)
+        else:
+            evidence = ("; a candidate it evaluated may never have been committed")
+
         incomplete = (f"the agent booked {rounds_done} of {rounds_budget} rounds"
                       + (f" and stopped on {stop_reason}" if stop_reason else "")
+                      + (f"/{agent_stop}" if agent_stop and agent_stop != stop_reason else "")
                       + (f" after {num_turns} turns" if num_turns else "")
-                      + " — a candidate it evaluated may never have been committed; raise the "
-                        "turn budget (optimizer_max_turns) or lower the round count")
+                      + evidence + " — " + fix)
 
     out = {
         "run_dir": str(run_dir),
@@ -680,9 +838,11 @@ def main(argv=None) -> int:
         "returncode": None if proc is None else proc.returncode,
         "timed_out": timed_out,
         "stop_reason": stop_reason,
+        "agent_stop_reason": agent_stop,
         "num_turns": num_turns,
         "rounds_booked": rounds_done,
         "rounds_budget": rounds_budget,
+        "unbooked_rounds": unbooked,
         "incomplete": incomplete,
         "seconds": round(seconds, 3),
         "usd": usd,

--- a/skills/algorithms/agent-optimize/scripts/round.py
+++ b/skills/algorithms/agent-optimize/scripts/round.py
@@ -308,11 +308,47 @@ def main(argv=None) -> int:
         "noise_floor_basis": ("control vs the STORED parent rollouts (differing trial counts are "
                               "part of this floor, which is the point)" if args.gate_against ==
                               "control" else "control vs the parent it was copied from"),
+        # ONE bar, matched to how this round actually gated. Reporting several numbers and
+        # leaving the driver to choose is not neutral: on run 32871360361 round 2 the table
+        # showed cand2 beating its CONCURRENT control by +0.19 (three times the k_se threshold,
+        # nineteen times the 0.01 gap between the control's own replicates) alongside a
+        # `noise_floor_from_control` of 0.14 — which is the control-vs-STORED-parent gap, i.e.
+        # temporal drift. The reading told the driver to treat any delta at or below the floor as
+        # no evidence, so it compared a control-relative delta against a drift-derived floor,
+        # resolved the contradiction conservatively, and booked a REJECT on the best candidate of
+        # the run.
+        #
+        # Which bar is right depends entirely on what the delta was measured against:
+        #   * control mode — the delta is against a control measured in THIS round, so drift is
+        #     already cancelled and the bar is the gap between identical replicates.
+        #   * parent mode  — the delta is against a reward measured in an earlier round, so drift
+        #     is inside it and the bar has to include the control's drift as well.
+        "evidence_bar": {
+            "value": (null_delta if args.gate_against == "control"
+                      else (None if (null_delta is None and floor is None)
+                            else max(null_delta or 0.0, floor or 0.0))),
+            "basis": ("gap between byte-identical control replicates measured in THIS round — "
+                      "drift is cancelled by gating against a concurrent control"
+                      if args.gate_against == "control" else
+                      "the larger of the replicate gap and the control's drift against the "
+                      "stored parent, because this round's deltas ARE against that stored "
+                      "reward and carry its drift"),
+        },
         "reading": (
+            "Judge every candidate's delta against `evidence_bar`, not against any other number "
+            "here. `noise_floor_from_control` is the gap between a byte-identical control "
+            "measured now and the parent's STORED reward: that is re-measurement DRIFT, and it "
+            "bounds how far the ABSOLUTE rewards in this table can be trusted — it is not a bar "
+            "a candidate gated against a concurrent control has to clear, because that "
+            "comparison never contained the drift. Do not re-derive a delta against the stored "
+            "parent and reject on it; that puts the drift back in."
+            if args.gate_against == "control" else
             "ctl_null is a byte-identical copy of the parent, so its delta is what ZERO change "
-            "measures today. Treat any candidate whose |delta| is at or below that as no evidence, "
-            "even if its verdict is accept."
-            if floor is not None else
+            "measures today. This round gated against the parent's STORED reward, so that drift "
+            "is inside every candidate delta here: treat any candidate at or below "
+            "`evidence_bar` as no evidence, even if its verdict is accept. Gating against the "
+            "control instead removes the drift from the comparison."
+            if floor is not None or null_delta is not None else
             "no null control in this round — you cannot separate a small gain from re-measurement."
         ),
         "candidates": sorted((r for r in rows if r["tag"] not in ctl_tags),

--- a/skills/algorithms/agent-optimize/scripts/round.py
+++ b/skills/algorithms/agent-optimize/scripts/round.py
@@ -211,7 +211,20 @@ def main(argv=None) -> int:
                                        "--no-control"}, indent=2))
             return 2
         gate_ref = CTL
-    parent = harness.split_result_from_rollouts(run_dir, gate_ref, args.split)
+    # TWO distinct objects, kept distinct. `gate_res` is what deltas and thresholds are measured
+    # against (the concurrent control under --gate-against control); `parent_res` is the
+    # candidate this round is climbing from. Under --gate-against parent they coincide.
+    #
+    # Conflating them reported the CONTROL's reward under the PARENT's tag: on run 32871360361
+    # the table said `parent: {tag: 'seed', reward: 0.34}` while baseline.json said the seed
+    # scored 0.38, which no reader could reconcile. Worse, the gap between the two IS this
+    # round's temporal drift — measured at 0.24/0.44/0.38 on identical seed bytes across three
+    # runs, i.e. several times the gate bar — so collapsing them erased the one number that says
+    # whether any delta in the table means anything.
+    gate_res = harness.split_result_from_rollouts(run_dir, gate_ref, args.split)
+    parent_res = (gate_res if gate_ref == best
+                  else harness.split_result_from_rollouts(run_dir, best, args.split))
+    parent = gate_res  # deltas/thresholds are always against the gate reference
     rows = []
     for ev in evals:
         tag = ev["tag"]
@@ -223,8 +236,9 @@ def main(argv=None) -> int:
         rows.append({
             "tag": tag,
             "reward": (g.get("candidate") or {}).get("reward"),
-            "delta_vs_parent": (None if (g.get("candidate") or {}).get("reward") is None
-                                else round((g["candidate"]["reward"] or 0.0) - parent.reward, 4)),
+            "delta_vs_gate_ref": (None if (g.get("candidate") or {}).get("reward") is None
+                                  else round((g["candidate"]["reward"] or 0.0)
+                                             - gate_res.reward, 4)),
             "gate_delta": (g.get("gate") or {}).get("delta"),
             "gate_threshold": (g.get("gate") or {}).get("threshold"),
             "verdict": g.get("verdict"),
@@ -242,8 +256,8 @@ def main(argv=None) -> int:
     if ctl is not None:
         if args.gate_against == "control":
             floor = abs(ctl["gate_delta"]) if ctl.get("gate_delta") is not None else None
-        elif ctl["delta_vs_parent"] is not None:
-            floor = abs(ctl["delta_vs_parent"])
+        elif ctl["delta_vs_gate_ref"] is not None:
+            floor = abs(ctl["delta_vs_gate_ref"])
     # The gap BETWEEN identical control replicates is the round's empirical bar. It is a
     # stronger statement than any single control's delta, because both replicates are the same
     # bytes on the same seeds: whatever separates them is pure re-measurement. Two such
@@ -263,8 +277,23 @@ def main(argv=None) -> int:
             "smaller than roughly 0.08. Re-run the gate at --concurrency 8 before believing an "
             "accept.")
     out = {
-        "parent": {"tag": best, "reward": parent.reward, "stderr": parent.stderr,
-                   "n_tasks": len(parent.per_task or [])},
+        "parent": {"tag": best, "reward": parent_res.reward, "stderr": parent_res.stderr,
+                   "n_tasks": len(parent_res.per_task or [])},
+        # What the deltas and thresholds in `candidates` are actually measured against.
+        "gate_reference": {"tag": gate_ref, "mode": args.gate_against,
+                           "reward": gate_res.reward, "stderr": gate_res.stderr},
+        # The round's OWN drift: identical-or-parent bytes measured now versus what the parent
+        # measured when it was scored. Non-null only when they are different measurements.
+        "parent_vs_gate_ref_drift": (None if gate_ref == best else
+                                     round((gate_res.reward or 0.0)
+                                           - (parent_res.reward or 0.0), 4)),
+        "drift_reading": (
+            "the parent's stored reward and a byte-identical control measured in THIS round "
+            "differ by this much. It is re-measurement drift, not progress, and any candidate "
+            "delta of comparable size is not evidence — whatever its verdict says."
+            if gate_ref != best else
+            "gated against the parent's stored reward, so this round cannot see how far that "
+            "reward has drifted since it was measured; --gate-against control measures it."),
         "measurement_concurrency": args.concurrency,
         "concurrency_warning": conc_warning,
         "null_delta_between_control_replicates": null_delta,

--- a/skills/algorithms/agent-optimize/scripts/round.py
+++ b/skills/algorithms/agent-optimize/scripts/round.py
@@ -247,6 +247,34 @@ def main(argv=None) -> int:
             "eval_error": ev.get("error"),
         })
 
+    # A parent-gated round has ALREADY measured the drift-free comparison — it just was not
+    # reporting it. On run 32871360361 round 4 the table showed cand4 at +0.15 against the seed's
+    # stored 0.38 with a bar of 0.11 (drift), i.e. marginal; the same round's two concurrent
+    # controls both read exactly 0.27, so the drift-free answer from the identical rollouts is
+    # +0.26 against a bar of 0.00. The 0.11 belongs to WHEN the seed was measured, not to cand4,
+    # so parent-mode gating understated the effect and inflated the bar at the same time.
+    #
+    # Reported rather than made the default: changing the default gate mode on one benchmark's
+    # drift would be a guess about every other workload, while an extra comparison is strictly
+    # more information and simply agrees with the primary one where there is no drift. Costs no
+    # rollouts — the controls are already evaluated and gate_check reads stored data.
+    if args.gate_against != "control" and ctl_tags:
+        for r in rows:
+            if r["tag"] in ctl_tags or r.get("reward") is None:
+                continue
+            g = _gate(Path(args.run_dir), r["tag"], args.k_se, args.mode,
+                      args.veto_regressions, current=CTL)
+            r["control_relative"] = {
+                "reference": CTL,
+                "gate_delta": (g.get("gate") or {}).get("delta"),
+                "gate_threshold": (g.get("gate") or {}).get("threshold"),
+                "verdict": g.get("verdict"),
+                "reading": ("the same comparison with the DRIFT removed: this candidate against a "
+                            "byte-identical control measured in this round rather than against a "
+                            "reward measured earlier. Where the two disagree, the difference is "
+                            "drift, not the edit."),
+            }
+
     # Would the verdict have survived a different control replicate? On run 32871360361 round 3
     # two byte-identical replicates read 0.32 and 0.20 two minutes apart, and the reference was
     # simply whichever carried the round-scoped tag (0.20) — so cand3 scored +0.17 and accepted

--- a/skills/algorithms/agent-optimize/scripts/round.py
+++ b/skills/algorithms/agent-optimize/scripts/round.py
@@ -247,6 +247,27 @@ def main(argv=None) -> int:
             "eval_error": ev.get("error"),
         })
 
+    # Would the verdict have survived a different control replicate? On run 32871360361 round 3
+    # two byte-identical replicates read 0.32 and 0.20 two minutes apart, and the reference was
+    # simply whichever carried the round-scoped tag (0.20) — so cand3 scored +0.17 and accepted
+    # where against the other replicate it is +0.05 and rejects. The table said nothing about the
+    # verdict resting on that choice. Re-gating costs no rollouts, so there is no reason not to
+    # check; a verdict that flips is not evidence, whatever the picked replicate showed.
+    if args.gate_against == "control" and len(ctl_tags) > 1:
+        for r in rows:
+            if r["tag"] in ctl_tags or r.get("reward") is None:
+                continue
+            by_ref = {}
+            for ref in ctl_tags:
+                g = _gate(Path(args.run_dir), r["tag"], args.k_se, args.mode,
+                          args.veto_regressions, current=ref)
+                by_ref[ref] = g.get("verdict")
+            r["verdict_by_reference"] = by_ref
+            verdicts = {v for v in by_ref.values() if v is not None}
+            r["verdict_stable"] = (len(verdicts) <= 1)
+            if not r["verdict_stable"]:
+                r["verdict"] = "inconclusive"
+
     ctl = next((r for r in rows if r["tag"] == CTL), None)
     # The floor must be the control's delta against the STORED parent, never against whatever
     # this round gated on. With --gate-against control the control IS the reference, so
@@ -335,6 +356,11 @@ def main(argv=None) -> int:
                       "reward and carry its drift"),
         },
         "reading": (
+            "A candidate marked `verdict_stable: false` has an UNSTABLE verdict and is "
+            "INCONCLUSIVE, never accepted: its "
+            "verdict changed depending on which byte-identical control replicate happened to be "
+            "the reference, so the round cannot tell its edit from re-measurement. Re-run it "
+            "with more trials before believing either answer. "
             "Judge every candidate's delta against `evidence_bar`, not against any other number "
             "here. `noise_floor_from_control` is the gap between a byte-identical control "
             "measured now and the parent's STORED reward: that is re-measurement DRIFT, and it "

--- a/skills/algorithms/agent-optimize/scripts/round.py
+++ b/skills/algorithms/agent-optimize/scripts/round.py
@@ -260,6 +260,29 @@ def main(argv=None) -> int:
         "control_replicates": ctl_rows,
         "next": "read regressions, then commit.py --decision accept|reject per candidate",
     }
+    # Persist the table as well as printing it. Until now the ONLY copy lived on stdout, so
+    # whether a round's verdict survived depended on the driver remembering to redirect —
+    # and on run 32814848187 the round that was abandoned was only reconstructible because
+    # the driver happened to have redirected it to a name someone guessed. A round's gate
+    # result is the run's evidence; it should not be optional.
+    #
+    # Per-iteration name for the same reason `control_tag` is per-iteration: a fixed name
+    # would let each round destroy the previous round's table. A same-iteration re-run gets a
+    # suffix rather than overwriting, since a re-gate is usually being COMPARED with the
+    # first one.
+    try:
+        work.mkdir(parents=True, exist_ok=True)
+        stem = f"round_i{int(run_dir.spent.iterations)}"
+        table = work / f"{stem}.json"
+        n = 1
+        while table.exists():
+            table = work / f"{stem}.r{n}.json"
+            n += 1
+        table.write_text(json.dumps(out, indent=2), encoding="utf-8")
+        out["table_path"] = str(table)
+    except OSError as exc:  # noqa: BLE001 — the printed table is still the primary output
+        out["table_write_error"] = str(exc)
+
     print(json.dumps(out, indent=2))
     return 0
 

--- a/skills/algorithms/agent-optimize/scripts/round.py
+++ b/skills/algorithms/agent-optimize/scripts/round.py
@@ -161,7 +161,6 @@ def main(argv=None) -> int:
         }, indent=2))
         return 2
 
-
     run_dir = RunDir.open(Path(args.run_dir))
     project = Path(args.project)
     work = Path(args.run_dir) / "work"

--- a/skills/algorithms/agent-optimize/scripts/round.py
+++ b/skills/algorithms/agent-optimize/scripts/round.py
@@ -38,6 +38,12 @@ import _bootstrap  # noqa: F401  # side-effect import: seeds sys.path for cap_ev
 
 from cap_evolve import RunDir, harness
 
+#: Gate measurement concurrency. The default is deliberately low; the ceiling is where the
+#: measured degradation is established (~0.08 at the arm level above 25, ~0.03 at 8), so above
+#: it a verdict cannot resolve the effect the round is looking for and the round is refused.
+DEFAULT_CONCURRENCY = 8
+MAX_RESOLVING_CONCURRENCY = 25
+
 HERE = Path(__file__).resolve().parent
 SKILLS = Path(os.environ.get("CAPEVOLVE_SKILLS_DIR", HERE.parents[2]))
 
@@ -102,7 +108,7 @@ def main(argv=None) -> int:
     p.add_argument("--k-se", type=float, default=1.0)
     p.add_argument("--mode", default="paired")
     p.add_argument("--split", default="val")
-    p.add_argument("--concurrency", type=int, default=8,
+    p.add_argument("--concurrency", type=int, default=DEFAULT_CONCURRENCY,
                    help="rollout concurrency per eval process (total = this x n_tags). Default "
                         "8, deliberately LOW, because the noise this script exists to expose is "
                         "largely load-induced and therefore fixable. Measured on byte-identical "
@@ -126,9 +132,35 @@ def main(argv=None) -> int:
                         "controls on identical seeds differed by 0.0800 paired on this "
                         "benchmark, enough to pass the gate on their own. The gap between the "
                         "replicates is the round's real bar.")
+    p.add_argument("--allow-high-concurrency", action="store_true",
+                   help="run the gate above MAX_RESOLVING_CONCURRENCY anyway. An explicit, "
+                        "recorded choice: the verdicts cannot resolve a small effect")
     p.add_argument("--no-control", action="store_true",
                    help="skip the null control (NOT recommended — you lose the noise floor)")
     args = p.parse_args(argv)
+
+    # A gate too coarse to resolve its own verdict is refused, not warned about. Measured on
+    # run 32861747778: the driver gated at --concurrency 100 after SKILL.md had told it "do not
+    # raise it to buy wall clock", and this script's own table then carried "a verdict from this
+    # round can therefore not resolve an effect smaller than roughly 0.08" while the run
+    # continued and booked decisions anyway. The skill's own edit-form rule applies to the
+    # skill: where the agent has the criterion and violates it regardless, the form that works
+    # is a guard in the code, not a third restatement in prose. Refusal (not a silent clamp) is
+    # already this script's idiom for an incoherent request — see --gate-against control
+    # --no-control below.
+    if args.concurrency and args.concurrency > MAX_RESOLVING_CONCURRENCY \
+            and not args.allow_high_concurrency:
+        print(json.dumps({
+            "error": f"--concurrency {args.concurrency} exceeds {MAX_RESOLVING_CONCURRENCY}: "
+                     "byte-identical code at identical seeds moves ~0.08 at this load versus "
+                     "~0.03 at 8, so no verdict from the round could resolve an effect smaller "
+                     "than the noise the concurrency itself adds",
+            "fix": f"re-run with --concurrency {DEFAULT_CONCURRENCY} (buy wall clock with "
+                   "fewer candidates per round, not with load), or pass "
+                   "--allow-high-concurrency to record the trade deliberately",
+        }, indent=2))
+        return 2
+
 
     run_dir = RunDir.open(Path(args.run_dir))
     project = Path(args.project)

--- a/skills/optimizers/registry.yaml
+++ b/skills/optimizers/registry.yaml
@@ -15,6 +15,11 @@
 #   install_url      : where to get the CLI (printed when it is not on PATH).
 #   auth_notes       : one-line auth hint.
 #   json_flag        : extra flag(s) to request machine-readable output, or "".
+#   transcript_flag  : OPTIONAL. flag(s) requesting a TURN-BY-TURN stream (every message and
+#                      tool call), used INSTEAD of json_flag when the caller passes
+#                      --transcript. Its last line must still be the result object json_flag
+#                      would have produced, so cost/stop parsing is unchanged. Omit for a CLI
+#                      with no streaming mode — --transcript then records whatever it printed.
 #   budget_flag      : flag(s) with a {budget} placeholder to cap one optimization
 #                      iteration's work (e.g. claude --max-turns N), or "" if the CLI
 #                      has no such knob. Appended only when run-optimizer gets --budget.
@@ -80,6 +85,14 @@ claude-code:
   install_url: "https://docs.claude.com/claude-code"
   auth_notes: "Logged-in Claude Code session or ANTHROPIC_API_KEY."
   json_flag: "--output-format json"
+  # `--output-format json` returns ONE result object: the final text, num_turns, cost. It does
+  # NOT contain the turns, so a run that stalls mid-loop leaves nothing to diagnose with — on
+  # run 32814848187 four hours of wall clock had to be inferred from event timestamps because
+  # the only record kept was an 800-char stdout tail. stream-json emits every message and tool
+  # call, and its LAST line is the same result object, so cost + stop parsing are unaffected.
+  # Separate key, not a change to json_flag: only a caller that asks for a transcript pays the
+  # extra output, so the deterministic per-iteration path is untouched.
+  transcript_flag: "--output-format stream-json --verbose"
   budget_flag: "--max-turns {budget}"
   usd_budget_flag: "--max-budget-usd {usd}"   # native per-iteration $ cap (works with -p/--print)
   offline: "false"

--- a/skills/optimizers/run-optimizer/scripts/run.py
+++ b/skills/optimizers/run-optimizer/scripts/run.py
@@ -173,6 +173,24 @@ def parse_cost(stdout: str) -> dict:
     return out
 
 
+#: Keys a headless agent CLI uses to say how a run ended. Vendor-neutral, like parse_cost:
+#: Claude Code's `--output-format json` result carries ``subtype`` (e.g. ``success`` /
+#: ``error_max_turns``), ``num_turns`` and ``is_error``; other CLIs use a subset or none.
+_STOP_KEYS = ("subtype", "num_turns", "is_error", "duration_ms", "stop_reason")
+
+
+def _stop_info(raw) -> dict:
+    """Lift the stop/termination fields out of a parsed agent result, if present.
+
+    Returns ``{}`` when the output carried none, so the key is simply absent rather than
+    present-and-empty — a caller can then tell "this CLI does not report it" from "it reported
+    a clean finish".
+    """
+    if not isinstance(raw, dict):
+        return {}
+    return {k: raw[k] for k in _STOP_KEYS if raw.get(k) is not None}
+
+
 def build_command(template: str, *, workdir: str, prompt: str, prompt_text: str,
                   model: str | None, self_dir: str) -> list[str]:
     """Expand the template into argv.
@@ -323,6 +341,14 @@ def main(argv=None) -> int:
             # Headless output wasn't parseable — say so; the loop falls back to no-cost.
             result["cost"]["note"] = ("no total_cost_usd in optimizer output; "
                                       "loop continues without a cost figure")
+        # WHY the agent stopped, from the same parsed object. An exit code of 0 covers both
+        # "finished the work" and "hit --max-turns with work outstanding", and those demand
+        # opposite responses from the caller. Reconstructing the difference from an 800-char
+        # stdout tail is what a caller had to do before this, on a run where the agent stopped
+        # mid-round with its best candidate evaluated and never committed.
+        stop = _stop_info(cost.get("raw"))
+        if stop:
+            result["stop"] = stop
     print(json.dumps(result))
     return proc.returncode
 

--- a/skills/optimizers/run-optimizer/scripts/run.py
+++ b/skills/optimizers/run-optimizer/scripts/run.py
@@ -176,7 +176,12 @@ def parse_cost(stdout: str) -> dict:
 #: Keys a headless agent CLI uses to say how a run ended. Vendor-neutral, like parse_cost:
 #: Claude Code's `--output-format json` result carries ``subtype`` (e.g. ``success`` /
 #: ``error_max_turns``), ``num_turns`` and ``is_error``; other CLIs use a subset or none.
-_STOP_KEYS = ("subtype", "num_turns", "is_error", "duration_ms", "stop_reason")
+_STOP_KEYS = ("subtype", "num_turns", "is_error", "duration_ms", "stop_reason",
+              # Verified present on Claude Code 2.1.241's result event. `terminal_reason` names
+              # the terminating condition outright, and `permission_denials` catches the case
+              # where the agent was blocked by the tool allowlist rather than by its own
+              # judgement — indistinguishable from a voluntary stop without it.
+              "terminal_reason", "permission_denials")
 
 
 def _stop_info(raw) -> dict:
@@ -189,6 +194,51 @@ def _stop_info(raw) -> dict:
     if not isinstance(raw, dict):
         return {}
     return {k: raw[k] for k in _STOP_KEYS if raw.get(k) is not None}
+
+
+#: Env vars whose VALUES must never reach a persisted transcript. A transcript records tool
+#: results verbatim, so one `env` or `printenv` the agent happened to run would otherwise put a
+#: gateway token into a CI artifact. Redacting the values (not the names) mirrors what the CI
+#: log scrubber does, and costs one pass over the text.
+_SECRET_ENV = ("ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL",
+               "OPENAI_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY", "GH_TOKEN",
+               "GITHUB_TOKEN")
+
+
+def _redact(text: str, extra_keys=()) -> str:
+    """Replace the VALUES of sensitive env vars with ``***``.
+
+    Only values of length 8 or more are substituted: a short or empty value would match
+    everywhere and turn the transcript into noise.
+    """
+    for key in (*_SECRET_ENV, *extra_keys):
+        val = os.environ.get(key) or ""
+        if len(val) >= 8:
+            text = text.replace(val, f"***{key}***")
+    return text
+
+
+def write_transcript(path: str, stdout: str, stderr: str, *, extra_keys=()) -> dict:
+    """Persist the agent CLI's full output next to the run it belongs to.
+
+    Returns ``{path, bytes, lines}`` — or ``{error}``; never raises, because losing the
+    transcript must not lose the run. ``stdout_tail`` in the result stays as it was, so a
+    caller that only reads the JSON payload is unaffected.
+    """
+    try:
+        dest = Path(path)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        body = _redact(stdout, extra_keys)
+        dest.write_text(body, encoding="utf-8")
+        info = {"path": str(dest), "bytes": len(body.encode("utf-8")),
+                "lines": body.count("\n")}
+        if stderr.strip():
+            err = dest.with_suffix(dest.suffix + ".stderr")
+            err.write_text(_redact(stderr, extra_keys), encoding="utf-8")
+            info["stderr_path"] = str(err)
+        return info
+    except OSError as exc:
+        return {"error": f"could not write transcript to {path}: {exc}"}
 
 
 def build_command(template: str, *, workdir: str, prompt: str, prompt_text: str,
@@ -241,6 +291,11 @@ def main(argv=None) -> int:
                    help="per-iteration USD cap rendered into the row's usd_budget_flag "
                         "(e.g. claude-code → --max-budget-usd N), enforced by the optimizer "
                         "CLI itself; ignored if the row has none (e.g. ibm-bob)")
+    p.add_argument("--transcript", default=os.environ.get("CAPEVOLVE_OPTIMIZER_TRANSCRIPT"),
+                   help="write the agent CLI's FULL output here (secret values redacted). "
+                        "When the registry row has a transcript_flag it is used instead of "
+                        "json_flag, so the record contains every turn and tool call rather "
+                        "than only the final result object")
     p.add_argument("--list", action="store_true", help="list known optimizers and exit")
     args = p.parse_args(argv)
 
@@ -284,6 +339,13 @@ def main(argv=None) -> int:
     # silently stays prose-fed even with --json.
     want_json = bool(args.json)
     json_flag = str(row.get("json_flag", "")).strip()
+    # A transcript needs the turn-by-turn stream, whose last line is the same result object
+    # json_flag yields — so it SUPERSEDES json_flag rather than adding to it (passing two
+    # --output-format flags is an error). A row without a transcript_flag keeps json_flag and
+    # --transcript simply records whatever that printed.
+    if args.transcript and str(row.get("transcript_flag", "")).strip():
+        json_flag = str(row["transcript_flag"]).strip()
+        want_json = True
     if want_json and json_flag and str(row.get("offline", "")).lower() != "true":
         cmd += shlex.split(os.path.expandvars(json_flag))
         # Claude Code: pair --output-format json with --json-schema for .structured_output.
@@ -334,6 +396,10 @@ def main(argv=None) -> int:
     # Best-effort cost capture: only when --json requested AND the row had a json_flag.
     # The prose-fed path (no --json, or empty json_flag) never reaches here, so the
     # offline/mock and generic flows are unchanged.
+    if args.transcript:
+        result["transcript"] = write_transcript(
+            args.transcript, proc.stdout, proc.stderr,
+            extra_keys=tuple(str(row.get("env_keys", "")).replace(",", " ").split()))
     if want_json and json_flag:
         cost = parse_cost(proc.stdout)
         result["cost"] = {"total_cost_usd": cost["usd"], "tokens": cost["tokens"]}


### PR DESCRIPTION
Makes `agent-optimize` actually usable unattended. It was reachable from CI but running blind: the hosted agent got no capability guidance, no honest stop diagnosis, and no record of what it did — so three consecutive smoke runs each failed a different way and none of them could be diagnosed from their own artifacts.

Every change here is tied to a measured run ID rather than a hypothesis. **16 commits, 17 files, +2919/−87.**

## Core changes

**The hosted agent could not really edit anything but prose.** `harness.OptimizerContext` exists so that *"an algorithm cannot silently run on a thinner prompt than its siblings"* — it stages each declared capability's skill, the diagnose method, `capability_sources` and the agent's features reference. Every deterministic algorithm calls `inject()`. **The host did not** — so the agent had guidance for editing prose and none at all for editing tool code, and did what it had guidance for: 4 of 4 candidates across runs [32649063850](https://github.com/skillberry-ai/cap-evolve/actions/runs/32649063850) and [32653934804](https://github.com/skillberry-ai/cap-evolve/actions/runs/32653934804) touched only `policy/policy.md`, on a `[system-prompt, tools]` capability with `tools/tools.py` writable and unopened. Naming the files in the briefing had already been tried and had already failed — run 32653934804's own prompt said *"ALL 3 of these files … every one is fair game"*. `test_optimizer_context_parity.py` had named this hole in its own docstring: an algorithm absent from `ALGORITHMS` *"can still run blind while this file stays green."*

The host now stages `guidance/{system-prompt,tools,diagnose,optimizer}/` and `.claude/skills/{…}/`, via a new `OptimizerContext.from_spec()` plus four public prompt-block accessors (`capability_brief`, `reader_brief`, `empty_seed_brief`, `render_template`) — composed rather than calling `instructions()`, whose per-iteration contract ("fix this ONE candidate and STOP; the harness re-scores you") is false for an agent that owns the search, the evaluation and the gate. `specfile.resolve_instructions_file()` extracts the `optimizer_instructions_file` resolution rule that `cli.py` held inline; two copies of that rule is how #252 happened. **`harness.py` and `specfile.py` are purely additive** — `instructions()` and `inject()` are untouched. Staging success is reported and warned on, because silent-off is indistinguishable from working while quietly optimizing less surface, which is how this survived two runs. A *declared* capability with no matching skill package is now reported too (`guidance_missing` + a warning) — the partial case of the same defect.

**Honest measurement and honest reporting.** The host guarantees a seal, reports why the agent stopped (`stop_reason`, `agent_stop_reason`, `num_turns`, `rounds_booked`) and flags a run that stopped with rounds left, with **per-cause** advice — a turn-starved agent gets "raise the turn budget", one that sealed itself gets "unspent budget, not a dead loop". It puts the correct interpreter first on the agent's `PATH`: every candidate eval in run [32861747778](https://github.com/skillberry-ai/cap-evolve/actions/runs/32861747778) died `ModuleNotFoundError` because the adapter's deps live in one venv that CI's `PATH` never contains, while SKILL.md tells the agent to run bare `python`. `round.py` persists its gate table instead of leaving stdout the only copy, refuses a concurrency too coarse to resolve its own verdict (the agent set 100 *after* being told not to — a guard in code beats a third restatement in prose), separates `parent` from `gate_reference` and reports `parent_vs_gate_ref_drift`, emits one `evidence_bar` matched to how it gated, marks a verdict that flips across control replicates as `inconclusive`, and shows the drift-free comparison a parent-gated round already paid to measure. `commit.py` refuses `--reject-basis gate` when the gate actually **accepted** — run 32871360361's audit log claimed the gate had rejected its best candidate when the driver had overridden it — adding `driver_judgement` for honest overrides and recording `gate_verdict`/`overrode_gate` on every decision.

## CI changes

`run_suite.sh`: **(a)** drops the stop-on-two-consecutive-rejections clause, which fired exactly where the algorithm prescribes *escalation* — on run 32701056043 the agent rejected two prose candidates and quit before trying the code-level guard its own reject note had already named; **(b)** raises the agent-mode turn budget to `max(optimizer_max_turns, 150) × (rounds + 1)`, measured from run 32733635494, which consumed ~126 turns/round and died on `error_max_turns` having just evaluated the best candidate of the run and never reached the `commit.py` that would have booked it; **(c)** copies `$RUN_DIR/host/` into the uploaded artifact, gzipping the transcript — the artifact path is `$OUT/**` while the run dir reaches it only via `export_static`, which caps every file at 256 KiB and keeps the *first* chunk. The real transcript was 1.9 MB and the answer was in the last 12%.

`run-optimizer` gains an opt-in `--transcript`, and the registry a `transcript_flag` (`--output-format stream-json --verbose`, verified against Claude Code 2.1.241 before being trusted to a multi-hour run — its last line is the same result object, so cost and stop parsing are unchanged). **`cli.py` never passes `--transcript`, so the deterministic path's `--output-format json` is untouched.** Secret values are scrubbed before the file is written, since a transcript records tool results verbatim and the run dir is a published artifact.

`benchmarks.yml` makes the `iterations` input reachable on smoke. The old expression put `matrix.tier == 'smoke' && '3'` first and GitHub's `||` short-circuits, so a dispatch of `iterations=10` on smoke silently ran 3 — discoverable only by reading `ITERATIONS` in the job log after the budget had been spent. It now mirrors the pattern `NUM_TRIALS` already used, input default `""` included. Blank dispatch and PR-label runs are byte-identical to before (smoke 3, others 10).

## Verified end to end

Run [32871360361](https://github.com/skillberry-ai/cap-evolve/actions/runs/32871360361) — smoke tau2, 10 iterations, 10 trials:

| check | result |
|---|---|
| rounds booked, none abandoned | 4/4, `unbooked_rounds: []` |
| accept **and** reject both booked | 3 rejects + 1 accept |
| `best_id` moves | seed → cand4 |
| evals clean, concurrency ≤ 25 | 8 throughout |
| not turn-limited | 121 / 1650 |
| sealed exactly once, by the agent | `seal: agent` |
| transcript readable in the artifact | 552 KB gz / 1.9 MB |

**Result: test 0.40 → 0.53 (+0.13), sealed once.** Mechanism traced, not inferred: the agent found tasks 22 and 40 failing identically (it yields a confirmation summary, the user replies `Yes.###STOP###`, the episode ends before the DB write), wrote a turn-economy policy rule, and **task 40 went 0.10 → 1.00**. It also reasoned about *which surface* to edit — *"a code guard can't fix a 'the agent never called any tool' failure, so policy is the correct surface"* — which is the staged guidance doing its job.

## Testing

**995 passed, 2 skipped, 1 failed.** The failure (`test_cli_surface.py::test_spec_defaults_relative_to_project_not_the_cwd`, a `run-optimizer` manifest lookup) reproduces identically on a clean `origin/main` worktree — pre-existing and unrelated. ~1500 lines of new tests across 4 files, each pinning a specific measured failure. Skill `check.py`, authoring lint and `actionlint` green; `check.py` caught two defects in this PR's own changes, which is its job.

## Reviewer notes

- **Blast radius:** everything behavioural is gated behind `ALGORITHM=agent-optimize` / `ORCH_MODE=agent` / `[ -d $RUN_DIR/host ]`. `agent-optimize` is dispatch-only and not in `OPTIMIZER_CONTEXT_ALGORITHMS` (`{hill-climb, gepa, skillopt}`). `round.py`/`commit.py` have no callers outside the skill; `run-optimizer`'s diff has zero removed lines.
- **One behaviour change reaching non-agent runs:** in `cli.py`, a *missing default* `optimizer/INSTRUCTIONS.md` no longer warns — only a spec-**named** missing file does. Deliberate and documented, but it is one fewer diagnostic line for `hill-climb`/`gepa`/`skillopt`.
- **Not CI-validated:** commits `21e41c3a`…`183b6105` are reporting-layer changes made while run 32871360361 was in flight. They are covered by unit tests and by `check.py` executing `round.py`/`commit.py` against a real run dir in both gate modes, but have not run against a live agent. They add fields and read-only re-gates rather than changing decisions.

## Measurement finding worth recording separately

On tau2 smoke the **same seed bytes** scored **0.24 / 0.44 / 0.38** across three runs in one day (sd 0.103, range 0.20) — roughly **3.7× the `gate_k_se=1.0` acceptance bar**. Within one run, byte-identical control replicates measured two minutes apart read 0.32 and 0.20. The default `--gate-against parent` compares against a *stored* reward, so that drift lands inside every accept/reject; `--gate-against control` pairs against a concurrently-measured control and removes it. This PR makes the drift visible per round but **deliberately does not change the default gate mode** — doing so on one benchmark's evidence would be a guess about every other workload. Two follow-ups worth considering on their own merits: raising `gate_k_se` on this tier, and telling the agent to prefer control-mode gating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
