### PR TITLE
fix(core): protect evaluate_candidate in run_step the way the optimizer call is protected

### DIFF
--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -1505,6 +1505,47 @@ def _tamper_step(run_dir: RunDir, *, cid: str, parent_id, workdir: Path,
     }
 
 
+_MAX_CONSECUTIVE_EVAL_ERRORS = 3  # N raises in a row -> the environment, not the candidates
+
+
+def _eval_error_step(run_dir: RunDir, *, cid: str, parent_id, workdir: Path, error: str,
+                     current_val: SplitResult, optimizer_seconds: float,
+                     opt_cost_usd: float, opt_tokens: int, optimizer_error,
+                     rejected=None) -> dict:
+    """A REJECTED step (mirrors the optimizer_error handling above) for a candidate
+    whose ``evaluate_candidate`` call raised — e.g. an adapter's ``live()``/rollout
+    setup blew up on this one candidate (#286). Same discipline as the optimizer
+    call beside it: log it, reject the candidate (parent unchanged, stall counted),
+    keep the run going. Unlike a tamper/validation step this is NOT indecisive —
+    there is no candidate-side wrongdoing to exempt from the stall counter, just a
+    failed evaluation, exactly like a failed proposal.
+    """
+    reason = f"candidate evaluation raised: {error}"
+    run_dir.snapshot(cid, workdir, ignore=_SNAPSHOT_IGNORE)
+    record_iteration(run_dir, workdir, cid, parent_id=parent_id, accepted=False,
+                     reason=reason, val=None, parent_val=current_val.reward,
+                     optimizer_seconds=round(optimizer_seconds, 2),
+                     opt_cost_usd=round(opt_cost_usd, 6), opt_tokens=opt_tokens)
+    summary = f"candidate {cid} (evaluation failed)"
+    if rejected is not None:
+        rejected.add(cid, summary, reason, None)
+    run_dir.record_spend_warnings()
+    return {
+        "candidate_id": cid,
+        "accepted": False,
+        "decision": {"accept": False, "reason": reason, "delta": 0.0, "threshold": 0.0},
+        "candidate_val": None,
+        "parent_val": current_val.to_dict(),
+        "eval_error": error,
+        "regressions": [],
+        "optimizer_seconds": optimizer_seconds,
+        "optimizer_usd": opt_cost_usd,
+        "optimizer_tokens": opt_tokens,
+        "optimizer_error": optimizer_error,
+        "workdir": str(workdir),
+    }
+
+
 def run_step(
     adapter,
     *,
@@ -1630,8 +1671,32 @@ def run_step(
                                 event="capability_invalid", detail_key="validation",
                                 rejected=rejected)
 
-    cand_val = evaluate_candidate(adapter, workdir, run_dir=run_dir, split="val",
-                                  n_trials=n_trials, tag=cid)
+    try:
+        cand_val = evaluate_candidate(adapter, workdir, run_dir=run_dir, split="val",
+                                      n_trials=n_trials, tag=cid)
+    except Exception as e:  # noqa: BLE001
+        # Mirrors the optimizer-call protection above (#286): an adapter can raise
+        # from live()/rollout setup for a reason specific to ONE candidate (a bad
+        # sandbox, an unrunnable candidate artifact) — that must cost an iteration,
+        # not the run. But N of these IN A ROW means the environment itself is
+        # unrunnable, not that N candidates in a row happened to be bad — that must
+        # still fail loudly rather than silently look like N ordinary rejections.
+        streak = getattr(run_dir, "_consecutive_eval_errors", 0) + 1
+        run_dir._consecutive_eval_errors = streak
+        eval_error = str(e)
+        run_dir.log_event("evaluate_error", candidate=cid, error=eval_error[:500],
+                          error_full=eval_error, consecutive=streak)
+        if streak >= _MAX_CONSECUTIVE_EVAL_ERRORS:
+            raise RuntimeError(
+                f"{streak} consecutive candidate evaluations raised — this looks like "
+                f"a broken environment/adapter, not bad candidates. Last error: {eval_error}"
+            ) from e
+        return _eval_error_step(run_dir, cid=cid, parent_id=parent_id, workdir=workdir,
+                                error=eval_error, current_val=current_val,
+                                optimizer_seconds=optimizer_seconds,
+                                opt_cost_usd=opt_cost_usd, opt_tokens=opt_tokens,
+                                optimizer_error=optimizer_error, rejected=rejected)
+    run_dir._consecutive_eval_errors = 0
 
     # Paired gate is the default when per-task data is available: candidate and
     # current were scored on the SAME val tasks, so the correct (and far more

--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -1510,30 +1510,38 @@ _MAX_CONSECUTIVE_EVAL_ERRORS = 3  # N raises in a row -> the environment, not th
 
 def _eval_error_step(run_dir: RunDir, *, cid: str, parent_id, workdir: Path, error: str,
                      current_val: SplitResult, optimizer_seconds: float,
-                     opt_cost_usd: float, opt_tokens: int, optimizer_error,
-                     rejected=None) -> dict:
-    """A REJECTED step (mirrors the optimizer_error handling above) for a candidate
-    whose ``evaluate_candidate`` call raised — e.g. an adapter's ``live()``/rollout
-    setup blew up on this one candidate (#286). Same discipline as the optimizer
-    call beside it: log it, reject the candidate (parent unchanged, stall counted),
-    keep the run going. Unlike a tamper/validation step this is NOT indecisive —
-    there is no candidate-side wrongdoing to exempt from the stall counter, just a
-    failed evaluation, exactly like a failed proposal.
+                     opt_cost_usd: float, opt_tokens: int, optimizer_error) -> dict:
+    """An INDECISIVE step for a candidate whose ``evaluate_candidate`` call raised —
+    e.g. an adapter's ``live()``/rollout setup blew up (#286). The run keeps going
+    (that is the whole point: one candidate's cost, not the run's) but the candidate
+    was NEVER MEASURED, so it takes the same path as a 0%-coverage eval and a tamper:
+
+      * ``indecisive=True`` leaves the stall counter alone — a failed evaluation is
+        not evidence the optimizer ran out of ideas (unlike ``optimizer_error``,
+        where the workdir stays == parent and the gate scores a real Δ of 0);
+      * it is NOT filed in the rejected memory — that list is fed back as "these
+        edits did not work", and an infra failure says nothing about the edit
+        (``test_infra_errors_not_zeros``: the optimizer must not burn an iteration
+        rediscovering that a rollout crash was not a content regression);
+      * no reward is recorded, so nothing poisons the split mean or the paired gate.
+
+    A genuinely unrunnable environment is caught by ``_MAX_CONSECUTIVE_EVAL_ERRORS``
+    in the caller, which re-raises — not by letting the stall counter guess.
     """
-    reason = f"candidate evaluation raised: {error}"
-    run_dir.snapshot(cid, workdir, ignore=_SNAPSHOT_IGNORE)
+    reason = f"indecisive (evaluation error): candidate evaluation raised: {error}"
+    run_dir.snapshot(cid, workdir, ignore=_SNAPSHOT_IGNORE)  # forensics only — never best
     record_iteration(run_dir, workdir, cid, parent_id=parent_id, accepted=False,
                      reason=reason, val=None, parent_val=current_val.reward,
+                     indecisive=True,
                      optimizer_seconds=round(optimizer_seconds, 2),
                      opt_cost_usd=round(opt_cost_usd, 6), opt_tokens=opt_tokens)
-    summary = f"candidate {cid} (evaluation failed)"
-    if rejected is not None:
-        rejected.add(cid, summary, reason, None)
+    run_dir.log_event("step_indecisive", candidate=cid, reason=reason)
     run_dir.record_spend_warnings()
     return {
         "candidate_id": cid,
         "accepted": False,
-        "decision": {"accept": False, "reason": reason, "delta": 0.0, "threshold": 0.0},
+        "decision": {"accept": False, "reason": reason, "delta": 0.0, "threshold": 0.0,
+                     "indecisive": True},
         "candidate_val": None,
         "parent_val": current_val.to_dict(),
         "eval_error": error,
@@ -1679,8 +1687,8 @@ def run_step(
         # from live()/rollout setup for a reason specific to ONE candidate (a bad
         # sandbox, an unrunnable candidate artifact) — that must cost an iteration,
         # not the run. But N of these IN A ROW means the environment itself is
-        # unrunnable, not that N candidates in a row happened to be bad — that must
-        # still fail loudly rather than silently look like N ordinary rejections.
+        # unrunnable, not that N candidates in a row happened to be unlucky — that
+        # must still fail loudly rather than silently look like N skipped candidates.
         streak = getattr(run_dir, "_consecutive_eval_errors", 0) + 1
         run_dir._consecutive_eval_errors = streak
         eval_error = str(e)
@@ -1695,7 +1703,7 @@ def run_step(
                                 error=eval_error, current_val=current_val,
                                 optimizer_seconds=optimizer_seconds,
                                 opt_cost_usd=opt_cost_usd, opt_tokens=opt_tokens,
-                                optimizer_error=optimizer_error, rejected=rejected)
+                                optimizer_error=optimizer_error)
     run_dir._consecutive_eval_errors = 0
 
     # Paired gate is the default when per-task data is available: candidate and

--- a/core/tests/test_evaluate_error_wiring.py
+++ b/core/tests/test_evaluate_error_wiring.py
@@ -2,8 +2,10 @@
 live()/rollout setup raising) must cost one candidate, not abort the run — the
 same discipline ``run_step`` already applies to the optimizer call beside it.
 
-* a single evaluate_candidate raise is a REJECTED step (parent unchanged, stall
-  counted), and the run keeps going to the next iteration;
+* a single evaluate_candidate raise is an INDECISIVE step (parent unchanged, stall
+  NOT counted, not filed in the rejected memory — the candidate was never measured,
+  so it is neither evidence the optimizer ran out of ideas nor a fact about the
+  edit), and the run keeps going to the next iteration;
 * N consecutive raises look like a broken environment, not N unlucky candidates,
   and must surface loudly (raise out of run_step) instead of being swallowed.
 """
@@ -106,25 +108,33 @@ def _step(rd, adapter, base, optimizer, **kw):
                             gate_kwargs={"mode": "significant", "k_se": 1.0}, **kw)
 
 
