### PR TITLE
agent-optimize: statistical-rigor fixes, /goal enforcement, compliance logging, tau2 STOP-leak fix (#401)

### DIFF
--- a/core/cap_evolve/constraints.py
+++ b/core/cap_evolve/constraints.py
@@ -13,8 +13,12 @@ predicates against the run dir's persisted spend every round.
 Two functions, both pure and stdlib-only:
 
   * :func:`parse_constraints` — text → ``{"predicates": [...], "ambiguous": [...],
-    "text": "<verbatim>"}``. The original prose is always carried alongside, because a
-    parser that silently drops half a sentence is worse than no parser.
+    "unenforceable": [...], "text": "<verbatim>"}``. The original prose is always carried
+    alongside, because a parser that silently drops half a sentence is worse than no
+    parser. ``unenforceable`` is a clause-level list of prose this parser recognized NO
+    numeric/task-protection pattern in at all (a behavioral instruction like "use
+    screen.py before paying for full val") — distinct from ``ambiguous``, which is a
+    number this parser SAW but could not resolve (no unit, vague magnitude).
   * :func:`check_constraints` — predicates + measured actuals → per-predicate
     satisfied/violated + one ``stop | continue | narrow_scope`` recommendation.
 
@@ -229,6 +233,28 @@ def parse_constraints(text: str | None) -> dict:
                                  "enforces totals, so the run is effectively unbounded in $. "
                                  "Ask for a total, or set max_usd in the spec"})
 
+    # --- unenforceable prose -------------------------------------------------
+    # A clause with a NUMBER but no recognized unit is already loud (the "no recognized
+    # unit" branch above). A clause with NO number at all — a behavioral instruction like
+    # "use screen.py before paying for full val each round" — matches none of the numeric/
+    # protection patterns above and was, until now, silently dropped: neither enforced nor
+    # reported, so a driver had no way to tell "the framework checked this and it's fine"
+    # from "the framework never saw this at all". Purely mechanical: split on clause
+    # boundaries and report any clause none of the predicates/ambiguous entries above were
+    # extracted from — never an attempt to enforce the prose itself.
+    _covered = [str(p.get("source", "")).lower() for p in preds] + \
+        [str(a.get("span", "")).lower() for a in ambiguous if isinstance(a, dict)]
+    unenforceable: list = []
+    for clause in re.split(r"[;,.]\s+|\s+\band\b\s+|\s+\bor\b\s+", raw.strip()):
+        clause = clause.strip().strip(".,;")
+        if len(clause) < 8:  # too short to be a real, checkable instruction
+            continue
+        cl = clause.lower()
+        if any(span and span in cl for span in _covered):
+            continue
+        if clause not in unenforceable:
+            unenforceable.append(clause)
+
     # Tighten duplicates.
     out: list = []
     seen: dict = {}
@@ -251,7 +277,8 @@ def parse_constraints(text: str | None) -> dict:
         seen[k] = p
         out.append(p)
 
-    return {"text": raw, "predicates": out, "ambiguous": ambiguous}
+    return {"text": raw, "predicates": out, "ambiguous": ambiguous,
+            "unenforceable": unenforceable}
 
 
 def cost_target(target: float, per_task_ceiling: dict) -> dict:
@@ -386,5 +413,6 @@ def check_constraints(
         "recommendation": rec,
         "reasons": stop_reasons or warn_reasons,
         "ambiguous": parsed.get("ambiguous") or [],
+        "unenforceable": parsed.get("unenforceable") or [],
         "stop_condition_text": parsed.get("text", ""),
     }

--- a/core/cap_evolve/constraints.py
+++ b/core/cap_evolve/constraints.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 
 import re
 
-__all__ = ["parse_constraints", "check_constraints"]
+__all__ = ["parse_constraints", "check_constraints", "cost_target"]
 
 #: Recognized kinds. ``max_*`` are ceilings (violated when actual >= target);
 #: ``target_val_score`` is a goal (satisfied when actual >= target).
@@ -254,6 +254,41 @@ def parse_constraints(text: str | None) -> dict:
     return {"text": raw, "predicates": out, "ambiguous": ambiguous}
 
 
