### PR TITLE
fix(gate): measure only what the edit can reach, and stop asserting causality the measurement cannot support

### DIFF
--- a/core/cap_evolve/footprint.py
+++ b/core/cap_evolve/footprint.py
@@ -11,26 +11,34 @@ spread (0.570-0.607) — the measurement could not tell an edit from a re-measur
 Restricting the delta vector to the tasks inside the edit's footprint is what fixes that:
 a task the edit cannot reach has Δ=0 BY CONSTRUCTION, not by measurement, so it belongs
 in the vector as a zero rather than as noise (see ``harness._paired_deltas``, which does
-the zero-padding — the vector keeps its full length, so Δ̄ stays on the same scale as the
-val reward while the SE stops being dominated by tasks the edit never touched).
+the zero-padding). The vector keeps its full LENGTH, so Δ̄ stays on the same SCALE as the
+val reward — but be clear that this changes BOTH halves of the test: the SE stops being
+dominated by tasks the edit never touched, and Δ̄ itself moves, because the out-of-footprint
+deltas that used to be averaged in are now zeros. Δ̄ moving is not a side effect, it IS the
+mechanism (the whole claim is that those deltas were noise and do not belong in the
+average) — and it is also why under-inclusion is dangerous rather than merely weak: zeroing
+a task that really regressed raises Δ̄ and lowers the SE at the same time, both pushing
+toward accept. Hence the two rules in ``_close`` and ``in_footprint_tasks`` that make a
+broadly-reaching edit unlocalizable instead of narrowly footprinted.
 
 Both steps here are deliberately dumb and generic — no benchmark, capability, agent or
 optimizer shape is assumed:
 
   * ``touched_symbols`` reads the NAMED SURFACES out of a unified diff (whatever
     ``harness._diff_capabilities`` produced for this candidate): definitions, calls, and
