### PR TITLE
dashboard: read gate numbers under both conventions, surface null controls, 9 render fixes

### DIFF
--- a/core/cap_evolve/dashboard.py
+++ b/core/cap_evolve/dashboard.py
@@ -798,10 +798,16 @@ def _read_config(root: Path) -> dict:
     if project_dir is None:
         return {}
     from .specfile import read_yaml
-    try:
-        spec = read_yaml((project_dir / "capevolve.yaml").read_text(encoding="utf-8")) or {}
-    except OSError:
-        spec = {}
+    # Joined through _safe_subpath like every other path here: the spec is read (and its
+    # presence reported) only when it is proven inside the project dir, so a capevolve.yaml
+    # symlinked out of it is treated as absent rather than followed.
+    spec_file = _safe_subpath(project_dir, "capevolve.yaml")
+    spec = {}
+    if spec_file is not None:
+        try:
+            spec = read_yaml(spec_file.read_text(encoding="utf-8")) or {}
+        except OSError:
+            spec = {}
     groups: dict[str, list] = {}
     for k, v in spec.items():
         groups.setdefault(_CONFIG_KEY_GROUPS.get(k, "Other"), []).append({"key": k, "value": v})
@@ -822,7 +828,7 @@ def _read_config(root: Path) -> dict:
         "project_dir": str(project_dir),
         # True ⇒ the project dir exists but has no capevolve.yaml. The section says so and still
         # lists the artifacts that ARE there, instead of disappearing without explanation.
-        "spec_missing": not (project_dir / "capevolve.yaml").is_file(),
+        "spec_missing": spec_file is None or not spec_file.is_file(),
         "spec_groups": spec_groups,
         "project_md": project_md,
         "files": files,

--- a/core/cap_evolve/dashboard.py
+++ b/core/cap_evolve/dashboard.py
@@ -31,9 +31,11 @@ The candidate **graph** schema (``reduced["graph"]``)::
      ],
      "root": "seed", "best_id": "..."}
 
-The ``gate_*`` keys are present only when the algorithm's commit step RECORDED that number
-on its accept/reject event instead of leaving it to be regexed out of the prose ``reason``;
-the gate-decisions table prefers them and falls back to the regex parse otherwise.
+The ``gate_*`` keys are present when the algorithm's commit step RECORDED that number on its
+accept/reject event — under either naming convention on disk: the prefixed ``gate_delta`` a
+current ``commit.py`` writes, or the UNPREFIXED ``delta`` an older one wrote (see
+``_GATE_FIELD_ALIASES``). The gate-decisions table prefers whichever is present and falls back
+to regexing the prose ``reason`` only when neither is.
 ``screened`` is ``None`` when no event recorded compliance for this candidate's tag, else
 the ``screened_before_fullval`` value read generically off any event that carries it.
 
@@ -48,9 +50,10 @@ The **summary** schema (``reduced["summary"]``)::
      "controls": [{"tag", "reward", "stderr", "n", "iteration", "t"}, ...]}
 
 ``controls`` lists null-control replicate evaluations — evaluate-only measurements with no