-def test_a_single_live_error_rejects_the_candidate_and_continues(tmp_path):
-    """One adapter raise costs an iteration, not the run — mirrors optimizer_error."""
+def test_a_single_live_error_is_indecisive_and_the_run_continues(tmp_path):
+    """One adapter raise costs an iteration, not the run — and is INDECISIVE, because
+    an unmeasured candidate is missing data, not a rejection (test_infra_errors_not_zeros)."""
+    from cap_evolve.memory import RejectedMemory
     inner = _adapter()
     adapter = RaisingLiveAdapter(inner, fail_times=1, skip=1)
     rd, base = _fresh_run(tmp_path, adapter, "single_error")
     best_before, stall_before = rd.best_id, rd.spent.stall
+    rejected = RejectedMemory(tmp_path / "single_error" / "rejected.jsonl")
 
-    step = _step(rd, adapter, base, _good_edit)
+    step = _step(rd, adapter, base, _good_edit, rejected=rejected)
 
     assert step["candidate_val"] is None
     assert step["accepted"] is False
+    assert step["decision"]["indecisive"] is True
     assert "eval_error" in step and "blew up" in step["eval_error"]
-    # a real rejection (unlike a tamper/validation step): parent unchanged, but the
-    # stall counter DOES count it — it is a wasted iteration, same as optimizer_error.
+    # parent unchanged, the iteration IS charged, but the stall counter is NOT — the
+    # candidate was never judged, so it is no evidence the optimizer ran out of ideas.
     assert rd.best_id == best_before
