### PR TITLE
fix(core): escalate empty JOURNAL.md handovers, add per-run insight files, and a default-on process narrative (#400)

### DIFF
--- a/core/cap_evolve/dashboard.py
+++ b/core/cap_evolve/dashboard.py
@@ -25,9 +25,17 @@ The candidate **graph** schema (``reduced["graph"]``)::
         {"id", "parent", "children": [...], "status": seed|accepted|rejected|failed,
          "val", "stderr", "per_task": {task_id: reward}, "feedback": {task_id: str},
          "cost_usd", "tokens", "seconds", "optimizer_seconds", "runner_seconds",
-         "iteration", "reason", "epoch"?, "merge_of"?, "best_so_far"}
+         "iteration", "reason", "epoch"?, "merge_of"?, "best_so_far",
+         "gate_fields": {delta?, stderr?, n?, k_se?, threshold?, resolvable_effect_size?},
+         "screened": bool | None}
      ],
      "root": "seed", "best_id": "..."}
+
+``gate_fields`` holds whichever of those keys the commit event carried DIRECTLY (any
+algorithm's commit step may attach them to its accept/reject event); absent keys mean the
+gate-decisions table falls back to parsing the prose ``reason`` string instead. ``screened``
+is ``None`` when no event recorded compliance for this candidate's tag, else the
+``screened_before_fullval`` value read generically off any event that carries it.
 
 The **summary** schema (``reduced["summary"]``)::
 
@@ -36,7 +44,13 @@ The **summary** schema (``reduced["summary"]``)::
      "frontier": int, "tasks": [task_id, ...],
      "wall_clock_seconds", "optimizer_seconds", "runner_seconds",
      "cost": {optimizer_usd, runner_usd, total_usd}, "tokens": int,
-     "gate_warnings": [...], "diagnoses": [...], "git_log": [...]}
+     "gate_warnings": [...], "diagnoses": [...], "git_log": [...],
+     "controls": [{"tag", "reward", "stderr", "n", "iteration", "t"}, ...]}
+
+``controls`` lists null-control replicate evaluations — evaluate-only measurements with no
+candidate-graph node — read generically off any ``evaluate`` event carrying ``role:
+"control"`` or a truthy ``is_control`` field. Empty until an algorithm's evaluate step
+attaches either.
 
 Optional panels degrade silently: when per-task data / diffs / finalize are missing
 the renderer hides the panel rather than crashing.
@@ -643,7 +657,24 @@ def _read_narrative(root: Path, best_id: str | None) -> dict:
     optimizer wrote across iterations, plus the best candidate's final ``PROCESS.md``
     (why THAT iteration was done the way it was). Returns ``{}`` when none of these
     exist yet (e.g. a synthetic log with no real optimizer session).
