### PR TITLE
fix(agent-optimize): make an agent-driven run's gate, its verdicts, its handover and its published cost honest

### DIFF
--- a/ci/benchmarks/lib/metrics.py
+++ b/ci/benchmarks/lib/metrics.py
@@ -74,6 +74,20 @@ def iteration_rows(run_dir: str, best_id: str | None = None) -> list[dict]:
     their optimizer_usd/optimizer_seconds are 0.0. ``best_id`` labels the ``finalize``
     row's candidate (the "evaluate" event itself only carries a fixed tag, not the
     actual candidate id — the caller already knows it from state.json).
+
+    A final ``unattributed`` row carries whatever the run METERED but no phase above claims,
+    because every consumer of these rows (``record.rollup``, ``results_md``, the Totals line
+    below, the Pages per-run table) reports cost by SUMMING them — so spend that belonged to no
+    step was not merely unattributed, it was published as if it had never happened. Measured on
+    smoke spreadsheetbench run 33046360451: ``suite.optimizer_usd: 0`` and ``eval_usd: 5.25``
+    for a run whose own state held ``optimizer_usd 9.11`` / ``usd 12.55`` — a $21.66 run
+    published as $5.25, a 4x understatement in the one figure a full tier's budget gets
+    projected from. Two independent holes fed it: agent mode meters the optimizer ONCE for the
+    whole loop (no round can own a share of it), and control replicates, re-gates and abandoned
+    rounds are real evaluations that no ``step`` event references. The residual is the honest
+    name for both, and it is visible as its own row rather than smuggled into a round that did
+    not spend it. Being a residual and not a sum, a run that DOES attribute everything per round
+    emits no row at all, and an unmetered run (``usd == 0``) cannot produce a negative one.
     """
     events_path = Path(run_dir) / "events.jsonl"
     rows: list[dict] = []
@@ -136,7 +150,53 @@ def iteration_rows(run_dir: str, best_id: str | None = None) -> list[dict]:
                 "optimizer_usd": 0.0, "optimizer_seconds": 0.0,
                 "eval_usd": ev.get("cost_usd"), "eval_seconds": ev.get("seconds"),
             })
+    residual = _unattributed_row(Path(run_dir), rows)
+    if residual:
+        rows.append(residual)
     return rows
+
+
+# Below a cent in either role, the residual is rounding between the meter and the events, and a
+# row saying "$0.00 went somewhere" costs a reader more than it tells them.
+_RESIDUAL_FLOOR_USD = 0.01
+
+
+def _unattributed_row(run_dir: Path, rows: list[dict]) -> dict | None:
+    """Metered spend that no row in ``rows`` accounts for, as one row — or None if it all is.
+
+    The run's own ``state.json`` is the meter of record: ``spent.usd`` is every rollout the run
+    paid for and ``spent.optimizer_usd`` every proposal, both accumulated by ``update_spent`` at
+    each booking, so each is an upper bound on what the per-phase events can attribute. Intake
+    spend rides in the optimizer column: it is non-runner cost with no step to call its own, and
+    the alternative is to keep dropping it.
+    """
+    state = _load(run_dir / "state.json")
+    spent = state.get("spent") or {}
+    if not spent:
+        return None
+    opt_metered = (spent.get("optimizer_usd") or 0.0) + (spent.get("intake_usd") or 0.0)
+    eval_metered = spent.get("usd") or 0.0
+    opt_secs_metered = ((spent.get("optimizer_seconds") or 0.0)
+                        + (spent.get("intake_seconds") or 0.0))
+    eval_secs_metered = spent.get("runner_seconds") or 0.0
+    opt_usd = round(max(0.0, opt_metered - sum(r.get("optimizer_usd") or 0.0 for r in rows)), 6)
+    eval_usd = round(max(0.0, eval_metered - sum(r.get("eval_usd") or 0.0 for r in rows)), 6)
+    if opt_usd < _RESIDUAL_FLOOR_USD and eval_usd < _RESIDUAL_FLOOR_USD:
+        return None
+    # Seconds only where the same role has unattributed money, so a row cannot claim time for a
+    # role whose spend was fully accounted for.
+    opt_secs = (round(max(0.0, opt_secs_metered
+                          - sum(r.get("optimizer_seconds") or 0.0 for r in rows)), 2)
+                if opt_usd >= _RESIDUAL_FLOOR_USD else 0.0)
+    eval_secs = (round(max(0.0, eval_secs_metered
+                           - sum(r.get("eval_seconds") or 0.0 for r in rows)), 2)
+                 if eval_usd >= _RESIDUAL_FLOOR_USD else None)
+    return {
+        "phase": "unattributed", "iter": None, "candidate": "(whole run)", "accepted": None,
+        "reward": None,
+        "optimizer_usd": opt_usd, "optimizer_seconds": opt_secs,
+        "eval_usd": eval_usd, "eval_seconds": eval_secs,
+    }
 
 
 def suite_report(run_dir: str, bench: str, tier: str, agent: str, iters, jsonl_path: str = "",
@@ -301,21 +361,32 @@ def suite_report(run_dir: str, bench: str, tier: str, agent: str, iters, jsonl_p
             eval_usd_t += s["eval_usd"] or 0
             eval_s_t += s["eval_seconds"] or 0
         out.append("")
+        # These sum the rows, INCLUDING the `unattributed` one, so they now reconcile with the
+        # run's own meters instead of reporting only the share some phase happened to claim.
         # Agent mode runs ONE optimizer process for the whole loop, so no per-round optimizer
-        # cost exists to sum — and summing the absent figures printed "optimizer $0.0000 over
-        # 0s" directly underneath a headline reading "optimizer $7.95" (run 32971129203). Fall
-        # back to the run-level spend the headline already uses, and say that it is whole-loop
-        # rather than silently implying it was attributed per round.
-        run_opt_usd = spent.get("optimizer_usd") or 0.0
-        run_opt_s = spent.get("optimizer_seconds") or 0.0
-        if not (opt_usd_t or opt_s_t) and (run_opt_usd or run_opt_s):
-            out.append(f"**Totals:** optimizer ${run_opt_usd:.4f} over "
-                       f"{_fmt_duration(run_opt_s)} (whole-loop — one optimizer process drove "
-                       f"every round, so there is no per-round figure to attribute) · "
-                       f"eval ${eval_usd_t:.4f} over {_fmt_duration(eval_s_t)}")
-        else:
-            out.append(f"**Totals:** optimizer ${opt_usd_t:.4f} over {_fmt_duration(opt_s_t)} · "
-                       f"eval ${eval_usd_t:.4f} over {_fmt_duration(eval_s_t)}")
+        # cost exists to sum — and summing the absent figures printed "optimizer $0.0000 over 0s"
+        # directly underneath a headline reading "optimizer $7.95" (run 32971129203). The note
+        # below names whichever role the residual came from rather than letting the total imply
+        # it was attributed per round.
+        out.append(f"**Totals:** optimizer ${opt_usd_t:.4f} over {_fmt_duration(opt_s_t)} · "
+                   f"eval ${eval_usd_t:.4f} over {_fmt_duration(eval_s_t)}")
+        resid = next((s for s in steps if s["phase"] == "unattributed"), None)
+        if resid:
+            parts = []
+            if (resid["optimizer_usd"] or 0) > 0:
+                parts.append(f"optimizer ${resid['optimizer_usd']:.4f} — agent mode runs ONE "
+                             "optimizer process, metered whole-loop, so no round owns a share "
+                             "of it")
+            if (resid["eval_usd"] or 0) > 0:
+                parts.append(f"eval ${resid['eval_usd']:.4f} — control replicates, re-gates and "
+                             "abandoned rounds are real evaluations that no committed step "
+                             "references")
+            out.append("")
+            out.append("> The `unattributed` row is metered spend no phase above owns ("
+                       + "; ".join(parts) + "). It is shown rather than dropped so these totals "
+                       f"match what the run actually paid: `spent` reads "
+                       f"${spent.get('usd', 0) or 0:.2f} runner + "
+                       f"${spent.get('optimizer_usd', 0) or 0:.2f} optimizer.")
     return "\n".join(out)
 
 

--- a/ci/benchmarks/lib/metrics.py
+++ b/ci/benchmarks/lib/metrics.py
@@ -81,6 +81,12 @@ def iteration_rows(run_dir: str, best_id: str | None = None) -> list[dict]:
         return rows
     seen_baseline = False
     it = 0
+    # Every candidate's eval cost/time is recorded on its own ``evaluate`` event. The
+    # deterministic loops ALSO copy those onto the ``step`` event; agent mode's commit.py does
+    # not, so run 32971129203 rendered "eval $ —" for all three rounds while its events.jsonl
+    # held $0.456/629.84s for cand_1 alone. A candidate is evaluated before it is booked, so
+    # accumulating as we go is enough — no second pass.
+    eval_by_tag: dict[str, dict] = {}
     for line in events_path.read_text(encoding="utf-8").splitlines():
         line = line.strip()
         if not line:
@@ -90,6 +96,8 @@ def iteration_rows(run_dir: str, best_id: str | None = None) -> list[dict]:
         except Exception:
             continue
         kind = ev.get("kind")
+        if kind == "evaluate" and ev.get("tag"):
+            eval_by_tag[str(ev.get("tag"))] = ev
         if kind == "evaluate" and ev.get("tag") == "seed" and ev.get("split") == "val" and not seen_baseline:
             seen_baseline = True
             rows.append({
@@ -100,12 +108,19 @@ def iteration_rows(run_dir: str, best_id: str | None = None) -> list[dict]:
             })
         elif kind == "step":
             it += 1
+            # The step's own figures win when it has them (the deterministic path); otherwise
+            # fall back to this candidate's evaluate event rather than rendering a dash over
+            # a cost the run did measure.
+            cev = eval_by_tag.get(str(ev.get("candidate"))) or {}
+            e_usd = ev.get("cost_usd")
+            e_secs = ev.get("runner_seconds")
             rows.append({
                 "phase": "iterate", "iter": it, "candidate": ev.get("candidate"),
                 "accepted": ev.get("accept"), "reward": ev.get("val"),
                 "optimizer_usd": round(ev.get("opt_cost_usd") or 0.0, 6),
                 "optimizer_seconds": ev.get("optimizer_seconds"),
-                "eval_usd": ev.get("cost_usd"), "eval_seconds": ev.get("runner_seconds"),
+                "eval_usd": e_usd if e_usd is not None else cev.get("cost_usd"),
+                "eval_seconds": e_secs if e_secs is not None else cev.get("seconds"),
             })
         elif kind == "evaluate" and ev.get("tag") == "FINAL" and ev.get("split") == "test":
             rows.append({
@@ -149,6 +164,12 @@ def suite_report(run_dir: str, bench: str, tier: str, agent: str, iters, jsonl_p
     state = _load(rd / "state.json")
     spent = state.get("spent", {})
     best_id = state.get("best_id", "seed")
+    # NULL RUN: no candidate cleared the gate, so the "optimized" capability IS the seed and
+    # the two evals paired below score the SAME BYTES. Every difference between them is
+    # re-measurement noise. Run 32971129203 published "0.500 → 0.544 (Δ +0.044 (+9% rel))"
+    # for a capability it never edited, with per-task rows to match (`47484` +0.333, `53161`
+    # -0.333) — and +0.044 was exactly the replicate noise round.py measured that run at.
+    null_run = best_id in ("seed", "", None)
 
     bval = baseline.get("val") or {}
     ftest = final.get("test") or {}
@@ -166,6 +187,15 @@ def suite_report(run_dir: str, bench: str, tier: str, agent: str, iters, jsonl_p
         held_out = False
         base_pt = val_pt
         task_ids = list(base_pt) or list(opt_pt)
+
+    # Pair the baseline against ITSELF on a null run, so no phantom per-task delta reaches
+    # metrics.jsonl — and from there record.rollup and the published benchmarks page, which is
+    # the durable harm. The discarded measurement is kept and reported below as what it is: a
+    # free read on the tier's noise floor, which a reader needs in order to judge whether the
+    # run could have resolved a real effect at all.
+    remeasured = ftest.get("reward") if null_run else None
+    if null_run and base_pt:
+        opt_pt = base_pt
 
     rows = []
     for tid in task_ids:
@@ -226,7 +256,9 @@ def suite_report(run_dir: str, bench: str, tier: str, agent: str, iters, jsonl_p
     else:
         agg_b = bval.get("reward")
     agg_o = ftest.get("reward")
-    accepted = "seed (no candidate beat baseline)" if best_id in ("seed", "", None) else f"`{best_id}`"
+    if null_run and isinstance(agg_b, (int, float)):
+        agg_o = agg_b
+    accepted = "seed (no candidate beat baseline)" if null_run else f"`{best_id}`"
     out.append("")
     if isinstance(agg_b, (int, float)) and isinstance(agg_o, (int, float)):
         rel = f" ({(agg_o-agg_b)/agg_b*100:+.0f}% rel)" if agg_b else ""
@@ -234,6 +266,14 @@ def suite_report(run_dir: str, bench: str, tier: str, agent: str, iters, jsonl_p
                    f"(Δ {agg_o-agg_b:+.3f}{rel}) · best = {accepted} · "
                    f"optimizer ${spent.get('optimizer_usd',0) or 0:.2f} over {spent.get('iterations','?')} iter(s)"
                    + (f" · {infra_n} task(s) infra-errored" if infra_n else ""))
+        if isinstance(remeasured, (int, float)) and isinstance(agg_b, (int, float)):
+            out.append("")
+            out.append(f"> No candidate was accepted, so base→opt is the seed against itself and Δ is "
+                       f"0.000 by construction. Re-scoring those same bytes for the finalize read "
+                       f"{remeasured:.3f} against the baseline's {agg_b:.3f} — a spread of "
+                       f"{abs(remeasured - agg_b):.3f}. That is this tier's re-measurement **noise**, "
+                       f"not a change in the capability, and it is the floor any real effect here "
+                       f"would have to clear.")
     elif infra_n:
         out.append(f"**Suite:** ⚠️ {infra_n}/{len(rows)} tasks infra-errored (gateway/runtime) — "
                    "no valid result. Check the model gateway (budget/429).")
@@ -261,8 +301,21 @@ def suite_report(run_dir: str, bench: str, tier: str, agent: str, iters, jsonl_p
             eval_usd_t += s["eval_usd"] or 0
             eval_s_t += s["eval_seconds"] or 0
         out.append("")
-        out.append(f"**Totals:** optimizer ${opt_usd_t:.4f} over {_fmt_duration(opt_s_t)} · "
-                   f"eval ${eval_usd_t:.4f} over {_fmt_duration(eval_s_t)}")
+        # Agent mode runs ONE optimizer process for the whole loop, so no per-round optimizer
+        # cost exists to sum — and summing the absent figures printed "optimizer $0.0000 over
+        # 0s" directly underneath a headline reading "optimizer $7.95" (run 32971129203). Fall
+        # back to the run-level spend the headline already uses, and say that it is whole-loop
+        # rather than silently implying it was attributed per round.
+        run_opt_usd = spent.get("optimizer_usd") or 0.0
+        run_opt_s = spent.get("optimizer_seconds") or 0.0
+        if not (opt_usd_t or opt_s_t) and (run_opt_usd or run_opt_s):
+            out.append(f"**Totals:** optimizer ${run_opt_usd:.4f} over "
+                       f"{_fmt_duration(run_opt_s)} (whole-loop — one optimizer process drove "
+                       f"every round, so there is no per-round figure to attribute) · "
+                       f"eval ${eval_usd_t:.4f} over {_fmt_duration(eval_s_t)}")
+        else:
+            out.append(f"**Totals:** optimizer ${opt_usd_t:.4f} over {_fmt_duration(opt_s_t)} · "
+                       f"eval ${eval_usd_t:.4f} over {_fmt_duration(eval_s_t)}")
     return "\n".join(out)
 
 

--- a/ci/benchmarks/lib/record.py
+++ b/ci/benchmarks/lib/record.py
@@ -31,6 +31,12 @@ def rollup(tasks: list[dict], steps: list[dict] | None = None) -> dict | None:
     each hill-climb step, finalize), NOT from summing a per-task field: every task row
     in ``tasks`` shares the SAME run-level reward only, it never carried real per-task
     cost/latency, so summing over tasks previously double/N-counted a constant value.
+
+    Summing ``steps`` is only honest because ``metrics.iteration_rows`` emits an
+    ``unattributed`` row for metered spend that no phase owns. Without it this rollup published
+    ``optimizer_usd: 0`` for every agent-mode run (one optimizer process drives the whole loop,
+    so no round can own a share of it) and silently dropped every control replicate and re-gate
+    from ``eval_usd`` — run 33046360451 went out as $5.25 against a metered $21.66.
     """
     # Infra-errored tasks are EXCLUDED from both means. An ungradeable task is missing data,
     # not a reward of 0.0 — the same principle the harness enforces via n_scored. Averaging

--- a/ci/benchmarks/lib/run_suite.sh
+++ b/ci/benchmarks/lib/run_suite.sh
@@ -95,7 +95,10 @@ case "$ALGORITHM" in
  recommendation is 'stop', or after ${_rounds} rounds.${_stop_usd} Do NOT stop early merely\
  because rounds were rejected: a rejection is the signal to change the edit FORM or the SURFACE\
  on the next round, not to finish. Use every round the budget allows. Gate every candidate on\
- FULL val at gate_k_se=${_k_se} over ${_trials} trial(s); never gate on a screen subset. Always\
+ FULL val at gate_k_se=${_k_se} over ${_trials} trial(s); never gate on a screen subset. Pass\
+ --gate-against control on every round.py call: its default reference is the parent's reward as\
+ measured in an EARLIER round, so that reward's drift since then sits inside every candidate\
+ delta, while a control is a byte-identical replicate measured in the SAME round. Always\
  finish by sealing test exactly once with measure.py and writing the report — a run with no\
  finalize has no result."
     ;;

--- a/core/cap_evolve/dashboard.py
+++ b/core/cap_evolve/dashboard.py
@@ -842,6 +842,15 @@ def reduce_run(run_dir) -> dict:
             "parent_val": parent_val,
             "best_so_far": best,
         }
+        # Structured gate numbers, when the algorithm recorded them instead of leaving them
+        # to be regexed out of a reason string (agent-optimize's commit.py reads them back
+        # from round.py's persisted table). Copied verbatim and only when present, so a
+        # deterministic step is byte-identical to before.
+        for _gk in ("gate_delta", "gate_stderr", "gate_n", "gate_k_se", "gate_threshold",
+                    "gate_mode", "gate_table", "control_relative_verdict",
+                    "control_relative_delta", "evidence_bar"):
+            if ev.get(_gk) is not None:
+                node[_gk] = ev.get(_gk)
         if "epoch" in ev:
             node["epoch"] = ev.get("epoch")
         if merge_of:
@@ -1061,7 +1070,11 @@ def reduce_run(run_dir) -> dict:
         m_se = re.search(r"(?<!·)\bSE\s*=\s*(\d*\.?\d+)", reason)
         m_n = re.search(r"\bn\s*=\s*(\d+)", reason)
         m_bar = re.search(r"([\d.]+)·SE\s*=\s*(\d*\.?\d+)", reason)
-        gate_decisions.append({
+        # A number the algorithm RECORDED beats the same number scraped out of prose. Agent
+        # mode writes free text, so every regex above missed and the whole numeric half of
+        # this record came back null (run 32971129203); the deterministic loops record no
+        # structured fields, so they still take the regex path exactly as before.
+        row = {
             "iteration": n.get("iteration"),
             "candidate": n["id"],
             "verdict": verdict,
@@ -1074,7 +1087,20 @@ def reduce_run(run_dir) -> dict:
             "k_se": float(m_bar.group(1)) if m_bar else None,
             "threshold": float(m_bar.group(2)) if m_bar else None,
             "reason": _sanitize_text(reason, 600),
-        })
+        }
+        for _field, _key in (("delta", "gate_delta"), ("stderr", "gate_stderr"),
+                             ("n", "gate_n"), ("k_se", "gate_k_se"),
+                             ("threshold", "gate_threshold")):
+            if n.get(_key) is not None:
+                row[_field] = n.get(_key)
+        # Which reference the gate actually used, and the drift-free second opinion when the
+        # round measured one. Without these a reader cannot tell that a rejection was
+        # reference-dependent — the finding run 32971129203 turned on.
+        for _key in ("gate_mode", "control_relative_verdict", "control_relative_delta",
+                     "evidence_bar"):
+            if n.get(_key) is not None:
+                row[_key] = n.get(_key)
+        gate_decisions.append(row)
 
     # --- cost ledger: every dollar, attributed to the thing that spent it -----
     # Rows are built from the events that actually recorded a spend (intake, each