-    assert rd.spent.stall == stall_before + 1
+    assert rd.spent.stall == stall_before
     assert rd.spent.iterations == 1
+    # and it is NOT taught to the optimizer as a failed edit: an infra failure says
+    # nothing about the content of the candidate.
+    assert not rejected.path.exists() or rejected.path.read_text(encoding="utf-8").strip() == ""
     ev = _events(rd, "evaluate_error")
     assert len(ev) == 1 and ev[0]["consecutive"] == 1
+    assert len(_events(rd, "step_indecisive")) == 1
 
     # the run continues: a second, clean step on the same run_dir still works.
     step2 = _step(rd, adapter, base, _good_edit)

--- a/core/tests/test_evaluate_error_wiring.py
+++ b/core/tests/test_evaluate_error_wiring.py
@@ -1,0 +1,157 @@
+"""Wiring proofs for #286: an exception from evaluate_candidate (e.g. an adapter's
+live()/rollout setup raising) must cost one candidate, not abort the run — the
+same discipline ``run_step`` already applies to the optimizer call beside it.
+
+* a single evaluate_candidate raise is a REJECTED step (parent unchanged, stall
+  counted), and the run keeps going to the next iteration;
+* N consecutive raises look like a broken environment, not N unlucky candidates,
+  and must surface loudly (raise out of run_step) instead of being swallowed.
+"""
+
+import contextlib
+import importlib.util
+import json
+import os
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+CORE = REPO / "core"
+EXAMPLE = REPO / "examples" / "toy_skill"
+
+sys.path.insert(0, str(CORE))
+
+
+@pytest.fixture(autouse=True)
+def _env():
+    old = dict(os.environ)
+    os.environ["CAPEVOLVE_CORE"] = str(CORE)
+    os.environ["CAPEVOLVE_TOY_DATA"] = str(EXAMPLE)
+    os.environ["CAPEVOLVE_SKILLS_DIR"] = str(REPO / "skills")
+    yield
+    os.environ.clear()
+    os.environ.update(old)
+
+
+def _adapter():
+    spec = importlib.util.spec_from_file_location("toy_skill_adapter", EXAMPLE / "adapter.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.Adapter()
+
+
+class RaisingLiveAdapter:
+    """Wraps a real adapter; ``live()`` raises for the first ``fail_times`` calls
+    AFTER ``skip`` calls (simulating an adapter's live()/rollout setup blowing up),
+    then delegates. ``skip`` lets the baseline's own evaluate_candidate call (which
+    happens before any run_step under test) go through cleanly."""
+
+    def __init__(self, inner, fail_times: int, skip: int = 0):
+        self._inner = inner
+        self.fail_times = fail_times
+        self.skip = skip
+        self.calls = 0
+
+    def __getattr__(self, name):
+        return getattr(self._inner, name)
+
+    @contextlib.contextmanager
+    def live(self, candidate_dir):
+        self.calls += 1
+        if self.skip < self.calls <= self.skip + self.fail_times:
+            raise RuntimeError(f"adapter live() blew up on call {self.calls}")
+        with self._inner.live(candidate_dir) as ctx:
+            yield ctx
+
+
+def _fresh_run(tmp_path: Path, adapter, ts: str):
+    from cap_evolve import Budget, RunDir, harness
+    seed = tmp_path / ts / "seed_capability"
+    shutil.copytree(EXAMPLE / "seed_capability", seed)
+    rd = RunDir.create(tmp_path / ts / ".capevolve", ts=ts,
+                       budget=Budget(max_iterations=5, stall=2))
+    harness.ensure_splits(adapter, rd, seed=0, ratios=(0.2, 0.4, 0.4))
+    return rd, harness.baseline(adapter, seed, run_dir=rd)
+
+
+_GOOD_EDITS = json.loads((EXAMPLE / "mock_script.json").read_text(encoding="utf-8"))["edits"]
+
+
+def _good_edit(workdir: Path, instructions: str):
+    for e in _GOOD_EDITS:
+        target = workdir / e["file"]
+        target.parent.mkdir(parents=True, exist_ok=True)
+        cur = target.read_text(encoding="utf-8") if target.exists() else ""
+        target.write_text(e["text"] if e["op"] == "set" else cur + e["text"], encoding="utf-8")
+
+
+def _events(run_dir, kind: str) -> list[dict]:
+    out = []
+    for line in (run_dir.root / "events.jsonl").read_text(encoding="utf-8").splitlines():
+        if line.strip():
+            e = json.loads(line)
+            if e.get("kind") == kind:
+                out.append(e)
+    return out
+
+
+def _step(rd, adapter, base, optimizer, **kw):
+    from cap_evolve import harness
+    return harness.run_step(adapter, run_dir=rd, parent_dir=rd.candidate_dir("seed"),
+                            optimizer=optimizer, instructions="improve val",
+                            current_val=base,
+                            gate_kwargs={"mode": "significant", "k_se": 1.0}, **kw)
+
+
+def test_a_single_live_error_rejects_the_candidate_and_continues(tmp_path):
+    """One adapter raise costs an iteration, not the run — mirrors optimizer_error."""
+    inner = _adapter()
+    adapter = RaisingLiveAdapter(inner, fail_times=1, skip=1)
+    rd, base = _fresh_run(tmp_path, adapter, "single_error")
+    best_before, stall_before = rd.best_id, rd.spent.stall
+
+    step = _step(rd, adapter, base, _good_edit)
+
+    assert step["candidate_val"] is None
+    assert step["accepted"] is False
+    assert "eval_error" in step and "blew up" in step["eval_error"]
+    # a real rejection (unlike a tamper/validation step): parent unchanged, but the
+    # stall counter DOES count it — it is a wasted iteration, same as optimizer_error.
+    assert rd.best_id == best_before
+    assert rd.spent.stall == stall_before + 1
+    assert rd.spent.iterations == 1
+    ev = _events(rd, "evaluate_error")
+    assert len(ev) == 1 and ev[0]["consecutive"] == 1
+
+    # the run continues: a second, clean step on the same run_dir still works.
+    step2 = _step(rd, adapter, base, _good_edit)
+    assert step2["candidate_val"] is not None
+    assert step2["accepted"] is True
+
+
+def test_n_consecutive_live_errors_abort_loudly_as_an_infra_failure(tmp_path):
+    """A truly broken adapter/environment must not look like N rejected candidates."""
+    from cap_evolve import harness
+    inner = _adapter()
+    adapter = RaisingLiveAdapter(inner, fail_times=99, skip=1)  # never recovers
+    rd, base = _fresh_run(tmp_path, adapter, "always_broken")
+
+    for _ in range(harness._MAX_CONSECUTIVE_EVAL_ERRORS - 1):
+        step = _step(rd, adapter, base, _good_edit)
+        assert step["accepted"] is False
+
+    with pytest.raises(RuntimeError, match="consecutive candidate evaluations raised"):
+        _step(rd, adapter, base, _good_edit)
+
+
+def test_a_success_after_failures_resets_the_streak(tmp_path):
+    inner = _adapter()
+    adapter = RaisingLiveAdapter(inner, fail_times=1, skip=1)
+    rd, base = _fresh_run(tmp_path, adapter, "resets")
+
+    _step(rd, adapter, base, _good_edit)  # fails once, streak -> 1
+    _step(rd, adapter, base, _good_edit)  # succeeds, streak -> 0
+    assert rd._consecutive_eval_errors == 0


### PR DESCRIPTION
Closes #286.

## What was wrong

`harness.run_step` deliberately wraps the optimizer call in `except Exception` — a bad proposal costs one iteration, not the run. The `evaluate_candidate(adapter, workdir, ...)` call right below it has no equivalent protection, so any exception an adapter raises in `live()`/rollout setup propagates out of `run_step` and aborts the whole run — destroying unrecoverable long-run work (e.g. a sealed test evaluation).

#285 worked around this locally in the spreadsheetbench adapter (report instead of raise). This PR generalizes that into the harness so tau2/swebench/skillsbench/future adapters all get the protection without opting in individually.

## Fix

`core/cap_evolve/harness.py`:

- Wrap the `evaluate_candidate` call in `run_step` the same way the optimizer call beside it already is: on exception, log an `evaluate_error` event, reject the candidate (parent unchanged, stall counted — same "wasted iteration" discipline as `optimizer_error`), and continue the run. New helper `_eval_error_step` mirrors the existing `_tamper_step` shape but is a real rejection (not indecisive) — there's no candidate-side wrongdoing to exempt from the stall counter here, just a failed evaluation, exactly like a failed proposal.
- To distinguish a genuine infrastructure/environment failure from a single bad candidate: track a consecutive-failure streak on the run (`run_dir._consecutive_eval_errors`, reset on any success). After `_MAX_CONSECUTIVE_EVAL_ERRORS` (3) raises in a row, re-raise instead of swallowing — so an unrunnable adapter/environment still fails loudly rather than silently looking like N rejected candidates.

No new abstraction layer — this mirrors the existing `except Exception` pattern already beside it.

## Tests

New `core/tests/test_evaluate_error_wiring.py`:
- `test_a_single_live_error_rejects_the_candidate_and_continues` — a `live()` raise on one candidate rejects it (parent unchanged, stall incremented, `evaluate_error` event logged) and the run continues to a clean next step.
- `test_n_consecutive_live_errors_abort_loudly_as_an_infra_failure` — an adapter whose `live()` never recovers raises `RuntimeError` out of `run_step` after 3 consecutive failures, instead of being silently absorbed.
- `test_a_success_after_failures_resets_the_streak` — a success after a failure resets the consecutive-error counter.

```
$ python -m pytest tests/test_evaluate_error_wiring.py -q
...
3 passed in 0.70s
```

Targeted regression run:
```
$ python -m pytest tests/ -k "harness or run_step or tamper or integrity or optimizer_error or capability_validation or regression_gate or iteration_record or spreadsheetbench" -q
194 passed, 11 skipped, 764 deselected in 41.46s
```

Full suite:
```
$ python -m pytest tests/ -q
957 passed, 12 skipped in 159.85s
```

## Smoke validation

`examples/toy_calc/run.sh` (zero-API, deterministic full pipeline: check → baseline → optimize → gate → finalize → report) ran end to end unaffected:

```
$ bash examples/toy_calc/run.sh
{
  "run_dir": ".capevolve/run_demo",
  "best_id": "cand_0001",
  "finalized": true,
  "baseline_val": 0.0,
  "best_val": 1.0,
  "test_reward": 1.0,
  "iterations": 3,
  ...
}
```

`examples/tau2_airline/smoke.sh` requires cloning tau2-bench and a Python 3.12 venv + LLM API access, which wasn't available in this environment, so `toy_calc` (zero-API, exercises the same `run_step` path) was used as the real end-to-end smoke check instead.