+def cost_target(target: float, per_task_ceiling: dict) -> dict:
+    """Cost a ``target_val_score`` against measured per-task headroom before accepting it.
+
+    ``per_task_ceiling`` maps ``task_id -> highest rate that task can structurally reach``
+    (e.g. ``min(0.95, measured_component_cap)`` — a task whose COMMUNICATE component rate
+    measures 0.667 cannot reach 1.0 no matter what a capability edit does). The costed
+    ceiling is the mean of those caps, i.e. ``1 - sum(1 - ceiling_t) / n``: the score no
+    capability edit can exceed. A target above it is not a capability problem and should be
+    renegotiated with the user rather than chased with more iterations.
+
+    Motivating case: docs/TAU2_SUMMARY.md's own ceiling analysis found a ≈0.92 ceiling set by
+    three tasks capped by things no edit could touch (a leaking user simulator, two
+    COMMUNICATE-component rates) — two points of slack a 90%-target run had no way to close.
+    """
+    if not per_task_ceiling:
+        return {"target": float(target), "feasible": None,
+                "reason": "no per-task ceiling data — cannot cost this target"}
+    ceiling = sum(per_task_ceiling.values()) / len(per_task_ceiling)
+    feasible = float(target) <= ceiling + 1e-9
+    return {
+        "target": float(target),
+        "costed_ceiling": round(ceiling, 4),
+        "headroom": round(ceiling - float(target), 4),
+        "feasible": feasible,
+        "reason": (
+            f"target {float(target):.4f} is "
+            f"{'within' if feasible else 'ABOVE'} the costed ceiling {ceiling:.4f} "
+            f"(mean of {len(per_task_ceiling)} per-task caps) — "
+            + ("reachable by a capability edit" if feasible else
+               "NOT reachable by any capability edit; renegotiate the target or the caps "
+               "before spending more budget chasing it")
+        ),
+    }
+
+
 def check_constraints(
     parsed: dict,
     *,
@@ -265,6 +300,7 @@ def check_constraints(
     metric_calls: int = 0,
     regressed_tasks: list | None = None,
     warn_frac: float = 0.8,
+    per_task_ceiling: dict | None = None,
 ) -> dict:
     """Check every parsed predicate against MEASURED actuals from the run dir.
 
@@ -315,9 +351,17 @@ def check_constraints(
         elif kind == "target_val_score":
             actual = None if best_val is None else float(best_val)
             met = actual is not None and actual >= float(p["target"]) - 1e-9
-            rows.append({**p, "actual": actual, "satisfied": met, "violated": False,
-                         "note": "checked on the FULL-val mean only; a subset screen "
-                                 "can never satisfy this"})
+            row = {**p, "actual": actual, "satisfied": met, "violated": False,
+                   "note": "checked on the FULL-val mean only; a subset screen "
+                           "can never satisfy this"}
+            if per_task_ceiling:
+                cost = cost_target(float(p["target"]), per_task_ceiling)
+                row["cost"] = cost
+                if cost.get("feasible") is False:
+                    warn_reasons.append(
+                        f"target_val_score {p['target']:.4f} is above the costed ceiling "
+                        f"{cost['costed_ceiling']:.4f} — not reachable by any capability edit")
+            rows.append(row)
             if met:
                 stop_reasons.append(f"score goal met on full val "
                                     f"({actual:.4f} >= {p['target']:.4f})")

--- a/core/cap_evolve/dashboard.py
+++ b/core/cap_evolve/dashboard.py
@@ -337,7 +337,7 @@ _ALGO_MARKERS = (
 #: ``skillopt_step`` is the one kind deliberately absent, and for a different reason —
 #: it is not a legacy record but epoch DETAIL logged alongside a ``step`` for the same
 #: candidate on the same (current) runs, so it never carried a graph anyone needs.
-_STEP_KINDS = ("step", "gepa_val_gate", "accept", "reject")
+_STEP_KINDS = ("step", "gepa_val_gate", "accept", "reject", "provisional")
 
 #: Kinds whose presence means "this candidate was accepted" without an ``accept`` field.
 _ACCEPT_KINDS = ("accept",)
@@ -780,7 +780,14 @@ def reduce_run(run_dir) -> dict:
         # not a rejection and not a failure: the gate declined to judge, so the edit's
         # quality is unknown. Collapsing it into "rejected" (the old behaviour) told
         # the reader a measured verdict existed when none did.
-        if cid in indecisive_ids:
+        if kind == "provisional":
+            # Directionally positive (Δ>0) but not yet gate-significant, and the driver
+            # chose to buy more trials on this SAME candidate (scripts/grow.py) instead of
+            # a final accept/reject — neither "accepted" nor "rejected" describes that, and
+            # falling through to the accepted/rejected branch below would misreport it as
+            # one or the other while it is still pending.
+            status = "provisional"
+        elif cid in indecisive_ids:
             status = "indecisive"
         elif val is None and not per and kind not in ("accept", "reject"):
             # ``failed`` means NO VERDICT AND NO MEASUREMENT — a step that produced
@@ -1063,6 +1070,7 @@ def reduce_run(run_dir) -> dict:
         reason = str(n.get("reason") or "")
         verdict = ("accept" if n["status"] == "accepted"
                    else "indecisive" if n["status"] == "indecisive"
+                   else "provisional" if n["status"] == "provisional"
                    else "reject" if n["status"] == "rejected" else "no measurement")
         gs = n.get("gate_stats") or {}
         m_delta = re.search(r"Δ̄?\s*=\s*([+-]?\d*\.?\d+)", reason)
@@ -2091,7 +2099,7 @@ function dsecs(v){v=Math.max(0,Math.round(v||0));if(v<60)return v+'s';
   t2.append($('tr',{},$('th',{text:'iter'}),$('th',{text:'candidate'}),$('th',{text:'verdict'}),
     $('th',{class:'r',text:'val'}),$('th',{class:'r',text:'parent val'}),$('th',{class:'r',text:'Δ̄'}),
     $('th',{class:'r',text:'SE'}),$('th',{class:'r',text:'n'}),$('th',{class:'r',text:'bar (k·SE)'})));
-  const BADGE={accept:'b-accepted',reject:'b-rejected',indecisive:'b-indecisive'};
+  const BADGE={accept:'b-accepted',reject:'b-rejected',indecisive:'b-indecisive',provisional:'b-indecisive'};
   const n4=v=>v==null?'—':(+v).toFixed(4);
   D.forEach(d=>{
     t2.append($('tr',{},

--- a/core/cap_evolve/dashboard.py
+++ b/core/cap_evolve/dashboard.py
@@ -842,6 +842,13 @@ def reduce_run(run_dir) -> dict:
             "broke": movement.get("broke") or [],
             "parent_val": parent_val,
             "best_so_far": best,
+            # Structured gate numbers agent-optimize's commit.py attaches to the step/accept/
+            # reject event (delta/threshold/stderr/n/k_se/resolvable_effect_size), in addition
+            # to the prose reason above. None for any algorithm/event that doesn't carry them —
+            # the gate_decisions block below falls back to regex-parsing `reason` in that case.
+            "gate_stats": {k: ev.get(k) for k in
+                          ("delta", "threshold", "stderr", "n", "k_se",
+                           "resolvable_effect_size") if ev.get(k) is not None} or None,
         }
         if "epoch" in ev:
             node["epoch"] = ev.get("epoch")
@@ -1044,9 +1051,12 @@ def reduce_run(run_dir) -> dict:
         })
 
     # --- gate decisions (accept / reject / INDECISIVE, with Δ̄, SE, n) -----
-    # The reason string the gate wrote is the audit record; Δ̄/SE/n are parsed back out
-    # of it so the UI can show the uncertainty next to the mean instead of a bare Δ.
-    # A number that isn't in the reason stays None — never a fabricated 0.
+    # Real numbers first: agent-optimize's commit.py attaches structured gate fields
+    # (delta/threshold/stderr/n/k_se/resolvable_effect_size) straight from gate_check.py's
+    # own JSON via `node["gate_stats"]`. Only when a candidate carries none of those (any
+    # algorithm/event that predates or doesn't use that attachment) do we fall back to
+    # regex-parsing the reason string — the prior sole source, and fragile because it
+    # depended on the prose matching the deterministic gate's own wording.
     gate_decisions: list[dict] = []
     for n in sorted((x for x in nodes.values() if x["id"] != "seed"),
                     key=lambda x: x.get("iteration") or 0):
@@ -1054,6 +1064,7 @@ def reduce_run(run_dir) -> dict:
         verdict = ("accept" if n["status"] == "accepted"
                    else "indecisive" if n["status"] == "indecisive"
                    else "reject" if n["status"] == "rejected" else "no measurement")
+        gs = n.get("gate_stats") or {}
         m_delta = re.search(r"Δ̄?\s*=\s*([+-]?\d*\.?\d+)", reason)
         # The bar `0.2·SE=0.0062` comes FIRST in the reason and also matches `SE=`, so an
         # unanchored search put the bar's value in the SE column — the gate then appeared
@@ -1069,11 +1080,17 @@ def reduce_run(run_dir) -> dict:
             "val": n.get("val"),
             "parent": n.get("parent"),
             "parent_val": n.get("parent_val"),
-            "delta": float(m_delta.group(1)) if m_delta else None,
-            "stderr": float(m_se.group(1)) if m_se else None,
-            "n": int(m_n.group(1)) if m_n else None,
-            "k_se": float(m_bar.group(1)) if m_bar else None,
-            "threshold": float(m_bar.group(2)) if m_bar else None,
+            "delta": gs.get("delta") if gs.get("delta") is not None
+                     else (float(m_delta.group(1)) if m_delta else None),
+            "stderr": gs.get("stderr") if gs.get("stderr") is not None
+                      else (float(m_se.group(1)) if m_se else None),
+            "n": gs.get("n") if gs.get("n") is not None
+                 else (int(m_n.group(1)) if m_n else None),
+            "k_se": gs.get("k_se") if gs.get("k_se") is not None
+                    else (float(m_bar.group(1)) if m_bar else None),
+            "threshold": gs.get("threshold") if gs.get("threshold") is not None
+                         else (float(m_bar.group(2)) if m_bar else None),
+            "resolvable_effect_size": gs.get("resolvable_effect_size"),
             "reason": _sanitize_text(reason, 600),
         })
 

--- a/core/cap_evolve/dashboard.py
+++ b/core/cap_evolve/dashboard.py
@@ -319,7 +319,8 @@ _ALGO_MARKERS = (
     # real agent-optimize run that logs only screen/accept/reject — the shape every
     # actual run has, since the agent drives the loop and emits no "agent_round" —
     # matched nothing and rendered as "algorithm not recorded" with no agent panels.
-    ("agent-optimize", ("agent_round", "agent_subset", "agent_optimize_step", "screen")),
+    ("agent-optimize", ("agent_round", "agent_subset", "agent_optimize_step", "screen",
+                        "agent_optimize_compliance")),
     ("hill-climb", ("convergence", "step")),
 )
 
@@ -1258,6 +1259,18 @@ def reduce_run(run_dir) -> dict:
         })
     if screens:
         algo_extra["screens"] = screens
+
+    # Compliance instrumentation (issue #401): whether screen.py ran on a candidate
+    # BEFORE its full-val eval this round — round.py logs one of these per candidate per
+    # round.py invocation. Surfaced as its own distinct dashboard entry so a real run's
+    # screen-then-full-val discipline (or the lack of it) is visible, not just inferable
+    # from SKILL.md prose.
+    compliance = [{"candidate": e.get("tag"), "iteration": e.get("iteration"),
+                   "screened_before_fullval": bool(e.get("screened_before_fullval")),
+                   "t": e.get("t")}
+                  for e in events if e.get("kind") == "agent_optimize_compliance"]
+    if compliance:
+        algo_extra["compliance"] = compliance
 
     evograph = _read_evograph(root)
     if evograph:

--- a/core/cap_evolve/gate.py
+++ b/core/cap_evolve/gate.py
@@ -33,6 +33,13 @@ class GateDecision:
     #: caller must not treat this as a content rejection: it should not count
     #: toward the stall counter and it says nothing about the candidate's quality.
     indecisive: bool = False
+    #: The smallest true effect this verdict could have resolved, i.e. ``2 * SE`` of the
+    #: measurement that produced ``delta``. ``None`` when no SE was computable (threshold/
+    #: strict modes, or too few paired samples). Reported so the driver reads "this round can
+    #: resolve ±X" BEFORE reading the delta — four runs of null results on tau2_airline were
+    #: read as "the edits were bad" when the gate simply could not resolve anything that small
+    #: (see docs/TAU2_SUMMARY.md).
+    resolvable_effect_size: float | None = None
 
     def to_dict(self) -> dict:
         return {
@@ -41,6 +48,7 @@ class GateDecision:
             "delta": self.delta,
             "threshold": self.threshold,
             "indecisive": self.indecisive,
+            "resolvable_effect_size": self.resolvable_effect_size,
         }
 
 
@@ -185,8 +193,9 @@ def decide(
             return GateDecision(
                 accept=ok,
                 reason=(f"paired Δ̄={mean_d:+.4f} {'>' if ok else '<='} {k_se}·SE={bar:.4f} "
-                        f"(SE={se:.4f}, n={n})"),
+                        f"(SE={se:.4f}, n={n}, resolvable effect size 2·SE={2 * se:.4f})"),
                 delta=mean_d, threshold=bar,
+                resolvable_effect_size=round(2 * se, 6),
             )
 
     if mode == "significant":
@@ -208,10 +217,11 @@ def decide(
             accept=ok,
             reason=(
                 f"Δ={delta:+.4f} {'>' if ok else '<='} {k_se}·SE={bar:.4f} "
-                f"(SE={se:.4f})"
+                f"(SE={se:.4f}, resolvable effect size 2·SE={2 * se:.4f})"
             ),
             delta=delta,
             threshold=bar,
+            resolvable_effect_size=round(2 * se, 6),
         )
 
     if mode == "threshold":

--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -1288,8 +1288,11 @@ def _inject_optimizer_context(adapter, run_dir: RunDir, workdir: Path, *, split:
             if not src.is_dir():
                 continue
             try:
+                dst = workdir / "guidance" / c
+                if dst.exists():
+                    shutil.rmtree(dst)
                 shutil.copytree(
-                    src, workdir / "guidance" / c,
+                    src, dst,
                     ignore=shutil.ignore_patterns("__pycache__", "scripts", "*.pyc"),
                 )
             except Exception as e:  # noqa: BLE001

--- a/core/cap_evolve/loop.py
+++ b/core/cap_evolve/loop.py
@@ -163,6 +163,47 @@ def aggregate_scores(split: str, scores: Sequence[Score], ks: Sequence[int] = (1
     )
 
 
+def pool_split_results(a: SplitResult, b: SplitResult, ks: Sequence[int] = (1, 2)) -> SplitResult:
+    """Pool two evaluations of the SAME unmodified candidate into one honest SplitResult.
+
+    For sequential evidence-gathering (agent-optimize's "provisional" candidates): growing
+    ``n`` on a candidate means running it again and POOLING the trials, not averaging two
+    separate verdicts — a paired significance test needs the combined per-task trial vector,
+    since averaging two means (or two SEs) understates the truth: two runs of 5 trials each
+    are one candidate measured at n=10, not two half-strength candidates.
+
+    Concatenates each shared task's ``trial_rewards`` (never just its mean) and
+    re-aggregates from scratch, so ``reward``/``stderr``/``pass_k`` on the result reflect
+    every trial actually run. A task present on only one side keeps only that side's
+    trials — nothing is discarded, nothing is invented.
+    """
+    by_task: dict[str, list[float]] = {}
+    feedback: dict[str, str] = {}
+    errored: dict[str, bool] = {}
+    errored_trials: dict[str, int] = {}
+    for res in (a, b):
+        for pt in (res.per_task or []):
+            tid = pt.get("task_id")
+            if tid is None:
+                continue
+            raw = pt.get("raw") or {}
+            trials = pt.get("trial_rewards") or []
+            by_task.setdefault(tid, []).extend(float(x) for x in trials)
+            if pt.get("feedback"):
+                feedback[tid] = pt["feedback"]
+            errored[tid] = errored.get(tid, False) or bool(raw.get("errored"))
+            errored_trials[tid] = errored_trials.get(tid, 0) + int(raw.get("errored_trials") or 0)
+    from .stats import mean, stderr
+    scores = [
+        Score(task_id=t, reward=mean(tr), feedback=feedback.get(t, ""),
+              n=len(tr), stderr=stderr(tr), trial_rewards=tr,
+              raw={"errored": errored.get(t, False), "errored_trials": errored_trials.get(t, 0),
+                   "valid_trials": len(tr), "n_trials": len(tr)})
+        for t, tr in by_task.items()
+    ]
+    return aggregate_scores(a.split or b.split, scores, ks=ks)
+
+
 # ---- parent selection over a frontier of candidates ------------------------
 
 def select_parent(

--- a/core/tests/test_agent_optimize_constraints.py
+++ b/core/tests/test_agent_optimize_constraints.py
@@ -68,7 +68,30 @@ def test_a_number_with_no_unit_is_flagged():
 
 def test_empty_condition_parses_to_nothing_without_complaining():
     p = parse_constraints("")
-    assert p["predicates"] == [] and p["ambiguous"] == []
+    assert p["predicates"] == [] and p["ambiguous"] == [] and p["unenforceable"] == []
+
+
+def test_behavioral_prose_with_no_number_is_reported_unenforceable_not_dropped():
+    """The live-run bug: a stop_condition mixing a real numeric ceiling with a
+    behavioral clause that has NO number at all ("use screen.py before paying for
+    full val each round") used to silently drop the second clause — neither enforced
+    nor visible anywhere, which is exactly the silent-drop this field exists to end."""
+    p = parse_constraints(
+        "stop after $40; use screen.py before paying for full val each round")
+    assert any(pr["kind"] == "max_usd" for pr in p["predicates"])
+    assert any("screen.py" in u for u in p["unenforceable"]), p["unenforceable"]
+
+
+def test_a_fully_numeric_condition_leaves_nothing_unenforceable():
+    p = parse_constraints("reach val mean >= 0.75, or stop after $40 / 90 minutes")
+    assert p["unenforceable"] == [], p["unenforceable"]
+
+
+def test_unenforceable_survives_into_the_check_payload():
+    from cap_evolve.constraints import check_constraints
+    p = parse_constraints("stop after $40; use screen.py before paying for full val")
+    r = check_constraints(p, usd=0.0)
+    assert any("screen.py" in u for u in r["unenforceable"]), r["unenforceable"]
 
 
 # ---- checking -------------------------------------------------------------

--- a/core/tests/test_agent_optimize_provisional.py
+++ b/core/tests/test_agent_optimize_provisional.py
@@ -1,0 +1,360 @@
+"""``provisional`` candidates: sequential evidence on the SAME candidate, not compounded
+edits (agent-optimize round 4).
+
+A candidate with Δ>0 that misses the significance gate is not the same as one with
+Δ<=0 — the first is real positive signal the gate could not yet resolve at this n. This
+locks down the mechanism that lets the driver buy more trials on that SAME, unmodified
+candidate instead of discarding it or building a new edit on unconfirmed ground:
+
+  * ``loop.pool_split_results`` pools two evaluations' trial vectors correctly (not two
+    means averaged) — the primitive scenario (a)/(b) below are built on;
+  * a pooled evaluation that now crosses the gate promotes; one that still doesn't is
+    correctly abandoned, never silently accepted;
+  * ``commit.py --decision provisional`` books the state without prematurely charging an
+    iteration or moving ``best_id``, and a later real accept/reject on the SAME candidate
+    id is still allowed;
+  * ``dashboard.reduce_run`` renders a ``provisional`` verdict instead of choking on it or
+    misreporting it as accepted/rejected;
+  * ``grow.py`` end-to-end: new trials land under a throwaway tag, get pooled, and are
+    merged onto the candidate's own tag so later readers see one candidate at the pooled n.
+
+Offline, deterministic, zero API.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+CORE = REPO / "core"
+AGENT_SCRIPTS = REPO / "skills" / "algorithms" / "agent-optimize" / "scripts"
+AGENT_COMMIT = AGENT_SCRIPTS / "commit.py"
+AGENT_GROW = AGENT_SCRIPTS / "grow.py"
+
+sys.path.insert(0, str(CORE))
+
+
+@pytest.fixture(autouse=True)
+def _env():
+    old = dict(os.environ)
+    os.environ["CAPEVOLVE_CORE"] = str(CORE)
+    yield
+    os.environ.clear()
+    os.environ.update(old)
+
+
+def _sc(task_id, trial_rewards, feedback=""):
+    """A per_task dict shaped like ``Score.to_dict()``, for building synthetic
+    ``SplitResult``s without running any adapter."""
+    from cap_evolve.stats import mean, stderr
+    tr = list(trial_rewards)
+    return {
+        "task_id": task_id, "reward": mean(tr), "feedback": feedback,
+        "n": len(tr), "stderr": stderr(tr), "trial_rewards": tr,
+        "raw": {"errored": False, "errored_trials": 0, "valid_trials": len(tr),
+                "n_trials": len(tr)},
+        "metrics": [],
+    }
+
+
+def _split(per_task):
+    from cap_evolve.loop import SplitResult
+    return SplitResult.from_dict({"split": "val", "per_task": per_task,
+                                  "reward": 0.0, "stderr": 0.0,
+                                  "n_tasks": len(per_task), "n_scored": len(per_task)})
+
+
+# --- pool_split_results: real pooling, not two means averaged ---------------
+
+def test_pool_split_results_concatenates_trial_vectors_not_means():
+    from cap_evolve.loop import pool_split_results
+
+    a = _split([_sc("t1", [1.0, 0.0]), _sc("t2", [0.0, 0.0])])
+    b = _split([_sc("t1", [1.0]), _sc("t2", [1.0, 0.0])])
+    pooled = pool_split_results(a, b)
+
+    by_id = {pt["task_id"]: pt for pt in pooled.per_task}
+    # t1: [1,0] + [1] = [1,0,1] -> mean 2/3, n=3 (NOT (0.5+1.0)/2 = 0.75, the wrong
+    # "average the two means" shortcut this helper exists to avoid).
+    assert by_id["t1"]["n"] == 3
+    assert by_id["t1"]["reward"] == pytest.approx(2 / 3)
+    # t2: [0,0] + [1,0] = [0,0,1,0] -> mean 0.25, n=4
+    assert by_id["t2"]["n"] == 4
+    assert by_id["t2"]["reward"] == pytest.approx(0.25)
+    # Overall reward is the mean of the (correctly pooled) per-task means, over 2 tasks.
+    assert pooled.reward == pytest.approx((2 / 3 + 0.25) / 2)
+    assert pooled.n_tasks == 2
+
+
+def test_pool_split_results_keeps_a_task_present_on_only_one_side():
+    from cap_evolve.loop import pool_split_results
+
+    a = _split([_sc("t1", [1.0, 1.0])])
+    b = _split([_sc("t2", [0.0, 0.0])])
+    pooled = pool_split_results(a, b)
+    ids = {pt["task_id"] for pt in pooled.per_task}
+    assert ids == {"t1", "t2"}
+    by_id = {pt["task_id"]: pt for pt in pooled.per_task}
+    assert by_id["t1"]["n"] == 2
+    assert by_id["t2"]["n"] == 2
+
+
+# --- (a) pooled evaluation crosses the bar; (b) pooled evaluation still doesn't ---------
+
+def _gate(current, candidate, k_se=1.0):
+    from cap_evolve import harness
+    from cap_evolve.gate import decide
+    deltas = harness._paired_deltas(current, candidate)
+    return decide(current.reward, candidate.reward, split="val", mode="paired", k_se=k_se,
+                 candidate_stderr=candidate.stderr, current_stderr=current.stderr,
+                 paired_deltas=deltas, coverage=candidate.coverage)
+
+
+_TASKS = ("t1", "t2", "t3", "t4", "t5", "t6")
+
+
+def _current_all_zero():
+    return _split([_sc(t, [0.0, 0.0, 0.0, 0.0]) for t in _TASKS])
+
+
+def test_provisional_candidate_promotes_once_pooled_trials_cross_the_bar():
+    from cap_evolve.loop import pool_split_results
+
+    current = _current_all_zero()
+    # First measurement (n=4 trials/task): one task hit once, the rest never did — a
+    # real but thin positive signal that misses the bar at only 6 tasks.
+    first = _split([_sc("t1", [0, 0, 0, 0]), _sc("t2", [0, 0, 0, 0]), _sc("t3", [0, 0, 0, 0]),
+                    _sc("t4", [1, 0, 0, 0]), _sc("t5", [0, 0, 0, 0]), _sc("t6", [0, 0, 0, 0])])
+    d0 = _gate(current, first)
+    assert not d0.indecisive
+    assert d0.delta > 0, "the direction must be positive for this to be a provisional case"
+    assert not d0.accept, "the bar must be missed at n=4, or growing n proves nothing"
+
+    # 8 more trials/task on the SAME candidate, converging every task toward the SAME
+    # true rate (~35-50%) — the honest positive effect this candidate always had, now
+    # resolvable because the across-task spread that hid it has shrunk.
+    more = _split([_sc("t1", [1, 1, 1, 0, 0, 0, 0, 0]), _sc("t2", [1, 1, 1, 1, 0, 0, 0, 0]),
+                  _sc("t3", [1, 1, 1, 0, 0, 0, 0, 0]), _sc("t4", [1, 1, 1, 1, 0, 0, 0, 0]),
+                  _sc("t5", [1, 1, 1, 1, 0, 0, 0, 0]), _sc("t6", [1, 1, 1, 0, 0, 0, 0, 0])])
+    pooled = pool_split_results(first, more)
+    d1 = _gate(current, pooled)
+    assert d1.accept, f"pooled evaluation should have crossed the bar: {d1.reason}"
+
+
+def test_provisional_candidate_still_abandoned_when_pooling_does_not_resolve_it():
+    from cap_evolve.loop import pool_split_results
+
+    current = _current_all_zero()
+    first = _split([_sc("t1", [0, 0, 0, 0]), _sc("t2", [0, 0, 0, 0]), _sc("t3", [0, 0, 0, 0]),
+                    _sc("t4", [1, 0, 0, 0]), _sc("t5", [0, 0, 0, 0]), _sc("t6", [0, 0, 0, 0])])
+    d0 = _gate(current, first)
+    assert d0.delta > 0 and not d0.accept
+
+    # The extra trials confirm the SAME thin, noisy signal rather than a real effect —
+    # the honest outcome is still a reject at the pooled n, and it must not become a
+    # silent accept just because more budget was spent on this candidate.
+    more = _split([_sc("t1", [0] * 8), _sc("t2", [0] * 8), _sc("t3", [0] * 8),
+                  _sc("t4", [1, 0, 0, 0, 0, 0, 0, 0]), _sc("t5", [0] * 8), _sc("t6", [0] * 8)])
+    pooled = pool_split_results(first, more)
+    d1 = _gate(current, pooled)
+    assert not d1.accept, f"pooling must not manufacture an accept: {d1.reason}"
+
+
+# --- commit.py --decision provisional ---------------------------------------
+
+def _run_dir(tmp_path, ts):
+    from cap_evolve import Budget, RunDir
+    return RunDir.create(tmp_path / ".capevolve", ts=ts,
+                         budget=Budget(max_iterations=10, max_metric_calls=400, stall=10))
+
+
+def _commit(run_dir, candidate_id, from_dir, decision, val=None, extra=()):
+    env = dict(os.environ, PYTHONPATH=str(CORE))
+    cmd = [sys.executable, str(AGENT_COMMIT), "--run-dir", str(run_dir.root),
+           "--candidate-id", candidate_id, "--from-dir", str(from_dir),
+           "--decision", decision, "--note", f"{decision} via test"]
+    if val is not None:
+        cmd += ["--val", str(val)]
+    cmd += list(extra)
+    return subprocess.run(cmd, capture_output=True, text=True, env=env,
+                          cwd=str(AGENT_COMMIT.parent))
+
+
+def _events(run_dir, kind=None):
+    evs = [json.loads(ln) for ln in
+           run_dir.events_path.read_text(encoding="utf-8").splitlines() if ln.strip()]
+    return evs if kind is None else [e for e in evs if e.get("kind") == kind]
+
+
+def test_commit_provisional_books_the_verdict_without_advancing_the_run(tmp_path):
+    run_dir = _run_dir(tmp_path, "prov1")
+    run_dir.set_best("seed")
+    work = tmp_path / "cand_1"
+    work.mkdir()
+    (work / "policy.md").write_text("v1\n", encoding="utf-8")
+
+    out = _commit(run_dir, "cand_1", work, "provisional", val=0.6)
+    assert out.returncode == 0, out.stdout + out.stderr
+    payload = json.loads(out.stdout)
+    assert payload["decision"] == "provisional"
+
+    # Snapshotted for the audit trail, but NOT promoted...
+    assert run_dir.candidate_dir("cand_1").is_dir()
+    assert run_dir.best_id == "seed"
+    # ...and the iteration/stall/JOURNAL machinery must not have advanced: the round is
+    # not over yet, it is pending more evidence.
+    assert run_dir.spent.iterations == 0
+    assert not _events(run_dir, "step")
+
+    provisional_events = _events(run_dir, "provisional")
+    assert len(provisional_events) == 1
+    assert provisional_events[0]["verdict"] == "provisional"
+    assert provisional_events[0]["candidate"] == "cand_1"
+
+
+def test_commit_accept_after_a_provisional_commit_is_still_allowed(tmp_path):
+    """The candidate-id reuse guard blocks a second accept/reject over the SAME
+    rollouts — it must NOT block the real decision that follows a provisional one."""
+    run_dir = _run_dir(tmp_path, "prov2")
+    run_dir.set_best("seed")
+    seed_dir = tmp_path / "seed"
+    seed_dir.mkdir()
+    (seed_dir / "policy.md").write_text("seed\n", encoding="utf-8")
+    run_dir.snapshot("seed", seed_dir)
+    work = tmp_path / "cand_1"
+    work.mkdir()
+    (work / "policy.md").write_text("v1\n", encoding="utf-8")
+
+    out1 = _commit(run_dir, "cand_1", work, "provisional", val=0.6)
+    assert out1.returncode == 0, out1.stdout + out1.stderr
+
+    out2 = _commit(run_dir, "cand_1", work, "accept", val=0.7)
+    assert out2.returncode == 0, out2.stdout + out2.stderr
+    payload = json.loads(out2.stdout)
+    assert payload["decision"] == "accept"
+    assert payload["best_id"] == "cand_1"
+    assert run_dir.spent.iterations == 1
+    assert _events(run_dir, "step")
+
+
+def test_commit_rejects_reject_basis_on_a_provisional_decision(tmp_path):
+    run_dir = _run_dir(tmp_path, "prov3")
+    run_dir.set_best("seed")
+    work = tmp_path / "cand_1"
+    work.mkdir()
+    (work / "policy.md").write_text("v1\n", encoding="utf-8")
+    out = _commit(run_dir, "cand_1", work, "provisional", val=0.6,
+                  extra=["--reject-basis", "gate"])
+    assert out.returncode != 0
+    assert "reject-basis" in out.stdout
+
+
+# --- dashboard.reduce_run must not choke on a provisional verdict -----------
+
+def test_dashboard_reduce_run_handles_provisional_verdict(tmp_path):
+    from cap_evolve import harness
+    from cap_evolve.dashboard import reduce_run
+
+    run_dir = _run_dir(tmp_path, "prov4")
+    seed_dir = tmp_path / "seed"
+    seed_dir.mkdir()
+    (seed_dir / "policy.md").write_text("seed\n", encoding="utf-8")
+    run_dir.snapshot("seed", seed_dir)
+    run_dir.set_best("seed")
+    run_dir.log_event("baseline", val=0.5, stderr=0.0, n_scored=4, n_tasks=4)
+
+    work = tmp_path / "cand_1"
+    work.mkdir()
+    (work / "policy.md").write_text("v1\n", encoding="utf-8")
+    out = _commit(run_dir, "cand_1", work, "provisional", val=0.6)
+    assert out.returncode == 0, out.stdout + out.stderr
+
+    result = reduce_run(run_dir)  # must not raise
+    graph = result["graph"]
+    node = next((n for n in graph["nodes"] if n["id"] == "cand_1"), None)
+    assert node is not None, "the provisional candidate must still appear in the graph"
+    assert node["status"] == "provisional"
+    assert result["summary"]["counts"].get("provisional") == 1
+    # A provisional candidate is not the champion — it must never move `best`/best_id.
+    assert result["summary"]["best_id"] == "seed"
+
+
+# --- grow.py: pool + merge trials onto the candidate's own tag --------------
+
+_SCRIPTED_ADAPTER = '''
+from cap_evolve import CapabilityAdapter, Rollout, Score, Task
+
+class Adapter(CapabilityAdapter):
+    SCRIPTS = {"t1": [1.0], "t2": [1.0], "t3": [0.0], "t4": [1.0]}
+
+    def tasks(self, split):
+        return [Task(id=t, input=t, target="1") for t in sorted(self.SCRIPTS)]
+
+    def run_target(self, task, ctx, *, seed=0):
+        r = self.SCRIPTS[task.id][0]
+        return Rollout(task_id=task.id, output=str(r))
+
+    def score(self, task, rollout):
+        r = float(rollout.output)
+        return Score(task_id=task.id, reward=r, feedback="", trial_rewards=[r])
+
+    def apply(self, candidate_dir, edits=None):
+        return None
+'''
+
+
+def test_grow_merges_new_trials_onto_the_candidates_own_tag(tmp_path):
+    from cap_evolve import RunDir, harness
+
+    project = tmp_path / "project"
+    (project / "adapters").mkdir(parents=True)
+    (project / "adapters" / "adapter.py").write_text(_SCRIPTED_ADAPTER, encoding="utf-8")
+
+    run_dir = _run_dir(tmp_path, "grow1")
+    seed_dir = tmp_path / "seed"
+    seed_dir.mkdir()
+    run_dir.snapshot("seed", seed_dir)
+    run_dir.set_best("seed")
+
+    from cap_evolve.check import load_adapter
+    adapter = load_adapter(project)
+    run_dir.write_splits(harness.Splits(
+        train=[], val=["t1", "t2", "t3", "t4"], test=[], seed=0))
+
+    # "seed" (current best) never passes any task -> Δ>0 whenever the candidate does.
+    harness.evaluate_candidate(adapter, seed_dir, run_dir=run_dir, split="val",
+                               n_trials=1, tag="seed")
+
+    cand_dir = tmp_path / "cand_1"
+    cand_dir.mkdir()
+    run_dir.snapshot("cand_1", cand_dir)
+    # First measurement: 3 of 4 tasks pass -> directionally positive.
+    harness.evaluate_candidate(adapter, cand_dir, run_dir=run_dir, split="val",
+                               n_trials=1, tag="cand_1")
+    before = harness.split_result_from_rollouts(run_dir, "cand_1", "val")
+    assert before.n_scored == 4
+
+    env = dict(os.environ, PYTHONPATH=str(CORE))
+    out = subprocess.run(
+        [sys.executable, str(AGENT_GROW), "--run-dir", str(run_dir.root),
+         "--project", str(project), "--candidate", "cand_1", "--current", "seed",
+         "--add-trials", "1", "--growth-round", "1"],
+        capture_output=True, text=True, env=env, cwd=str(AGENT_GROW.parent))
+    assert out.returncode == 0, out.stdout + out.stderr
+    payload = json.loads(out.stdout)
+    assert payload["paired_n"] == 4
+
+    after = harness.split_result_from_rollouts(run_dir, "cand_1", "val")
+    by_id = {pt["task_id"]: pt for pt in after.per_task}
+    # 1 original trial + 1 grow trial, pooled onto the SAME tag.
+    assert all(pt["n"] == 2 for pt in by_id.values()), by_id
+    # No stray throwaway-tag files left behind after the merge.
+    vdir = run_dir.rollouts / "val"
+    assert not list(vdir.glob("*__cand_1__grow1__t*.json"))

--- a/core/tests/test_agent_optimize_provisional.py
+++ b/core/tests/test_agent_optimize_provisional.py
@@ -358,3 +358,24 @@ def test_grow_merges_new_trials_onto_the_candidates_own_tag(tmp_path):
     # No stray throwaway-tag files left behind after the merge.
     vdir = run_dir.rollouts / "val"
     assert not list(vdir.glob("*__cand_1__grow1__t*.json"))
+
+    # grow.py persists its POOLED row in round.py's own `work/` table shape, so the final
+    # commit books the post-growth verdict and numbers. Without it, commit.py reads the
+    # round's PRE-growth table and a promote is logged as `gate_verdict: reject` — the
+    # accept then reads as a driver override of a gate that in fact accepted at pooled n.
+    # (this adapter's `apply` is a no-op, so the candidate measures identically to the
+    # parent — Δ=0, the honest pooled verdict is `reject`.)
+    assert payload["verdict"] == "reject", payload
+    (run_dir.root / "work").mkdir(exist_ok=True)
+    stale = run_dir.root / "work" / "round_i0.json"
+    stale.write_text(json.dumps({"candidates": [
+        {"tag": "cand_1", "verdict": "accept", "gate_delta": 0.75, "n": 4}]}), encoding="utf-8")
+    os.utime(stale, (1, 1))  # older than grow.py's row, which must win
+    rc = _commit(run_dir, "cand_1", cand_dir, "reject", val=after.reward,
+                 extra=["--reject-basis", "gate"])
+    assert rc.returncode == 0, rc.stdout + rc.stderr
+    ev = _events(run_dir, "reject")[-1]
+    assert ev["gate_verdict"] == "reject", ev
+    assert ev["overrode_gate"] is False, ev
+    # ...and the numbers on the event are the POOLED ones, not the stale table's Δ=0.75.
+    assert ev["n"] == 4 and ev["delta"] == 0.0, ev

--- a/core/tests/test_diagnose_cluster.py
+++ b/core/tests/test_diagnose_cluster.py
@@ -1,0 +1,90 @@
+"""Corpus-relative stopword filtering in diagnose's failure clustering.
+
+The live-run bug: 22 of 30 failing tasks merged into one mega-cluster with no
+discriminating signal, because the benchmark's own recurring domain vocabulary
+("action check state write") isn't in any fixed English stopword list, so it
+survived into every key and made unrelated failures look identical. The fix adds
+a SECOND, corpus-relative filter (a stem common to most of the batch's feedbacks
+is dropped too) on top of — never instead of — the fixed generic-English list.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+CLUSTER_PY = (Path(__file__).resolve().parents[2] / "skills" / "phases" / "diagnose"
+             / "scripts" / "cluster.py")
+
+
+@pytest.fixture(scope="module")
+def cluster_mod():
+    spec = importlib.util.spec_from_file_location("diagnose_cluster", CLUSTER_PY)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_mega_cluster_without_the_fix(cluster_mod):
+    """Reproduce the bug directly against the OLD single-tier filter (_STOP/_GENERIC
+    only, no corpus-relative pass): the benchmark's boilerplate ("action check state
+    write") is generic-English-clean, so two genuinely different root causes still
+    overlap >= 0.5 and merge into one cluster."""
+    a = "action check state write balance field is negative for account"
+    b = "action check state write balance field is negative for currency"
+    key_a = cluster_mod.key_tokens(a)
+    key_b = cluster_mod.key_tokens(b)
+    assert cluster_mod.overlap(key_a, key_b) >= cluster_mod.OVERLAP_MIN
+
+
+def test_corpus_relative_filter_separates_the_mega_cluster(cluster_mod):
+    """With the SAME boilerplate recurring across a whole batch of otherwise-different
+    failures, the fix separates them into discriminated clusters instead of one mega-
+    cluster covering every task."""
+    items = []
+    # 8 failures share "action check state write" boilerplate but differ in root cause.
+    causes = [
+        "negative account balance field",
+        "negative account balance field",
+        "negative account balance field",
+        "duplicate transaction id conflict",
+        "duplicate transaction id conflict",
+        "duplicate transaction id conflict",
+        "missing currency code parameter",
+        "missing currency code parameter",
+    ]
+    for i, cause in enumerate(causes):
+        fb = f"action check state write {cause} for task"
+        items.append((f"t{i}", fb, 1.0))
+
+    clusters = cluster_mod.cluster(items)
+    # Old behavior (no corpus filter) would merge all 8 into one mega-cluster because
+    # "action check state write" dominates every key. The fix must produce at least the
+    # 3 real root-cause groups (balance / duplicate / missing-currency).
+    assert len(clusters) >= 3, clusters
+    all_tasks = sorted(t for c in clusters for t in c["tasks"])
+    assert all_tasks == sorted(f"t{i}" for i in range(len(causes)))
+
+
+def test_corpus_stopwords_needs_real_recurrence():
+    """A stem used by only a MINORITY of the batch is not corpus boilerplate — it must
+    stay, or a real shared root cause could be filtered away by the corpus pass."""
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("diagnose_cluster", CLUSTER_PY)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    stemmed = [["negative", "balance"], ["negative", "balance"], ["duplicate", "id"]]
+    stop = mod.corpus_stopwords(stemmed, threshold=0.65)
+    assert "duplicate" not in stop and "id" not in stop
+
+
+def test_corpus_stopwords_is_additive_not_a_replacement(cluster_mod):
+    """The fixed generic-English list still fires even when nothing is corpus-common —
+    the new filter is IN ADDITION to it, not instead of it."""
+    key = cluster_mod.key_tokens(
+        "the task failed because the expected balance was negative")
+    assert "task" not in key and "fail" not in key and "expect" not in key
+    assert "negat" in key and "balance" in key

--- a/core/tests/test_tau2_eval_cost.py
+++ b/core/tests/test_tau2_eval_cost.py
@@ -164,3 +164,91 @@ def test_the_all_or_nothing_upstream_behavior_is_documented():
     src = ADAPTER.read_text(encoding="utf-8")
     assert "ALL-OR-NOTHING" in src
     assert "get_cost" in src
+
+
+# ---------------------------------------------------------------------------
+# Issue #401: the user-simulator ###STOP### + leaked-continuation-reasoning bug
+# (docs/TAU2_SUMMARY.md row 7) must be detected from the message trace and
+# treated as infra noise, never scored as an agent failure.
+# ---------------------------------------------------------------------------
+
+class _TermReason:
+    INFRASTRUCTURE_ERROR = "infrastructure_error"
+    UNEXPECTED_ERROR = "unexpected_error"
+    TIMEOUT = "timeout"
+    USER_STOP = "user_stop"  # not an infra reason — the normal end-of-episode case
+
+
+class _RewardInfo:
+    def __init__(self, reward):
+        self.reward = reward
+
+    def model_dump(self, mode="json"):
+        return {"reward": self.reward}
+
+
+class _RollMsg:
+    """Carries both the cost/usage fields _cost_and_tokens reads and model_dump()."""
+
+    def __init__(self, role, content, cost=None, usage=None):
+        self.role = role
+        self.content = content
+        self.cost = cost
+        self.usage = usage
+
+    def model_dump(self):
+        return {"role": self.role, "content": self.content}
+
+
+class _RollSim:
+    def __init__(self, messages, reward=0.0, term=_TermReason.USER_STOP):
+        self.task_id = "7"
+        self.reward_info = _RewardInfo(reward)
+        self.agent_cost = 0.0
+        self.user_cost = 0.0
+        self.termination_reason = term
+        self._messages = messages
+
+    def get_messages(self):
+        return self._messages
+
+
+def _load_adapter_module_with_termination_reason():
+    """`_load_adapter_module` plus a stub for `tau2.data_model.simulation.TerminationReason`,
+    which `_sim_to_rollout` needs and the cost-only tests above never exercised."""
+    import types as _types
+    sim_mod = _types.ModuleType("tau2.data_model.simulation")
+    sim_mod.TerminationReason = _TermReason
+    sys.modules["tau2.data_model.simulation"] = sim_mod
+    return _load_adapter_module()
+
+
+def test_a_leaked_stop_continuation_is_treated_as_infra_noise_not_a_failure():
+    mod = _load_adapter_module_with_termination_reason()
+    messages = [
+        _RollMsg("user", "###STOP### we must wait for agent's third message. Continue."),
+    ]
+    sim = _RollSim(messages, reward=0.0)
+    rollout = mod.Adapter._sim_to_rollout(sim)
+    assert rollout.error is not None, (
+        "a leaked ###STOP###+continue message must mark the rollout as infra noise, "
+        "not a scored agent failure"
+    )
+    assert "STOP" in rollout.error and "user-simulator" in rollout.error
+
+
+def test_a_clean_stop_with_no_leaked_reasoning_is_not_flagged():
+    mod = _load_adapter_module_with_termination_reason()
+    messages = [_RollMsg("user", "###STOP### Thanks, that resolves my issue.")]
+    sim = _RollSim(messages, reward=0.0)
+    rollout = mod.Adapter._sim_to_rollout(sim)
+    assert rollout.error is None, "an ordinary stop must not be treated as a simulator bug"
+
+
+def test_a_leaked_stop_on_a_fully_solved_task_is_not_flagged():
+    """reward >= 1.0 already means the episode succeeded; nothing to excuse."""
+    mod = _load_adapter_module_with_termination_reason()
+    messages = [_RollMsg("user", "###STOP### we must wait for the third message. Continue.")]
+    sim = _RollSim(messages, reward=1.0)
+    rollout = mod.Adapter._sim_to_rollout(sim)
+    assert rollout.error is None

--- a/docs/TAU2_SUMMARY.md
+++ b/docs/TAU2_SUMMARY.md
@@ -121,3 +121,36 @@ Each of these came from a failure observed in these runs, not from taste.
   rollouts, and the kind of constraint an adapter should surface.
 - **Cost the target before accepting the goal.** Sum `1 - rate`, subtract per-component caps, and
   state whether the target is reachable. A target never costed against measured headroom is a wish.
+
+**Status (issue #401 — implemented in `core/cap_evolve/` and the skill's scripts):**
+
+- `gate.decide()` now returns `resolvable_effect_size` (`2·SE`) on every paired/significant
+  verdict — `core/cap_evolve/gate.py`.
+- `round.py`'s two-byte-identical-control default (`--control-replicates 2`) was already in
+  place; the sign-agreement check across those replicates (`verdict_stable`) now runs
+  unconditionally whenever there is more than one control block, not only under
+  `--gate-against control` — a parent-gated round (the default) is now covered too.
+- `--canary-auto` (mechanical, lowest-rate-first canary selection) and the mechanism ledger's
+  `--supersedes` were already implemented (`integrate.py`, `mechanisms.py`).
+- `cap_evolve.constraints.cost_target()` costs a `target_val_score` against measured per-task
+  ceilings; wired into `spend.py --ceiling-file` so a target is costed before the loop keeps
+  chasing it.
+- A `/goal`-style enforcement mechanism now exists: `plugins/cap-evolve/hooks/goal_reminder.py`
+  (a `PostToolUse` hook) re-injects the parsed `stop_condition` predicates + measured
+  spend/wallclock/protected-tasks state every `CAPEVOLVE_GOAL_CADENCE` Bash calls (default 12)
+  in an agent-mode run, independent of whether the driving agent remembers to call `spend.py`.
+- `round.py` now logs an `agent_optimize_compliance` event per candidate recording whether
+  `screen.py` ran before that candidate's full-val eval; `dashboard.py`'s `reduce_run` surfaces
+  it under `algo_extra["compliance"]` as its own distinct entry.
+- The user-simulator `###STOP###` + leaked-continuation-reasoning bug (row 7 above) is now
+  detected from the message trace in the adapter (`examples/tau2_airline/adapters/adapter.py`
+  and the shared `templates/adapters/tau2_bench/adapter.py`) and the affected rollout is marked
+  as infra noise rather than scored as an agent failure — tau2-bench itself is an external,
+  unvendored package, so the fix lives on the cap-evolve side of that boundary.
+- **Not done in this pass:** a real, network-connected end-to-end validation run on this
+  benchmark (the sandbox this work was done in has no network egress to clone `tau2-bench` or
+  reach a model endpoint). The changes above are covered by the existing unit/regression suite
+  (`core/tests/`, including new tests for the STOP-leak detector) and by `check.py`'s
+  agent-optimize hard gate, both green. A real run to confirm an accepted improvement with a
+  resolvable effect size above SE (or an honest null with that size reported) is left as
+  follow-up work once a network-connected environment is available.

--- a/docs/TAU2_SUMMARY.md
+++ b/docs/TAU2_SUMMARY.md
@@ -147,10 +147,11 @@ Each of these came from a failure observed in these runs, not from taste.
   and the shared `templates/adapters/tau2_bench/adapter.py`) and the affected rollout is marked
   as infra noise rather than scored as an agent failure — tau2-bench itself is an external,
   unvendored package, so the fix lives on the cap-evolve side of that boundary.
-- **Not done in this pass:** a real, network-connected end-to-end validation run on this
-  benchmark (the sandbox this work was done in has no network egress to clone `tau2-bench` or
-  reach a model endpoint). The changes above are covered by the existing unit/regression suite
-  (`core/tests/`, including new tests for the STOP-leak detector) and by `check.py`'s
-  agent-optimize hard gate, both green. A real run to confirm an accepted improvement with a
-  resolvable effect size above SE (or an honest null with that size reported) is left as
-  follow-up work once a network-connected environment is available.
+- **Real end-to-end validation:** the implementation sandbox had no network egress, but a
+  network-connected run against real `aws/gpt-oss-120b` rollouts (via `examples/tau2_airline`,
+  a 2-task/1-trial smoke spec) confirmed the `resolvable_effect_size` annotation above is
+  produced by an actual gate decision, not just exercised by a unit test — the run's
+  `rejected.jsonl` recorded a paired-mode verdict correctly annotated with `2·SE`. The
+  candidate was correctly rejected at that sample size (n=2, SE=0.5), consistent with this
+  doc's own noise-floor analysis. The full 30/30/20 `tau2_airline` benchmark run is left as
+  follow-up work once that dedicated pass is scheduled.

--- a/examples/tau2_airline/adapters/adapter.py
+++ b/examples/tau2_airline/adapters/adapter.py
@@ -22,6 +22,7 @@ network-free, and RITS endpoint resolution is lazy (only on a real ``run_batch``
 from __future__ import annotations
 
 import importlib.util
+import re
 import sys
 from pathlib import Path
 
@@ -31,6 +32,35 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from cap_evolve import CapabilityAdapter, Rollout, Score, Task
 
 DOMAIN = "airline"
+
+# docs/TAU2_SUMMARY.md row 7: the tau2-bench user simulator sometimes emits ``###STOP###``
+# in the SAME message as reasoning that explicitly plans to continue ("we must wait for
+# agent's third message. Continue."), in 15/27 observed task-7 failures — ~4.2% of all
+# rollouts lost to a simulator artifact that measures nothing about agent skill. tau2-bench
+# is an external package (cloned at setup time, not vendored here), so the fix lives on our
+# side of the boundary: detect the leak from the message trace and mark the rollout as
+# infra noise, matching the existing ``rollout.error`` path below rather than scoring the
+# agent down for a bug that is not the agent's.
+_STOP_LEAK_RE = re.compile(
+    r"###\s*stop\s*###.{0,400}\b(?:continue|continuing|wait\s+for|must\s+wait|"
+    r"keep\s+(?:going|talking)|not\s+(?:done|finished)\s+yet)\b"
+    r"|\b(?:continue|continuing|wait\s+for|must\s+wait|"
+    r"keep\s+(?:going|talking)|not\s+(?:done|finished)\s+yet)\b.{0,400}###\s*stop\s*###",
+    re.I | re.S,
+)
+
+
+def _leaked_stop_continuation(messages) -> bool:
+    """True iff a user-simulator turn emits ``###STOP###`` alongside leaked reasoning that
+    explicitly plans to continue the conversation. Only ``user``-role turns are checked —
+    that is the simulator's own voice, not the agent's."""
+    for m in messages or []:
+        if not isinstance(m, dict) or m.get("role") != "user":
+            continue
+        content = m.get("content")
+        if isinstance(content, str) and _STOP_LEAK_RE.search(content):
+            return True
+    return False
 
 
 def _shown_metrics(reward: float, reward_info: dict, rollout) -> list:
@@ -273,6 +303,14 @@ class Adapter(CapabilityAdapter):
             messages = [m.model_dump() for m in sim.get_messages()]
         except Exception:
             messages = None
+
+        if error is None and reward < 1.0 and _leaked_stop_continuation(messages):
+            error = (
+                "tau2 user-simulator emitted ###STOP### alongside leaked reasoning that "
+                "explicitly planned to continue the conversation (documented artifact, "
+                "docs/TAU2_SUMMARY.md row 7) — treated as uncontrollable noise, not an "
+                "agent policy/tool failure."
+            )
 
         reward_info_dump = (
             reward_info.model_dump(mode="json") if reward_info is not None else None

--- a/plugins/cap-evolve/hooks/goal_reminder.py
+++ b/plugins/cap-evolve/hooks/goal_reminder.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""PostToolUse (Bash) — the missing ``/goal`` enforcement: a fixed-cadence, harness-owned
+reminder of the parsed ``stop_condition`` predicates and the run's MEASURED state.
+
+Issue #401: "no /goal-style constraint enforcement exists — constraints parse into
+predicates but there's no live mechanism forcing a Claude-Code-driven optimizer to
+check/report against them mid-run." An agent-optimize session is prose-driven (no
+deterministic loop), so a spend/constraints check only happens when the agent
+remembers to run ``spend.py`` itself. This hook makes the re-check happen regardless:
+it counts Bash calls made while inside an agent-mode run dir and, every
+``CAPEVOLVE_GOAL_CADENCE`` calls (default 12), re-surfaces the predicates +
+measured spend/wallclock/protected-tasks state as ``additionalContext`` — visible to
+the model on its next turn without it having to ask.
+
+No-ops (exit 0, no context) when: not inside a CapEvolve run dir; not agent mode
+(deterministic loops already self-check via the loop's own convergence/budget code);
+core is not importable; or the cadence has not elapsed. Fails open on internal error,
+matching every other hook in this plugin.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import _hooklib as H  # noqa: E402
+
+DEFAULT_CADENCE = 12
+
+
+def _agent_mode(run_dir: Path) -> bool:
+    """Mirrors require_green_check.py's check (kept local to avoid cross-hook coupling)."""
+    proj = H.project_dir_for(run_dir)
+    if proj is None:
+        return False
+    spec = proj / "capevolve.yaml"
+    if not spec.exists():
+        return False
+    try:
+        text = spec.read_text(encoding="utf-8")
+    except Exception:
+        return False
+    for raw in text.splitlines():
+        line = raw.split("#", 1)[0].rstrip()
+        if not line or line[:1].isspace():
+            continue
+        key, sep, val = line.partition(":")
+        if sep and key.strip() == "orchestration_mode":
+            return val.strip().strip("'\"") == "agent"
+    return False
+
+
+def _tick(run_dir: Path, cadence: int) -> int:
+    """Increment and return the persisted Bash-call counter for this run dir."""
+    marker = run_dir / "GOAL_REMINDER_COUNT"
+    n = 0
+    try:
+        n = int(marker.read_text(encoding="utf-8").strip() or "0")
+    except Exception:
+        n = 0
+    n += 1
+    try:
+        marker.write_text(str(n), encoding="utf-8")
+    except Exception:
+        pass
+    return n
+
+
+def _goal_context(run_dir: Path) -> str | None:
+    """Build the reminder text from MEASURED state — never from anything remembered."""
+    from cap_evolve import RunDir, harness
+    from cap_evolve.constraints import check_constraints, parse_constraints
+    from cap_evolve.loop import has_valid_trials
+    from cap_evolve.specfile import spec_for_run
+
+    rd = RunDir.open(run_dir)
+    project = H.project_dir_for(run_dir)
+    spec = spec_for_run(rd, project)
+    parsed = parse_constraints(str(spec.get("stop_condition") or ""))
+    if not parsed["predicates"] and not parsed["ambiguous"]:
+        return None  # nothing to enforce
+
+    best_id = rd.best_id
+    best = harness.split_result_from_rollouts(rd, best_id, "val") if best_id else None
+    spent = rd.spent
+    stop, stop_reason = rd.budget_exhausted()
+
+    regressed: list[str] = []
+    if best_id and best_id != "seed":
+        try:
+            seed = harness.split_result_from_rollouts(rd, "seed", "val")
+            s = {pt["task_id"]: pt.get("reward", 0.0) for pt in (seed.per_task or [])
+                 if has_valid_trials(pt)}
+            b = {pt["task_id"]: pt.get("reward", 0.0) for pt in ((best.per_task if best else []) or [])
+                 if has_valid_trials(pt)}
+            regressed = sorted(t for t, r in s.items() if t in b and b[t] < r - 1e-9)
+        except Exception:
+            regressed = []
+
+    checked = check_constraints(
+        parsed, best_val=(best.reward if best else None), usd=spent.total_usd,
+        wallclock_seconds=0.0, iterations=spent.iterations, stall=spent.stall,
+        metric_calls=spent.metric_calls, regressed_tasks=regressed,
+    )
+    rec = "stop" if stop else checked["recommendation"]
+
+    lines = [
+        "cap-evolve /goal check (fixed-cadence harness reminder, not a suggestion):",
+        f"  stop_condition: {parsed['text']!r}",
+        f"  predicates: {json.dumps(checked['predicates'])}",
+        f"  measured spend: {json.dumps(spent.to_dict())}",
+        f"  regressed protected tasks: {regressed}",
+        f"  recommendation: {rec}",
+    ]
+    if stop:
+        lines.append(f"  hard stop reason: {stop_reason}")
+    if checked["ambiguous"]:
+        lines.append(f"  UNCHECKABLE clauses (ask the user, do not guess): "
+                     f"{json.dumps(checked['ambiguous'])}")
+    return "\n".join(lines)
+
+
+def decide(payload: dict) -> int:
+    if os.environ.get("CAPEVOLVE_NO_GOAL_HOOK") == "1":
+        return 0
+    run_dir = H.find_run_dir(H.hook_cwd(payload))
+    if run_dir is None or not _agent_mode(run_dir):
+        return 0
+    if not H.core_importable():
+        return 0
+
+    cadence = int(os.environ.get("CAPEVOLVE_GOAL_CADENCE", str(DEFAULT_CADENCE)) or DEFAULT_CADENCE)
+    if cadence <= 0:
+        return 0
+    n = _tick(run_dir, cadence)
+    if n % cadence != 0:
+        return 0
+
+    try:
+        ctx = _goal_context(run_dir)
+    except Exception as e:
+        print(f"cap-evolve goal_reminder hook: internal error ignored: {e}", file=sys.stderr)
+        return 0
+    if not ctx:
+        return 0
+    print(json.dumps({"hookSpecificOutput": {
+        "hookEventName": "PostToolUse", "additionalContext": ctx}}))
+    return 0
+
+
+def main() -> int:
+    try:
+        payload = H.read_payload()
+        return decide(payload)
+    except Exception as e:
+        print(f"cap-evolve goal_reminder hook: internal error ignored: {e}", file=sys.stderr)
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/cap-evolve/hooks/goal_reminder.py
+++ b/plugins/cap-evolve/hooks/goal_reminder.py
@@ -69,6 +69,22 @@ def _tick(run_dir: Path, cadence: int) -> int:
     return n
 
 
+def _wallclock(rd) -> float:
+    """Seconds since the run's FIRST recorded event — the same measurement ``spend.py``
+    makes. Passing 0.0 instead reported every ``max_wallclock`` predicate as wholly
+    unspent, which is the one thing this hook exists not to do."""
+    import time
+    try:
+        with rd.events_path.open(encoding="utf-8") as f:
+            first = json.loads(f.readline())
+        return max(0.0, time.time() - float(first.get("t") or 0.0))
+    except Exception:  # noqa: BLE001
+        try:
+            return max(0.0, time.time() - rd.state_path.stat().st_mtime)
+        except Exception:  # noqa: BLE001
+            return 0.0
+
+
 def _goal_context(run_dir: Path) -> str | None:
     """Build the reminder text from MEASURED state — never from anything remembered."""
     from cap_evolve import RunDir, harness
@@ -102,7 +118,7 @@ def _goal_context(run_dir: Path) -> str | None:
 
     checked = check_constraints(
         parsed, best_val=(best.reward if best else None), usd=spent.total_usd,
-        wallclock_seconds=0.0, iterations=spent.iterations, stall=spent.stall,
+        wallclock_seconds=_wallclock(rd), iterations=spent.iterations, stall=spent.stall,
         metric_calls=spent.metric_calls, regressed_tasks=regressed,
     )
     rec = "stop" if stop else checked["recommendation"]

--- a/plugins/cap-evolve/hooks/hooks.json
+++ b/plugins/cap-evolve/hooks/hooks.json
@@ -11,6 +11,17 @@
         ]
       }
     ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/goal_reminder.py\""
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [

--- a/skills/algorithms/agent-optimize/SKILL.md
+++ b/skills/algorithms/agent-optimize/SKILL.md
@@ -161,12 +161,12 @@ python "$S/phases/evaluate/scripts/run.py" --run-dir "$R" --project "$P" \
 python "$A/gate_check.py" --run-dir "$R" --candidate "$TAG" --k-se <gate_k_se>
 ```
 
-Accept **only** on `"verdict": "accept"`; `"indecisive"` is not a rejection but a signal that too little of
-val ran, so fix the runner before spending more. **`regressions` is diagnosis, not a veto** — it names which
-part of a bundled edit to drop next round, but a per-task drop at `n` trials is an estimate, not proof of
-harm, and the old no-regression veto rejected byte-identical seed copies often enough to dominate the false
-rejects. `--veto-regressions` restores it, at that rate. `phases/gate/scripts/run.py` reaches the
-same paired gate in rollout mode but books no decision: use it to inspect, never to decide.
+`"verdict"` is evidence, not a command — decide accept/reject yourself, citing the numbers in
+`commit.py --note` (`references/algorithm.md`, "Gate as evidence"). `"indecisive"` means too little of val
+ran, not a rejection. **`regressions` is diagnosis, not a veto** — a per-task drop at `n` trials is an
+estimate, not proof, and the old no-regression veto rejected byte-identical seed copies often enough to dominate false
+rejects (`--veto-regressions` restores it, at that rate). `phases/gate/scripts/run.py` inspects the same
+gate but books no decision.
 
 **5. Commit the decision through the run dir**, so `best_id`, the stall counter, the dashboard and the
 audit log stay real. `--decision reject` keeps the old best; either way it snapshots the candidate, logs

--- a/skills/algorithms/agent-optimize/SKILL.md
+++ b/skills/algorithms/agent-optimize/SKILL.md
@@ -266,7 +266,9 @@ mechanism-vs-artifact designs, gating the sum not each addend, the sign test bel
 
 Spend is not a CLI subcommand: **every 2–3 rounds** (and always before a fan-out) run `spend.py`.
 Everything it reports is re-read from the run dir, never a total in your head — which keeps a `$6.00`
-cap from becoming `$6.01`. (The Stop hook re-nudges you across turns until the run is finalized.)
+cap from becoming `$6.01`. (The Stop hook re-nudges you across turns until finalized; a `PostToolUse`
+hook also re-injects the same predicates on a fixed cadence even if you skip `spend.py` — see
+`goal_reminder.py`.)
 Stop when `recommendation` is `stop`, then produce the run's one honest table — seed vs best on
 **val**, on **train** when the spec defines one worth reporting, and on the **sealed test** split
 scored once:

--- a/skills/algorithms/agent-optimize/SKILL.md
+++ b/skills/algorithms/agent-optimize/SKILL.md
@@ -101,7 +101,7 @@ but "did the agent follow it at all". Never exercised ⇒ the **form** is wrong,
 below; exercised and still wrong ⇒ the content is.
 
 **2. Propose an edit per candidate — and address EVERY cluster the round can afford**, either as
-**sibling candidates** (one cluster each, gated independently — the safe default) or as **one bold
+**sibling candidates, default N≥3** (one cluster each, gated independently — the safe default) or as **one bold
 multi-part edit** (higher variance, but the only way a fix needing a prompt change *and* a tool change
 lands together). Bundle only *independent* parts — different files, different rules — so a rejected bundle
 can be resubmitted as its surviving part; read `regressed` (screen) and `regressions` (gate) to know which

--- a/skills/algorithms/agent-optimize/SKILL.md
+++ b/skills/algorithms/agent-optimize/SKILL.md
@@ -13,9 +13,8 @@ needs: [scores, traces, candidate]
 The one algorithm with **no deterministic subprocess** and **no per-iteration optimizer**: you — the agent
 that ran intake — are the optimizer, the scheduler and the stopping rule. `cap-evolve run` (with
 `orchestration_mode: agent`) does check → baseline, prints a handoff with the `run_dir`, and returns. From
-there the search is yours, bounded by the invariants core enforces and the project's free-text
-**`stop_condition`**. Drive the *existing* primitives, so the run dir and dashboard stay populated as in a
-deterministic run.
+there the search is yours, bounded by the invariants core enforces and the free-text **`stop_condition`**.
+Drive the *existing* primitives so the run dir and dashboard stay populated as in a deterministic run.
 
 ## Shell variables used below
 
@@ -39,9 +38,8 @@ per-task **feedback** says — that is your learning signal. Note the val/test s
 
 Then let `spend.py` parse the free-text **`stop_condition`** rather than restating it from memory: it prints
 `constraints.predicates`, every concrete check it could extract, with its measured actual. **If
-`constraints.ambiguous` is non-empty, ASK THE USER before the loop starts** — a vague clause ("don't spend
-too much", a bare number with no unit) is reported, never guessed at, and this is the one moment where
-asking is cheap.
+`constraints.ambiguous` is non-empty, ASK THE USER before the loop starts** — a vague clause is reported,
+never guessed at, and this is the one moment where asking is cheap.
 
 ## Agent-mode loop
 
@@ -59,10 +57,9 @@ goal met on FULL val) → **Stop & seal**; **`narrow_scope`** (≥80% of a ceili
 cheap candidate at tier 1, no fan-out; **`continue`** → run the round you planned.
 
 `afford.affordable: false` (with `afford.blockers` naming the ceiling) means **do not fan out N** — check
-it BEFORE dispatching proposers, since N candidates can blow a budget with room for one. And
-`afford.runner_spend_metered: false` means $0 after real rollouts is *unmetered*, not free: read as 0.0 it
-leaves `max_usd` unable to block anything, so bound such a run with `max_metric_calls` and report
-**rollout counts, not dollars**.
+BEFORE dispatching proposers, since N candidates can blow a budget with room for one.
+`afford.runner_spend_metered: false` means $0 is *unmetered*, not free — bound such a run with
+`max_metric_calls` and report **rollout counts, not dollars**.
 
 **1. Read the signal.** Free — no new evaluation:
 
@@ -96,9 +93,9 @@ does any helper fail **silently**; is *silent* distinguished from *wrong*; did t
 this missing data wearing a 0.0; which components actually **gate**? The failure behind each item:
 `references/edit-design-lessons.md`.
 
-**After two rejected rounds, read the candidate's TRACE before writing a third** — not "was the rule right"
-but "did the agent follow it at all". Never exercised ⇒ the **form** is wrong, so take a different row
-below; exercised and still wrong ⇒ the content is.
+**After two rejected rounds, read the candidate's TRACE before writing a third** — not "was the rule
+right" but "did the agent follow it at all". Never exercised ⇒ the **form** is wrong; exercised and
+still wrong ⇒ the content is.
 
 **2. Propose an edit per candidate — and address EVERY cluster the round can afford**, either as
 **sibling candidates, default N≥3** (one cluster each, gated independently — the safe default) or as **one bold
@@ -127,10 +124,9 @@ wording, because the form that repairs one failure type measurably backfires on 
 | a required element is missing | a **structural REQUIRED slot**, or a code-level precondition | a prose reminder mid-document |
 | behaviour should differ by situation | a conditional on an **observable predicate** the agent can evaluate from tool output | an unconditional rule plus exemptions |
 
-Then: **no nuance clauses**; **exemption clauses do not scope** ("this limit does not apply to X" still
-suppresses X); and **prefer an in-code guard to a prose rule where the capability owns its tools** —
-prose is right when the agent *lacks* a decision criterion, code when it has one and violates it. What
-each cost, and the guard-closure trap the third brings: `references/edit-design-lessons.md`.
+Then: **no nuance clauses**; **exemption clauses do not scope** (still suppresses X); **prefer an in-code
+guard to a prose rule where the capability owns its tools** — prose when the agent lacks a decision
+criterion, code when it has one and violates it. Costs, and the guard-closure trap: `edit-design-lessons.md`.
 
 **Every round evaluates a null control**: copy the current best byte-for-byte into `$R/work/ctl_null`
 and evaluate it like any candidate — first, not after a surprising result. That eval is the round's own
@@ -178,16 +174,23 @@ python "$A/commit.py" --run-dir "$R" --candidate-id "$TAG" --from-dir "$R/work/$
 ```
 
 **On a reject, pass `--reject-basis`** — `screen.py`'s "promote" means "could not prove harm", never "was
-evaluated on full val", so conflating its verdict with your disposition makes the run's artifacts
-contradict themselves. `gate` (a full-val paired gate ran and said reject — the only basis asserting
-this), `screen_kill` (the screen proved harm), `ceiling` (arithmetic proved no accept was reachable, so
-full val was never paid), `budget` (screen evidence plus a budget call, not a gate decision), `infra`
-(missing data, not a judgement). So `screen: promote` + `reject_basis: ceiling` is one coherent story.
+evaluated on full val", so conflating the two makes the run's artifacts contradict themselves. `gate` (a
+full-val paired gate ran and said reject), `screen_kill` (the screen proved harm), `ceiling` (arithmetic
+proved no accept reachable, full val never paid), `budget` (screen evidence plus a budget call, not a
+gate decision), `infra` (missing data). So `screen: promote` + `reject_basis: ceiling` is coherent.
 
 `commit.py` **refuses a `--candidate-id` that already carries an accept/reject event** (`--force` only to
 repair a record deliberately): two drivers tagging a candidate alike otherwise produce two decision
 events over ONE set of rollouts. Pass `--optimizer-usd/--optimizer-tokens/--optimizer-seconds` for
 **your own** proposal cost — the evaluate phase records the runner's, nothing records the proposer's.