--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -257,6 +257,32 @@ def evaluate_candidate(
     out_dir = run_dir.rollouts / split
     out_dir.mkdir(parents=True, exist_ok=True)
 
+    # Trials are written as ``<task>__<tag>__t{k}.json`` for ``k in range(n_trials)``, so
+    # re-evaluating a tag that already has rollouts REPLACES ``t0..t9`` — it does not append
+    # ``t10..t19``. Re-evaluation is legitimate (``--resume`` reads its champion's val score
+    # back off disk), so this warns rather than refuses. What it must not be is silent: on run
+    # 33046360451 the agent, told by ``round.py`` to "re-run with more trials" after an
+    # inconclusive verdict, re-measured control ``ctl_null_i1`` under its own tag and replaced a
+    # 0.4967 replicate with 0.5067 — spending 100 metric calls to swap a data point rather than
+    # add one, and WIDENING the round's replicate spread. In the event stream that is
+    # indistinguishable from progress. ``prior_reward`` is recorded because once the files are
+    # overwritten the destroyed reading exists nowhere else.
+    prior = sorted(out_dir.glob(f"*__{tag}__t*.json"))
+    if prior:
+        prior_reward = None
+        try:
+            prior_reward = split_result_from_rollouts(run_dir, tag, split).reward
+        except Exception:  # noqa: BLE001 — a torn/partial rollout must not block the eval
+            pass
+        run_dir.log_event(
+            "rollout_overwrite_warning", split=split, tag=tag,
+            prior_trials=len({p.name.rsplit("__t", 1)[-1] for p in prior}),
+            prior_rollouts=len(prior), prior_reward=prior_reward,
+            why=("this tag already has rollouts and they are being REPLACED, not added to — "
+                 "trials are always written t0..t{n_trials-1}. To accumulate evidence instead, "
+                 "use a fresh tag, or ask for the higher trial count in ONE evaluation."),
+        )
+
     from .stats import mean, stderr
     has_batch = hasattr(adapter, "run_batch")
     has_run_trials = hasattr(adapter, "run_trials")
@@ -900,8 +926,12 @@ def _journal_tail(workdir: Path) -> str:
         tail = text.split(_JOURNAL_MARK, 1)[1].strip()
     else:
         # Optimizer rewrote the file (no marker) — fall back to its last ## Iteration block.
-        idx = text.rfind("\n## ")
-        tail = text[idx:].strip() if idx != -1 else ""
+        # Anchored per-line rather than on "\n## ": an agent-mode optimizer is not handed a
+        # seeded journal to append to, so it writes a FRESH file that STARTS with its heading,
+        # and a "\n## " search misses a heading at offset 0 — silently booking "(no handover
+        # written by the optimizer)" for a handover that was in fact written.
+        heads = list(re.finditer(r"(?m)^## ", text))
+        tail = text[heads[-1].start():].strip() if heads else ""
     # Strip any marker the optimizer copied into its entry text.
     return tail.replace(_JOURNAL_MARK, "").strip()
 
@@ -992,14 +1022,22 @@ def _seed_journal(workdir: Path, run_dir: RunDir) -> None:
 
 
 def _reconcile_journal(workdir: Path, run_dir: RunDir, cid: str, *,
-                       accepted: bool, val: float | None, delta: float | None) -> None:
+                       accepted: bool, val: float | None, delta: float | None,
+                       indecisive: bool = False) -> None:
     """Fold the optimizer's newly-appended journal entry into the run-level JOURNAL,
     stamped with the framework's objective outcome. Append-only at the run level so the
     handover truly accumulates across accepted AND rejected iterations.
 
     ``val``/``delta`` are None for an iteration that never bought a val eval (gepa's
     minibatch-local reject) or whose measurement is void (an indecisive tamper step):
-    the entry is still folded in, with "—" where the number would be."""
+    the entry is still folded in, with "—" where the number would be.
+
+    ``indecisive=True`` gets its own verdict, because the RESULT line is the one artifact
+    written to stop the next iteration repeating a refuted idea — and a void measurement
+    refutes nothing. Stamped as a rejection it read "REJECTED (champion unchanged) … its
+    WHOLE batch was reverted; re-introduce only the edits that did NOT break a task above",
+    telling the next iteration to redesign an edit that had never actually been judged. The
+    correct next move for an unresolved edit is to RE-MEASURE it."""
     tail = _journal_tail(workdir)
     run_journal = run_dir.root / "JOURNAL.md"
     base = run_journal.read_text(encoding="utf-8") if run_journal.exists() else _JOURNAL_SEED
@@ -1011,15 +1049,25 @@ def _reconcile_journal(workdir: Path, run_dir: RunDir, cid: str, *,
     impact = _candidate_task_impact(run_dir, cid, "val") or {}
     broke = ", ".join(str(t) for t in (impact.get("broke") or [])[:30]) or "—"
     fixed = ", ".join(str(t) for t in (impact.get("fixed") or [])[:30]) or "—"
-    verdict = "ACCEPTED (new champion)" if accepted else "REJECTED (champion unchanged)"
-    guidance = ("" if accepted else
-                " — its WHOLE batch was reverted; re-introduce only the edits that did NOT "
-                "break a task above, dropping/redesigning the ones that did.")
+    if indecisive:
+        verdict = "UNRESOLVED (not judged; champion unchanged)"
+        guidance = (" — the measurement could not separate this edit from re-measurement noise, "
+                    "so it is NOT evidence against the edit. Its batch was still reverted. To "
+                    "resolve it, re-measure it under a FRESH tag (re-running the same tag "
+                    "REPLACES its rollouts) or with more trials in ONE evaluation; do not "
+                    "redesign it on this round's numbers, and do not re-derive it as a new idea.")
+    elif accepted:
+        verdict, guidance = "ACCEPTED (new champion)", ""
+    else:
+        verdict = "REJECTED (champion unchanged)"
+        guidance = (" — its WHOLE batch was reverted; re-introduce only the edits that did NOT "
+                    "break a task above, dropping/redesigning the ones that did.")
     vs = f"{val:.3f}" if isinstance(val, (int, float)) else "—"
     ds = f"{delta:+.3f}" if isinstance(delta, (int, float)) else "—"
     stamp = (f"\n\n> **RESULT (framework, objective):** {verdict} · val={vs} "
              f"Δ={ds} · fixed={{{fixed}}} · broke={{{broke}}}.{guidance}\n"
-             f"<!-- {cid}: {'ACCEPTED' if accepted else 'rejected'} "
+             f"<!-- {cid}: "
+             f"{'unresolved' if indecisive else 'ACCEPTED' if accepted else 'rejected'} "
              f"val={vs} Δ={ds} -->")
     tail = tail.strip()
     # Dedup guard: if the optimizer dropped the marker without appending (so the tail
@@ -1074,7 +1122,8 @@ def record_iteration(run_dir: RunDir, workdir: Path, cid: str, *,
                       val=val, parent=parent_id, parent_val=parent_val, **extra)
     delta = (val - parent_val if isinstance(val, (int, float))
              and isinstance(parent_val, (int, float)) else None)
-    _reconcile_journal(workdir, run_dir, cid, accepted=accepted, val=val, delta=delta)
+    _reconcile_journal(workdir, run_dir, cid, accepted=accepted, val=val, delta=delta,
+                       indecisive=indecisive)
 
 
 def _build_runmap(workdir: Path, run_dir: RunDir) -> None:

--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -1058,10 +1058,28 @@ def _reconcile_journal(workdir: Path, run_dir: RunDir, cid: str, *,
                     "redesign it on this round's numbers, and do not re-derive it as a new idea.")
     elif accepted:
         verdict, guidance = "ACCEPTED (new champion)", ""
-    else:
+    elif impact.get("broke"):
         verdict = "REJECTED (champion unchanged)"
         guidance = (" — its WHOLE batch was reverted; re-introduce only the edits that did NOT "
                     "break a task above, dropping/redesigning the ones that did.")
+    elif impact:
+        # Rejected with NOTHING regressed: the batch was not harmful, it just did not clear the
+        # bar. The regression guidance is not merely unhelpful here, it is misdirection — it
+        # says "drop nothing, redesign nothing" while inviting a rewrite of edits that were
+        # just measured HELPING. Observed on a round stamped `Δ=+0.043 · fixed={2 tasks} ·
+        # broke={—}`, rejected against a 0.048 threshold.
+        verdict = "REJECTED (champion unchanged)"
+        guidance = (" — no task that was passing under the parent regressed: this batch did not "
+                    "clear the gate's threshold, it did not do damage. So the lever is POWER or "
+                    "SIZE, not a redesign — re-measure with more trials in ONE evaluation, or "
+                    "make the effect bigger. Keep the edits that produced the `fixed` tasks "
+                    "above as your starting point; do not rewrite them on this round's numbers.")
+    else:
+        verdict = "REJECTED (champion unchanged)"
+        guidance = (" — its WHOLE batch was reverted. No per-task comparison was available this "
+                    "round (one side had no rollouts on disk), so `fixed`/`broke` above are "
+                    "UNKNOWN rather than empty and this line cannot tell you which edit cost "
+                    "you: attribute per-task before redesigning anything.")
     vs = f"{val:.3f}" if isinstance(val, (int, float)) else "—"
     ds = f"{delta:+.3f}" if isinstance(delta, (int, float)) else "—"
     stamp = (f"\n\n> **RESULT (framework, objective):** {verdict} · val={vs} "

--- a/core/tests/test_a_published_cost_covers_what_the_run_paid.py
+++ b/core/tests/test_a_published_cost_covers_what_the_run_paid.py
@@ -1,0 +1,209 @@
+"""The published cost of a run was a sum of per-step attributions, so unattributed spend vanished.
+
+``record.rollup`` builds a run's headline cost by summing ``steps.jsonl`` — one row per phase
+(baseline, each committed round, finalize). Any money the run metered that no phase owns is
+therefore not merely unattributed: it is published as if it had never been spent. Two independent
+holes fed that, and smoke spreadsheetbench run 33046360451 hit both at once:
+
+* **Agent mode meters the optimizer once for the whole loop.** One agent process drives every
+  round, so no round can own a share of its cost. The run's own state held
+  ``optimizer_usd: 9.11``; the published record said ``suite.optimizer_usd: 0``.
+* **Not every evaluation belongs to a committed step.** Control replicates, re-gates and
+  abandoned rounds are real rollouts against the real gateway. ``spent.usd`` was ``12.55``
+  while the summed step rows came to ``5.25``.
+
+The record went out as $5.25 for a run that metered $21.66 — a 4x understatement in the single
+figure a full tier's budget gets projected from, and one that reads as a completed, green,
+cheap run. Both halves are fixed by giving the residual a row of its own rather than by
+inventing a per-round split that the run never measured.
+
+The second defect here is upstream of that: the host meters the whole agent process AND the
+skill tells the agent to book its own proposal cost per round through ``commit.py
+--optimizer-usd``. Those are the same money. An agent that complied made the run report
+roughly twice the optimizer spend it used, which is worse than the understatement it sits
+next to, because a cost-based ``stop_condition`` would then end a run that still had budget.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO / "ci" / "benchmarks" / "lib"))
+
+import metrics  # noqa: E402
+import record  # noqa: E402
+
+HOST = REPO / "skills" / "algorithms" / "agent-optimize" / "scripts" / "host.py"
+
+
+def _run(tmp_path, *, events: list[dict], spent: dict) -> Path:
+    """A minimal run dir: the event stream a report is built from, plus the run's own meters."""
+    rd = tmp_path / "run"
+    rd.mkdir()
+    (rd / "events.jsonl").write_text(
+        "".join(json.dumps(e) + "\n" for e in events), encoding="utf-8")
+    (rd / "state.json").write_text(json.dumps({"best_id": "seed", "spent": spent}),
+                                   encoding="utf-8")
+    return rd
+
+
+# One round, committed, whose candidate eval cost $1. The run also paid $4 more in rollouts
+# (control replicates and a re-gate) and $9 of optimizer, neither of which any step claims.
+AGENT_EVENTS = [
+    {"kind": "evaluate", "tag": "seed", "split": "val", "reward": 0.5, "cost_usd": 1.0,
+     "seconds": 60.0},
+    {"kind": "evaluate", "tag": "cand_1", "split": "val", "reward": 0.55, "cost_usd": 1.0,
+     "seconds": 60.0},
+    {"kind": "step", "candidate": "cand_1", "accept": False, "val": 0.55},
+    {"kind": "evaluate", "tag": "FINAL", "split": "test", "reward": 0.5, "cost_usd": 1.0,
+     "seconds": 60.0},
+]
+AGENT_SPENT = {"iterations": 1, "usd": 7.0, "optimizer_usd": 9.0, "optimizer_seconds": 3600.0,
+               "runner_seconds": 400.0, "metric_calls": 100}
+
+
+def test_metered_optimizer_spend_is_not_published_as_zero(tmp_path):
+    rd = _run(tmp_path, events=AGENT_EVENTS, spent=AGENT_SPENT)
+    rows = metrics.iteration_rows(str(rd), best_id="seed")
+    total = sum(r.get("optimizer_usd") or 0.0 for r in rows)
+    assert abs(total - 9.0) < 1e-6, (
+        f"the timeline accounts for ${total:.2f} of a metered $9.00 of optimizer spend; agent "
+        f"mode attributes none of it per round, so summing the rows publishes $0: {rows}")
+
+
+def test_evaluations_that_belong_to_no_step_are_still_paid_for(tmp_path):
+    rd = _run(tmp_path, events=AGENT_EVENTS, spent=AGENT_SPENT)
+    rows = metrics.iteration_rows(str(rd), best_id="seed")
+    total = sum(r.get("eval_usd") or 0.0 for r in rows)
+    assert abs(total - 7.0) < 1e-6, (
+        f"the timeline accounts for ${total:.2f} of a metered $7.00 of rollout spend — the "
+        f"control replicates and re-gates that no committed step references were dropped: {rows}")
+
+
+def test_the_residual_is_its_own_row_not_charged_to_a_round_that_did_not_spend_it(tmp_path):
+    rd = _run(tmp_path, events=AGENT_EVENTS, spent=AGENT_SPENT)
+    rows = metrics.iteration_rows(str(rd), best_id="seed")
+    rounds = [r for r in rows if r["phase"] == "iterate"]
+    assert len(rounds) == 1 and (rounds[0]["optimizer_usd"] or 0.0) == 0.0, (
+        "the whole-loop optimizer cost was split onto a round, inventing an attribution the run "
+        f"never measured: {rounds}")
+    resid = [r for r in rows if r["phase"] == "unattributed"]
+    assert len(resid) == 1, f"no unattributed row: {rows}"
+    assert resid[0]["iter"] is None and resid[0]["accepted"] is None, (
+        f"the residual row poses as a round: {resid[0]}")
+
+
+def test_the_published_record_totals_what_the_run_actually_metered(tmp_path):
+    """The regression as a consumer sees it: ``suite.eval_usd``/``optimizer_usd`` in the record
+    that lands on the history page and drives every cost projection."""
+    rd = _run(tmp_path, events=AGENT_EVENTS, spent=AGENT_SPENT)
+    steps = metrics.iteration_rows(str(rd), best_id="seed")
+    tasks = [{"task": "t1", "reward_baseline": 0.5, "reward_opt": 0.5, "opt_infra": False}]
+    suite = record.rollup(tasks, steps)
+    assert suite is not None
+    published = (suite["eval_usd"] or 0) + (suite["optimizer_usd"] or 0)
+    metered = AGENT_SPENT["usd"] + AGENT_SPENT["optimizer_usd"]
+    assert abs(published - metered) < 1e-6, (
+        f"the record publishes ${published:.2f} for a run that metered ${metered:.2f}; a tier's "
+        f"budget projected from this figure is off by {metered / max(published, 1e-9):.1f}x")
+
+
+def test_a_run_that_attributes_everything_per_round_gets_no_residual_row(tmp_path):
+    """Control: the deterministic loops DO book optimizer cost per step. Nothing is missing
+    there, and a $0.00 row saying so would be noise."""
+    events = [
+        {"kind": "evaluate", "tag": "seed", "split": "val", "reward": 0.5, "cost_usd": 2.0,
+         "seconds": 10.0},
+        {"kind": "step", "candidate": "cand_1", "accept": True, "val": 0.6, "cost_usd": 3.0,
+         "runner_seconds": 20.0, "opt_cost_usd": 4.0, "optimizer_seconds": 30.0},
+    ]
+    rd = _run(tmp_path, events=events,
+              spent={"usd": 5.0, "optimizer_usd": 4.0, "optimizer_seconds": 30.0,
+                     "runner_seconds": 30.0})
+    rows = metrics.iteration_rows(str(rd), best_id="cand_1")
+    assert [r["phase"] for r in rows] == ["baseline", "iterate"], (
+        f"a fully-attributed run grew a residual row: {rows}")
+
+
+def test_an_unmetered_run_cannot_produce_a_negative_residual(tmp_path):
+    """Not every gateway reports cost. ``spent.usd == 0`` with priced events must not subtract."""
+    rd = _run(tmp_path, events=AGENT_EVENTS,
+              spent={"usd": 0.0, "optimizer_usd": 0.0, "iterations": 1})
+    rows = metrics.iteration_rows(str(rd), best_id="seed")
+    assert not [r for r in rows if r["phase"] == "unattributed"], (
+        f"an unmetered run invented a residual: {rows}")
+    assert all((r.get("eval_usd") or 0.0) >= 0.0 for r in rows)
+
+
+def test_a_run_dir_without_state_json_still_reports_its_timeline(tmp_path):
+    """Older artifacts and partial runs have no meters to reconcile against."""
+    rd = tmp_path / "bare"
+    rd.mkdir()
+    (rd / "events.jsonl").write_text(
+        "".join(json.dumps(e) + "\n" for e in AGENT_EVENTS), encoding="utf-8")
+    rows = metrics.iteration_rows(str(rd), best_id="seed")
+    assert [r["phase"] for r in rows] == ["baseline", "iterate", "finalize"], rows
+
+
+# --------------------------------------------------------------- the host's own booking
+
+
+def _host():
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("_host_cost_booking", HOST)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.path.insert(0, str(HOST.parent))
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_the_host_does_not_book_optimizer_cost_the_agent_already_booked():
+    """The host meters the agent process; the agent books rounds inside it. Same money."""
+    host = _host()
+    book = host.optimizer_spend_to_book(
+        {"usd": 9.0, "tokens": 60_000, "seconds": 3600.0},
+        {"usd": 0.0, "tokens": 0, "seconds": 0.0},          # nothing booked before the agent ran
+        {"usd": 6.0, "tokens": 40_000, "seconds": 2000.0})  # the agent attributed this per round
+    assert abs(book["usd"] - 3.0) < 1e-9, (
+        f"booked ${book['usd']:.2f} on top of the $6.00 the agent already attributed, so the run "
+        "reports $15.00 for $9.00 of metered spend")
+    assert book["tokens"] == 20_000 and abs(book["seconds"] - 1600.0) < 1e-9
+
+
+def test_a_resumed_run_does_not_lose_the_new_agents_spend():
+    """An earlier host invocation's spend sits in the same counter and is not this agent's
+    attribution to net out — bracketing the invocation is what keeps the two apart."""
+    host = _host()
+    book = host.optimizer_spend_to_book(
+        {"usd": 9.0, "tokens": 0, "seconds": 0.0},
+        {"usd": 20.0, "tokens": 0, "seconds": 0.0},   # a previous host already spent $20
+        {"usd": 20.0, "tokens": 0, "seconds": 0.0})   # this agent attributed nothing
+    assert abs(book["usd"] - 9.0) < 1e-9, (
+        f"booked ${book['usd']:.2f}: a resumed run's earlier spend was mistaken for this agent's "
+        "own attribution, so the whole second invocation went unrecorded")
+
+
+def test_an_agent_that_over_attributes_cannot_drive_a_booking_negative():
+    host = _host()
+    book = host.optimizer_spend_to_book(
+        {"usd": 1.0, "tokens": 10, "seconds": 5.0},
+        {"usd": 0.0, "tokens": 0, "seconds": 0.0},
+        {"usd": 99.0, "tokens": 0, "seconds": 0.0})   # guessed its own cost wildly high
+    assert book == {"usd": 0.0, "tokens": 10, "seconds": 5.0}, (
+        f"one over-attributed role leaked into the others or went negative: {book}")
+
+
+def test_the_host_records_how_long_the_optimizer_ran():
+    """`optimizer_seconds: 0.0` for a loop that ran for hours made every per-hour cost figure
+    undefined and printed a dash where metrics.py reports the whole-loop total."""
+    host = _host()
+    book = host.optimizer_spend_to_book(
+        {"usd": 9.0, "tokens": 0, "seconds": 3600.0},
+        {"usd": 0.0, "tokens": 0, "seconds": 0.0},
+        {"usd": 0.0, "tokens": 0, "seconds": 0.0})
+    assert book["seconds"] == 3600.0, f"the loop's wall time was not booked at all: {book}"