+
+    Each file is compared against its own known seed-template text (harness.py's
+    ``_seed_journal``/``_seed_accumulator``/``_PROCESS_SEED``): a file whose content is
+    STILL exactly that template — no real entry ever appended — carries
+    ``"template_only": True`` so the renderer can flag it instead of presenting an
+    unedited instructional template as real optimizer narrative.
     """
+    try:
+        from . import harness
+        seed_by_name = {
+            "JOURNAL.md": harness._JOURNAL_SEED,
+            "INSIGHTS.md": harness._INSIGHTS_SEED,
+            "META_INSIGHTS.md": harness._META_INSIGHTS_SEED,
+            "FRAMEWORK_IMPROVEMENTS.md": harness._FRAMEWORK_IMPROVEMENTS_SEED,
+        }
+        process_seed = harness._PROCESS_SEED.strip()
+    except Exception:  # noqa: BLE001 — template detection is a nicety, not load-bearing
+        seed_by_name, process_seed = {}, None
     files = []
     for name, title in _NARRATIVE_FILES:
         p = _safe_subpath(root, name)
@@ -654,7 +685,9 @@ def _read_narrative(root: Path, best_id: str | None) -> dict:
         except OSError:
             continue
         if text:
-            files.append({"title": title, "text": _sanitize_text(text, 20000)})
+            seed_text = seed_by_name.get(name)
+            files.append({"title": title, "text": _sanitize_text(text, 20000),
+                          "template_only": bool(seed_text) and text == seed_text.strip()})
     process_text = None
     if best_id:
         p = _safe_subpath(root, "candidates", best_id, "PROCESS.md")
@@ -665,7 +698,8 @@ def _read_narrative(root: Path, best_id: str | None) -> dict:
                 process_text = None
     if process_text:
         files.append({"title": f"Process — best candidate ({best_id})",
-                      "text": _sanitize_text(process_text, 20000)})
+                      "text": _sanitize_text(process_text, 20000),
+                      "template_only": bool(process_seed) and process_text == process_seed})
     if not files:
         return {}
     return {"files": files}
@@ -763,6 +797,18 @@ def reduce_run(run_dir) -> dict:
             minibatch_evals.discard(ev.get("tag"))
         if ev.get("kind") == "minibatch":
             minibatch_evals.add(ev.get("tag"))
+
+    # Cheap-screen compliance, keyed by candidate tag: whether a candidate paid for a
+    # cheap screen before its full-val eval. Read generically off ANY event that carries a
+    # ``screened_before_fullval`` field (agent-optimize's ``agent_optimize_compliance`` is
+    # the first emitter, but nothing here assumes that kind name — a future algorithm
+    # emitting the same field under a different event kind is picked up identically).
+    screened_by_tag: dict = {}
+    for ev in events:
+        if "screened_before_fullval" in ev:
+            tag = ev.get("tag") or ev.get("candidate")
+            if tag:
+                screened_by_tag[str(tag)] = bool(ev.get("screened_before_fullval"))
 
     best = baseline_val if baseline_val is not None else 0.0
     it = 0
@@ -886,6 +932,18 @@ def reduce_run(run_dir) -> dict:
             "broke": movement.get("broke") or [],
             "parent_val": parent_val,
             "best_so_far": best,
+            # Structured gate fields, WHEN a commit event carries them directly (any
+            # algorithm's commit step may attach these to its accept/reject event instead
+            # of leaving them only in prose) — read generically by key, never assumed to be
+            # agent-optimize-specific. Absent on older runs / algorithms that never
+            # populate them; the gate-decisions table below falls back to parsing ``reason``.
+            "gate_fields": {k: ev.get(k) for k in
+                            ("delta", "stderr", "n", "k_se", "threshold",
+                             "resolvable_effect_size") if ev.get(k) is not None},
+            # Cheap-screen compliance for this candidate tag, when ANY event recorded it —
+            # looked up generically by tag below (see ``screened_by_tag``), not tied to the
+            # agent-optimize algorithm that happens to be the first emitter.
+            "screened": screened_by_tag.get(cid),
         }
         if "epoch" in ev:
             node["epoch"] = ev.get("epoch")
@@ -1088,13 +1146,17 @@ def reduce_run(run_dir) -> dict:
         })
 
     # --- gate decisions (accept / reject / INDECISIVE, with Δ̄, SE, n) -----
-    # The reason string the gate wrote is the audit record; Δ̄/SE/n are parsed back out
-    # of it so the UI can show the uncertainty next to the mean instead of a bare Δ.
-    # A number that isn't in the reason stays None — never a fabricated 0.
+    # Preferred source: structured fields a commit event attaches directly (``gate_fields``,
+    # captured generically above — any algorithm's commit step may populate ``delta``/
+    # ``stderr``/``n``/``k_se``/``threshold``/``resolvable_effect_size`` on its accept/reject
+    # event). Fallback: the reason string is the audit record when those fields are absent
+    # (older runs, or an algorithm that never populates them), so Δ̄/SE/n are parsed back out
+    # of it. A number that isn't available from either source stays None — never fabricated.
     gate_decisions: list[dict] = []
     for n in sorted((x for x in nodes.values() if x["id"] != "seed"),
                     key=lambda x: x.get("iteration") or 0):
         reason = str(n.get("reason") or "")
+        gf = n.get("gate_fields") or {}
         verdict = ("accept" if n["status"] == "accepted"
                    else "indecisive" if n["status"] == "indecisive"
                    else "reject" if n["status"] == "rejected" else "no measurement")
@@ -1106,6 +1168,7 @@ def reduce_run(run_dir) -> dict:
         m_se = re.search(r"(?<!·)\bSE\s*=\s*(\d*\.?\d+)", reason)
         m_n = re.search(r"\bn\s*=\s*(\d+)", reason)
         m_bar = re.search(r"([\d.]+)·SE\s*=\s*(\d*\.?\d+)", reason)
+        m_res = re.search(r"resolvable effect size 2·SE\s*=\s*([\d.]+)", reason)
         gate_decisions.append({
             "iteration": n.get("iteration"),
             "candidate": n["id"],
@@ -1113,11 +1176,13 @@ def reduce_run(run_dir) -> dict:
             "val": n.get("val"),
             "parent": n.get("parent"),
             "parent_val": n.get("parent_val"),
-            "delta": float(m_delta.group(1)) if m_delta else None,
-            "stderr": float(m_se.group(1)) if m_se else None,
-            "n": int(m_n.group(1)) if m_n else None,
-            "k_se": float(m_bar.group(1)) if m_bar else None,
-            "threshold": float(m_bar.group(2)) if m_bar else None,
+            "delta": gf["delta"] if "delta" in gf else (float(m_delta.group(1)) if m_delta else None),
+            "stderr": gf["stderr"] if "stderr" in gf else (float(m_se.group(1)) if m_se else None),
+            "n": gf["n"] if "n" in gf else (int(m_n.group(1)) if m_n else None),
+            "k_se": gf["k_se"] if "k_se" in gf else (float(m_bar.group(1)) if m_bar else None),
+            "threshold": gf["threshold"] if "threshold" in gf else (float(m_bar.group(2)) if m_bar else None),
+            "resolvable_effect_size": gf["resolvable_effect_size"] if "resolvable_effect_size" in gf
+                                      else (float(m_res.group(1)) if m_res else None),
             "reason": _sanitize_text(reason, 600),
         })
 
@@ -1304,6 +1369,29 @@ def reduce_run(run_dir) -> dict:
     if screens:
         algo_extra["screens"] = screens
 
+    # --- null-control replicates: the noise-floor check, kept OUT of the candidate graph ---
+    # A control replicate (a byte-identical re-measurement, run to bound run-to-run noise)
+    # is evaluate-only: it never gets an accept/reject commit, so it has no graph node — and
+    # with no way to see it happened, a real run's noise-floor check was invisible in the
+    # dashboard. Detecting it by TAG naming (e.g. agent-optimize's ``ctl_null_i<N>``) would
+    # bake one algorithm's convention into a generic reducer, so this reads a generic marker
+    # instead: any ``evaluate`` event carrying ``role: "control"`` or a truthy ``is_control``
+    # field. Neither field is emitted yet as of this writing (checked agent-optimize's
+    # round.py/commit.py, which still identify their own controls only by tag) — this stays
+    # ready to surface them the moment an algorithm's evaluate step attaches either.
+    controls = [{
+        "tag": e.get("tag"),
+        "reward": e.get("reward"),
+        "stderr": e.get("stderr"),
+        "n": e.get("n_scored"),
+        "iteration": e.get("iteration"),
+        "t": e.get("t"),
+    } for e in events if e.get("kind") == "evaluate"
+       and (e.get("role") == "control" or e.get("is_control"))]
+    # Kept as its own top-level summary list (not nested under algo_extra): a null-control
+    # replicate is a generic evaluation-methodology signal any algorithm could emit, not a
+    # per-algorithm extra like screens/gepa/skillopt below.
+
     evograph = _read_evograph(root)
     if evograph:
         algo_extra["evograph"] = evograph
@@ -1334,6 +1422,8 @@ def reduce_run(run_dir) -> dict:
         "screens": "screens" in algo_extra,
         "parallel": "parallel" in algo_extra,
         "narrative": bool(narrative),
+        "controls": bool(controls),
+        "screened": any(n.get("screened") is not None for n in nodes.values()),
         # A free-form (agent-driven) run has no deterministic step loop: candidates
         # arrive from an agent's own decisions, so iteration numbers are not a schedule.
         "freeform": algorithm in ("evograph", "agent-optimize"),
@@ -1369,6 +1459,7 @@ def reduce_run(run_dir) -> dict:
         "event_count": len(events),
         "splits": splits_info,
         "gate_decisions": gate_decisions,
+        "controls": controls,
         "cost_ledger": cost_ledger,
         "log": log_rows,
         "algo_extra": algo_extra,
@@ -2117,7 +2208,8 @@ function dsecs(v){v=Math.max(0,Math.round(v||0));if(v<60)return v+'s';
   const t2=$('table');
   t2.append($('tr',{},$('th',{text:'iter'}),$('th',{text:'candidate'}),$('th',{text:'verdict'}),
     $('th',{class:'r',text:'val'}),$('th',{class:'r',text:'parent val'}),$('th',{class:'r',text:'Δ̄'}),
-    $('th',{class:'r',text:'SE'}),$('th',{class:'r',text:'n'}),$('th',{class:'r',text:'bar (k·SE)'})));
+    $('th',{class:'r',text:'SE'}),$('th',{class:'r',text:'n'}),$('th',{class:'r',text:'bar (k·SE)'}),
+    $('th',{class:'r',text:'resolvable ±'})));
   const BADGE={accept:'b-accepted',reject:'b-rejected',indecisive:'b-indecisive'};
   const n4=v=>v==null?'—':(+v).toFixed(4);
   D.forEach(d=>{
@@ -2131,11 +2223,33 @@ function dsecs(v){v=Math.max(0,Math.round(v||0));if(v<60)return v+'s';
               text:d.delta==null?'—':(d.delta>0?'+':'')+d.delta.toFixed(4)}),
       $('td',{class:'r num muted',text:d.stderr==null?'—':'±'+d.stderr.toFixed(4)}),
       $('td',{class:'r num muted',text:d.n??'—'}),
-      $('td',{class:'r num muted',text:n4(d.threshold)+(d.k_se!=null?'  k='+d.k_se:'')})));
+      $('td',{class:'r num muted',text:n4(d.threshold)+(d.k_se!=null?'  k='+d.k_se:'')}),
+      $('td',{class:'r num muted',text:d.resolvable_effect_size==null?'—':'±'+(+d.resolvable_effect_size).toFixed(4)})));
   });
   s.append(t2);
   D.forEach(d=>s.append($('div',{class:'ann',style:'margin:6px 0'},
     $('div',{class:'who',text:d.candidate}),$('div',{text:d.reason}))));
+})();
+
+/* ---------- 6g. Noise-floor check — null-control replicates ---------- */
+(function(){
+  const C=S.controls||[]; if(!C.length)return;
+  const s=sec('Noise-floor check (null-control replicates)');
+  const rewards=C.map(c=>c.reward).filter(x=>x!=null);
+  const spread=rewards.length>1?(Math.max(...rewards)-Math.min(...rewards)):null;
+  s.append($('p',{class:'muted',style:'margin:0 0 12px',text:
+    C.length+' control replicate(s) evaluated this run — byte-identical re-measurements '+
+    'run to bound run-to-run noise, never gated/committed as candidates.'+
+    (spread!=null?' Spread between replicates: '+spread.toFixed(4)+' — the empirical noise floor.':'')}));
+  const t=$('table');
+  t.append($('tr',{},$('th',{text:'tag'}),$('th',{class:'r',text:'reward ± stderr'}),
+    $('th',{class:'r',text:'n'}),$('th',{class:'r',text:'iter'})));
+  C.forEach(c=>t.append($('tr',{},
+    $('td',{},$('code',{text:c.tag||'—'})),
+    $('td',{class:'r num',text:c.reward==null?'—':fmt(c.reward)+(c.stderr!=null?' ± '+(+c.stderr).toFixed(4):'')}),
+    $('td',{class:'r num muted',text:c.n??'—'}),
+    $('td',{class:'r num muted',text:c.iteration??'—'}))));
+  s.append(t);
 })();
 
 /* ---------- 9. Activity log — every event, filterable ---------- */
@@ -2281,6 +2395,10 @@ function dsecs(v){v=Math.max(0,Math.round(v||0));if(v<60)return v+'s';
   (NAR.files||[]).forEach(f=>{
     const box=$('div',{class:'narrative-box',style:'margin-bottom:14px'});
     box.append($('h3',{style:'margin:0 0 8px',text:f.title}));
+    // The file is still byte-for-byte the seed instructional template — no real entry
+    // was ever appended. Flagged rather than rendered as if it were populated narrative.
+    if(f.template_only)box.append($('div',{class:'banner',style:'margin-bottom:10px',
+      text:'⚠ template only — no real entries yet'}));
     box.append($('div',{class:'md',html:mdToHtml(f.text)}));
     s.append(box);
   });
@@ -2289,17 +2407,26 @@ function dsecs(v){v=Math.max(0,Math.round(v||0));if(v<60)return v+'s';
 /* ---------- 8. Candidate leaderboard + git log ---------- */
 (function(){
   const s=sec('Candidates'); const t=$('table');
-  t.append($('tr',{},$('th',{text:'id'}),$('th',{text:'status'}),$('th',{class:'r',text:'val'}),
-    $('th',{class:'r',text:'Δ parent'}),$('th',{class:'r',text:'iter'}),$('th',{text:'reason'})));
+  // "screened" (did this candidate pay for a cheap screen before full-val?) only shown
+  // when SOME node has a recorded signal — never rendered as a column of bare "—".
+  const showScreened=!!(S.capabilities&&S.capabilities.screened);
+  const hdr=[$('th',{text:'id'}),$('th',{text:'status'}),$('th',{class:'r',text:'val'}),
+    $('th',{class:'r',text:'Δ parent'}),$('th',{class:'r',text:'iter'})];
+  if(showScreened)hdr.push($('th',{text:'screened'}));
+  hdr.push($('th',{text:'reason'}));
+  t.append($('tr',{},...hdr));
   G.nodes.slice().sort((a,b)=>(b.val||-1)-(a.val||-1)).forEach(n=>{
     const dlt=n.parent_val!=null&&n.val!=null?(n.val-n.parent_val):null;
-    t.append($('tr',{},
+    const cells=[
       $('td',{},n.id===S.best_id?'★ '+n.id:n.id),
       $('td',{},$('span',{class:'badge b-'+n.status,text:n.status})),
       $('td',{class:'r num',text:fmt(n.val)}),
       $('td',{class:'r num',text:dlt==null?'—':(dlt>0?'+':'')+dlt.toFixed(3)}),
-      $('td',{class:'r num',text:n.iteration}),
-      $('td',{class:'muted',text:(n.reason||'').slice(0,80)})));
+      $('td',{class:'r num',text:n.iteration})];
+    if(showScreened)cells.push($('td',{},n.screened==null?'—':
+      $('span',{class:'badge '+(n.screened?'b-accepted':'b-rejected'),text:n.screened?'✓ screened':'✗ not screened'})));
+    cells.push($('td',{class:'muted',text:(n.reason||'').slice(0,80)}));
+    t.append($('tr',{},...cells));
   });
   s.append(t);
   if(S.git_log&&S.git_log.length){

--- a/core/cap_evolve/dashboard.py
+++ b/core/cap_evolve/dashboard.py
@@ -2539,7 +2539,10 @@ function dsecs(v){v=Math.max(0,Math.round(v||0));if(v<60)return v+'s';
 
 /* ---------- 10c. Config — the full run configuration ---------- */
 (function(){
-  const CFG=S.config; if(!CFG)return;
+  // An absent config reduces to `{}`, which is TRUTHY in JS — guard on the field the
+  // header text needs, or a run with no project dir renders an empty Config section
+  // claiming to have read "straight off undefined".
+  const CFG=S.config; if(!CFG||!CFG.project_dir)return;
   const s=sec('Config — run configuration');
   s.append($('p',{class:'muted',style:'margin:0 0 12px',text:
     'Every input the intake phase produced or the user set, read straight off '+

--- a/core/cap_evolve/dashboard.py
+++ b/core/cap_evolve/dashboard.py
@@ -650,6 +650,135 @@ _NARRATIVE_FILES = (
 )
 
 
+# ---------------------------------------------------------------------------
+# Config tab: the full run configuration (spec + PROJECT.md + project dir)
+# ---------------------------------------------------------------------------
+
+#: A small, generic classification of the ``capevolve.yaml`` keys documented in
+#: ``skills/phases/intake/inputs/INPUTS.md``. Anything NOT listed here (an older key,
+#: or a new input a future intake adds) falls into "Other" rather than disappearing —
+#: this is a display grouping only, never a schema/validation of the spec.
+_CONFIG_KEY_GROUPS = {
+    "capabilities": "Capability", "capability_path": "Capability",
+    "capability_sources": "Capability", "actions": "Capability",
+    "algorithm_skill": "Algorithm & optimizer", "optimizer_skill": "Algorithm & optimizer",
+    "optimizer_model": "Algorithm & optimizer", "optimizer_max_turns": "Algorithm & optimizer",
+    "optimizer_usd_per_iter": "Algorithm & optimizer",
+    "optimizer_instructions_file": "Algorithm & optimizer",
+    "orchestration_mode": "Algorithm & optimizer", "stop_condition": "Algorithm & optimizer",
+    "target_model": "Algorithm & optimizer", "target_profile_file": "Algorithm & optimizer",
+    "runner_repo_path": "Algorithm & optimizer",
+    "dataset_source": "Data & splits", "split_seed": "Data & splits",
+    "split_train": "Data & splits", "split_val": "Data & splits", "split_test": "Data & splits",
+    "split_ids_file": "Data & splits", "num_trials": "Data & splits",
+    "max_iterations": "Budget & gate", "stall": "Budget & gate",
+    "max_metric_calls": "Budget & gate", "max_usd": "Budget & gate",
+    "max_optimizer_usd": "Budget & gate", "gate_mode": "Budget & gate",
+    "gate_k_se": "Budget & gate", "no_regression": "Budget & gate",
+    "memory_skill": "Memory",
+    "metric_primary": "Metrics & display", "metrics_display": "Metrics & display",
+    "metric_directions": "Metrics & display",
+    "github_integration": "GitHub",
+}
+_CONFIG_GROUP_ORDER = ("Capability", "Algorithm & optimizer", "Data & splits",
+                        "Budget & gate", "Memory", "Metrics & display", "GitHub", "Other")
+
+#: A file this big gets size + path only in the Config tab's file tree — never an
+#: attempt to read and render megabytes of adapter/trajectory content.
+_PROJECT_PREVIEW_MAX_BYTES = 200_000
+
+
+def _find_project_dir(root: Path) -> Path | None:
+    """The ``project/`` dir that scaffolded this run, or ``None``.
+
+    Same two candidate locations ``_algorithm_from_spec`` already reads (a sibling
+    ``project/`` next to the run dir is the normal shape; some fixtures write
+    ``capevolve.yaml`` directly under the run dir).
+    """
+    for cand in (_safe_subpath(root.parent, "project"), root):
+        if cand is not None and cand.is_dir() and (cand / "capevolve.yaml").is_file():
+            return cand
+    return None
+
+
+def _read_project_files(project_dir: Path, skip: set) -> list[dict]:
+    """Every file under ``project_dir`` except ``skip`` (top-level names already
+    shown elsewhere — ``capevolve.yaml``, ``PROJECT.md``), walked generically so a
+    NEW artifact (a future intake output, a split file, an intake transcript) shows
+    up automatically instead of needing a new reader.
+
+    Returns ``[{"path", "size", "preview", "truncated", "binary"}]`` sorted by path.
+    ``preview`` is ``None`` for a binary file or one over ``_PROJECT_PREVIEW_MAX_BYTES``
+    — those degrade to size + path only, never a megabyte dump.
+    """
+    out = []
+    for f in sorted(project_dir.rglob("*")):
+        if not f.is_file():
+            continue
+        rel = f.relative_to(project_dir)
+        if str(rel) in skip or "__pycache__" in rel.parts or ".git" in rel.parts:
+            continue
+        try:
+            size = f.stat().st_size
+        except OSError:
+            continue
+        rec = {"path": str(rel), "size": size, "preview": None,
+               "truncated": False, "binary": False}
+        if size == 0:
+            rec["preview"] = ""
+        elif size <= _PROJECT_PREVIEW_MAX_BYTES:
+            try:
+                text = f.read_text(encoding="utf-8")
+            except (UnicodeDecodeError, OSError):
+                rec["binary"] = True
+            else:
+                rec["preview"] = _sanitize_text(text, 4000)
+                rec["truncated"] = len(text) > 4000
+        out.append(rec)
+    return out
+
+
+def _read_config(root: Path) -> dict:
+    """The full run configuration, generically — every intake artifact on disk.
+
+    Reads the sibling ``project/`` dir's ``capevolve.yaml`` (the parsed spec, grouped
+    for display — see ``_CONFIG_KEY_GROUPS``), ``PROJECT.md`` (the intake-authored
+    narrative of what was resolved/defaulted), and every other file under the project
+    dir (adapters/, seed_capability/, split files, ...) as a generic listing/preview.
+    Returns ``{}`` when no project dir is found — the panel hides itself.
+    """
+    project_dir = _find_project_dir(root)
+    if project_dir is None:
+        return {}
+    from .specfile import read_yaml
+    try:
+        spec = read_yaml((project_dir / "capevolve.yaml").read_text(encoding="utf-8")) or {}
+    except OSError:
+        spec = {}
+    groups: dict[str, list] = {}
+    for k, v in spec.items():
+        groups.setdefault(_CONFIG_KEY_GROUPS.get(k, "Other"), []).append({"key": k, "value": v})
+    spec_groups = [{"group": g, "items": groups[g]} for g in _CONFIG_GROUP_ORDER if g in groups]
+
+    project_md = None
+    pmd = project_dir / "PROJECT.md"
+    if pmd.is_file():
+        try:
+            project_md = _sanitize_text(pmd.read_text(encoding="utf-8"), 20000)
+        except OSError:
+            project_md = None
+
+    files = _read_project_files(project_dir, {"capevolve.yaml", "PROJECT.md"})
+    if not spec_groups and not project_md and not files:
+        return {}
+    return {
+        "project_dir": str(project_dir),
+        "spec_groups": spec_groups,
+        "project_md": project_md,
+        "files": files,
+    }
+
+
 def _read_narrative(root: Path, best_id: str | None) -> dict:
     """The optimizer-authored process narrative for this run, read straight off disk.
 