-candidate-graph node — read generically off any ``evaluate`` event carrying ``role:
-"control"`` or a truthy ``is_control`` field. Empty until an algorithm's evaluate step
-attaches either.
+candidate-graph node — detected by ``_is_control_event``: the documented ``ctl_null`` TAG
+PREFIX convention (agent-optimize's ``ctl_null_i<N>`` plus its ``r<k>``/``a<k>`` replicates),
+or an explicit ``role: "control"`` / truthy ``is_control`` field on the event. They also appear
+in ``evaluations`` with ``kind: "control"``, so a control is never in neither place.
 
 Optional panels degrade silently: when per-task data / diffs / finalize are missing
 the renderer hides the panel rather than crashing.
@@ -355,6 +358,40 @@ _STEP_KINDS = ("step", "gepa_val_gate", "accept", "reject", "provisional")
 
 #: Kinds whose presence means "this candidate was accepted" without an ``accept`` field.
 _ACCEPT_KINDS = ("accept",)
+
+#: Prefixed gate field → the UNPREFIXED spelling of the same number. Both conventions are
+#: real and both are on disk: older ``commit.py`` revisions wrote ``delta``/``stderr``/``n``/
+#: ``k_se``/``threshold``/``resolvable_effect_size`` straight onto the accept/reject event,
+#: current ones write ``gate_*``. The reducer reads the prefixed name first and falls back to
+#: the unprefixed one, so a run renders its real gate numbers whichever version produced it.
+_GATE_FIELD_ALIASES = {
+    "gate_delta": "delta",
+    "gate_stderr": "stderr",
+    "gate_n": "n",
+    "gate_k_se": "k_se",
+    "gate_threshold": "threshold",
+    "gate_resolvable_effect_size": "resolvable_effect_size",
+}
+
+#: Tag-naming convention for a null-control replicate: any evaluate tag starting with
+#: ``ctl_null`` (agent-optimize's ``round.py`` writes ``ctl_null_i<N>`` per round plus
+#: ``...r<k>``/``...a<k>`` replicates). This is a DOCUMENTED convention, not one algorithm's
+#: private detail — an algorithm that wants its controls surfaced either follows the prefix
+#: or sets ``role: "control"`` / ``is_control`` on the event.
+_CONTROL_TAG_PREFIX = "ctl_null"
+
+
+def _is_control_event(ev: dict) -> bool:
+    """Is this ``evaluate`` event a null-control replicate (a noise-floor measurement)?
+
+    Three signals, any of which suffices: an explicit ``role: "control"``, a truthy
+    ``is_control``, or the ``ctl_null`` tag prefix. Only the last one is actually emitted
+    today (checked round.py/commit.py), which is exactly why reading only the first two
+    dropped the whole noise-floor section for every real run; the explicit fields stay
+    recognized so an algorithm that starts setting them needs no reducer change.
+    """
+    return bool(ev.get("role") == "control" or ev.get("is_control")
+                or str(ev.get("tag") or "").startswith(_CONTROL_TAG_PREFIX))
 
 
 def _algorithm_from_spec(root: Path) -> str | None:
@@ -695,10 +732,19 @@ def _find_project_dir(root: Path) -> Path | None:
     Same two candidate locations ``_algorithm_from_spec`` already reads (a sibling
     ``project/`` next to the run dir is the normal shape; some fixtures write
     ``capevolve.yaml`` directly under the run dir).
+
+    A sibling ``project/`` dir with NO ``capevolve.yaml`` still counts: it holds adapters/,
+    seed_capability/, split files — the whole Config section used to vanish with no explanation
+    when the spec file was missing, hiding project artifacts that were sitting right there.
+    ``root`` itself is only accepted WITH a spec, since a run dir full of rollouts/ and
+    events.jsonl is not a project listing.
     """
     for cand in (_safe_subpath(root.parent, "project"), root):
         if cand is not None and cand.is_dir() and (cand / "capevolve.yaml").is_file():
             return cand
+    sibling = _safe_subpath(root.parent, "project")
+    if sibling is not None and sibling.is_dir():
+        return sibling
     return None
 
 
@@ -774,6 +820,9 @@ def _read_config(root: Path) -> dict:
         return {}
     return {
         "project_dir": str(project_dir),
+        # True ⇒ the project dir exists but has no capevolve.yaml. The section says so and still
+        # lists the artifacts that ARE there, instead of disappearing without explanation.
+        "spec_missing": not (project_dir / "capevolve.yaml").is_file(),
         "spec_groups": spec_groups,
         "project_md": project_md,
         "files": files,
@@ -816,7 +865,9 @@ def _read_narrative(root: Path, best_id: str | None) -> dict:
             continue
         if text:
             seed_text = seed_by_name.get(name)
-            files.append({"title": title, "text": _sanitize_text(text, 20000),
+            # ``name`` is the bare filename: the section intro lists what this run ACTUALLY
+            # wrote instead of the fixed catalogue of every narrative file that could exist.
+            files.append({"name": name, "title": title, "text": _sanitize_text(text, 20000),
                           "template_only": bool(seed_text) and text == seed_text.strip()})
     process_text = None
     if best_id:
@@ -827,7 +878,8 @@ def _read_narrative(root: Path, best_id: str | None) -> dict:
             except OSError:
                 process_text = None
     if process_text:
-        files.append({"title": f"Process — best candidate ({best_id})",
+        files.append({"name": "PROCESS.md",
+                      "title": f"Process — best candidate ({best_id})",
                       "text": _sanitize_text(process_text, 20000),
                       "template_only": bool(process_seed) and process_text == process_seed})
     if not files:
@@ -1082,8 +1134,16 @@ def reduce_run(run_dir) -> dict:
                     "gate_resolvable_effect_size",
                     "gate_mode", "gate_table", "control_relative_verdict",
                     "control_relative_delta", "evidence_bar"):
-            if ev.get(_gk) is not None:
-                node[_gk] = ev.get(_gk)
+            _v = ev.get(_gk)
+            # Version skew, not a hypothetical: older commit.py revisions wrote these on the
+            # accept/reject event UNPREFIXED (``delta``/``stderr``/``n``/...), current ones write
+            # ``gate_*``. Reading only the prefixed name made every already-completed run render
+            # "—" for every gate stat while the real numbers sat in the same event, and pushed the
+            # gate table onto its lossy regex-on-prose fallback. Accept both spellings.
+            if _v is None:
+                _v = ev.get(_GATE_FIELD_ALIASES.get(_gk, ""))
+            if _v is not None:
+                node[_gk] = _v
         if "epoch" in ev:
             node["epoch"] = ev.get("epoch")
         if merge_of:
@@ -1218,6 +1278,35 @@ def reduce_run(run_dir) -> dict:
         "resolution_note": tp_ev.get("resolution_note") or "",
     } if tp_ev is not None else None)
 
+    # --- null-control replicates: the noise-floor check, kept OUT of the candidate graph ---
+    # A control replicate (a byte-identical re-measurement, run to bound run-to-run noise) is
+    # evaluate-only: it never gets an accept/reject commit, so it has no graph node. Detection
+    # is ``_is_control_event`` — the ``ctl_null`` tag-prefix CONVENTION plus the explicit
+    # ``role``/``is_control`` fields. Reading only the explicit fields (which nothing emits)
+    # produced an empty list and a silently dropped section on every real run that measured a
+    # noise floor: run_finalrun5 has four such evaluations (ctl_null_i0=0.58, ctl_null_i0r1=0.57,
+    # ctl_null_i3=0.653, ctl_null_i3r1=0.593) whose 0.06 swing is larger than the accepted
+    # candidate's own Δ — the single most important finding in that run.
+    #
+    # Kept as its own top-level summary list (not nested under algo_extra): a null-control
+    # replicate is a generic evaluation-methodology signal any algorithm could emit, not a
+    # per-algorithm extra like screens/gepa/skillopt.
+    control_events = [e for e in events
+                      if e.get("kind") == "evaluate" and _is_control_event(e)]
+    controls = [{
+        "tag": e.get("tag"),
+        "split": e.get("split"),
+        "reward": e.get("reward"),
+        "stderr": e.get("stderr"),
+        # ``n_scored`` is the modern field; older evaluate events wrote ``n``.
+        "n": e.get("n_scored") if e.get("n_scored") is not None else e.get("n"),
+        "iteration": e.get("iteration"),
+        "cost_usd": e.get("cost_usd"),
+        "seconds": e.get("seconds"),
+        "tokens": e.get("tokens"),
+        "t": e.get("t"),
+    } for e in control_events]
+
     # --- first-class evaluations (split-oriented, distinct from per_iteration) ---
     # An evaluation is one scoring of a candidate on one split: the seed baseline on
     # val, every candidate that earned a full val score on val, and the sealed test
@@ -1265,6 +1354,22 @@ def reduce_run(run_dir) -> dict:
             "tokens": int(n.get("tokens") or 0),
         })
 
+    # null-control replicates. They have no graph node (evaluate-only), so the loop above
+    # cannot see them and they used to appear in NEITHER this table nor the noise-floor
+    # section. Labeled ``kind: "control"`` so the UI can show them as controls rather than
+    # mixing a re-measurement of the SAME capability in as an anonymous candidate row.
+    for c in controls:
+        evaluations.append({
+            "id": c["tag"], "kind": "control", "candidate": c["tag"],
+            "split": c.get("split") or "val",
+            "reward": c.get("reward"), "stderr": c.get("stderr"),
+            "n_tasks": c.get("n") or 0,
+            "trials": _trials_for(run_dir, str(c["tag"]), c.get("split") or "val") or 1,
+            "cost_usd": float(c.get("cost_usd") or 0.0),
+            "seconds": float(c.get("seconds") or 0.0),
+            "tokens": int(c.get("tokens") or 0),
+        })
+
     # test (the sealed test eval, from final.json)
     test_obj = final.get("test") or {}
     if test_obj:
@@ -1298,7 +1403,11 @@ def reduce_run(run_dir) -> dict:
                    else "indecisive" if n["status"] == "indecisive"
                    else "provisional" if n["status"] == "provisional"
                    else "reject" if n["status"] == "rejected" else "no measurement")
-        m_delta = re.search(r"Δ̄?\s*=\s*([+-]?\d*\.?\d+)", reason)
+        # Agent-authored notes write "delta -0.0167 vs cand_3, threshold 0.0276" where the
+        # deterministic gate writes "Δ̄ = -0.0167"; matching only the symbol left three real
+        # rejections in run_finalrun5 with an all-"—" row whose numbers were right there in
+        # the prose. Both spellings, with or without the ``=``.
+        m_delta = re.search(r"(?:Δ̄?|\bdelta)\s*=?\s*([+-]?\d*\.?\d+)", reason)
         # The bar `0.2·SE=0.0062` comes FIRST in the reason and also matches `SE=`, so an
         # unanchored search put the bar's value in the SE column — the gate then appeared
         # to have compared Δ̄ against five times its own standard error. Skip the `k·SE`
@@ -1306,6 +1415,7 @@ def reduce_run(run_dir) -> dict:
         m_se = re.search(r"(?<!·)\bSE\s*=\s*(\d*\.?\d+)", reason)
         m_n = re.search(r"\bn\s*=\s*(\d+)", reason)
         m_bar = re.search(r"([\d.]+)·SE\s*=\s*(\d*\.?\d+)", reason)
+        m_thr = re.search(r"\bthreshold\s*=?\s*(\d*\.?\d+)", reason)
         m_res = re.search(r"resolvable effect size 2·SE\s*=\s*([\d.]+)", reason)
         # A number the algorithm RECORDED beats the same number scraped out of prose. Agent
         # mode writes free text, so every regex above missed and the whole numeric half of
@@ -1322,7 +1432,8 @@ def reduce_run(run_dir) -> dict:
             "stderr": float(m_se.group(1)) if m_se else None,
             "n": int(m_n.group(1)) if m_n else None,
             "k_se": float(m_bar.group(1)) if m_bar else None,
-            "threshold": float(m_bar.group(2)) if m_bar else None,
+            "threshold": (float(m_bar.group(2)) if m_bar else
+                          float(m_thr.group(1)) if m_thr else None),
             "resolvable_effect_size": float(m_res.group(1)) if m_res else None,
             "reason": _sanitize_text(reason, 600),
         }
@@ -1395,6 +1506,39 @@ def reduce_run(run_dir) -> dict:
                 "note": ("the optimizer process exited non-zero (commonly its own budget "
                          "cap) — the spend below is real and was still charged"
                          if truncated else ""),
+            })
+    # --- reconcile the rows against Spent, PER ROLE ---------------------------
+    # A run whose proposer spend lives only in state.json's Spent (agent mode: older commit.py
+    # revisions never put opt_cost_usd on the decision event) attributed $0 of it, so the KPI
+    # strip showed the SAME dollar figure as both "cost" and "unattributed" — 100% unattributed —
+    # while the wall-clock KPI put every second in the runner bucket. Two contradictory readings
+    # of one run. Book the Spent-recorded remainder to the ROLE that actually spent it as an
+    # explicit reconciliation row: the money now lands in the same bucket the seconds do, and
+    # "unattributed" means what it says (spend no role can explain) instead of "spend no event
+    # happened to carry".
+    _ROLE_FOR_KIND = {"intake": "intake", "optimizer_call": "optimizer"}
+    by_role = {"runner": 0.0, "optimizer": 0.0, "intake": 0.0}
+    for r in ledger:
+        if r["usd"] is not None:
+            by_role[_ROLE_FOR_KIND.get(r["kind"], "runner")] += float(r["usd"])
+    for _role, _spent, _secs, _tok, _label in (
+            ("optimizer", opt_usd, opt_secs, opt_tokens,
+             "Optimizer spend recorded in state.json but carried by no event"),
+            ("runner", runner_usd, run_secs, tokens - opt_tokens - int(intake_tokens or 0),
+             "Runner spend recorded in state.json but carried by no event")):
+        gap = round(float(_spent or 0.0) - by_role[_role], 6)
+        if abs(gap) > 5e-5:
+            ledger.append({
+                "phase": "optimize" if _role == "optimizer" else "evaluate",
+                "kind": _role + "_reconciliation", "split": None,
+                "label": _label, "candidate": None, "usd": gap,
+                # Seconds/tokens are NOT re-added here — the per-role rows above already
+                # carry them, and double-counting time to reconcile money would trade one
+                # inconsistency for another.
+                "seconds": 0.0, "tokens": 0,
+                "note": (f"the run's Spent accumulator books ${_spent:.4f} to the {_role}; "
+                         f"{_secs:.0f}s and {max(0, int(_tok or 0)):,} tokens are attributed to "
+                         f"the same role, so the dollars and the time now agree"),
             })
     attributed = sum(r["usd"] for r in ledger if r["usd"] is not None)
     total_usd = round(opt_usd + runner_usd + intake_usd, 6)
@@ -1535,29 +1679,6 @@ def reduce_run(run_dir) -> dict:
                   for e in events if e.get("kind") == "agent_optimize_compliance"]
     if compliance:
         algo_extra["compliance"] = compliance
-
-    # --- null-control replicates: the noise-floor check, kept OUT of the candidate graph ---
-    # A control replicate (a byte-identical re-measurement, run to bound run-to-run noise)
-    # is evaluate-only: it never gets an accept/reject commit, so it has no graph node — and
-    # with no way to see it happened, a real run's noise-floor check was invisible in the
-    # dashboard. Detecting it by TAG naming (e.g. agent-optimize's ``ctl_null_i<N>``) would
-    # bake one algorithm's convention into a generic reducer, so this reads a generic marker
-    # instead: any ``evaluate`` event carrying ``role: "control"`` or a truthy ``is_control``
-    # field. Neither field is emitted yet as of this writing (checked agent-optimize's
-    # round.py/commit.py, which still identify their own controls only by tag) — this stays
-    # ready to surface them the moment an algorithm's evaluate step attaches either.
-    controls = [{
-        "tag": e.get("tag"),
-        "reward": e.get("reward"),
-        "stderr": e.get("stderr"),
-        "n": e.get("n_scored"),
-        "iteration": e.get("iteration"),
-        "t": e.get("t"),
-    } for e in events if e.get("kind") == "evaluate"
-       and (e.get("role") == "control" or e.get("is_control"))]
-    # Kept as its own top-level summary list (not nested under algo_extra): a null-control
-    # replicate is a generic evaluation-methodology signal any algorithm could emit, not a
-    # per-algorithm extra like screens/gepa/skillopt below.
 
     evograph = _read_evograph(root)
     if evograph:
@@ -1940,6 +2061,9 @@ header .meta{color:var(--muted);font-size:12px}
 main{max-width:1180px;margin:0 auto;padding:26px;display:flex;flex-direction:column;gap:26px}
 section{background:var(--card);border:1px solid var(--line);border-radius:var(--radius);padding:18px 20px}
 section h2{font-size:13px;text-transform:uppercase;letter-spacing:.07em;color:var(--muted);margin:0 0 14px}
+/* The page header is position:sticky, so jumping to an anchor scrolled the target heading
+   underneath it. scroll-margin-top parks the landing point below the header instead. */
+section,section h2,section h3{scroll-margin-top:74px}
 .kpis{display:grid;grid-template-columns:repeat(auto-fit,minmax(132px,1fr));gap:12px}
 .kpi{background:var(--card2);border:1px solid var(--line);border-radius:10px;padding:12px 14px}
 .kpi .l{color:var(--muted);font-size:11px;text-transform:uppercase;letter-spacing:.05em}
@@ -2087,13 +2211,24 @@ function dsecs(v){v=Math.max(0,Math.round(v||0));if(v<60)return v+'s';
     kp('best val',fmt(S.best_val),'champ',S.best_id),
     kp('baseline',fmt(S.baseline_val)),
     kp('Δ vs baseline',dpct,(S.delta_abs>0?'ok':'')),
-    kp('held-out test',fmt(S.test_reward),'',S.test_sealed?'sealed once':'not finalized'),
+    kp('held-out test',fmt(S.test_reward),'',
+       // The raw sealed score alone is not the result — the DELTA against the seed's own test
+       // score is, and both were already in final.json. A run can lift val and lose test.
+       (S.test_delta!=null||S.test_baseline_reward!=null)
+         ?((S.test_delta!=null?(S.test_delta>0?'+':'')+S.test_delta.toFixed(3)+' vs seed ':'')+
+           (S.test_baseline_reward!=null?fmt(S.test_baseline_reward):'')+
+           (S.test_sealed?' · sealed once':''))
+         :(S.test_sealed?'sealed once':'not finalized')),
     kp('candidates',c.total-(c.seed||0),'',
        `${c.accepted} accept · ${c.rejected} reject · ${c.indecisive||0} indecisive · ${c.failed} no-measure`),
     kp('frontier',S.frontier,'','gated leaves with no accepted child'),
     kp('wall clock',`${S.wall_clock_seconds}s`,'',`opt ${S.optimizer_seconds}s · run ${S.runner_seconds}s`),
     kp('cost',`$${cost.total_usd.toFixed(4)}`,'',`opt $${cost.optimizer_usd.toFixed(4)} · run $${cost.runner_usd.toFixed(4)}`),
-    kp('tokens',S.tokens.toLocaleString()),
+    // Token count without its split reads as implausible next to the dollar figure (a real run:
+    // 206M tokens for $4.80). The split explains it: nearly all of them are RUNNER tokens on a
+    // self-hosted endpoint that bills $0, and the dollars are the optimizer's.
+    kp('tokens',S.tokens.toLocaleString(),'',S.tokens_by_role?
+       `run ${S.tokens_by_role.runner.toLocaleString()} · opt ${S.tokens_by_role.optimizer.toLocaleString()}`:''),
     kp('unattributed $',
        S.cost_ledger?`$${S.cost_ledger.unattributed_usd.toFixed(4)}`:'—',
        (S.cost_ledger&&Math.abs(S.cost_ledger.unattributed_usd)>0.0005?'champ':''),
@@ -2203,7 +2338,12 @@ function dsecs(v){v=Math.max(0,Math.round(v||0));if(v<60)return v+'s';
   const champ=pts.reduce((a,b)=>(b.best_so_far>=a.best_so_far?b:a),pts[0]);
   const cx=X(champ.iteration),cy=Y(champ.best_so_far);
   el.append(svg('path',{d:starPath(cx,cy-12,7,3),fill:'var(--champion)',stroke:'var(--bg)'}));
-  txt(el,{x:cx+10,y:cy-8,fill:'var(--text)','font-size':12},fmt(champ.best_so_far));
+  // The champion is usually the RIGHTMOST point, where a left-anchored label runs off the plot
+  // and gets clipped by the viewBox. Flip the anchor to the left of the star when there is not
+  // room to its right.
+  const tight=cx>W-m.r-46;
+  txt(el,{x:tight?cx-10:cx+10,y:cy-8,fill:'var(--text)','font-size':12,
+          'text-anchor':tight?'end':'start'},fmt(champ.best_so_far));
   s.append(el);
   s.append($('div',{class:'legend',html:
     '<span><i style="background:var(--ok)"></i>running best / accept</span>'+
@@ -2308,7 +2448,11 @@ function dsecs(v){v=Math.max(0,Math.round(v||0));if(v<60)return v+'s';
       stroke:spine.has(n.id)?'var(--champion)':'var(--bg)','stroke-width':spine.has(n.id)?2:1});
     c.addEventListener('mousemove',e=>showTip(e,`${n.id}\n${n.status}  val=${fmt(n.val)}\n${n.reason||''}`));
     c.addEventListener('mouseleave',hideTip); el.append(c);
-    txt(el,{x:p.x+12,y:p.y+4,fill:'var(--muted)','font-size':10},n.id);
+    // A node with outgoing edges (the seed, above all) has a connector leaving at exactly
+    // y=p.y, so a label on the baseline right of the node is drawn UNDER that line and reads
+    // as struck through. Lift those labels clear of the connector.
+    const outgoing=(n.children||[]).some(c2=>pos[c2]);
+    txt(el,{x:p.x+12,y:outgoing?p.y-8:p.y+4,fill:'var(--muted)','font-size':10},n.id);
   });
   s.append(el);
   s.append($('div',{class:'legend',html:'<span><i style="background:var(--champion)"></i>best lineage spine</span>'+
@@ -2321,15 +2465,15 @@ function dsecs(v){v=Math.max(0,Math.round(v||0));if(v<60)return v+'s';
   if(!evals.length)return;
   const s=sec('Evaluations');
   s.append($('p',{class:'muted',text:'Each scoring of a candidate on a split — '+
-    'baseline (seed on val), every full val eval, and the sealed test eval. '+
-    'Distinct from the optimizer-step view above.'}));
+    'baseline (seed on val), every full val eval, each null-control replicate, and the '+
+    'sealed test eval. Distinct from the optimizer-step view above.'}));
   const t=$('table');
   t.append($('tr',{},$('th',{text:'kind'}),$('th',{text:'candidate'}),$('th',{text:'split'}),
     $('th',{class:'r',text:'reward ± stderr'}),$('th',{class:'r',text:'runner $'}),
     $('th',{class:'r',text:'time'}),$('th',{class:'r',text:'tokens'}),$('th',{class:'r',text:'tasks × trials'})));
   const dsec=v=>{v=Math.max(0,Math.round(v||0));if(v<60)return v+'s';
     const m=Math.floor(v/60);if(m<60)return m+'m '+(v%60)+'s';return Math.floor(m/60)+'h '+(m%60)+'m';};
-  const kindBadge={baseline:'b-seed',candidate:'b-accepted',test:'b-failed'};
+  const kindBadge={baseline:'b-seed',candidate:'b-accepted',test:'b-failed',control:'b-indecisive'};
   evals.forEach(e=>{
     const re=e.reward==null?'—':fmt(e.reward)+(e.stderr!=null?' ± '+(+e.stderr).toFixed(3):'');
     t.append($('tr',{},
@@ -2340,7 +2484,7 @@ function dsecs(v){v=Math.max(0,Math.round(v||0));if(v<60)return v+'s';
       $('td',{class:'r num',text:e.cost_usd?'$'+(+e.cost_usd).toFixed(4):'—'}),
       $('td',{class:'r num',text:dsec(e.seconds)}),
       $('td',{class:'r num',text:(e.tokens||0).toLocaleString()}),
-      $('td',{class:'r num',text:(e.n_tasks||0)+' × '+(e.trials||1)})));
+      $('td',{class:'r num',text:e.n_tasks?e.n_tasks+' × '+(e.trials||1):'—'})));
   });
   s.append(t);
 })();
@@ -2559,10 +2703,12 @@ function dsecs(v){v=Math.max(0,Math.round(v||0));if(v<60)return v+'s';
 (function(){
   const NAR=S.narrative; if(!NAR||!(NAR.files||[]).length)return;
   const s=sec('Process narrative');
+  // List what this run ACTUALLY has, not the full catalogue of narrative files that could
+  // exist — the fixed list implied four missing documents on a run that wrote one.
+  const names=(NAR.files||[]).map(f=>f.name||f.title).filter(Boolean);
   s.append($('p',{class:'muted',style:'margin:0 0 12px',text:
-    'Written by the optimizer as it worked (JOURNAL / INSIGHTS / META_INSIGHTS / '+
-    'FRAMEWORK_IMPROVEMENTS, plus the best candidate’s PROCESS.md) — rendered here '+
-    'as-is, for a human reader.'}));
+    'Written by the optimizer as it worked'+(names.length?' ('+names.join(' / ')+')':'')+
+    ' — rendered here as-is, for a human reader.'}));
   (NAR.files||[]).forEach(f=>{
     const box=$('div',{class:'narrative-box',style:'margin-bottom:14px'});
     box.append($('h3',{style:'margin:0 0 8px',text:f.title}));
@@ -2586,6 +2732,9 @@ function dsecs(v){v=Math.max(0,Math.round(v||0));if(v<60)return v+'s';
     'Every input the intake phase produced or the user set, read straight off '+
     CFG.project_dir+' — the parsed capevolve.yaml spec, PROJECT.md, and every other '+
     'project artifact (adapters/, seed_capability/, split files, ...).'}));
+  if(CFG.spec_missing)s.append($('div',{class:'banner',style:'margin:0 0 12px',
+    text:'No capevolve.yaml found in this project dir, so there is no parsed spec to show. '+
+         'Everything else the project contains is listed below.'}));
   const h3=(t)=>$('h2',{style:'margin:16px 0 6px;text-transform:none;letter-spacing:0;'+
     'font-size:13px;color:var(--text)',text:t});
   (CFG.spec_groups||[]).forEach(g=>{
@@ -2645,20 +2794,31 @@ function dsecs(v){v=Math.max(0,Math.round(v||0));if(v<60)return v+'s';
   // "screened" (did this candidate pay for a cheap screen before full-val?) only shown
   // when SOME node has a recorded signal — never rendered as a column of bare "—".
   const showScreened=!!(S.capabilities&&S.capabilities.screened);
+  // agent-optimize's cheap screen is OPTIONAL. In a run that never attempted one, every
+  // candidate carried a warning-orange "✗ not screened" badge, which reads as a compliance
+  // violation when nothing was violated. The badge is only a flag when SOME candidate in the
+  // run did screen and this one skipped it; otherwise the column shows "—", the way the seed
+  // row already correctly did.
+  const anyScreened=G.nodes.some(n=>n.screened===true);
+  const byId=Object.fromEntries(G.nodes.map(n=>[n.id,n]));
   const hdr=[$('th',{text:'id'}),$('th',{text:'status'}),$('th',{class:'r',text:'val'}),
     $('th',{class:'r',text:'Δ parent'}),$('th',{class:'r',text:'iter'})];
   if(showScreened)hdr.push($('th',{text:'screened'}));
   hdr.push($('th',{text:'reason'}));
   t.append($('tr',{},...hdr));
   G.nodes.slice().sort((a,b)=>(b.val||-1)-(a.val||-1)).forEach(n=>{
-    const dlt=n.parent_val!=null&&n.val!=null?(n.val-n.parent_val):null;
+    // parent_val is only recorded when the algorithm's round table carried it; when it did
+    // not, the parent's OWN val is sitting right there in the same graph, so fall back to it
+    // rather than printing "—" for a delta both halves of which are known.
+    const pv=n.parent_val!=null?n.parent_val:(n.parent&&byId[n.parent]?byId[n.parent].val:null);
+    const dlt=pv!=null&&n.val!=null?(n.val-pv):null;
     const cells=[
       $('td',{},n.id===S.best_id?'★ '+n.id:n.id),
       $('td',{},$('span',{class:'badge b-'+n.status,text:n.status})),
       $('td',{class:'r num',text:fmt(n.val)}),
       $('td',{class:'r num',text:dlt==null?'—':(dlt>0?'+':'')+dlt.toFixed(3)}),
       $('td',{class:'r num',text:n.iteration})];
-    if(showScreened)cells.push($('td',{},n.screened==null?'—':
+    if(showScreened)cells.push($('td',{},(n.screened==null||(!n.screened&&!anyScreened))?'—':
       $('span',{class:'badge '+(n.screened?'b-accepted':'b-rejected'),text:n.screened?'✓ screened':'✗ not screened'})));
     cells.push($('td',{class:'muted',text:(n.reason||'').slice(0,80)}));
     t.append($('tr',{},...cells));

--- a/core/tests/test_dashboard.py
+++ b/core/tests/test_dashboard.py
@@ -446,3 +446,144 @@ def test_shipped_spa_bundles_have_no_external_cdn_reference():
     # Floors: a vanished bundle dir or an emptied bundle must fail, not silently pass.
     assert len(bundles) >= 4, f"expected >=4 bundle dirs, discovered {len(bundles)}: {bundles}"
     assert checked >= 60, f"expected >=60 shipped SPA files, checked only {checked} — paths moved?"
+
+
+def test_gate_fields_read_both_prefixed_and_unprefixed_conventions(tmp_path):
+    """The gate-decisions table must find the numbers under EITHER naming convention.
+
+    Both are real and both are on disk: current ``commit.py`` writes ``gate_delta`` &co on
+    the accept/reject event, older revisions wrote ``delta``/``stderr``/``n``/``k_se``/
+    ``threshold``/``resolvable_effect_size`` directly. Reading only the prefixed spelling
+    made every already-completed run of the older kind render "—" for every gate stat and
+    fall back to regexing the prose ``reason`` — with the real numbers in the same event.
+    """
+    from cap_evolve.dashboard import reduce_run
+    numbers = {"delta": 0.05, "stderr": 0.0705, "n": 30, "k_se": 1.0,
+               "threshold": 0.0295, "resolvable_effect_size": 0.0589}
+    for prefixed in (False, True):
+        payload = ({"gate_" + k: v for k, v in numbers.items()} if prefixed
+                   else dict(numbers))
+        rd = _mk_run(tmp_path / ("pre" if prefixed else "un"), events=[
+            {"kind": "evaluate", "split": "val", "tag": "seed", "reward": 0.5},
+            {"kind": "evaluate", "split": "val", "tag": "c1", "reward": 0.55},
+            # No parseable numbers in the prose: the structured fields are the only source.
+            {"kind": "accept", "candidate": "c1", "val": 0.55,
+             "note": "accepted on the driver's judgement", **payload},
+        ])
+        row = next(r for r in reduce_run(rd)["summary"]["gate_decisions"]
+                   if r["candidate"] == "c1")
+        for field, want in numbers.items():
+            assert row[field] == want, (
+                f"{'prefixed' if prefixed else 'unprefixed'} {field!r}: "
+                f"got {row[field]!r}, want {want!r}")
+
+
+def test_gate_prefixed_field_wins_over_unprefixed(tmp_path):
+    """When an event carries both, the PREFIXED (current-convention) value is used."""
+    from cap_evolve.dashboard import reduce_run
+    rd = _mk_run(tmp_path, events=[
+        {"kind": "evaluate", "split": "val", "tag": "seed", "reward": 0.5},
+        {"kind": "accept", "candidate": "c1", "val": 0.55, "note": "ok",
+         "gate_delta": 0.05, "delta": 0.99},
+    ])
+    row = next(r for r in reduce_run(rd)["summary"]["gate_decisions"]
+               if r["candidate"] == "c1")
+    assert row["delta"] == 0.05
+
+
+def test_gate_regex_on_prose_is_still_the_last_resort(tmp_path):
+    """Even-older data has neither convention — the prose scrape must still work."""
+    from cap_evolve.dashboard import reduce_run
+    rd = _mk_run(tmp_path, events=[
+        {"kind": "evaluate", "split": "val", "tag": "seed", "reward": 0.5},
+        {"kind": "step", "candidate": "c1", "val": 0.55, "accept": True,
+         "reason": "accept: Δ̄ = 0.0500 > 1.0·SE=0.0295 (SE=0.0295, n=30)"},
+    ])
+    row = next(r for r in reduce_run(rd)["summary"]["gate_decisions"]
+               if r["candidate"] == "c1")
+    assert row["delta"] == 0.05 and row["n"] == 30
+
+
+def test_control_replicates_are_detected_by_tag_prefix(tmp_path):
+    """Null-control replicates are identifiable ONLY by their ``ctl_null`` tag today.
+
+    Nothing in round.py/commit.py sets ``role``/``is_control``, so requiring either dropped
+    the entire noise-floor section on every real run that measured one — including a run
+    whose controls swung 0.06, more than the accepted candidate's own delta. Controls must
+    reach the ``controls`` list AND the evaluations table, labelled as controls.
+    """
+    from cap_evolve.dashboard import reduce_run
+    rd = _mk_run(tmp_path, events=[
+        {"kind": "evaluate", "split": "val", "tag": "seed", "reward": 0.50},
+        {"kind": "evaluate", "split": "val", "tag": "ctl_null_i0", "reward": 0.58,
+         "stderr": 0.069, "n_scored": 30},
+        {"kind": "evaluate", "split": "val", "tag": "ctl_null_i0r1", "reward": 0.57},
+        {"kind": "evaluate", "split": "val", "tag": "ctl_null_i3a1", "reward": 0.65},
+        {"kind": "evaluate", "split": "val", "tag": "cand_1", "reward": 0.61},
+    ])
+    S = reduce_run(rd)["summary"]
+    assert [c["tag"] for c in S["controls"]] == ["ctl_null_i0", "ctl_null_i0r1", "ctl_null_i3a1"]
+    assert S["controls"][0]["reward"] == 0.58 and S["controls"][0]["n"] == 30
+    assert S["capabilities"]["controls"] is True
+    # ...and they are not invisible in the eval table either (the old bug put them in NEITHER).
+    ctl_rows = [e for e in S["evaluations"] if e["kind"] == "control"]
+    assert [e["candidate"] for e in ctl_rows] == [c["tag"] for c in S["controls"]]
+    assert "cand_1" not in [e["candidate"] for e in ctl_rows]
+
+
+def test_control_replicates_still_detected_by_explicit_role_field(tmp_path):
+    """Forward-compatibility: an explicit ``role``/``is_control`` marker also counts."""
+    from cap_evolve.dashboard import reduce_run
+    rd = _mk_run(tmp_path, events=[
+        {"kind": "evaluate", "split": "val", "tag": "seed", "reward": 0.5},
+        {"kind": "evaluate", "split": "val", "tag": "replay_a", "reward": 0.51,
+         "role": "control"},
+        {"kind": "evaluate", "split": "val", "tag": "replay_b", "reward": 0.49,
+         "is_control": True},
+    ])
+    assert [c["tag"] for c in reduce_run(rd)["summary"]["controls"]] == ["replay_a", "replay_b"]
+
+
+def test_a_plain_candidate_eval_is_not_mistaken_for_a_control(tmp_path):
+    """The prefix must not swallow ordinary tags — no controls means an absent section."""
+    from cap_evolve.dashboard import reduce_run
+    rd = _mk_run(tmp_path, events=[
+        {"kind": "evaluate", "split": "val", "tag": "seed", "reward": 0.5},
+        {"kind": "evaluate", "split": "val", "tag": "controller_fix", "reward": 0.55},
+        {"kind": "evaluate", "split": "val", "tag": "cand_1", "reward": 0.55},
+    ])
+    S = reduce_run(rd)["summary"]
+    assert S["controls"] == [] and S["capabilities"]["controls"] is False
+
+
+def test_optimizer_spend_recorded_only_in_state_json_is_attributed(tmp_path):
+    """Money and time must land in the SAME bucket.
+
+    An agent-mode run whose proposer spend reaches only state.json's Spent attributed $0 of
+    it, so the KPI strip showed one dollar figure as both "cost" and "unattributed" (100%
+    unattributed) while the wall-clock KPI put every second in the other bucket.
+    """
+    from cap_evolve.dashboard import reduce_run
+    rd = _mk_run(tmp_path, events=[
+        {"kind": "evaluate", "split": "val", "tag": "seed", "reward": 0.5, "cost_usd": 0.0},
+        {"kind": "accept", "candidate": "c1", "val": 0.6, "note": "ok"},
+    ])
+    rd.update_spent(optimizer_usd=4.8, optimizer_tokens=69224, optimizer_seconds=12.0)
+    L = reduce_run(rd)["summary"]["cost_ledger"]
+    assert abs(L["unattributed_usd"]) < 0.001, L
+    recon = [r for r in L["rows"] if r["kind"] == "optimizer_reconciliation"]
+    assert len(recon) == 1 and abs(recon[0]["usd"] - 4.8) < 1e-6
+
+
+def test_config_section_survives_a_project_dir_with_no_spec(tmp_path):
+    """No capevolve.yaml is a NOTE, not a reason to omit every project artifact."""
+    from cap_evolve.dashboard import reduce_run
+    rd = _mk_run(tmp_path, events=[
+        {"kind": "evaluate", "split": "val", "tag": "seed", "reward": 0.5},
+    ])
+    proj = rd.root.parent / "project"
+    (proj / "adapters").mkdir(parents=True)
+    (proj / "adapters" / "adapter.py").write_text("# real adapter\n", encoding="utf-8")
+    cfg = reduce_run(rd)["summary"]["config"]
+    assert cfg["spec_missing"] is True
+    assert [f["path"] for f in cfg["files"]] == ["adapters/adapter.py"]

--- a/core/tests/test_dashboard_agent_run.py
+++ b/core/tests/test_dashboard_agent_run.py
@@ -391,11 +391,16 @@ def test_gate_fields_read_directly_from_the_event_when_present():
 
 
 def test_controls_are_read_generically_and_absent_by_default():
-    """Null-control replicates surface as their own summary list, keyed by a generic
-    ``role``/``is_control`` marker — never by tag pattern (that would bake one
-    algorithm's naming convention, e.g. agent-optimize's ``ctl_null_i<N>``, into a
-    generic reducer). Absent today (no algorithm emits the marker yet): the list must
-    stay empty rather than guessing from tag names."""
+    """Null-control replicates surface as their own summary list, detected by EITHER the
+    documented ``ctl_null`` tag-prefix convention or a generic ``role``/``is_control``
+    marker.
+
+    The prefix half is not optional: nothing in round.py/commit.py sets ``role`` or
+    ``is_control``, so keying on the marker alone produced an empty list and a silently
+    dropped noise-floor section on every real run that measured one — while four real
+    control evaluations with real rewards sat in the same event log. The marker half stays
+    for forward-compatibility with an algorithm that names its controls differently.
+    """
     from cap_evolve import Budget, RunDir, dashboard
     tmp = Path(tempfile.mkdtemp())
     rd = RunDir.create(tmp, ts="t", budget=Budget())
@@ -403,23 +408,27 @@ def test_controls_are_read_generically_and_absent_by_default():
         {"t": 1.0, "kind": "splits", "train": 4, "val": 2, "test": 2, "seed": 0},
         {"t": 2.0, "kind": "evaluate", "split": "val", "tag": "seed", "reward": 0.5},
         {"t": 3.0, "kind": "baseline", "val": 0.5},
-        # Tag LOOKS like a control (agent-optimize's convention) but carries no marker —
-        # must NOT be picked up by name alone.
+        # The ``ctl_null`` prefix IS the signal agent-optimize actually emits.
         {"t": 4.0, "kind": "evaluate", "split": "val", "tag": "ctl_null_i0", "reward": 0.52},
     ]
     rd.events_path.write_text("\n".join(json.dumps(e) for e in events) + "\n", encoding="utf-8")
     (rd.root / "baseline.json").write_text(json.dumps({"val": {"reward": 0.5}}), encoding="utf-8")
     reduced = dashboard.reduce_run(rd)
-    assert reduced["summary"]["controls"] == []
-    assert reduced["summary"]["capabilities"]["controls"] is False
+    (by_tag,) = reduced["summary"]["controls"]
+    assert by_tag["tag"] == "ctl_null_i0" and by_tag["reward"] == 0.52
+    assert reduced["summary"]["capabilities"]["controls"] is True
+    # A control is never in NEITHER place: it has no graph node, so it must at least appear
+    # in the evaluations table, labelled as a control rather than as an anonymous row.
+    assert [e["candidate"] for e in reduced["summary"]["evaluations"]
+            if e["kind"] == "control"] == ["ctl_null_i0"]
 
-    # Now with the generic marker present — it must be picked up regardless of tag shape.
+    # And with the generic marker present — picked up regardless of tag shape.
     events.append({"t": 5.0, "kind": "evaluate", "split": "val", "tag": "anything_at_all",
                    "reward": 0.48, "stderr": 0.02, "n_scored": 4, "role": "control"})
     rd.events_path.write_text("\n".join(json.dumps(e) for e in events) + "\n", encoding="utf-8")
     reduced2 = dashboard.reduce_run(rd)
-    (ctl,) = reduced2["summary"]["controls"]
-    assert ctl["tag"] == "anything_at_all" and ctl["reward"] == 0.48 and ctl["n"] == 4
+    ctl = next(c for c in reduced2["summary"]["controls"] if c["tag"] == "anything_at_all")
+    assert ctl["reward"] == 0.48 and ctl["n"] == 4
     assert reduced2["summary"]["capabilities"]["controls"] is True
 
 

--- a/core/tests/test_dashboard_status_cost_log.py
+++ b/core/tests/test_dashboard_status_cost_log.py
@@ -270,13 +270,26 @@ def test_cost_ledger_attributes_every_dollar_and_reconciles():
             "intake", "baseline", "optimize", "optimize", "finalize"]
 
 
-def test_cost_ledger_publishes_the_unattributed_remainder_instead_of_hiding_it():
+def test_cost_ledger_books_the_remainder_to_the_role_that_spent_it():
+    """Spend recorded only in state.json's Spent is ROLE-TAGGED, so it is attributable.
+
+    Publishing it as "unattributed" made the KPI strip show one dollar figure as both the
+    run's cost and its unattributed cost (100% unattributed) while the wall-clock KPI put
+    every second in the other bucket — two contradictory readings of one run. It is now a
+    reconciliation row against the role Spent names, and a residual that NO role can explain
+    is what "unattributed" reports.
+    """
     from cap_evolve import dashboard
     with tempfile.TemporaryDirectory() as d:
         rd = _mk(Path(d), events=_events(finalize=False), baseline=_BASELINE)
-        rd.update_spent(usd=0.75, optimizer_usd=3.0)  # $1.75 more than events explain
-        s = dashboard.reduce_run(rd)["summary"]
-        assert s["cost_ledger"]["unattributed_usd"] == 1.75
+        # $1.75 of optimizer spend no event carries; the eval rows already explain the runner's.
+        rd.update_spent(usd=0.75, optimizer_usd=3.0)
+        led = dashboard.reduce_run(rd)["summary"]["cost_ledger"]
+        recon = {r["kind"]: r["usd"] for r in led["rows"] if "reconciliation" in r["kind"]}
+        assert recon == {"optimizer_reconciliation": 1.75}
+        assert led["total_usd"] == 3.75
+        assert led["attributed_usd"] == 3.75
+        assert led["unattributed_usd"] == 0.0
 
 
 def test_a_budget_truncated_optimizer_call_is_labelled_and_still_charged():


### PR DESCRIPTION
Fixes 11 dashboard defects found by a real dashboard review with Playwright screenshots against real completed run data. Every one was reproduced and every fix re-verified by re-rendering the same run dirs (`run_finalrun5`, a sealed tau2-airline run, and `run_finalrun6`) with the fixed code.

## BUG 1 (HIGH) — gate-decisions table showed "—" everywhere

`commit.py` has written the gate numbers under **two naming conventions** over this repo's history: prefixed (`gate_delta`, `gate_stderr`, …) in current revisions, **unprefixed** (`delta`, `stderr`, `n`, `k_se`, `threshold`, `resolvable_effect_size`) in older ones. `reduce_run` recognized only the prefixed spelling, so every already-completed run of the older kind fell through to a lossy regex over the prose `note` — with the real numbers sitting in the very same event.

Reader-side fix (`_GATE_FIELD_ALIASES`): prefixed key first, then the unprefixed key of the same meaning, then the prose scrape as the last resort for even-older data with neither. Renders both the runs already on disk and anything new, whichever `commit.py` produced them.

**Before** (`run_finalrun5`, every row): `delta: None, stderr: None, n: None, threshold: None, resolvable_effect_size: None`

**After** — the numbers that were on disk the whole time:

```
iter | candidate | verdict | val   | Δ̄       | SE      | n  | bar (k·SE)  | resolvable ±
1    | cand_3    | accept  | 0.613 | +0.0500 | ±0.0705 | 30 | 0.0295 k=1  | ±0.0589
2    | cand_2    | reject  | 0.607 | +0.0433 | ±0.0682 | 30 | 0.0270 k=1  | ±0.0540
3    | cand_1    | reject  | 0.590 | +0.0267 | ±0.0697 | 30 | 0.0249 k=1  | ±0.0498
4    | cand_4    | reject  | 0.597 | -0.0167 | —       | —  | 0.0276 k=1  | —
5    | cand_5    | reject  | 0.607 | -0.0067 | —       | —  | 0.0318 k=1  | —
6    | cand_6    | reject  | 0.641 | +0.0278 | —       | —  | 0.0272 k=1  | —
```

(cand_4/5/6 have `null` for the structured fields in the event; their agent-authored notes spell it `delta -0.0167 … threshold 0.0276` where the deterministic gate writes `Δ̄ = …`, so the prose regex was widened to accept both spellings — three more rows of real data recovered.)

## BUG 2 (HIGH) — the null-control / noise-floor section never rendered

The filter required `role == "control"` or a truthy `is_control`. **Nothing in the codebase emits either** — `round.py` identifies its controls purely by tag (`control_tag()` → `ctl_null_i<N>`, plus `r<k>`/`a<k>` replicates). Result: an empty list and a silently dropped section on every run that measured a noise floor.

Detection is now `_is_control_event`: the documented `ctl_null` **tag-prefix convention** (a module constant, not a hardcoded list) **in addition to** the `role`/`is_control` fields, which stay recognized for forward-compatibility.

**Before**: `controls == []`, `capabilities.controls == False`, section absent.

**After** (`run_finalrun5` — the section renders with all four real evaluations):

```
NOISE-FLOOR CHECK (NULL-CONTROL REPLICATES)
4 control replicate(s) evaluated this run — byte-identical re-measurements run to bound
run-to-run noise, never gated/committed as candidates.
Spread between replicates: 0.0833 — the empirical noise floor.

TAG              REWARD ± STDERR
ctl_null_i0r1    0.570 ± 0.0689
ctl_null_i0      0.580 ± 0.0689
ctl_null_i3r1    0.593 ± 0.0745
ctl_null_i3      0.653 ± 0.0695
```

That 0.0833 spread is larger than the accepted candidate's own Δ (0.0500) — the run's most important finding, previously visible only as buried prose.

**On the Evaluations table**: controls were also absent there (`candidate: null`, filtered out), so they appeared in **neither** place. They now get a row with `kind: "control"` and a distinct badge — a re-measurement of the same capability, labelled as such rather than mixed in as an anonymous candidate row.

## Smaller bugs — all 9 also fixed

| # | Fix | Verified after |
|---|-----|----------------|
| 3 | Config section no longer hard-gates on `capevolve.yaml` existing | `run_finalrun5`'s project dir has no spec: section renders with *"No capevolve.yaml found in this project dir… Everything else the project contains is listed below"* + `adapters (2)`, `seed_capability (1)`. `run_finalrun6` (has a spec) unchanged, `spec_missing: false` |
| 4 | Champion label flips anchor when it is the rightmost point | `{x: 1054, text-anchor: "end"}` inside `viewBox` width 1080 — was left-anchored at 1074 and clipped |
| 5 | Lineage labels on nodes with outgoing edges lifted clear of the connector | `seed@72,32` and `cand_3@222,32` (nodes at `cy=40`); leaf labels stay at `y+4` |
| 6 | Candidates "Δ parent" falls back to the parent node's own `val` | was `—` for all; now `cand_6 +0.028`, `cand_3 +0.050`, `cand_2 -0.007`, `cand_5 -0.007`, `cand_4 -0.017`, `cand_1 -0.023` |
| 7 | `✗ not screened` badge only when SOME candidate in the run did screen | SCREENED column now `—` for every row in this run (screening was never attempted), instead of 6 orange compliance-looking warnings |
| 8 | `scroll-margin-top: 74px` on section headings | computed style confirmed `74px`; sticky header no longer covers an anchor target |
| 9 | Cost attribution made self-consistent (below) | `unattributed $0.0000` (was `$4.7967` = 100%) |
| 10 | Sealed-test KPI surfaces `test_delta` + the seed's test score | `HELD-OUT TEST · 0.500 · +0.200 vs seed 0.300 · sealed once` (was just `sealed once`) |
| 11 | Narrative intro lists what this run actually wrote | `Written by the optimizer as it worked (JOURNAL.md)` — was unconditionally naming JOURNAL / INSIGHTS / META_INSIGHTS / FRAMEWORK_IMPROVEMENTS / PROCESS.md for a run with one file |

### On #9, investigated as asked

The KPI showed the same `$4.7967` as both **cost** and **unattributed** (100%) while the wall-clock KPI put all 58,504s in the runner bucket. Root cause: `state.json`'s `Spent` is **role-tagged** (`optimizer_usd: 4.7967`, `usd: 0.0`, `runner_seconds: 58504`, `optimizer_seconds: 0`), so that spend *is* attributable — but no event carried `opt_cost_usd`, and the ledger only built rows from events. It is now booked as a per-role reconciliation row, so money and time land in the same bucket and "unattributed" means what it says.

**The 206M tokens for $4.80 is not a summing bug.** `Spent` records `runner_tokens: 206,221,938` / `optimizer_tokens: 69,224` across 3,340 metric calls (~62k tokens/call — plausible for tau2 agent rollouts), and the runner is a self-hosted endpoint billing `cost_usd: 0.0` on every eval. Nothing double-counts. The KPI now shows the split (`run 206,221,938 · opt 69,224`) so the figure reads correctly next to the dollars instead of looking implausible.

## Tests

```
$ .venv-tau2/bin/python -m pytest core/tests -q
2 failed, 1068 passed, 12 skipped in 180.15s
```

Both failures are the known full-suite-order flakes and pass in isolation:

```
$ .venv-tau2/bin/python -m pytest core/tests/test_eventstream.py -q
38 passed in 7.94s
```

New in `core/tests/test_dashboard.py` (6 for bugs 1 & 2, 2 for bugs 9 & 3):

- `test_gate_fields_read_both_prefixed_and_unprefixed_conventions` — same six numbers under both spellings, with prose carrying nothing parseable
- `test_gate_prefixed_field_wins_over_unprefixed`
- `test_gate_regex_on_prose_is_still_the_last_resort`
- `test_control_replicates_are_detected_by_tag_prefix` — `ctl_null_i0` / `_i0r1` / `_i3a1` detected, `cand_1` not; asserts they reach the Evaluations table too
- `test_control_replicates_still_detected_by_explicit_role_field`
- `test_a_plain_candidate_eval_is_not_mistaken_for_a_control` — `controller_fix` is not a control
- `test_optimizer_spend_recorded_only_in_state_json_is_attributed`
- `test_config_section_survives_a_project_dir_with_no_spec`

Two existing tests asserted the pre-fix behaviour and were updated in place with the reason:
- `test_dashboard_agent_run.py::test_controls_are_read_generically_and_absent_by_default` — asserted controls must NOT be found by tag pattern, which is what dropped the section
- `test_dashboard_status_cost_log.py::test_cost_ledger_publishes_the_unattributed_remainder_instead_of_hiding_it` → `..._books_the_remainder_to_the_role_that_spent_it`

Both fixture run dirs were treated as read-only. The rendered pages were also executed in a headless browser: **no page errors, no console errors, no horizontal body overflow** on either run.