--- a/core/tests/test_a_regate_accumulates_evidence.py
+++ b/core/tests/test_a_regate_accumulates_evidence.py
@@ -1,0 +1,182 @@
+"""Re-gating an iteration destroyed the very control readings its own table cited.
+
+``round.py`` is careful about this in two places and inconsistent in the third:
+
+* ``control_tag`` is per-ITERATION, and its docstring says why — "a fixed ``ctl_null`` tag makes
+  each round's control OVERWRITE the previous round's on disk — destroying the one measurement
+  that proves what zero change looked like at that point in the run. The noise floor is
+  evidence."
+* the round TABLE gets a ``.r<n>`` suffix on a same-iteration re-run rather than overwriting,
+  "since a re-gate is usually being COMPARED with the first one".
+* the control ROLLOUTS get neither. So the one operation ``round.py`` explicitly supports —
+  re-gating the same iteration — preserves the summary and deletes the measurements it
+  summarises, because rollouts are ``<task>__<tag>__t{k}.json`` for ``k in range(n_trials)`` and
+  the second attempt writes the same ``ctl_null_i<N>`` / ``ctl_null_i<N>r1`` tags.
+
+Measured on smoke spreadsheetbench run 33046360451, where the driver was told by an inconclusive
+verdict to "re-run with more trials" and did exactly that:
+
+    ctl_null_i1     0.4967  ->  0.5067   (replaced)
+    ctl_null_i1r1   0.4800  ->  0.4367   (replaced)
+
+200 of the run's 900 metric calls — about $2 and an hour of wall clock — bought no new evidence:
+they swapped two readings for two other readings. The round's replicate spread went from 0.0167
+to 0.0700, so the bar the candidate had to clear grew 4.2x, and ``round_i1.json`` was left citing
+an ``evidence_bar`` of 0.0167 derived from two numbers that no longer exist anywhere on disk. Its
+own re-gate table disagrees with it and only the second is reproducible.
+
+Pooling is the whole point. Four byte-identical replicates of the same parent in the same round
+are four samples of the same null — which is precisely the extra evidence a re-gate is run to
+buy — so the second attempt should report the null over all four, not over its own two.
+"""
+
+from __future__ import annotations
+
+import json
+
+
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPTS = REPO / "skills" / "algorithms" / "agent-optimize" / "scripts"
+
+
+def _load_round():
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("_ao_round_regate", SCRIPTS / "round.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.path.insert(0, str(SCRIPTS))
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class _Spent:
+    def __init__(self, iterations):
+        self.iterations = iterations
+
+
+class _RD:
+    """Just enough RunDir for ``control_tag``."""
+    def __init__(self, root, iterations=1):
+        self.root = Path(root)
+        self.spent = _Spent(iterations)
+
+
+def test_a_regate_does_not_reuse_the_first_attempts_control_tags(tmp_path):
+    rnd = _load_round()
+    work = tmp_path / "work"
+    work.mkdir()
+    rd = _RD(tmp_path, iterations=1)
+
+    first = rnd.control_tag(rd)
+    # The first attempt's table on disk is what marks the iteration as already gated once.
+    (work / "round_i1.json").write_text("{}", encoding="utf-8")
+    second = rnd.control_tag(rd)
+
+    assert first != second, (
+        f"a re-gate of iteration 1 reuses the control tag {first!r}, so its rollouts "
+        "(<task>__<tag>__t{k}.json) overwrite the first attempt's — the re-gate deletes the "
+        "measurements its own first table cites")
+    assert first in second or "i1" in second, (
+        f"the re-gate's control tag {second!r} must still name the iteration it belongs to")
+
+
+def test_the_control_tag_still_changes_between_iterations(tmp_path):
+    """Control: the per-iteration property the existing docstring argues for must survive."""
+    rnd = _load_round()
+    (tmp_path / "work").mkdir()
+    assert rnd.control_tag(_RD(tmp_path, 1)) != rnd.control_tag(_RD(tmp_path, 2))
+
+
+def test_the_table_and_the_control_tags_agree_on_which_attempt_this_is(tmp_path):
+    """The table name and the control tags are the two halves of one round's identity. If they
+    are derived independently they can disagree — and then a reader cannot tell which table
+    summarises which rollouts, which is the failure this whole file is about."""
+    rnd = _load_round()
+    work = tmp_path / "work"
+    work.mkdir()
+    rd = _RD(tmp_path, iterations=1)
+
+    assert rnd.round_attempt(rd) == 0
+    assert rnd.table_stem(rd) == "round_i1"
+    (work / "round_i1.json").write_text("{}", encoding="utf-8")
+    assert rnd.round_attempt(rd) == 1
+    assert rnd.table_stem(rd) == "round_i1.r1"
+    assert "1" in rnd.control_tag(rd).removeprefix("ctl_null_i1")
+    (work / "round_i1.r1.json").write_text("{}", encoding="utf-8")
+    assert rnd.round_attempt(rd) == 2
+
+
+def test_a_regate_pools_the_earlier_attempts_replicates(tmp_path):
+    """A second attempt's null must be computed over EVERY byte-identical replicate of this
+    iteration, not just its own two. That is the extra evidence a re-gate is run to buy, and
+    without pooling the re-gate throws away half the samples it has already paid for."""
+    rnd = _load_round()
+    work = tmp_path / "work"
+    work.mkdir()
+    rd = _RD(tmp_path, iterations=1)
+    (work / "round_i1.json").write_text(json.dumps({
+        "control_replicates": [{"tag": "ctl_null_i1", "reward": 0.4967},
+                               {"tag": "ctl_null_i1r1", "reward": 0.48}],
+    }), encoding="utf-8")
+
+    prior = rnd.prior_attempt_controls(rd)
+    tags = {r["tag"] for r in prior}
+    assert tags == {"ctl_null_i1", "ctl_null_i1r1"}, (
+        f"the earlier attempt's replicates are not recovered, so the re-gate's null is computed "
+        f"over half the samples the round has paid for: {prior}")
+    assert all(r.get("from_attempt") is not None for r in prior), (
+        "a pooled replicate must say which attempt it came from, or the table cannot be audited")
+
+
+def test_pooling_is_absent_when_this_is_the_first_attempt(tmp_path):
+    """No false positives: a first attempt has nothing to pool and must say so, not invent rows."""
+    rnd = _load_round()
+    (tmp_path / "work").mkdir()
+    assert rnd.prior_attempt_controls(_RD(tmp_path, 1)) == []
+
+
+def test_round_warns_when_it_is_re_gating_rather_than_doing_it_silently():
+    """A re-gate is a legitimate and expensive operation. The table must say it is one, because
+    on the live run nothing in the output distinguished "second opinion on iteration 1" from
+    "iteration 1" — the operator watching the event stream saw two identical control evaluations
+    and no statement that the second had replaced the first."""
+    src = (SCRIPTS / "round.py").read_text(encoding="utf-8")
+    assert "round_attempt" in src and "prior_attempt_controls" in src
+    assert '"attempt"' in src or "'attempt'" in src, (
+        "the round table never states which attempt it is")
+
+
+def test_the_end_to_end_regate_keeps_both_attempts_rollouts(tmp_path):
+    """The property that actually matters, checked on real rollout files rather than tag strings:
+    after a re-gate, BOTH attempts' control rollouts are still on disk and readable."""
+    from cap_evolve import Budget, RunDir, harness
+    from cap_evolve.skillcheck import SyntheticAdapter, seed_capability_dir
+
+    adapter = SyntheticAdapter(n=12)
+    seed = seed_capability_dir(tmp_path, level=3)
+    run_dir = RunDir.create(tmp_path / ".capevolve", ts="ci", budget=Budget(max_iterations=3))
+    harness.ensure_splits(adapter, run_dir, seed=0)
+    harness.baseline(adapter, seed, run_dir=run_dir)
+
+    rnd = _load_round()
+    (run_dir.root / "work").mkdir(parents=True, exist_ok=True)
+    rd = _RD(run_dir.root, iterations=1)
+    first = rnd.control_tag(rd)
+
+    # Rollouts live at rollouts/<split>/<task>__<tag>__t<k>.json (RunDir's own docstring).
+    roll = run_dir.rollouts / "val"
+    roll.mkdir(parents=True, exist_ok=True)
+    for k in range(3):
+        (roll / f"t1__{first}__t{k}.json").write_text("{}", encoding="utf-8")
+    (run_dir.root / "work" / "round_i1.json").write_text("{}", encoding="utf-8")
+
+    second = rnd.control_tag(rd)
+    assert second != first, "the re-gate would write over the first attempt's rollout files"
+    # The concrete files the second attempt would write must not collide with the first's.
+    firsts = {p.name for p in roll.glob(f"*__{first}__t*.json")}
+    seconds = {f"t1__{second}__t{k}.json" for k in range(3)}
+    assert firsts and not (firsts & seconds), (
+        f"the re-gate writes the same rollout filenames as the first attempt: "
+        f"{sorted(firsts & seconds)}")

--- a/core/tests/test_a_reject_that_broke_nothing_says_so.py
+++ b/core/tests/test_a_reject_that_broke_nothing_says_so.py
@@ -1,0 +1,133 @@
+"""A reject's journal guidance assumed the reject was caused by a regression. Usually it isn't.
+
+The RESULT line the framework stamps under every journal entry exists to tell the NEXT iteration
+what to do differently. For a reject it said, unconditionally:
+
+    its WHOLE batch was reverted; re-introduce only the edits that did NOT break a task above,
+    dropping/redesigning the ones that did.
+
+Read that against the line it was stamped on, from smoke spreadsheetbench run 33046360451:
+
+    REJECTED (champion unchanged) · val=0.553 Δ=+0.043 · fixed={47484, 53161} · broke={—}
+
+The candidate fixed two tasks, broke none, and gained +0.043 — it was rejected because +0.043 did
+not clear a 0.048 threshold. So the guidance instructed the next iteration to drop nothing and
+redesign nothing, while telling it the batch was reverted: the one sentence that was supposed to
+say what to do next said nothing actionable at all. Worse, "redesign the ones that did" invites a
+rewrite of edits that had just been measured HELPING, which is how a run talks itself out of its
+own best lever.
+
+A reject with no regressions is a different instruction from a reject with them: the edits did not
+harm anything, they simply did not clear the bar, so the lever is more measurement power or a
+bigger effect — not a redesign. This is not agent-mode specific; every algorithm's below-threshold
+reject reaches the same stamp through ``record_iteration``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+def _journal_after(tmp_path, *, broke: list[str], fixed: list[str], accepted=False,
+                   indecisive=False) -> str:
+    """Stamp a journal RESULT line for a candidate with a known per-task impact.
+
+    The impact is derived from rollouts on disk, so it is staged by writing the parent's and the
+    candidate's per-task rewards rather than by patching the reader.
+    """
+    import json
+
+    from cap_evolve import Budget, RunDir, harness
+    from cap_evolve.skillcheck import SyntheticAdapter, seed_capability_dir
+
+    adapter = SyntheticAdapter(n=6)
+    seed = seed_capability_dir(tmp_path, level=3)
+    run_dir = RunDir.create(tmp_path / ".capevolve", ts="ci", budget=Budget(max_iterations=3))
+    harness.ensure_splits(adapter, run_dir, seed=0)
+    harness.baseline(adapter, seed, run_dir=run_dir)
+
+    tasks = sorted(set(broke) | set(fixed) | {"steady"})
+    roll = run_dir.rollouts / "val"
+    roll.mkdir(parents=True, exist_ok=True)
+    for task in tasks:
+        # parent passes what the candidate broke, fails what the candidate fixed
+        par = 1.0 if (task in broke or task == "steady") else 0.0
+        cand = 0.0 if task in broke else 1.0
+        (roll / f"{task}__seed__t0.json").write_text(
+            json.dumps({"score": {"task_id": task, "reward": par}}), encoding="utf-8")
+        (roll / f"{task}__cand_x__t0.json").write_text(
+            json.dumps({"score": {"task_id": task, "reward": cand}}), encoding="utf-8")
+
+    workdir = tmp_path / "wd"
+    workdir.mkdir()
+    harness.record_iteration(run_dir, workdir, "cand_x", parent_id="seed", accepted=accepted,
+                             reason="below threshold", val=0.553, parent_val=0.51,
+                             indecisive=indecisive)
+    return (run_dir.root / "JOURNAL.md").read_text(encoding="utf-8")
+
+
+def test_a_reject_with_no_regressions_is_not_told_to_redesign_the_edits_that_broke_a_task(
+        tmp_path):
+    text = _journal_after(tmp_path, broke=[], fixed=["47484", "53161"])
+    entry = text[text.rindex("RESULT (framework"):]
+    assert "broke={—}" in entry, f"the fixture did not produce a no-regression reject: {entry}"
+    assert "dropping/redesigning the ones that did" not in entry, (
+        "the reject guidance still tells the next iteration to redesign the edits that broke a "
+        f"task, on a round where nothing broke: {entry}")
+
+
+def test_a_reject_with_no_regressions_says_what_to_do_instead(tmp_path):
+    """Not enough to delete the wrong sentence — the line exists to say what to do next."""
+    text = _journal_after(tmp_path, broke=[], fixed=["47484", "53161"])
+    entry = text[text.rindex("RESULT (framework"):]
+    assert "did not clear" in entry or "below the bar" in entry or "threshold" in entry, (
+        f"the reject does not say the batch failed on the BAR rather than on a regression: {entry}")
+    # The two real levers for an unregressed near-miss.
+    assert "trials" in entry or "power" in entry, (
+        f"no mention of buying measurement power: {entry}")
+    assert "fixed" in entry, f"the tasks it DID fix are not offered as the thing to build on: {entry}"
+
+
+def test_a_reject_that_did_break_tasks_still_gets_the_redesign_guidance(tmp_path):
+    """Control: the original guidance is right when a regression actually caused the reject."""
+    text = _journal_after(tmp_path, broke=["160-6"], fixed=[])
+    entry = text[text.rindex("RESULT (framework"):]
+    assert "160-6" in entry and "dropping/redesigning the ones that did" in entry, (
+        f"the regression case lost its guidance: {entry}")
+
+
+def test_no_regression_claim_is_not_made_when_there_was_nothing_to_compare(tmp_path):
+    """``_candidate_task_impact`` returns None when either side has no rollouts, and then
+    ``broke={—}`` means "unknown", not "nothing broke". Claiming no regressions there would be
+    an invented fact — the exact failure mode this file is about, inverted."""
+    import json
+
+    from cap_evolve import Budget, RunDir, harness
+    from cap_evolve.skillcheck import SyntheticAdapter, seed_capability_dir
+
+    adapter = SyntheticAdapter(n=6)
+    seed = seed_capability_dir(tmp_path, level=3)
+    run_dir = RunDir.create(tmp_path / ".capevolve", ts="ci", budget=Budget(max_iterations=3))
+    harness.ensure_splits(adapter, run_dir, seed=0)
+    harness.baseline(adapter, seed, run_dir=run_dir)
+    # Candidate rollouts only — no parent side, so no comparison is possible.
+    roll = run_dir.rollouts / "val"
+    roll.mkdir(parents=True, exist_ok=True)
+    (roll / "t1__cand_x__t0.json").write_text(
+        json.dumps({"score": {"task_id": "t1", "reward": 1.0}}), encoding="utf-8")
+    workdir = tmp_path / "wd"
+    workdir.mkdir()
+    harness.record_iteration(run_dir, workdir, "cand_x", parent_id="seed", accepted=False,
+                             reason="below threshold", val=0.553, parent_val=0.51)
+    entry = (run_dir.root / "JOURNAL.md").read_text(encoding="utf-8")
+    entry = entry[entry.rindex("RESULT (framework"):]
+    assert "no task that was passing" not in entry, (
+        f"claims nothing regressed when no per-task comparison existed at all: {entry}")
+
+
+def test_an_accept_is_unchanged(tmp_path):
+    text = _journal_after(tmp_path, broke=[], fixed=["47484"], accepted=True)
+    entry = text[text.rindex("RESULT (framework"):]
+    assert "ACCEPTED (new champion)" in entry and "did not clear" not in entry, entry

--- a/core/tests/test_agent_mode_keeps_its_own_learning_substrate.py
+++ b/core/tests/test_agent_mode_keeps_its_own_learning_substrate.py
@@ -1,0 +1,159 @@
+"""An agent-mode run accumulated no learning across its rounds — two independent holes.
+
+Both observed on smoke spreadsheetbench run 33046360451 (and 32971129203 before it), and both
+are about the loop's memory of ITSELF, which is the thing that is supposed to make round 3
+better than round 1.
+
+1. **Optimizer memory was empty.** ``rejected.jsonl`` / ``history.jsonl`` back the dashboard's
+   Memory panel (``memory.py``'s docstring names it) and are written by every DETERMINISTIC
+   algorithm — ``harness``'s hill-climb, ``gepa``, ``skillopt`` all call ``RejectedMemory.add`` /
+   ``History.add`` inline. Agent mode books its rounds through ``commit.py``, which never did, so
+   the panel published ``{"history": [], "rejected": []}`` for the whole run.
+
+2. **Every round's handover said "(no handover written by the optimizer)".** ``JOURNAL.md`` is
+   two halves: the framework stamps an objective RESULT line (outcome + the exact tasks
+   broke/fixed), and the optimizer appends the INTENT above it — what it tried, why, and which
+   hypotheses prior RESULTs already refuted. ``_reconcile_journal`` folds the intent half out of
+   ``<workdir>/JOURNAL.md``. Nothing ever told the agent to write it: ``host.py`` says only that
+   ``commit.py`` "reconciles it as you book rounds, so it accrues your own history and is worth
+   reading from round 2 on" — true of the RESULT half, false of the half the agent owns. So from
+   round 2 the agent could read WHICH task it broke but never WHAT IT HAD TRIED, and the
+   journal's own standing instruction ("never re-test a refuted idea") was unfollowable.
+
+The fix for (2) needs no core change: ``_journal_tail`` already falls back to the last
+``## Iteration`` block when the marker is absent, so an agent that writes the file at all is
+folded in correctly. What was missing was being asked, and being told when it forgot.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPTS = REPO / "skills" / "algorithms" / "agent-optimize" / "scripts"
+
+
+def _staged(tmp_path, cid="cand_1"):
+    from cap_evolve import Budget, RunDir, harness
+    from cap_evolve.skillcheck import SyntheticAdapter, seed_capability_dir
+
+    adapter = SyntheticAdapter(n=12)
+    seed = seed_capability_dir(tmp_path, level=3)
+    run_dir = RunDir.create(tmp_path / ".capevolve", ts="ci", budget=Budget(max_iterations=5))
+    harness.ensure_splits(adapter, run_dir, seed=0)
+    harness.baseline(adapter, seed, run_dir=run_dir)
+    work = run_dir.root / "work" / cid
+    work.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(run_dir.root / "candidates" / "seed", work)
+    return run_dir, work
+
+
+def _commit(run_dir, work, *extra, cid="cand_1", decision="reject", val="0.4967"):
+    p = subprocess.run(
+        [sys.executable, str(SCRIPTS / "commit.py"), "--run-dir", str(run_dir.root),
+         "--candidate-id", cid, "--from-dir", str(work),
+         "--decision", decision, "--val", val,
+         "--note", "compute-not-hardcode replay + over-write contract", *extra],
+        capture_output=True, text=True,
+        env={**os.environ, "CAPEVOLVE_CORE": str(REPO / "core")})
+    assert p.returncode == 0, f"commit.py failed: {p.stdout}\n{p.stderr}"
+    return json.loads(p.stdout)
+
+
+def _jsonl(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    return [json.loads(l) for l in path.read_text(encoding="utf-8").splitlines() if l.strip()]
+
+
+# --- 1. optimizer memory -----------------------------------------------------------------
+
+def test_a_rejected_round_lands_in_the_memory_the_dashboard_publishes(tmp_path):
+    run_dir, work = _staged(tmp_path)
+    _commit(run_dir, work)
+
+    rejected = _jsonl(Path(run_dir.rejected_path))
+    assert rejected, (
+        "the round was rejected and left no trace in rejected.jsonl, so the dashboard's Memory "
+        "panel publishes {} for the whole run and the next round cannot see what was refuted")
+    rec = rejected[-1]
+    assert rec["candidate_id"] == "cand_1"
+    assert rec.get("val") == 0.4967, f"the rejected candidate's val was dropped: {rec}"
+    assert "compute-not-hardcode" in (rec.get("reason") or ""), (
+        f"the reason the round was rejected is not recorded: {rec}")
+
+
+def test_an_accepted_round_lands_in_history(tmp_path):
+    run_dir, work = _staged(tmp_path, cid="cand_2")
+    _commit(run_dir, work, cid="cand_2", decision="accept", val="0.54")
+
+    hist = _jsonl(Path(run_dir.history_path))
+    assert hist, "an accepted round left no lineage in history.jsonl"
+    assert hist[-1]["candidate_id"] == "cand_2" and hist[-1]["val"] == 0.54
+    assert not _jsonl(Path(run_dir.rejected_path)), (
+        "an ACCEPTED candidate was filed as rejected — that teaches the next round to avoid "
+        "the one edit that worked")
+
+
+# --- 2. the handover half of the journal -------------------------------------------------
+
+HANDOVER = """## Iteration cand_1 — compute-not-hardcode replay + over-write contract
+- Changes I made: prompt.md (replay rationale), task_template.md (write-only-required-cells)
+- Refuted hypotheses: none yet
+- Focus next iteration: the TYPE cluster
+"""
+
+
+def test_a_handover_the_agent_wrote_is_folded_into_the_run_journal(tmp_path):
+    """The mechanism already worked — this pins it, because the guidance fix depends on it."""
+    run_dir, work = _staged(tmp_path)
+    (work / "JOURNAL.md").write_text(HANDOVER, encoding="utf-8")
+    _commit(run_dir, work)
+
+    journal = (run_dir.root / "JOURNAL.md").read_text(encoding="utf-8")
+    assert "compute-not-hardcode replay + over-write contract" in journal
+    assert "no handover written by the optimizer" not in journal, (
+        "the agent DID write a handover and it was still recorded as absent")
+    assert "RESULT (framework, objective)" in journal, "the framework RESULT half is missing"
+
+
+def test_a_missing_handover_is_reported_back_to_the_agent(tmp_path):
+    """``commit.py`` is the only thing the agent runs every round, so it is the only place a
+    forgotten handover can be surfaced while there are still rounds left to fix it. Silence is
+    what produced three straight rounds of "(no handover written by the optimizer)"."""
+    run_dir, work = _staged(tmp_path)
+    out = _commit(run_dir, work)
+
+    assert out.get("handover_recorded") is False, (
+        f"commit.py did not report that the round booked no handover: {out}")
+    warns = " ".join(out.get("warnings") or [])
+    assert "JOURNAL.md" in warns, (
+        f"nothing told the agent where to write its handover next round: {out}")
+
+
+def test_the_handover_flag_is_true_when_one_was_written(tmp_path):
+    run_dir, work = _staged(tmp_path)
+    (work / "JOURNAL.md").write_text(HANDOVER, encoding="utf-8")
+    out = _commit(run_dir, work)
+
+    assert out.get("handover_recorded") is True, f"a written handover reported as missing: {out}"
+    assert not [w for w in (out.get("warnings") or []) if "JOURNAL" in w], (
+        f"warned about a handover that was in fact written: {out}")
+
+
+# --- 3. the guidance that asks for it ----------------------------------------------------
+
+def test_the_host_tells_the_agent_to_write_the_handover():
+    """Guidance, not plumbing, is why this was empty. The host brief is the agent's only
+    instruction sheet for the parts of the loop it drives itself."""
+    src = (SCRIPTS / "host.py").read_text(encoding="utf-8")
+    assert "JOURNAL.md" in src
+    lo = src.lower()
+    assert "append" in lo and "handover" in lo, (
+        "the host brief never asks the agent to APPEND its own handover entry — it only says "
+        "the journal is worth READING, which is how every round booked an empty intent half")

--- a/core/tests/test_agent_optimize_round_attribution.py
+++ b/core/tests/test_agent_optimize_round_attribution.py
@@ -1,0 +1,258 @@
+"""Agent-mode rounds measured their cost and their gate, then reported neither.
+
+Three symptoms, all observed on smoke spreadsheetbench run 32971129203, all of data that the
+run had already computed and written down:
+
+1. **The report contradicted itself inside one document.** Its Suite headline said
+   ``optimizer $7.95 over 3 iter(s)`` (from ``state.json``'s run-level ``spent``) while its
+   Totals line said ``optimizer $0.0000 over 0s`` (summing the per-step figures, which agent
+   mode does not fill in — the whole loop is ONE agent process, so there is no per-round
+   optimizer cost to attribute). A reader cannot tell which number to believe.
+
+2. **Every iterate row showed no eval cost or time** (``eval $ —``, ``eval time —``) even
+   though each candidate's ``evaluate`` event carried both — cand_1 alone was $0.456 over
+   629.84s. ``iteration_rows`` only looked at the ``step`` event, which agent mode's
+   ``commit.py`` does not populate with eval figures.
+
+3. **The published ``gate_decisions[]`` had ``parent_val``/``delta``/``stderr``/``n``/
+   ``k_se``/``threshold`` all null**, with the numbers surviving only inside the prose
+   ``reason`` string. ``commit.py``'s comment explained this as "the agent gates via
+   gate_check, which prints but does not persist the parent mean" — no longer true:
+   ``round.py`` persists the whole table to ``$RUN_DIR/work/round_i<N>.json``, which is where
+   the drift-vs-control finding in this run was ultimately read from.
+
+None of this fabricates a number. It reports the ones already measured, and labels the
+run-level optimizer spend as whole-loop rather than pretending it was per round.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+LIB = REPO / "ci" / "benchmarks" / "lib"
+SCRIPTS = REPO / "skills" / "algorithms" / "agent-optimize" / "scripts"
+
+
+def _metrics():
+    if str(LIB) not in sys.path:
+        sys.path.insert(0, str(LIB))
+    spec = importlib.util.spec_from_file_location("_bench_metrics_attr", LIB / "metrics.py")
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["_bench_metrics_attr"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# --- the round table -> gate record contract ---------------------------------------------
+
+# The exact shape round.py writes, trimmed to the fields commit.py needs. Values are the real
+# ones from run 32971129203's work/round_i0.json.
+ROUND_TABLE = {
+    "parent": {"tag": "seed", "reward": 0.5, "stderr": 0.14396882759686525, "n_tasks": 10},
+    "gate_reference": {"tag": "seed", "mode": "parent", "reward": 0.5,
+                       "stderr": 0.14396882759686525},
+    "null_delta_between_control_replicates": 0.0444,
+    "evidence_bar": {"value": 0.0444, "basis": "the larger of the replicate gap and drift"},
+    "gated_against": {"tag": "seed", "mode": "parent"},
+    "candidates": [{
+        "tag": "cand_1", "reward": 0.5333333333333333,
+        "gate_delta": 0.03333333333333333, "gate_threshold": 0.0439790447668071,
+        "verdict": "reject", "regressions": [], "eval_rc": 0, "eval_error": None,
+        "control_relative": {"reference": "ctl_null_i0", "gate_delta": 0.05555555555555556,
+                             "gate_threshold": 0.03414646095293662, "verdict": "accept"},
+    }],
+}
+
+
+def test_commit_reads_only_fields_round_actually_writes():
+    """Guards the fixture above against drifting from round.py's real output."""
+    src = (SCRIPTS / "round.py").read_text(encoding="utf-8")
+    for key in ("\"parent\"", "\"gate_reference\"", "\"gated_against\"", "\"candidates\"",
+                "gate_delta", "gate_threshold", "control_relative",
+                "null_delta_between_control_replicates", "evidence_bar"):
+        assert key in src, f"round.py no longer writes {key}; this fixture is stale"
+    assert 'stem = f"round_i{int(run_dir.spent.iterations)}"' in src, (
+        "round.py's table filename changed; commit.py's lookup must follow")
+
+
+def _run_dir_with_round_table(tmp_path, *, table: dict | None = ROUND_TABLE):
+    """A live run dir mid-round: baseline done, cand_1 staged, round table written."""
+    from cap_evolve import Budget, RunDir, harness
+    from cap_evolve.skillcheck import SyntheticAdapter, seed_capability_dir
+
+    adapter = SyntheticAdapter(n=20)
+    seed = seed_capability_dir(tmp_path, level=3)
+    run_dir = RunDir.create(tmp_path / ".capevolve", ts="ci", budget=Budget(max_iterations=5))
+    harness.ensure_splits(adapter, run_dir, seed=0)
+    harness.baseline(adapter, seed, run_dir=run_dir)
+
+    work = run_dir.root / "work" / "cand_1"
+    work.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(run_dir.root / "candidates" / "seed", work)
+    if table is not None:
+        # round.py names it from spent.iterations, which commit.py has not charged yet.
+        (run_dir.root / "work" / "round_i0.json").write_text(json.dumps(table), encoding="utf-8")
+    return run_dir, work
+
+
+def _commit(run_dir, work, *extra):
+    p = subprocess.run(
+        [sys.executable, str(SCRIPTS / "commit.py"), "--run-dir", str(run_dir.root),
+         "--candidate-id", "cand_1", "--from-dir", str(work),
+         "--decision", "reject", "--val", "0.5333333333333333",
+         "--note", "delta +0.033 within control noise 0.044", *extra],
+        capture_output=True, text=True,
+        env={**os.environ, "CAPEVOLVE_CORE": str(REPO / "core")})
+    assert p.returncode == 0, f"commit.py failed: {p.stdout}\n{p.stderr}"
+    return p
+
+
+def _gate_decision(run_dir) -> dict:
+    """The published gate record for the last booked round.
+
+    ``gate_decisions[]`` is built by ``dashboard.reduce_run`` from the event stream — it is
+    what the dashboard, the TUI and the CI live snapshot all read, and it is where run
+    32971129203's nulls were observed. state.json does not carry it.
+    """
+    from cap_evolve import dashboard
+    decisions = dashboard.reduce_run(run_dir)["summary"]["gate_decisions"]
+    assert decisions, "the round booked no gate decision at all"
+    return decisions[-1]
+
+
+def test_a_booked_round_carries_its_gate_numbers_not_only_prose(tmp_path):
+    run_dir, work = _run_dir_with_round_table(tmp_path)
+    _commit(run_dir, work)
+
+    d = _gate_decision(run_dir)
+
+    assert d["parent_val"] == 0.5, (
+        f"parent_val is still unpopulated though round.py measured it: {d}")
+    assert d["delta"] == 0.03333333333333333, f"the gate delta was dropped: {d}"
+    assert d["threshold"] == 0.0439790447668071, f"the gate threshold was dropped: {d}"
+    assert d["stderr"] == 0.14396882759686525, f"the parent stderr was dropped: {d}"
+    assert d["n"] == 10, f"the task count was dropped: {d}"
+
+
+def test_a_booked_round_records_the_drift_free_comparison_it_measured(tmp_path):
+    """The finding that mattered on run 32971129203 lived ONLY in work/round_i0.json: the
+    same candidate the parent-mode gate rejected, a control-mode gate accepted. A reader of
+    state.json could not see that the verdict was reference-dependent."""
+    run_dir, work = _run_dir_with_round_table(tmp_path)
+    _commit(run_dir, work)
+
+    d = _gate_decision(run_dir)
+    assert d.get("gate_mode") == "parent", f"the gate's REFERENCE is not recorded: {d}"
+    assert d.get("control_relative_verdict") == "accept", (
+        "the drift-free verdict that disagreed with the booked one is not recorded, so a "
+        f"reader cannot tell that this rejection was reference-dependent: {d}")
+
+
+def test_a_round_with_no_table_still_books_cleanly(tmp_path):
+    """round.py's table write is best-effort (it catches OSError), and gate_check-only rounds
+    never produce one. A missing table must not break booking or invent numbers."""
+    run_dir, work = _run_dir_with_round_table(tmp_path, table=None)
+    _commit(run_dir, work)
+
+    d = _gate_decision(run_dir)
+    assert d["candidate"] == "cand_1" and d["verdict"] == "reject"
+    assert d["parent_val"] is None, f"a number was invented with no table to read: {d}"
+
+
+# --- the CI timeline ---------------------------------------------------------------------
+
+def _events(tmp_path, lines: list[dict], spent: dict) -> Path:
+    rd = tmp_path / "run_suite"
+    rd.mkdir(parents=True, exist_ok=True)
+    (rd / "events.jsonl").write_text(
+        "".join(json.dumps(l) + "\n" for l in lines), encoding="utf-8")
+    (rd / "state.json").write_text(json.dumps({"best_id": "seed", "spent": spent}))
+    (rd / "baseline.json").write_text(json.dumps(
+        {"val": {"reward": 0.5, "per_task": [{"task_id": "t1", "reward": 0.5,
+                                              "raw": {"errored": False}}]}}))
+    (rd / "final.json").write_text(json.dumps(
+        {"test": {"reward": 0.5444, "per_task": [{"task_id": "t1", "reward": 0.5444,
+                                                  "raw": {"errored": False}}]},
+         "best_id": "seed"}))
+    return rd
+
+
+# The agent-mode event stream: each candidate is evaluated (cost recorded there), then booked
+# by commit.py, whose `step` event carries no eval figures.
+AGENT_EVENTS = [
+    {"kind": "evaluate", "split": "val", "tag": "seed", "reward": 0.5,
+     "cost_usd": 0.27643775, "seconds": 608.35},
+    {"kind": "evaluate", "split": "val", "tag": "cand_1", "reward": 0.5333,
+     "cost_usd": 0.45601625, "seconds": 629.84},
+    {"kind": "step", "candidate": "cand_1", "accept": False, "val": 0.5333},
+    {"kind": "evaluate", "split": "test", "tag": "FINAL", "reward": 0.5444,
+     "cost_usd": 0.31075925, "seconds": 731.28},
+]
+
+
+def test_an_iterate_row_reports_the_eval_cost_the_run_already_measured(tmp_path):
+    m = _metrics()
+    rd = _events(tmp_path, AGENT_EVENTS, {"iterations": 1, "optimizer_usd": 7.95})
+    row = [r for r in m.iteration_rows(str(rd)) if r["phase"] == "iterate"][0]
+
+    assert row["eval_usd"] == 0.45601625, (
+        f"the candidate's eval cost was measured and dropped: {row}")
+    assert row["eval_seconds"] == 629.84, (
+        f"the candidate's eval time was measured and dropped: {row}")
+
+
+def test_an_explicit_step_cost_still_wins_over_the_evaluate_fallback(tmp_path):
+    """The deterministic path DOES put eval figures on the step event; it must keep them."""
+    m = _metrics()
+    events = [e.copy() for e in AGENT_EVENTS]
+    events[2] = {**events[2], "cost_usd": 0.99, "runner_seconds": 12.0}
+    rd = _events(tmp_path, events, {"iterations": 1})
+    row = [r for r in m.iteration_rows(str(rd)) if r["phase"] == "iterate"][0]
+
+    assert row["eval_usd"] == 0.99 and row["eval_seconds"] == 12.0
+
+
+def test_the_totals_line_does_not_contradict_the_suite_headline(tmp_path):
+    m = _metrics()
+    rd = _events(tmp_path, AGENT_EVENTS, {"iterations": 3, "optimizer_usd": 7.95})
+    md = m.suite_report(str(rd), "spreadsheetbench", "smoke", "Azure/gpt-5-mini-2025-08-07", 3)
+
+    assert "optimizer $7.95 over 3 iter(s)" in md, "the headline figure changed"
+    assert "optimizer $0.0000" not in md, (
+        f"Totals still reports $0.0000 while the headline reports $7.95:\n{md}")
+    assert "whole-loop" in md, (
+        f"the run-level figure is shown without saying it is not per-round:\n{md}")
+
+
+def test_per_step_optimizer_cost_is_still_summed_when_it_exists(tmp_path):
+    """The deterministic path attributes optimizer spend per iteration; Totals must keep
+    summing it rather than switching to the run-level number for everyone."""
+    m = _metrics()
+    events = [e.copy() for e in AGENT_EVENTS]
+    events[2] = {**events[2], "opt_cost_usd": 4.25, "optimizer_seconds": 300.0}
+    rd = _events(tmp_path, events, {"iterations": 1, "optimizer_usd": 4.25})
+    md = m.suite_report(str(rd), "spreadsheetbench", "smoke", "aws/gpt-oss-120b", 1)
+
+    assert "optimizer $4.2500 over 5m00s" in md, f"per-step attribution was lost:\n{md}"
+    assert "whole-loop" not in md, f"a per-step run was labelled whole-loop:\n{md}"
+
+
+def test_the_operative_re_gate_wins_past_nine_re_gates(tmp_path):
+    """A same-iteration re-gate is run to SUPERSEDE the first, so the highest suffix is the
+    one that counts — and `.r10` must outrank `.r2`, which a lexical sort gets backwards."""
+    run_dir, work = _run_dir_with_round_table(tmp_path)
+    for n, delta in ((2, 0.222), (10, 0.999)):
+        t = json.loads(json.dumps(ROUND_TABLE))
+        t["candidates"][0]["gate_delta"] = delta
+        (run_dir.root / "work" / f"round_i0.r{n}.json").write_text(json.dumps(t))
+    _commit(run_dir, work)
+
+    assert _gate_decision(run_dir)["delta"] == 0.999, "the tenth re-gate lost to the second"

--- a/core/tests/test_agent_optimize_round_attribution.py
+++ b/core/tests/test_agent_optimize_round_attribution.py
@@ -79,8 +79,53 @@ def test_commit_reads_only_fields_round_actually_writes():
                 "gate_delta", "gate_threshold", "control_relative",
                 "null_delta_between_control_replicates", "evidence_bar"):
         assert key in src, f"round.py no longer writes {key}; this fixture is stale"
-    assert 'stem = f"round_i{int(run_dir.spent.iterations)}"' in src, (
-        "round.py's table filename changed; commit.py's lookup must follow")
+    assert "round_i{int(run_dir.spent.iterations)}" in src, (
+        "round.py's table filename no longer keys off spent.iterations; commit.py's lookup must "
+        "follow")
+
+
+def test_commit_finds_the_table_wherever_round_decided_to_name_it(tmp_path):
+    """The naming coupling itself, checked by behaviour rather than by matching source text.
+
+    The two files used to be kept in step by a filename literal duplicated in both. That is a
+    guard against editing one copy, not against the schemes diverging — and the scheme now has
+    two halves (iteration, and the ``.r<k>`` attempt suffix a re-gate gets). So write a table at
+    the name ``round.py`` itself would choose and assert ``commit.py`` reads its numbers back.
+    """
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("_ao_round_naming", SCRIPTS / "round.py")
+    rnd = importlib.util.module_from_spec(spec)
+    sys.path.insert(0, str(SCRIPTS))
+    spec.loader.exec_module(rnd)
+
+    run_dir, work = _run_dir_with_round_table(tmp_path, table=None)
+    (run_dir.root / "work").mkdir(parents=True, exist_ok=True)
+    stem = rnd.table_stem(run_dir)
+    (run_dir.root / "work" / f"{stem}.json").write_text(json.dumps(ROUND_TABLE),
+                                                        encoding="utf-8")
+    _commit(run_dir, work)
+    d = _gate_decision(run_dir)
+    # These can only have come from the table, since the prose note carries no numbers.
+    assert d.get("threshold") == ROUND_TABLE["candidates"][0]["gate_threshold"], (
+        f"commit.py did not read the table round.py would have written ({stem}.json): {d}")
+    assert d.get("evidence_bar") == ROUND_TABLE["evidence_bar"]["value"]
+
+    # And on a re-gate, the LATER attempt's table is the operative one. Checked on the lookup
+    # itself rather than by booking twice, since booking one candidate id twice is a different
+    # rule (and one commit.py deliberately refuses).
+    spec_c = importlib.util.spec_from_file_location("_ao_commit_naming", SCRIPTS / "commit.py")
+    cmt = importlib.util.module_from_spec(spec_c)
+    spec_c.loader.exec_module(cmt)
+
+    stem2 = rnd.table_stem(run_dir)
+    assert stem2 != stem, "a second table did not advance the attempt index"
+    later = {**ROUND_TABLE, "candidates": [{**ROUND_TABLE["candidates"][0],
+                                            "gate_delta": 0.12345}]}
+    (run_dir.root / "work" / f"{stem2}.json").write_text(json.dumps(later), encoding="utf-8")
+    nums = cmt._round_gate_numbers(run_dir, "cand_1")
+    assert nums.get("gate_table") == f"{stem2}.json" and nums.get("gate_delta") == 0.12345, (
+        f"the re-gate's table did not supersede the first attempt's: {nums}")
 
 
 def _run_dir_with_round_table(tmp_path, *, table: dict | None = ROUND_TABLE):

--- a/core/tests/test_an_unresolved_gate_is_not_a_rejection.py
+++ b/core/tests/test_an_unresolved_gate_is_not_a_rejection.py
@@ -1,0 +1,299 @@
+"""``round.py`` can return a verdict of ``inconclusive``; ``commit.py`` could only book accept
+or reject. So an unresolvable measurement had to be recorded as one of two things it was not.
+
+``round.py`` marks a candidate ``inconclusive`` when its verdict is not stable across the round's
+byte-identical control replicates (``verdict_stable: false``) — it accepts against one replicate
+and rejects against another, so the round cannot separate the edit from re-measurement. Its own
+`reading` says such a candidate is "never accepted … Re-run it with more trials before believing
+either answer". That is a THIRD outcome, and the loop had no way to write it down.
+
+Observed on smoke spreadsheetbench run 33046360451 round i1: cand_2 at +0.0433 against a
+threshold of 0.0492, `verdict_by_reference: {ctl_null_i1: reject, ctl_null_i1r1: accept}`. The
+agent's only options were to book a reject — asserting the gate refuted an edit it had not — or
+to book nothing, which ``host._unbooked_rounds`` correctly reports as a defective run.
+
+Booking it as a reject is not a cosmetic misfiling. ``update_spent(accepted=False)`` increments
+the STALL counter, and ``budget_exhausted()`` stops the run when stall hits its cap (3 here,
+already at 1). Stall means "the optimizer has run out of ideas" — the one thing an ambiguous
+measurement is no evidence of. Two ambiguous rounds could therefore end a run for a reason that
+never happened, on a benchmark whose replicate noise makes ambiguity the common case.
+
+``harness.record_iteration`` has supported exactly this since #216/#224 — ``indecisive=True``
+charges the iteration and leaves the stall counter alone — and the deterministic hill-climb uses
+it. Agent mode simply could not reach it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPTS = REPO / "skills" / "algorithms" / "agent-optimize" / "scripts"
+
+# The real round_i1.json from run 33046360451, trimmed: an unstable verdict.
+UNSTABLE_TABLE = {
+    "parent": {"tag": "seed", "reward": 0.51, "stderr": 0.1319184184858296, "n_tasks": 10},
+    "gate_reference": {"tag": "ctl_null_i1", "mode": "control", "reward": 0.4966666666666667},
+    "gated_against": {"tag": "ctl_null_i1", "mode": "control"},
+    "null_delta_between_control_replicates": 0.0167,
+    "evidence_bar": {"value": 0.0167, "basis": "gap between byte-identical control replicates"},
+    "candidates": [{
+        "tag": "cand_2", "reward": 0.54, "gate_delta": 0.04333333333333332,
+        "gate_threshold": 0.04920353294552117, "verdict": "inconclusive",
+        "verdict_by_reference": {"ctl_null_i1": "reject", "ctl_null_i1r1": "accept"},
+        "verdict_stable": False, "regressions": ["40467"], "eval_rc": 0, "eval_error": None,
+    }],
+}
+
+
+def _staged(tmp_path, cid="cand_2", table=UNSTABLE_TABLE):
+    from cap_evolve import Budget, RunDir, harness
+    from cap_evolve.skillcheck import SyntheticAdapter, seed_capability_dir
+
+    adapter = SyntheticAdapter(n=12)
+    seed = seed_capability_dir(tmp_path, level=3)
+    run_dir = RunDir.create(tmp_path / ".capevolve", ts="ci",
+                            budget=Budget(max_iterations=3, stall=3))
+    harness.ensure_splits(adapter, run_dir, seed=0)
+    harness.baseline(adapter, seed, run_dir=run_dir)
+    work = run_dir.root / "work" / cid
+    work.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(run_dir.root / "candidates" / "seed", work)
+    if table is not None:
+        (run_dir.root / "work" / "round_i0.json").write_text(json.dumps(table), encoding="utf-8")
+    return run_dir, work
+
+
+def _commit(run_dir, work, *extra, cid="cand_2", decision="inconclusive", val="0.54"):
+    return subprocess.run(
+        [sys.executable, str(SCRIPTS / "commit.py"), "--run-dir", str(run_dir.root),
+         "--candidate-id", cid, "--from-dir", str(work),
+         "--decision", decision, "--val", val,
+         "--note", "verdict flipped between control replicates; not resolvable this round",
+         *extra],
+        capture_output=True, text=True,
+        env={**os.environ, "CAPEVOLVE_CORE": str(REPO / "core")})
+
+
+def _ok(p):
+    assert p.returncode == 0, f"commit.py failed: {p.stdout}\n{p.stderr}"
+    return json.loads(p.stdout)
+
+
+def test_an_inconclusive_round_can_be_booked_at_all(tmp_path):
+    run_dir, work = _staged(tmp_path)
+    out = _ok(_commit(run_dir, work))
+    assert out["decision"] == "inconclusive"
+
+
+def test_an_inconclusive_round_charges_the_iteration_but_not_the_stall(tmp_path):
+    """The budget was really spent, so the iteration is charged. The stall counter means "the
+    optimizer is out of ideas" and must not move on a measurement that failed to resolve."""
+    from cap_evolve import RunDir
+
+    run_dir, work = _staged(tmp_path)
+    _ok(_commit(run_dir, work))
+
+    spent = RunDir.open(run_dir.root).spent
+    assert spent.iterations == 1, f"the round's real spend was not charged: {spent.to_dict()}"
+    assert spent.stall == 0, (
+        "an unresolved measurement incremented the stall counter, which is what ends a run "
+        f"early for 'no ideas left': {spent.to_dict()}")
+
+
+def test_a_reject_still_charges_the_stall(tmp_path):
+    """Control: the new decision must not weaken a real reject, which IS stall evidence."""
+    from cap_evolve import RunDir
+
+    run_dir, work = _staged(tmp_path)
+    _ok(_commit(run_dir, work, decision="reject"))
+    assert RunDir.open(run_dir.root).spent.stall == 1
+
+
+def test_an_inconclusive_round_neither_takes_the_champion_nor_files_a_refutation(tmp_path):
+    from cap_evolve import RunDir
+
+    run_dir, work = _staged(tmp_path)
+    _ok(_commit(run_dir, work))
+
+    assert RunDir.open(run_dir.root).best_id in ("seed", None), (
+        "an unresolved candidate became the champion")
+    rejected = Path(run_dir.rejected_path)
+    text = rejected.read_text(encoding="utf-8") if rejected.exists() else ""
+    assert "cand_2" not in text, (
+        "an unresolved candidate was filed as a REFUTED approach, so a later round is taught "
+        "to avoid an edit that was never actually judged")
+
+
+def test_the_iteration_record_marks_it_unresolved_not_rejected(tmp_path):
+    """A reader of the event stream — dashboard, TUI, CI report — must be able to tell an
+    unresolved round from a refuted one, or the run's own history is wrong."""
+    run_dir, work = _staged(tmp_path)
+    _ok(_commit(run_dir, work))
+
+    kinds = []
+    for line in Path(run_dir.events_path).read_text(encoding="utf-8").splitlines():
+        if line.strip():
+            kinds.append(json.loads(line).get("kind"))
+    assert "step_indecisive" in kinds, (
+        f"nothing in the event stream marks the round unresolved: {kinds}")
+    assert "reject" not in kinds, f"an unresolved round logged a reject event: {kinds}"
+
+
+def test_claiming_the_gate_rejected_an_unresolved_candidate_is_refused(tmp_path):
+    """``--reject-basis gate`` asserts a full-val paired gate ran AND rejected. Against an
+    ``inconclusive`` verdict that is the same misattribution the existing guard already catches
+    for an ACCEPTED verdict: the gate did not refute the edit, it failed to resolve it."""
+    run_dir, work = _staged(tmp_path)
+    p = _commit(run_dir, work, "--reject-basis", "gate", decision="reject")
+
+    assert p.returncode != 0, (
+        "commit.py let the run record 'the gate rejected cand_2' when the gate returned "
+        f"inconclusive: {p.stdout}")
+    assert "inconclusive" in p.stdout
+
+
+def test_reject_basis_is_meaningless_on_an_inconclusive_decision(tmp_path):
+    run_dir, work = _staged(tmp_path)
+    p = _commit(run_dir, work, "--reject-basis", "gate")
+    assert p.returncode != 0, f"--reject-basis was accepted on a non-reject: {p.stdout}"
+
+
+def test_an_inconclusive_candidate_cannot_be_silently_rebooked_under_its_own_tag(tmp_path):
+    """The tag-reuse guard exists because rollouts are ``<task>__<tag>__t<k>.json``: re-running
+    a tag overwrites its evidence. Resolving an inconclusive candidate therefore needs a FRESH
+    tag, and re-booking the old one must be refused like any other double decision."""
+    run_dir, work = _staged(tmp_path)
+    _ok(_commit(run_dir, work))
+    p = _commit(run_dir, work, decision="accept")
+
+    assert p.returncode != 0, (
+        f"the same tag was booked twice, the second time as an accept: {p.stdout}")
+    assert "already has" in p.stdout
+
+
+def test_the_journal_does_not_tell_the_next_round_its_batch_was_refuted(tmp_path):
+    """``JOURNAL.md`` is the handover the NEXT round reads. Its framework RESULT line said
+    "REJECTED (champion unchanged) … its WHOLE batch was reverted; re-introduce only the edits
+    that did NOT break a task above" for every non-accept — including a step whose measurement
+    was void. That is the misattribution of this whole file, written into the one artifact whose
+    job is to stop the next round repeating a refuted idea. An unresolved edit is not refuted;
+    it is unmeasured, and the correct next move is to re-measure it, not to redesign it."""
+    run_dir, work = _staged(tmp_path)
+    (work / "JOURNAL.md").write_text(
+        "## Iteration cand_2 — replay rationale + write-only-required-cells\n", encoding="utf-8")
+    _ok(_commit(run_dir, work))
+
+    journal = (run_dir.root / "JOURNAL.md").read_text(encoding="utf-8")
+    assert "REJECTED" not in journal, (
+        f"an unresolved round is stamped REJECTED in the handover the next round reads:\n{journal}")
+    assert "WHOLE batch was reverted" not in journal, (
+        "the next round is told to redesign an edit that was never actually judged")
+    assert "UNRESOLVED" in journal, f"nothing marks the round unresolved:\n{journal}"
+
+
+def test_every_algorithms_void_step_gets_the_same_journal_treatment(tmp_path):
+    """The stamp is written by ``_reconcile_journal``, which every algorithm reaches through
+    ``record_iteration`` — so fixing it there also fixes the tamper-voided steps in the
+    deterministic hill-climb (``harness``) and ``gepa``, which have always stamped a void
+    measurement as REJECTED too."""
+    from cap_evolve import harness
+
+    run_dir, work = _staged(tmp_path, table=None)
+    (work / "JOURNAL.md").write_text("## Iteration cand_2 — whatever\n", encoding="utf-8")
+    harness.record_iteration(run_dir, work, "cand_2", parent_id="seed", accepted=False,
+                             reason="indecisive (integrity): capability dir was mutated",
+                             val=None, indecisive=True)
+
+    journal = (run_dir.root / "JOURNAL.md").read_text(encoding="utf-8")
+    assert "UNRESOLVED" in journal and "REJECTED" not in journal, journal
+
+
+# --- the guidance that makes the third decision reachable --------------------------------
+
+def test_round_offers_the_driver_the_decision_it_actually_needs():
+    """``round.py``'s `next` line is the driver's instruction for what to do with the table it
+    just read. It said "commit.py --decision accept|reject per candidate" — so a driver holding
+    an INCONCLUSIVE verdict was told, by the same tool that produced that verdict, to book one
+    of the two dispositions that verdict rules out."""
+    src = (SCRIPTS / "round.py").read_text(encoding="utf-8")
+    assert "accept|reject|inconclusive" in src, (
+        "round.py can return `inconclusive` but still tells the driver to book accept|reject")
+
+
+def test_round_says_how_to_re_measure_not_just_that_it_should():
+    """"Re-run it with more trials" is unactionable in a system where trials are written
+    ``<task>__<tag>__t{k}.json`` for ``k in range(n_trials)``: re-running the SAME tag replaces
+    t0..t9 rather than adding t10..t19. Following the advice literally is what happened on run
+    33046360451 — the agent re-measured control ``ctl_null_i1`` under its own tag, spent 100
+    metric calls, and swapped a 0.4967 replicate for a 0.5067 one instead of adding one, WIDENING
+    the round's replicate spread."""
+    src = (SCRIPTS / "round.py").read_text(encoding="utf-8")
+    lo = src.lower()
+    assert "fresh tag" in lo, (
+        "nothing tells the driver that re-measuring needs a fresh tag, so 'more trials' reads "
+        "as 're-run this tag' — which destroys the reading it meant to add to")
+
+
+def test_the_evidence_bar_is_not_presented_as_the_only_number_that_matters():
+    """"Judge every candidate's delta against `evidence_bar`, not against any other number here"
+    is true about which NOISE FLOOR to use, and false as stated: `gate_threshold` (k·SE on the
+    paired per-task differences) is the number the verdict is actually computed from, and it is
+    the stricter of the two. Live on run 33046360451 i1, cand_2 cleared evidence_bar 0.0167 with
+    Δ +0.0433 and still did not clear its threshold of 0.0492 — a driver following the sentence
+    literally would read the table as an accept."""
+    src = (SCRIPTS / "round.py").read_text(encoding="utf-8")
+    assert "gate_threshold" in src, "the reading never names the number the verdict is computed from"
+    lo = src.lower()
+    assert "necessary" in lo and "not sufficient" in lo, (
+        "the reading still presents clearing `evidence_bar` as the whole test, inviting a driver "
+        "to book an accept the paired gate did not give")
+
+
+def _load_host():
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("_ao_host_unresolved", SCRIPTS / "host.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.path.insert(0, str(SCRIPTS))
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_an_honestly_booked_unresolved_round_is_not_reported_as_abandoned(tmp_path):
+    """``host._unbooked_rounds`` names candidates a round GATED that nobody booked, and it drives
+    the run-quality diagnosis ("gated but never booked with commit.py") and the ``finished_itself``
+    branch. It recognises a booking by its event kind, so an ``inconclusive`` booking would read as
+    no booking at all — punishing the driver for recording the honest outcome and telling the
+    operator a completed round was abandoned."""
+    host = _load_host()
+    run_dir, work = _staged(tmp_path)
+    # round.py's table lives under work/ where _unbooked_rounds scans for it.
+    (run_dir.root / "work" / "round_i0.json").write_text(json.dumps(UNSTABLE_TABLE),
+                                                         encoding="utf-8")
+    _ok(_commit(run_dir, work))
+
+    assert "cand_2" in host._decided_candidates(run_dir.root), (
+        "an inconclusive booking is not recognised as a decision")
+    assert host._unbooked_rounds(run_dir.root) == [], (
+        "a round booked as inconclusive is reported as gated-but-never-booked, so the run is "
+        f"diagnosed as defective for doing the right thing: {host._unbooked_rounds(run_dir.root)}")
+
+
+def test_the_host_brief_tells_the_agent_the_third_decision_exists():
+    """The host brief is the agent's only instruction sheet. Its per-round checklist said
+    ``commit.py | always, accept or reject`` — an agent reading only that has no way to know an
+    unresolved round is bookable, and will pick whichever of the two it thinks is safer."""
+    src = (SCRIPTS / "host.py").read_text(encoding="utf-8")
+    assert "inconclusive" in src, (
+        "the host brief never mentions --decision inconclusive, so the agent cannot use it")
+
+
+def test_the_skill_documents_the_third_decision():
+    md = (SCRIPTS.parent / "SKILL.md").read_text(encoding="utf-8")
+    assert "--decision inconclusive" in md or "inconclusive" in md, (
+        "SKILL.md documents only accept/reject")

--- a/core/tests/test_benchmarks_agent_optimize.py
+++ b/core/tests/test_benchmarks_agent_optimize.py
@@ -413,3 +413,35 @@ def test_the_iterations_input_defaults_to_blank_so_the_tier_default_can_win():
         f"from a deliberate choice — otherwise smoke silently gets the input's number: {block}")
     assert "BLANK" in block or "blank" in block, (
         f"the input description must tell the operator blank means the tier default: {block}")
+
+
+def test_agent_mode_gates_against_a_concurrent_control_not_a_stored_reward():
+    """The derived stop_condition named the gate's STRICTNESS but never its REFERENCE.
+
+    `round.py` defaults to `--gate-against parent`, which compares a candidate against the
+    parent's reward as it was measured EARLIER — so however much that stored number has
+    drifted since, the drift lands inside every candidate delta. `--gate-against control`
+    pairs against a byte-identical replicate measured in the SAME round, which removes it.
+    The stop_condition said only "Gate every candidate on FULL val at gate_k_se=... over N
+    trial(s)", so the agent took the default and every round carried drift.
+
+    Measured on smoke spreadsheetbench run 32971129203, whose `work/round_i0.json` recorded
+    BOTH comparisons for cand_1:
+
+        parent  (default) delta 0.0333 vs threshold 0.0440 -> reject
+        control          delta 0.0556 vs threshold 0.0341 -> ACCEPT
+
+    0.0556 also cleared that round's own `evidence_bar` of 0.0444, so it was real evidence.
+    Rounds i1/i2 rejected under both modes — genuine negatives. So exactly one candidate in
+    the run mattered and the default reference discarded it, and the run published `best=seed`
+    ("null result") on the strength of a comparison its own round table called drift-carrying.
+    PR #399 named this as a follow-up on tau2 evidence alone; this is a second benchmark.
+    """
+    got = _select(ALGORITHM="agent-optimize", ITERATIONS="3", NUM_TRIALS="3", GATE_K_SE="1.0")
+    stop = got["stop"]
+
+    assert "--gate-against control" in stop, (
+        "the stop_condition does not tell the agent which gate REFERENCE to use, so round.py's "
+        f"drift-carrying `parent` default wins: {stop}")
+    assert "drift" in stop.lower(), (
+        f"the stop_condition does not say WHY the control reference is required: {stop}")

--- a/core/tests/test_benchmarks_null_run_reports_no_gain.py
+++ b/core/tests/test_benchmarks_null_run_reports_no_gain.py
@@ -1,0 +1,162 @@
+"""A run that accepted NOTHING advertised an improvement it had not made.
+
+On a no-holdout tier (`smoke`: train==val==test) `metrics.suite_report` takes the baseline
+side from `baseline.json` (the val eval of the seed) and the optimized side from `final.json`
+(the test eval of `best_id`). When `best_id == "seed"` — no candidate cleared the gate — those
+two evals score the SAME BYTES, so every difference between them is re-measurement noise.
+Nothing subtracted it, so the report published it as progress.
+
+Measured on smoke spreadsheetbench run 32971129203, whose three rounds were all rejected:
+
+    **Suite (train-fit):** mean reward 0.500 -> 0.544 (Δ +0.044 (+9% rel))
+    · best = seed (no candidate beat baseline)
+
+with per-task rows to match — `47484` "0.667 -> 1.000 (+0.333)" and `53161`
+"1.000 -> 0.667 (-0.333)" — for a capability that was never edited. The +0.044 was exactly
+the replicate noise `round.py` had measured that run at (`null_delta_between_control
+_replicates: 0.0444`). The parenthetical "best = seed (no candidate beat baseline)" is the
+only contradicting signal in the document, and it loses to the headline number.
+
+This is not agent-optimize-specific: any run of any algorithm that accepts nothing hits it.
+It reaches published history too, because `metrics.jsonl` feeds `record.rollup` and the
+benchmarks page.
+
+The held-out path was already correct (see test_benchmarks_holdout_base_opt.py) because
+`final.json` carries `test_baseline` and `test` over the same sealed split, and with
+`best_id == "seed"` those are the same numbers. Only the no-holdout fallback was exposed.
+"""
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+LIB = REPO / "ci" / "benchmarks" / "lib"
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _metrics():
+    if str(LIB) not in sys.path:
+        sys.path.insert(0, str(LIB))
+    return _load("_bench_metrics_null", LIB / "metrics.py")
+
+
+def _pt(task_id, reward):
+    return {"task_id": task_id, "reward": reward, "raw": {"errored": False}}
+
+
+def _null_run(tmp: Path) -> Path:
+    """A no-holdout run where NOTHING was accepted, so best_id stays `seed`.
+
+    val and test carry the same task ids (train==val==test) and DIFFERENT rewards — the
+    two independent measurements of one unchanged capability that the real run produced.
+    val mean 0.500, test mean 0.667: a phantom +0.167.
+    """
+    rd = tmp / "run_suite"
+    rd.mkdir(parents=True)
+    ids = ["t1", "t2", "t3"]
+    (rd / "baseline.json").write_text(json.dumps({
+        "val": {"split": "val", "reward": 0.5, "stderr": 0.14,
+                "per_task": [_pt("t1", 0.0), _pt("t2", 0.5), _pt("t3", 1.0)]},
+        "best_id": "seed",
+    }))
+    (rd / "final.json").write_text(json.dumps({
+        "test": {"split": "test", "reward": 0.6667, "stderr": 0.14,
+                 "per_task": [_pt("t1", 0.5), _pt("t2", 0.5), _pt("t3", 1.0)]},
+        "best_id": "seed",
+    }))
+    (rd / "state.json").write_text(json.dumps({
+        "best_id": "seed",
+        "spent": {"iterations": 3, "optimizer_usd": 7.95},
+    }))
+    (rd / "events.jsonl").write_text("")
+    assert set(ids) == {"t1", "t2", "t3"}
+    return rd
+
+
+def test_a_null_run_publishes_a_zero_per_task_delta(tmp_path):
+    m = _metrics()
+    rd = _null_run(tmp_path)
+    jsonl = tmp_path / "metrics.jsonl"
+    m.suite_report(str(rd), "spreadsheetbench", "smoke", "Azure/gpt-5-mini-2025-08-07", 3,
+                   jsonl_path=str(jsonl))
+    rows = [json.loads(l) for l in jsonl.read_text().splitlines()]
+
+    assert rows, "no per-task rows were written"
+    assert all(r["reward_delta"] == 0.0 for r in rows), (
+        "a run that accepted nothing published per-task gains from re-measurement noise: "
+        f"{[(r['task'], r['reward_delta']) for r in rows]}")
+    assert all(r["reward_opt"] == r["reward_baseline"] for r in rows), (
+        "base and opt are the same bytes, so they must report the same reward: "
+        f"{[(r['task'], r['reward_baseline'], r['reward_opt']) for r in rows]}")
+
+
+def test_a_null_run_does_not_roll_up_into_published_history_as_a_gain(tmp_path):
+    """metrics.jsonl feeds record.rollup and the benchmarks page — the durable harm."""
+    m = _metrics()
+    if str(LIB) not in sys.path:
+        sys.path.insert(0, str(LIB))
+    rec = _load("_bench_record_null", LIB / "record.py")
+
+    rd = _null_run(tmp_path)
+    jsonl = tmp_path / "metrics.jsonl"
+    m.suite_report(str(rd), "spreadsheetbench", "smoke", "Azure/gpt-5-mini-2025-08-07", 3,
+                   jsonl_path=str(jsonl))
+    rows = [json.loads(l) for l in jsonl.read_text().splitlines()]
+
+    suite = rec.rollup(rows, [])
+    assert suite is not None
+    assert suite["reward_base"] == suite["reward_opt"], (
+        f"published history records a gain for a run that changed nothing: {suite}")
+
+
+def test_the_report_headline_states_no_change_rather_than_noise(tmp_path):
+    m = _metrics()
+    md = m.suite_report(str(_null_run(tmp_path)), "spreadsheetbench", "smoke",
+                        "Azure/gpt-5-mini-2025-08-07", 3)
+
+    assert "+17% rel" not in md and "+0.167" not in md, (
+        f"the headline still advertises re-measurement noise as a gain:\n{md}")
+    assert "0.500 → 0.500" in md, f"the suite line must show no change:\n{md}"
+    assert "no candidate beat baseline" in md
+
+
+def test_the_re_measurement_is_still_reported_as_a_noise_reading(tmp_path):
+    """Suppressing the phantom delta must not throw the information away: two evals of one
+    unchanged capability are a free read on the tier's noise floor, and the reader needs it
+    to judge whether the run could have resolved a real effect at all."""
+    m = _metrics()
+    md = m.suite_report(str(_null_run(tmp_path)), "spreadsheetbench", "smoke",
+                        "Azure/gpt-5-mini-2025-08-07", 3)
+
+    assert "0.667" in md, f"the seed's re-measurement is gone entirely:\n{md}"
+    assert "noise" in md.lower(), (
+        f"the re-measurement is shown without saying what it is:\n{md}")
+
+
+def test_a_run_that_DID_accept_a_candidate_is_untouched(tmp_path):
+    """The guard must key on best_id, not on the tier — a real smoke win still reports."""
+    m = _metrics()
+    rd = _null_run(tmp_path)
+    for name in ("final.json", "state.json"):
+        d = json.loads((rd / name).read_text())
+        d["best_id"] = "cand_3"
+        (rd / name).write_text(json.dumps(d))
+
+    jsonl = tmp_path / "metrics.jsonl"
+    md = m.suite_report(str(rd), "spreadsheetbench", "smoke", "Azure/gpt-5-mini-2025-08-07", 3,
+                        jsonl_path=str(jsonl))
+    rows = {json.loads(l)["task"]: json.loads(l) for l in jsonl.read_text().splitlines()}
+
+    assert rows["t1"]["reward_baseline"] == 0.0 and rows["t1"]["reward_opt"] == 0.5
+    assert rows["t1"]["reward_delta"] == 0.5, "a real accepted candidate lost its delta"
+    assert "0.500 → 0.667" in md, f"an accepted candidate must still report its gain:\n{md}"

--- a/core/tests/test_rollout_tag_reuse_is_visible.py
+++ b/core/tests/test_rollout_tag_reuse_is_visible.py
@@ -1,0 +1,115 @@
+"""Re-measuring an existing tag REPLACES its rollouts, and nothing said so.
+
+``evaluate_candidate`` writes ``<task>__<tag>__t{k}.json`` for ``k in range(n_trials)``, so a
+second evaluation under a tag that already has rollouts overwrites ``t0..t9`` rather than adding
+``t10..t19``. There is no trial accumulation. That is a defensible implementation choice; the
+defect is that it happened **silently**, in a loop whose own guidance asks for the opposite.
+
+Observed on smoke spreadsheetbench run 33046360451, round i1. ``round.py`` marked cand_2
+``inconclusive`` (its verdict flipped between two byte-identical control replicates) and its
+``reading`` field said "Re-run it with more trials before believing either answer". The agent
+did exactly that — and re-measured the control under the EXISTING tag ``ctl_null_i1``, replacing
+the 0.4967 reading with 0.5067. Net effect of 100 metric calls and ~30 minutes: still two
+distinct replicates rather than three, and the replicate spread WIDENED from 0.0167 to 0.0267,
+raising the bar the candidate had to clear. Nothing in the event stream, the state or the
+dashboard marked the replacement; in the event stream it is indistinguishable from progress.
+
+A warning, not a refusal: re-evaluating an existing tag is legitimate on ``--resume`` (a run
+picks its champion's val score back up) and the harness must not break that. What it must not do
+is let a measurement be destroyed without a record.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+def _mk(tmp_path):
+    from cap_evolve import Budget, RunDir, harness
+    from cap_evolve.skillcheck import SyntheticAdapter, seed_capability_dir
+
+    adapter = SyntheticAdapter(n=12)
+    seed = seed_capability_dir(tmp_path, level=3)
+    run_dir = RunDir.create(tmp_path / ".capevolve", ts="ci", budget=Budget(max_iterations=5))
+    harness.ensure_splits(adapter, run_dir, seed=0)
+    return adapter, seed, run_dir
+
+
+def _events(run_dir, kind: str) -> list[dict]:
+    out = []
+    p = Path(run_dir.events_path)
+    if not p.exists():
+        return out
+    for line in p.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            ev = json.loads(line)
+        except ValueError:
+            continue
+        if ev.get("kind") == kind:
+            out.append(ev)
+    return out
+
+
+def test_reusing_a_tag_records_that_a_measurement_was_replaced(tmp_path):
+    from cap_evolve import harness
+
+    adapter, seed, run_dir = _mk(tmp_path)
+    first = harness.evaluate_candidate(adapter, seed, run_dir=run_dir, split="val",
+                                       n_trials=2, tag="ctl_null_i1")
+    assert not _events(run_dir, "rollout_overwrite_warning"), (
+        "a FIRST evaluation under a fresh tag overwrote nothing and must not warn")
+
+    harness.evaluate_candidate(adapter, seed, run_dir=run_dir, split="val",
+                               n_trials=2, tag="ctl_null_i1")
+
+    warns = _events(run_dir, "rollout_overwrite_warning")
+    assert len(warns) == 1, (
+        "re-measuring an existing tag replaced its rollouts and left no record: "
+        f"{[e.get('kind') for e in _events(run_dir, 'rollout_overwrite_warning')]}")
+    w = warns[0]
+    assert w.get("tag") == "ctl_null_i1" and w.get("split") == "val"
+    assert w.get("prior_reward") == pytest.approx(first.reward), (
+        "the warning must name the reading that was destroyed, which is the only place it "
+        f"survives once the files are gone: {w}")
+    assert w.get("prior_trials") == 2, f"the replaced trial count is not recorded: {w}"
+
+
+def test_a_fresh_tag_never_warns_however_many_siblings_exist(tmp_path):
+    """The fix must not cry wolf: distinct tags are the NORMAL case (every candidate and every
+    control replicate gets its own), and a warning on those would train readers to ignore it."""
+    from cap_evolve import harness
+
+    adapter, seed, run_dir = _mk(tmp_path)
+    for tag in ("ctl_null_i1", "ctl_null_i1r1", "ctl_null_i1r2", "cand_2"):
+        harness.evaluate_candidate(adapter, seed, run_dir=run_dir, split="val",
+                                   n_trials=1, tag=tag)
+
+    assert not _events(run_dir, "rollout_overwrite_warning"), (
+        "four distinct tags overwrote nothing, so nothing should have warned")
+
+
+def test_the_replaced_reading_is_recoverable_from_the_warning_alone(tmp_path):
+    """Why ``prior_reward`` and not just a "you overwrote this" flag: once ``t0..t9`` are gone
+    the old number exists nowhere else unless a round table happened to capture it. On run
+    33046360451 the 0.4967 replicate survived only because ``round_i1.json`` had already been
+    written — had the agent re-measured before gating, the reading would have been lost."""
+    from cap_evolve import harness
+
+    adapter, seed, run_dir = _mk(tmp_path)
+    r1 = harness.evaluate_candidate(adapter, seed, run_dir=run_dir, split="val",
+                                    n_trials=2, tag="ctl")
+    harness.evaluate_candidate(adapter, seed, run_dir=run_dir, split="val",
+                               n_trials=2, tag="ctl")
+    r3 = harness.split_result_from_rollouts(run_dir, "ctl", "val")
+
+    w = _events(run_dir, "rollout_overwrite_warning")[0]
+    assert w["prior_reward"] == pytest.approx(r1.reward)
+    # On disk, only the newest measurement survives — which is exactly the problem.
+    assert harness.split_result_from_rollouts(run_dir, "ctl", "val").reward == \
+        pytest.approx(r3.reward)

--- a/skills/algorithms/agent-optimize/SKILL.md
+++ b/skills/algorithms/agent-optimize/SKILL.md
@@ -177,6 +177,9 @@ python "$A/commit.py" --run-dir "$R" --candidate-id "$TAG" --from-dir "$R/work/$
        --decision accept --val <cand_mean> --note "<one line: the general rule you added>"
 ```
 
+An unresolved round (`verdict_stable: false`) is `--decision inconclusive`, not a reject — that
+advances **stall**. See `references/measured-lessons.md`.
+
 **On a reject, pass `--reject-basis`** — `screen.py`'s "promote" means "could not prove harm", never "was
 evaluated on full val", so conflating its verdict with your disposition makes the run's artifacts
 contradict themselves. `gate` (a full-val paired gate ran and said reject — the only basis asserting
@@ -184,7 +187,7 @@ this), `screen_kill` (the screen proved harm), `ceiling` (arithmetic proved no a
 full val was never paid), `budget` (screen evidence plus a budget call, not a gate decision), `infra`
 (missing data, not a judgement). So `screen: promote` + `reject_basis: ceiling` is one coherent story.
 
-`commit.py` **refuses a `--candidate-id` that already carries an accept/reject event** (`--force` only to
+`commit.py` **refuses a `--candidate-id` that already carries a decision event** (`--force` only to
 repair a record deliberately): two drivers tagging a candidate alike otherwise produce two decision
 events over ONE set of rollouts. Pass `--optimizer-usd/--optimizer-tokens/--optimizer-seconds` for
 **your own** proposal cost — the evaluate phase records the runner's, nothing records the proposer's.

--- a/skills/algorithms/agent-optimize/references/algorithm.md
+++ b/skills/algorithms/agent-optimize/references/algorithm.md
@@ -161,6 +161,15 @@ agent mode *the agent is the proposer*, so `scripts/commit.py` takes `--optimize
 (which drives the stall counter). Without those, a cost- or stall-based `stop_condition` is
 unenforceable no matter how carefully it is written.
 
+Those per-round figures **attribute** cost inside the total the host already meters for your
+whole process; they do not add to it. The host books the residual (`host.optimizer_spend_to_book`),
+so passing them moves spend from the run-level `unattributed` row onto the round that caused it
+and never double-counts — which is exactly what it used to do: the host booked its metered total
+*on top of* whatever the agent had booked, so an agent following this instruction made the run
+report up to twice the optimizer spend it used, and a `max_usd` stop then fired on money nobody
+spent. Pass them when you can estimate your own cost for a round; a round you cannot price is
+better left unattributed than guessed, since the run total is right either way.
+
 ## Parallelism: fan out on the cheap steps, stay serial where state moves
 
 Arbor's discipline — dispatch independent workers into separate worktrees, evaluate each on

--- a/skills/algorithms/agent-optimize/references/measured-lessons.md
+++ b/skills/algorithms/agent-optimize/references/measured-lessons.md
@@ -750,3 +750,53 @@ seed **42.8%** of the time at 5 trials, and in one run it vetoed *both* candidat
 significance test. Read `regressions` as a pointer to look at, never as a verdict, and always next to
 the control's own list.
 
+
+**"Not resolvable" is a decision you can book, and booking it as a reject costs the run.**
+`round.py` marks a candidate `verdict: inconclusive` when `verdict_stable: false` — its verdict changed
+depending on which byte-identical control replicate happened to be the reference, so the round cannot tell
+its edit from re-measurement. Measured on a smoke run: cand_2 at Δ +0.0433 against a threshold of 0.0492,
+`verdict_by_reference: {ctl_null_i1: reject, ctl_null_i1r1: accept}`.
+
+Book it as `commit.py --decision inconclusive`. Two things follow from booking it as a `reject` instead, and
+neither is cosmetic:
+
+- **A reject advances the stall counter, and stall ends the run.** `update_spent(accepted=False)` increments
+  it, and `budget_exhausted()` stops on the cap (3 in the smoke tier). Stall means *the optimizer has run out
+  of ideas* — the one thing an ambiguous measurement is no evidence of. On a benchmark whose replicate noise
+  makes ambiguity common, two unresolved rounds can end a run for a reason that never happened.
+  `inconclusive` charges `iterations` (the budget really was spent) and leaves stall alone.
+- **A reject files the edit in `rejected.jsonl`**, which later rounds read as *tried, did not work*. An edit
+  nothing could judge has not been tried in that sense, so filing it there teaches you to avoid your own
+  untested idea. `inconclusive` skips that file and logs `step_indecisive` instead — which is also the event
+  the dashboard reads to render the step as `indecisive` rather than red.
+
+The `JOURNAL.md` RESULT line follows the same rule: an unresolved round is stamped `UNRESOLVED (not judged)`,
+not `REJECTED … its WHOLE batch was reverted`, because the correct next move for an unresolved edit is to
+**re-measure** it, not to redesign it.
+
+**To re-measure, use a FRESH tag.** Rollouts are written `<task>__<tag>__t{k}.json` for
+`k in range(n_trials)`, so re-running a tag **replaces** `t0..t9` rather than adding `t10..t19` — it swaps a
+reading for another reading and buys no evidence. Either pick a new tag (`cand_2b`) or ask for the higher
+`--trials` in ONE evaluation. This is not hypothetical: told to "re-run with more trials", one run
+re-measured its own control under the same tag, spent 100 metric calls, replaced a 0.4967 replicate with a
+0.5067 one, and *widened* the round's replicate spread. `harness` now logs a `rollout_overwrite_warning`
+naming the reading that was destroyed, because once the files are gone it exists nowhere else.
+
+**`evidence_bar` is necessary, not sufficient.** It is the noise floor to compare a delta against, but
+`gate_threshold` (k·SE on the paired per-task differences) is what each `verdict` is actually computed from,
+and it is usually stricter. A delta above `evidence_bar` and below `gate_threshold` is not an accept — cand_2
+above cleared 0.0167 and missed 0.0492.
+
+**A re-gate must not eat the evidence it was run to add.** `round.py` gave its *table* a `.r<k>` suffix on a
+same-iteration re-run — "since a re-gate is usually being COMPARED with the first one" — but gave the control
+*rollouts* the same `ctl_null_i<N>` tags as the first attempt. So the one operation the script explicitly
+supports preserved the summary and deleted the measurements it summarises. Measured: the second attempt at
+iteration 1 replaced `ctl_null_i1` (0.4967 → 0.5067) and `ctl_null_i1r1` (0.4800 → 0.4367), spending 200 of
+the run's 900 metric calls to swap two readings for two others; the replicate spread went 0.0167 → 0.0700, so
+the bar grew 4.2×, and `round_i1.json` was left quoting an `evidence_bar` derived from two numbers that no
+longer existed anywhere on disk. The round's identity is (iteration, attempt) and **both** halves have to
+reach the names on disk: control tags are now `ctl_null_i<N>a<k>` from the second attempt on, the table name
+comes from the same attempt index rather than a second independent probe, and `prior_attempt_controls` pools
+the earlier attempts' replicates into `null_delta_between_control_replicates` (`max − min` needed no change
+to accept four samples instead of two). Re-gating is now accumulative: it reports the null over every
+replicate the round has paid for.

--- a/skills/algorithms/agent-optimize/references/measured-lessons.md
+++ b/skills/algorithms/agent-optimize/references/measured-lessons.md
@@ -812,3 +812,20 @@ regressions keeps that guidance; a reject with none says the lever is power or s
 one evaluation, or a bigger effect) and to keep the `fixed` edits as the starting point; and a
 reject where no per-task comparison was possible at all says `fixed`/`broke` are UNKNOWN rather
 than empty, instead of implying nothing regressed.
+
+**A run published a quarter of what it spent, and the two causes pulled in opposite directions.**
+The benchmark record's cost is a sum over per-phase rows (baseline, each committed round, finalize),
+so metered spend that no phase owned was not merely unattributed — it was published as if it had
+never happened. Run 33046360451 went out as `optimizer_usd: 0` / `eval_usd: 5.25` while its own
+state held `optimizer_usd 9.11` / `usd 12.55`: a $21.66 run reported as $5.25, in the one figure a
+full tier's budget gets projected from. Two independent holes fed it — agent mode meters the
+optimizer once for the whole loop, so no round can own a share of it; and control replicates,
+re-gates and abandoned rounds are real rollouts that no committed step references. Both are fixed by
+giving the residual a row of its own rather than inventing a per-round split the run never measured.
+The opposite error was live at the same time and worse: the host booked its metered process total
+*on top of* any `commit.py --optimizer-usd` the agent had already booked for the same money, so an
+agent that followed the skill's own instruction made the run report up to twice its optimizer spend
+— and a cost-based `stop_condition` would have ended a run that still had budget. The host now books
+only the residual, bracketed to its own invocation so a `--resume` run does not mistake an earlier
+host's spend for this agent's attribution, and it books the loop's wall time, which nothing recorded
+at all (`optimizer_seconds: 0.0` for a run that took hours).

--- a/skills/algorithms/agent-optimize/references/measured-lessons.md
+++ b/skills/algorithms/agent-optimize/references/measured-lessons.md
@@ -800,3 +800,15 @@ comes from the same attempt index rather than a second independent probe, and `p
 the earlier attempts' replicates into `null_delta_between_control_replicates` (`max − min` needed no change
 to accept four samples instead of two). Re-gating is now accumulative: it reports the null over every
 replicate the round has paid for.
+
+**A reject is usually not caused by a regression, and the RESULT line used to assume it was.** The
+guidance stamped under every reject read *"re-introduce only the edits that did NOT break a task
+above, dropping/redesigning the ones that did"* — unconditionally. Stamped on a real round it
+produced `REJECTED · val=0.553 Δ=+0.043 · fixed={47484, 53161} · broke={—}`: the batch fixed two
+tasks, broke none, and lost to a 0.048 threshold on a +0.047 effect. The one sentence meant to say
+what to do next told the next iteration to drop nothing and redesign nothing — while inviting a
+rewrite of the edits that had just been measured helping. The stamp now branches: a reject WITH
+regressions keeps that guidance; a reject with none says the lever is power or size (more trials in
+one evaluation, or a bigger effect) and to keep the `fixed` edits as the starting point; and a
+reject where no per-task comparison was possible at all says `fixed`/`broke` are UNKNOWN rather
+than empty, instead of implying nothing regressed.

--- a/skills/algorithms/agent-optimize/scripts/commit.py
+++ b/skills/algorithms/agent-optimize/scripts/commit.py
@@ -8,7 +8,7 @@ Does exactly what the deterministic loops do at the end of a step:
   * ``snapshot`` the working copy as a candidate (always — the audit trail should
     show rejects too),
   * ``set_best`` on accept only,
-  * ``log_event`` the accept/reject (agent-mode detail the other scripts read), and
+  * ``log_event`` the decision (agent-mode detail the other scripts read), and
   * ``harness.record_iteration`` — the ONE shared iteration step every algorithm
     routes through (#216/#224): charges ``iterations=1`` **and** ``accepted=`` so the
     stall counter that ``budget_exhausted()`` reads actually moves, writes the
@@ -98,8 +98,50 @@ def _round_gate_numbers(run_dir: RunDir, candidate_id: str) -> dict:
     return {k: v for k, v in out.items() if v is not None}
 
 
+def _record_memory(run_dir: RunDir, candidate_id: str, *, accepted: bool, reason: str,
+                   val: float | None, parent_val: float | None) -> None:
+    """File this round in the optimizer memory every OTHER algorithm already writes.
+
+    ``rejected.jsonl`` / ``history.jsonl`` are what ``memory.py`` calls the readers of its two
+    audit records: the dashboard's Memory panel (``GET /api/runs/{id}/memory`` and the static
+    export) and any optimizer prompt that greps ``rejected.jsonl`` for approaches already
+    refuted. The deterministic loops write them inline — ``harness``'s hill-climb, ``gepa``
+    (including its merge paths) and ``skillopt`` all call ``.add`` themselves. Agent mode never
+    did, so run 33046360451 published ``{"history": [], "rejected": []}``: a whole run of
+    rejected approaches that the run itself could not enumerate.
+
+    NOT hoisted into ``harness.record_iteration`` alongside the other three per-iteration
+    records, though that is where it belongs by the argument in that docstring: gepa's
+    local-gate merge reject (``_try_merge``) files a rejection WITHOUT routing through
+    record_iteration, so centralising there would silently drop it, and the deterministic
+    callers pass richer, algorithm-specific summaries than record_iteration's arguments can
+    reconstruct. Both are fixable; neither is fixable safely in the same change as this.
+    """
+    from cap_evolve.memory import History, RejectedMemory
+
+    delta = (val - parent_val if isinstance(val, (int, float))
+             and isinstance(parent_val, (int, float)) else None)
+    bits = [f"candidate {candidate_id}"]
+    if isinstance(val, (int, float)):
+        bits.append(f"(val {val:.3f}" + (f", Δ {delta:+.3f})" if delta is not None else ")"))
+    summary = " ".join(bits)
+    try:
+        if accepted:
+            History(run_dir.history_path).add(candidate_id, summary, float(val or 0.0))
+        else:
+            RejectedMemory(run_dir.rejected_path).add(candidate_id, summary, reason, val)
+    except OSError as e:
+        # Memory is an audit record, not the decision. Never lose a booked round over it.
+        run_dir.log_event("optimizer_context_warning", what="memory", error=str(e)[:300])
+
+
 def _prior_decision(run_dir: RunDir, candidate_id: str) -> dict | None:
-    """The first accept/reject event already recorded for ``candidate_id``, if any.
+    """The first decision event already recorded for ``candidate_id``, if any.
+
+    ``inconclusive`` counts: an unresolved round is a booked round, and resolving it needs a
+    FRESH tag anyway (re-running a tag REPLACES its rollouts — see ``harness``'s
+    ``rollout_overwrite_warning``), so silently re-booking the old one is the same collision
+    this guard exists for.
 
     Reads ``events.jsonl`` (the audit log, not memory) so the guard holds across
     processes — which is the only way it can catch two concurrent drivers, the exact
@@ -113,7 +155,7 @@ def _prior_decision(run_dir: RunDir, candidate_id: str) -> dict | None:
                 except Exception:  # noqa: BLE001 — a torn line is not a decision
                     continue
                 # NB: log_event writes the event name under "kind", not "event".
-                if ev.get("kind") in ("accept", "reject") and \
+                if ev.get("kind") in ("accept", "reject", "inconclusive") and \
                         str(ev.get("candidate")) == str(candidate_id):
                     return {"kind": ev.get("kind"), "t": ev.get("t"),
                             "note": ev.get("note"), "val": ev.get("val")}
@@ -156,7 +198,16 @@ def main(argv=None) -> int:
     p.add_argument("--candidate-id", required=True,
                    help="candidate id == the tag its rollouts were written under")
     p.add_argument("--from-dir", required=True, help="the working copy to snapshot")
-    p.add_argument("--decision", required=True, choices=["accept", "reject"])
+    # ``inconclusive`` is the third outcome ``round.py`` can actually return (``verdict_stable:
+    # false`` — the verdict flips depending on which byte-identical control replicate is the
+    # reference, so the round cannot separate the edit from re-measurement). Without it an
+    # unresolvable round had to be booked as one of two things it was not, and booking it as a
+    # reject moves the STALL counter — the signal that means "the optimizer has run out of
+    # ideas", which is the one thing an ambiguous measurement is no evidence of.
+    p.add_argument("--decision", required=True, choices=["accept", "reject", "inconclusive"],
+                   help="accept=new champion; reject=the edit was judged and refuted; "
+                        "inconclusive=the measurement could not resolve it (charges the "
+                        "iteration, not the stall; re-measure under a FRESH tag)")
     p.add_argument("--val", type=float, default=None, help="candidate's full-val mean")
     p.add_argument("--note", default="", help="one line: why this edit, in general terms")
     # The DRIVER's disposition, recorded machine-readably alongside the screen's own
@@ -207,9 +258,13 @@ def main(argv=None) -> int:
             return 2
 
     accepted = args.decision == "accept"
-    if accepted and args.reject_basis:
-        print(json.dumps({"error": "--reject-basis is meaningless on an accept",
-                          "fix": "drop it, or pass --decision reject"}, indent=2))
+    indecisive = args.decision == "inconclusive"
+    if args.decision != "reject" and args.reject_basis:
+        print(json.dumps({
+            "error": f"--reject-basis is meaningless on an {args.decision}",
+            "why": "it records what evidence a REJECT rests on. An unresolved round rests on "
+                   "no evidence about the edit at all — that is what makes it unresolved.",
+            "fix": "drop it, or pass --decision reject"}, indent=2))
         return 2
     # `--reject-basis gate` asserts the gate rejected this candidate. On run 32871360361 it was
     # booked for cand2, which round_i1.json recorded as `verdict: accept` at +0.19 against a
@@ -217,15 +272,26 @@ def main(argv=None) -> int:
     # best candidate of the run when in fact the driver had overridden it. Overriding is
     # legitimate (round.py leaves the decision to the driver on purpose); misattributing it is
     # not, and it is the one thing this log exists to get right.
+    # An ``inconclusive`` gate verdict is the same misattribution one step further: the gate did
+    # not refute the edit, it failed to resolve it. Observed live on run 33046360451 i1, where
+    # cand_2's verdict was `{ctl_null_i1: reject, ctl_null_i1r1: accept}` — booking that as
+    # "the gate rejected it" makes events.jsonl assert a judgement no measurement supports.
     gate_verdict = _gate_verdict(run_dir, args.candidate_id)
-    overrode_gate = bool(not accepted and gate_verdict == "accept")
-    if overrode_gate and args.reject_basis == "gate":
+    overrode_gate = bool(args.decision == "reject" and gate_verdict == "accept")
+    if args.reject_basis == "gate" and gate_verdict in ("accept", "inconclusive"):
+        verb = ("ACCEPTED" if gate_verdict == "accept"
+                else "could not resolve (verdict: inconclusive)")
+        fix = ("pass --reject-basis driver_judgement and say in --note why you are overriding "
+               "the gate — e.g. a task you care about regressed"
+               if gate_verdict == "accept" else
+               "book it as --decision inconclusive (charges the iteration, not the stall) and "
+               "re-measure under a FRESH tag; or, if you are choosing to drop the edit anyway, "
+               "pass --reject-basis driver_judgement and say so in --note")
         print(json.dumps({
-            "error": f"--reject-basis gate, but the gate ACCEPTED {args.candidate_id} "
+            "error": f"--reject-basis gate, but the gate {verb} {args.candidate_id} "
                      "(see its row in work/round_*.json)",
-            "fix": "pass --reject-basis driver_judgement and say in --note why you are "
-                   "overriding the gate — e.g. the verdict was unstable across control "
-                   "replicates, or a task you care about regressed",
+            "gate_verdict": gate_verdict,
+            "fix": fix,
         }, indent=2))
         return 2
 
@@ -255,14 +321,48 @@ def main(argv=None) -> int:
     # dashboard's ``gate_decisions[]`` does not have to regex them back out of an agent's
     # prose — read from round.py's persisted table, and simply absent when it wrote none.
     gate = _round_gate_numbers(run_dir, args.candidate_id)
+    parent_val = gate.pop("parent_val", None)
+    # Did the agent write the INTENT half of its handover? ``_reconcile_journal`` (inside
+    # record_iteration) folds ``<workdir>/JOURNAL.md`` into the run-level journal and silently
+    # substitutes "(no handover written by the optimizer)" when there is none — which is what
+    # every round of runs 32971129203 and 33046360451 recorded, because nothing asked the agent
+    # for one. Read it BEFORE booking, and report the answer so a forgotten handover is
+    # correctable while rounds remain rather than discovered when the run is over.
+    handover = bool(harness._journal_tail(src).strip())
+    reason = args.note or args.decision
+    if indecisive:
+        reason = f"indecisive (gate): {reason}"
     harness.record_iteration(run_dir, src, args.candidate_id, parent_id=parent_id,
-                             accepted=accepted, reason=args.note or args.decision,
+                             accepted=accepted, reason=reason,
                              val=args.val,
-                             parent_val=gate.pop("parent_val", None),
+                             parent_val=parent_val,
+                             indecisive=indecisive,
                              opt_cost_usd=args.optimizer_usd or None,
                              opt_tokens=args.optimizer_tokens or None,
                              optimizer_seconds=args.optimizer_seconds or None,
                              **gate)
+    if indecisive:
+        # The event the dashboard/TUI already read to render a step as `indecisive` rather than
+        # rejected (``dashboard`` keys its status, badge and banner off this exact kind), and the
+        # only thing that distinguishes an unresolved round from a refuted one downstream.
+        run_dir.log_event("step_indecisive", candidate=args.candidate_id, reason=reason,
+                          val=args.val, gate_verdict=gate_verdict)
+    else:
+        # Deliberately NOT for an unresolved round: ``rejected.jsonl`` is fed back as "these
+        # edits did not work", and an edit the measurement could not judge says nothing of the
+        # kind — filing it there teaches the next round to avoid a change never evaluated. Same
+        # reasoning as the deterministic hill-climb's own indecisive branch.
+        _record_memory(run_dir, args.candidate_id, accepted=accepted,
+                       reason=reason, val=args.val, parent_val=parent_val)
+    warnings: list[str] = []
+    if not handover:
+        warnings.append(
+            "no handover recorded for this round: the run-level JOURNAL.md now reads "
+            "'(no handover written by the optimizer)' for "
+            f"{args.candidate_id}, so the next round can see WHICH tasks moved but not what you "
+            "tried or why. Before the next commit.py, write your entry to "
+            "<from-dir>/JOURNAL.md as a '## Iteration <candidate> — <headline>' block (changes "
+            "made, expected effect, hypotheses prior RESULT lines already refuted, focus next).")
     spent = run_dir.spent
     run_dir.record_spend_warnings()
     stop, reason = run_dir.budget_exhausted()
@@ -270,6 +370,8 @@ def main(argv=None) -> int:
                       "reject_basis": args.reject_basis,
                       "gate_verdict": gate_verdict,
                       "overrode_gate": overrode_gate,
+                      "handover_recorded": handover,
+                      "warnings": warnings,
                       "best_id": run_dir.best_id, "spent": spent.to_dict(),
                       "stop": stop, "stop_reason": reason}, indent=2))
     return 0

--- a/skills/algorithms/agent-optimize/scripts/commit.py
+++ b/skills/algorithms/agent-optimize/scripts/commit.py
@@ -35,6 +35,69 @@ import _bootstrap  # noqa: F401  # side-effect import, see above
 from cap_evolve import RunDir, harness
 
 
+def _round_gate_numbers(run_dir: RunDir, candidate_id: str) -> dict:
+    """The gate's NUMBERS for ``candidate_id``, read back from ``round.py``'s own table.
+
+    ``dashboard.reduce_run`` builds the published ``gate_decisions[]`` (read by the dashboard,
+    the TUI and CI's live snapshot) by regex-parsing the deterministic gate's reason string
+    (``Δ̄ = …, SE=…, n=…, k·SE=…``). An agent writes free prose, so nothing matched and every
+    numeric column came back null — on run 32971129203 the deltas and thresholds existed only
+    inside sentences like "delta +0.033 within control noise 0.044". This function is why that
+    is now avoidable: ``round.py`` persists the whole gate table to ``$R/work/round_i<N>.json``,
+    so the numbers are on disk, structured, already.
+
+    ``N`` is ``spent.iterations`` at gate time, and ``record_iteration`` has not charged this
+    round yet — so the current count still names this round's table. A same-iteration re-gate
+    gets a ``.r<k>`` suffix rather than overwriting; the highest suffix is the operative one,
+    because a re-gate is run to supersede the first.
+
+    Returns {} when there is no table (``gate_check``-only rounds never write one, and
+    ``round.py``'s write is best-effort) — a missing measurement must stay missing, never
+    become a fabricated 0.
+    """
+    work = run_dir.root / "work"
+    stem = f"round_i{int(run_dir.spent.iterations)}"
+    # Numeric, not lexical: a plain string sort ranks `.r10` below `.r2`, so the tenth re-gate
+    # would lose to the second. Re-gates are rare but a wrong one here is silently wrong.
+    def _suffix(p: Path) -> int:
+        tail = p.name[len(stem):].removesuffix(".json")
+        return int(tail[2:]) if tail.startswith(".r") and tail[2:].isdigit() else 0
+    tables = sorted(work.glob(f"{stem}.json")) + sorted(work.glob(f"{stem}.r*.json"),
+                                                        key=_suffix)
+    if not tables:
+        return {}
+    try:
+        table = json.loads(tables[-1].read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    entry = next((c for c in (table.get("candidates") or [])
+                  if c.get("tag") == candidate_id), None)
+    if entry is None:
+        return {}
+    parent = table.get("parent") or {}
+    out = {
+        "parent_val": parent.get("reward"),
+        "gate_stderr": parent.get("stderr"),
+        "gate_n": parent.get("n_tasks"),
+        "gate_delta": entry.get("gate_delta"),
+        "gate_threshold": entry.get("gate_threshold"),
+        "gate_mode": (table.get("gated_against") or {}).get("mode"),
+        "gate_table": tables[-1].name,
+    }
+    # The drift-free second opinion, when the round measured one. On run 32971129203 this is
+    # the whole finding: cand_1 was rejected against the parent's STORED reward (Δ 0.0333 vs
+    # threshold 0.0440) while the control-relative comparison ACCEPTED it (Δ 0.0556 vs 0.0341).
+    # Recording only the booked verdict hides that the decision was reference-dependent.
+    ctl = entry.get("control_relative") or {}
+    if ctl:
+        out["control_relative_verdict"] = ctl.get("verdict")
+        out["control_relative_delta"] = ctl.get("gate_delta")
+    bar = (table.get("evidence_bar") or {}).get("value")
+    if bar is not None:
+        out["evidence_bar"] = bar
+    return {k: v for k, v in out.items() if v is not None}
+
+
 def _prior_decision(run_dir: RunDir, candidate_id: str) -> dict | None:
     """The first accept/reject event already recorded for ``candidate_id``, if any.
 
@@ -188,14 +251,18 @@ def main(argv=None) -> int:
                          optimizer_tokens=args.optimizer_tokens,
                          optimizer_seconds=args.optimizer_seconds)
     # The shared iteration step: charges iterations/stall, writes the canonical ``step``
-    # record, reconciles the run-level JOURNAL.md. ``parent_val`` is unknown in agent mode
-    # (the agent gates via gate_check, which prints but does not persist the parent mean),
-    # so it stays None rather than being guessed.
+    # record, reconciles the run-level JOURNAL.md. The gate's numbers ride along so the
+    # dashboard's ``gate_decisions[]`` does not have to regex them back out of an agent's
+    # prose — read from round.py's persisted table, and simply absent when it wrote none.
+    gate = _round_gate_numbers(run_dir, args.candidate_id)
     harness.record_iteration(run_dir, src, args.candidate_id, parent_id=parent_id,
                              accepted=accepted, reason=args.note or args.decision,
                              val=args.val,
+                             parent_val=gate.pop("parent_val", None),
                              opt_cost_usd=args.optimizer_usd or None,
-                             opt_tokens=args.optimizer_tokens or None)
+                             opt_tokens=args.optimizer_tokens or None,
+                             optimizer_seconds=args.optimizer_seconds or None,
+                             **gate)
     spent = run_dir.spent
     run_dir.record_spend_warnings()
     stop, reason = run_dir.budget_exhausted()

--- a/skills/algorithms/agent-optimize/scripts/host.py
+++ b/skills/algorithms/agent-optimize/scripts/host.py
@@ -664,6 +664,29 @@ def _stage_context(*, run_dir: Path, project: Path, workdir: Path, spec: dict,
                      "error": f"{type(exc).__name__}: {exc}"[:400]}
 
 
+def optimizer_spend_to_book(metered: dict, before: dict, now: dict) -> dict:
+    """The share of THIS agent process's metered spend that is not already in the run's state.
+
+    The host meters the whole agent process; the agent books its own proposal cost per round
+    through ``commit.py --optimizer-usd/--optimizer-tokens/--optimizer-seconds``, which the skill
+    asks it to do. Those are the SAME money — a round's proposal happens inside this process — so
+    booking the metered total on top of them reports up to twice the optimizer spend actually
+    used, and a run's `max_usd`/cost-based stop condition then fires against a number no one
+    spent. Book the residual instead.
+
+    ``before``/``now`` bracket THIS invocation: a ``--resume`` run carries an earlier host's
+    optimizer spend in the same counter, and that is not this agent's attribution to net out.
+    Each role is netted independently, and never below zero — an agent that over-attributes
+    (guessing its own cost high) must not subtract from another role or from the run total.
+    """
+    out = {}
+    for key in ("usd", "tokens", "seconds"):
+        booked_by_agent = max(0, (now.get(key) or 0) - (before.get(key) or 0))
+        out[key] = max(0, (metered.get(key) or 0) - booked_by_agent)
+    return {"usd": float(out["usd"]), "tokens": int(out["tokens"]),
+            "seconds": float(out["seconds"])}
+
+
 def _child_env() -> dict:
     env = dict(os.environ)
     env.setdefault("CAPEVOLVE_SKILLS_DIR", str(SKILLS))
@@ -846,6 +869,24 @@ def main(argv=None) -> int:
     if args.usd_budget:
         cmd += ["--usd-budget", str(float(args.usd_budget))]
 
+    # What the run had already booked as optimizer spend BEFORE this agent started. The agent
+    # books its own proposal cost per round through commit.py --optimizer-usd (the skill asks it
+    # to), and that is the SAME money this subprocess meters — so the host must book the
+    # RESIDUAL, not the total, or a compliant agent makes the run report roughly twice the
+    # optimizer spend it actually used. Snapshotted rather than read at the end because a
+    # `--resume` run carries a PREVIOUS host invocation's spend in the same counter, and that is
+    # not this agent's attribution to net out.
+    booked_before = {"usd": 0.0, "tokens": 0, "seconds": 0.0}
+    try:
+        from cap_evolve import RunDir as _RunDir
+
+        _sp = _RunDir.open(run_dir).spent
+        booked_before = {"usd": float(_sp.optimizer_usd or 0.0),
+                         "tokens": int(_sp.optimizer_tokens or 0),
+                         "seconds": float(_sp.optimizer_seconds or 0.0)}
+    except Exception:  # noqa: BLE001 — a missing snapshot must not stop the run
+        pass
+
     started = time.time()
     try:
         proc = subprocess.run(cmd, capture_output=True, text=True, timeout=args.timeout,
@@ -894,8 +935,19 @@ def main(argv=None) -> int:
                      usd=usd, tokens=tokens, seconds=round(seconds, 3),
                      returncode=(None if proc is None else proc.returncode),
                      timed_out=timed_out, stop_reason=stop_reason, num_turns=num_turns)
-        if usd or tokens:
-            rd.update_spent(optimizer_usd=usd, optimizer_tokens=tokens)
+        # Book only what the agent did not already attribute to a round during THIS invocation.
+        # `seconds` is booked too: without it the run recorded `optimizer_seconds: 0.0` for a
+        # loop that ran for hours, so metrics.py's whole-loop total rendered a dash and every
+        # per-hour cost figure was undefined.
+        now = rd.spent
+        book = optimizer_spend_to_book(
+            {"usd": usd, "tokens": tokens, "seconds": seconds},
+            booked_before,
+            {"usd": float(now.optimizer_usd or 0.0), "tokens": int(now.optimizer_tokens or 0),
+             "seconds": float(now.optimizer_seconds or 0.0)})
+        if book["usd"] or book["tokens"] or book["seconds"]:
+            rd.update_spent(optimizer_usd=book["usd"], optimizer_tokens=book["tokens"],
+                            optimizer_seconds=book["seconds"])
         # The run dir's budget, not the spec's: baseline freezes it there, `--resume` can
         # extend it, and it is what `budget_exhausted()` actually judges against.
         rounds_done = int(rd.spent.iterations or 0)

--- a/skills/algorithms/agent-optimize/scripts/host.py
+++ b/skills/algorithms/agent-optimize/scripts/host.py
@@ -402,12 +402,34 @@ skipped one leaves artifacts that cannot be audited afterwards:
 | --- | --- | --- |
 | `$A/spend.py` | before | affordability + your stop condition as checkable predicates |
 | `$A/gate_check.py` | after the full-val eval | the paired significance gate — the accept decision |
-| `$A/commit.py` | always, accept or reject | books the decision: snapshot, best_id, iteration, event |
+| `$A/commit.py` | always, whatever the outcome | books the decision: snapshot, best_id, iteration, event |
 | `$A/measure.py` | once, at the end | seals test exactly once and prints the honest table |
 
 `commit.py` is the one most easily skipped on a reject, and skipping it is what makes a run
 report zero iterations having done real work. `screen.py` and `round.py` are optional
 accelerators; the four above are not.
+
+`--decision` has THREE values, and the third is not a formality. `accept` = new champion.
+`reject` = the edit was judged and refuted. `inconclusive` = the measurement could not resolve it
+— which is exactly what `round.py` reports as `verdict: inconclusive` (`verdict_stable: false`,
+the verdict flipping depending on which byte-identical control replicate was the reference). Book
+that as `inconclusive`, not as a reject:
+
+- a reject increments the STALL counter, and stall is the signal that means *the optimizer has run
+  out of ideas* — the one thing an ambiguous measurement is no evidence of. Two ambiguous rounds
+  booked as rejects can end your run early for a reason that never happened.
+- a reject files the edit in `rejected.jsonl`, which later rounds read as *this was tried and it
+  did not work*. An edit nothing could judge has not been tried in that sense; filing it there
+  teaches you to avoid your own untested idea.
+- `inconclusive` still charges the iteration (the budget really was spent) and still snapshots the
+  candidate, so nothing is hidden. To resolve it, re-measure under a **fresh tag** — re-running the
+  same tag REPLACES its rollouts rather than adding to them. The control side needs no care: a
+  re-gate of the same iteration measures its own `ctl_null_i<N>a<k>` replicates and pools the
+  earlier attempt's, so `null_delta_between_control_replicates` covers every replicate the round
+  has paid for and the earlier attempt's table stays on disk beside the new one.
+
+`--reject-basis gate` asserts the gate ran AND rejected; `commit.py` refuses it when the gate
+accepted or returned inconclusive, because that field is the run's record of what the evidence was.
 
 ## Your stop condition
 
@@ -421,8 +443,26 @@ its single `recommendation` (`stop` | `narrow_scope` | `continue`), as SKILL.md 
 Your always-on instructions mention `LEDGER.md`, `RUNMAP.md` and `prior_iterations/`. Those are
 built by the *deterministic* loop, which calls one optimizer per iteration; you are driving the
 whole search yourself, so they will not exist here and their absence is not a problem — do not
-go looking for them or try to recreate them. `JOURNAL.md` is different: `commit.py` reconciles
-it as you book rounds, so it accrues your own history and is worth reading from round 2 on.
+go looking for them or try to recreate them.
+
+`JOURNAL.md` is different, and it has TWO halves — one of them is yours to write.
+
+- The FRAMEWORK half: `commit.py` stamps an objective `RESULT` line under each entry (outcome,
+  Δ, and the exact task ids that round broke and fixed). You get that for free.
+- YOUR half, the handover: **before each `commit.py`, append your entry for the round to
+  `<your working dir>/JOURNAL.md`** — the same `--from-dir` you are about to commit — as a
+  block starting `## Iteration <candidate id> — <one-line headline>`, covering: the changes you
+  made (file + cluster each targets), the effect you expected and why it was safe, which prior
+  RESULT lines you built on, hypotheses a prior RESULT has already REFUTED (never re-test one),
+  and your focus next round. Read the accumulated `$R/JOURNAL.md` before writing, so you build
+  on every prior round rather than the last one.
+
+Skipping your half is silent and cheap in the moment and expensive by round 3: the run-level
+journal records "(no handover written by the optimizer)", and your later rounds can then see
+WHICH tasks each edit broke but not WHAT WAS TRIED — so refuted ideas get re-tested with the
+budget that should have gone to new ones. Measured: three-round runs where every entry read that
+way. `commit.py` returns `handover_recorded` and warns when it books an empty one; if you see
+that warning, write the entry before the next round rather than at the end of the run.
 
 ## Unattended — this is the one real difference from an interactive run
 
@@ -487,7 +527,11 @@ def _decided_candidates(run_dir: Path) -> set[str]:
                     ev = json.loads(line)
                 except Exception:  # noqa: BLE001 — a torn line is not a decision
                     continue
-                if ev.get("kind") in ("accept", "reject") and ev.get("candidate"):
+                # ``inconclusive`` is a booking too. Leaving it out would report a round booked
+                # with the honest decision as gated-but-never-booked, i.e. diagnose the run as
+                # defective precisely for not misfiling an unresolvable verdict as a reject.
+                if ev.get("kind") in ("accept", "reject", "inconclusive") and \
+                        ev.get("candidate"):
                     decided.add(str(ev["candidate"]))
     except OSError:
         return decided

--- a/skills/algorithms/agent-optimize/scripts/round.py
+++ b/skills/algorithms/agent-optimize/scripts/round.py
@@ -48,16 +48,109 @@ HERE = Path(__file__).resolve().parent
 SKILLS = Path(os.environ.get("CAPEVOLVE_SKILLS_DIR", HERE.parents[2]))
 
 
+def _table_attempt(name: str, iteration: int) -> int | None:
+    """Attempt index encoded in a round-table filename, or None if it is a different round.
+
+    Matched strictly rather than by glob: ``round_i1*.json`` also matches ``round_i10.json``, so
+    a glob would count iteration 10's tables as re-gates of iteration 1 and shift every name in
+    this round — quietly, and worse the further a run gets.
+    """
+    stem = name.removesuffix(".json")
+    if stem == name:
+        return None
+    tail = stem.removeprefix(f"round_i{iteration}")
+    if tail == stem:
+        return None
+    if tail == "":
+        return 0
+    if tail.startswith(".r") and tail[2:].isdigit():
+        return int(tail[2:])
+    return None
+
+
+def _round_tables(run_dir) -> list[tuple[int, Path]]:
+    """This iteration's tables as (attempt, path), lowest attempt first."""
+    work = run_dir.root / "work"
+    if not work.is_dir():
+        return []
+    it = int(run_dir.spent.iterations)
+    found = []
+    for path in work.iterdir():
+        if not path.is_file():
+            continue
+        att = _table_attempt(path.name, it)
+        if att is not None:
+            found.append((att, path))
+    return sorted(found)
+
+
+def round_attempt(run_dir) -> int:
+    """How many times this iteration has already been gated: 0 for the first attempt.
+
+    A round's identity is (iteration, attempt), and BOTH halves have to reach the names on
+    disk. The table already had the attempt half — a same-iteration re-run is written
+    ``round_i1.r1.json`` rather than overwriting ``round_i1.json`` — but the control ROLLOUTS
+    did not, so the one operation this script explicitly supports re-measured the previous
+    attempt's control under the same tag and deleted the numbers the first table cites.
+    Counting the tables here is what keeps the two halves in agreement.
+    """
+    tables = _round_tables(run_dir)
+    # max+1 rather than len, so a hand-deleted table cannot hand out a name that is still taken.
+    return max((att for att, _ in tables), default=-1) + 1
+
+
+def table_stem(run_dir) -> str:
+    """Filename stem for this attempt's table: ``round_i1``, then ``round_i1.r1``, …"""
+    it = int(run_dir.spent.iterations)
+    a = round_attempt(run_dir)
+    return f"round_i{it}" if a == 0 else f"round_i{it}.r{a}"
+
+
 def control_tag(run_dir) -> str:
-    """Round-scoped control tag, e.g. ``ctl_null_i2``.
+    """Round-scoped control tag, e.g. ``ctl_null_i2`` — and ``ctl_null_i2a1`` on a re-gate.
 
     Rollout files are ``<task>__<tag>__t<k>.json``, so a fixed ``ctl_null`` tag makes each
     round's control OVERWRITE the previous round's on disk — destroying the one measurement
     that proves what zero change looked like at that point in the run. The noise floor is
     evidence, and it is per-round (it moves with the parent and with the provider's mood),
     so it gets its own tag per iteration.
+
+    The same argument applies WITHIN an iteration, which is what the ``a<k>`` suffix is for. A
+    re-gate is normally run to buy MORE evidence about the same round, and without the suffix it
+    bought none: on run 33046360451 the second attempt at iteration 1 re-measured
+    ``ctl_null_i1`` (0.4967 -> 0.5067) and ``ctl_null_i1r1`` (0.4800 -> 0.4367) under those exact
+    tags, spending 200 metric calls to swap two readings for two others. The round's replicate
+    spread went 0.0167 -> 0.0700 and ``round_i1.json`` was left quoting an ``evidence_bar``
+    computed from two numbers that no longer existed. With the suffix the attempts accumulate,
+    ``prior_attempt_controls`` pools them, and the re-gate gets the four samples it paid for.
     """
-    return f"ctl_null_i{int(run_dir.spent.iterations)}"
+    it = int(run_dir.spent.iterations)
+    a = round_attempt(run_dir)
+    return f"ctl_null_i{it}" if a == 0 else f"ctl_null_i{it}a{a}"
+
+
+def prior_attempt_controls(run_dir) -> list[dict]:
+    """Control replicates measured by EARLIER attempts at this same iteration.
+
+    Read from those attempts' tables rather than from rollouts, because the table is the record
+    that survives: a pre-fix run has tables whose rollouts were already overwritten, and the
+    table is then the only place the destroyed reading still exists.
+
+    They are byte-identical copies of the same parent measured in the same round, so they are
+    samples of the same null and belong in it. Pooling them is the entire point of re-gating.
+    """
+    out: list[dict] = []
+    for att, path in _round_tables(run_dir):
+        try:
+            table = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        if not isinstance(table, dict):
+            continue
+        for row in table.get("control_replicates") or []:
+            if isinstance(row, dict) and row.get("reward") is not None:
+                out.append({**row, "from_attempt": att})
+    return out
 
 
 def _evaluate(run_dir: Path, project: Path, tag: str, split: str, n_trials: int,
@@ -179,6 +272,11 @@ def main(argv=None) -> int:
 
     # The null control is built here, not by the driver, so it cannot silently be skipped
     # or accidentally differ from the parent.
+    # Derive the round's identity ONCE: the table name and the control tags are two halves of
+    # it, and independently derived halves can disagree about which attempt this is.
+    ATTEMPT = round_attempt(run_dir)
+    STEM = table_stem(run_dir)
+    PRIOR_CTL = prior_attempt_controls(run_dir)
     CTL = control_tag(run_dir)
     ctl_tags: list[str] = []
     if not args.no_control:
@@ -311,10 +409,16 @@ def main(argv=None) -> int:
     # bytes on the same seeds: whatever separates them is pure re-measurement. Two such
     # replicates differed by 0.0800 paired on this benchmark — enough to pass a k_se=1.0 gate on
     # zero change — so a candidate that does not clear this number has shown nothing.
+    #
+    # Earlier attempts at THIS iteration are pooled in. They are the same parent bytes on the
+    # same seeds in the same round, so they are samples of the same null, and a re-gate is run
+    # precisely to buy more of them: reporting only this attempt's two would discard half the
+    # evidence the round has already paid for. `max - min` needs no change to accept them.
     ctl_rows = [r for r in rows if r["tag"] in ctl_tags and r.get("reward") is not None]
+    pooled_rows = [{**r, "from_attempt": ATTEMPT} for r in ctl_rows] + PRIOR_CTL
     null_delta = None
-    if len(ctl_rows) > 1:
-        rewards = [r["reward"] for r in ctl_rows]
+    if len(pooled_rows) > 1:
+        rewards = [r["reward"] for r in pooled_rows]
         null_delta = round(max(rewards) - min(rewards), 4)
     conc_warning = None
     if args.concurrency and args.concurrency > 12:
@@ -325,6 +429,18 @@ def main(argv=None) -> int:
             "smaller than roughly 0.08. Re-run the gate at --concurrency 8 before believing an "
             "accept.")
     out = {
+        # Which gate of this iteration this is. On the live run nothing in the output
+        # distinguished "second opinion on iteration 1" from "iteration 1", so an operator
+        # watching the stream saw two identical control evaluations and no statement that the
+        # second had replaced the first.
+        "attempt": ATTEMPT,
+        "attempt_reading": (
+            f"RE-GATE: attempt {ATTEMPT} at iteration {int(run_dir.spent.iterations)}. Its "
+            f"{len(PRIOR_CTL)} earlier control replicate(s) are pooled into `null_delta_...` "
+            "below, so the bar here rests on every replicate this round has paid for. This "
+            "attempt's candidate rollouts are written under fresh tags; the earlier attempt's "
+            "table is still on disk beside this one."
+            if ATTEMPT else "first gate of this iteration"),
         "parent": {"tag": best, "reward": parent_res.reward, "stderr": parent_res.stderr,
                    "n_tasks": len(parent_res.per_task or [])},
         # What the deltas and thresholds in `candidates` are actually measured against.
@@ -345,9 +461,12 @@ def main(argv=None) -> int:
         "measurement_concurrency": args.concurrency,
         "concurrency_warning": conc_warning,
         "null_delta_between_control_replicates": null_delta,
+        "null_delta_replicates": len(pooled_rows),
         "null_delta_reading": (
             "identical bytes on identical seeds, so this is pure re-measurement noise. Any "
             "candidate delta at or below it is NOT evidence, whatever its verdict says."
+            + (f" Pooled over {len(pooled_rows)} replicates of this iteration, "
+               f"{len(PRIOR_CTL)} of them from earlier attempts." if PRIOR_CTL else "")
             if null_delta is not None else
             "only one control replicate — run with --control-replicates 2 to measure the bar "
             "instead of assuming a formula gives it"),
@@ -386,10 +505,26 @@ def main(argv=None) -> int:
             "A candidate marked `verdict_stable: false` has an UNSTABLE verdict and is "
             "INCONCLUSIVE, never accepted: its "
             "verdict changed depending on which byte-identical control replicate happened to be "
-            "the reference, so the round cannot tell its edit from re-measurement. Re-run it "
-            "with more trials before believing either answer. "
-            "Judge every candidate's delta against `evidence_bar`, not against any other number "
-            "here. `noise_floor_from_control` is the gap between a byte-identical control "
+            "the reference, so the round cannot tell its edit from re-measurement. Book it as "
+            "`commit.py --decision inconclusive` — that charges the iteration but NOT the stall "
+            "counter, because a measurement that could not resolve is no evidence you have run "
+            "out of ideas, and it keeps the edit out of `rejected.jsonl` so a later round is not "
+            "taught to avoid a change nothing ever judged. To resolve it, re-measure under a "
+            "FRESH tag (e.g. `cand_2b`) or ask for the higher `--trials` in ONE evaluation: "
+            "rollouts are written `<task>__<tag>__t{k}.json` for k in range(n_trials), so "
+            "re-running the SAME tag REPLACES t0..t9 rather than adding t10..t19 — it swaps a "
+            "reading for another reading and buys no extra evidence. That applies to the "
+            "CANDIDATE tags you pass; the control side is handled for you — a re-gate of the "
+            "same iteration gets its own `ctl_null_i<N>a<k>` replicates and POOLS the earlier "
+            "attempt's into `null_delta_between_control_replicates`, so re-running this script "
+            "adds control evidence instead of replacing it. Do not re-use a candidate tag to "
+            "get that; there is no pooling for candidates. "
+            "Judge every candidate's delta against `evidence_bar` rather than any other noise "
+            "number here — but clearing it is NECESSARY, not sufficient: `gate_threshold` "
+            "(k·SE on the paired per-task differences) is what each `verdict` is actually "
+            "computed from and is usually the stricter of the two, so a delta above "
+            "`evidence_bar` and below `gate_threshold` is not an accept. "
+            "`noise_floor_from_control` is the gap between a byte-identical control "
             "measured now and the parent's STORED reward: that is re-measurement DRIFT, and it "
             "bounds how far the ABSOLUTE rewards in this table can be trusted — it is not a bar "
             "a candidate gated against a concurrent control has to clear, because that "
@@ -407,8 +542,14 @@ def main(argv=None) -> int:
         "candidates": sorted((r for r in rows if r["tag"] not in ctl_tags),
                              key=lambda r: (r["reward"] is None, -(r["reward"] or 0.0))),
         "control": ctl,
+        # `control_replicates` stays THIS attempt's own measurements — that is what a later
+        # attempt reads back to pool, and storing the pooled set here would make attempt 2
+        # count attempt 0's replicates twice. The pooled view is reported separately.
         "control_replicates": ctl_rows,
-        "next": "read regressions, then commit.py --decision accept|reject per candidate",
+        "pooled_control_replicates": pooled_rows if PRIOR_CTL else None,
+        "next": ("read regressions, then commit.py --decision accept|reject|inconclusive per "
+                 "candidate — `inconclusive` for any row whose `verdict` is inconclusive, so the "
+                 "round is not recorded as refuting an edit it could not judge"),
     }
     # Persist the table as well as printing it. Until now the ONLY copy lived on stdout, so
     # whether a round's verdict survived depended on the driver remembering to redirect —
@@ -420,14 +561,18 @@ def main(argv=None) -> int:
     # would let each round destroy the previous round's table. A same-iteration re-run gets a
     # suffix rather than overwriting, since a re-gate is usually being COMPARED with the
     # first one.
+    #
+    # The name comes from the SAME attempt index the control tags were built from, rather than
+    # from a second, independent probe of the directory. When the two derivations disagreed the
+    # table survived and the rollouts it cites did not, which is the whole defect this attempt
+    # index exists to close.
     try:
         work.mkdir(parents=True, exist_ok=True)
-        stem = f"round_i{int(run_dir.spent.iterations)}"
-        table = work / f"{stem}.json"
-        n = 1
-        while table.exists():
-            table = work / f"{stem}.r{n}.json"
+        table = work / f"{STEM}.json"
+        n = ATTEMPT
+        while table.exists():  # belt-and-braces: never overwrite a sibling attempt's table
             n += 1
+            table = work / f"round_i{int(run_dir.spent.iterations)}.r{n}.json"
         table.write_text(json.dumps(out, indent=2), encoding="utf-8")
         out["table_path"] = str(table)
     except OSError as exc:  # noqa: BLE001 — the printed table is still the primary output


### PR DESCRIPTION
Closes #406.

Three defects measured on smoke spreadsheetbench run [32971129203](https://github.com/skillberry-ai/cap-evolve/actions/runs/32971129203) — the first `agent-optimize` run after #399. Each is data the run had already computed and then failed to use, or failed to report. Every claim below is tied to that run's artifact rather than to a hypothesis.

**7 files, +612/−11.** Related to #401 (agent-optimize statistical rigour) but disjoint from it; this does not close it.

## 1. The gate compared against a drifted reference

`run_suite.sh`'s agent-mode `STOP_CONDITION` named the gate's *strictness* (`gate_k_se`, trials) and never its *reference*, so the agent took `round.py`'s `--gate-against parent` default. That compares against the parent's reward as measured in an **earlier** round, so that reward's drift since then sits inside every candidate delta.

The run's own `work/round_i0.json` recorded both comparisons for `cand_1`:

| reference | delta | threshold | verdict |
|---|---|---|---|
| parent (the default) | 0.0333 | 0.0440 | reject |
| control (byte-identical replicate, same round) | 0.0556 | 0.0341 | **accept** |

0.0556 also cleared that round's own `evidence_bar` of 0.0444, so it was real evidence, not noise. Rounds i1/i2 rejected under **both** modes — genuine negatives. **Exactly one candidate in the run mattered and the default reference discarded it**, after which the run published `best=seed` as a null result on the strength of a comparison its own round table described as drift-carrying.

The `STOP_CONDITION` now requires `--gate-against control` and states why. #399 named this as a follow-up on tau2 evidence alone and deliberately declined to change the default on one benchmark's evidence; this is a second benchmark, and the change is scoped to the CI stop_condition rather than to `round.py`'s default, so no non-CI caller's behaviour moves.

## 2. A run that accepted nothing advertised an improvement

`metrics.py` published this for a capability it never edited:

> **Suite (train-fit):** mean reward 0.500 → 0.544 (Δ **+0.044 (+9% rel)**) · best = seed (no candidate beat baseline)

On a no-holdout tier it pairs `baseline.json` (val) against `final.json` (test), and with `best_id == "seed"` those score the **same bytes** — so +0.044 was re-measurement noise, exactly the replicate noise `round.py` had measured that run at. Per-task rows said the same (`47484` +0.333, `53161` −0.333). The `best = seed (no candidate beat baseline)` parenthetical was the only contradicting signal in the document, and it loses to the headline number.

This reached published history too, via `metrics.jsonl` → `record.rollup` → the benchmarks page, and it is **not agent-optimize-specific**: any run of any algorithm that accepts nothing hit it. It surfaced now only because this was the first run to reject everything.

A null run now pairs the baseline against itself, so `Δ` is `0.000` and no phantom per-task delta reaches `metrics.jsonl`. The discarded measurement is **not** thrown away — it is reported as what it is:

> No candidate was accepted, so base→opt is the seed against itself and Δ is 0.000 by construction. Re-scoring those same bytes for the finalize read 0.544 against the baseline's 0.500 — a spread of 0.044. That is this tier's re-measurement **noise**, not a change in the capability, and it is the floor any real effect here would have to clear.

Two evals of one unchanged capability are a free read on the tier's noise floor, and a reader needs it to judge whether the run could resolve a real effect at all.

## 3. Rounds measured their gate and their cost, then published neither

- **The report contradicted itself in one document**: headline `optimizer $7.95`, Totals `optimizer $0.0000 over 0s`. Agent mode runs ONE optimizer process for the whole loop, so there is no per-round figure to sum. Totals now falls back to the run-level spend the headline already uses and labels it `whole-loop`, rather than implying per-round attribution.
- **Every iterate row showed `eval $ —`** though each candidate's `evaluate` event carried the cost (`$0.456` / `629.84s` for `cand_1` alone). `iteration_rows` now falls back to that event when the `step` event has no figures. The deterministic path *does* put them on the step, and keeps winning.
- **The published `gate_decisions[]` had `parent_val`/`delta`/`stderr`/`n`/`threshold` all null.** `dashboard.reduce_run` regexes them out of the deterministic gate's reason string; an agent writes prose, so nothing matched. `commit.py`'s comment blamed `gate_check` for not persisting the parent mean — untrue since #399, which made `round.py` persist the whole table to `work/round_i<N>.json`. `commit.py` now reads it, including `gate_mode` and the **drift-free second opinion**, without which a reader cannot tell that a rejection was reference-dependent. That is the finding in item 1, and it was recoverable only by hand-reading a file the published record never pointed at.

## Design decisions

- **No number is fabricated.** A missing round table yields `{}` and the fields stay absent (`test_a_round_with_no_table_still_books_cleanly` asserts `parent_val is None` rather than `0`). `k_se` is genuinely not in the round table, so it stays null instead of being back-derived from the threshold.
- **The deterministic path is untouched in behaviour.** It records no structured gate fields, so `gate_decisions` still takes the regex path; its per-step optimizer cost is still summed (`test_per_step_optimizer_cost_is_still_summed_when_it_exists`); its step-level eval figures still win over the new fallback.
- **Item 1 is fixed in the CI stop_condition, not in `round.py`'s default.** Changing a shared default on one more benchmark's evidence would be the same over-reach #399 declined.
- `commit.py` sorts re-gate suffixes **numerically** — a lexical sort ranks `.r10` below `.r2`, so the tenth re-gate would silently lose to the second.

## Testing

**1057 passed, 2 skipped, 1 failed.** The failure (`test_cli_surface.py::test_spec_defaults_relative_to_project_not_the_cwd`, a `run-optimizer` manifest lookup) reproduces identically with this branch's changes stashed on clean `origin/main` — pre-existing and unrelated, and independently verified here rather than taken from #399's note.

14 new tests across 3 files, each pinning a measured symptom. Every one was watched failing first; the two most load-bearing:

- The re-gate ordering test was confirmed to fail against a lexical sort before the numeric sort was kept.
- `test_a_null_run_publishes_a_zero_per_task_delta` failed with the real `Δ +0.167 (+33% rel)` in its output.

`skills/algorithms/agent-optimize/scripts/check.py` → `ok: true`, 0 problems, 78 executed assertions. Skill authoring lint clean. `actionlint` clean. `bash -n` on `run_suite.sh` clean. Pyright on `dashboard.py` reports the **same 5 pre-existing errors before and after** (verified by stashing; only line numbers shift).

### End-to-end on the real artifact

Run 32971129203's actual `baseline.json` / `final.json` / `state.json` / `events.jsonl` / `work/round_i*.json` were reconstructed from its uploaded artifact and re-rendered through this branch:

| symptom | before | after |
|---|---|---|
| suite headline | `0.500 → 0.544 (Δ +0.044 (+9% rel))` | `0.500 → 0.500 (Δ +0.000)` + noise note naming 0.544 / spread 0.044 |
| phantom per-task moves | `47484` +0.333, `53161` −0.333 | all `+0.000` |
| iterate eval cost | `—` on all 3 rounds | `$0.4560` / `$0.5323` / `$0.3069` |
| Totals vs headline | `$0.0000 over 0s` vs `$7.95` | `$7.9524 over 40m00s (whole-loop …)` |
| eval totals | `$0.5872 over 22m20s` | `$1.8824 over 70m05s` (the three candidate evals were missing) |

## Reviewer notes

- **Blast radius.** `run_suite.sh`'s change is inside the `agent-optimize)` case arm only. `commit.py` has no callers outside the agent-optimize skill. `metrics.py`'s two changes are both guarded (`best_id == seed`; per-step cost absent). `dashboard.py` copies fields only when present, so a deterministic step's node and gate row are unchanged.
- **CI-validated (see the second round below).** Originally filed as unit-tested + artifact-replayed only. The re-dispatch called for here has since run — spreadsheetbench smoke, `agent-optimize`, `trials=10` — and is written up below, along with the seven further defects it found.
- **Why `trials=10` for the re-run.** This run's per-eval SE was ~0.14 and its replicate noise 0.044, while the largest real effect measured was 0.056 — at 3 trials the tier sits below its own resolution, so a null there is uninterpretable either way. The reference deterministic run's "win" (+0.078) was itself measured against a baseline that had drifted 0.069.


---

# Second round: seven more defects, found by the validation this PR asked for

The re-run this PR called for was dispatched: smoke spreadsheetbench under `agent-optimize` at `trials=10`, run [33046360451](https://github.com/skillberry-ai/cap-evolve/actions/runs/33046360451). It sealed as an **honest null** — `reward_base 0.51 → reward_opt 0.51`, `reward_delta 0.0` on all 10 tasks — which is item 2 above working as intended: the same run on `main` would have published a several-percent "gain" for a capability it never changed.

Driving a real agent through a real loop then exposed seven further defects. All seven are generic; four live in `core/` and affect **every** algorithm, not just agent mode. **+1782/−62 across 16 files** on top of the original commit, in three commits.

> **On item 1 above.** This run does not settle whether `--gate-against control` was the right call — no candidate cleared the bar under either reference. What it does show is that the control gate is not a rubber stamp.

## 4. An unresolvable verdict had to be booked as a rejection

`round.py` marks a candidate `inconclusive` when its verdict is not stable across the round's byte-identical control replicates (`verdict_stable: false`): it accepts against one replicate and rejects against the other, so the round cannot separate the edit from re-measurement. Its own `reading` says such a candidate is "never accepted … Re-run it with more trials before believing either answer."

That is a **third** outcome, and the loop had nowhere to write it. `commit.py --decision` accepted only `accept|reject`, so an agent's options were to book a reject — asserting the gate refuted an edit it had not — or to book nothing, which `host._unbooked_rounds` correctly diagnoses as a defective run.

Live, from `work/round_i1.json`:

```
cand_2  Δ +0.0433  threshold 0.0492  verdict inconclusive  verdict_stable false
        verdict_by_reference: {ctl_null_i1: reject, ctl_null_i1r1: accept}
```

Booking that as a reject is not cosmetic misfiling:

- **`update_spent(accepted=False)` increments the STALL counter**, and `budget_exhausted()` stops the run when stall hits its cap (3 here, already at 1). Stall means *the optimizer has run out of ideas* — the one thing an ambiguous measurement is no evidence of. Two ambiguous rounds can therefore end a run for a reason that never happened, on a benchmark whose replicate noise makes ambiguity the common case.
- **It files the edit in `rejected.jsonl`**, which later rounds read as *tried, did not work* — teaching the run to avoid its own never-evaluated idea.
- **It stamps the journal's `RESULT` line as a rejection**, telling the next iteration its batch was reverted for cause.

`--decision inconclusive` now exists. `harness.record_iteration` has supported exactly this since #216/#224 — `indecisive=True` charges the iteration and leaves stall alone — and the deterministic hill-climb already uses it; agent mode simply could not reach it. The round is still snapshotted and still charged, a `step_indecisive` event is filed instead of a rejection in memory, and the `RESULT` line reads `UNRESOLVED (not judged; champion unchanged)` with re-measure guidance. `--reject-basis gate` is now also refused when the gate returned `inconclusive`, for the same reason it was already refused when the gate said accept: that field is the run's record of what the evidence was.

The dashboard needed no change — it already renders `indecisive` as a first-class status (`indecisive_ids`, the `b-indecisive` badge). That the display half was complete and only the booking path missing is itself the shape of the bug.

## 5. A re-gate destroyed the evidence it was run to add

A round's identity is `(iteration, attempt)`, and both halves have to reach the names on disk. The **table** had the attempt half — a re-gate writes `round_i1.r1.json` rather than overwriting `round_i1.json`. The control **rollouts** did not: they were tagged `ctl_null_i<N>` regardless of attempt. Rollouts are persisted as `<task>__<tag>__t{k}.json`, so the one operation `round.py` explicitly supports re-measured the previous attempt's control under the same tags and deleted the numbers the first table cites.

Measured at iteration 1 of the live run:

| | attempt 0 | after the re-gate |
|---|---|---|
| `ctl_null_i1` | 0.4967 | 0.5067 |
| `ctl_null_i1r1` | 0.4800 | 0.4367 |
| `null_delta_between_control_replicates` | 0.0167 | **0.0700** |

200 metric calls bought a *worse* null estimate than the 100 before them, because the re-gate swapped two readings for two others instead of pooling four — and `round_i1.json` was left quoting an `evidence_bar` computed from numbers that no longer existed. A 0.07 bar then exceeded the effect under test, so the round could not resolve: item 4's inconclusive verdict, manufactured by item 5.

Control tags now carry the attempt (`ctl_null_i<N>a<k>`), and `prior_attempt_controls` pools earlier attempts' replicates into the null with a `from_attempt` marker, so `null_delta_...` covers every replicate the round has paid for. Pooling reads from the earlier **tables** rather than their rollouts, deliberately: on a pre-fix run the rollouts are already gone and the table is the only place the destroyed reading survives. `round_attempt(run_dir)` is called **once** and both the table stem and the control tag derive from it, because two independently derived halves can disagree about which attempt this is; it returns `max(attempt)+1` rather than `len(tables)` so a hand-deleted table cannot hand out a name that is still taken.

**Known limitation, flagged not smuggled.** The two attempts' *candidate* measurements still cannot be combined: the fresh-tag rule guarantees they have different tags, and pooling them would need an explicit "this tag re-measures that one" declaration. That is a design change, not a bug fix.

## 6. Re-measuring a tag silently replaced its rollouts

The general form of item 5, in `core`, and the reason the agent walked into it. `evaluate_candidate` writes `t0..t{n_trials-1}`, so a second evaluation under an existing tag **replaces** those trials rather than adding `t10..t19`. There is no trial accumulation. That is a defensible implementation choice; the defect is that it happened silently, in a loop whose own guidance asks for the opposite — `round.py` told the agent to "re-run it with more trials", the agent did exactly that under the existing tag, and 100 metric calls swapped the 0.4967 control reading for 0.5067 rather than adding a third sample. In the event stream that is indistinguishable from progress.

A **warning, not a refusal**: re-evaluating an existing tag is legitimate on `--resume`, where a run reads its champion's val score back off disk, and the harness must not break that. `evaluate_candidate` now logs `rollout_overwrite_warning` with the trial count being replaced and — computed *before* the overwrite — `prior_reward`, because once the files are gone the destroyed reading exists nowhere else.

## 7. The loop accumulated no learning across its rounds

Two independent holes, both about the loop's memory of *itself* — the thing that is supposed to make round 3 better than round 1. Observed on this run and on 32971129203 before it.

**Optimizer memory was empty.** `rejected.jsonl` / `history.jsonl` back the dashboard's Memory panel and any optimizer prompt that greps for already-refuted approaches. Every deterministic algorithm writes them inline — hill-climb, `gepa` (including its merge paths) and `skillopt` all call `.add` themselves. Agent mode books through `commit.py`, which never did, so the run published `{"history": [], "rejected": []}`: a whole run of rejected approaches that the run itself could not enumerate. `commit.py` now files them (and deliberately does **not** file an `inconclusive` round, per item 4). It is *not* hoisted into `record_iteration` alongside the other three per-iteration records even though that is where it belongs by that function's own argument, because `gepa._try_merge` files a rejection without routing through it and centralising would silently drop that — recorded in the code as fixable, but not safely in the same change.

**Every round's handover read "(no handover written by the optimizer)".** `JOURNAL.md` has two halves: the framework stamps the objective `RESULT` line, the optimizer appends the INTENT above it. Nothing ever asked the agent for its half — `host.py` said only that `commit.py` "reconciles it as you book rounds", which is true of the framework half and false of the half the agent owns. So from round 2 the agent could read *which* task it broke but never *what it had tried*, and the journal's own standing instruction ("never re-test a refuted idea") was unfollowable. The host prompt now asks for the entry explicitly, before each `commit.py`, in the shape `_journal_tail` reads; `commit.py` reads it **before** booking and returns `handover_recorded` plus a warning, so a forgotten handover is correctable while rounds remain rather than discovered when the run is over.

And a latent `core` bug underneath, which would have swallowed the entry even once written: `_journal_tail`'s no-marker fallback searched for `"\n## "`, so a **heading at offset 0 was missed**. An agent-mode optimizer is not handed a seeded journal to append to — it writes a fresh file that starts with its heading. Now anchored per-line (`(?m)^## `).

## 8. A reject that broke nothing was told to redesign the edits that broke something

The `RESULT` line stamped under every journal entry exists to tell the next iteration what to do differently. For a reject it said, unconditionally: *"its WHOLE batch was reverted; re-introduce only the edits that did NOT break a task above, dropping/redesigning the ones that did."*

Read against the line it was actually stamped on:

```
REJECTED (champion unchanged) · val=0.553 Δ=+0.043 · fixed={47484, 53161} · broke={—}
```

The batch fixed two tasks, broke none, and gained +0.043 — rejected only because that did not clear a 0.048 threshold. So the one sentence meant to say what to do next said nothing actionable, while "redesign the ones that did" invited a rewrite of edits just measured **helping**. That is how a run talks itself out of its own best lever.

The stamp now branches three ways: a reject **with** regressions keeps the original guidance; a reject with **none** says the lever is measurement power or a bigger effect, not a redesign, and to keep the `fixed` edits as the starting point; and a reject where no per-task comparison was possible (`_candidate_task_impact` returns `None` when either side has no rollouts) says `fixed`/`broke` are **UNKNOWN** rather than empty — because `broke={—}` meaning "nothing broke" and `broke={—}` meaning "we could not tell" are different instructions, and printing the second as the first invents a fact. **Not agent-mode specific:** every algorithm's below-threshold reject reaches this stamp through `record_iteration`.

## 9. The published cost was a quarter of what the run spent

A run's published cost is a sum over per-phase rows (baseline, each committed round, finalize). Metered spend that no phase owned was therefore not merely unattributed — **it was published as if it had never happened**:

| | published | the run's own meters |
|---|---|---|
| `suite.optimizer_usd` | **0** | 9.11 |
| `suite.eval_usd` | 5.25 | 12.55 (`spent.usd`) |
| total | **$5.25** | **$21.66** |

A 4× understatement in the single figure a full tier's budget gets projected from — reported by a run that looks completed, green and cheap. Two independent holes fed it: agent mode meters the optimizer **once for the whole loop**, so no round can own a share of it; and control replicates, re-gates and abandoned rounds are real rollouts that no committed `step` event references.

`metrics.iteration_rows` now emits one `unattributed` row for the residual between the run's meters and what the phases claim. Every consumer already sums these rows — `record.rollup`, `results_md.load_suite_totals`, the report's Totals line, the Pages per-run table — so one row repairs all four at once. It is a *row* rather than a per-round split because the run never measured a per-round split; being a residual it vanishes on a run that does attribute everything (the deterministic loops), and it is floored at zero so an unmetered run cannot produce a negative. Replayed against the sealed artifact:

```
published before: eval $5.2519  + optimizer $0.0000 = $5.25
published after : eval $12.5493 + optimizer $9.1108 = $21.66
run metered     : $21.66          rewards unchanged: True
```

The per-run dashboard needed no change: it already published `cost.total_usd: 21.6601` correctly, beside per-iteration nulls that were accurate ("no optimizer cost is attributed to this round"). The two views now agree.

## 10. The host double-booked the agent's own cost

Found while fixing item 9, and worse than it, because it errs in the expensive direction. The host meters the whole agent process **and** the skill instructs the agent to book its own proposal cost per round via `commit.py --optimizer-usd`. Those are the same money — a round's proposal happens inside that process — and the host booked its metered total *on top of* whatever the agent had booked. An agent that followed the skill's own written instruction made the run report **up to twice** the optimizer spend it used, and a cost-based `stop_condition` would then have ended a run that still had budget.

`host.optimizer_spend_to_book` now books only the residual, per role, never below zero, and **bracketed to this invocation** so a `--resume` run does not mistake an earlier host's spend for this agent's attribution. It also books the loop's **wall time**, which nothing recorded at all: `optimizer_seconds: 0.0` for a run that took hours left every per-hour figure undefined. `references/algorithm.md` now states that the per-round figures *attribute within* the metered total rather than adding to it, so the instruction and the accounting agree.

## Testing (second round)

`core/tests` + `ci/benchmarks/lib`: **1107 passed, 2 skipped, 0 failed.**

> The `test_cli_surface.py` failure noted above is an environment artifact, now pinned down: `_find_skills_dir()` prefers an installed `~/.claude/skills` over the repo's own, and the stale installed manifest on this machine lacks `run-optimizer`. With `CAPEVOLVE_SKILLS_DIR` pointed at the repo's `skills/` the suite is fully green. Not a code defect and not touched by this branch — recorded so the next reader does not re-investigate it.

**+49 tests across 6 new files**, each pinning a measured symptom from the run, and every one watched failing before its fix. Two notes on that discipline:

- The four cost guards were re-run against the pre-fix behaviour (residual suppressed) and all four failed with the live numbers in their own messages — `"the timeline accounts for $0.00 of a metered $9.00"`.
- `test_commit_reads_only_fields_round_actually_writes` broke when the round-table naming changed. It was a legitimate coupling guard, so it was **replaced with a behavioural cross-file test** — `commit.py` must find the table wherever `round.py` chose to name it, asserted through `threshold`/`evidence_bar`, which can only come from that table — rather than by editing the string it matched on.

Also clean: skill authoring lint (advisories only, baseline unchanged), `check.py --self-check`, and a line-length/dead-code sweep of every touched file. The `agent-optimize` `SKILL.md` body sits at its exact 5000-token cap, so the new prose went to `references/` and `host.py`'s prompt — the sanctioned overflow — with only a two-line pointer added to `SKILL.md` itself.

### Deliberately out of scope

- **Per-iteration optimizer cost attribution in agent mode.** The host is blocked on `subprocess.run` for the agent's whole lifetime so it cannot book incrementally, and the agent cannot meter its own process; fixing it means streaming cost out of the transcript. Consequence worth knowing: **`max_optimizer_usd` cannot bind mid-run in agent mode.** Item 9 makes the *reporting* honest; the *enforcement* gap is real and unfixed.
- **Pooling candidate measurements across re-gate attempts** (item 5).
- **Hoisting memory writes into `record_iteration`** (item 7) — blocked on `gepa._try_merge`'s out-of-band rejection path.

Signed-off-by: Eran Raichstein <eranra@il.ibm.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