@@ -1396,6 +1525,7 @@ def reduce_run(run_dir) -> dict:
     if evograph:
         algo_extra["evograph"] = evograph
     narrative = _read_narrative(root, best_id)
+    config = _read_config(root)
     par = [e for e in events if e.get("kind") == "parallel"]
     if par:
         algo_extra["parallel"] = [{k: v for k, v in e.items()
@@ -1422,6 +1552,7 @@ def reduce_run(run_dir) -> dict:
         "screens": "screens" in algo_extra,
         "parallel": "parallel" in algo_extra,
         "narrative": bool(narrative),
+        "config": bool(config),
         "controls": bool(controls),
         "screened": any(n.get("screened") is not None for n in nodes.values()),
         # A free-form (agent-driven) run has no deterministic step loop: candidates
@@ -1512,6 +1643,7 @@ def reduce_run(run_dir) -> dict:
         "diagnoses": diagnoses,
         "git_log": _git_log(root),
         "narrative": narrative,
+        "config": config,
     }
 
     graph = {"nodes": list(nodes.values()), "root": "seed", "best_id": best_id}
@@ -1865,6 +1997,32 @@ const svg=(t,a={})=>{const e=document.createElementNS(NS,t);for(const[p,v]of Obj
    the fitness chart (heatmap, lineage, cost, evaluations, candidates). */
 const txt=(el,a,content)=>{const n=svg('text',a);n.textContent=content==null?'':String(content);el.append(n);return n;};
 const fmt=v=>v==null?'—':(+v).toFixed(3);
+function escN(t){return String(t).replace(/&/g,'&amp;').replace(/</g,'&lt;');}
+// A tiny, deliberately non-general markdown renderer: headings, bullet lines,
+// blockquotes, bold, everything else is a paragraph. Good enough for the structured
+// templates the narrative files are seeded from (_JOURNAL_SEED etc.) and for a
+// PROJECT.md — not a general markdown engine, so it never needs a dependency. Shared
+// by the Process narrative and Config tabs so there is exactly one renderer.
+function mdToHtml(text){
+  const lines=escN(text).split('\n');
+  let html='',inList=false;
+  const closeList=()=>{if(inList){html+='</ul>';inList=false;}};
+  lines.forEach(line=>{
+    const bold=line.replace(/\*\*(.+?)\*\*/g,'<b>$1</b>');
+    let m;
+    if((m=bold.match(/^(#{1,4})\s+(.*)$/))){closeList();
+      html+=`<h${Math.min(4,m[1].length)+1}>${m[2]}</h${Math.min(4,m[1].length)+1}>`;}
+    else if(/^\s*[-*]\s+/.test(bold)){if(!inList){html+='<ul>';inList=true;}
+      html+='<li>'+bold.replace(/^\s*[-*]\s+/,'')+'</li>';}
+    else if(/^>\s?/.test(bold)){closeList();
+      html+='<blockquote>'+bold.replace(/^>\s?/,'')+'</blockquote>';}
+    else if(/^<!--/.test(bold.trim())){/* skip HTML-comment markers */}
+    else if(!bold.trim()){closeList();}
+    else{closeList();html+='<p>'+bold+'</p>';}
+  });
+  closeList();
+  return html;
+}
 const main=document.getElementById('main'), tip=document.getElementById('tip');
 const STATUS_META={running:['running','var(--accent)'],awaiting_agent:['awaiting agent','var(--idk)'],
   completed:['completed','var(--ok)'],budget_exhausted:['budget exhausted','var(--warn)'],
@@ -2367,31 +2525,6 @@ function dsecs(v){v=Math.max(0,Math.round(v||0));if(v<60)return v+'s';
     'Written by the optimizer as it worked (JOURNAL / INSIGHTS / META_INSIGHTS / '+
     'FRAMEWORK_IMPROVEMENTS, plus the best candidate’s PROCESS.md) — rendered here '+
     'as-is, for a human reader.'}));
-  function escN(t){return String(t).replace(/&/g,'&amp;').replace(/</g,'&lt;');}
-  // A tiny, deliberately non-general markdown renderer: headings, bullet lines,
-  // blockquotes, bold, everything else is a paragraph. Good enough for the
-  // structured templates these files are seeded from (_JOURNAL_SEED etc.) — not a
-  // general markdown engine, so it never needs a dependency.
-  function mdToHtml(text){
-    const lines=escN(text).split('\n');
-    let html='',inList=false;
-    const closeList=()=>{if(inList){html+='</ul>';inList=false;}};
-    lines.forEach(line=>{
-      const bold=line.replace(/\*\*(.+?)\*\*/g,'<b>$1</b>');
-      let m;
-      if((m=bold.match(/^(#{1,4})\s+(.*)$/))){closeList();
-        html+=`<h${Math.min(4,m[1].length)+1}>${m[2]}</h${Math.min(4,m[1].length)+1}>`;}
-      else if(/^\s*[-*]\s+/.test(bold)){if(!inList){html+='<ul>';inList=true;}
-        html+='<li>'+bold.replace(/^\s*[-*]\s+/,'')+'</li>';}
-      else if(/^>\s?/.test(bold)){closeList();
-        html+='<blockquote>'+bold.replace(/^>\s?/,'')+'</blockquote>';}
-      else if(/^<!--/.test(bold.trim())){/* skip HTML-comment markers */}
-      else if(!bold.trim()){closeList();}
-      else{closeList();html+='<p>'+bold+'</p>';}
-    });
-    closeList();
-    return html;
-  }
   (NAR.files||[]).forEach(f=>{
     const box=$('div',{class:'narrative-box',style:'margin-bottom:14px'});
     box.append($('h3',{style:'margin:0 0 8px',text:f.title}));
@@ -2402,6 +2535,67 @@ function dsecs(v){v=Math.max(0,Math.round(v||0));if(v<60)return v+'s';
     box.append($('div',{class:'md',html:mdToHtml(f.text)}));
     s.append(box);
   });
+})();
+
+/* ---------- 10c. Config — the full run configuration ---------- */
+(function(){
+  const CFG=S.config; if(!CFG)return;
+  const s=sec('Config — run configuration');
+  s.append($('p',{class:'muted',style:'margin:0 0 12px',text:
+    'Every input the intake phase produced or the user set, read straight off '+
+    CFG.project_dir+' — the parsed capevolve.yaml spec, PROJECT.md, and every other '+
+    'project artifact (adapters/, seed_capability/, split files, ...).'}));
+  const h3=(t)=>$('h2',{style:'margin:16px 0 6px;text-transform:none;letter-spacing:0;'+
+    'font-size:13px;color:var(--text)',text:t});
+  (CFG.spec_groups||[]).forEach(g=>{
+    s.append(h3(g.group));
+    const t=$('table');
+    g.items.forEach(it=>{
+      const v=it.value;
+      const vt=v==null?'—':(typeof v==='object'?JSON.stringify(v):String(v));
+      t.append($('tr',{},$('td',{},$('code',{text:it.key})),
+        $('td',{class:'muted',style:'white-space:pre-wrap',text:vt})));
+    });
+    s.append(t);
+  });
+  if(CFG.project_md){
+    s.append(h3('PROJECT.md'));
+    s.append($('div',{class:'narrative-box md',html:mdToHtml(CFG.project_md)}));
+  }
+  const files=CFG.files||[];
+  if(files.length){
+    s.append(h3('Other project files ('+files.length+')'));
+    const bySize=v=>v<1024?v+' B':v<1048576?(v/1024).toFixed(1)+' KB':(v/1048576).toFixed(1)+' MB';
+    const groups=new Map();
+    files.forEach(f=>{
+      const top=f.path.includes('/')?f.path.split('/')[0]:'.';
+      if(!groups.has(top))groups.set(top,[]);
+      groups.get(top).push(f);
+    });
+    [...groups.keys()].sort().forEach(top=>{
+      const det=$('details',{style:'margin:4px 0'});
+      det.append($('summary',{style:'cursor:pointer;font-weight:600',
+        text:top+' ('+groups.get(top).length+')'}));
+      groups.get(top).forEach(f=>{
+        const fdet=$('details',{style:'margin:2px 0 2px 16px'});
+        fdet.append($('summary',{style:'cursor:pointer;color:var(--muted2);font-size:12px',
+          text:f.path+'  ·  '+bySize(f.size)+
+               (f.binary?' · binary':f.truncated?' · truncated preview':'')}));
+        if(f.binary){
+          fdet.append($('p',{class:'muted',style:'margin:4px 0',text:'binary file — not previewed'}));
+        }else if(f.preview==null){
+          fdet.append($('p',{class:'muted',style:'margin:4px 0',
+            text:'too large to preview — '+bySize(f.size)}));
+        }else if(f.preview===''){
+          fdet.append($('p',{class:'muted',style:'margin:4px 0',text:'empty file'}));
+        }else{
+          fdet.append($('div',{class:'diff',style:'max-height:260px',text:f.preview}));
+        }
+        det.append(fdet);
+      });
+      s.append(det);
+    });
+  }
 })();
 
 /* ---------- 8. Candidate leaderboard + git log ---------- */

--- a/core/cap_evolve/dashboard.py
+++ b/core/cap_evolve/dashboard.py
@@ -626,6 +626,51 @@ def _read_evograph(root: Path) -> dict:
     return {"rounds": rounds, "weaknesses": weaknesses}
 
 
+#: run-level narrative files, in reading order — see harness.py's cross-iteration
+#: file-header comment (JOURNAL/INSIGHTS/META_INSIGHTS/FRAMEWORK_IMPROVEMENTS).
+_NARRATIVE_FILES = (
+    ("JOURNAL.md", "Journal — per-iteration handover"),
+    ("INSIGHTS.md", "Insights — verified findings"),
+    ("META_INSIGHTS.md", "Meta-insights — the optimization process"),
+    ("FRAMEWORK_IMPROVEMENTS.md", "Framework improvements — for cap-evolve itself"),
+)
+
+
+def _read_narrative(root: Path, best_id: str | None) -> dict:
+    """The optimizer-authored process narrative for this run, read straight off disk.
+
+    Every run gets this by default (#400): the run-level accumulator files the
+    optimizer wrote across iterations, plus the best candidate's final ``PROCESS.md``
+    (why THAT iteration was done the way it was). Returns ``{}`` when none of these
+    exist yet (e.g. a synthetic log with no real optimizer session).
+    """
+    files = []
+    for name, title in _NARRATIVE_FILES:
+        p = _safe_subpath(root, name)
+        if p is None or not p.is_file():
+            continue
+        try:
+            text = p.read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        if text:
+            files.append({"title": title, "text": _sanitize_text(text, 20000)})
+    process_text = None
+    if best_id:
+        p = _safe_subpath(root, "candidates", best_id, "PROCESS.md")
+        if p is not None and p.is_file():
+            try:
+                process_text = p.read_text(encoding="utf-8").strip() or None
+            except OSError:
+                process_text = None
+    if process_text:
+        files.append({"title": f"Process — best candidate ({best_id})",
+                      "text": _sanitize_text(process_text, 20000)})
+    if not files:
+        return {}
+    return {"files": files}
+
+
 def reduce_run(run_dir) -> dict:
     """Fold the run dir into ``{"graph": ..., "summary": ...}`` (redacted)."""
     root = Path(run_dir.root)
@@ -1262,6 +1307,7 @@ def reduce_run(run_dir) -> dict:
     evograph = _read_evograph(root)
     if evograph:
         algo_extra["evograph"] = evograph
+    narrative = _read_narrative(root, best_id)
     par = [e for e in events if e.get("kind") == "parallel"]
     if par:
         algo_extra["parallel"] = [{k: v for k, v in e.items()
@@ -1287,6 +1333,7 @@ def reduce_run(run_dir) -> dict:
         "evograph": "evograph" in algo_extra,
         "screens": "screens" in algo_extra,
         "parallel": "parallel" in algo_extra,
+        "narrative": bool(narrative),
         # A free-form (agent-driven) run has no deterministic step loop: candidates
         # arrive from an agent's own decisions, so iteration numbers are not a schedule.
         "freeform": algorithm in ("evograph", "agent-optimize"),
@@ -1373,6 +1420,7 @@ def reduce_run(run_dir) -> dict:
         "gate_warnings": gate_warnings,
         "diagnoses": diagnoses,
         "git_log": _git_log(root),
+        "narrative": narrative,
     }
 
     graph = {"nodes": list(nodes.values()), "root": "seed", "best_id": best_id}
@@ -1687,6 +1735,14 @@ border-radius:8px;padding:10px;overflow:auto;max-height:420px;white-space:pre}
 .diff .file{color:var(--text);font-weight:700;margin:8px 0 2px}
 .ann{border-left:3px solid var(--warn);padding:6px 12px;margin:8px 0;background:var(--card2);border-radius:0 8px 8px 0}
 .ann.diag{border-left-color:var(--accent)}
+.narrative-box{background:var(--card2);border:1px solid var(--line);border-radius:8px;
+padding:12px 14px;overflow:auto;max-height:480px}
+.md h2,.md h3,.md h4{margin:14px 0 6px;color:var(--text)}
+.md h2:first-child,.md h3:first-child,.md h4:first-child{margin-top:0}
+.md p{margin:6px 0}
+.md ul{margin:6px 0;padding-left:20px}
+.md blockquote{margin:8px 0;padding:4px 10px;border-left:3px solid var(--accent);
+background:var(--card);color:var(--muted)}
 .ann .who{color:var(--muted);font-size:11px}
 .heat rect{cursor:pointer} .heat text{fill:var(--muted);font-size:10px}
 code{background:var(--card2);padding:1px 5px;border-radius:5px;font-size:12px}
@@ -2185,6 +2241,47 @@ function dsecs(v){v=Math.max(0,Math.round(v||0));if(v<60)return v+'s';
     if((w.affected_tasks||[]).length)bits.push('affects '+w.affected_tasks.join(', '));
     if((w.related||[]).length)bits.push('related → '+w.related.join(', '));
     box.append($('div',{class:'muted num',style:'font-size:11px;margin-top:4px',text:bits.join('  ·  ')}));
+    s.append(box);
+  });
+})();
+
+/* ---------- 10b. process narrative — optimizer-authored, self-contained ---------- */
+(function(){
+  const NAR=S.narrative; if(!NAR||!(NAR.files||[]).length)return;
+  const s=sec('Process narrative');
+  s.append($('p',{class:'muted',style:'margin:0 0 12px',text:
+    'Written by the optimizer as it worked (JOURNAL / INSIGHTS / META_INSIGHTS / '+
+    'FRAMEWORK_IMPROVEMENTS, plus the best candidate’s PROCESS.md) — rendered here '+
+    'as-is, for a human reader.'}));
+  function escN(t){return String(t).replace(/&/g,'&amp;').replace(/</g,'&lt;');}
+  // A tiny, deliberately non-general markdown renderer: headings, bullet lines,
+  // blockquotes, bold, everything else is a paragraph. Good enough for the
+  // structured templates these files are seeded from (_JOURNAL_SEED etc.) — not a
+  // general markdown engine, so it never needs a dependency.
+  function mdToHtml(text){
+    const lines=escN(text).split('\n');
+    let html='',inList=false;
+    const closeList=()=>{if(inList){html+='</ul>';inList=false;}};
+    lines.forEach(line=>{
+      const bold=line.replace(/\*\*(.+?)\*\*/g,'<b>$1</b>');
+      let m;
+      if((m=bold.match(/^(#{1,4})\s+(.*)$/))){closeList();
+        html+=`<h${Math.min(4,m[1].length)+1}>${m[2]}</h${Math.min(4,m[1].length)+1}>`;}
+      else if(/^\s*[-*]\s+/.test(bold)){if(!inList){html+='<ul>';inList=true;}
+        html+='<li>'+bold.replace(/^\s*[-*]\s+/,'')+'</li>';}
+      else if(/^>\s?/.test(bold)){closeList();
+        html+='<blockquote>'+bold.replace(/^>\s?/,'')+'</blockquote>';}
+      else if(/^<!--/.test(bold.trim())){/* skip HTML-comment markers */}
+      else if(!bold.trim()){closeList();}
+      else{closeList();html+='<p>'+bold+'</p>';}
+    });
+    closeList();
+    return html;
+  }
+  (NAR.files||[]).forEach(f=>{
+    const box=$('div',{class:'narrative-box',style:'margin-bottom:14px'});
+    box.append($('h3',{style:'margin:0 0 8px',text:f.title}));
+    box.append($('div',{class:'md',html:mdToHtml(f.text)}));
     s.append(box);
   });
 })();

--- a/core/cap_evolve/dashboard.py
+++ b/core/cap_evolve/dashboard.py
@@ -1388,7 +1388,8 @@ def reduce_run(run_dir) -> dict:
 # shows only the real change. (The big read-context dirs trajectories/ and guidance/
 # are already excluded from the snapshot itself; see harness._SNAPSHOT_IGNORE.)
 _DIFF_SKIP = {"INSTRUCTIONS.md", "MEMORY.md", "STATE.md",
-              "LEDGER.md", "JOURNAL.md", "PROCESS.md", "RUNMAP.md"}
+              "LEDGER.md", "JOURNAL.md", "PROCESS.md", "RUNMAP.md",
+              "INSIGHTS.md", "META_INSIGHTS.md", "FRAMEWORK_IMPROVEMENTS.md"}
 
 
 def _read_dir_files(d: Path) -> dict[str, str]:

--- a/core/cap_evolve/dashboard_launch.py
+++ b/core/cap_evolve/dashboard_launch.py
@@ -25,6 +25,12 @@ def _free_port(start: int, tries: int = 25) -> int:
     if another (possibly unrelated) server already holds ``start``, our spawn would
     silently fail to bind and that stale server would keep serving the WRONG run.
     Picking a free port guarantees this run gets its own dashboard on its own base.
+
+    Raises when every port in the scanned range is taken, rather than falling back
+    to ``start`` — a caller that silently reused a taken port would print a URL that
+    actually serves a stale, unrelated dashboard (observed live: ~25 leaked dashboard
+    processes from old sessions squatting this whole range made every run's dashboard
+    silently point at someone else's project). Callers decide how to surface this.
     """
     for p in range(start, start + tries):
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
@@ -33,7 +39,9 @@ def _free_port(start: int, tries: int = 25) -> int:
                 return p
             except OSError:
                 continue
-    return start
+    raise RuntimeError(
+        f"no free port in [{start}, {start + tries}) — {tries} candidates all taken; "
+        "leaked dashboard processes from prior runs may be squatting this range")
 
 
 def resolve_mode(cli_arg: str | None, spec_value: str | None, default: str = "auto") -> str:
@@ -75,7 +83,10 @@ def maybe_launch(base_dir, *, mode: str, port: int = DEFAULT_PORT,
         return {"dashboard": "skipped",
                 "reason": "capevolve-dashboard not installed "
                           "(pip install -e dashboard/backend)"}
-    port = _free_port(port)  # avoid reusing a stale server squatting the default port
+    try:
+        port = _free_port(port)  # avoid reusing a stale server squatting the default port
+    except RuntimeError as e:
+        return {"dashboard": "error", "reason": str(e)}
     try:
         subprocess.Popen(
             launch_command(Path(base_dir), port=port, open_browser=open_browser),

--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -1095,7 +1095,8 @@ def _seed_journal(workdir: Path, run_dir: RunDir) -> None:
 
 
 def _reconcile_journal(workdir: Path, run_dir: RunDir, cid: str, *,
-                       accepted: bool, val: float | None, delta: float | None) -> None:
+                       accepted: bool, val: float | None, delta: float | None,
+                       reason: str | None = None) -> None:
     """Fold the optimizer's newly-appended journal entry into the run-level JOURNAL,
     stamped with the framework's objective outcome. Append-only at the run level so the
     handover truly accumulates across accepted AND rejected iterations.
@@ -1104,11 +1105,15 @@ def _reconcile_journal(workdir: Path, run_dir: RunDir, cid: str, *,
     minibatch-local reject) or whose measurement is void (an indecisive tamper step):
     the entry is still folded in, with "—" where the number would be.
 
-    A genuinely empty handover (the confirmed bug this fixes) is no longer silently
-    accepted: it is ESCALATED — logged as an ``optimizer_context_warning`` event and
-    stamped into the journal itself with a visible ``EMPTY HANDOVER`` marker — so an
-    operator or the dashboard can see it happened, instead of the old placeholder text
-    reading like an unremarkable, silently-accepted note.
+    A genuinely empty handover is still ESCALATED — logged as an
+    ``optimizer_context_warning`` event, so an operator or the dashboard can see it
+    happened — but the journal itself is no longer left contentless: every caller
+    already carries a real, substantive ``reason`` (the same text that becomes the
+    commit's ``--note``, confirmed rich in practice across every accept/reject this
+    repo has produced), so that text is folded in as the entry's content instead of
+    a placeholder that admits nothing was learned. This is a fallback, not a
+    substitute for the optimizer's own reflection — it does not fire when the
+    optimizer already wrote a real entry.
     """
     tail = _journal_tail(workdir)
     run_journal = run_dir.root / "JOURNAL.md"
@@ -1140,12 +1145,15 @@ def _reconcile_journal(workdir: Path, run_dir: RunDir, cid: str, *,
         run_dir.log_event("optimizer_context_warning", what="JOURNAL.md",
                           error="empty handover: optimizer wrote no ## Iteration entry",
                           candidate=cid)
-        tail = (f"## Iteration {cid} — ⚠ EMPTY HANDOVER (framework escalation)\n"
-                "The optimizer wrote NO journal entry this iteration. This is a bug "
-                "in the optimizer/session, not a normal outcome — see the "
-                "`optimizer_context_warning` event in events.jsonl. The next "
-                "iteration has no narrative context for this candidate beyond the "
-                "RESULT line below.")
+        synthesized = (reason or "").strip()
+        tail = (f"## Iteration {cid} — ⚠ EMPTY HANDOVER, framework-synthesized from the "
+                "commit reason (the optimizer wrote no entry of its own — see the "
+                "`optimizer_context_warning` event):\n" + synthesized) if synthesized else (
+                f"## Iteration {cid} — ⚠ EMPTY HANDOVER (framework escalation)\n"
+                "The optimizer wrote NO journal entry this iteration, and no commit "
+                "reason was available to synthesize one from. This is a bug in the "
+                "optimizer/session, not a normal outcome — see the "
+                "`optimizer_context_warning` event in events.jsonl.")
     elif tail in base:
         # Dedup guard: the optimizer dropped the marker without appending (so the tail
         # fallback returned an entry already recorded in the run-level journal). Do NOT
@@ -1198,7 +1206,8 @@ def record_iteration(run_dir: RunDir, workdir: Path, cid: str, *,
                       val=val, parent=parent_id, parent_val=parent_val, **extra)
     delta = (val - parent_val if isinstance(val, (int, float))
              and isinstance(parent_val, (int, float)) else None)
-    _reconcile_journal(workdir, run_dir, cid, accepted=accepted, val=val, delta=delta)
+    _reconcile_journal(workdir, run_dir, cid, accepted=accepted, val=val, delta=delta,
+                       reason=reason)
     for filename, seed, mark in _ACCUMULATORS:
         _fold_accumulator(workdir, run_dir, filename=filename, seed=seed, mark=mark)
 

--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -703,7 +703,7 @@ def _paired_deltas(current_val: SplitResult, cand_val: SplitResult) -> list | No
 
 
 
-# The optimizer's working dir carries FOUR cross-iteration files, with clean ownership
+# The optimizer's working dir carries cross-iteration files, with clean ownership
 # so there is never confusion about who writes what (the recurring user complaint about
 # the old MEMORY.md/STATE.md pair):
 #   LEDGER.md   — FRAMEWORK-owned, FACTUAL, regenerated each iter (the objective record:
@@ -715,6 +715,11 @@ def _paired_deltas(current_val: SplitResult, cand_val: SplitResult) -> list | No
 #                 subagents/features used, what to preserve).
 #   RUNMAP.md   — FRAMEWORK-owned manifest of every prior iteration's working dir, with
 #                 each prior PROCESS.md + capability diff copied into ./prior_iterations/.
+#   INSIGHTS.md / META_INSIGHTS.md / FRAMEWORK_IMPROVEMENTS.md — OPTIMIZER-owned,
+#                 append-only across the WHOLE run like JOURNAL.md, but a SUMMARY layer
+#                 above it (verified findings / process meta-learning / cross-run
+#                 framework feedback) so a future iteration need not re-read the whole
+#                 journal. See the comment near ``_INSIGHTS_MARK``.
 # Rule: FACTS are deterministic + framework-owned; JUDGMENT and PROCESS are agent-owned.
 
 _JOURNAL_MARK = "<!-- cap-evolve:journal-append-below — add your Iteration entry under this line; do not edit anything above it -->"
@@ -748,6 +753,103 @@ _JOURNAL_SEED = (
     "    - Focus next iteration:\n"
 )
 
+#   INSIGHTS.md / META_INSIGHTS.md / FRAMEWORK_IMPROVEMENTS.md — OPTIMIZER-owned,
+#   append-only across the WHOLE run like JOURNAL.md, but each is a SUMMARY layer
+#   above it: JOURNAL.md is the per-iteration narrative (verbose, one entry per
+#   candidate); these three are the compressed, verified takeaways a future
+#   iteration (or a human) should read INSTEAD of re-reading the whole journal.
+#   Same accumulate-across-the-run mechanic as JOURNAL.md, no framework RESULT
+#   stamp (that is journal-specific) — see ``_seed_accumulator``/``_fold_accumulator``.
+
+_INSIGHTS_MARK = "<!-- cap-evolve:insights-append-below -->"
+_INSIGHTS_SEED = (
+    "# INSIGHTS — summarized, verified findings (accumulate across the whole run)\n\n"
+    "The JOURNAL is your per-iteration diary; THIS file is the distilled, VERIFIED "
+    "takeaway a future iteration should read instead of re-reading the whole journal "
+    "or old sessions/traces. Update it whenever you have a genuinely NEW, confirmed "
+    "finding (an accepted/rejected RESULT counts as confirmation; a guess does not) — "
+    "not every iteration needs a new entry. Structure each addition as:\n\n"
+    "    ## <task or mechanism name>\n"
+    "    - What worked (confirmed by a RESULT, cite the candidate id):\n"
+    "    - What didn't (confirmed by a RESULT, cite the candidate id):\n"
+    "    - Promising but not yet tried:\n"
+)
+
+_META_INSIGHTS_MARK = "<!-- cap-evolve:meta-insights-append-below -->"
+_META_INSIGHTS_SEED = (
+    "# META-INSIGHTS — about the optimization PROCESS itself (this run)\n\n"
+    "Not about the capability — about HOW this run is searching for it: which "
+    "strategies/edit classes/algorithms are helping vs stalling, and what to try "
+    "next iteration. Update at the end of the run at minimum; sooner if a plateau "
+    "or a clear strategy shift is worth recording now. Structure each addition as:\n\n"
+    "    ## Iteration <id> (or 'run so far')\n"
+    "    - Strategy tried, and whether it moved val (cite LEDGER rows):\n"
+    "    - Plateau/stall signal, if any, and the lever switched to:\n"
+    "    - What to try next iteration:\n"
+)
+
+_FRAMEWORK_IMPROVEMENTS_MARK = "<!-- cap-evolve:framework-improvements-append-below -->"
+_FRAMEWORK_IMPROVEMENTS_SEED = (
+    "# FRAMEWORK-IMPROVEMENTS — suggestions for cap-evolve itself (cross-run)\n\n"
+    "NOT about this capability or this run's result — about what cap-evolve the "
+    "FRAMEWORK should change so FUTURE runs (any capability, any project) go better: "
+    "a confusing prompt section, a missing tool, a file you wished existed, a gate "
+    "that felt wrong. Optional most iterations; add an entry whenever something "
+    "about the framework itself (not the task) got in your way or surprised you.\n"
+)
+
+
+def _seed_accumulator(workdir: Path, run_dir: RunDir, *, filename: str, seed: str,
+                      mark: str) -> None:
+    """Generic ``_seed_journal``: copy a run-level, whole-run accumulator file into
+    the workdir with its marker re-appended, ready for the optimizer to append below."""
+    run_file = run_dir.root / filename
+    try:
+        text = run_file.read_text(encoding="utf-8") if run_file.exists() else seed
+    except Exception:  # noqa: BLE001
+        text = seed
+    text = text.replace(mark, "").rstrip() + "\n\n" + mark + "\n"
+    (workdir / filename).write_text(text, encoding="utf-8")
+
+
+def _fold_accumulator(workdir: Path, run_dir: RunDir, *, filename: str, seed: str,
+                      mark: str) -> None:
+    """Generic ``_reconcile_journal`` minus the framework RESULT stamp: fold whatever
+    the optimizer appended below the marker back into the run-level accumulator file.
+
+    Unlike JOURNAL.md, an empty tail here is NOT escalated — a summarized-insights
+    file legitimately has nothing new to add most iterations (see the seed text)."""
+    path = workdir / filename
+    if not path.exists():
+        return
+    try:
+        text = path.read_text(encoding="utf-8")
+    except Exception:  # noqa: BLE001
+        return
+    tail = (text.split(mark, 1)[1] if mark in text else "").replace(mark, "").strip()
+    if not tail:
+        return
+    run_file = run_dir.root / filename
+    try:
+        base = run_file.read_text(encoding="utf-8") if run_file.exists() else seed
+    except Exception:  # noqa: BLE001
+        base = seed
+    base = base.replace(mark, "").rstrip()
+    if tail in base:  # already recorded — do not duplicate
+        return
+    try:
+        run_file.write_text(base + "\n\n" + tail + "\n", encoding="utf-8")
+    except Exception as e:  # noqa: BLE001
+        run_dir.log_event("optimizer_context_warning", what=filename, error=str(e)[:300])
+
+
+_ACCUMULATORS = (
+    ("INSIGHTS.md", _INSIGHTS_SEED, _INSIGHTS_MARK),
+    ("META_INSIGHTS.md", _META_INSIGHTS_SEED, _META_INSIGHTS_MARK),
+    ("FRAMEWORK_IMPROVEMENTS.md", _FRAMEWORK_IMPROVEMENTS_SEED, _FRAMEWORK_IMPROVEMENTS_MARK),
+)
+
+
 _PROCESS_SEED = (
     "# PROCESS — what I did this iteration (explainability; REQUIRED)\n\n"
     "Fill this in as you work. It is the human-readable record of HOW this iteration was "
@@ -774,7 +876,8 @@ _PROCESS_SEED = (
 # State/handover files that are NOT part of the capability — excluded from any
 # capability diff (kept in one place; mirrors dashboard._DIFF_SKIP).
 _CAP_DIFF_SKIP = {"INSTRUCTIONS.md", "MEMORY.md", "STATE.md",
-                  "LEDGER.md", "JOURNAL.md", "PROCESS.md", "RUNMAP.md"}
+                  "LEDGER.md", "JOURNAL.md", "PROCESS.md", "RUNMAP.md",
+                  "INSIGHTS.md", "META_INSIGHTS.md", "FRAMEWORK_IMPROVEMENTS.md"}
 
 
 def _capability_files(d: Path) -> dict[str, str]:
@@ -1096,6 +1199,8 @@ def record_iteration(run_dir: RunDir, workdir: Path, cid: str, *,
     delta = (val - parent_val if isinstance(val, (int, float))
              and isinstance(parent_val, (int, float)) else None)
     _reconcile_journal(workdir, run_dir, cid, accepted=accepted, val=val, delta=delta)
+    for filename, seed, mark in _ACCUMULATORS:
+        _fold_accumulator(workdir, run_dir, filename=filename, seed=seed, mark=mark)
 
 
 def _build_runmap(workdir: Path, run_dir: RunDir) -> None:
@@ -1162,7 +1267,7 @@ def _build_runmap(workdir: Path, run_dir: RunDir) -> None:
 
 
 def _augment_instructions(instructions: str, workdir: Path, run_dir: RunDir) -> str:
-    """Give the optimizer its four cross-iteration files + a prompt pointer to each.
+    """Give the optimizer its cross-iteration files + a prompt pointer to each.
 
     Clean ownership (see the file-header comment near ``_JOURNAL_SEED``):
       - LEDGER.md  — framework-written facts (outcomes + per-task broke/fixed);
@@ -1170,15 +1275,19 @@ def _augment_instructions(instructions: str, workdir: Path, run_dir: RunDir) -> 
       - PROCESS.md — optimizer-authored explainability, fresh each iteration;
       - RUNMAP.md + prior_iterations/ — framework manifest + copies of every prior
         iteration's PROCESS.md and capability diff (real prior-work-dir access).
+      - INSIGHTS.md / META_INSIGHTS.md / FRAMEWORK_IMPROVEMENTS.md — optimizer-authored,
+        append-only summary layer above JOURNAL.md (see the comment near ``_INSIGHTS_MARK``).
     """
     _build_ledger(workdir, run_dir)
     _seed_journal(workdir, run_dir)
+    for filename, seed, mark in _ACCUMULATORS:
+        _seed_accumulator(workdir, run_dir, filename=filename, seed=seed, mark=mark)
     if not (workdir / "PROCESS.md").exists():
         (workdir / "PROCESS.md").write_text(_PROCESS_SEED, encoding="utf-8")
     _build_runmap(workdir, run_dir)
 
     pointer = (
-        "## Cross-iteration files in THIS working dir (clean ownership — read all four)\n"
+        "## Cross-iteration files in THIS working dir (clean ownership — read all)\n"
         "- `LEDGER.md` — FACTS (framework, read-only): every iteration's outcome + the exact "
         "tasks it broke/fixed. Never re-introduce a change that broke a task.\n"
         "- `JOURNAL.md` — HANDOVER (yours, append-only across the whole run): read the whole "
@@ -1191,6 +1300,16 @@ def _augment_instructions(instructions: str, workdir: Path, run_dir: RunDir) -> 
         "- `RUNMAP.md` + `./prior_iterations/<id>/` — every prior iteration's PROCESS.md + "
         "capability diff, copied in for you. Read the ones targeting your cluster BEFORE "
         "proposing, so you build on prior work instead of repeating it.\n"
+        "- `INSIGHTS.md` — SUMMARIZED, VERIFIED findings (yours, append-only, optional most "
+        "iterations): a distilled 'what worked / what didn't / what's promising' a future "
+        "iteration reads INSTEAD of the whole journal. Add an entry whenever you have a new "
+        "CONFIRMED finding (cite the RESULT that confirmed it).\n"
+        "- `META_INSIGHTS.md` — about the SEARCH PROCESS itself (yours, append-only): which "
+        "strategies helped or stalled, what to try next. Update AT LEAST once, at the end of "
+        "the run.\n"
+        "- `FRAMEWORK_IMPROVEMENTS.md` — cross-run suggestions for cap-evolve ITSELF, not this "
+        "task (yours, append-only, optional): what confused you or was missing about the "
+        "framework. Update AT LEAST once, at the end of the run.\n"
     )
     return f"{instructions}\n\n{pointer}\n"
 
@@ -1995,6 +2114,7 @@ _DEFAULT_INSTRUCTIONS_TEMPLATE = (
 # beside it, so the literal list has to be complete anyway.)
 _SNAPSHOT_IGNORE = ("trajectories", "guidance", "prior_iterations",
                     "LEDGER.md", "JOURNAL.md", "RUNMAP.md",
+                    "INSIGHTS.md", "META_INSIGHTS.md", "FRAMEWORK_IMPROVEMENTS.md",
                     "FOCUS.md", "REFLECTION.md",
                     ".claude", ".agents", ".gemini", ".opencode", ".bob", ".cursor",
                     "CLAUDE.md", "AGENTS.md", "GEMINI.md")

--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -999,7 +999,14 @@ def _reconcile_journal(workdir: Path, run_dir: RunDir, cid: str, *,
 
     ``val``/``delta`` are None for an iteration that never bought a val eval (gepa's
     minibatch-local reject) or whose measurement is void (an indecisive tamper step):
-    the entry is still folded in, with "—" where the number would be."""
+    the entry is still folded in, with "—" where the number would be.
+
+    A genuinely empty handover (the confirmed bug this fixes) is no longer silently
+    accepted: it is ESCALATED — logged as an ``optimizer_context_warning`` event and
+    stamped into the journal itself with a visible ``EMPTY HANDOVER`` marker — so an
+    operator or the dashboard can see it happened, instead of the old placeholder text
+    reading like an unremarkable, silently-accepted note.
+    """
     tail = _journal_tail(workdir)
     run_journal = run_dir.root / "JOURNAL.md"
     base = run_journal.read_text(encoding="utf-8") if run_journal.exists() else _JOURNAL_SEED
@@ -1022,11 +1029,25 @@ def _reconcile_journal(workdir: Path, run_dir: RunDir, cid: str, *,
              f"<!-- {cid}: {'ACCEPTED' if accepted else 'rejected'} "
              f"val={vs} Δ={ds} -->")
     tail = tail.strip()
-    # Dedup guard: if the optimizer dropped the marker without appending (so the tail
-    # fallback returned an entry already recorded in the run-level journal), do NOT
-    # re-append it — that would duplicate a prior iteration's entry under this cid.
-    if not tail or (tail and tail in base):
-        tail = f"## Iteration {cid} — (no handover written by the optimizer)"
+    if not tail:
+        # Confirmed data-loss bug (#400): the optimizer wrote no handover at all, and
+        # this used to be accepted with no trace anywhere. Escalate — log it AND make
+        # the journal entry itself unmissable — instead of a placeholder that reads
+        # like ordinary content.
+        run_dir.log_event("optimizer_context_warning", what="JOURNAL.md",
+                          error="empty handover: optimizer wrote no ## Iteration entry",
+                          candidate=cid)
+        tail = (f"## Iteration {cid} — ⚠ EMPTY HANDOVER (framework escalation)\n"
+                "The optimizer wrote NO journal entry this iteration. This is a bug "
+                "in the optimizer/session, not a normal outcome — see the "
+                "`optimizer_context_warning` event in events.jsonl. The next "
+                "iteration has no narrative context for this candidate beyond the "
+                "RESULT line below.")
+    elif tail in base:
+        # Dedup guard: the optimizer dropped the marker without appending (so the tail
+        # fallback returned an entry already recorded in the run-level journal). Do NOT
+        # re-append it — that would duplicate a prior iteration's entry under this cid.
+        tail = f"## Iteration {cid} — (duplicate handover; optimizer re-appended a prior entry unchanged)"
     new = base + "\n\n" + tail + stamp + "\n"
     try:
         run_journal.write_text(new, encoding="utf-8")

--- a/core/tests/test_dashboard.py
+++ b/core/tests/test_dashboard.py
@@ -330,6 +330,11 @@ def test_config_absent_without_a_project_dir():
         r = dashboard.reduce_run(rd)
         assert r["summary"]["config"] == {}
         assert r["summary"]["capabilities"]["config"] is False
+        # The Config panel's JS guards on `CFG.project_dir`, not on `CFG` itself: `{}` is
+        # truthy in JS, so a bare `if(!CFG)return` would render an empty panel claiming to
+        # have read the config "straight off undefined". (Can't be asserted from the HTML
+        # text — the section title is a JS string literal that is always present.)
+        assert "project_dir" not in r["summary"]["config"]
 
 
 # ---- ANSI terminal --------------------------------------------------------

--- a/core/tests/test_dashboard.py
+++ b/core/tests/test_dashboard.py
@@ -232,6 +232,106 @@ def test_narrative_does_not_flag_a_real_appended_entry():
         assert journal["template_only"] is False
 
 
+# ---- Config tab: full run configuration ------------------------------------
+
+def _mk_project(base: Path, *, extra_spec: str = "", write_project_md: bool = True):
+    """A minimal project dir mirroring the real tau2_airline layout (capevolve.yaml,
+    PROJECT.md, adapters/, seed_capability/) without depending on the live path."""
+    proj = base / "project"
+    proj.mkdir(parents=True, exist_ok=True)
+    (proj / "capevolve.yaml").write_text(
+        "capabilities:       [system-prompt, tools]\n"
+        "capability_path:    seed_capability\n"
+        "algorithm_skill:    agent-optimize\n"
+        "optimizer_skill:    claude-code\n"
+        "gate_mode:          paired\n"
+        "gate_k_se:          1.0\n"
+        "split_ids_file:     split_ids.json\n"
+        + extra_spec, encoding="utf-8")
+    if write_project_md:
+        (proj / "PROJECT.md").write_text(
+            "# Project\n\n- num_trials=1 — single-trial scores\n", encoding="utf-8")
+    (proj / "adapters").mkdir(exist_ok=True)
+    (proj / "adapters" / "adapter.py").write_text(
+        "def run_target():\n    pass\n", encoding="utf-8")
+    (proj / "seed_capability" / "policy").mkdir(parents=True, exist_ok=True)
+    (proj / "seed_capability" / "policy" / "policy.md").write_text(
+        "# Policy\nBe helpful.\n", encoding="utf-8")
+    return proj
+
+
+def test_config_reads_spec_groups_project_md_and_files():
+    """A future, unrecognised spec key must still show up (in 'Other'), never vanish."""
+    from cap_evolve import dashboard
+    with tempfile.TemporaryDirectory() as d:
+        base = Path(d)
+        _mk_project(base, extra_spec="future_input:      some-new-thing\n")
+        rd = _mk_run(base, events=_BASE_EVENTS, baseline=_BASELINE)
+        r = dashboard.reduce_run(rd)
+        cfg = r["summary"]["config"]
+        assert r["summary"]["capabilities"]["config"] is True
+
+        groups = {g["group"]: {i["key"]: i["value"] for i in g["items"]}
+                   for g in cfg["spec_groups"]}
+        assert groups["Capability"]["capability_path"] == "seed_capability"
+        assert groups["Algorithm & optimizer"]["algorithm_skill"] == "agent-optimize"
+        assert groups["Budget & gate"]["gate_mode"] == "paired"
+        # unrecognised key lands in "Other", not dropped
+        assert groups["Other"]["future_input"] == "some-new-thing"
+
+        assert "single-trial scores" in cfg["project_md"]
+
+        files = {f["path"]: f for f in cfg["files"]}
+        assert "adapters/adapter.py" in files
+        assert "def run_target" in files["adapters/adapter.py"]["preview"]
+        assert "seed_capability/policy/policy.md" in files
+        # capevolve.yaml / PROJECT.md are shown separately, not duplicated in the tree
+        assert "capevolve.yaml" not in files
+        assert "PROJECT.md" not in files
+
+        html = dashboard.render_html(r, rd)
+        _parse_html(html)
+        assert "Config — run configuration" in html
+        assert "future_input" in html
+
+
+def test_config_degrades_binary_and_oversized_files():
+    from cap_evolve import dashboard
+    with tempfile.TemporaryDirectory() as d:
+        base = Path(d)
+        proj = _mk_project(base)
+        (proj / "seed_capability" / "reference").mkdir(parents=True, exist_ok=True)
+        (proj / "seed_capability" / "reference" / "blob.bin").write_bytes(bytes(range(256)) * 4)
+        big = proj / "seed_capability" / "reference" / "huge.py"
+        big.write_text("x = 1\n" * 60000, encoding="utf-8")  # > 200_000 bytes
+
+        rd = _mk_run(base, events=_BASE_EVENTS, baseline=_BASELINE)
+        r = dashboard.reduce_run(rd)
+        files = {f["path"]: f for f in r["summary"]["config"]["files"]}
+
+        blob = files["seed_capability/reference/blob.bin"]
+        assert blob["binary"] is True
+        assert blob["preview"] is None
+
+        huge = files["seed_capability/reference/huge.py"]
+        assert huge["binary"] is False
+        assert huge["preview"] is None  # too large to preview — size + path only
+        assert huge["size"] > 200_000
+
+        html = dashboard.render_html(r, rd)
+        _parse_html(html)  # renders without trying to dump the huge/binary file
+
+
+def test_config_absent_without_a_project_dir():
+    """No sibling project/ at all → the panel's data is absent, not faked."""
+    from cap_evolve import dashboard
+    with tempfile.TemporaryDirectory() as d:
+        rd = _mk_run(Path(d), events=_BASE_EVENTS, baseline=_BASELINE)
+        r = dashboard.reduce_run(rd)
+        assert r["summary"]["config"] == {}
+        assert r["summary"]["capabilities"]["config"] is False
+
+
 # ---- ANSI terminal --------------------------------------------------------
 
 def test_render_ansi_kpis_and_no_color():

--- a/core/tests/test_dashboard.py
+++ b/core/tests/test_dashboard.py
@@ -198,6 +198,40 @@ def test_dashboard_degrades_without_rollouts_or_finalize():
         assert '"diffs": {}' in text or '"diffs":{}' in text
 
 
+# ---- Process narrative: template-only detection ---------------------------
+
+def test_narrative_flags_an_unedited_seed_template():
+    """A run-level accumulator file that is STILL byte-for-byte its seed instructional
+    template (no real handover was ever appended) must not be presented as populated
+    narrative — it needs its own ``template_only`` flag so the renderer can flag it."""
+    from cap_evolve import dashboard, harness
+    with tempfile.TemporaryDirectory() as d:
+        rd = _mk_run(Path(d), events=_BASE_EVENTS, baseline=_BASELINE)
+        (rd.root / "JOURNAL.md").write_text(harness._JOURNAL_SEED, encoding="utf-8")
+        r = dashboard.reduce_run(rd)
+        (journal,) = [f for f in r["summary"]["narrative"]["files"]
+                      if f["title"].startswith("Journal")]
+        assert journal["template_only"] is True
+
+        html = dashboard.render_html(r, rd)
+        _parse_html(html)
+        assert "template only" in html
+
+
+def test_narrative_does_not_flag_a_real_appended_entry():
+    """The moment a real entry is appended below the marker, the file is no longer
+    byte-identical to its seed — must not be flagged."""
+    from cap_evolve import dashboard, harness
+    with tempfile.TemporaryDirectory() as d:
+        rd = _mk_run(Path(d), events=_BASE_EVENTS, baseline=_BASELINE)
+        real = harness._JOURNAL_SEED + "\n## Iteration cand_0001 — a real handover\n- did X\n"
+        (rd.root / "JOURNAL.md").write_text(real, encoding="utf-8")
+        r = dashboard.reduce_run(rd)
+        (journal,) = [f for f in r["summary"]["narrative"]["files"]
+                      if f["title"].startswith("Journal")]
+        assert journal["template_only"] is False
+
+
 # ---- ANSI terminal --------------------------------------------------------
 
 def test_render_ansi_kpis_and_no_color():

--- a/core/tests/test_dashboard_agent_run.py
+++ b/core/tests/test_dashboard_agent_run.py
@@ -354,9 +354,10 @@ def test_an_accepted_candidate_still_raises_the_running_best():
 # ---- second round: gate structured fields / null-control replicates / screened badge ----
 
 def test_gate_fields_read_directly_from_the_event_when_present():
-    """A commit event that attaches delta/stderr/n/k_se/threshold/resolvable_effect_size
-    directly is preferred over parsing them back out of the prose ``reason`` (#402 will
-    make agent-optimize's commit.py do this; the reducer must not assume it has landed)."""
+    """A commit event that RECORDS the gate numbers (``gate_delta``/``gate_stderr``/
+    ``gate_n``/``gate_k_se``/``gate_threshold``/``gate_resolvable_effect_size``) is
+    preferred over parsing them back out of the prose ``reason``; a prose-only event
+    (every deterministic loop) still takes the regex path unchanged."""
     from cap_evolve import Budget, RunDir, dashboard
     tmp = Path(tempfile.mkdtemp())
     rd = RunDir.create(tmp, ts="t", budget=Budget())
@@ -371,8 +372,8 @@ def test_gate_fields_read_directly_from_the_event_when_present():
         # Structured fields present — must win over the (deliberately contradictory) prose.
         {"t": 5.0, "kind": "reject", "candidate": "cand_struct", "val": 0.55,
          "note": "Δ̄=+0.0300 <= 1.0·SE=0.0500 (SE=0.0500, n=8)",
-         "delta": 0.099, "stderr": 0.011, "n": 40, "k_se": 1.0, "threshold": 0.011,
-         "resolvable_effect_size": 0.022},
+         "gate_delta": 0.099, "gate_stderr": 0.011, "gate_n": 40, "gate_k_se": 1.0,
+         "gate_threshold": 0.011, "gate_resolvable_effect_size": 0.022},
     ]
     rd.events_path.write_text("\n".join(json.dumps(e) for e in events) + "\n", encoding="utf-8")
     (rd.root / "baseline.json").write_text(json.dumps({"val": {"reward": 0.5}}), encoding="utf-8")

--- a/core/tests/test_dashboard_agent_run.py
+++ b/core/tests/test_dashboard_agent_run.py
@@ -349,3 +349,100 @@ def test_an_accepted_candidate_still_raises_the_running_best():
         assert any(n["status"] == "accepted" for n in nodes), run
         assert max(n.get("best_so_far") or 0 for n in nodes) == red["summary"]["best_val"]
         assert red["summary"]["best_val"] == 1.0, run
+
+
+# ---- second round: gate structured fields / null-control replicates / screened badge ----
+
+def test_gate_fields_read_directly_from_the_event_when_present():
+    """A commit event that attaches delta/stderr/n/k_se/threshold/resolvable_effect_size
+    directly is preferred over parsing them back out of the prose ``reason`` (#402 will
+    make agent-optimize's commit.py do this; the reducer must not assume it has landed)."""
+    from cap_evolve import Budget, RunDir, dashboard
+    tmp = Path(tempfile.mkdtemp())
+    rd = RunDir.create(tmp, ts="t", budget=Budget())
+    events = [
+        {"t": 1.0, "kind": "splits", "train": 4, "val": 2, "test": 2, "seed": 0},
+        {"t": 2.0, "kind": "evaluate", "split": "val", "tag": "seed", "reward": 0.5},
+        {"t": 3.0, "kind": "baseline", "val": 0.5},
+        # No structured fields at all — the fallback path (prose-only, as every existing
+        # agent-optimize run writes today) must still populate delta/stderr/n from ``note``.
+        {"t": 4.0, "kind": "reject", "candidate": "cand_prose", "val": 0.53,
+         "note": "Δ̄=+0.0300 <= 1.0·SE=0.0500 (SE=0.0500, n=8)"},
+        # Structured fields present — must win over the (deliberately contradictory) prose.
+        {"t": 5.0, "kind": "reject", "candidate": "cand_struct", "val": 0.55,
+         "note": "Δ̄=+0.0300 <= 1.0·SE=0.0500 (SE=0.0500, n=8)",
+         "delta": 0.099, "stderr": 0.011, "n": 40, "k_se": 1.0, "threshold": 0.011,
+         "resolvable_effect_size": 0.022},
+    ]
+    rd.events_path.write_text("\n".join(json.dumps(e) for e in events) + "\n", encoding="utf-8")
+    (rd.root / "baseline.json").write_text(json.dumps({"val": {"reward": 0.5}}), encoding="utf-8")
+    reduced = dashboard.reduce_run(rd)
+    gd = {d["candidate"]: d for d in reduced["summary"]["gate_decisions"]}
+
+    prose = gd["cand_prose"]
+    assert prose["delta"] == 0.03 and prose["stderr"] == 0.05 and prose["n"] == 8
+    assert prose["resolvable_effect_size"] is None  # not in the prose, no fallback pattern
+
+    struct = gd["cand_struct"]
+    assert struct["delta"] == 0.099 and struct["stderr"] == 0.011 and struct["n"] == 40
+    assert struct["k_se"] == 1.0 and struct["threshold"] == 0.011
+    assert struct["resolvable_effect_size"] == 0.022
+
+
+def test_controls_are_read_generically_and_absent_by_default():
+    """Null-control replicates surface as their own summary list, keyed by a generic
+    ``role``/``is_control`` marker — never by tag pattern (that would bake one
+    algorithm's naming convention, e.g. agent-optimize's ``ctl_null_i<N>``, into a
+    generic reducer). Absent today (no algorithm emits the marker yet): the list must
+    stay empty rather than guessing from tag names."""
+    from cap_evolve import Budget, RunDir, dashboard
+    tmp = Path(tempfile.mkdtemp())
+    rd = RunDir.create(tmp, ts="t", budget=Budget())
+    events = [
+        {"t": 1.0, "kind": "splits", "train": 4, "val": 2, "test": 2, "seed": 0},
+        {"t": 2.0, "kind": "evaluate", "split": "val", "tag": "seed", "reward": 0.5},
+        {"t": 3.0, "kind": "baseline", "val": 0.5},
+        # Tag LOOKS like a control (agent-optimize's convention) but carries no marker —
+        # must NOT be picked up by name alone.
+        {"t": 4.0, "kind": "evaluate", "split": "val", "tag": "ctl_null_i0", "reward": 0.52},
+    ]
+    rd.events_path.write_text("\n".join(json.dumps(e) for e in events) + "\n", encoding="utf-8")
+    (rd.root / "baseline.json").write_text(json.dumps({"val": {"reward": 0.5}}), encoding="utf-8")
+    reduced = dashboard.reduce_run(rd)
+    assert reduced["summary"]["controls"] == []
+    assert reduced["summary"]["capabilities"]["controls"] is False
+
+    # Now with the generic marker present — it must be picked up regardless of tag shape.
+    events.append({"t": 5.0, "kind": "evaluate", "split": "val", "tag": "anything_at_all",
+                   "reward": 0.48, "stderr": 0.02, "n_scored": 4, "role": "control"})
+    rd.events_path.write_text("\n".join(json.dumps(e) for e in events) + "\n", encoding="utf-8")
+    reduced2 = dashboard.reduce_run(rd)
+    (ctl,) = reduced2["summary"]["controls"]
+    assert ctl["tag"] == "anything_at_all" and ctl["reward"] == 0.48 and ctl["n"] == 4
+    assert reduced2["summary"]["capabilities"]["controls"] is True
+
+
+def test_screened_badge_read_generically_by_candidate_tag():
+    """``screened_before_fullval`` is looked up by whatever event carries it, keyed by
+    tag — not tied to the ``agent_optimize_compliance`` kind name agent-optimize happens
+    to emit it under today."""
+    from cap_evolve import Budget, RunDir, dashboard
+    tmp = Path(tempfile.mkdtemp())
+    rd = RunDir.create(tmp, ts="t", budget=Budget())
+    events = [
+        {"t": 1.0, "kind": "splits", "train": 4, "val": 2, "test": 2, "seed": 0},
+        {"t": 2.0, "kind": "evaluate", "split": "val", "tag": "seed", "reward": 0.5},
+        {"t": 3.0, "kind": "baseline", "val": 0.5},
+        {"t": 4.0, "kind": "some_future_algorithms_event", "tag": "cand_1",
+         "screened_before_fullval": True},
+        {"t": 5.0, "kind": "reject", "candidate": "cand_1", "val": 0.5, "note": "x"},
+        # cand_2 has no compliance signal at all -> stays None, not False.
+        {"t": 6.0, "kind": "reject", "candidate": "cand_2", "val": 0.51, "note": "y"},
+    ]
+    rd.events_path.write_text("\n".join(json.dumps(e) for e in events) + "\n", encoding="utf-8")
+    (rd.root / "baseline.json").write_text(json.dumps({"val": {"reward": 0.5}}), encoding="utf-8")
+    reduced = dashboard.reduce_run(rd)
+    nodes = {n["id"]: n for n in reduced["graph"]["nodes"]}
+    assert nodes["cand_1"]["screened"] is True
+    assert nodes["cand_2"]["screened"] is None
+    assert reduced["summary"]["capabilities"]["screened"] is True

--- a/core/tests/test_dashboard_launch.py
+++ b/core/tests/test_dashboard_launch.py
@@ -82,6 +82,19 @@ def test_maybe_launch_steps_past_an_occupied_port(monkeypatch):
     assert str(taken) not in calls["cmd"]
 
 
+def test_maybe_launch_reports_error_when_every_port_in_range_is_taken(monkeypatch):
+    """Every port in the scanned range squatted (observed live: ~25 leaked
+    dashboard processes from old sessions) must surface as an error, not silently
+    fall back to the first (also-taken) port — that fallback used to print a URL
+    that actually served a stale, unrelated dashboard."""
+    monkeypatch.setattr(dl, "is_available", lambda: True)
+    monkeypatch.setattr(dl, "_free_port", lambda start, tries=25: (_ for _ in ()).throw(
+        RuntimeError(f"no free port in [{start}, {start + tries})")))
+    out = dl.maybe_launch("/runs", mode="auto")
+    assert out["dashboard"] == "error"
+    assert "no free port" in out["reason"]
+
+
 def test_maybe_launch_never_raises_on_spawn_error(monkeypatch):
     monkeypatch.setattr(dl, "is_available", lambda: True)
 

--- a/core/tests/test_empty_seed.py
+++ b/core/tests/test_empty_seed.py
@@ -172,6 +172,68 @@ def test_baseline_with_nonexistent_seed_dir(tmp_path):
     assert seed.is_dir()
 
 
+# ---- _reconcile_journal: synthesize from the commit reason on an empty handover ----
+
+def test_reconcile_journal_synthesizes_from_reason_when_handover_is_empty(tmp_path):
+    """A confirmed live gap: the optimizer's own handover is empty, but every caller
+    already carries a real, substantive ``reason`` (the same text that becomes the
+    commit's --note). The journal must not be left contentless when that text is
+    available — it folds the reason in as the entry, instead of an admission-only
+    placeholder, while still escalating the warning event."""
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    (workdir / "JOURNAL.md").write_text(harness._JOURNAL_SEED, encoding="utf-8")  # no entry appended
+
+    run_dir = RunDir.create(tmp_path / ".capevolve", ts="synth", budget=Budget(max_iterations=1))
+    harness._reconcile_journal(workdir, run_dir, "cand_1", accepted=False, val=0.5, delta=-0.02,
+                               reason="policy.md: tried X because Y. Gate rejected: below threshold.")
+
+    journal = (run_dir.root / "JOURNAL.md").read_text(encoding="utf-8")
+    assert "policy.md: tried X because Y. Gate rejected: below threshold." in journal
+    assert "EMPTY HANDOVER" in journal  # still visibly flagged, not silently papered over
+
+    warnings = [json.loads(ln) for ln in run_dir.events_path.read_text(encoding="utf-8").splitlines()
+                if ln.strip() and json.loads(ln).get("kind") == "optimizer_context_warning"]
+    assert any(w.get("candidate") == "cand_1" for w in warnings)
+
+
+def test_reconcile_journal_falls_back_to_generic_note_with_no_reason(tmp_path):
+    """When there is truly nothing to synthesize from (no reason string either), the
+    old generic escalation text is still used — this fallback must not crash or
+    silently invent content."""
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    (workdir / "JOURNAL.md").write_text(harness._JOURNAL_SEED, encoding="utf-8")
+
+    run_dir = RunDir.create(tmp_path / ".capevolve", ts="nosynth", budget=Budget(max_iterations=1))
+    harness._reconcile_journal(workdir, run_dir, "cand_1", accepted=False, val=None, delta=None,
+                               reason=None)
+
+    journal = (run_dir.root / "JOURNAL.md").read_text(encoding="utf-8")
+    assert "EMPTY HANDOVER" in journal
+    assert "no commit reason was available" in journal
+
+
+def test_reconcile_journal_prefers_the_optimizers_own_entry_over_synthesis(tmp_path):
+    """Synthesis is a fallback, not a substitute: when the optimizer DID write a real
+    entry, its own text is used verbatim and the reason-based synthesis never fires."""
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    (workdir / "JOURNAL.md").write_text(
+        harness._JOURNAL_SEED + "\n\n" + harness._JOURNAL_MARK
+        + "\n\n## Iteration cand_1 — my own reflection\n",
+        encoding="utf-8")
+
+    run_dir = RunDir.create(tmp_path / ".capevolve", ts="own", budget=Budget(max_iterations=1))
+    harness._reconcile_journal(workdir, run_dir, "cand_1", accepted=False, val=0.5, delta=-0.02,
+                               reason="a completely different synthesized reason that must not appear")
+
+    journal = (run_dir.root / "JOURNAL.md").read_text(encoding="utf-8")
+    assert "my own reflection" in journal
+    assert "must not appear" not in journal
+    assert "EMPTY HANDOVER" not in journal
+
+
 # ---- optimizer instructions: empty seed note ------------------------------
 
 def test_empty_seed_note_when_all_failing():

--- a/core/tests/test_iteration_record_parity.py
+++ b/core/tests/test_iteration_record_parity.py
@@ -118,6 +118,14 @@ def _run_agent_optimize(tmp_path):
     (work / "prompt.txt").write_text("[CALC] answer the arithmetic.\n", encoding="utf-8")
     env = dict(os.environ, PYTHONPATH=str(CORE))
     for cid, decision, val in (("cand_r1", "accept", "1.0"), ("cand_r2", "reject", "0.5")):
+        # Agent mode does not seed a marker in the workdir's JOURNAL.md (host.py: only
+        # the deterministic loop's LEDGER/RUNMAP/JOURNAL seeding applies); the agent
+        # writes a free-form entry itself. harness.record_iteration now hard-fails an
+        # empty handover, so give it one here the way a real agent-optimize round would.
+        (work / "JOURNAL.md").write_text(
+            f"# JOURNAL\n\n## Iteration {cid} — {decision} candidate\n"
+            f"- test handover for {cid}\n",
+            encoding="utf-8")
         out = subprocess.run(
             [sys.executable, str(AGENT_COMMIT), "--run-dir", str(run_dir.root),
              "--candidate-id", cid, "--from-dir", str(work), "--decision", decision,

--- a/core/tests/test_iteration_record_parity.py
+++ b/core/tests/test_iteration_record_parity.py
@@ -120,7 +120,7 @@ def _run_agent_optimize(tmp_path):
     for cid, decision, val in (("cand_r1", "accept", "1.0"), ("cand_r2", "reject", "0.5")):
         # Agent mode does not seed a marker in the workdir's JOURNAL.md (host.py: only
         # the deterministic loop's LEDGER/RUNMAP/JOURNAL seeding applies); the agent
-        # writes a free-form entry itself. harness.record_iteration now hard-fails an
+        # writes a free-form entry itself. harness.record_iteration now escalates an
         # empty handover, so give it one here the way a real agent-optimize round would.
         (work / "JOURNAL.md").write_text(
             f"# JOURNAL\n\n## Iteration {cid} — {decision} candidate\n"

--- a/skills/algorithms/hill-climb/references/run-step.md
+++ b/skills/algorithms/hill-climb/references/run-step.md
@@ -29,7 +29,7 @@ and `workdir` (`harness.py:1614-1626`).
 
 ## Cross-iteration files, and who owns each
 
-Written into the workdir before the optimizer runs, with a prompt pointer to all four
+Written into the workdir before the optimizer runs, with a prompt pointer to all of them
 (`harness.py:1062-1094`):
 
 | file | owner | lifetime |
@@ -38,10 +38,14 @@ Written into the workdir before the optimizer runs, with a prompt pointer to all
 | `JOURNAL.md` | the optimizer, append-only | run-level handover; earlier entries must not be edited |
 | `PROCESS.md` | the optimizer, required | fresh each iteration; **snapshotted with the candidate** and surfaced per-iteration by the dashboard |
 | `RUNMAP.md` + `prior_iterations/<id>/` | framework | manifest plus every prior iteration's `PROCESS.md` and capability diff |
+| `INSIGHTS.md` / `META_INSIGHTS.md` / `FRAMEWORK_IMPROVEMENTS.md` | the optimizer, append-only, optional most iterations | run-level, distilled: verified findings / process meta-learning / cross-run framework feedback — a summary layer above `JOURNAL.md` |
 
 `_reconcile_journal` folds the optimizer's appended entry into the run-level journal
 for accepted *and* rejected iterations, and reuses it as the candidate's lineage note
-(`harness.py:1586-1588`).
+(`harness.py:1586-1588`). A genuinely empty handover is escalated (logged, and stamped
+into the journal itself), not silently dropped. `_fold_accumulator` does the same for
+the three summary files, minus the escalation — those are legitimately empty most
+iterations.
 
 ## Memory across iterations
 

--- a/skills/optimizers/run-optimizer/scripts/_mock_apply.py
+++ b/skills/optimizers/run-optimizer/scripts/_mock_apply.py
@@ -34,10 +34,10 @@ def _find_script(workdir: Path) -> Path | None:
 def _append_mock_journal(workdir: Path) -> None:
     """Append a minimal handover entry to JOURNAL.md, if the harness seeded one.
 
-    The harness now hard-fails an iteration whose optimizer wrote an empty JOURNAL.md
-    handover (see ``harness.EmptyHandoverError``). The mock optimizer stands in for a
-    real one in tests, so it writes a (trivial but non-empty) handover too instead of
-    tripping that check.
+    The harness now escalates (logs + visibly flags) an iteration whose optimizer wrote
+    an empty JOURNAL.md handover (see ``harness._reconcile_journal``). The mock optimizer
+    stands in for a real one in tests, so it writes a (trivial but non-empty) handover too
+    instead of tripping that escalation.
     """
     journal = workdir / "JOURNAL.md"
     if not journal.exists():

--- a/skills/optimizers/run-optimizer/scripts/_mock_apply.py
+++ b/skills/optimizers/run-optimizer/scripts/_mock_apply.py
@@ -31,6 +31,24 @@ def _find_script(workdir: Path) -> Path | None:
     return None
 
 
+def _append_mock_journal(workdir: Path) -> None:
+    """Append a minimal handover entry to JOURNAL.md, if the harness seeded one.
+
+    The harness now hard-fails an iteration whose optimizer wrote an empty JOURNAL.md
+    handover (see ``harness.EmptyHandoverError``). The mock optimizer stands in for a
+    real one in tests, so it writes a (trivial but non-empty) handover too instead of
+    tripping that check.
+    """
+    journal = workdir / "JOURNAL.md"
+    if not journal.exists():
+        return
+    text = journal.read_text(encoding="utf-8")
+    if "cap-evolve:journal-append-below" not in text:
+        return
+    text += "\n## Iteration (mock) — applied mock_script.json edits\n- deterministic mock edit, see mock_script.json\n"
+    journal.write_text(text, encoding="utf-8")
+
+
 def apply_edits(workdir: Path, edits: list[dict]) -> list[dict]:
     applied = []
     for e in edits:
@@ -74,6 +92,7 @@ def main(argv=None) -> int:
         return 0
     edits = json.loads(script.read_text(encoding="utf-8")).get("edits", [])
     applied = apply_edits(workdir, edits)
+    _append_mock_journal(workdir)
     print(json.dumps({"optimizer": "mock", "script": str(script), "applied": applied}))
     return 0
 

--- a/skills/phases/intake/inputs/INPUTS.md
+++ b/skills/phases/intake/inputs/INPUTS.md
@@ -105,6 +105,14 @@ path, how to obtain it, and the alternatives. Never invent a NEEDED input.
   `run-optimizer` skill against `optimizers/registry.yaml` (run `run-optimizer --list`
   to see the available names); `optimizer_model` is the backend-specific model id.
 
+- **memory_skill** (default `md-files`): which cross-iteration memory scheme the
+  optimizer reads/writes. `md-files` is `harness.py`'s built-in LEDGER/JOURNAL/
+  INSIGHTS/META_INSIGHTS/FRAMEWORK_IMPROVEMENTS scheme (always on today — every run
+  gets it regardless of this key) and is the only fully-wired option; note the choice
+  in `PROJECT.md` either way. The deprecated `evograph` algorithm's `wiki/` weakness-
+  graph format is a candidate SECOND option once it is extracted into a standalone
+  memory skill (tracked separately — not selectable yet).
+
 - **target_model** (default `""` = profile-agnostic): the runtime/CONSUMING LLM the
   agent reads these capabilities with — DISTINCT from `optimizer_model`, which proposes
   the edits. Give a concrete model id (e.g. `gpt-oss-120b`) or a capability tier


### PR DESCRIPTION
Addresses #400 (partially — see Deferred below; follow-up filed as #404).

## What's implemented

**1. Fix the confirmed journal-trimming/empty-handover bug**
`core/cap_evolve/harness.py`'s `_reconcile_journal` used to silently substitute
`(no handover written by the optimizer)` when the optimizer wrote no `## Iteration`
entry, with no trace anywhere. It now:
- logs an `optimizer_context_warning` event, and
- stamps the journal itself with a visible `⚠ EMPTY HANDOVER (framework escalation)`
  marker instead of unremarkable filler text.

**Deliberate choice — escalation, not hard-fail.** The issue offered "hard-fail or
explicit escalation." I tried hard-failing (`EmptyHandoverError`) first, but it broke
28 unrelated unit tests across 8 files that pass small in-process fake "optimizer"
functions (testing gate/integrity/skillopt mechanics, not journal content) and never
touch `JOURNAL.md` at all — none of those are the bug this issue is about, and
rewriting 8 test files' fixtures to fake a handover was out of scope for a surgical
fix. Escalation (always logged + visibly flagged) fixes the actual "silent" part of
the bug without that blast radius. Real-run validation below confirms a working
optimizer's real handover flows through untouched.

The mock optimizer (`skills/optimizers/run-optimizer/scripts/_mock_apply.py`, the
offline test double) now writes a trivial handover too, matching what a real
optimizer does.

**2. Per-run summarized/verified insight files**
Three new optimizer-authored, run-level, append-only files — `INSIGHTS.md` (verified
per-task/per-mechanism findings), `META_INSIGHTS.md` (about the optimization process
itself), `FRAMEWORK_IMPROVEMENTS.md` (cross-run suggestions for cap-evolve itself) —
seeded into the workdir and folded back the same way `JOURNAL.md` already is
(`_seed_accumulator`/`_fold_accumulator`, generalizing the existing
`_seed_journal`/`_reconcile_journal` mechanic, minus the journal's RESULT stamp).
Unlike `JOURNAL.md` these are optional most iterations — no escalation on an empty
tail — but the optimizer prompt asks for at least one entry by the end of the run.
Excluded from candidate snapshots/diffs the same way LEDGER/JOURNAL/RUNMAP already are.

**3. Memory as a (partially) selectable component**
`skills/phases/intake/inputs/INPUTS.md` now documents `memory_skill` as an input
(default and only wired value: `md-files`, i.e. the scheme above). The full
pluggability (a real interface + the evograph wiki extraction) is deferred — see below.

**4. Default-on HTML process-narrative dashboard section**
`dashboard.py`'s `reduce_run` now reads the run-level JOURNAL/INSIGHTS/META_INSIGHTS/
FRAMEWORK_IMPROVEMENTS files plus the best candidate's `PROCESS.md` straight off disk
(`_read_narrative`, modeled on the existing `_read_evograph`) and a new JS section
renders them — with a small dependency-free markdown-to-HTML pass (headings, bullets,
blockquotes, bold) — reusing `render_html`'s existing self-contained JSON-island
pattern. Shown as its own "Process narrative" section for every run by default,
whenever any of those files have content — no algorithm special-casing.

**5. Skill injection: verified, not just wired**
Ran a real `claude-code` optimizer session (see Validation below) and inspected its
working dir: `.claude/skills/system-prompt/` and `.claude/skills/diagnose/` were
injected, and its `PROCESS.md` output used the diagnose skill's own failure-taxonomy
vocabulary verbatim (`KNOWLEDGE` / `BEHAVIORAL` / `CAPABILITY-GAP`) — real evidence the
optimizer read and used the injected skill, not just had it sitting unused. No CLAUDE.md
enforcement text was needed.

## Deferred (follow-up: #404)

- Full memory pluggability: extracting the evograph `wiki/` format into a standalone
  selectable memory skill + a real plug-in interface into `harness.py`. `memory_skill`
  is documented but not yet functionally selectable beyond the default.
- The optimizer isn't told when a run is ending, so the optional `META_INSIGHTS.md`/
  `FRAMEWORK_IMPROVEMENTS.md` "update at least once, at the end of the run" instruction
  is sometimes not honored on a short run — real finding from the validation run below.

## Validation (real, not fabricated)

Two real end-to-end runs via the actual `cap-evolve` CLI (not just pytest):

1. **`examples/toy_calc/run.sh`** (zero-API, deterministic mock optimizer) — full
   loop (check → baseline → optimize → gate → finalize → report → dashboard),
   3 iterations, confirmed `JOURNAL.md` has real per-iteration entries (mock optimizer
   now writes one), no empty-handover markers.
2. **A real `claude-code` optimizer session** against the same `toy_calc` capability
   (1 iteration, `$0.367252`, 14464 tokens, 66s wall — real API cost, no target-model
   calls since `toy_calc`'s target is deterministic arithmetic):
   - `JOURNAL.md` got a real, substantive entry (`## Iteration cand_0001 — add explicit
     arithmetic-answer-only output contract to system prompt`, with expected-effect
     reasoning, a `RESULT` stamp correctly showing `REJECTED` since val stayed 0.000,
     and no `EMPTY HANDOVER` marker anywhere).
   - `PROCESS.md` was filled in with a ranked-issue table tagging the failure
     `KNOWLEDGE` — the exact taxonomy from the injected `diagnose` skill.
   - `INSIGHTS.md`/`META_INSIGHTS.md`/`FRAMEWORK_IMPROVEMENTS.md` were seeded into the
     workdir (confirmed via `work/cand_0001/`) but left empty by the optimizer — the
     real finding written up in #404.
   - `dashboard.html`'s "Process narrative" section rendered the real journal content
     (confirmed via `grep -o "arithmetic-answer-only" dashboard.html`), with zero
     "no handover written" placeholder text anywhere in the output.
   - Run report (`report.md`) honestly reported a null result (val stayed 0.0, gate
     correctly rejected) — no fabricated gain.

Full test suite (`core/tests`, 952+ tests): all green except two pre-existing
flaky tests in `test_eventstream.py` (thread-timing / module-identity races under
full-suite ordering) confirmed to fail identically on `main` with none of this PR's
changes applied, and to pass standalone either way.

## Git identity
Commits authored as `Osher-Elhadad <Osher.Elhadad@ibm.com>`, no Claude/Anthropic
co-author trailer.