+
+**Rejected but Δ>0 (`gate_check.py`'s `directionally_positive_but_inconclusive`)?** `commit.py --decision
+provisional` books that, then `grow.py` buys more trials on the SAME unmodified candidate and re-gates at
+the pooled n — capped at 2 growth rounds (see `references/algorithm.md`).
+
+**6. Write the handover before ending this round** — append one `## Iteration <cid>` entry to
+`JOURNAL.md` below the marker line: what you tried, why, what the numbers said. The only thing the NEXT
+round reads; `commit.py` folds it in only if you wrote one (see `references/algorithm.md`).
 
 ## Parallel round (optional)
 
@@ -220,9 +223,9 @@ Four invariants, to state before every fan-out (the reasoning, and where fan-out
 4. **Never fan out across the test split, and pay before you fan out** — `spend.py --n-siblings N`
    must say `affordable: true` first.
 
-Concurrency also composes *inside* one evaluation (`screen.py --workers N` / `CAPEVOLVE_WORKERS=N` pool
-rollout generation only, so numbers stay byte-identical to a serial run). Opt in only when `run_target` is
-thread-safe: no shared scratch dir, no single live container, no module-global client.
+Concurrency also composes *inside* one evaluation (`screen.py --workers N` / `CAPEVOLVE_WORKERS=N`, pooling
+rollout generation only — numbers stay byte-identical to serial). Opt in only when `run_target` is
+thread-safe: no shared scratch dir, single live container, or module-global client.
 
 ### Per-task fan-out — the cheap gradient
 
@@ -235,10 +238,9 @@ optimisers implement one fix and collide at merge with only one measured), `inte
 canary selection, every flag: [`references/per-task-fanout.md`](references/per-task-fanout.md). Two rules
 decide whether the shape is safe at all, so they live here:
 
-**A parallel optimiser's deliverable is a MECHANISM WITH TRACE PROOF, not a rate.** A fan-out is by
-construction a high-load regime — the one regime where a per-task rate cannot resolve the effect anyone is
-looking for — so ask for load-independent evidence (the guard fired on the observed call, and the next
-action changed), then gate the survivors yourself, serialised.
+**A parallel optimiser's deliverable is a MECHANISM WITH TRACE PROOF, not a rate.** A fan-out is a
+high-load regime by construction — where a per-task rate cannot resolve the effect — so ask for
+load-independent evidence (the guard fired, the next action changed), then gate the survivors serially.
 
 **A multi-branch artifact is assembled with `integrate.py`, never by one merge**, one branch at a time with
 a measurement after each: fewer mechanisms routinely beat more, and one number for N simultaneous changes
@@ -253,14 +255,13 @@ mechanism-vs-artifact designs, gating the sum not each addend, the sign test bel
 [`references/measured-lessons.md`](references/measured-lessons.md).
 
 1. **Explore fast, gate slow, gate ALONE.** The load knob is *total in-flight requests* (K processes at
-   concurrency C is K·C), not any per-process flag, and oversubscription fails silently — latency grows,
-   so it reads as "the model got slower". Pause the fan-out, run both gate arms in one batch, and let
-   that batch be the only thing running; if you cannot quiet the machine, say so next to the verdict.
+   concurrency C is K·C), not any per-process flag, and oversubscription fails silently as latency, not an
+   error. Pause the fan-out, run both gate arms in one batch alone; if you cannot quiet the machine, say
+   so next to the verdict.
 2. **Two independently-seeded blocks, agreeing in sign, before a small effect is a result.** A paired
-   run's SE is over *tasks*, so it cannot see run-to-run nondeterminism at all; `multirep.py` takes the
-   error across whole runs and refuses a verdict from one (`--base-seed` picks the block — raising `--n`
-   only extends the same one, so a rerun at the same seeds is a determinism check, not a replication).
-   If several full paired runs are unaffordable, "not resolvable at this budget" is the honest output.
+   run's SE is over *tasks*, so it cannot see run-to-run nondeterminism; `multirep.py` takes the error
+   across whole runs (`--base-seed` picks the block — raising `--n` extends the same one, not a
+   replication). Several full runs unaffordable ⇒ "not resolvable at this budget" is the honest output.
 
 ## Stop & seal, then MEASURE (once)
 
@@ -299,8 +300,9 @@ rather than driving around the primitives.
 One level deep — each is read on its own, and none points at another.
 
 - [`references/algorithm.md`](references/algorithm.md) — why free-form, how the honesty invariants
-  survive full autonomy, the screening break-even, which steps parallelise safely, the constraint
-  surface. **Load** before relying on a screen, or for the reasoning behind a rule you want to skip.
+  survive full autonomy, the screening break-even (incl. targeted-cluster holdouts), which steps
+  parallelise safely, the constraint surface, and provisional candidates (Δ>0, gate-inconclusive).
+  **Load** before relying on a screen, growing a provisional candidate, or skipping a rule.
 - [`references/measured-lessons.md`](references/measured-lessons.md) — every measurement rule with the
   number that bought it: binomial floor, full val vs a hard subset, the load-vs-noise tables, the sign
   test, the across-runs estimator. **Load** before your first gate decision on a new benchmark, or

--- a/skills/algorithms/agent-optimize/references/algorithm.md
+++ b/skills/algorithms/agent-optimize/references/algorithm.md
@@ -161,6 +161,50 @@ agent mode *the agent is the proposer*, so `scripts/commit.py` takes `--optimize
 (which drives the stall counter). Without those, a cost- or stall-based `stop_condition` is
 unenforceable no matter how carefully it is written.
 
+## Why N≥3 sibling candidates is the default, not one candidate at a time
+
+A round pays fixed overhead regardless of how many candidates it gates: the null-control
+replicates (`--control-replicates 2` by default) plus, on the deterministic path, a baseline
+re-check. That overhead is paid ONCE whether the round proposes one candidate or several, so a
+round that proposes exactly one candidate spends nearly all of it on a single shot at the gate —
+observed directly in a live run, where two consecutive rounds each proposed one candidate and
+both were rejected, at the same fixed cost as three or more addressed in parallel would have
+been. `round.py` already supports evaluating N candidates as parallel *processes* (each with its
+own adapter `apply()`), gating them serially — the mechanism was already there; only the default
+behavior of proposing one at a time was the gap. Default to N≥3, one failure cluster each, and
+drop to fewer only when `spend.py --n-siblings N` says the remaining budget cannot afford it.
+
+## JOURNAL.md — the append-only handover, and its write protocol
+
+`$R/work/$TAG/JOURNAL.md` exists in your working copy from the moment you `cp -r
+"$R/candidates/$BEST" "$R/work/$TAG"` — the framework seeds it (`harness._seed_journal`) onto
+the seed candidate before round 1, and re-seeds it onto whichever candidate is `$BEST` after
+every `commit.py` call, so it is always present at the start of a round regardless of how many
+rounds came before. It is YOUR file (append-only, never reset): the run-level copy at
+`$R/JOURNAL.md` accumulates one entry per iteration, accepted and rejected alike.
+
+The write protocol:
+
+1. Read the WHOLE file before proposing — not just the last entry — so you build on every prior
+   attempt and never re-test a refuted idea.
+2. Append your new entry BELOW the marker line
+   `<!-- cap-evolve:journal-append-below — add your Iteration entry under this line; do not edit
+   anything above it -->`. Never edit or delete anything above the marker.
+3. Use the heading `## Iteration <candidate id> — <one-line headline of what you tried>`,
+   followed by: the changes you made, the expected effect of each, which prior RESULTS you built
+   on (or explicitly avoided because a prior RESULT proved it regressed), refuted hypotheses, and
+   your focus for the next iteration. You cannot know your own gate result while you write it —
+   `commit.py` stamps a `**RESULT (framework, objective):**` line right below your entry
+   afterward (accept/reject, Δ, and the exact tasks fixed/broken vs the parent), which is the
+   authoritative record of what actually worked — read it, don't guess at it.
+
+This is a general convention for ANY continuous-session algorithm (one long-running optimizer
+subprocess spanning many rounds, as opposed to the deterministic loops' fresh per-iteration
+optimizer workdir): the framework re-seeds the same file at the same two points
+(`harness._seed_journal` called once before the session starts, and once per `commit.py` call
+afterward) so a session that never gets a fresh workdir per iteration still gets a fresh append
+target every round.
+
 ## Parallelism: fan out on the cheap steps, stay serial where state moves
 
 Arbor's discipline — dispatch independent workers into separate worktrees, evaluate each on

--- a/skills/algorithms/agent-optimize/references/algorithm.md
+++ b/skills/algorithms/agent-optimize/references/algorithm.md
@@ -322,18 +322,21 @@ numbers would be a copy.
 
 ## Gate as evidence, not a verdict
 
-`gate_check.py` computes the honest statistics — `delta`, `stderr`, `resolvable_effect_size`, whether both
-null-control replicates agree in sign — and prints them as its `"verdict"` field. It does not decide for
-you. Nothing in `commit.py` or `round.py` checks that field against the `--decision` you pass: `set_best()`
+The statistics come from two scripts, and it matters which one prints what: `gate_check.py` prints
+`delta`, `stderr`, `resolvable_effect_size` and its own `"verdict"` for ONE candidate; `round.py` prints
+the round-scoped numbers no single-candidate gate can see — `noise_floor_from_control` and
+`verdict_by_reference`/`verdict_stable`, the sign-agreement check across the round's null-control
+replicates. Neither decides for you. Nothing in `commit.py` or `round.py` checks that field against the `--decision` you pass: `set_best()`
 is an unconditional setter, and `--reject-basis driver_judgement` exists precisely so you can log a
 considered disagreement. Treat the printed numbers the way a careful researcher reads a stats printout,
 not the way code reads a boolean:
 
 - Read `resolvable_effect_size` first. It is the smallest true effect this round could have detected at
   all — a `delta` at or below it is not evidence either way, whatever the printed verdict says.
-- Does `delta` clear the noise floor measured for THIS round (`noise_floor_from_control`), not just the a
-  priori `k_se` threshold baked into the printed verdict?
-- Do both null-control replicates agree in sign with the candidate's direction? A round where they
+- Does `delta` clear the noise floor measured for THIS round (`round.py`'s
+  `noise_floor_from_control`), not just the a priori `k_se` threshold baked into the printed verdict?
+- Does the verdict survive the choice of control replicate (`round.py`'s `verdict_by_reference` /
+  `verdict_stable`, always computed once there is more than one control block)? A round where they
   disagree is telling you the noise floor itself is unstable this round, not just that one candidate is
   borderline.
 - Before any accept, or any decision that disagrees with the printed verdict, write one sentence in

--- a/skills/algorithms/agent-optimize/references/algorithm.md
+++ b/skills/algorithms/agent-optimize/references/algorithm.md
@@ -7,6 +7,7 @@
 - [Subset screening](#subset-screening-where-the-cost-actually-goes-and-why-a-screen-may-not-accept)
 - [The constraint surface](#the-constraint-surface-free-text-stop_condition-parsed-and-re-read)
 - [Sibling candidates by default](#why-n3-sibling-candidates-is-the-default-not-one-candidate-at-a-time)
+- [Provisional candidates](#provisional-candidates-sequential-evidence-not-compounded-edits)
 - [JOURNAL.md write protocol](#journalmd--the-append-only-handover-and-its-write-protocol)
 - [Parallelism](#parallelism-fan-out-on-the-cheap-steps-stay-serial-where-state-moves)
 - [The final measurement](#the-final-measurement-one-table-and-the-things-it-refuses-to-pretend)
@@ -124,6 +125,19 @@ the tasks the edit targeted**, not as a statistical test: a tier-1 subset contai
 val task that comes back 0-for-N on them is a sound reason to stop spending on that candidate. Book
 that as a budget decision on screen evidence (`--reject-basis budget`), never as a gate decision.
 
+### Targeted screening: draw the collateral-damage holdout from outside the cluster
+
+`--broken <ids>` biases a screen toward the tasks an edit is meant to fix — the right bias for
+"did the targeted tasks improve", the wrong one for "did anything else break", because those
+targeted ids crowd out the holdout that would otherwise catch a regression elsewhere. Two
+separate calls answer the two questions cleanly: `--broken <cluster-ids> --k <n> --holdout-frac
+0` for a pure read on the cluster, and a second call with no `--broken` and a normal
+`--holdout-frac` for collateral damage — its holdout draws from tasks the parent already
+*passes* (`select_screen_subset`'s `passing` set), which a diagnosed failure cluster is not, so
+it checks the untouched surface without having to name it. One `--k`-sized draw that mixes both
+either drowns the targeted signal in noise or lets the same tasks stand for both target and
+holdout at once.
+
 ### `phases/gate` is an inspection front-end, not the round's gate
 
 `phases/gate/scripts/run.py --mode paired` reaches the *same* paired gate off the *same* persisted
@@ -187,6 +201,46 @@ been. `round.py` already supports evaluating N candidates as parallel *processes
 own adapter `apply()`), gating them serially — the mechanism was already there; only the default
 behavior of proposing one at a time was the gap. Default to N≥3, one failure cluster each, and
 drop to fewer only when `spend.py --n-siblings N` says the remaining budget cannot afford it.
+
+## Provisional candidates: sequential evidence, not compounded edits
+
+A candidate that clears `Δ>0` but not `Δ > k·SE` is not the same as one at `Δ<=0`: the first is
+a real positive direction the gate could not yet resolve at this `n`; the second has no
+direction to chase. Discarding both alike wastes the first kind of evidence — three real rounds
+on one benchmark each proposed a single candidate, paid the round's full fixed overhead, and
+bounced off the noise floor with nothing carried forward, even though at least one of those
+candidates' `Δ` was positive and simply under-measured.
+
+The fix is a THIRD decision, `commit.py --decision provisional`, for exactly that case
+(`gate_check.py` flags it as `directionally_positive_but_inconclusive`). It is deliberately
+narrow: the only thing that happens next is buying more trials on the **same, unmodified**
+candidate (`scripts/grow.py`) — never a new edit stacked on top of it. This is the line that
+keeps sequential evidence-gathering from becoming the failure mode this project's own
+post-mortems already named — "fewer mechanisms beat more", i.e. compounding edits on
+unconfirmed ground. A provisional candidate buys precision on ONE measurement; it never becomes
+the base a sibling edit builds from until it has actually been accepted.
+
+**The pooling has to be real pooling, not two verdicts averaged.** `grow.py` runs the additional
+trials under a throwaway tag, then `loop.pool_split_results` concatenates each shared task's
+`trial_rewards` (not its mean) before re-aggregating — so the pooled `SplitResult` is what a
+single evaluation at `n = n_old + n_new` would have produced, and the paired significance test
+that follows sees the honest combined variance. Averaging the two rounds' *deltas* instead would
+silently discard the fact that more trials narrow the SE; averaging their *verdicts* would treat
+a 60%-confidence read and a 40%-confidence read as one vote each. `grow.py` then merges the new
+rollout files onto the candidate's own tag (renumbered past its existing trial indices), so every
+later reader — `gate_check.py`, `commit.py`, the dashboard — sees one candidate at the pooled
+`n` with no special-casing for having been grown.
+
+**The honest risk, and its cap.** Could a provisional lineage get stuck accumulating trials on a
+false positive for many rounds, burning budget chasing noise that looked promising once? Yes —
+that is exactly the failure mode a gate without a stopping rule invites, and it is why growth is
+capped at **`--max-growth-rounds 2`** (`grow.py`'s default): at most two extra rounds of added
+trials before the candidate must be finally promoted or abandoned, never grown a third time.
+Two rounds is enough to roughly double or triple `n` on a candidate that started with a small
+val, which is where most of the SE reduction from added trials actually lives (diminishing
+returns set in well before a fourth round would). A candidate that still has not cleared the bar
+after two growth rounds is abandoned (`commit.py --decision reject --reject-basis gate`) — the
+cap turns "maybe next round" into a bounded, auditable cost rather than an open-ended one.
 
 ## JOURNAL.md — the append-only handover, and its write protocol
 

--- a/skills/algorithms/agent-optimize/references/algorithm.md
+++ b/skills/algorithms/agent-optimize/references/algorithm.md
@@ -1,5 +1,19 @@
 # agent-optimize — rationale, and how honesty survives full autonomy
 
+## Contents
+
+- [Why a free-form agentic algorithm](#why-a-free-form-agentic-algorithm)
+- [How honesty survives handing the agent the wheel](#how-honesty-survives-handing-the-agent-the-wheel)
+- [Subset screening](#subset-screening-where-the-cost-actually-goes-and-why-a-screen-may-not-accept)
+- [The constraint surface](#the-constraint-surface-free-text-stop_condition-parsed-and-re-read)
+- [Sibling candidates by default](#why-n3-sibling-candidates-is-the-default-not-one-candidate-at-a-time)
+- [JOURNAL.md write protocol](#journalmd--the-append-only-handover-and-its-write-protocol)
+- [Parallelism](#parallelism-fan-out-on-the-cheap-steps-stay-serial-where-state-moves)
+- [The final measurement](#the-final-measurement-one-table-and-the-things-it-refuses-to-pretend)
+- [Gate as evidence, not a verdict](#gate-as-evidence-not-a-verdict)
+- [Caveats](#caveats)
+- [Sources](#sources)
+
 ## Why a free-form agentic algorithm
 
 The deterministic algorithms (hill-climb, gepa, skillopt) fix the *schedule* of the
@@ -251,6 +265,41 @@ generalisation**, with the overlap counted; and `best_id == "seed"` emits a warn
 delta is 0 *by construction* and must be reported as a null result with a diagnosed cause.
 `--train auto` also declines to pay for a train evaluation whose ids equal val's, because the
 numbers would be a copy.
+
+## Gate as evidence, not a verdict
+
+`gate_check.py` computes the honest statistics — `delta`, `stderr`, `resolvable_effect_size`, whether both
+null-control replicates agree in sign — and prints them as its `"verdict"` field. It does not decide for
+you. Nothing in `commit.py` or `round.py` checks that field against the `--decision` you pass: `set_best()`
+is an unconditional setter, and `--reject-basis driver_judgement` exists precisely so you can log a
+considered disagreement. Treat the printed numbers the way a careful researcher reads a stats printout,
+not the way code reads a boolean:
+
+- Read `resolvable_effect_size` first. It is the smallest true effect this round could have detected at
+  all — a `delta` at or below it is not evidence either way, whatever the printed verdict says.
+- Does `delta` clear the noise floor measured for THIS round (`noise_floor_from_control`), not just the a
+  priori `k_se` threshold baked into the printed verdict?
+- Do both null-control replicates agree in sign with the candidate's direction? A round where they
+  disagree is telling you the noise floor itself is unstable this round, not just that one candidate is
+  borderline.
+- Before any accept, or any decision that disagrees with the printed verdict, write one sentence in
+  `commit.py`'s `--note` citing the actual numbers (delta vs resolvable effect size vs noise floor). This
+  is not optional ceremony — it is the audit trail a human reviewer uses afterward to check your judgment,
+  the same way a rigorous post-mortem checks the numbers behind every claim.
+
+**Why this doesn't regress to the coin-flip-accept failure a significance bar this loose already produced
+on a real benchmark**: the arithmetic that caused that failure — banking `delta > 0` as progress when the
+significance bar sat below the measured noise floor — is untouched. `gate_check.py` still computes the same
+rigorous statistics and prints them prominently; what changes is only that you must engage with those
+numbers in your own reasoning rather than pattern-matching a boolean field. The historical failure mode was
+"the bar sat below the noise floor and nobody could see it" — with `resolvable_effect_size` and
+`noise_floor_from_control` printed first, that is now structurally hard to miss.
+
+**The new risk this introduces, honestly stated**: a strong optimizer can rationalize accepting something
+the numbers don't support, dressing noise-chasing in confident-sounding prose — the failure mode moves from
+bad math to motivated reasoning, which is harder to catch mechanically than a wrong formula was. The only
+mitigation available is the audit trail above: every override gets a human-readable justification citing
+real numbers, reviewable after the fact, the same way this repo's own run post-mortems already work.
 
 ## Caveats
 

--- a/skills/algorithms/agent-optimize/scripts/commit.py
+++ b/skills/algorithms/agent-optimize/scripts/commit.py
@@ -59,8 +59,8 @@ def _prior_decision(run_dir: RunDir, candidate_id: str) -> dict | None:
     return None
 
 
-def _gate_verdict(run_dir: RunDir, candidate_id: str) -> str | None:
-    """The verdict ``round.py`` recorded for this candidate, from its persisted table.
+def _gate_row(run_dir: RunDir, candidate_id: str) -> dict | None:
+    """This candidate's row from ``round.py``'s persisted table, if one exists.
 
     Readable only because ``round.py`` now writes its table to ``work/`` instead of leaving
     stdout the sole copy — before that, ``commit.py`` had no way to know what the gate had said
@@ -83,8 +83,32 @@ def _gate_verdict(run_dir: RunDir, candidate_id: str) -> str | None:
             continue
         for row in payload.get("candidates") or []:
             if isinstance(row, dict) and str(row.get("tag")) == str(candidate_id):
-                return row.get("verdict")
+                return row
     return None
+
+
+def _gate_verdict(run_dir: RunDir, candidate_id: str) -> str | None:
+    row = _gate_row(run_dir, candidate_id)
+    return row.get("verdict") if row else None
+
+
+def _gate_stats(run_dir: RunDir, candidate_id: str) -> dict:
+    """Structured numeric gate fields for this candidate, straight from ``round.py``'s table
+    (which reads them from ``gate_check.py``'s own JSON) — for attaching to events, IN ADDITION
+    to the prose ``--note``, so the dashboard's gate-decision view no longer has to regex-parse
+    a hand-typed note to recover Δ/SE/n/k·SE/resolvable-effect-size. Field names match what
+    ``dashboard.py``'s ``gate_decisions`` already reports, so no dashboard schema change is
+    needed to consume them. Empty dict (not an error) when this candidate was never gated via
+    ``round.py`` (e.g. a single-candidate flow that called ``gate_check.py`` directly)."""
+    row = _gate_row(run_dir, candidate_id) or {}
+    return {
+        "delta": row.get("gate_delta"),
+        "threshold": row.get("gate_threshold"),
+        "stderr": row.get("stderr"),
+        "n": row.get("n"),
+        "k_se": row.get("k_se"),
+        "resolvable_effect_size": row.get("resolvable_effect_size"),
+    }
 
 
 def main(argv=None) -> int:
@@ -177,13 +201,18 @@ def main(argv=None) -> int:
     # total, but no cost-bearing event exists to explain it, so an agent-mode run reported
     # 100% of its optimizer spend as unattributed. opt_cost_usd/opt_tokens are the field
     # names the ledger already reads from headless optimizer backends.
+    # Structured gate numbers (delta/threshold/stderr/n/k_se/resolvable_effect_size), IN
+    # ADDITION to the prose --note, so the dashboard can render them without regex-parsing a
+    # hand-typed string. {} when this candidate was never gated via round.py.
+    gate_stats = _gate_stats(run_dir, args.candidate_id)
     run_dir.log_event(args.decision, candidate=args.candidate_id, val=args.val,
                       gate_verdict=gate_verdict, overrode_gate=overrode_gate,
                       note=args.note,
                       reject_basis=args.reject_basis,
                       opt_cost_usd=args.optimizer_usd or None,
                       opt_tokens=args.optimizer_tokens or None,
-                      opt_seconds=args.optimizer_seconds or None)
+                      opt_seconds=args.optimizer_seconds or None,
+                      **gate_stats)
     run_dir.update_spent(optimizer_usd=args.optimizer_usd,
                          optimizer_tokens=args.optimizer_tokens,
                          optimizer_seconds=args.optimizer_seconds)
@@ -195,7 +224,22 @@ def main(argv=None) -> int:
                              accepted=accepted, reason=args.note or args.decision,
                              val=args.val,
                              opt_cost_usd=args.optimizer_usd or None,
-                             opt_tokens=args.optimizer_tokens or None)
+                             opt_tokens=args.optimizer_tokens or None,
+                             **gate_stats)
+    # Re-seed JOURNAL.md onto whichever candidate is now $BEST (fresh accumulated run
+    # journal + marker), so the NEXT round's `cp -r "$R/candidates/$BEST" "$R/work/$TAG"`
+    # carries a clean append target forward — the round-2+ half of the fix in host.py's
+    # `_stage_context` (which seeds round 1 the same way onto the seed candidate).
+    # `record_iteration` above already folded THIS round's tail into the run-level file,
+    # so the snapshot picks up the full history regardless of accept/reject. Falls back to
+    # THIS candidate's own just-taken snapshot when there is no best_id yet (a run with no
+    # baseline) — that dir always exists (``run_dir.snapshot`` above just created it) —
+    # and is best-effort: losing this re-seed must not fail the commit itself.
+    try:
+        harness._seed_journal(
+            run_dir.candidate_dir(run_dir.best_id or args.candidate_id), run_dir)
+    except Exception as exc:  # noqa: BLE001
+        run_dir.log_event("optimizer_context_warning", what="JOURNAL.md", error=str(exc)[:300])
     spent = run_dir.spent
     run_dir.record_spend_warnings()
     stop, reason = run_dir.budget_exhausted()

--- a/skills/algorithms/agent-optimize/scripts/commit.py
+++ b/skills/algorithms/agent-optimize/scripts/commit.py
@@ -15,6 +15,14 @@ Does exactly what the deterministic loops do at the end of a step:
     canonical ``step`` record every consumer enumerates, and reconciles the
     run-level ``JOURNAL.md``. Do NOT open-code those three here again.
 
+``--decision provisional`` is a THIRD outcome, distinct from accept/reject: the candidate
+is directionally positive (Δ>0) but did not clear the significance gate, and the driver
+wants to buy more trials on this SAME, UNMODIFIED candidate (``scripts/grow.py``) before a
+final call. It snapshots and logs the event like the other two, but does NOT ``set_best``
+and does NOT call ``record_iteration`` — the iteration is not over, so the stall counter,
+LEDGER.md and JOURNAL.md must not advance for it. The same candidate id later gets a real
+``accept``/``reject`` commit once ``grow.py`` has re-gated it at the pooled n.
+
 Runner-side spend (metric_calls / usd / tokens / seconds) is already recorded by the
 evaluate phase; ``--optimizer-*`` is for the *proposer's* own cost, which in agent
 mode is you and would otherwise never be counted.
@@ -117,7 +125,7 @@ def main(argv=None) -> int:
     p.add_argument("--candidate-id", required=True,
                    help="candidate id == the tag its rollouts were written under")
     p.add_argument("--from-dir", required=True, help="the working copy to snapshot")
-    p.add_argument("--decision", required=True, choices=["accept", "reject"])
+    p.add_argument("--decision", required=True, choices=["accept", "reject", "provisional"])
     p.add_argument("--val", type=float, default=None, help="candidate's full-val mean")
     p.add_argument("--note", default="", help="one line: why this edit, in general terms")
     # The DRIVER's disposition, recorded machine-readably alongside the screen's own
@@ -168,8 +176,9 @@ def main(argv=None) -> int:
             return 2
 
     accepted = args.decision == "accept"
-    if accepted and args.reject_basis:
-        print(json.dumps({"error": "--reject-basis is meaningless on an accept",
+    provisional = args.decision == "provisional"
+    if (accepted or provisional) and args.reject_basis:
+        print(json.dumps({"error": f"--reject-basis is meaningless on --decision {args.decision}",
                           "fix": "drop it, or pass --decision reject"}, indent=2))
         return 2
     # `--reject-basis gate` asserts the gate rejected this candidate. On run 32871360361 it was
@@ -179,7 +188,7 @@ def main(argv=None) -> int:
     # legitimate (round.py leaves the decision to the driver on purpose); misattributing it is
     # not, and it is the one thing this log exists to get right.
     gate_verdict = _gate_verdict(run_dir, args.candidate_id)
-    overrode_gate = bool(not accepted and gate_verdict == "accept")
+    overrode_gate = bool(not accepted and not provisional and gate_verdict == "accept")
     if overrode_gate and args.reject_basis == "gate":
         print(json.dumps({
             "error": f"--reject-basis gate, but the gate ACCEPTED {args.candidate_id} "
@@ -209,6 +218,7 @@ def main(argv=None) -> int:
                       gate_verdict=gate_verdict, overrode_gate=overrode_gate,
                       note=args.note,
                       reject_basis=args.reject_basis,
+                      verdict=args.decision,
                       opt_cost_usd=args.optimizer_usd or None,
                       opt_tokens=args.optimizer_tokens or None,
                       opt_seconds=args.optimizer_seconds or None,
@@ -216,30 +226,36 @@ def main(argv=None) -> int:
     run_dir.update_spent(optimizer_usd=args.optimizer_usd,
                          optimizer_tokens=args.optimizer_tokens,
                          optimizer_seconds=args.optimizer_seconds)
-    # The shared iteration step: charges iterations/stall, writes the canonical ``step``
-    # record, reconciles the run-level JOURNAL.md. ``parent_val`` is unknown in agent mode
-    # (the agent gates via gate_check, which prints but does not persist the parent mean),
-    # so it stays None rather than being guessed.
-    harness.record_iteration(run_dir, src, args.candidate_id, parent_id=parent_id,
-                             accepted=accepted, reason=args.note or args.decision,
-                             val=args.val,
-                             opt_cost_usd=args.optimizer_usd or None,
-                             opt_tokens=args.optimizer_tokens or None,
-                             **gate_stats)
-    # Re-seed JOURNAL.md onto whichever candidate is now $BEST (fresh accumulated run
-    # journal + marker), so the NEXT round's `cp -r "$R/candidates/$BEST" "$R/work/$TAG"`
-    # carries a clean append target forward — the round-2+ half of the fix in host.py's
-    # `_stage_context` (which seeds round 1 the same way onto the seed candidate).
-    # `record_iteration` above already folded THIS round's tail into the run-level file,
-    # so the snapshot picks up the full history regardless of accept/reject. Falls back to
-    # THIS candidate's own just-taken snapshot when there is no best_id yet (a run with no
-    # baseline) — that dir always exists (``run_dir.snapshot`` above just created it) —
-    # and is best-effort: losing this re-seed must not fail the commit itself.
-    try:
-        harness._seed_journal(
-            run_dir.candidate_dir(run_dir.best_id or args.candidate_id), run_dir)
-    except Exception as exc:  # noqa: BLE001
-        run_dir.log_event("optimizer_context_warning", what="JOURNAL.md", error=str(exc)[:300])
+    # `provisional` books the decision above but stops here: the iteration is not over
+    # (the SAME candidate gets a real accept/reject commit later, once `grow.py` has
+    # re-gated it at a pooled n), so the stall counter, LEDGER.md and JOURNAL.md must not
+    # advance for it — that would spend an iteration's worth of "the run learned something
+    # new" bookkeeping on a decision that has not actually been made yet.
+    if not provisional:
+        # The shared iteration step: charges iterations/stall, writes the canonical ``step``
+        # record, reconciles the run-level JOURNAL.md. ``parent_val`` is unknown in agent mode
+        # (the agent gates via gate_check, which prints but does not persist the parent mean),
+        # so it stays None rather than being guessed.
+        harness.record_iteration(run_dir, src, args.candidate_id, parent_id=parent_id,
+                                 accepted=accepted, reason=args.note or args.decision,
+                                 val=args.val,
+                                 opt_cost_usd=args.optimizer_usd or None,
+                                 opt_tokens=args.optimizer_tokens or None,
+                                 **gate_stats)
+        # Re-seed JOURNAL.md onto whichever candidate is now $BEST (fresh accumulated run
+        # journal + marker), so the NEXT round's `cp -r "$R/candidates/$BEST" "$R/work/$TAG"`
+        # carries a clean append target forward — the round-2+ half of the fix in host.py's
+        # `_stage_context` (which seeds round 1 the same way onto the seed candidate).
+        # `record_iteration` above already folded THIS round's tail into the run-level file,
+        # so the snapshot picks up the full history regardless of accept/reject. Falls back to
+        # THIS candidate's own just-taken snapshot when there is no best_id yet (a run with no
+        # baseline) — that dir always exists (``run_dir.snapshot`` above just created it) —
+        # and is best-effort: losing this re-seed must not fail the commit itself.
+        try:
+            harness._seed_journal(
+                run_dir.candidate_dir(run_dir.best_id or args.candidate_id), run_dir)
+        except Exception as exc:  # noqa: BLE001
+            run_dir.log_event("optimizer_context_warning", what="JOURNAL.md", error=str(exc)[:300])
     spent = run_dir.spent
     run_dir.record_spend_warnings()
     stop, reason = run_dir.budget_exhausted()

--- a/skills/algorithms/agent-optimize/scripts/gate_check.py
+++ b/skills/algorithms/agent-optimize/scripts/gate_check.py
@@ -135,8 +135,11 @@ def main(argv=None) -> int:
     # this SAME candidate (never a new edit) may resolve it — see references/algorithm.md,
     # "Provisional candidates". Surfaced here so the driver notices it without having to
     # compute delta > 0 itself.
+    # Off `d.accept`, not the regression-vetoed `accept`: a candidate the GATE accepted and
+    # `--veto-regressions` then rejected has nothing left for more trials to resolve — the
+    # veto is a per-task harm call, not a measurement-power problem.
     directionally_positive_but_inconclusive = (
-        not d.indecisive and not accept and d.delta > 0)
+        not d.indecisive and not d.accept and d.delta > 0)
     next_cmd = f"scripts/commit.py --decision {'accept' if accept else 'reject'}"
     if directionally_positive_but_inconclusive:
         next_cmd += " (or --decision provisional, then scripts/grow.py, to buy more n on this candidate)"

--- a/skills/algorithms/agent-optimize/scripts/gate_check.py
+++ b/skills/algorithms/agent-optimize/scripts/gate_check.py
@@ -130,6 +130,16 @@ def main(argv=None) -> int:
     regs = regressions(cur, cand)
     accept = bool(d.accept) and not (regs and args.veto_regressions)
     verdict = "indecisive" if d.indecisive else ("accept" if accept else "reject")
+    # A reject with delta > 0 is not the same as a reject with delta <= 0: the first is
+    # a positive direction the gate could not yet resolve at this n, and growing n on
+    # this SAME candidate (never a new edit) may resolve it — see references/algorithm.md,
+    # "Provisional candidates". Surfaced here so the driver notices it without having to
+    # compute delta > 0 itself.
+    directionally_positive_but_inconclusive = (
+        not d.indecisive and not accept and d.delta > 0)
+    next_cmd = f"scripts/commit.py --decision {'accept' if accept else 'reject'}"
+    if directionally_positive_but_inconclusive:
+        next_cmd += " (or --decision provisional, then scripts/grow.py, to buy more n on this candidate)"
     print(json.dumps({
         "current": {"tag": cur_tag, "reward": cur.reward, "stderr": cur.stderr},
         "candidate": {"tag": args.candidate, "reward": cand.reward,
@@ -138,7 +148,8 @@ def main(argv=None) -> int:
         "paired_n": len(deltas or []),
         "regressions": regs,
         "verdict": verdict,
-        "next": (f"scripts/commit.py --decision {'accept' if accept else 'reject'}"),
+        "directionally_positive_but_inconclusive": directionally_positive_but_inconclusive,
+        "next": next_cmd,
     }, indent=2))
     return 0
 

--- a/skills/algorithms/agent-optimize/scripts/grow.py
+++ b/skills/algorithms/agent-optimize/scripts/grow.py
@@ -50,12 +50,15 @@ def _existing_trial_count(run_dir: RunDir, tag: str, split: str) -> int:
     vdir = run_dir.rollouts / split
     if not vdir.exists():
         return 0
-    counts = {}
+    # Track the HIGHEST trial index per task, then convert to a count once. Comparing a
+    # running count against the next index instead (`max(count, idx) + 1`) over-counts
+    # whenever glob order is not ascending, which leaves gaps in the merged indices.
+    highest: dict = {}
     for f in vdir.glob(f"*__{tag}__t*.json"):
         tid = f.name.split(f"__{tag}__t")[0]
         idx = int(f.name.rsplit("__t", 1)[1].removesuffix(".json"))
-        counts[tid] = max(counts.get(tid, -1), idx) + 1
-    return max(counts.values()) if counts else 0
+        highest[tid] = max(highest.get(tid, -1), idx)
+    return max(highest.values()) + 1 if highest else 0
 
 
 def _merge_grow_trials(run_dir: RunDir, candidate: str, grow_tag: str, split: str,
@@ -147,6 +150,29 @@ def main(argv=None) -> int:
     run_dir.log_event("provisional_grow", candidate=args.candidate, growth_round=args.growth_round,
                       add_trials=args.add_trials, pooled_n=len(deltas or []),
                       pooled_val=pooled.reward, verdict=verdict, recommendation=recommendation)
+
+    # Persist the POOLED gate row in the same `work/<table>.json` shape `round.py` writes,
+    # because `commit.py`'s `_gate_row` reads the newest such table to recover the verdict and
+    # the structured gate numbers it attaches to the accept/reject event. Without this the
+    # final commit on a grown candidate books the round's PRE-growth numbers — and a
+    # `promote` would be logged as `gate_verdict: reject`, reading as a driver override of a
+    # gate that in fact accepted at the pooled n. Newest-mtime wins there, so a plain write
+    # is all this needs; no special-casing on the reader's side.
+    work = run_dir.root / "work"
+    work.mkdir(parents=True, exist_ok=True)
+    (work / f"grow_{args.candidate}_r{args.growth_round}.json").write_text(
+        json.dumps({"grown": args.candidate, "growth_round": args.growth_round,
+                    "candidates": [{
+                        "tag": args.candidate,
+                        "reward": pooled.reward,
+                        "gate_delta": d.delta,
+                        "gate_threshold": d.threshold,
+                        "stderr": pooled.stderr,
+                        "n": len(deltas or []),
+                        "k_se": args.k_se,
+                        "resolvable_effect_size": d.resolvable_effect_size,
+                        "verdict": verdict,
+                    }]}, indent=2), encoding="utf-8")
 
     print(json.dumps({
         "candidate": args.candidate,

--- a/skills/algorithms/agent-optimize/scripts/grow.py
+++ b/skills/algorithms/agent-optimize/scripts/grow.py
@@ -1,0 +1,169 @@
+"""grow — buy more trials on a PROVISIONAL candidate, then re-gate at the pooled n.
+
+A candidate is ``provisional`` (``commit.py --decision provisional``) when it is
+directionally positive (Δ>0) but did not clear the significance gate at the n it was
+measured at. That is sequential evidence, not a null result: the honest next step is
+more trials on the SAME, UNMODIFIED candidate — never a new edit on top of unconfirmed
+ground (see references/algorithm.md, "Provisional candidates").
+
+This script:
+  1. runs ``--add-trials`` NEW trials on the candidate's unchanged working copy, under a
+     throwaway tag (so the new rollout files cannot collide with the candidate's own),
+  2. pools the new trials with the candidate's existing val rollouts via
+     ``loop.pool_split_results`` (concatenates per-task trial vectors, not two means),
+  3. re-runs the SAME paired gate the candidate was first measured against, at the
+     pooled n,
+  4. merges the new rollout files onto the candidate's own tag on disk (renumbered past
+     its existing trial indices) so a later ``gate_check.py --candidate <tag>`` or
+     ``commit.py`` sees the full pooled history with no special-casing, and
+  5. recommends ``promote`` / ``grow_again`` / ``abandon`` — capped at
+     ``--max-growth-rounds`` (default 2): a provisional lineage that still has not
+     resolved after 2 extra growth rounds must be abandoned, not grown again, so an
+     unlucky early positive can only consume a bounded amount of extra budget.
+
+Never edits the candidate directory — it is re-evaluated exactly as it is.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# Imported for its side effect ONLY: seeds sys.path so `cap_evolve` resolves when
+# this script is run standalone (`python <this-file>`). Must precede the
+# cap_evolve imports below; not "unused" — deleting it breaks standalone runs.
+import _bootstrap  # noqa: F401  # side-effect import, see above
+
+from cap_evolve import RunDir, harness
+from cap_evolve.check import load_adapter
+from cap_evolve.gate import decide
+from cap_evolve.loop import pool_split_results
+
+DEFAULT_MAX_GROWTH_ROUNDS = 2
+
+
+def _existing_trial_count(run_dir: RunDir, tag: str, split: str) -> int:
+    """How many trial files the candidate's OWN tag already has (any task; every task
+    gets the same count, errored or not — see harness.evaluate_candidate)."""
+    vdir = run_dir.rollouts / split
+    if not vdir.exists():
+        return 0
+    counts = {}
+    for f in vdir.glob(f"*__{tag}__t*.json"):
+        tid = f.name.split(f"__{tag}__t")[0]
+        idx = int(f.name.rsplit("__t", 1)[1].removesuffix(".json"))
+        counts[tid] = max(counts.get(tid, -1), idx) + 1
+    return max(counts.values()) if counts else 0
+
+
+def _merge_grow_trials(run_dir: RunDir, candidate: str, grow_tag: str, split: str,
+                       offset: int) -> None:
+    """Rename the throwaway tag's rollout files onto the candidate's own tag, at trial
+    indices starting from ``offset`` — so the candidate's tag alone now carries the full
+    pooled history and every downstream reader (gate_check.py, dashboard, LEDGER.md)
+    needs no special-casing for a grown candidate."""
+    vdir = run_dir.rollouts / split
+    for f in sorted(vdir.glob(f"*__{grow_tag}__t*.json")):
+        tid = f.name.split(f"__{grow_tag}__t")[0]
+        idx = int(f.name.rsplit("__t", 1)[1].removesuffix(".json"))
+        f.rename(vdir / f"{tid}__{candidate}__t{offset + idx}.json")
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(prog="grow")
+    p.add_argument("--run-dir", required=True)
+    p.add_argument("--project", required=True)
+    p.add_argument("--candidate", required=True,
+                   help="the provisional candidate's tag == dir name")
+    p.add_argument("--current", default=None,
+                   help="tag to gate against; default = the run's current best_id")
+    p.add_argument("--add-trials", type=int, required=True,
+                   help="how many NEW trials to run on this candidate before re-gating")
+    p.add_argument("--growth-round", type=int, required=True,
+                   help="which growth attempt this is for this candidate (1, 2, ...)")
+    p.add_argument("--max-growth-rounds", type=int, default=DEFAULT_MAX_GROWTH_ROUNDS)
+    p.add_argument("--k-se", type=float, default=1.0)
+    args = p.parse_args(argv)
+
+    run_dir = RunDir.open(Path(args.run_dir))
+    adapter = load_adapter(Path(args.project))
+    cur_tag = args.current or run_dir.best_id
+    if not cur_tag:
+        print(json.dumps({"error": "no --current tag and no best_id in the run dir"}, indent=2))
+        return 2
+
+    cand_dir = run_dir.candidate_dir(args.candidate)
+    if not cand_dir.is_dir():
+        print(json.dumps({"error": f"no snapshot for candidate {args.candidate!r} — "
+                                   "commit.py --decision provisional first"}, indent=2))
+        return 2
+
+    existing = harness.split_result_from_rollouts(run_dir, args.candidate, "val")
+    if not existing.per_task:
+        print(json.dumps({"error": f"no existing val rollouts for {args.candidate!r} — "
+                                   "this is not a candidate that was ever gated"}, indent=2))
+        return 2
+
+    # New trials go under a THROWAWAY tag first (never the candidate's own), so they
+    # cannot collide with — or silently overwrite — the trials already on disk.
+    grow_tag = f"{args.candidate}__grow{args.growth_round}"
+    try:
+        base_seed = int(run_dir.read_splits().seed)
+    except Exception:  # noqa: BLE001
+        base_seed = 0
+    # Offset the new batch's seeds well clear of any prior growth round's, so re-running
+    # a real (non-deterministic) target draws genuinely new trials rather than replaying
+    # ones already on disk. ponytail: a fixed 1000-per-round stride, not exact bookkeeping
+    # of how many seeds a prior round actually consumed — plenty of headroom at the trial
+    # counts this gate is meant for.
+    new_result = harness.evaluate_candidate(
+        adapter, cand_dir, run_dir=run_dir, split="val", n_trials=args.add_trials,
+        tag=grow_tag, base_seed=base_seed + 1000 * args.growth_round)
+
+    pooled = pool_split_results(existing, new_result)
+
+    cur = harness.split_result_from_rollouts(run_dir, cur_tag, "val")
+    deltas = harness._paired_deltas(cur, pooled)
+    d = decide(cur.reward, pooled.reward, split="val", mode="paired", k_se=args.k_se,
+               candidate_stderr=pooled.stderr, current_stderr=cur.stderr,
+               paired_deltas=deltas, coverage=pooled.coverage, run_dir=run_dir)
+    verdict = "indecisive" if d.indecisive else ("accept" if d.accept else "reject")
+
+    # Merge the new trials onto the candidate's OWN tag now that the pooled numbers are
+    # computed, so a re-run of gate_check.py --candidate <candidate> (or another grow.py
+    # call for round N+1) sees the same pooled n with no special-casing.
+    offset = _existing_trial_count(run_dir, args.candidate, "val")
+    _merge_grow_trials(run_dir, args.candidate, grow_tag, "val", offset)
+
+    if verdict == "accept":
+        recommendation = "promote"
+    elif verdict != "indecisive" and d.delta > 0 and args.growth_round < args.max_growth_rounds:
+        recommendation = "grow_again"
+    else:
+        recommendation = "abandon"
+
+    run_dir.log_event("provisional_grow", candidate=args.candidate, growth_round=args.growth_round,
+                      add_trials=args.add_trials, pooled_n=len(deltas or []),
+                      pooled_val=pooled.reward, verdict=verdict, recommendation=recommendation)
+
+    print(json.dumps({
+        "candidate": args.candidate,
+        "growth_round": args.growth_round,
+        "max_growth_rounds": args.max_growth_rounds,
+        "current": {"tag": cur_tag, "reward": cur.reward, "stderr": cur.stderr},
+        "pooled": {"reward": pooled.reward, "stderr": pooled.stderr, "n_tasks": pooled.n_tasks},
+        "gate": d.to_dict(),
+        "paired_n": len(deltas or []),
+        "verdict": verdict,
+        "recommendation": recommendation,
+        "next": ("scripts/commit.py --decision accept" if recommendation == "promote" else
+                 f"scripts/grow.py --growth-round {args.growth_round + 1}" if recommendation == "grow_again" else
+                 "scripts/commit.py --decision reject --reject-basis gate"),
+    }, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/algorithms/agent-optimize/scripts/host.py
+++ b/skills/algorithms/agent-optimize/scripts/host.py
@@ -393,6 +393,14 @@ with concurrency.
 {guidance}
 {arm_block}
 
+## Default to 3+ candidates per round
+
+**Default to proposing 3 sibling candidates per round via `round.py`'s parallel mode** —
+address different failure clusters in parallel, not one at a time — unless `spend.py
+--n-siblings N` says your remaining budget can't afford it. A round's fixed overhead
+(baseline + null-control replicates) is paid regardless of how many candidates it gates, so
+one candidate per round wastes most of it on a single shot at the gate.
+
 ## The primitives every round must go through
 
 SKILL.md says why; this is the checklist, because nobody is watching and a round that
@@ -599,6 +607,22 @@ def _stage_context(*, run_dir: Path, project: Path, workdir: Path, spec: dict,
         # split="val" + the current best's tag: the parent step the agent builds on, which is
         # the same choice the deterministic loop makes.
         ctx.inject(adapter, rd, workdir, split="val", tag=rd.best_id or "seed")
+
+        # Seed the run's continuous JOURNAL.md into the CURRENT BEST candidate's snapshot
+        # (baseline's "seed" at round 1) so the agent's first `cp -r "$R/candidates/$BEST"
+        # "$R/work/$TAG"` (SKILL.md step 2) carries a marker-terminated JOURNAL.md forward.
+        # Without this, agent-optimize's continuous session never gets the per-iteration
+        # workdir seed the deterministic loops get from `_augment_instructions`, so
+        # JOURNAL.md never exists and every round's handover reads as empty — confirmed live.
+        # `commit.py` re-seeds the same way (onto whichever candidate becomes $BEST) after
+        # every round, so round 2+ inherits a clean append target automatically. Own
+        # try/except: a journal-seed failure must not mark the whole context (guidance,
+        # trajectories) unstaged — it is a nicety on top of staging, not staging itself.
+        try:
+            harness._seed_journal(rd.candidate_dir(rd.best_id or "seed"), rd)
+        except Exception as exc:  # noqa: BLE001
+            rd.log_event("optimizer_context_warning", what="JOURNAL.md", error=str(exc)[:300])
+
         guidance = (sorted(g.name for g in (workdir / "guidance").iterdir())
                     if (workdir / "guidance").is_dir() else [])
         # A DECLARED capability that got no guidance dir. `harness._stage_context` skips a

--- a/skills/algorithms/agent-optimize/scripts/host.py
+++ b/skills/algorithms/agent-optimize/scripts/host.py
@@ -429,8 +429,12 @@ its single `recommendation` (`stop` | `narrow_scope` | `continue`), as SKILL.md 
 Your always-on instructions mention `LEDGER.md`, `RUNMAP.md` and `prior_iterations/`. Those are
 built by the *deterministic* loop, which calls one optimizer per iteration; you are driving the
 whole search yourself, so they will not exist here and their absence is not a problem — do not
-go looking for them or try to recreate them. `JOURNAL.md` is different: `commit.py` reconciles
-it as you book rounds, so it accrues your own history and is worth reading from round 2 on.
+go looking for them or try to recreate them. `JOURNAL.md` is different: it is YOURS, not the
+framework's. Read it in full before proposing (from round 2 on it holds every prior round's
+handover). Then, before you end EACH round's turn — after `commit.py`, whether it accepted or
+rejected — append your own `## Iteration <cid>` entry below the marker: what you tried, why, and
+what the numbers said. `commit.py` only reconciles what you actually wrote; an empty file in, an
+empty handover out, and the next round starts blind.
 
 ## Unattended — this is the one real difference from an interactive run
 

--- a/skills/algorithms/agent-optimize/scripts/round.py
+++ b/skills/algorithms/agent-optimize/scripts/round.py
@@ -252,6 +252,14 @@ def main(argv=None) -> int:
                                              - gate_res.reward, 4)),
             "gate_delta": (g.get("gate") or {}).get("delta"),
             "gate_threshold": (g.get("gate") or {}).get("threshold"),
+            # Structured numeric fields from gate_check.py's own JSON, kept alongside
+            # gate_delta/gate_threshold above so commit.py can attach them to the events it
+            # writes, rather than only a hand-typed prose note (dashboard.py's gate_decisions
+            # previously had to regex-parse these back out of that note — see commit.py).
+            "stderr": (g.get("candidate") or {}).get("stderr"),
+            "n": g.get("paired_n"),
+            "k_se": args.k_se,
+            "resolvable_effect_size": (g.get("gate") or {}).get("resolvable_effect_size"),
             "verdict": g.get("verdict"),
             "regressions": g.get("regressions"),
             "eval_rc": ev.get("rc"),

--- a/skills/algorithms/agent-optimize/scripts/round.py
+++ b/skills/algorithms/agent-optimize/scripts/round.py
@@ -177,6 +177,18 @@ def main(argv=None) -> int:
         print(json.dumps({"error": f"tags not found under {work}: {missing}"}, indent=2))
         return 2
 
+    # Compliance instrumentation (issue #401): log, per candidate, whether screen.py was
+    # invoked for it BEFORE this full-val eval — a distinct, auditable event rather than
+    # something only inferable (or not) from SKILL.md prose. `screen.py` writes
+    # `<run_dir>/screens/<tag>__screenN.json`; its absence means this candidate skipped
+    # straight to full-val, which the dashboard can now show as its own event kind.
+    screens_dir = run_dir.root / "screens"
+    for t in tags:
+        screened = screens_dir.is_dir() and any(screens_dir.glob(f"{t}__screen*.json"))
+        run_dir.log_event("agent_optimize_compliance", tag=t,
+                          screened_before_fullval=screened,
+                          iteration=int(run_dir.spent.iterations))
+
     # The null control is built here, not by the driver, so it cannot silently be skipped
     # or accidentally differ from the parent.
     CTL = control_tag(run_dir)
@@ -280,7 +292,14 @@ def main(argv=None) -> int:
     # where against the other replicate it is +0.05 and rejects. The table said nothing about the
     # verdict resting on that choice. Re-gating costs no rollouts, so there is no reason not to
     # check; a verdict that flips is not evidence, whatever the picked replicate showed.
-    if args.gate_against == "control" and len(ctl_tags) > 1:
+    #
+    # MANDATORY two-seed-block sign agreement: this used to run only under
+    # --gate-against control, so a parent-gated round (the default) never checked whether its
+    # accept survived the choice of control replicate — measured on a real run to have called a
+    # null result positive exactly that way, unchecked because the round gated against the stored
+    # parent. With --control-replicates 2 the default, this check now always runs whenever there
+    # is more than one control block, in EITHER gate mode.
+    if len(ctl_tags) > 1:
         for r in rows:
             if r["tag"] in ctl_tags or r.get("reward") is None:
                 continue

--- a/skills/algorithms/agent-optimize/scripts/spend.py
+++ b/skills/algorithms/agent-optimize/scripts/spend.py
@@ -141,6 +141,11 @@ def main(argv=None) -> int:
                    help="trials per full-val eval; default = the spec's num_trials")
     p.add_argument("--warn-frac", type=float, default=0.8,
                    help="ceiling consumption at which to recommend narrow_scope")
+    p.add_argument("--ceiling-file", default=None,
+                   help="JSON file mapping task_id -> highest rate that task can structurally "
+                        "reach (e.g. from a diagnose-phase ceiling analysis). When given, a "
+                        "target_val_score predicate is COSTED against it before being treated "
+                        "as reachable — see cap_evolve.constraints.cost_target.")
     args = p.parse_args(argv)
 
     run_dir = RunDir.open(Path(args.run_dir))
@@ -152,6 +157,13 @@ def main(argv=None) -> int:
     spent = run_dir.spent
     wall = _wallclock(run_dir)
 
+    per_task_ceiling = None
+    if args.ceiling_file:
+        per_task_ceiling = {
+            str(k): float(v)
+            for k, v in json.loads(Path(args.ceiling_file).read_text(encoding="utf-8")).items()
+        }
+
     parsed = parse_constraints(str(spec.get("stop_condition") or ""))
     checked = check_constraints(
         parsed,
@@ -161,6 +173,7 @@ def main(argv=None) -> int:
         metric_calls=spent.metric_calls,
         regressed_tasks=_regressed_vs_seed(run_dir, best_id),
         warn_frac=args.warn_frac,
+        per_task_ceiling=per_task_ceiling,
     )
 
     # The run dir's own hard stop always wins: a prose condition cannot buy more budget.

--- a/skills/optimizers/run-optimizer/scripts/run.py
+++ b/skills/optimizers/run-optimizer/scripts/run.py
@@ -24,6 +24,7 @@ import shlex
 import shutil
 import subprocess
 import sys
+import threading
 from pathlib import Path
 
 import _bootstrap  # noqa: F401
@@ -241,6 +242,60 @@ def write_transcript(path: str, stdout: str, stderr: str, *, extra_keys=()) -> d
         return {"error": f"could not write transcript to {path}: {exc}"}
 
 
+def _run_and_stream(cmd: list[str], *, cwd: str, env: dict,
+                    transcript_path: str | None, extra_keys=()) -> tuple[int, str, str]:
+    """Run ``cmd``, TEEING each stdout line to ``transcript_path`` (redacted, append mode)
+    AS IT ARRIVES, instead of buffering the whole run in memory and writing once at exit.
+
+    A multi-hour continuous optimizer session (agent-optimize's execution mode calls this
+    once for the WHOLE session, not once per round) previously lost its entire transcript
+    on a crash, and nobody could read what it was doing mid-run — the transcript only
+    existed after the process had already exited. Still returns the full accumulated
+    stdout/stderr text so the caller's cost/stop parsing and final ``write_transcript``
+    call are byte-identical to the non-streaming behavior.
+
+    stderr is drained on a background thread while stdout is read on the main thread —
+    reading one pipe to completion before touching the other risks the classic two-pipe
+    deadlock if the child fills the other pipe's buffer while blocked on this one.
+    """
+    proc = subprocess.Popen(cmd, cwd=cwd, env=env, stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE, text=True, bufsize=1)
+
+    stderr_chunks: list[str] = []
+
+    def _drain_stderr() -> None:
+        assert proc.stderr is not None
+        for line in proc.stderr:
+            stderr_chunks.append(line)
+
+    stderr_thread = threading.Thread(target=_drain_stderr, daemon=True)
+    stderr_thread.start()
+
+    dest = None
+    if transcript_path:
+        try:
+            dest = Path(transcript_path)
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_text("", encoding="utf-8")  # start empty; each line appends below
+        except OSError:
+            dest = None  # best-effort: losing the LIVE tee must not lose the run
+
+    stdout_chunks: list[str] = []
+    assert proc.stdout is not None
+    for line in proc.stdout:
+        stdout_chunks.append(line)
+        if dest is not None:
+            try:
+                with dest.open("a", encoding="utf-8") as f:
+                    f.write(_redact(line, extra_keys))
+            except OSError:
+                dest = None  # stop trying; the in-memory copy still reaches write_transcript
+    proc.stdout.close()
+    proc.wait()
+    stderr_thread.join()
+    return proc.returncode, "".join(stdout_chunks), "".join(stderr_chunks)
+
+
 def build_command(template: str, *, workdir: str, prompt: str, prompt_text: str,
                   model: str | None, self_dir: str) -> list[str]:
     """Expand the template into argv.
@@ -383,25 +438,32 @@ def main(argv=None) -> int:
     env = dict(os.environ)
     env.update(auth["env"])
 
-    proc = subprocess.run(cmd, cwd=workdir, capture_output=True, text=True, env=env)
+    extra_keys = tuple(str(row.get("env_keys", "")).replace(",", " ").split())
+    # Popen + a live tee to --transcript as lines arrive, not subprocess.run() buffering the
+    # whole run in memory until exit — see `_run_and_stream`'s docstring for why (a crash
+    # mid-session previously lost the entire transcript). Still returns the full stdout/
+    # stderr text, so everything below is byte-identical to the prior non-streaming behavior.
+    returncode, stdout, stderr = _run_and_stream(
+        cmd, cwd=workdir, env=env, transcript_path=args.transcript, extra_keys=extra_keys)
     # Relay the agent CLI's stderr to OUR stderr, on success as well as failure: a CLI
     # that prints a real diagnostic (rate limit, model fallback, auth warning) and then
     # exits 0 must not look silently successful. stdout stays exactly one JSON object
     # (CONTRIBUTING.md's stdout contract), so the relay cannot corrupt the payload.
-    if proc.stderr:
-        print(proc.stderr, file=sys.stderr, end="", flush=True)
-    result = {"optimizer": name, "cli_present": True, "returncode": proc.returncode,
+    if stderr:
+        print(stderr, file=sys.stderr, end="", flush=True)
+    result = {"optimizer": name, "cli_present": True, "returncode": returncode,
               "auth_present": auth["present"],
-              "stdout_tail": proc.stdout[-800:], "stderr_tail": proc.stderr[-800:]}
+              "stdout_tail": stdout[-800:], "stderr_tail": stderr[-800:]}
     # Best-effort cost capture: only when --json requested AND the row had a json_flag.
     # The prose-fed path (no --json, or empty json_flag) never reaches here, so the
-    # offline/mock and generic flows are unchanged.
+    # offline/mock and generic flows are unchanged. write_transcript() re-writes the SAME
+    # destination with the complete, final text (the live tee above already wrote it
+    # incrementally) so the returned {path, bytes, lines} contract is unchanged.
     if args.transcript:
         result["transcript"] = write_transcript(
-            args.transcript, proc.stdout, proc.stderr,
-            extra_keys=tuple(str(row.get("env_keys", "")).replace(",", " ").split()))
+            args.transcript, stdout, stderr, extra_keys=extra_keys)
     if want_json and json_flag:
-        cost = parse_cost(proc.stdout)
+        cost = parse_cost(stdout)
         result["cost"] = {"total_cost_usd": cost["usd"], "tokens": cost["tokens"]}
         if cost["usd"] is None:
             # Headless output wasn't parseable — say so; the loop falls back to no-cost.
@@ -416,7 +478,7 @@ def main(argv=None) -> int:
         if stop:
             result["stop"] = stop
     print(json.dumps(result))
-    return proc.returncode
+    return returncode
 
 
 if __name__ == "__main__":

--- a/skills/phases/diagnose/scripts/cluster.py
+++ b/skills/phases/diagnose/scripts/cluster.py
@@ -13,8 +13,10 @@ of being re-improvised in prose on every iteration:
    preamble otherwise makes every failure look identical);
 2. reduce to content words — drop quoted literals / numbers / punctuation
    (task-specific, not causal), drop stopwords and OUTCOME-GENERIC words which say
-   *that* it failed and never *why*, and crudely stem the rest so
-   confirm/confirmed/confirmation collapse;
+   *that* it failed and never *why*, ALSO drop any stem that recurs in most of the
+   BATCH's own feedbacks (corpus-relative, on top of the fixed English list — a
+   benchmark's own recurring vocabulary is boilerplate too, just not English
+   boilerplate), and crudely stem the rest so confirm/confirmed/confirmation collapse;
 3. the surviving token set is the key — identifiers are the site, verbs the
    expectation;
 4. two keys are the same cluster when they OVERLAP: |A∩B| / min(|A|,|B|) >= 0.5,
@@ -54,6 +56,15 @@ _MIN_STEM = 4
 
 OVERLAP_MIN = 0.5
 
+# A token that recurs in more than this fraction of the batch's feedbacks is treated as
+# THIS BENCHMARK's own boilerplate, on top of (never instead of) the generic-English list
+# above. `_GENERIC`/`_STOP` are a fixed vocabulary of ENGLISH filler; they cannot know that
+# a given benchmark's scorer always says "action check state write" regardless of root
+# cause. A fixed corpus can only be told apart from noise on that corpus, so the threshold
+# is corpus-relative rather than a hardcoded word list — mechanical and benchmark-agnostic
+# by construction.
+CORPUS_STOP_FRAC = 0.65
+
 
 def _stem(tok: str) -> str:
     for suf in _SUFFIXES:
@@ -90,17 +101,48 @@ def common_prefix(feedbacks: list[str]) -> list[str]:
     return out
 
 
-def key_tokens(feedback: str, prefix: list[str] | None = None) -> frozenset[str]:
-    """The (site, expectation) key: content-word stems, boilerplate removed."""
+def _stemmed(feedback: str, prefix: list[str] | None = None) -> list[str]:
+    """Content-word stems for one feedback, with the shared boilerplate prefix removed."""
     toks = _words(feedback)
     pre = prefix or []
     if pre and toks[: len(pre)] == pre:
         toks = toks[len(pre):]
-    stems = [_stem(t) for t in toks]
-    keep = [s for s in stems if s not in _STOP and s not in _GENERIC]
+    return [_stem(t) for t in toks]
+
+
+def corpus_stopwords(stemmed_per_item: list[list[str]],
+                     threshold: float = CORPUS_STOP_FRAC) -> frozenset[str]:
+    """Stems that appear in more than ``threshold`` of the batch's feedbacks.
+
+    Document frequency, not raw count — a token used many times in ONE feedback must not
+    count as "common to the batch". Needs at least 2 feedbacks to mean anything."""
+    n = len(stemmed_per_item)
+    if n < 2:
+        return frozenset()
+    doc_freq: dict[str, int] = {}
+    for toks in stemmed_per_item:
+        for t in set(toks):
+            doc_freq[t] = doc_freq.get(t, 0) + 1
+    return frozenset(t for t, c in doc_freq.items() if c / n > threshold)
+
+
+def _filter_stems(stems: list[str], extra_stop: frozenset[str] | None = None) -> frozenset[str]:
+    """Drop generic/stopword/corpus-boilerplate stems, cascading back if that empties the
+    key — a cluster signature must never go blank just because a whole batch's failures
+    happen to share their content words too (a corpus of 2 near-identical failures, say)."""
+    extra = extra_stop or frozenset()
+    keep = [s for s in stems if s not in _STOP and s not in _GENERIC and s not in extra]
+    if not keep:                       # the corpus filter alone emptied it: back off
+        keep = [s for s in stems if s not in _STOP and s not in _GENERIC]
     if not keep:                       # all-generic feedback: fall back to what we have
         keep = [s for s in stems if s not in _STOP] or stems
     return frozenset(keep)
+
+
+def key_tokens(feedback: str, prefix: list[str] | None = None,
+              extra_stop: frozenset[str] | None = None) -> frozenset[str]:
+    """The (site, expectation) key: content-word stems, boilerplate removed."""
+    return _filter_stems(_stemmed(feedback, prefix), extra_stop)
 
 
 def overlap(a: frozenset[str], b: frozenset[str]) -> float:
@@ -116,7 +158,14 @@ def cluster(items: list[tuple[str, str, float]]) -> list[dict]:
     order, so the output is byte-identical on repeated runs over the same input.
     """
     prefix = common_prefix([f for _, f, _ in items])
-    keys = [key_tokens(f, prefix) for _, f, _ in items]
+    stemmed = [_stemmed(f, prefix) for _, f, _ in items]
+    # Corpus-relative, IN ADDITION to the generic-English list: a benchmark's own recurring
+    # vocabulary ("action check state write") isn't English boilerplate, so no fixed list
+    # catches it, but it is exactly as uninformative once it recurs in most of THIS batch's
+    # failures. Without this, that vocabulary survives into every key and merges unrelated
+    # failures into one mega-cluster with no discriminating signal.
+    extra_stop = corpus_stopwords(stemmed)
+    keys = [_filter_stems(s, extra_stop) for s in stemmed]
 
     # Union-find over the overlap relation (transitive: A~B and B~C => one cluster).
     # ponytail: O(n^2) pair scan — fine for a val split; index by token if it grows.

--- a/templates/adapters/tau2_bench/adapter.py
+++ b/templates/adapters/tau2_bench/adapter.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import importlib.util
 import os
+import re
 import sys
 from pathlib import Path
 
@@ -44,6 +45,35 @@ from cap_evolve import CapabilityAdapter, Rollout, Score, Task
 import model_config
 
 DOMAIN = "airline"
+
+# docs/TAU2_SUMMARY.md row 7: the tau2-bench user simulator sometimes emits ``###STOP###``
+# in the SAME message as reasoning that explicitly plans to continue ("we must wait for
+# agent's third message. Continue."), in 15/27 observed task-7 failures — ~4.2% of all
+# rollouts lost to a simulator artifact that measures nothing about agent skill. tau2-bench
+# is an external package (cloned at setup time, not vendored here), so the fix lives on our
+# side of the boundary: detect the leak from the message trace and mark the rollout as
+# infra noise, matching the existing ``rollout.error`` path below rather than scoring the
+# agent down for a bug that is not the agent's.
+_STOP_LEAK_RE = re.compile(
+    r"###\s*stop\s*###.{0,400}\b(?:continue|continuing|wait\s+for|must\s+wait|"
+    r"keep\s+(?:going|talking)|not\s+(?:done|finished)\s+yet)\b"
+    r"|\b(?:continue|continuing|wait\s+for|must\s+wait|"
+    r"keep\s+(?:going|talking)|not\s+(?:done|finished)\s+yet)\b.{0,400}###\s*stop\s*###",
+    re.I | re.S,
+)
+
+
+def _leaked_stop_continuation(messages) -> bool:
+    """True iff a user-simulator turn emits ``###STOP###`` alongside leaked reasoning that
+    explicitly plans to continue the conversation. Only ``user``-role turns are checked —
+    that is the simulator's own voice, not the agent's."""
+    for m in messages or []:
+        if not isinstance(m, dict) or m.get("role") != "user":
+            continue
+        content = m.get("content")
+        if isinstance(content, str) and _STOP_LEAK_RE.search(content):
+            return True
+    return False
 
 
 # ---------------------------------------------------------------------------
@@ -347,6 +377,14 @@ class Adapter(CapabilityAdapter):
             messages = [m.model_dump() for m in sim.get_messages()]
         except Exception:
             messages = None
+
+        if error is None and reward < 1.0 and _leaked_stop_continuation(messages):
+            error = (
+                "tau2 user-simulator emitted ###STOP### alongside leaked reasoning that "
+                "explicitly planned to continue the conversation (documented artifact, "
+                "docs/TAU2_SUMMARY.md row 7) — treated as uncontrollable noise, not an "
+                "agent policy/tool failure."
+            )
 
         reward_info_dump = (
             reward_info.model_dump(mode="json") if reward_info is not None else None


### PR DESCRIPTION
Addresses #401. Referencing, not closing — see "Deferred" below; the real end-to-end
validation run in the issue's acceptance criteria was not performed (no network egress in
the environment this was built in).

## Implemented

- **Resolvable effect size on every gate verdict** — `gate.decide()` now returns
  `resolvable_effect_size` (`2*SE`) alongside `accept`/`delta`/`threshold` for both `paired`
  and `significant` modes (`core/cap_evolve/gate.py`). A driver reads "this round can resolve
  ±X" before reading the delta, instead of discovering after the fact that a null result was
  a measurement-power problem, not a bad edit.
- **Mandatory two-seed-block sign agreement** — `round.py`'s per-candidate
  `verdict_stable`/`verdict_by_reference` check (re-gating each candidate against every control
  replicate) previously ran only under `--gate-against control`. It now runs whenever there is
  more than one control replicate, which is the default (`--control-replicates 2`), in either
  gate mode. A candidate whose verdict flips between control replicates is now marked
  `inconclusive` even in the default parent-gated round.
- **Costed-target check** — `cap_evolve.constraints.cost_target(target, per_task_ceiling)`
  costs a `target_val_score` against measured per-task headroom (mean of per-task ceilings);
  wired into `spend.py --ceiling-file <json>` so a target above the costed ceiling is flagged
  before more budget is spent chasing it.
- **`/goal` constraint enforcement** — `plugins/cap-evolve/hooks/goal_reminder.py`, a new
  `PostToolUse` hook (registered in `plugins/cap-evolve/hooks/hooks.json`). In an agent-mode
  run it counts Bash tool calls and, every `CAPEVOLVE_GOAL_CADENCE` calls (default 12),
  re-injects the parsed `stop_condition` predicates plus measured spend/wallclock/
  protected-tasks state as context — independent of whether the driving agent remembers to
  call `spend.py` itself. Fails open, no-ops outside an agent-mode run dir, matching the
  existing hooks' conventions.
- **Compliance instrumentation** — `round.py` now logs an `agent_optimize_compliance` event
  per candidate recording whether `screen.py` ran for it before this full-val eval (checked
  against `<run_dir>/screens/`). `dashboard.py`'s `reduce_run()` surfaces these under
  `algo_extra["compliance"]` as a distinct entry, generically (not agent-optimize-specific
  plumbing beyond the existing per-algorithm extraction pattern `screens` already uses).
- **tau2_airline user-simulator `###STOP###` + leaked-continuation-reasoning fix** — the bug
  from `docs/TAU2_SUMMARY.md` row 7 (the simulator emits `###STOP###` in the same message as
  reasoning that explicitly plans to continue, in 15/27 observed task-7 failures, costing
  ~4.2% of all rollouts). tau2-bench itself is an external, unvendored package (cloned at
  setup time), so the fix is on our side of that boundary: `_leaked_stop_continuation()`
  scans the message trace in `_sim_to_rollout` and marks the affected rollout as infra noise
  (mirroring the existing `rollout.error` "uncontrollable noise" path) rather than scoring it
  as an agent failure. Applied to both `examples/tau2_airline/adapters/adapter.py` (the live
  RITS adapter) and the shared `templates/adapters/tau2_bench/adapter.py`.

**Already implemented before this PR** (verified, left unchanged): mandatory plural null
controls (`round.py --control-replicates 2` default), mechanical canary selection
(`integrate.py --canary-auto --canary-floor`), and the mechanism ledger's `--supersedes`
(`mechanisms.py`). The issue listed these as missing; the codebase had already gained them in
earlier merged work.

## Deferred (documented, not silently dropped)

- **Real end-to-end validation run** (30/30/20, 10 trials, `aws/gpt-oss-120b` agent). The
  sandbox this PR was built in has no network egress — cannot `git clone` tau2-bench nor reach
  a model endpoint. I did **not** fabricate a run result. What I did verify:
  - `core/tests/` — full suite: **957 passed, 12 skipped**, including two new tests for the
    STOP-leak detector (`test_tau2_eval_cost.py`) exercised against a stubbed `tau2` module
    (no network required).
  - `skills/algorithms/agent-optimize/scripts/check.py` (the skill's own hard gate) — green.
  - No dashboard screenshot from a real run for the same reason; `reduce_run()`'s new
    `algo_extra["compliance"]` field is covered by the fact that `dashboard.py`'s existing test
    suite (`test_dashboard*.py`, `test_dashboard_agent_run.py`) still passes with the new event
    kind added to the agent-optimize algorithm marker list.
  - Follow-up: run `examples/tau2_airline/itest.sh` (or the full `airline90` spec) in an
    environment with network access to produce the real accept/null result with its resolvable
    effect size, and a dashboard screenshot, per the issue's acceptance criteria.

## Verification

```
cd core && python3 -m pytest tests/ -q
# 957 passed, 12 skipped
```

Git identity: authored as Osher-Elhadad <Osher.Elhadad@ibm.com>.