-    ``"name": "…"`` declarations on the changed lines, falling back per hunk to the
-    enclosing definition when a hunk names nothing of its own. Not "every identifier" —
-    most changed lines in a real capability edit are docstring prose, and its words match
-    every rollout in the split.
+    ``"name": "…"`` declarations on the changed lines, ALWAYS together with the enclosing
+    definition (an edit inside a body reaches everything that calls the body). Not "every
+    identifier" — most changed lines in a real capability edit are docstring prose, and its
+    words match every rollout in the split.
   * ``in_footprint_tasks`` asks, per task, whether any of those names appears anywhere in
     the persisted rollout record. One flat substring search over the serialized rollout,
     rather than a walk of some particular trace schema: ``Rollout.tool_calls`` is the
     framework's only cross-adapter contract for "what the agent called", and adapters
     legitimately leave it empty while putting the same names in their own trace shape
     (harbor's tau2 rollouts do exactly this). The flat search reads both and cares about
-    neither. A name that reaches almost every task is then dropped, because it localizes
-    nothing — see ``_UBIQUITOUS_FRACTION``.
+    neither. If ANY of the edit's surfaces reaches almost every task, the whole footprint is
+    ABANDONED rather than that name dropped — the edit reaches almost everything, so there is
+    no narrow footprint to be had. See ``_UBIQUITOUS_FRACTION``.
 
 The search still OVER-includes, and that is the safe direction on purpose: over-including
 gives back some of the noise the restriction removes, while under-including would zero out
@@ -44,20 +52,28 @@ meaningless, no rollouts on disk, or a footprint that covers every task anyway. 
 that gets ``None`` falls back to the full delta vector, so nothing breaks when footprint
 detection cannot determine a surface.
 
-Measured on run_finalrun6's own rollouts, this is what the restriction does to the gate's
-bar for each of the run's 7 candidates (no new rollouts spent)::
+Measured on run_finalrun6's own rollouts (no new rollouts spent), with the safety rules in
+``_close`` and ``in_footprint_tasks`` applied::
 
-    cand_1  footprint None    SE 0.0222 -> 0.0222   (cross-cutting guard: no restriction)
-    cand_2  footprint 18/30   SE 0.0250 -> 0.0193
-    cand_3  footprint 13/30   SE 0.0276 -> 0.0208
-    cand_4  footprint 14/30   SE 0.0244 -> 0.0159
-    cand_5  footprint 11/30   SE 0.0318 -> 0.0255
-    cand_6  footprint 16/30   SE 0.0313 -> 0.0262
-    cand_7  footprint  4/30   SE 0.0346 -> 0.0046   (docstring-only edit to ONE tool)
+    cand_1  None    guard across all 6 write tools -> reaches everything -> full split
+    cand_2  None    new batch tool wrapping cancel_reservation (26/30 tasks)
+    cand_3  None    bundle of cand_1 + cand_2
+    cand_4  None    re-measurement of cand_2, byte-identical
+    cand_5  17/30   SE 0.0318 -> 0.0268
+    cand_6  None    bundle of cand_2 + cand_5
+    cand_7   4/30   SE 0.0346 -> 0.0113 (floored; see ``harness.paired_se_floor``)
+
+Be honest about what that shows: on THIS run, five of seven edits reach the split broadly
+enough that no restriction is available, and neither restricted verdict changes. The
+mechanism earns its keep on genuinely narrow edits, and its real value here is that it
+ABSTAINS instead of manufacturing confidence — an earlier revision of this module, which
+took the enclosing definition only when a hunk named nothing else and dropped ubiquitous
+symbols instead of abandoning, narrowed cand_7 to those 4 tasks at SE 0.0046 and ACCEPTED a
+docstring-only edit on two flipped rollouts.
 
 Note what stays unrestricted: the candidate's recorded ``val`` reward is still the mean over
 the WHOLE split, and so is every number the report and the val curve publish. The footprint
-narrows only the vector the significance test's variance is computed from.
+narrows only the vector the significance test is computed from.
 """
 
 from __future__ import annotations
@@ -90,12 +106,12 @@ _SURFACE = re.compile(
 _ENCLOSING = re.compile(
     r"\b(?:def|class|function|func|fn|sub|method)\s+([A-Za-z_][A-Za-z0-9_]{2,})")
 
-#: A symbol found in this fraction of the split's tasks or more is discarded before the
-#: footprint is built. It localizes nothing — whatever it is (a shared exception type, a
-#: helper every rollout touches, a common English word that survived the extractor), a
-#: footprint containing it is the whole split. Adaptive rather than another stop-list: the
-#: run's own rollouts say which names discriminate, and no hand-maintained word list has to
-#: guess it per capability, language or benchmark.
+#: A surface reaching this fraction of the split's tasks or more makes the edit UNLOCALIZABLE:
+#: ``in_footprint_tasks`` abandons and the caller measures the full split. It is not dropped so
+#: the rarer surfaces beside it can define a footprint — that is precisely how a 28-of-30-task
+#: edit got narrowed to its 3-task helper. Adaptive rather than another stop-list: the run's own
+#: rollouts say which names discriminate, so no hand-maintained word list has to guess it per
+#: capability, language or benchmark.
 _UBIQUITOUS_FRACTION = 0.8
 
 #: Keywords and ubiquitous library names that take a call-shape and would otherwise be
@@ -126,10 +142,18 @@ def touched_symbols(diff_text: str, *, max_symbols: int = 40) -> set[str]:
     lines = list((diff_text or "").splitlines())
 
     def _close():
-        # A hunk that named nothing of its own is an edit INSIDE something — its surface is
-        # the enclosing definition. Only then, so a hunk that does name its surfaces cannot
-        # drag in whatever else happens to sit within the diff's context window.
-        out.update(hunk or ({enclosing} if enclosing else set()))
+        # ALWAYS both — never "the enclosing definition only when the hunk named nothing".
+        # An edit INSIDE a broadly-reached function that adds a call to a rare helper is
+        # reached by everything that calls the function, not only by the helper's own callers:
+        # taking the helper alone footprints a 28-of-30-task edit to 3 tasks and zero-pads 25
+        # tasks that really moved. That is UNDER-inclusion, the one direction this module must
+        # never fail in — zero-padding an out-of-footprint regression raises Δ̄ *and* lowers
+        # the SE, so a net-harmful candidate can come out of the gate accepted. Including a
+        # neighbouring definition that merely sits inside the diff's context window costs some
+        # of the power gain instead, which is the safe direction.
+        out.update(hunk)
+        if enclosing:
+            out.add(enclosing)
 
     for line in lines:
         if line[:3] in ("+++", "---"):
@@ -168,9 +192,9 @@ def in_footprint_tasks(run_dir, tags, symbols, split: str = "val") -> set[str]:
     if not d.is_dir():
         return set()
     symbols = set(symbols)
-    # Which tasks each symbol reaches, counted per symbol rather than unioned as we go, so a
-    # symbol that reaches nearly everything can be dropped before the union — see
-    # _UBIQUITOUS_FRACTION.
+    # Which tasks each symbol reaches, counted PER SYMBOL rather than unioned as we go: one
+    # ubiquitous surface has to be recognizable as such, and it cannot be once the reaches are
+    # merged — see _UBIQUITOUS_FRACTION and the abandon below.
     reach: dict[str, set[str]] = {s: set() for s in symbols}
     tasks: set[str] = set()
     for tag in tags:
@@ -194,8 +218,15 @@ def in_footprint_tasks(run_dir, tags, symbols, split: str = "val") -> set[str]:
     cap = _UBIQUITOUS_FRACTION * len(tasks)
     hit: set[str] = set()
     for s, ts in reach.items():
-        if ts and len(ts) < cap:
-            hit |= ts
+        if len(ts) >= cap:
+            # ABANDON, do not drop-and-keep-the-rest. One of the edit's own surfaces reaches
+            # nearly the whole split, so the EDIT reaches nearly the whole split — there is no
+            # narrow footprint to be had, and the rarer surfaces beside it would otherwise
+            # define a confident, narrow, WRONG one (the 28-of-30 function beside its 3-task
+            # helper). An empty return reads as "unlocalizable" upstream and falls back to the
+            # full vector, which is the honest answer for a broadly-reaching edit.
+            return set()
+        hit |= ts
     return hit
 
 

--- a/core/cap_evolve/footprint.py
+++ b/core/cap_evolve/footprint.py
@@ -1,0 +1,230 @@
+"""Footprint detection — which val tasks an edit could causally have affected.
+
+A candidate's edit touches a handful of named surfaces (a tool, a prompt section, a
+function). The gate, though, measures its delta across EVERY val task, so every task the
+edit cannot reach contributes pure measurement noise to the SE and buries the effect.
+Measured on run_finalrun6 (7 candidates, 30 val tasks): SE(paired Δ) ran 0.022-0.035
+while the real per-edit effects were 0.011-0.05, and the 7-way null-control replicate
+spread (0.567-0.603) was statistically indistinguishable from the 7-way across-candidate
+spread (0.570-0.607) — the measurement could not tell an edit from a re-measurement.
+
+Restricting the delta vector to the tasks inside the edit's footprint is what fixes that:
+a task the edit cannot reach has Δ=0 BY CONSTRUCTION, not by measurement, so it belongs
+in the vector as a zero rather than as noise (see ``harness._paired_deltas``, which does
+the zero-padding — the vector keeps its full length, so Δ̄ stays on the same scale as the
+val reward while the SE stops being dominated by tasks the edit never touched).
+
+Both steps here are deliberately dumb and generic — no benchmark, capability, agent or
+optimizer shape is assumed:
+
+  * ``touched_symbols`` reads the NAMED SURFACES out of a unified diff (whatever
+    ``harness._diff_capabilities`` produced for this candidate): definitions, calls, and
+    ``"name": "…"`` declarations on the changed lines, falling back per hunk to the
+    enclosing definition when a hunk names nothing of its own. Not "every identifier" —
+    most changed lines in a real capability edit are docstring prose, and its words match
+    every rollout in the split.
+  * ``in_footprint_tasks`` asks, per task, whether any of those names appears anywhere in
+    the persisted rollout record. One flat substring search over the serialized rollout,
+    rather than a walk of some particular trace schema: ``Rollout.tool_calls`` is the
+    framework's only cross-adapter contract for "what the agent called", and adapters
+    legitimately leave it empty while putting the same names in their own trace shape
+    (harbor's tau2 rollouts do exactly this). The flat search reads both and cares about
+    neither. A name that reaches almost every task is then dropped, because it localizes
+    nothing — see ``_UBIQUITOUS_FRACTION``.
+
+The search still OVER-includes, and that is the safe direction on purpose: over-including
+gives back some of the noise the restriction removes, while under-including would zero out
+a task the edit really did move and manufacture a gain out of a task that regressed. Every
+failure mode degrades toward "no footprint", which callers read as "measure everything, as
+before".
+
+``footprint`` returns ``None`` — never a partial guess — whenever it cannot establish a
+restriction worth applying: no diff, no surfaces, a diff so broad that its surface set is
+meaningless, no rollouts on disk, or a footprint that covers every task anyway. A caller
+that gets ``None`` falls back to the full delta vector, so nothing breaks when footprint
+detection cannot determine a surface.
+
+Measured on run_finalrun6's own rollouts, this is what the restriction does to the gate's
+bar for each of the run's 7 candidates (no new rollouts spent)::
+
+    cand_1  footprint None    SE 0.0222 -> 0.0222   (cross-cutting guard: no restriction)
+    cand_2  footprint 18/30   SE 0.0250 -> 0.0193
+    cand_3  footprint 13/30   SE 0.0276 -> 0.0208
+    cand_4  footprint 14/30   SE 0.0244 -> 0.0159
+    cand_5  footprint 11/30   SE 0.0318 -> 0.0255
+    cand_6  footprint 16/30   SE 0.0313 -> 0.0262
+    cand_7  footprint  4/30   SE 0.0346 -> 0.0046   (docstring-only edit to ONE tool)
+
+Note what stays unrestricted: the candidate's recorded ``val`` reward is still the mean over
+the WHOLE split, and so is every number the report and the val curve publish. The footprint
+narrows only the vector the significance test's variance is computed from.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+#: NAMED SURFACES on a changed line, in three shapes — a definition (``def x`` / ``class X``
+#: / ``function x``), a call (``x(``), and a declared name in a data file (``"name": "x"``,
+#: which is how ``tools.json`` and most manifest formats spell a tool). Deliberately NOT
+#: "every identifier": most changed lines in a real capability edit are docstring prose, and
+#: the words in it ("cancelled", "flights", "upcoming", "user") match every rollout in the
+#: split. Measured on run_finalrun6's cand_2 — a 1.7KB diff adding one tool — an
+#: every-identifier extractor produced 67 symbols of which 60 were English; the surface
+#: extractor produces the two that matter (``cancel_reservations``, ``cancel_reservation``).
+#: NOTE the call arm has NO ``\s*`` before ``\(``. Prose puts a space before a parenthesis
+#: ("more than one reservation cancelled (e.g. …)"); a call never does, in any language's
+#: style. That one character is what stops docstring English from being read as a surface.
+_SURFACE = re.compile(
+    r"(?:\b(?:def|class|function|func|fn|sub|method)\s+([A-Za-z_][A-Za-z0-9_]{2,}))"
+    r"|(?:\b([A-Za-z_][A-Za-z0-9_]{2,})\()"
+    r"|(?:[\"']name[\"']\s*:\s*[\"']([^\"']{3,})[\"'])"
+)
+
+#: Definitions only, for the lines a hunk shows as CONTEXT rather than as changed — plus the
+#: trailing section label on a ``@@`` header, which most diff tools fill with the enclosing
+#: definition. An edit inside a function body (a docstring-only change, say) names no surface
+#: on its own changed lines, and the enclosing definition IS its surface: run_finalrun6's
+#: cand_7 rewrote one tool's docstring and would otherwise have had no footprint at all.
+_ENCLOSING = re.compile(
+    r"\b(?:def|class|function|func|fn|sub|method)\s+([A-Za-z_][A-Za-z0-9_]{2,})")
+
+#: A symbol found in this fraction of the split's tasks or more is discarded before the
+#: footprint is built. It localizes nothing — whatever it is (a shared exception type, a
+#: helper every rollout touches, a common English word that survived the extractor), a
+#: footprint containing it is the whole split. Adaptive rather than another stop-list: the
+#: run's own rollouts say which names discriminate, and no hand-maintained word list has to
+#: guess it per capability, language or benchmark.
+_UBIQUITOUS_FRACTION = 0.8
+
+#: Keywords and ubiquitous library names that take a call-shape and would otherwise be
+#: extracted as surfaces. They appear in nearly every edit and name nothing specific to it.
+_STOP = frozenset("""
+append assert bool break case catch class const continue def defaultdict del dict elif
+else enum except exception export extends filter finally float for foreach format from
+func function get getattr goto hasattr if implements import in include index insert
+instanceof int interface isinstance items join keys lambda len let list map max min new
+next nil none not null object open or pass pop print property put raise range replace
+return round self set setattr sorted split staticmethod str strip string struct sum super
+switch throw throws try tuple type typeof union update use values var void while with
+yield
+""".split())
+
+
+def touched_symbols(diff_text: str, *, max_symbols: int = 40) -> set[str]:
+    """Named surfaces defined, called or declared on the changed (+/-) lines of a diff.
+
+    ``max_symbols`` is a give-up threshold, not a truncation: a diff that names more distinct
+    surfaces than this is a rewrite rather than a targeted edit, and its footprint would cover
+    the split anyway. Returning the empty set makes the caller fall back to measuring
+    everything, which is the honest answer for a rewrite.
+    """
+    out: set[str] = set()
+    hunk: set[str] = set()          # surfaces named by THIS hunk's own changed lines
+    enclosing: str | None = None    # nearest definition seen in context before them
+    lines = list((diff_text or "").splitlines())
+
+    def _close():
+        # A hunk that named nothing of its own is an edit INSIDE something — its surface is
+        # the enclosing definition. Only then, so a hunk that does name its surfaces cannot
+        # drag in whatever else happens to sit within the diff's context window.
+        out.update(hunk or ({enclosing} if enclosing else set()))
+
+    for line in lines:
+        if line[:3] in ("+++", "---"):
+            continue
+        if line.startswith("@@"):
+            _close()
+            hunk, enclosing = set(), None
+            for m in _ENCLOSING.finditer(line):   # git-style section label, when present
+                enclosing = m.group(1)
+            continue
+        if line[:1] in ("+", "-"):
+            for m in _SURFACE.finditer(line[1:]):
+                w = m.group(1) or m.group(2) or m.group(3)
+                if w and w.lower() not in _STOP:
+                    hunk.add(w)
+        else:
+            for m in _ENCLOSING.finditer(line):
+                if m.group(1).lower() not in _STOP:
+                    enclosing = m.group(1)        # nearest one wins
+    _close()
+    return set() if len(out) > max_symbols else out
+
+
+def in_footprint_tasks(run_dir, tags, symbols, split: str = "val") -> set[str]:
+    """Task ids whose persisted rollouts (under any of ``tags``) mention any symbol.
+
+    Both sides' tags belong in ``tags``: an edit that ADDS a surface is exercised only in
+    the candidate's rollouts, one that REMOVES a surface only in the parent's, and a task
+    that either side routed through the edited surface is inside the footprint. The union
+    is the conservative (over-including) choice, which is the direction that cannot
+    manufacture a gain.
+    """
+    if not symbols:
+        return set()
+    d = Path(getattr(run_dir, "rollouts", run_dir)) / split
+    if not d.is_dir():
+        return set()
+    symbols = set(symbols)
+    # Which tasks each symbol reaches, counted per symbol rather than unioned as we go, so a
+    # symbol that reaches nearly everything can be dropped before the union — see
+    # _UBIQUITOUS_FRACTION.
+    reach: dict[str, set[str]] = {s: set() for s in symbols}
+    tasks: set[str] = set()
+    for tag in tags:
+        if not tag:
+            continue
+        for f in sorted(d.glob(f"*__{tag}__t*.json")):
+            tid = f.name.split("__", 1)[0]
+            tasks.add(tid)
+            pending = [s for s in symbols if tid not in reach[s]]
+            if not pending:
+                continue          # every symbol already reaches this task
+            try:
+                text = f.read_text(encoding="utf-8")
+            except OSError:
+                continue
+            for s in pending:
+                if s in text:
+                    reach[s].add(tid)
+    if not tasks:
+        return set()
+    cap = _UBIQUITOUS_FRACTION * len(tasks)
+    hit: set[str] = set()
+    for s, ts in reach.items():
+        if ts and len(ts) < cap:
+            hit |= ts
+    return hit
+
+
+def footprint(run_dir, *, parent_dir, cand_dir, tags, split: str = "val",
+              all_task_ids=None) -> set[str] | None:
+    """The task ids a candidate's edit can causally reach — or ``None`` if unknowable.
+
+    ``None`` means "no usable footprint data": the caller must measure the full split, the
+    behaviour every run had before this existed. It is returned for a candidate whose diff
+    is empty or too broad to localize, whose rollouts are not on disk, and — importantly —
+    whose footprint turns out to cover every task that was measured, since restricting to
+    everything is not a restriction and claiming one would be misleading.
+    """
+    from .harness import _diff_capabilities
+
+    try:
+        # A much higher cap than the optimizer-prompt default: this diff is read by a
+        # regex, not by a human with a context window, and a truncated tail silently
+        # drops the symbols that localize the edit.
+        diff = _diff_capabilities(Path(parent_dir), Path(cand_dir), max_chars=400_000,
+                                  context=12)
+    except Exception:  # noqa: BLE001 — an unreadable snapshot means no footprint, not a crash
+        return None
+    symbols = touched_symbols(diff)
+    if not symbols:
+        return None
+    tasks = in_footprint_tasks(run_dir, tags, symbols, split)
+    if not tasks:
+        return None
+    if all_task_ids is not None and set(map(str, all_task_ids)) <= tasks:
+        return None
+    return tasks

--- a/core/cap_evolve/gate.py
+++ b/core/cap_evolve/gate.py
@@ -111,6 +111,7 @@ def decide(
     current_stderr: float = 0.0,
     threshold: float = 0.0,
     paired_deltas: list | None = None,
+    paired_se_floor: float = 0.0,
     coverage: float | None = None,
     min_coverage: float = 0.6,
     run_dir=None,
@@ -139,8 +140,17 @@ def decide(
     optimizer to go fix content that was never evaluated. Pass ``min_coverage=0.0``
     to disable the guard.
 
-    ``run_dir`` (optional) is used only to log a ``gate_warning`` event when an SE
-    collapses to 0 (so the silent degeneration to strict is auditable).
+    ``paired_se_floor`` (paired mode only, 0 = off) is a lower bound on the paired SE,
+    for when the CROSS-TASK SPREAD of ``paired_deltas`` is known to understate the real
+    uncertainty. The paired SE is estimated from how much the per-task deltas differ from
+    each other, which silently assumes each per-task delta is measured precisely. On a few
+    tasks it is not: a footprint-restricted vector of 4 real deltas whose values happen to
+    be {0, +0.1, 0, +0.1} yields SE 0.0046 and an ACCEPT, while each of those +0.1 moves is
+    one flipped rollout out of ten — moves ``harness.move_is_resolved`` refuses to call real
+    at all. Pass ``sqrt(Σ_t (par_se_t² + cand_se_t²)) / n`` (see
+    ``harness.paired_se_floor``) and the two tests stop contradicting each other. Measured
+    on run_finalrun6's cand_7 — a docstring-only edit — this is the difference between a
+    fabricated accept at SE 0.0046 and a reject at the floor's 0.0113.
     """
     if split.lower() != "val":
         raise TrainGateError(
@@ -176,6 +186,8 @@ def decide(
                 se = math.sqrt(var / n)
             else:
                 se = 0.0
+            # The cross-task spread cannot go below what per-task trial noise implies.
+            se = max(se, float(paired_se_floor or 0.0))
             if se == 0.0:
                 # Paired SE collapsed (n=1, or every task moved identically). Do not
                 # silently act strict — warn loudly, then apply the documented strict

--- a/core/cap_evolve/gepa.py
+++ b/core/cap_evolve/gepa.py
@@ -57,6 +57,7 @@ from .cache import EvalCache, hash_candidate_dir
 from .harness import (
     OptimizerContext,
     _augment_instructions,
+    move_is_resolved,
     _init_memory_store,
     _live,
     _paired_deltas,
@@ -775,15 +776,21 @@ def _full_val_gate(
     )
     accepted = decision.accept
     if accepted and no_regression:
-        eps = 1e-9
         # Compare only tasks BOTH sides actually measured: an unscored candidate
         # task is missing data, and reading its 0.0 as "broke a task the parent
         # passed" would let one image-pull failure veto a genuinely better edit.
-        pr = {pt["task_id"]: pt.get("reward", 0.0) for pt in parent_result.per_task
-              if has_valid_trials(pt)}
-        cr = {pt["task_id"]: pt.get("reward", 0.0) for pt in cand_val.per_task
-              if has_valid_trials(pt)}
-        regressions = sorted(t for t, v in pr.items() if t in cr and cr[t] < v - eps)
+        # The drop must also clear 2*SE of its own per-task measurement
+        # (``harness.move_is_resolved``): this veto REJECTS a gate-passing candidate, so a
+        # single flipped rollout out of ten must not be able to do it.
+        pr = {pt["task_id"]: pt for pt in parent_result.per_task if has_valid_trials(pt)}
+        cr = {pt["task_id"]: pt for pt in cand_val.per_task if has_valid_trials(pt)}
+        regressions = sorted(
+            t for t, pt in pr.items()
+            if t in cr
+            and (cr[t].get("reward", 0.0) or 0.0) < (pt.get("reward", 0.0) or 0.0)
+            and move_is_resolved(pt.get("reward", 0.0) or 0.0,
+                                 cr[t].get("reward", 0.0) or 0.0,
+                                 pt.get("stderr") or 0.0, cr[t].get("stderr") or 0.0))
         if regressions:
             accepted = False
             decision.reason += f"; REJECTED by no-regression gate (broke {regressions})"

--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -742,8 +742,17 @@ def _paired_deltas(current_val: SplitResult, cand_val: SplitResult,
     buries the effect. Measured on run_finalrun6, SE(paired Δ) over all 30 val tasks ran
     0.022-0.035 while the real per-edit effects were 0.011-0.05 — the gate could not
     resolve the thing it was built to resolve. Zero-padding rather than dropping keeps the
-    vector's full length, so Δ̄ stays on the same scale as the val reward (and as every
-    threshold, ledger row and val curve derived from it) while only the variance changes.
+    vector's full LENGTH, so Δ̄ stays on the same SCALE as the val reward (and as every
+    threshold, ledger row and val curve derived from it).
+
+    It changes BOTH halves of the test, not just the variance: Δ̄ moves too, since the
+    out-of-footprint deltas that used to be averaged in are now zeros. That is the mechanism,
+    not a side effect — but it is also why the footprint must never under-include. Zeroing a
+    task that really regressed raises Δ̄ and lowers the SE together, both pushing toward
+    accept, so a net-harmful candidate could be accepted. ``footprint`` is built to abandon
+    (return ``None``) rather than narrow when it cannot be sure; see its ``_close`` and
+    ``in_footprint_tasks``.
+
     ``None`` applies no restriction, which is what every caller without footprint data
     passes.
 
@@ -1071,6 +1080,33 @@ def _per_task_stderr(run_dir: RunDir, tag: str, split: str = "val") -> dict[str,
     except Exception:  # noqa: BLE001
         return {}
     return {pt["task_id"]: float(pt.get("stderr") or 0.0) for pt in (sr.per_task or [])}
+
+
+def paired_se_floor(run_dir: RunDir, cid: str, parent_id: str, tasks, n_total: int,
+                    split: str = "val") -> float:
+    """Lower bound on the paired SE implied by PER-TASK trial noise: √Σ(σ²par+σ²cand) / n.
+
+    The paired gate estimates its SE from the cross-task SPREAD of the delta vector, which
+    quietly assumes each per-task delta is itself measured precisely. On a footprint-restricted
+    vector that assumption breaks: run_finalrun6's cand_7 restricts to 4 tasks whose deltas are
+    {0, +0.1, 0, +0.1}; the spread of those four numbers is small, so the gate read SE 0.0046
+    and ACCEPTED — on two moves of one flipped rollout each, the very moves
+    ``move_is_resolved`` refuses to call real. Without this floor the two halves of this change
+    contradict each other: the ledger says ``unresolved``, the gate says ``significant``. With
+    it, cand_7's bar is 0.0113 against a Δ̄ of +0.0067 and it correctly rejects.
+
+    ``tasks`` are the in-footprint task ids and ``n_total`` the full (zero-padded) vector
+    length, so the result is on the same split scale as the Δ̄ it bounds. Returns 0.0 — no floor
+    — when no per-task SEs exist, e.g. a single-trial run, where there is no variance estimate
+    to build one from and the cross-task spread is all there is."""
+    import math
+
+    par_se = _per_task_stderr(run_dir, parent_id, split)
+    cand_se = _per_task_stderr(run_dir, cid, split)
+    if not par_se and not cand_se:
+        return 0.0
+    total = sum(par_se.get(str(t), 0.0) ** 2 + cand_se.get(str(t), 0.0) ** 2 for t in tasks)
+    return math.sqrt(total) / n_total if n_total else 0.0
 
 
 def _candidate_task_impact(run_dir: RunDir, cid: str, split: str = "val",
@@ -2214,6 +2250,12 @@ def run_step(
                               n_in_footprint=len(fp), n_tasks=len(cand_val.per_task or []),
                               tasks=sorted(map(str, fp))[:60])
     paired_deltas = _paired_deltas(current_val, cand_val, footprint=fp)
+    # Only when restricted: the zeros make the cross-task spread an unreliable SE estimate on
+    # a small footprint, so it is floored by what per-task trial noise implies. Unrestricted
+    # vectors keep the SE they always had, so no existing verdict moves.
+    if fp is not None and paired_deltas:
+        gate_kwargs.setdefault("paired_se_floor", paired_se_floor(
+            run_dir, cid, parent_id or "seed", fp, len(paired_deltas)))
     if "mode" not in gate_kwargs and paired_deltas is not None:
         gate_kwargs["mode"] = "paired"
     decision = gate_mod.decide(
@@ -2231,13 +2273,23 @@ def run_step(
         # actually measured — an unscored task is missing data, and treating its
         # 0.0 as "broke a task the parent passed" would let a single image-pull
         # failure veto a genuinely better candidate.
-        eps = 1e-9
-        parent_reward = {pt["task_id"]: pt.get("reward", 0.0) for pt in current_val.per_task
+        # The drop must clear 2*SE of its own per-task measurement (``move_is_resolved`` — the
+        # ONE bar every broke/fixed claim in this framework uses). This veto has a STRONGER
+        # consequence than the reported lists: it turns a gate-passing candidate into a
+        # rejection, so a single flipped rollout out of ten used to be able to veto a
+        # genuinely better edit outright.
+        parent_reward = {pt["task_id"]: pt for pt in current_val.per_task
                          if has_valid_trials(pt)}
-        cand_reward = {pt["task_id"]: pt.get("reward", 0.0) for pt in cand_val.per_task
+        cand_reward = {pt["task_id"]: pt for pt in cand_val.per_task
                        if has_valid_trials(pt)}
-        regressions = sorted(t for t, pr in parent_reward.items()
-                             if t in cand_reward and cand_reward[t] < pr - eps)
+        regressions = sorted(
+            t for t, pt in parent_reward.items()
+            if t in cand_reward
+            and (cand_reward[t].get("reward", 0.0) or 0.0) < (pt.get("reward", 0.0) or 0.0)
+            and move_is_resolved(pt.get("reward", 0.0) or 0.0,
+                                 cand_reward[t].get("reward", 0.0) or 0.0,
+                                 pt.get("stderr") or 0.0,
+                                 cand_reward[t].get("stderr") or 0.0))
         if regressions:
             accepted = False
             decision.reason += f"; REJECTED by no-regression gate (broke {regressions})"

--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -26,6 +26,7 @@ from pathlib import Path
 from typing import Callable
 
 from . import convergence as convergence_mod
+from . import footprint as footprint_mod
 from . import gate as gate_mod
 from . import integrity
 from .loop import SplitResult, aggregate_scores, has_valid_trials
@@ -475,21 +476,31 @@ def evaluate_candidate(
     return result
 
 
-def split_result_from_rollouts(run_dir: RunDir, tag: str, split: str = "val", ks=(1, 2)) -> SplitResult:
+def split_result_from_rollouts(run_dir: RunDir, tag, split: str = "val", ks=(1, 2)) -> SplitResult:
     """Reconstruct a candidate's SplitResult from its persisted rollouts.
 
     Used to RESUME a run from the current best candidate (its val score is read
     back from disk) without re-scoring it.
+
+    ``tag`` may be a SEQUENCE of tags, in which case their trials are POOLED per task into
+    one estimate. That is how a round's null-control replicates become a better parent
+    reference than any one of them: they are byte-identical copies of the same parent
+    measured in the same round, so they are draws from the same distribution, and pooling
+    two of them halves the parent side's per-task variance for free — the rollouts are
+    already on disk (see ``round.py``'s ``control_replicates``). Pooling is not the same as
+    averaging their means: it merges the underlying trials, so a task measured by only one
+    replicate is not silently upweighted.
     """
     import json as _json
     from .stats import mean, stderr
+    tags = [tag] if isinstance(tag, str) else [str(t) for t in tag]
     vdir = run_dir.rollouts / split
     by_task: dict[str, list[float]] = {}
     feedback: dict[str, str] = {}
     raw: dict[str, dict] = {}
     metrics_by_task: dict[str, list] = {}
     if vdir.exists():
-        for f in sorted(vdir.glob(f"*__{tag}__t*.json")):
+        for f in sorted(g for t in tags for g in vdir.glob(f"*__{t}__t*.json")):
             rec = _json.loads(f.read_text(encoding="utf-8"))
             sc = rec.get("score", {})
             tid = sc.get("task_id") or f.name.split("__")[0]
@@ -716,12 +727,25 @@ def _optimizer_failure_detail(proc: "subprocess.CompletedProcess") -> str:
 
 # ---- one propose -> gate step ---------------------------------------------
 
-def _paired_deltas(current_val: SplitResult, cand_val: SplitResult) -> list | None:
+def _paired_deltas(current_val: SplitResult, cand_val: SplitResult,
+                   footprint=None) -> list | None:
     """Aligned per-task ``cand_reward[t] - curr_reward[t]`` over shared val tasks.
 
     Returns ``None`` if either side lacks per-task data or they share no task ids
     (so the caller falls back to the unpaired significance test). Tasks present in
     only one side are dropped — a paired test needs both halves of the pair.
+
+    ``footprint`` (optional, from ``footprint.footprint``) is the set of task ids the
+    candidate's edit can causally reach. Tasks OUTSIDE it enter the vector as **0.0**
+    rather than as their measured delta: an edit that cannot reach a task has Δ=0 by
+    construction, and the wobble measured there is pure noise that inflates the SE and
+    buries the effect. Measured on run_finalrun6, SE(paired Δ) over all 30 val tasks ran
+    0.022-0.035 while the real per-edit effects were 0.011-0.05 — the gate could not
+    resolve the thing it was built to resolve. Zero-padding rather than dropping keeps the
+    vector's full length, so Δ̄ stays on the same scale as the val reward (and as every
+    threshold, ledger row and val curve derived from it) while only the variance changes.
+    ``None`` applies no restriction, which is what every caller without footprint data
+    passes.
 
     A task is also dropped when EITHER side failed to produce a valid trial. This
     matters more here than anywhere else: pairing is per-task, so an unscored task
@@ -737,7 +761,9 @@ def _paired_deltas(current_val: SplitResult, cand_val: SplitResult) -> list | No
               if t in cur and has_valid_trials(cand[t]) and has_valid_trials(cur[t])]
     if not shared:
         return None
-    return [float(cand[t].get("reward", 0.0) or 0.0)
+    fp = None if footprint is None else {str(t) for t in footprint}
+    return [0.0 if (fp is not None and str(t) not in fp) else
+            float(cand[t].get("reward", 0.0) or 0.0)
             - float(cur[t].get("reward", 0.0) or 0.0)
             for t in sorted(shared)]
 
@@ -747,8 +773,8 @@ def _paired_deltas(current_val: SplitResult, cand_val: SplitResult) -> list | No
 # The optimizer's working dir carries cross-iteration files, with clean ownership
 # so there is never confusion about who writes what (the recurring user complaint about
 # the old MEMORY.md/STATE.md pair):
-#   LEDGER.md   — FRAMEWORK-owned, FACTUAL, regenerated each iter (the objective record:
-#                 per-iteration outcomes + the exact tasks each candidate broke/fixed).
+#   LEDGER.md   — FRAMEWORK-owned, FACTUAL, regenerated each iter (the measured record:
+#                 per-iteration outcomes + the tasks each candidate measurably broke/fixed).
 #   JOURNAL.md  — OPTIMIZER-owned, JUDGMENT, append-only across the WHOLE run (what was
 #                 tried, what worked, what regressed, refuted hypotheses, focus-next).
 #   PROCESS.md  — OPTIMIZER-owned, EXPLAINABILITY, fresh each iter, snapshotted with the
@@ -774,7 +800,8 @@ _JOURNAL_SEED = (
     "EVERY prior attempt (not just the last accepted one) and never re-test a refuted "
     "idea.\n\n"
     "You CANNOT know your own gate result while you write — the harness scores you AFTER "
-    "you stop and stamps a **RESULT** line (outcome + Δ + the EXACT tasks you broke/fixed) "
+    "you stop and stamps a **RESULT** line (outcome + Δ + the tasks you measurably broke/fixed, "
+    "plus the ones whose move was too small to resolve) "
     "right below your entry. So do NOT write 'what worked' as a guess. To learn what "
     "actually worked, READ the framework RESULT lines of prior entries (and LEDGER.md): an "
     "entry whose RESULT says `rejected` with `broke={...}` tells you which specific edits to "
@@ -943,8 +970,14 @@ def _capability_files(d: Path) -> dict[str, str]:
     return out
 
 
-def _diff_capabilities(parent_dir: Path, cand_dir: Path, *, max_chars: int = 8000) -> str:
-    """Unified diff of capability files between a parent and candidate snapshot."""
+def _diff_capabilities(parent_dir: Path, cand_dir: Path, *, max_chars: int = 8000,
+                       context: int = 2) -> str:
+    """Unified diff of capability files between a parent and candidate snapshot.
+
+    ``context`` is the diff's ``n``. Footprint detection asks for a wide one: an edit inside a
+    function body (a docstring rewrite, say) names no surface on its own changed lines, and the
+    only place its enclosing definition appears is a context line — ``difflib`` does not fill
+    in the ``@@`` section label the way git does."""
     import difflib
     pf, cf = _capability_files(parent_dir), _capability_files(cand_dir)
     blocks: list[str] = []
@@ -954,7 +987,7 @@ def _diff_capabilities(parent_dir: Path, cand_dir: Path, *, max_chars: int = 800
         if a == b:
             continue
         diff = "\n".join(ln for ln in difflib.unified_diff(
-            a, b, fromfile=f"a/{path}", tofile=f"b/{path}", lineterm="", n=2))
+            a, b, fromfile=f"a/{path}", tofile=f"b/{path}", lineterm="", n=context))
         if diff.strip():
             blocks.append(diff)
     text = "\n".join(blocks)
@@ -997,15 +1030,77 @@ def _per_task_rewards(run_dir: RunDir, tag: str, split: str = "val") -> dict[str
     return {pt["task_id"]: float(pt.get("reward", 0.0)) for pt in (sr.per_task or [])}
 
 
+def move_is_resolved(par: float, cand: float,
+                     par_se: float = 0.0, cand_se: float = 0.0,
+                     eps: float = 1e-9) -> bool:
+    """Did this task's reward move by more than its own measurement error can explain?
+
+    THE one resolution bar behind every per-task broke/fixed/regressed claim the framework
+    makes — ``_candidate_task_impact`` (LEDGER.md + the journal RESULT stamp),
+    ``gate_check.regressions`` (the round table's diagnosis list), ``measure.py``'s sealed
+    seed→best movement, and ``spend.py``'s "don't regress task X" check. It lives here, once,
+    because four copies of a bar is how three of them stayed at ``1e-9`` while one was fixed.
+
+    ``2·SE`` of the PAIRED per-task difference (the two sides' per-task SEs in quadrature) —
+    the same "smallest resolvable effect" the gate reports for the split mean, applied per
+    task. Below it, the move is inside the noise of measuring the task twice and asserting
+    the edit caused it is a fabrication: on run_finalrun6 a 1.0 → 0.9 move at 10 trials (ONE
+    flipped rollout) was stamped a behavioural break, byte-identical code got different
+    broke/fixed labels across two measurements, and the optimizer spent three rounds
+    reasoning about the phantom regression — including on a docstring-only edit that cannot
+    change behaviour at all.
+
+    ``eps`` is the floor, so a run at one trial per task — where every per-task SE is 0 and
+    the single draw is all the evidence there is — classifies exactly as it always did.
+    """
+    import math
+    return abs(cand - par) > max(2.0 * math.sqrt(par_se ** 2 + cand_se ** 2), eps)
+
+
+def _per_task_stderr(run_dir: RunDir, tag: str, split: str = "val") -> dict[str, float]:
+    """Per-task standard error over trials for ``tag`` (σ/√T), rebuilt from rollouts.
+
+    The same numbers the gate's variance already rests on — ``Score.stderr``, computed by
+    ``aggregate_scores`` from the per-trial rewards — so the broke/fixed bar below is
+    derived from this run's own measured noise and carries no benchmark-specific constant.
+    ``{}`` when no rollouts were persisted; a single-trial tag yields 0.0 per task, which
+    is correct: at one trial there is no variance estimate and the one draw is all the
+    evidence there is."""
+    try:
+        sr = split_result_from_rollouts(run_dir, tag, split)
+    except Exception:  # noqa: BLE001
+        return {}
+    return {pt["task_id"]: float(pt.get("stderr") or 0.0) for pt in (sr.per_task or [])}
+
+
 def _candidate_task_impact(run_dir: RunDir, cid: str, split: str = "val",
                            parent_of: dict | None = None) -> dict | None:
     """Per-task reward Δ of candidate ``cid`` vs its PARENT, from rollouts.
 
-    Returns ``{"broke": [...], "fixed": [...], "delta": float}`` where ``broke`` are
-    tasks that were PASSING (reward ≈ 1) under the parent and DROPPED under the
-    candidate, and ``fixed`` are tasks that were failing under the parent and now
-    PASS. ``delta`` is the mean per-task reward change over shared tasks. Returns
-    ``None`` when either side has no rollouts on disk (nothing to compare)."""
+    Returns ``{"broke": [...], "fixed": [...], "unresolved": [...], "delta": float}``.
+    ``broke`` are tasks that were PASSING (reward ≈ 1) under the parent and dropped
+    MEASURABLY under the candidate; ``fixed`` are tasks that were failing under the parent
+    and now pass. ``delta`` is the mean per-task reward change over shared tasks. Returns
+    ``None`` when either side has no rollouts on disk (nothing to compare).
+
+    "Measurably" is the whole point of the ``bar`` below, and it used to be missing: the
+    test was ``> 1e-9``, so a task that went 1.0 → 0.9 because ONE of ten rollouts flipped
+    was stamped a real behavioural break. That is not a hypothetical — on run_finalrun6,
+    byte-identical code measured twice (cand_2 and its fresh-tag re-measurement cand_4) got
+    DIFFERENT broke/fixed labels, and the optimizer reasoned from them: its journal spent
+    three rounds re-deriving that "task 27" was noise after the label asserted a regression
+    on structurally unrelated candidates, one of them a docstring-only edit that cannot
+    change behaviour at all.
+
+    So a move counts as broke/fixed only when it exceeds ``2·SE`` of its own per-task
+    measurement (SE of the paired difference: the two sides' per-task SEs in quadrature —
+    the same 2·SE "smallest resolvable effect" the gate reports for the split mean, applied
+    per task). Sub-threshold movers are returned as ``unresolved``: they moved, the
+    measurement cannot say whether the edit did it, and asserting causality either way is
+    the thing that poisoned the reasoning. At one trial per task every SE is 0, the bar
+    collapses to ``eps``, and the classification is exactly what it always was."""
+    import math
+
     parent_of = parent_of if parent_of is not None else _parent_map(run_dir)
     parent_id = parent_of.get(cid, "seed")
     cand = _per_task_rewards(run_dir, cid, split)
@@ -1016,12 +1111,22 @@ def _candidate_task_impact(run_dir: RunDir, cid: str, split: str = "val",
     if not shared:
         return None
     eps = 1e-9
-    broke = sorted(t for t in shared
-                   if par[t] >= 1.0 - eps and cand[t] < par[t] - eps)
-    fixed = sorted(t for t in shared
-                   if par[t] < 1.0 - eps and cand[t] >= 1.0 - eps)
+    cand_se = _per_task_stderr(run_dir, cid, split)
+    par_se = _per_task_stderr(run_dir, parent_id, split)
+    broke, fixed, unresolved = [], [], []
+    for t in sorted(shared):
+        d = cand[t] - par[t]
+        if abs(d) <= eps:
+            continue
+        if not move_is_resolved(par[t], cand[t], par_se.get(t, 0.0), cand_se.get(t, 0.0)):
+            unresolved.append(t)
+        elif par[t] >= 1.0 - eps and d < 0:
+            broke.append(t)
+        elif par[t] < 1.0 - eps and cand[t] >= 1.0 - eps:
+            fixed.append(t)
     delta = sum(cand[t] - par[t] for t in shared) / len(shared)
-    return {"broke": broke, "fixed": fixed, "delta": delta, "parent": parent_id}
+    return {"broke": broke, "fixed": fixed, "unresolved": unresolved,
+            "delta": delta, "parent": parent_id}
 
 
 def _journal_tail(workdir: Path) -> str:
@@ -1072,7 +1177,7 @@ def pending_handover(workdir: Path, run_dir: RunDir) -> str:
 
 def _build_ledger(workdir: Path, run_dir: RunDir) -> None:
     """Write the FACTUAL, framework-owned LEDGER.md: one row per prior iteration with
-    its outcome + the exact tasks it broke/fixed. Deterministic — the objective record;
+    its outcome + the tasks it measurably broke/fixed. Deterministic — the measured record;
     the optimizer's own narrative lives in JOURNAL.md."""
     parent_of = _parent_map(run_dir)
     # Outcome per candidate from step events (accept/reject + val + parent).
@@ -1089,8 +1194,9 @@ def _build_ledger(workdir: Path, run_dir: RunDir) -> None:
     except Exception:  # noqa: BLE001
         rows = []
 
-    table = ["| iter | candidate | parent | outcome | val | Δ vs parent | broke (were passing) | fixed |",
-             "| --- | --- | --- | --- | --- | --- | --- | --- |"]
+    table = ["| iter | candidate | parent | outcome | val | Δ vs parent | broke (were passing) "
+             "| fixed | unresolved (moved < 2·SE) |",
+             "| --- | --- | --- | --- | --- | --- | --- | --- | --- |"]
     void: list[str] = []
     for i, rec in enumerate(rows, 1):
         cid = str(rec.get("candidate"))
@@ -1109,19 +1215,27 @@ def _build_ledger(workdir: Path, run_dir: RunDir) -> None:
         imp = _candidate_task_impact(run_dir, cid, "val", parent_of=parent_of) or {}
         broke = "{" + ", ".join(str(t) for t in (imp.get("broke") or [])[:20]) + "}"
         fixed = "{" + ", ".join(str(t) for t in (imp.get("fixed") or [])[:20]) + "}"
+        unres = "{" + ", ".join(str(t) for t in (imp.get("unresolved") or [])[:20]) + "}"
         vstr = f"{val:.3f}" if isinstance(val, (int, float)) else ""
-        table.append(f"| {i} | {cid} | {par} | {outcome} | {vstr} | {d} | {broke} | {fixed} |")
+        table.append(f"| {i} | {cid} | {par} | {outcome} | {vstr} | {d} | {broke} | {fixed} "
+                     f"| {unres} |")
     if len(table) == 2:
-        table.append("| — | (baseline only) | — | — | — | — | {} | {} |")
+        table.append("| — | (baseline only) | — | — | — | — | {} | {} | {} |")
 
     best = run_dir.best_id or "seed"
     text = (
         "# LEDGER — factual run record (framework-maintained; READ-ONLY)\n\n"
-        "The objective record of every iteration: which candidate, its parent, whether the "
-        "gate ACCEPTED it, the val reward + Δ, and the EXACT tasks it broke / fixed. Facts "
+        "The measured record of every iteration: which candidate, its parent, whether the "
+        "gate ACCEPTED it, the val reward + Δ, and the tasks it broke / fixed. Facts "
         "only — your own narrative, lessons, and refuted hypotheses go in JOURNAL.md. Use "
         "this to never re-introduce a change that broke a task, and to see which approaches "
         "the gate accepted vs rejected.\n\n"
+        "`broke` / `fixed` list only tasks whose move EXCEEDED 2·SE of its own per-task "
+        "measurement error, so they are claims the measurement can support. A task that "
+        "moved by less is in `unresolved`: it is NOT evidence the edit did anything to that "
+        "task, in either direction, and must not be reasoned about as a regression or a "
+        "win. Do not redesign an edit because a task appears there — re-measure it, or "
+        "ignore it.\n\n"
         "## Iterations\n" + "\n".join(table) + "\n\n"
         + ("## Not scored — fix the execution, keep the idea\n"
            "These candidates were never measured, so their reward says nothing. Correct the "
@@ -1159,7 +1273,7 @@ def _reconcile_journal(workdir: Path, run_dir: RunDir, cid: str, *,
                        accepted: bool, val: float | None, delta: float | None,
                        reason: str | None = None, indecisive: bool = False) -> None:
     """Fold the optimizer's newly-appended journal entry into the run-level JOURNAL,
-    stamped with the framework's objective outcome. Append-only at the run level so the
+    stamped with the framework's measured outcome. Append-only at the run level so the
     handover truly accumulates across accepted AND rejected iterations.
 
     ``val``/``delta`` are None for an iteration that never bought a val eval (gepa's
@@ -1191,12 +1305,13 @@ def _reconcile_journal(workdir: Path, run_dir: RunDir, cid: str, *,
     base = run_journal.read_text(encoding="utf-8") if run_journal.exists() else _JOURNAL_SEED
     # Run-level file is pure accumulated entries — strip any marker before appending.
     base = base.replace(_JOURNAL_MARK, "").rstrip()
-    # Framework-owned RESULT: the objective gate outcome + the EXACT tasks this candidate
+    # Framework-owned RESULT: the gate outcome + the tasks this candidate measurably
     # broke/fixed (vs its parent), folded VISIBLY into the journal so the next iteration
     # learns what actually worked/regressed from the narrative — not just a terse comment.
     impact = _candidate_task_impact(run_dir, cid, "val") or {}
     broke = ", ".join(str(t) for t in (impact.get("broke") or [])[:30]) or "—"
     fixed = ", ".join(str(t) for t in (impact.get("fixed") or [])[:30]) or "—"
+    unres = ", ".join(str(t) for t in (impact.get("unresolved") or [])[:30]) or "—"
     if indecisive:
         verdict = "UNRESOLVED (not judged; champion unchanged)"
         guidance = (" — the measurement could not separate this edit from re-measurement noise, "
@@ -1230,8 +1345,10 @@ def _reconcile_journal(workdir: Path, run_dir: RunDir, cid: str, *,
                     "you: attribute per-task before redesigning anything.")
     vs = f"{val:.3f}" if isinstance(val, (int, float)) else "—"
     ds = f"{delta:+.3f}" if isinstance(delta, (int, float)) else "—"
-    stamp = (f"\n\n> **RESULT (framework, objective):** {verdict} · val={vs} "
-             f"Δ={ds} · fixed={{{fixed}}} · broke={{{broke}}}.{guidance}\n"
+    stamp = (f"\n\n> **RESULT (framework, measured):** {verdict} · val={vs} "
+             f"Δ={ds} · fixed={{{fixed}}} · broke={{{broke}}} · unresolved={{{unres}}} "
+             f"(moved less than 2·SE of its own measurement — NOT evidence the edit touched "
+             f"those tasks; do not redesign on them).{guidance}\n"
              f"<!-- {cid}: "
              f"{'unresolved' if indecisive else 'ACCEPTED' if accepted else 'rejected'} "
              f"val={vs} Δ={ds} -->")
@@ -1376,6 +1493,54 @@ def _build_runmap(workdir: Path, run_dir: RunDir) -> None:
     (workdir / "RUNMAP.md").write_text(text, encoding="utf-8")
 
 
+def seed_framework_memory(target: Path, run_dir: RunDir) -> list[str]:
+    """Create every cross-iteration memory file the optimizer is TOLD to read, in ``target``.
+
+    The set is exactly what ``_write_instructions_pointer`` and ``_augment_instructions``
+    promise: ``LEDGER.md``, ``JOURNAL.md``, ``PROCESS.md``, ``RUNMAP.md`` +
+    ``prior_iterations/<id>/``, and the three accumulators. All of them are pure functions
+    of the run dir's ``step`` events and candidate snapshots, so this is idempotent and
+    cheap to call again — which is why it can be the ONE place that guarantees the promise.
+
+    It exists because the promise and the creation had drifted apart. The deterministic
+    loops call ``_augment_instructions`` per iteration and get all of it; an agent-driven
+    run reaches ``_write_instructions_pointer`` (via ``OptimizerContext.inject`` →
+    ``_inject_native_skills``) and got the pointer alone. On run_finalrun6 the staged
+    ``CLAUDE.md`` told the agent to read ``./LEDGER.md``, ``./PROCESS.md``, ``./RUNMAP.md``
+    and ``./prior_iterations/<id>/`` while the working dir held only ``INSTRUCTIONS.md``,
+    ``CLAUDE.md``, ``guidance/``, ``project/`` and ``trajectories/`` — and ``JOURNAL.md``'s
+    own seed text points at ``./prior_iterations/<id>/diff.patch`` for each prior
+    candidate's exact edit, a directory nothing ever created.
+
+    Returns the names that now exist, so the caller writing the pointer can promise exactly
+    those and nothing more. Best-effort per file: one unwritable file must not cost the rest.
+    """
+    target = Path(target)
+    written: list[str] = []
+    for name, fn in (("LEDGER.md", _build_ledger), ("JOURNAL.md", _seed_journal),
+                     ("RUNMAP.md", _build_runmap)):
+        try:
+            fn(target, run_dir)
+            written.append(name)
+        except Exception as e:  # noqa: BLE001
+            run_dir.log_event("optimizer_context_warning", what=name, error=str(e)[:300])
+    for filename, seed, mark in _ACCUMULATORS:
+        try:
+            _seed_accumulator(target, run_dir, filename=filename, seed=seed, mark=mark)
+            written.append(filename)
+        except Exception as e:  # noqa: BLE001
+            run_dir.log_event("optimizer_context_warning", what=filename, error=str(e)[:300])
+    try:
+        if not (target / "PROCESS.md").exists():
+            (target / "PROCESS.md").write_text(_PROCESS_SEED, encoding="utf-8")
+        written.append("PROCESS.md")
+    except OSError as e:
+        run_dir.log_event("optimizer_context_warning", what="PROCESS.md", error=str(e)[:300])
+    if (target / "prior_iterations").is_dir():
+        written.append("prior_iterations/")
+    return written
+
+
 def _augment_instructions(instructions: str, workdir: Path, run_dir: RunDir) -> str:
     """Give the optimizer its cross-iteration files + a prompt pointer to each.
 
@@ -1388,18 +1553,14 @@ def _augment_instructions(instructions: str, workdir: Path, run_dir: RunDir) -> 
       - INSIGHTS.md / META_INSIGHTS.md / FRAMEWORK_IMPROVEMENTS.md — optimizer-authored,
         append-only summary layer above JOURNAL.md (see the comment near ``_INSIGHTS_MARK``).
     """
-    _build_ledger(workdir, run_dir)
-    _seed_journal(workdir, run_dir)
-    for filename, seed, mark in _ACCUMULATORS:
-        _seed_accumulator(workdir, run_dir, filename=filename, seed=seed, mark=mark)
-    if not (workdir / "PROCESS.md").exists():
-        (workdir / "PROCESS.md").write_text(_PROCESS_SEED, encoding="utf-8")
-    _build_runmap(workdir, run_dir)
+    seed_framework_memory(workdir, run_dir)
 
     pointer = (
         "## Cross-iteration files in THIS working dir (clean ownership — read all)\n"
-        "- `LEDGER.md` — FACTS (framework, read-only): every iteration's outcome + the exact "
-        "tasks it broke/fixed. Never re-introduce a change that broke a task.\n"
+        "- `LEDGER.md` — FACTS (framework, read-only): every iteration's outcome + the tasks "
+        "it MEASURABLY broke/fixed, plus the ones whose move was under 2·SE and so resolves "
+        "nothing. Never re-introduce a change that broke a task; never redesign an edit "
+        "because a task landed in `unresolved`.\n"
         "- `JOURNAL.md` — HANDOVER (yours, append-only across the whole run): read the whole "
         "thing, then APPEND your entry for this iteration below the marker line. Do NOT edit "
         "earlier entries. This is how you avoid repeating refuted ideas and hitting the same "
@@ -1420,6 +1581,10 @@ def _augment_instructions(instructions: str, workdir: Path, run_dir: RunDir) -> 
         "- `FRAMEWORK_IMPROVEMENTS.md` — cross-run suggestions for cap-evolve ITSELF, not this "
         "task (yours, append-only, optional): what confused you or was missing about the "
         "framework. Update AT LEAST once, at the end of the run.\n"
+        f"- `{run_dir.rejected_path}` — ALREADY-REFUTED approaches (framework, read-only; JSON "
+        "lines, one per rejected candidate with the gate's reason). Read it and make each "
+        "proposal STRUCTURALLY different from what is in it. Its sibling `history.jsonl` is "
+        "the same record for accepts.\n"
     )
     return f"{instructions}\n\n{pointer}\n"
 
@@ -1665,7 +1830,8 @@ def _inject_native_skills(run_dir: RunDir, workdir: Path, caps, repo_root: Path,
         # Always-on instructions file: write a short, generic, idempotent pointer block.
         if instructions_file:
             try:
-                _write_instructions_pointer(workdir / instructions_file, skills_dir)
+                _write_instructions_pointer(workdir / instructions_file, skills_dir,
+                                            run_dir=run_dir, workdir=workdir)
             except Exception as e:  # noqa: BLE001
                 run_dir.log_event("optimizer_context_warning",
                                   what=f"instructions/{instructions_file}", error=str(e)[:300])
@@ -1676,9 +1842,54 @@ def _inject_native_skills(run_dir: RunDir, workdir: Path, caps, repo_root: Path,
 _NATIVE_POINTER_MARK = "<!-- cap-evolve:native-skills -->"
 
 
-def _write_instructions_pointer(path: Path, skills_dir: str) -> None:
+#: The cross-iteration files the pointer describes, in the order it lists them, each with
+#: the one-line brief the optimizer needs. Only entries whose file actually exists in the
+#: working dir are written into the pointer — see ``_write_instructions_pointer``.
+_POINTER_FILES = (
+    ("LEDGER.md",
+     "`./LEDGER.md` — FACTS (framework, read-only): every iteration's outcome + the tasks "
+     "it measurably broke/fixed, and the ones whose move was too small to resolve. Never "
+     "re-introduce a change that broke a task."),
+    ("JOURNAL.md",
+     "`./JOURNAL.md` — HANDOVER (yours, append-only across the whole run): read it, then "
+     "APPEND your entry for this iteration below the marker line. Do not edit earlier "
+     "entries. Each entry carries the framework's RESULT stamp under it."),
+    ("PROCESS.md",
+     "`./PROCESS.md` — EXPLAINABILITY (yours, REQUIRED this iteration): fill it in as you "
+     "work. It is snapshotted with your candidate."),
+    ("RUNMAP.md",
+     "`./RUNMAP.md` + `./prior_iterations/<id>/` — every prior iteration's PROCESS.md and "
+     "capability `diff.patch`, copied in for you. Read the ones targeting your cluster "
+     "BEFORE proposing, so you build on prior work instead of repeating it."),
+    ("INSIGHTS.md",
+     "`./INSIGHTS.md` — SUMMARIZED, VERIFIED findings (yours, append-only): the distilled "
+     "'what worked / what didn't / what's promising' a future iteration reads instead of "
+     "the whole journal."),
+    ("META_INSIGHTS.md",
+     "`./META_INSIGHTS.md` — about the SEARCH PROCESS itself (yours, append-only): which "
+     "strategies helped or stalled, what to try next. Update at least once."),
+    ("FRAMEWORK_IMPROVEMENTS.md",
+     "`./FRAMEWORK_IMPROVEMENTS.md` — cross-run suggestions for cap-evolve ITSELF, not this "
+     "task (yours, append-only, optional)."),
+)
+
+
+def _write_instructions_pointer(path: Path, skills_dir: str, *, run_dir=None,
+                                workdir: Path | None = None) -> None:
     """Write (or append) a short generic pointer block into the agent's instructions
-    file, idempotently (keyed on a marker comment so it is not duplicated)."""
+    file, idempotently (keyed on a marker comment so it is not duplicated).
+
+    Given ``run_dir`` + ``workdir`` it first CREATES the cross-iteration files it is about
+    to name (``seed_framework_memory``) and then lists only the ones that exist. Both
+    halves matter: the promise used to be unconditional prose, so an agent-driven run was
+    told to read four files and a directory that nothing on its path ever created (see
+    ``seed_framework_memory``). Tying the text to the filesystem means the pointer cannot
+    drift back into promising a file again — if a file stops being created, it stops being
+    named, instead of silently sending the optimizer to a dead path.
+    """
+    present = set()
+    if run_dir is not None and workdir is not None:
+        present = set(seed_framework_memory(workdir, run_dir))
     existing = ""
     if path.exists():
         try:
@@ -1689,6 +1900,26 @@ def _write_instructions_pointer(path: Path, skills_dir: str) -> None:
         return
     skills_note = (f"the optimization skills are available natively under `{skills_dir}/` and "
                    if skills_dir else "the optimization skills are available under ")
+    listed = [brief for name, brief in _POINTER_FILES if name in present]
+    files_note = ""
+    if listed:
+        files_note = ("Cross-iteration files in this directory (clean ownership) — read all of "
+                      "these before you start:\n"
+                      + "".join(f"- {b}\n" for b in listed))
+    # ``rejected.jsonl`` has always existed in the run dir and was never mentioned: it is the
+    # run's own record of approaches already refuted, written by every algorithm, and an
+    # optimizer that does not know about it re-proposes what the run has already paid to rule
+    # out. Named by absolute path because it lives in the run dir, not the working dir.
+    rejected_note = ""
+    if run_dir is not None:
+        rejected_path = getattr(run_dir, "rejected_path", None)
+        if rejected_path is not None:
+            rejected_note = (
+                f"Already-refuted approaches: `{rejected_path}` (JSON lines, one per rejected "
+                "candidate: its id, a one-line summary and the gate's reason). Read it and make "
+                "each proposal STRUCTURALLY different from what is in it — a re-proposal of a "
+                "refuted edit spends an iteration to learn what the run already knows. Its "
+                "sibling `history.jsonl` is the same record for accepts.\n")
     block = (
         f"{_NATIVE_POINTER_MARK}\n"
         "## cap-evolve optimization task\n"
@@ -1697,12 +1928,7 @@ def _write_instructions_pointer(path: Path, skills_dir: str) -> None:
         "capability to improve, the failures to fix, and how your edit is judged.\n"
         f"For method/edit-space guidance, {skills_note}under `./guidance/` "
         "(capability skill(s) + the diagnose failure-clustering method).\n"
-        "Cross-iteration files (clean ownership): `./LEDGER.md` (framework facts — every "
-        "iteration's outcome + tasks broken/fixed), `./JOURNAL.md` (YOUR append-only "
-        "handover across the whole run — append your entry below the marker), `./PROCESS.md` "
-        "(YOUR required explainability for this iteration), and `./RUNMAP.md` + "
-        "`./prior_iterations/<id>/` (every prior iteration's PROCESS.md + diff — read before "
-        "proposing). Read all of these before you start.\n"
+        + files_note + rejected_note
     )
     sep = "" if (not existing or existing.endswith("\n\n")) else ("\n" if existing.endswith("\n") else "\n\n")
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -1826,6 +2052,7 @@ def run_step(
     eval_split: str = "val",
     ctx: "OptimizerContext | None" = None,
     protected_patterns=None,
+    footprint_gate: bool = True,
 ) -> dict:
     """Materialize parent → optimize → evaluate on val → gate → accept/reject.
 
@@ -1842,6 +2069,11 @@ def run_step(
     untouched, best is unchanged) — the same discipline the coverage guard and the
     infra-error path already use, because the score would measure a compromised
     harness, not the edit.
+
+    ``footprint_gate`` (default on) restricts the paired delta vector to the val tasks the
+    candidate's edit can causally reach, so tasks outside it stop contributing noise to the
+    SE — see ``footprint`` and ``_paired_deltas``. It is a no-op whenever the footprint
+    cannot be established, and ``footprint_gate=False`` forces the full-vector behaviour.
     """
     gate_kwargs = dict(gate_kwargs or {})
     cid = candidate_id or f"cand_{run_dir.spent.iterations + 1:04d}"
@@ -1964,7 +2196,24 @@ def run_step(
     # powerful) test is mean(per-task Δ) vs the SE of those paired deltas. Build the
     # aligned delta vector here; fall back to the unpaired ``significant`` test when
     # the caller has pinned a different mode or the per-task data isn't aligned.
-    paired_deltas = _paired_deltas(current_val, cand_val)
+    #
+    # Restricted to the candidate's FOOTPRINT when one can be established: a task the edit
+    # cannot causally reach contributes Δ=0 by construction, so its measured wobble is
+    # noise in the SE and nothing else. ``footprint.footprint`` returns None whenever it
+    # cannot localize the edit, and ``_paired_deltas(footprint=None)`` is byte-identical to
+    # the behaviour before this existed — so a capability whose surface cannot be detected
+    # is measured exactly as it always was rather than restricted on a guess.
+    fp = None
+    if footprint_gate:
+        fp = footprint_mod.footprint(
+            run_dir, parent_dir=run_dir.candidate_dir(parent_id or "seed"),
+            cand_dir=workdir, tags=(parent_id or "seed", cid), split="val",
+            all_task_ids=[pt.get("task_id") for pt in (cand_val.per_task or [])])
+        if fp is not None:
+            run_dir.log_event("gate_footprint", candidate=cid, parent=parent_id,
+                              n_in_footprint=len(fp), n_tasks=len(cand_val.per_task or []),
+                              tasks=sorted(map(str, fp))[:60])
+    paired_deltas = _paired_deltas(current_val, cand_val, footprint=fp)
     if "mode" not in gate_kwargs and paired_deltas is not None:
         gate_kwargs["mode"] = "paired"
     decision = gate_mod.decide(

--- a/core/cap_evolve/skillopt.py
+++ b/core/cap_evolve/skillopt.py
@@ -169,21 +169,27 @@ def _slow_update_instructions(epoch: int, categories: dict[str, list[dict]]) -> 
 def _categorize(prev_pt: list, cur_pt: list) -> dict[str, list[dict]]:
     """Categorize each task improved / regressed / persistent_fail / stable_success
     from two per-task reward maps (carrying the CURRENT feedback)."""
-    prev = {pt.get("task_id"): float(pt.get("reward", 0.0) or 0.0) for pt in (prev_pt or [])}
+    prev = {pt.get("task_id"): pt for pt in (prev_pt or [])}
     cur = {pt.get("task_id"): pt for pt in (cur_pt or [])}
     cats: dict[str, list[dict]] = {"improved": [], "regressed": [],
                                    "persistent_fail": [], "stable_success": []}
-    eps = 1e-9
     for tid, pt in cur.items():
         if tid not in prev:
             continue
-        before = prev[tid]
+        before = float(prev[tid].get("reward", 0.0) or 0.0)
         after = float(pt.get("reward", 0.0) or 0.0)
+        # ``improved`` feeds the within-epoch buffer the optimizer prompt reads, so it must
+        # clear 2*SE of its own per-task measurement (``harness.move_is_resolved`` — the ONE
+        # shared bar). At 10 trials a 0.9 -> 1.0 move is one flipped rollout, and booking that
+        # as an improvement teaches the next mini-batch to keep an edit that did nothing.
+        resolved = harness.move_is_resolved(before, after,
+                                            prev[tid].get("stderr") or 0.0,
+                                            pt.get("stderr") or 0.0)
         passed_before = before >= 1.0
         passed_after = after >= 1.0
-        if after > before + eps:
+        if after > before and resolved:
             cats["improved"].append(pt)
-        if passed_before and not passed_after:
+        if passed_before and not passed_after and resolved:
             cats["regressed"].append(pt)
         elif not passed_before and not passed_after:
             cats["persistent_fail"].append(pt)

--- a/core/tests/test_agent_mode_keeps_its_own_learning_substrate.py
+++ b/core/tests/test_agent_mode_keeps_its_own_learning_substrate.py
@@ -119,7 +119,7 @@ def test_a_handover_the_agent_wrote_is_folded_into_the_run_journal(tmp_path):
     assert "compute-not-hardcode replay + over-write contract" in journal
     assert "no handover written by the optimizer" not in journal, (
         "the agent DID write a handover and it was still recorded as absent")
-    assert "RESULT (framework, objective)" in journal, "the framework RESULT half is missing"
+    assert "RESULT (framework, measured)" in journal, "the framework RESULT half is missing"
 
 
 def test_a_missing_handover_is_reported_back_to_the_agent(tmp_path):

--- a/core/tests/test_gate_measures_only_what_the_edit_can_reach.py
+++ b/core/tests/test_gate_measures_only_what_the_edit_can_reach.py
@@ -161,6 +161,75 @@ def test_no_footprint_data_measures_the_full_split_rather_than_guessing():
         "@@ -1 +1 @@\n+        self.cancel_reservation(rid)") == {"cancel_reservation"}
 
 
+def test_a_broadly_reached_edit_is_never_footprinted_to_a_rare_helper_it_calls():
+    """The one direction the restriction must never fail in: UNDER-inclusion.
+
+    An edit inside a broadly-reached function (`book_reservation`, exercised by 28 of 30
+    tasks) that adds a call to a rare helper (`audit_trace`, 3 tasks) really reaches all 28.
+    Footprinting it to the helper's 3 tasks zero-pads 25 tasks that DID move, and the bias
+    is not symmetric: zero-padding an out-of-footprint regression raises Δ̄ *and* lowers the
+    SE, both pushing toward accept. A candidate whose true full-split Δ is NEGATIVE can
+    therefore be accepted — a fabricated gain, which is strictly worse than the low-power
+    measurement the restriction exists to fix.
+
+    Two rules keep it out, and both are needed:
+      * the enclosing definition is ALWAYS part of the footprint, not only when the hunk
+        happens to name nothing else;
+      * a surface reaching ≥ ``_UBIQUITOUS_FRACTION`` of tasks makes the edit UNLOCALIZABLE
+        (fall back to the full vector) rather than being dropped so that the remaining rare
+        symbols can define a confident, narrow, wrong footprint.
+    """
+    from cap_evolve import footprint, harness
+    from cap_evolve.gate import decide
+    from cap_evolve.loop import Score, aggregate_scores
+
+    rd = _fresh("under")
+    parent, cand = rd.candidate_dir("seed"), rd.candidate_dir("cand_1")
+    parent.mkdir(parents=True, exist_ok=True)
+    cand.mkdir(parents=True, exist_ok=True)
+    (parent / "tools.py").write_text(
+        "def book_reservation(self, rid):\n"
+        "    total = self.price(rid)\n"
+        "    return total\n")
+    # The edit is INSIDE book_reservation; the only name it adds is the rare helper.
+    (cand / "tools.py").write_text(
+        "def book_reservation(self, rid):\n"
+        "    total = self.price(rid)\n"
+        "    audit_trace(rid)\n"
+        "    return total\n")
+
+    broad = {f"t{i}" for i in range(28)}       # exercise book_reservation
+    rare = {"t0", "t1", "t2"}                  # ALSO exercise audit_trace
+    par_r, cand_r = {}, {}
+    for i in range(30):
+        t = f"t{i}"
+        text = ("book_reservation ran " if t in broad else "searched flights ")
+        if t in rare:
+            text += "audit_trace logged"
+        par_r[t] = 1.0
+        # Net HARMFUL: every task reached by the edit lost 0.15.
+        cand_r[t] = 0.85 if t in broad else 1.0
+        _rollout(rd, "seed", t, 0, par_r[t], text=text)
+        _rollout(rd, "cand_1", t, 0, cand_r[t], text=text)
+
+    fp = footprint.footprint(rd, parent_dir=parent, cand_dir=cand,
+                             tags=("seed", "cand_1"), all_task_ids=list(par_r))
+    # NOT the rare helper's 3 tasks: either the whole broad reach, or no footprint at all.
+    assert fp is None or len(fp) >= len(broad), fp
+
+    def _sr(d):
+        return aggregate_scores("val", [Score(task_id=t, reward=r, n=10) for t, r in d.items()])
+
+    true_delta = (sum(cand_r.values()) - sum(par_r.values())) / 30
+    assert true_delta < 0, true_delta                     # the candidate is harmful
+
+    deltas = harness._paired_deltas(_sr(par_r), _sr(cand_r), footprint=fp)
+    d = decide(1.0, 1.0 + true_delta, split="val", mode="paired", paired_deltas=deltas)
+    # A net-harmful candidate must never leave the footprint-restricted gate accepted.
+    assert not d.accept, (d.reason, fp)
+    assert sum(deltas) / len(deltas) < 0, (sum(deltas) / len(deltas), fp)
+
+
 def test_an_edit_inside_a_body_takes_its_enclosing_definition_as_its_surface():
     """run_finalrun6's cand_7 rewrote one tool's docstring and nothing else. Its changed lines
     name no surface at all, so on the changed lines alone it has no footprint and gets measured
@@ -180,14 +249,19 @@ def test_an_edit_inside_a_body_takes_its_enclosing_definition_as_its_surface():
         "         return rid\n")
     assert footprint.touched_symbols(docstring_only) == {"update_reservation_passengers"}
 
-    # A hunk that names its own surface does NOT also claim the neighbour in its context.
-    names_itself = (
+    # A hunk that names its own surface keeps the enclosing definition ANYWAY. Taking only
+    # what the hunk named is what let a broadly-reached edit be footprinted to a rare helper
+    # it calls (see the under-inclusion test above); over-including a neighbour that merely
+    # sits in the context window costs power, which is the direction that cannot fabricate a
+    # gain.
+    both = (
         "@@ -1,6 +1,6 @@\n"
         "     def some_unrelated_neighbour(self):\n"
         "         pass\n"
         "+    def cancel_reservations(self, ids):\n"
         "+        return ids\n")
-    assert footprint.touched_symbols(names_itself) == {"cancel_reservations"}
+    assert footprint.touched_symbols(both) == {"cancel_reservations",
+                                              "some_unrelated_neighbour"}
 
 
 def test_control_replicates_pool_into_one_lower_variance_parent_reference():
@@ -281,6 +355,44 @@ def test_an_unresolved_move_is_named_as_such_where_the_optimizer_reads_it():
     assert "RESULT (framework, objective)" not in journal
 
 
+def test_a_small_footprint_cannot_call_a_few_flipped_rollouts_significant():
+    """The trap the footprint restriction opens, and the floor that closes it.
+
+    run_finalrun6's cand_7 restricts to 4 tasks whose deltas are {0, +0.1, 0, +0.1}. The
+    CROSS-TASK SPREAD of those four numbers is small, so the paired SE reads 0.0046 and the
+    gate ACCEPTS — on two moves of one flipped rollout each at 10 trials, the very moves
+    ``move_is_resolved`` refuses to call real. Unfloored, the two halves of this change
+    contradict each other: the ledger says ``unresolved``, the gate says ``significant``.
+    """
+    from cap_evolve import harness
+    from cap_evolve.gate import decide
+
+    deltas = [0.1, 0.0, 0.1, 0.0] + [0.0] * 26        # 4 in footprint, 26 zero-padded
+    unfloored = decide(0.5, 0.5067, split="val", mode="paired", paired_deltas=deltas)
+    assert unfloored.accept, unfloored.reason          # the trap, reproduced
+
+    # Each of those tasks carries a per-task SE of ~0.1 at 10 trials (one flip in ten).
+    se_floor = (4 * (0.1 ** 2 + 0.1 ** 2)) ** 0.5 / 30
+    floored = decide(0.5, 0.5067, split="val", mode="paired", paired_deltas=deltas,
+                     paired_se_floor=se_floor)
+    assert not floored.accept, floored.reason
+    # The ledger's bar calls the same per-task move unresolved — the two now agree.
+    assert not harness.move_is_resolved(0.9, 1.0, 0.1, 0.1)
+    # An UNRESTRICTED vector keeps the SE it always had: the floor defaults to 0.
+    assert decide(0.5, 0.5067, split="val", mode="paired",
+                  paired_deltas=deltas).threshold == unfloored.threshold
+
+
+def test_the_no_regression_veto_cannot_fire_on_one_flipped_rollout():
+    """The veto REJECTS a candidate the gate had accepted, so it is the strongest consequence
+    of the broke/fixed bar — and both the hill-climb and gepa copies were still at 1e-9."""
+    from cap_evolve import harness
+
+    assert not harness.move_is_resolved(1.0, 0.9, 0.0, 0.1)   # one flipped rollout of ten
+    assert harness.move_is_resolved(1.0, 0.0, 0.0, 0.0)       # a real break clears it
+    assert not harness.move_is_resolved(1.0, 1.0, 0.0, 0.0)   # no move at all
+
+
 # --- 3. the published SE is this round's own, not a constant -----------------------------
 
 def test_the_published_gate_stderr_is_the_se_the_threshold_was_built_from():
@@ -315,7 +427,10 @@ def test_the_published_gate_stderr_is_the_se_the_threshold_was_built_from():
         while int(rd.spent.iterations) < it:
             rd.update_spent(iterations=1)
         g = commit_mod._round_gate_numbers(rd, f"cand_{it}")
-        assert g["gate_stderr"] * g["gate_k_se"] == round(g["gate_threshold"], 6), g
+        # approx, not exact: gate_stderr is rounded to 6dp, so `k_se · stderr == threshold`
+        # holds to that precision but not bit-for-bit, and would be fragile at a
+        # non-integer k_se where the rounding error is scaled rather than preserved.
+        assert abs(g["gate_stderr"] * g["gate_k_se"] - g["gate_threshold"]) < 1e-6, g
         seen.append(g["gate_stderr"])
     # The whole point: it MOVES with the round instead of being one frozen number.
     assert len(set(seen)) == 3, seen

--- a/core/tests/test_gate_measures_only_what_the_edit_can_reach.py
+++ b/core/tests/test_gate_measures_only_what_the_edit_can_reach.py
@@ -1,0 +1,380 @@
+"""The gate's four statistical-honesty defects, each with the run data that exposed it.
+
+Audited on run_finalrun6 (7 candidates, 30 val tasks, agent-optimize):
+
+1. **No statistical power.** SE(paired Δ) ran 0.022-0.035 while real per-edit effects were
+   0.011-0.05, because the delta was measured across ALL 30 val tasks even though each edit
+   touched a handful. The 7-way null-control replicate spread (0.567-0.603) was
+   statistically indistinguishable from the 7-way across-candidate spread (0.570-0.607).
+2. **False broke/fixed.** ``eps = 1e-9`` stamped a single flipped rollout (1.0 → 0.9 at 10
+   trials) as a behavioural break. Byte-identical code measured twice (cand_2, and its
+   fresh-tag re-measurement cand_4) got different broke/fixed labels, and the optimizer
+   reasoned from them across three rounds.
+3. **Stale gate_stderr.** ``gate_stderr`` was published as 0.0738 on rounds i0, i3 and i6 —
+   identical — while the ``gate_threshold`` it is supposed to generate moved 0.0222 →
+   0.0244 → 0.0346 at ``k_se = 1.0``.
+4. **Promised memory files that never existed.** The staged instructions pointer told the
+   optimizer to read ``LEDGER.md`` / ``PROCESS.md`` / ``RUNMAP.md`` / ``prior_iterations/``;
+   on disk the working dir held only ``INSTRUCTIONS.md``, ``CLAUDE.md``, ``guidance/``,
+   ``project/`` and ``trajectories/``. ``rejected.jsonl`` DID exist and was never mentioned.
+"""
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO / "core"))
+
+
+def _rollout(run_dir, tag, task_id, k, reward, *, split="val", text=""):
+    """One synthetic per-trial rollout file in the harness's on-disk format.
+
+    ``text`` lands in the trace, which is where footprint detection looks for the names the
+    edit touched — the same flat search it runs over a real adapter's rollout.
+    """
+    vdir = run_dir.rollouts / split
+    vdir.mkdir(parents=True, exist_ok=True)
+    rec = {"input": {}, "rollout": {"task_id": task_id, "error": None, "trace": text},
+           "score": {"task_id": task_id, "reward": reward, "feedback": "", "raw": {}}}
+    (vdir / f"{task_id}__{tag}__t{k}.json").write_text(json.dumps(rec), encoding="utf-8")
+
+
+def _fresh(name):
+    from cap_evolve import RunDir
+    return RunDir.create(Path(tempfile.mkdtemp()) / ".capevolve", ts=name)
+
+
+# --- 1. footprint-restricted measurement ------------------------------------------------
+
+def test_a_real_effect_on_three_tasks_survives_the_noise_of_twenty_seven_others():
+    """The defect, at the scale it was measured at: a genuine +0.1 on the three tasks the
+    edit can reach is INVISIBLE when the other 27 tasks contribute their measurement wobble
+    to the SE, and RESOLVED when they contribute the 0.0 they have by construction.
+
+    Same rewards, same gate, same k_se — the only difference is which tasks the delta vector
+    treats as capable of having moved.
+    """
+    from cap_evolve import harness
+    from cap_evolve.gate import decide
+    from cap_evolve.loop import Score, aggregate_scores
+
+    reached = [f"t{i}" for i in range(3)]
+    # Parent and candidate agree everywhere except the three in-footprint tasks (+0.1 each).
+    # The 27 others carry ±0.1 re-measurement wobble in alternating directions: identical
+    # code, different draw — exactly what the null-control replicates showed.
+    par, cand = {}, {}
+    for i in range(30):
+        t = f"t{i}"
+        par[t] = 0.5
+        cand[t] = 0.6 if t in reached else (0.6 if i % 2 else 0.4)
+
+    def _sr(d):
+        return aggregate_scores("val", [Score(task_id=t, reward=r, n=10) for t, r in d.items()])
+
+    cur_sr, cand_sr = _sr(par), _sr(cand)
+
+    full = harness._paired_deltas(cur_sr, cand_sr)
+    restricted = harness._paired_deltas(cur_sr, cand_sr, footprint=set(reached))
+
+    # Both vectors describe the same 30 tasks and the same mean movement over them...
+    assert len(full) == len(restricted) == 30
+    mean_full = sum(full) / 30
+    mean_restricted = sum(restricted) / 30
+    assert round(mean_restricted, 10) == 0.01              # 3 tasks x +0.1 over 30
+    # ...but the unrestricted mean is dominated by the wobble, not by the edit.
+    assert mean_full > mean_restricted
+
+    unres = decide(0.5, mean_full + 0.5, split="val", mode="paired", paired_deltas=full)
+    res = decide(0.5, 0.51, split="val", mode="paired", paired_deltas=restricted)
+
+    # THE defect: the noisy vector cannot resolve the effect it is measuring — its
+    # significance bar is wider than the whole effect, which is the run_finalrun6 shape
+    # (SE 0.022-0.035 against effects of 0.011-0.05).
+    assert not unres.accept, unres.reason
+    assert unres.threshold > mean_restricted, unres.reason
+    # Restricted, the same +0.01 clears its own bar: the 27 tasks the edit cannot reach
+    # stopped contributing variance, and the bar fell ~4x with them.
+    assert res.accept, res.reason
+    assert res.threshold < unres.threshold / 3, (res.threshold, unres.threshold)
+
+
+def test_footprint_is_the_tasks_whose_rollouts_exercise_the_edited_surface():
+    """Which tasks the edit can reach is read from the diff + the persisted rollouts —
+    generically, with no knowledge of the capability, the benchmark or the adapter."""
+    from cap_evolve import footprint
+
+    rd = _fresh("fp")
+    parent = rd.candidate_dir("seed")
+    cand = rd.candidate_dir("cand_1")
+    parent.mkdir(parents=True, exist_ok=True)
+    cand.mkdir(parents=True, exist_ok=True)
+    (parent / "tools.py").write_text("def cancel_reservation(rid):\n    return rid\n")
+    (cand / "tools.py").write_text(
+        "def cancel_reservation(rid):\n    return rid\n\n"
+        "def cancel_reservations(rids):\n    return rids\n")
+
+    # t0/t1 route through the new surface; t2 never mentions it.
+    for tag in ("seed", "cand_1"):
+        _rollout(rd, tag, "t0", 0, 1.0, text="called cancel_reservations([1,2])")
+        _rollout(rd, tag, "t1", 0, 1.0, text="cancel_reservations again")
+        _rollout(rd, tag, "t2", 0, 1.0, text="searched for a flight")
+
+    fp = footprint.footprint(rd, parent_dir=parent, cand_dir=cand,
+                             tags=("seed", "cand_1"), all_task_ids=["t0", "t1", "t2"])
+    assert fp == {"t0", "t1"}
+
+
+def test_no_footprint_data_measures_the_full_split_rather_than_guessing():
+    """Every unknowable case degrades to today's full-vector behaviour, never to a crash and
+    never to a restriction invented from nothing."""
+    from cap_evolve import footprint
+
+    rd = _fresh("fpnone")
+    d = rd.candidate_dir("seed")
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "tools.py").write_text("x = 1\n")
+
+    # Identical snapshots -> no diff -> no symbols -> no footprint.
+    assert footprint.footprint(rd, parent_dir=d, cand_dir=d, tags=("seed",)) is None
+    # A snapshot that does not exist at all must not raise.
+    assert footprint.footprint(rd, parent_dir=d, cand_dir=rd.candidate_dir("ghost"),
+                              tags=("seed",)) is None
+    # A footprint covering every measured task is not a restriction, so it is not reported.
+    cand = rd.candidate_dir("cand_1")
+    cand.mkdir(parents=True, exist_ok=True)
+    (cand / "tools.py").write_text("x = 1\n\ndef widget_helper():\n    pass\n")
+    for t in ("t0", "t1"):
+        _rollout(rd, "cand_1", t, 0, 1.0, text="widget_helper ran")
+    assert footprint.footprint(rd, parent_dir=d, cand_dir=cand, tags=("cand_1",),
+                              all_task_ids=["t0", "t1"]) is None
+    # A rewrite-sized diff names too many surfaces to localize anything.
+    assert footprint.touched_symbols(
+        "@@ -1 +1 @@\n" + "\n".join(f"+def surface_{i}(x):" for i in range(200))) == set()
+    # And docstring PROSE is not a surface: an English word before a parenthesis is not a
+    # call, which is the distinction that kept "cancelled"/"flights"/"user" out of the set.
+    assert footprint.touched_symbols(
+        '@@ -1 +1 @@\n+        """Cancel MULTIPLE reservations (e.g. ABC and XYZ) at once."""'
+    ) == set()
+    assert footprint.touched_symbols(
+        "@@ -1 +1 @@\n+        self.cancel_reservation(rid)") == {"cancel_reservation"}
+
+
+def test_an_edit_inside_a_body_takes_its_enclosing_definition_as_its_surface():
+    """run_finalrun6's cand_7 rewrote one tool's docstring and nothing else. Its changed lines
+    name no surface at all, so on the changed lines alone it has no footprint and gets measured
+    against the whole split — where its SE was 0.0346, against a real effect of 0.0067.
+
+    The enclosing definition IS the surface for an edit inside a body, and it is taken ONLY
+    when the hunk named nothing of its own: a hunk that does name its surfaces must not drag in
+    every neighbouring definition that happens to sit inside the diff's context window.
+    """
+    from cap_evolve import footprint
+
+    docstring_only = (
+        "@@ -1,6 +1,6 @@\n"
+        "     def update_reservation_passengers(self, rid, passengers):\n"
+        '-        """Update the passengers."""\n'
+        '+        """Update the passengers on an existing reservation."""\n'
+        "         return rid\n")
+    assert footprint.touched_symbols(docstring_only) == {"update_reservation_passengers"}
+
+    # A hunk that names its own surface does NOT also claim the neighbour in its context.
+    names_itself = (
+        "@@ -1,6 +1,6 @@\n"
+        "     def some_unrelated_neighbour(self):\n"
+        "         pass\n"
+        "+    def cancel_reservations(self, ids):\n"
+        "+        return ids\n")
+    assert footprint.touched_symbols(names_itself) == {"cancel_reservations"}
+
+
+def test_control_replicates_pool_into_one_lower_variance_parent_reference():
+    """The parent-side power gain that costs no rollouts: two byte-identical control
+    replicates already on disk are draws from one distribution, so pooling their TRIALS per
+    task (not averaging their means) is a better estimate of the same parent."""
+    from cap_evolve import harness
+
+    rd = _fresh("pool")
+    # Two replicates of the same parent, each 1 trial per task, disagreeing on t0.
+    _rollout(rd, "ctl_a", "t0", 0, 1.0)
+    _rollout(rd, "ctl_b", "t0", 0, 0.0)
+
+    one = harness.split_result_from_rollouts(rd, "ctl_a", "val")
+    pooled = harness.split_result_from_rollouts(rd, ["ctl_a", "ctl_b"], "val")
+    assert [pt["n"] for pt in one.per_task] == [1]
+    assert [pt["n"] for pt in pooled.per_task] == [2]      # trials merged, not means averaged
+    assert pooled.per_task[0]["reward"] == 0.5
+
+
+# --- 2. broke/fixed thresholded at the measurement's own resolution ----------------------
+
+def test_one_flipped_rollout_in_ten_is_not_a_behavioural_break():
+    """The exact shape that poisoned the optimizer's reasoning: 1.0 -> 0.9 at 10 trials.
+
+    That is one rollout out of ten, well inside the task's own measurement error, and it was
+    being asserted as a task the candidate BROKE. It must land in ``unresolved`` — a real,
+    supra-threshold regression on the same run must still land in ``broke``.
+    """
+    from cap_evolve import harness
+
+    rd = _fresh("bf")
+    # t_noise: parent 10/10, candidate 9/10 -> Δ = -0.1, inside 2·SE (SE_cand = 0.095).
+    # t_real:  parent 10/10, candidate 0/10 -> Δ = -1.0, far outside any SE.
+    for k in range(10):
+        _rollout(rd, "seed", "t_noise", k, 1.0)
+        _rollout(rd, "seed", "t_real", k, 1.0)
+        _rollout(rd, "cand_1", "t_noise", k, 0.0 if k == 0 else 1.0)
+        _rollout(rd, "cand_1", "t_real", k, 0.0)
+
+    imp = harness._candidate_task_impact(rd, "cand_1", "val", parent_of={"cand_1": "seed"})
+    assert imp["broke"] == ["t_real"], imp
+    assert imp["unresolved"] == ["t_noise"], imp
+
+
+def test_a_single_trial_run_classifies_exactly_as_it_always_did():
+    """At one trial per task there is no variance estimate, the bar collapses to eps, and the
+    one draw is all the evidence there is — so the old behaviour is preserved exactly."""
+    from cap_evolve import harness
+
+    rd = _fresh("bf1")
+    for tid, r in (("1", 1.0), ("2", 1.0), ("3", 0.0)):
+        _rollout(rd, "seed", tid, 0, r)
+    for tid, r in (("1", 1.0), ("2", 0.0), ("3", 1.0)):
+        _rollout(rd, "cand_1", tid, 0, r)
+
+    imp = harness._candidate_task_impact(rd, "cand_1", "val", parent_of={"cand_1": "seed"})
+    assert imp["broke"] == ["2"]
+    assert imp["fixed"] == ["3"]
+    assert imp["unresolved"] == []
+
+
+def test_an_unresolved_move_is_named_as_such_where_the_optimizer_reads_it():
+    """Both places the classification reaches the optimizer must carry the distinction, and
+    neither may keep calling the classification 'objective' — a 1-in-10 rollout flip stamped
+    as a break was the opposite of objective."""
+    from cap_evolve import harness
+
+    rd = _fresh("bfdoc")
+    for k in range(10):
+        _rollout(rd, "seed", "t_noise", k, 1.0)
+        _rollout(rd, "cand_1", "t_noise", k, 0.0 if k == 0 else 1.0)
+    rd.log_event("step", candidate="cand_1", parent="seed", accept=False, val=0.99)
+
+    work = Path(tempfile.mkdtemp())
+    harness._build_ledger(work, rd)
+    ledger = (work / "LEDGER.md").read_text(encoding="utf-8")
+    row = [ln for ln in ledger.splitlines() if "cand_1" in ln][0]
+    assert "unresolved" in ledger
+    assert "2·SE" in ledger
+    assert "objective" not in ledger
+    # The noisy task is in the row's unresolved cell, and NOT claimed as broken.
+    assert "t_noise" in row
+    assert row.index("t_noise") > row.index("|", row.index("reject"))
+
+    harness._reconcile_journal(work, rd, "cand_1", accepted=False, val=0.99, delta=-0.01,
+                              reason="docstring-only edit")
+    journal = (rd.root / "JOURNAL.md").read_text(encoding="utf-8")
+    assert "unresolved={t_noise}" in journal
+    assert "broke={—}" in journal
+    assert "RESULT (framework, objective)" not in journal
+
+
+# --- 3. the published SE is this round's own, not a constant -----------------------------
+
+def test_the_published_gate_stderr_is_the_se_the_threshold_was_built_from():
+    """Three rounds of run_finalrun6 published gate_stderr 0.0738, 0.0738, 0.0738 against
+    thresholds 0.0222, 0.0244, 0.0346 at k_se 1.0 — a constant beside three different bars
+    derived from it. The published SE must satisfy ``threshold == k_se · SE`` for its own
+    round, which is what makes the two numbers readable in one row.
+    """
+    sys.path.insert(0, str(REPO / "skills" / "algorithms" / "agent-optimize" / "scripts"))
+    import commit as commit_mod
+
+    rd = _fresh("se")
+    work = rd.root / "work"
+    work.mkdir(parents=True, exist_ok=True)
+    for it, (thr, res) in enumerate([(0.022173, 0.044347), (0.024361, 0.048721),
+                                     (0.034646, 0.069292)]):
+        (work / f"round_i{it}.json").write_text(json.dumps({
+            # The mean-over-tasks SE the old code published: identical every round, and
+            # several times the bar it was printed beside.
+            "parent": {"tag": "seed", "reward": 0.5933, "stderr": 0.0737942671874435,
+                       "n_tasks": 30},
+            "gated_against": {"mode": "parent"},
+            "candidates": [{"tag": f"cand_{it}", "stderr": 0.0737942671874435,
+                            "gate_delta": 0.001, "gate_threshold": thr, "k_se": 1.0,
+                            "n": 30, "resolvable_effect_size": res}],
+        }), encoding="utf-8")
+
+    seen = []
+    for it in range(3):
+        rd.update_spent(iterations=1) if it else None
+        # spent.iterations names the round table _round_gate_numbers reads.
+        while int(rd.spent.iterations) < it:
+            rd.update_spent(iterations=1)
+        g = commit_mod._round_gate_numbers(rd, f"cand_{it}")
+        assert g["gate_stderr"] * g["gate_k_se"] == round(g["gate_threshold"], 6), g
+        seen.append(g["gate_stderr"])
+    # The whole point: it MOVES with the round instead of being one frozen number.
+    assert len(set(seen)) == 3, seen
+
+
+# --- 4. every promised memory file exists, and the ones that exist are promised ----------
+
+def test_the_instructions_pointer_promises_exactly_the_files_it_creates():
+    """The pointer told the optimizer to read four files and a directory that nothing on the
+    agent-mode path created. Now the code that writes the promise also creates the files, and
+    names only what exists — so the promise cannot drift away from the filesystem again."""
+    from cap_evolve import harness
+
+    rd = _fresh("mem")
+    rd.candidate_dir("seed").mkdir(parents=True, exist_ok=True)
+    rd.log_event("step", candidate="cand_1", parent="seed", accept=False, val=0.5)
+
+    work = Path(tempfile.mkdtemp())
+    harness._write_instructions_pointer(work / "CLAUDE.md", ".claude/skills",
+                                        run_dir=rd, workdir=work)
+    pointer = (work / "CLAUDE.md").read_text(encoding="utf-8")
+
+    for name in ("LEDGER.md", "JOURNAL.md", "PROCESS.md", "RUNMAP.md",
+                 "INSIGHTS.md", "META_INSIGHTS.md", "FRAMEWORK_IMPROVEMENTS.md"):
+        assert name in pointer, f"{name} not promised"
+        assert (work / name).is_file(), f"{name} promised but not created"
+    # JOURNAL.md's own seed text points every prior candidate's exact edit at this path.
+    assert (work / "prior_iterations").is_dir()
+    assert "prior_iterations" in pointer
+    # rejected.jsonl always existed on disk and was never mentioned to the optimizer.
+    assert "rejected.jsonl" in pointer
+    assert str(rd.rejected_path) in pointer
+
+
+def test_the_pointer_names_no_file_it_could_not_create():
+    """Called without a run dir there is nothing to build from, so the pointer must promise
+    no cross-iteration file at all rather than name files that are not there."""
+    from cap_evolve import harness
+
+    work = Path(tempfile.mkdtemp())
+    harness._write_instructions_pointer(work / "CLAUDE.md", ".claude/skills")
+    pointer = (work / "CLAUDE.md").read_text(encoding="utf-8")
+    for name in ("LEDGER.md", "RUNMAP.md", "prior_iterations", "PROCESS.md"):
+        assert name not in pointer, f"{name} promised with nothing to create it from"
+    assert "INSTRUCTIONS.md" in pointer      # the one file staging always writes
+
+
+def test_agent_mode_carries_the_memory_forward_every_round():
+    """Not just at staging: ``seed_framework_memory`` writes into the candidate snapshot the
+    next round copies from, the same mechanism JOURNAL.md already relied on. A round-1-only
+    seed leaves a LEDGER that never mentions any round."""
+    from cap_evolve import harness
+
+    rd = _fresh("mem2")
+    rd.candidate_dir("seed").mkdir(parents=True, exist_ok=True)
+    rd.set_best("seed")
+    rd.log_event("step", candidate="cand_1", parent="seed", accept=True, val=0.7)
+
+    written = harness.seed_framework_memory(rd.candidate_dir("seed"), rd)
+    assert {"LEDGER.md", "JOURNAL.md", "PROCESS.md", "RUNMAP.md"} <= set(written)
+    ledger = (rd.candidate_dir("seed") / "LEDGER.md").read_text(encoding="utf-8")
+    assert "cand_1" in ledger and "ACCEPT" in ledger

--- a/core/tests/test_regression_gate.py
+++ b/core/tests/test_regression_gate.py
@@ -116,7 +116,9 @@ def test_gate_check_regression_matches_the_harness_rule():
     assert gc.regressions(_Side({"t1": 0.4}), _Side({"t1": 1.0})) == []
 
     # The harness's rule, written out once. gate_check must agree on every
-    # combination of fifths -- the reward granularity at num_trials=5.
+    # combination of fifths -- the reward granularity at num_trials=5. Written with the SEs
+    # at 0 (the `_Side` fixture records none), which is the single-trial case where the
+    # 2*SE bar both sides now apply collapses to eps and the rule is the historical one.
     eps = 1e-9
     def harness_rule(par, cand):
         return sorted(t for t in cand if t in par
@@ -130,10 +132,17 @@ def test_gate_check_regression_matches_the_harness_rule():
 
     # And pin the harness source, so changing ITS rule fails here and forces the two
     # to be re-synced rather than silently diverging again.
+    # Both halves of the shared rule are pinned: the parent-passed condition AND the 2*SE
+    # bar the drop has to clear. The bar is the half that was missing -- a 1.0 -> 0.9 move at
+    # 10 trials was stamped a real break -- so a change to either must re-sync gate_check.
     src = (CORE / "cap_evolve" / "harness.py").read_text()
-    assert "par[t] >= 1.0 - eps and cand[t] < par[t] - eps" in src, (
+    assert "par[t] >= 1.0 - eps and d < 0" in src, (
         "harness's no-regression predicate changed -- re-sync "
         "skills/algorithms/agent-optimize/scripts/gate_check.py:regressions()")
+    assert "abs(cand - par) > max(2.0 * math.sqrt(par_se ** 2 + cand_se ** 2), eps)" in src, (
+        "harness.move_is_resolved -- the ONE per-task resolution bar shared by "
+        "_candidate_task_impact, gate_check.regressions, measure.py and spend.py -- changed. "
+        "Re-check every caller.")
     assert harness is not None      # the import is the point: keep it live
 
 

--- a/skills/algorithms/agent-optimize/SKILL.md
+++ b/skills/algorithms/agent-optimize/SKILL.md
@@ -84,8 +84,6 @@ scores val only, so pay one `evaluate --split train` first.)
 | `4/10` – `7/10` | genuinely unstable behaviour | fix by *removing* ambiguity, not adding rules |
 | `8/10` – `9/10` | noise around a working path | **leave it alone**; "fixing" it is how churn starts |
 
-A task that "regressed" from `10/10` to `9/10` between rounds is a re-measurement, not damage.
-
 **Audit the MEASUREMENT before you credit a failure**, in round 1 while it is still free (scoring
 re-derives on persisted rollouts): a failing task is a claim by the scorer, and an optimizer that skips
 this optimizes against its own instrumentation. Does the feedback name the **defect** or only the tool;
@@ -101,9 +99,9 @@ still wrong ⇒ the content is.
 **sibling candidates, default N≥3** (one cluster each, gated independently — the safe default) or as **one bold
 multi-part edit** (higher variance, but the only way a fix needing a prompt change *and* a tool change
 lands together). Bundle only *independent* parts — different files, different rules — so a rejected bundle
-can be resubmitted as its surviving part; read `regressed` (screen) and `regressions` (gate) to know which
-to drop. That is also what stops **churn** — a candidate whose mean matches its parent while a *different*
-set of tasks passes — from reading as a tie.
+can be resubmitted as its surviving part; `regressed` (screen) and `regressions` (gate) say which to drop.
+Siblings gate better (a narrow edit's footprint is resolvable, a bundle's is the whole split) and stop
+**churn** — same mean, a *different* set of tasks passing — from reading as a tie.
 
 ```bash
 TAG="cand_1"                                   # unique per candidate — it IS the rollout tag
@@ -158,10 +156,10 @@ python "$A/gate_check.py" --run-dir "$R" --candidate "$TAG" --k-se <gate_k_se>
 
 `"verdict"` is evidence, not a command — decide accept/reject yourself, citing the numbers in
 `commit.py --note` (`references/algorithm.md`, "Gate as evidence"). `"indecisive"` means too little of val
-ran, not a rejection. **`regressions` is diagnosis, not a veto** — a per-task drop at `n` trials is an
-estimate, not proof, and the old no-regression veto rejected byte-identical seed copies often enough to dominate false
-rejects (`--veto-regressions` restores it, at that rate). `phases/gate/scripts/run.py` inspects the same
-gate but books no decision.
+ran, not a rejection. **`regressions` is diagnosis, not a veto**: a per-task drop at `n` trials is an
+estimate, not proof (`--veto-regressions` restores the old no-regression veto; see `gate_check.py`). **Read
+`footprint` before the delta; `unresolved` is no evidence** — `references/algorithm.md`, "Measuring only
+what the edit reaches". `phases/gate/scripts/run.py` inspects the same gate but books no decision.
 
 **5. Commit the decision through the run dir**, so `best_id`, the stall counter, the dashboard and the
 audit log stay real. `--decision reject` keeps the old best; either way it snapshots the candidate, logs

--- a/skills/algorithms/agent-optimize/references/algorithm.md
+++ b/skills/algorithms/agent-optimize/references/algorithm.md
@@ -388,18 +388,42 @@ against its reference, reads the identifier-like names off the changed lines, an
 persisted rollouts mention any of them (`cap_evolve.footprint` — deliberately a flat substring search over
 the whole rollout record, so it works for any adapter's trace shape and any capability). Tasks outside that
 set enter the delta vector as **0.0 rather than as their measured wobble**: an edit that cannot reach a
-task has no effect on it by construction. The vector keeps its full length, so `Δ̄` stays on the same scale
-as the val reward — and every threshold, ledger row and val-curve point derived from it stays comparable —
-while only the variance changes. On the worked case in `core/tests/`, a real +0.1 on 3 of 30 tasks goes
-from unresolvable to accepted, with the bar falling roughly 4x.
+task has no effect on it by construction. The vector keeps its full LENGTH, so `Δ̄` stays on the same SCALE
+as the val reward, and every threshold, ledger row and val-curve point derived from it stays comparable.
+
+It changes **both** halves of the test, not just the variance: `Δ̄` moves too, because the out-of-footprint
+deltas that used to be averaged in are now zeros. That is the mechanism, not a side effect — and it is why
+the footprint must never UNDER-include. Zeroing a task that really regressed raises `Δ̄` *and* lowers the SE
+together, both pushing toward accept, so a net-harmful candidate could be accepted on a fabricated gain.
+Two rules prevent it: the enclosing definition is **always** part of the footprint (an edit inside a body
+reaches everything that calls the body, not just the rare helper it happens to call), and a surface that
+reaches ≥80% of tasks makes the edit **unlocalizable** — abandon and measure the full split — rather than
+being dropped so the rarer surfaces beside it can define a confident, narrow, wrong footprint.
+
+A third rule guards the other end. On a SMALL footprint the paired SE, which is estimated from the
+cross-task spread of the vector, understates the real uncertainty: 4 tasks whose deltas are
+{0, +0.1, 0, +0.1} have a small spread, so the gate reads SE 0.0046 and accepts — on two moves of one
+flipped rollout each, the very moves `broke`/`fixed` below refuses to call real. So a restricted vector's
+SE is floored by `harness.paired_se_floor`, the SE those tasks' own per-trial noise implies. Unrestricted
+vectors keep the SE they always had, so no pre-existing verdict moves.
+
+On the worked case in `core/tests/`, a real +0.1 on 3 of 30 tasks goes from unresolvable to accepted with
+the bar falling roughly 4x. On run_finalrun6's real rollouts the mechanism is far more conservative: five
+of seven edits reach the split too broadly to restrict at all, and neither restricted verdict changes
+(cand_5 17/30, SE 0.0318 → 0.0268; cand_7 4/30, SE 0.0346 → 0.0113 floored). Its value on that run is that
+it ABSTAINS rather than manufacturing confidence — an earlier revision without the three rules narrowed
+cand_7 to 4 tasks at SE 0.0046 and accepted a docstring-only edit.
 
 Read the `footprint` block in each row before the delta:
 
 - `restricted: true` — `n_in_footprint` of `n_tasks` were in play. The SE describes those tasks.
 - `restricted: false` — the surface could not be localized: no diff, a rewrite-sized diff (more distinct
-  symbols than a targeted edit would name), no rollouts on disk, or a footprint that covers every task
-  anyway. The measurement fell back to the whole split, so it carries every task's noise. **A null result
-  here is weak evidence about the edit, not evidence against it.** `--no-footprint` forces this mode.
+  symbols than a targeted edit would name), no rollouts on disk, a footprint that covers every task
+  anyway, or one of the edit's own surfaces reaching ≥80% of tasks. The measurement fell back to the whole
+  split, so it carries every task's noise. **A null result here is weak evidence about the edit, not
+  evidence against it.** `--no-footprint` forces this mode.
+- `paired_se_floor` — the bar the restricted SE was floored at. When it equals `gate_threshold / k_se`, the
+  verdict rests on per-task trial noise rather than on the cross-task spread.
 
 The over-inclusion is deliberate: a symbol mentioned only in prose still counts as a hit. Over-including
 gives back some of the noise the restriction removes; under-including would zero out a task the edit really
@@ -432,11 +456,13 @@ change behaviour at all.
 
 Every such claim now has to clear **2·SE of its own per-task measurement** — the two sides' per-task SEs in
 quadrature, the same "smallest resolvable effect" the gate reports for the split mean, applied per task.
-One function, `harness.move_is_resolved`, is the single bar behind all four places the framework makes the
-claim: `LEDGER.md` + the journal RESULT stamp (`_candidate_task_impact`), the round table's diagnosis list
-(`gate_check.regressions`), the sealed report's seed→best movement (`measure.py`), and the
-"don't regress task X" constraint check (`spend.py`). Four copies of a bar is how three of them stayed at
-`1e-9` while one got fixed.
+One function, `harness.move_is_resolved`, is the single bar behind every place the framework makes the
+claim: `LEDGER.md` + the journal RESULT stamp (`_candidate_task_impact`); the `no_regression` veto in both
+the hill-climb and gepa loops, which is the strongest consequence of the set since it turns a
+gate-PASSING candidate into a rejection; the round table's diagnosis list (`gate_check.regressions`);
+skillopt's within-epoch improved/regressed buffer (`_categorize`); the sealed report's seed→best movement
+and its improved/regressed counts (`measure.py`); and the "don't regress task X" constraint check
+(`spend.py`). Seven copies of a bar is how six of them stay at `1e-9` while one gets fixed.
 
 A sub-threshold move is reported as **`unresolved`**, which is neither "broke" nor "unchanged": the reward
 moved, and the measurement cannot say the edit did it. Do not redesign an edit because a task appears

--- a/skills/algorithms/agent-optimize/references/algorithm.md
+++ b/skills/algorithms/agent-optimize/references/algorithm.md
@@ -12,6 +12,7 @@
 - [Parallelism](#parallelism-fan-out-on-the-cheap-steps-stay-serial-where-state-moves)
 - [The final measurement](#the-final-measurement-one-table-and-the-things-it-refuses-to-pretend)
 - [Gate as evidence, not a verdict](#gate-as-evidence-not-a-verdict)
+- [Measuring only what the edit reaches](#measuring-only-what-the-edit-reaches)
 - [Caveats](#caveats)
 - [Sources](#sources)
 
@@ -366,6 +367,81 @@ the numbers don't support, dressing noise-chasing in confident-sounding prose �
 bad math to motivated reasoning, which is harder to catch mechanically than a wrong formula was. The only
 mitigation available is the audit trail above: every override gets a human-readable justification citing
 real numbers, reviewable after the fact, the same way this repo's own run post-mortems already work.
+
+## Measuring only what the edit reaches
+
+Two things a round prints are claims about *causality*, and both were being made at a precision the
+measurement did not have. The evidence is run_finalrun6 — 7 candidates, 30 val tasks, 10 trials.
+
+### The footprint: which tasks could the edit have moved at all?
+
+An edit touches a handful of named surfaces. The gate, though, used to measure its delta across every val
+task. The tasks the edit cannot reach do not sit at zero — they wobble, because measuring a task twice is
+not the same as measuring it once — and that wobble goes straight into the SE of the mean. On
+run_finalrun6, `SE(paired Δ)` ran **0.022-0.035** while the real per-edit effects were **0.011-0.05**: the
+bar was as wide as the thing it was measuring. The same run's 7-way null-control replicate spread
+(0.567-0.603) was statistically indistinguishable from its 7-way across-candidate spread (0.570-0.607) —
+the round could not tell an edit from a re-measurement of the same code.
+
+The fix is to measure over the tasks the edit can causally reach. `gate_check.py` diffs the candidate
+against its reference, reads the identifier-like names off the changed lines, and asks which tasks'
+persisted rollouts mention any of them (`cap_evolve.footprint` — deliberately a flat substring search over
+the whole rollout record, so it works for any adapter's trace shape and any capability). Tasks outside that
+set enter the delta vector as **0.0 rather than as their measured wobble**: an edit that cannot reach a
+task has no effect on it by construction. The vector keeps its full length, so `Δ̄` stays on the same scale
+as the val reward — and every threshold, ledger row and val-curve point derived from it stays comparable —
+while only the variance changes. On the worked case in `core/tests/`, a real +0.1 on 3 of 30 tasks goes
+from unresolvable to accepted, with the bar falling roughly 4x.
+
+Read the `footprint` block in each row before the delta:
+
+- `restricted: true` — `n_in_footprint` of `n_tasks` were in play. The SE describes those tasks.
+- `restricted: false` — the surface could not be localized: no diff, a rewrite-sized diff (more distinct
+  symbols than a targeted edit would name), no rollouts on disk, or a footprint that covers every task
+  anyway. The measurement fell back to the whole split, so it carries every task's noise. **A null result
+  here is weak evidence about the edit, not evidence against it.** `--no-footprint` forces this mode.
+
+The over-inclusion is deliberate: a symbol mentioned only in prose still counts as a hit. Over-including
+gives back some of the noise the restriction removes; under-including would zero out a task the edit really
+did move and manufacture a gain. Every unknowable case degrades to `restricted: false`, never to a crash
+and never to a restriction invented from nothing.
+
+This is also the mechanical argument for **sibling candidates over bundles**: a bundle's footprint is the
+union of its parts', so a two-surface bundle is measured at close to full-split noise while each part
+measured alone would have been resolvable.
+
+**Not built, and why**: the round does not yet spend the freed budget on more trials over the smaller
+in-footprint task set. That needs subset-scoped evaluation plumbed through `round.py`, and `grow.py`
+already buys more `n` on an unresolved candidate — footprint-scoped growth is the natural next step, not a
+prerequisite for the restriction being correct.
+
+Free on the reference side, and already done: `gate_check.py --current` accepts a comma-separated list of
+tags and **pools their trials per task**. `round.py` passes every one of the round's byte-identical
+null-control replicates, so the control-relative comparison is against a pooled estimate rather than
+whichever replicate happened to carry the round-scoped tag — which was a coin flip (the same candidate read
++0.0867 against one replicate and +0.0067 against the other). No new rollouts: those files are on disk.
+
+### broke / fixed: is this task's move a claim the measurement supports?
+
+`broke` and `fixed` used to be thresholded at `1e-9`, i.e. at nothing. At 10 trials a task that goes
+`1.0 → 0.9` has had **one rollout out of ten** flip, and that was being stamped as a task the candidate
+broke. It is not a hypothetical failure: on run_finalrun6, byte-identical code measured twice — `cand_2`
+and its own fresh-tag re-measurement `cand_4` — got *different* `broke`/`fixed` labels, and the optimizer
+reasoned from them for three rounds, including asserting a regression on a docstring-only edit that cannot
+change behaviour at all.
+
+Every such claim now has to clear **2·SE of its own per-task measurement** — the two sides' per-task SEs in
+quadrature, the same "smallest resolvable effect" the gate reports for the split mean, applied per task.
+One function, `harness.move_is_resolved`, is the single bar behind all four places the framework makes the
+claim: `LEDGER.md` + the journal RESULT stamp (`_candidate_task_impact`), the round table's diagnosis list
+(`gate_check.regressions`), the sealed report's seed→best movement (`measure.py`), and the
+"don't regress task X" constraint check (`spend.py`). Four copies of a bar is how three of them stayed at
+`1e-9` while one got fixed.
+
+A sub-threshold move is reported as **`unresolved`**, which is neither "broke" nor "unchanged": the reward
+moved, and the measurement cannot say the edit did it. Do not redesign an edit because a task appears
+there, and do not cite one as a regression — re-measure it, or ignore it. At one trial per task every
+per-task SE is 0, the bar collapses to `eps`, and the classification is exactly what it always was.
 
 ## Caveats
 

--- a/skills/algorithms/agent-optimize/scripts/commit.py
+++ b/skills/algorithms/agent-optimize/scripts/commit.py
@@ -94,15 +94,22 @@ def _round_gate_numbers(run_dir: RunDir, candidate_id: str) -> dict:
     if entry is None:
         return {}
     parent = table.get("parent") or {}
+    # The SE of the PAIRED per-task deltas — the number every ``gate_threshold`` in these
+    # tables is ``k_se ×``, and therefore the only SE that belongs in the same row.
+    # DERIVED, never read off a stderr column: neither table records the paired SE, and both
+    # carry a ``stderr`` that is a mean-over-tasks SE instead. Publishing one of those is the
+    # defect this is replacing — on run_finalrun6 it put an identical ``gate_stderr``
+    # 0.0738 on rounds i0, i3 and i6 while the threshold it is supposed to generate moved
+    # 0.0222 → 0.0244 → 0.0346, i.e. a constant beside three different bars derived from it.
+    # ``resolvable_effect_size`` is ``2·SE``, written by ``gate.decide`` from the vector it
+    # actually gated on, so halving it recovers that round's real SE exactly. Absent when the
+    # gate reported no SE (threshold/strict modes, or too few paired samples), and a missing
+    # measurement must stay missing rather than become a fabricated number.
+    _res = entry.get("resolvable_effect_size")
     out = {
         "parent_val": parent.get("reward"),
-        # No ``gate_stderr``: the published ``stderr`` column is the SE of the PAIRED per-task
-        # deltas (``threshold == k_se * SE`` in every deterministic gate's own reason string),
-        # and NEITHER table records it — ``parent.stderr`` (round table) is the SE of the
-        # parent's MEAN over tasks and ``entry["stderr"]`` is the candidate's/pooled mean SE,
-        # both typically much larger. Publishing one there put "±0.144" beside a threshold of
-        # 0.044 in a single row, the same self-contradiction this function exists to remove, so
-        # it stays null like ``k_se``.
+        "gate_stderr": (round(float(_res) / 2.0, 6)
+                        if isinstance(_res, (int, float)) else None),
         # The parent block is the round table's; a grow table has no parent, so fall back to the
         # candidate entry's own paired n — which IS what the gate used.
         "gate_n": parent.get("n_tasks", entry.get("n")),
@@ -406,20 +413,24 @@ def main(argv=None) -> int:
                                  opt_tokens=args.optimizer_tokens or None,
                                  optimizer_seconds=args.optimizer_seconds or None,
                                  **gate)
-        # Re-seed JOURNAL.md onto whichever candidate is now $BEST (fresh accumulated run
-        # journal + marker), so the NEXT round's `cp -r "$R/candidates/$BEST" "$R/work/$TAG"`
-        # carries a clean append target forward — the round-2+ half of the fix in host.py's
-        # `_stage_context` (which seeds round 1 the same way onto the seed candidate).
-        # `record_iteration` above already folded THIS round's tail into the run-level file, so
-        # the snapshot picks up the full history regardless of the decision. Falls back to THIS
-        # candidate's own just-taken snapshot when there is no best_id yet (a run with no
-        # baseline) — that dir always exists (``run_dir.snapshot`` above just created it) — and
-        # is best-effort: losing this re-seed must not fail the commit itself.
+        # Re-seed the framework's cross-iteration memory onto whichever candidate is now
+        # $BEST, so the NEXT round's `cp -r "$R/candidates/$BEST" "$R/work/$TAG"` carries a
+        # CURRENT copy forward — the round-2+ half of the fix in host.py's `_stage_context`
+        # (which seeds round 1 the same way onto the seed candidate).
+        # `record_iteration` above already folded THIS round's tail into the run-level journal
+        # and wrote its `step` event, so the LEDGER/RUNMAP rebuilt here include this round.
+        # Everything the staged CLAUDE.md pointer names, not JOURNAL.md alone: LEDGER.md,
+        # RUNMAP.md and prior_iterations/<id>/diff.patch are the files the pointer (and
+        # JOURNAL.md's own seed text) tell the agent to read, and re-seeding only the journal
+        # is what left them absent for a whole run — see harness.seed_framework_memory.
+        # Falls back to THIS candidate's own just-taken snapshot when there is no best_id yet
+        # (a run with no baseline) — that dir always exists (``run_dir.snapshot`` above just
+        # created it) — and is best-effort: losing the re-seed must not fail the commit.
         try:
-            harness._seed_journal(
+            harness.seed_framework_memory(
                 run_dir.candidate_dir(run_dir.best_id or args.candidate_id), run_dir)
         except Exception as exc:  # noqa: BLE001
-            run_dir.log_event("optimizer_context_warning", what="JOURNAL.md",
+            run_dir.log_event("optimizer_context_warning", what="framework_memory",
                               error=str(exc)[:300])
         if indecisive:
             # The event the dashboard/TUI already read to render a step as `indecisive` rather

--- a/skills/algorithms/agent-optimize/scripts/gate_check.py
+++ b/skills/algorithms/agent-optimize/scripts/gate_check.py
@@ -159,10 +159,15 @@ def main(argv=None) -> int:
             all_task_ids=[pt.get("task_id") for pt in (cand.per_task or [])])
 
     deltas = harness._paired_deltas(cur, cand, footprint=fp)
+    # Only when restricted: on a small footprint the zero-padded vector's cross-task spread
+    # understates the real uncertainty, so floor it with per-task trial noise. Unrestricted
+    # vectors keep the SE they always had.
+    se_floor = (harness.paired_se_floor(run_dir, args.candidate, cur_tags[0], fp, len(deltas))
+                if fp is not None and deltas else 0.0)
     d = decide(cur.reward, cand.reward, split="val", mode=args.mode, k_se=args.k_se,
                candidate_stderr=cand.stderr, current_stderr=cur.stderr,
                threshold=args.threshold, paired_deltas=deltas,
-               coverage=cand.coverage, run_dir=run_dir)
+               paired_se_floor=se_floor, coverage=cand.coverage, run_dir=run_dir)
 
     regs = regressions(cur, cand)
     accept = bool(d.accept) and not (regs and args.veto_regressions)
@@ -192,9 +197,13 @@ def main(argv=None) -> int:
         # tasks the edit cannot reach — read the verdict knowing that.
         "footprint": ({"restricted": True, "n_in_footprint": len(fp),
                        "n_tasks": len(cand.per_task or []), "tasks": sorted(map(str, fp)),
+                       "paired_se_floor": round(se_floor, 6),
                        "reading": "tasks OUTSIDE this set entered the delta vector as 0.0 (an "
                                   "edit that cannot reach a task has no effect on it by "
-                                  "construction), so the SE reflects only the tasks in play"}
+                                  "construction), so the SE reflects only the tasks in play — "
+                                  "floored by `paired_se_floor`, the SE those tasks' own "
+                                  "per-trial noise implies, so a handful of one-rollout flips "
+                                  "cannot read as a significant mean"}
                       if fp is not None else
                       {"restricted": False,
                        "reading": ("disabled by --no-footprint" if args.no_footprint else

--- a/skills/algorithms/agent-optimize/scripts/gate_check.py
+++ b/skills/algorithms/agent-optimize/scripts/gate_check.py
@@ -30,7 +30,7 @@ from pathlib import Path
 # cap_evolve imports below; not "unused" — deleting it breaks standalone runs.
 import _bootstrap  # noqa: F401  # side-effect import, see above
 
-from cap_evolve import RunDir, harness
+from cap_evolve import RunDir, footprint, harness
 from cap_evolve.gate import decide
 from cap_evolve.loop import has_valid_trials
 
@@ -81,13 +81,26 @@ def regressions(current, candidate) -> list[str]:
 
     The old rule got WORSE as trials rose, so no trial count could fix it; the
     harness rule converges, which is the behaviour a variance-aware gate must have.
+
+    And it converges FASTER than "any strict drop below 1.0", because the drop must clear
+    ``2·SE`` of its own per-task measurement — the same bar ``harness._candidate_task_impact``
+    applies, kept in sync by ``test_regression_gate``. Without it the list reported a task as
+    regressed for a single flipped rollout out of ten: on run_finalrun6 the same "task 27"
+    was reported against structurally unrelated candidates, one of them a docstring-only edit
+    that cannot change behaviour, and the optimizer spent three rounds re-deriving that it was
+    noise. At one trial every SE is 0, the bar collapses to ``EPS``, and the rule is
+    unchanged.
     """
-    cur = {pt["task_id"]: pt.get("reward", 0.0) for pt in (current.per_task or [])
-           if has_valid_trials(pt)}
-    cand = {pt["task_id"]: pt.get("reward", 0.0) for pt in (candidate.per_task or [])
-            if has_valid_trials(pt)}
-    return sorted(t for t, pr in cur.items()
-                  if t in cand and pr >= 1.0 - EPS and cand[t] < pr - EPS)
+    cur = {pt["task_id"]: pt for pt in (current.per_task or []) if has_valid_trials(pt)}
+    cand = {pt["task_id"]: pt for pt in (candidate.per_task or []) if has_valid_trials(pt)}
+
+    def _dropped(t) -> bool:
+        pr = cur[t].get("reward", 0.0) or 0.0
+        cd = cand[t].get("reward", 0.0) or 0.0
+        return pr >= 1.0 - EPS and cd < pr and harness.move_is_resolved(
+            pr, cd, cur[t].get("stderr") or 0.0, cand[t].get("stderr") or 0.0)
+
+    return sorted(t for t in cur if t in cand and _dropped(t))
 
 
 def main(argv=None) -> int:
@@ -95,7 +108,17 @@ def main(argv=None) -> int:
     p.add_argument("--run-dir", required=True)
     p.add_argument("--candidate", required=True, help="candidate tag (== its dir name)")
     p.add_argument("--current", default=None,
-                   help="tag to compare against; default = the run's current best_id")
+                   help="tag to compare against; default = the run's current best_id. Accepts a "
+                        "COMMA-SEPARATED list, whose trials are POOLED per task into one "
+                        "reference — the way a round's byte-identical null-control replicates "
+                        "become a lower-variance estimate of the same parent for free, since "
+                        "their rollouts are already on disk (see round.py's control_replicates).")
+    p.add_argument("--no-footprint", action="store_true",
+                   help="measure the delta across EVERY val task, including the ones the edit "
+                        "cannot causally reach. Footprint restriction is on by default and is a "
+                        "no-op whenever the edit's surface cannot be determined; see "
+                        "cap_evolve.footprint for why the unrestricted vector buries real "
+                        "effects in the noise of tasks the edit never touched.")
     p.add_argument("--mode", default="paired",
                    choices=["paired", "significant", "strict", "threshold"])
     p.add_argument("--k-se", type=float, default=1.0)
@@ -108,20 +131,34 @@ def main(argv=None) -> int:
     args = p.parse_args(argv)
 
     run_dir = RunDir.open(Path(args.run_dir))
-    cur_tag = args.current or run_dir.best_id
-    if not cur_tag:
+    cur_tags = [t.strip() for t in (args.current or "").split(",") if t.strip()] \
+        or ([run_dir.best_id] if run_dir.best_id else [])
+    if not cur_tags:
         print(json.dumps({"error": "no --current tag and no best_id in the run dir "
                                    "(has baseline run?)"}, indent=2))
         return 2
+    cur_tag = ",".join(cur_tags)
 
-    cur = harness.split_result_from_rollouts(run_dir, cur_tag, "val")
+    cur = harness.split_result_from_rollouts(run_dir, cur_tags, "val")
     cand = harness.split_result_from_rollouts(run_dir, args.candidate, "val")
     if not cand.per_task:
         print(json.dumps({"error": f"no val rollouts for tag {args.candidate!r} — run the "
                                    "evaluate phase on FULL val first"}, indent=2))
         return 2
 
-    deltas = harness._paired_deltas(cur, cand)
+    # Which val tasks the edit can causally reach. The candidate snapshot is diffed against
+    # the FIRST reference tag's snapshot: a pooled reference is several byte-identical copies
+    # of one parent, so any of them gives the same diff. None when it cannot be determined,
+    # which leaves the full-vector behaviour exactly as it was.
+    fp = None
+    if not args.no_footprint:
+        fp = footprint.footprint(
+            run_dir, parent_dir=run_dir.candidate_dir(cur_tags[0]),
+            cand_dir=run_dir.candidate_dir(args.candidate),
+            tags=[*cur_tags, args.candidate], split="val",
+            all_task_ids=[pt.get("task_id") for pt in (cand.per_task or [])])
+
+    deltas = harness._paired_deltas(cur, cand, footprint=fp)
     d = decide(cur.reward, cand.reward, split="val", mode=args.mode, k_se=args.k_se,
                candidate_stderr=cand.stderr, current_stderr=cur.stderr,
                threshold=args.threshold, paired_deltas=deltas,
@@ -144,11 +181,26 @@ def main(argv=None) -> int:
     if directionally_positive_but_inconclusive:
         next_cmd += " (or --decision provisional, then scripts/grow.py, to buy more n on this candidate)"
     print(json.dumps({
-        "current": {"tag": cur_tag, "reward": cur.reward, "stderr": cur.stderr},
+        "current": {"tag": cur_tag, "reward": cur.reward, "stderr": cur.stderr,
+                    "pooled_tags": cur_tags if len(cur_tags) > 1 else None},
         "candidate": {"tag": args.candidate, "reward": cand.reward,
                       "stderr": cand.stderr, "coverage": cand.coverage},
         "gate": d.to_dict(),
         "paired_n": len(deltas or []),
+        # What the delta was measured over. `restricted: false` means the edit's surface could
+        # not be determined, so every val task is in the vector and the SE carries the noise of
+        # tasks the edit cannot reach — read the verdict knowing that.
+        "footprint": ({"restricted": True, "n_in_footprint": len(fp),
+                       "n_tasks": len(cand.per_task or []), "tasks": sorted(map(str, fp)),
+                       "reading": "tasks OUTSIDE this set entered the delta vector as 0.0 (an "
+                                  "edit that cannot reach a task has no effect on it by "
+                                  "construction), so the SE reflects only the tasks in play"}
+                      if fp is not None else
+                      {"restricted": False,
+                       "reading": ("disabled by --no-footprint" if args.no_footprint else
+                                   "the edit's surface could not be localized (no diff, a "
+                                   "rewrite-sized diff, no rollouts, or it reaches every "
+                                   "task) — full-vector measurement, as before")}),
         "regressions": regs,
         "verdict": verdict,
         "directionally_positive_but_inconclusive": directionally_positive_but_inconclusive,

--- a/skills/algorithms/agent-optimize/scripts/host.py
+++ b/skills/algorithms/agent-optimize/scripts/host.py
@@ -662,10 +662,14 @@ def _stage_context(*, run_dir: Path, project: Path, workdir: Path, spec: dict,
         # every round, so round 2+ inherits a clean append target automatically. Own
         # try/except: a journal-seed failure must not mark the whole context (guidance,
         # trajectories) unstaged — it is a nicety on top of staging, not staging itself.
+        # `seed_framework_memory`, not `_seed_journal` alone: LEDGER.md, RUNMAP.md and
+        # prior_iterations/ are named by the staged CLAUDE.md pointer AND by JOURNAL.md's own
+        # seed text, and seeding only the journal is what left them absent for a whole run.
         try:
-            harness._seed_journal(rd.candidate_dir(rd.best_id or "seed"), rd)
+            harness.seed_framework_memory(rd.candidate_dir(rd.best_id or "seed"), rd)
         except Exception as exc:  # noqa: BLE001
-            rd.log_event("optimizer_context_warning", what="JOURNAL.md", error=str(exc)[:300])
+            rd.log_event("optimizer_context_warning", what="framework_memory",
+                         error=str(exc)[:300])
 
         guidance = (sorted(g.name for g in (workdir / "guidance").iterdir())
                     if (workdir / "guidance").is_dir() else [])

--- a/skills/algorithms/agent-optimize/scripts/measure.py
+++ b/skills/algorithms/agent-optimize/scripts/measure.py
@@ -70,9 +70,17 @@ def _compare(seed: SplitResult | None, best: SplitResult | None, *, split: str,
     if n >= 2:
         var = sum((d - mean_d) ** 2 for d in deltas) / (n - 1)
         se = (var / n) ** 0.5
+    # `improved`/`regressed` count the RESOLVED movers (`_per_task_movement`, which applies
+    # `harness.move_is_resolved`), not every task whose reward differs by more than 1e-9.
+    # Counting the latter put two bars in one output: this block would report a task as
+    # improved while `val_per_task_movement` right beside it called the same task unresolved.
+    mv = _per_task_movement(seed, best)
     row["paired"] = {"n": n, "mean_delta": round(mean_d, 6), "se": round(se, 6),
-                     "improved": sum(1 for d in deltas if d > 1e-9),
-                     "regressed": sum(1 for d in deltas if d < -1e-9)}
+                     "improved": len(mv["fixed"]), "regressed": len(mv["broke"]),
+                     "unresolved": len(mv["unresolved"]),
+                     "counts_reading": "improved/regressed count only tasks whose move cleared "
+                                       "2*SE of its own per-task measurement; smaller movers "
+                                       "are in `unresolved` and are not evidence either way"}
     if split == "val":
         d = decide(seed.reward, best.reward, split="val", mode=mode, k_se=k_se,
                    candidate_stderr=best.stderr, current_stderr=seed.stderr,

--- a/skills/algorithms/agent-optimize/scripts/measure.py
+++ b/skills/algorithms/agent-optimize/scripts/measure.py
@@ -85,16 +85,34 @@ def _compare(seed: SplitResult | None, best: SplitResult | None, *, split: str,
 
 
 def _per_task_movement(seed: SplitResult, best: SplitResult) -> dict:
+    """Which tasks the whole run measurably fixed or broke, seed -> best.
+
+    `fixed`/`broke` require the move to clear 2*SE of its own per-task measurement
+    (``harness.move_is_resolved`` — the ONE bar every broke/fixed claim in the framework
+    uses). A smaller move goes to `unresolved`: it is not `unchanged` (the reward did move)
+    and it is not evidence the run changed that task's behaviour. This is the sealed report a
+    human reads, so a task listed here as fixed or broken had better be a claim the
+    measurement supports — at 10 trials the old ``1e-9`` test promoted a single flipped
+    rollout to a headline behavioural change.
+    """
     from cap_evolve.loop import has_valid_trials
-    s = {pt["task_id"]: pt.get("reward", 0.0) for pt in (seed.per_task or [])
-         if has_valid_trials(pt)}
-    b = {pt["task_id"]: pt.get("reward", 0.0) for pt in (best.per_task or [])
-         if has_valid_trials(pt)}
+    s = {pt["task_id"]: pt for pt in (seed.per_task or []) if has_valid_trials(pt)}
+    b = {pt["task_id"]: pt for pt in (best.per_task or []) if has_valid_trials(pt)}
     shared = sorted(set(s) & set(b))
+
+    def _r(d, t):
+        return d[t].get("reward", 0.0) or 0.0
+
+    def _resolved(t):
+        return harness.move_is_resolved(_r(s, t), _r(b, t),
+                                        s[t].get("stderr") or 0.0, b[t].get("stderr") or 0.0)
+
     return {
-        "fixed": [t for t in shared if b[t] > s[t] + 1e-9],
-        "broke": [t for t in shared if b[t] < s[t] - 1e-9],
-        "unchanged": [t for t in shared if abs(b[t] - s[t]) <= 1e-9],
+        "fixed": [t for t in shared if _r(b, t) > _r(s, t) and _resolved(t)],
+        "broke": [t for t in shared if _r(b, t) < _r(s, t) and _resolved(t)],
+        "unresolved": [t for t in shared
+                       if abs(_r(b, t) - _r(s, t)) > 1e-9 and not _resolved(t)],
+        "unchanged": [t for t in shared if abs(_r(b, t) - _r(s, t)) <= 1e-9],
         "unpaired": sorted((set(s) | set(b)) - set(shared)),
     }
 

--- a/skills/algorithms/agent-optimize/scripts/round.py
+++ b/skills/algorithms/agent-optimize/scripts/round.py
@@ -450,6 +450,11 @@ def main(argv=None) -> int:
             "n": g.get("paired_n"),
             "k_se": args.k_se,
             "resolvable_effect_size": (g.get("gate") or {}).get("resolvable_effect_size"),
+            # Which val tasks the delta was actually measured over. A row whose footprint is
+            # `restricted: false` was measured across the whole split, so its SE carries the
+            # noise of every task the edit cannot reach — the defect that made SE(paired Δ)
+            # 0.022-0.035 on run_finalrun6 while real per-edit effects were 0.011-0.05.
+            "footprint": g.get("footprint"),
             "verdict": g.get("verdict"),
             "regressions": g.get("regressions"),
             "eval_rc": ev.get("rc"),
@@ -473,17 +478,26 @@ def main(argv=None) -> int:
         for r in rows:
             if r["tag"] in ctl_tags or r.get("reward") is None:
                 continue
+            # POOLED over every control replicate this round has, not just the one carrying
+            # the round-scoped tag. They are byte-identical copies of the same parent measured
+            # in the same round, so they are draws from one distribution and pooling their
+            # trials per task is the lower-variance estimate of the same quantity — for free,
+            # since these rollouts are already on disk. Measuring against a single replicate is
+            # what made this comparison a coin flip: the same candidate read +0.0867 against
+            # one replicate and +0.0067 against the other.
             g = _gate(Path(args.run_dir), r["tag"], args.k_se, args.mode,
-                      args.veto_regressions, current=CTL)
+                      args.veto_regressions, current=",".join(ctl_tags))
             r["control_relative"] = {
-                "reference": CTL,
+                "reference": ctl_tags if len(ctl_tags) > 1 else CTL,
                 "gate_delta": (g.get("gate") or {}).get("delta"),
                 "gate_threshold": (g.get("gate") or {}).get("threshold"),
                 "verdict": g.get("verdict"),
-                "reading": ("the same comparison with the DRIFT removed: this candidate against a "
-                            "byte-identical control measured in this round rather than against a "
-                            "reward measured earlier. Where the two disagree, the difference is "
-                            "drift, not the edit."
+                "reading": ("the same comparison with the DRIFT removed: this candidate against "
+                            f"{len(ctl_tags)} byte-identical control(s) measured in this round — "
+                            "their trials POOLED per task, so the reference carries less of its "
+                            "own measurement error than any single replicate — rather than "
+                            "against a reward measured earlier. Where the two disagree, the "
+                            "difference is drift, not the edit."
                             if not REUSED else
                             f"this candidate against a byte-identical control of the SAME parent "
                             f"measured in iteration {REUSED['from_iteration']} and reused here. "

--- a/skills/algorithms/agent-optimize/scripts/spend.py
+++ b/skills/algorithms/agent-optimize/scripts/spend.py
@@ -67,11 +67,17 @@ def _regressed_vs_seed(run_dir: RunDir, best_id: str | None) -> list:
         return []
     seed = harness.split_result_from_rollouts(run_dir, "seed", "val")
     best = harness.split_result_from_rollouts(run_dir, best_id, "val")
-    s = {pt["task_id"]: pt.get("reward", 0.0) for pt in (seed.per_task or [])
-         if has_valid_trials(pt)}
-    b = {pt["task_id"]: pt.get("reward", 0.0) for pt in (best.per_task or [])
-         if has_valid_trials(pt)}
-    return sorted(str(t) for t, r in s.items() if t in b and b[t] < r - 1e-9)
+    s = {pt["task_id"]: pt for pt in (seed.per_task or []) if has_valid_trials(pt)}
+    b = {pt["task_id"]: pt for pt in (best.per_task or []) if has_valid_trials(pt)}
+    # The move must clear 2*SE of its own per-task measurement (harness.move_is_resolved —
+    # the ONE bar every broke/fixed claim in the framework uses). A constraint clause is
+    # checked against this list, so a task that only wobbled by one flipped rollout must not
+    # report a violated promise.
+    return sorted(str(t) for t in s if t in b
+                  and (b[t].get("reward", 0.0) or 0.0) < (s[t].get("reward", 0.0) or 0.0)
+                  and harness.move_is_resolved(
+                      s[t].get("reward", 0.0) or 0.0, b[t].get("reward", 0.0) or 0.0,
+                      s[t].get("stderr") or 0.0, b[t].get("stderr") or 0.0))
 
 
 def _afford(run_dir: RunDir, spec: dict, n_siblings: int, n_trials: int) -> dict:


### PR DESCRIPTION
Four statistical-honesty defects, each root-caused against real run data: **run_finalrun6** — 7 candidates, 30 val tasks, 10 trials, agent-optimize.

`1117 passed, 12 skipped`; `agent-optimize/scripts/check.py` ok, linkcheck ok. 15 new tests, all of which fail against `main` at 49fcedb6.

> **Second commit (`351150d1`) fixes a blocking under-inclusion bug found in review, and corrects the power claims below.** The restriction is now considerably more conservative than the first revision claimed, and the numbers in this description are the post-fix ones.

---

## 1. The paired gate had no statistical power

**Evidence.** The gate measured a candidate's delta across **all 30** val tasks even though each edit touched a handful, so the ~26 tasks the edit could not reach contributed pure re-measurement wobble to the SE. `SE(paired Δ)` ran **0.022–0.035** while the real per-edit effects were **0.011–0.05** — the significance bar was as wide as the thing it was measuring. The same run's 7-way null-control replicate spread (**0.567–0.603**, byte-identical code) was statistically indistinguishable from its 7-way across-candidate spread (**0.570–0.607**): the round could not tell an edit from a re-measurement of the same code.

**Fix.** New `core/cap_evolve/footprint.py` reads the **named surfaces** out of the candidate's diff — definitions, calls, `"name": "…"` declarations on changed lines, **always** together with the enclosing definition — then asks which tasks' persisted rollouts mention any of them. Tasks outside that set enter the delta vector as **0.0 rather than as their measured wobble**: an edit that cannot reach a task has Δ=0 by construction.

Zero-padding rather than dropping keeps the vector's full **length**, so Δ̄ stays on the same **scale** as the val reward and every threshold, ledger row and val-curve point derived from it stays comparable. It changes **both** halves of the test, not just the variance — Δ̄ moves too, since the out-of-footprint deltas that used to be averaged in are now zeros. That is the mechanism, and it is precisely why the footprint must never under-include (see the review fix below).

**Three rules keep it honest**, and all three are load-bearing:

1. the enclosing definition is **always** part of the footprint — an edit inside a body reaches everything that calls the body, not just a rare helper it happens to call;
2. a surface reaching **≥80%** of tasks makes the edit **unlocalizable** → abandon and measure the full split, rather than dropping that name so the rarer surfaces beside it can define a confident narrow footprint;
3. a restricted vector's SE is **floored** by `harness.paired_se_floor` — the SE the in-footprint tasks' own per-trial noise implies — because the cross-task spread understates uncertainty on a small footprint.

**Replayed on run_finalrun6's own rollouts** (no new rollouts spent), all three rules applied:

| candidate | footprint | SE before | SE after | |
| --- | --- | --- | --- | --- |
| cand_1 | None | 0.0222 | — | guard across all 6 write tools → reaches everything |
| cand_2 | None | 0.0250 | — | batch tool wrapping `cancel_reservation` (26/30 tasks) |
| cand_3 | None | 0.0276 | — | bundle of cand_1 + cand_2 |
| cand_4 | None | 0.0244 | — | re-measurement of cand_2, byte-identical |
| cand_5 | 17/30 | 0.0318 | **0.0268** | |
| cand_6 | None | 0.0313 | — | bundle of cand_2 + cand_5 |
| cand_7 | 4/30 | 0.0346 | **0.0113** | floored; unfloored this was 0.0046 and a false ACCEPT |

**Be clear about what that shows.** Five of seven edits on this run reach the split too broadly to restrict at all, and **neither restricted verdict changes**. The mechanism earns its keep on genuinely narrow edits; on this run its value is that it **abstains** instead of manufacturing confidence. The worked synthetic case in `core/tests/` (a real +0.1 on 3 of 30 tasks) does go from unresolvable to accepted with the bar falling ~4x.

Getting the extractor to work on real data took two iterations worth recording. An *every-identifier* extractor produced **67 symbols for cand_2's 1.7 KB one-tool diff, 60 of them English** ("cancelled", "flights", "user") straight out of the docstring — those match every rollout, so the footprint was the whole split and the fix delivered nothing. Two things fixed it: taking only named surfaces, with **no `\s*` before `(`** (prose puts a space before a parenthesis, a call never does), and the adaptive ≥80% rule instead of a hand-maintained stop-list.

**Also free, on the reference side.** `split_result_from_rollouts` now accepts several tags and **pools their trials per task** (not their means), and `gate_check.py --current` takes a comma-separated list. `round.py` passes every null-control replicate the round has instead of whichever one carried the round-scoped tag — which was a coin flip: the same candidate read **+0.0867 against one replicate and +0.0067 against the other**. Those rollouts are already on disk.

**Configurable off, and never a crash.** Every unknowable case returns `None` and falls back to the exact full-vector behaviour that shipped before. `--no-footprint` / `footprint_gate=False` force it off.

## 2. False `broke`/`fixed` classification

**Evidence.** The threshold was `eps = 1e-9`, i.e. nothing. At 10 trials a `1.0 → 0.9` move is **one flipped rollout**, and it was being stamped as a task the candidate broke. It poisoned real reasoning: byte-identical code measured twice — `cand_2` and its own fresh-tag re-measurement `cand_4` — got **different `broke`/`fixed` labels**, and the optimizer's journal spent three rounds re-deriving that "task 27" was noise after the label asserted a regression on structurally unrelated candidates, one of them a **docstring-only edit that cannot change behaviour at all**.

**Fix.** `harness.move_is_resolved` — a move must clear **2·SE of its own per-task measurement** (the two sides' per-task SEs in quadrature; the same "smallest resolvable effect" the gate reports for the split mean, applied per task, from the variance data the gate already uses). It is one function because it is the single bar behind **all seven** places the framework makes that claim:

- `_candidate_task_impact` → LEDGER.md + the journal RESULT stamp
- `harness.run_step` **and** `gepa._full_val_gate` `no_regression` veto → the strongest consequence of the set, since it turns a gate-**passing** candidate into a rejection
- `gate_check.regressions` → the round table's diagnosis list
- `skillopt._categorize` → the within-epoch improved/regressed buffer the optimizer prompt reads
- `measure.py` → the sealed report's seed→best movement **and** its improved/regressed counts, which previously reported a second, unfixed bar in the same output
- `spend.py` → the "don't regress task X" constraint check

Six of those seven were still at `1e-9`, which is what copies of a bar get you.

Sub-threshold movers are reported as **`unresolved`**, not asserted either way. Adjacent text no longer calls the classification "objective". At one trial per task every per-task SE is 0, the bar collapses to `eps`, and the classification is byte-identical to before (pinned by a test).

## 3. Stale `gate_stderr` constant

**Evidence.** `gate_stderr` was published as **0.0738 on rounds i0, i3 and i6 alike** while the `gate_threshold` it is supposed to generate moved **0.0222 → 0.0244 → 0.0346** at `k_se = 1.0` — one frozen constant beside three different bars derived from it.

**Note:** #414 had already removed the field, so `main` publishes nothing rather than a wrong number. This wires the **real** value through instead, derived from the round table's `resolvable_effect_size` (`== 2·SE`, written by `gate.decide` from the vector it actually gated on), so `threshold == k_se · gate_stderr` holds for its own round.

## 4. Memory files promised but never created

**Evidence.** The staged pointer (`.capevolve/CLAUDE.md`) told the optimizer to read `./LEDGER.md`, `./PROCESS.md`, `./RUNMAP.md` and `./prior_iterations/<id>/`, and `JOURNAL.md`'s own seed text points at `./prior_iterations/<id>/diff.patch` for every prior candidate's exact edit. On disk the agent-mode working dir held only `INSTRUCTIONS.md`, `CLAUDE.md`, `guidance/`, `project/` and `trajectories/`. Root cause: only the deterministic loops' `_augment_instructions` built those files; agent mode reaches `_write_instructions_pointer` (via `OptimizerContext.inject` → `_inject_native_skills`) and got the pointer alone.

**Fix — create, not un-promise.** All of them are pure functions of the run's `step` events and candidate snapshots, so building them is cheap and idempotent, and `prior_iterations/<id>/diff.patch` is already assumed to exist by JOURNAL.md. `harness.seed_framework_memory` builds the whole set; the code that **writes** the promise now calls it and lists **only the files that exist**, so the text cannot drift away from the filesystem again. `host.py` seeds round 1 and `commit.py` re-seeds each round onto the candidate the next round copies from — the same carry-forward mechanism JOURNAL.md already used, so the LEDGER the optimizer reads includes the round just booked.

`rejected.jsonl` always existed with real data and was never mentioned; it is now named (by absolute path) in both pointers, with `history.jsonl` beside it.

---

## Deliberately NOT fixed

- **Increased trial count on the smaller in-footprint task set.** Needs subset-scoped evaluation plumbed through `round.py` and the evaluate phase, and `grow.py` already buys more `n` on an unresolved candidate. Footprint-scoped growth is the natural next step. Recorded in `references/algorithm.md`.
- **`dashboard._val_per_task_file`'s `fixed`/`broke`.** Read from a `val_per_task.json` an external run wrote; the dashboard reports what is in the file rather than re-deriving it, so the bar belongs at the writer.

## Risk worth naming

Footprint restriction changes what the significance test is computed over, so a candidate whose real damage lands **outside** the detected footprint would have that damage zeroed out — and the bias is asymmetric, since zeroing a regression raises Δ̄ and lowers the SE together. The three rules above exist for that reason, and the review's repro (a net-harmful candidate accepted at Δ̄ +0.05) is now a regression test. The recorded `val` reward and everything the report and val curve publish remain **whole-split means**; only the significance test's vector is narrowed.
