### PR TITLE
fix(round): a gate that never ran is not a gate that decided nothing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ All notable changes to cap-evolve are documented here. The format follows
 
 ## [Unreleased]
 ### Fixed
+- **A gate that never ran was published as a gate that decided nothing.** On run 33492876620
+  round 3 the whole round table came back with `reward`, `gate_delta`, `gate_threshold` and
+  `verdict` `null` for all three candidates *and* for the control, `control_replicates: []` and
+  `evidence_bar: null` — while `eval_rc: 0` and all 100 rollouts sat on disk, fully scored. The
+  round was booked anyway, and only the driver noticing by hand kept a garbage verdict out of
+  the ledger. Three things had to line up: `round.py`'s `--mode` had no `choices=` at all, so
+  argparse accepted `--mode val` (the caller meant `--split val`, which is the default and a
+  no-op); `gate_check.py` *does* validate `--mode`, so it exited 2 with empty stdout; and
+  `_gate` caught the `json.loads` failure and returned `{"error": ...}` — a dict with every
+  verdict key **missing**, which the caller `.get()`s into `None`. A row that reads "this
+  candidate did not move" for a candidate nothing judged is the most expensive kind of wrong
+  this script can be. Fixed at all three levels: `--mode`'s `choices=` is now imported from
+  `gate_check.GATE_MODES` rather than repeated, so the two cannot drift apart again; `_gate`
+  raises `GateCheckFailed` on any non-zero rc, which also closes the **second** path to the same
+  silent table — the two `return 2` branches in `gate_check.py` print well-formed JSON, so
+  `json.loads` *succeeded* on them and `_gate` never noticed it had failed; and
+  `assert_rows_were_judged` refuses to publish any row with no reward whose evaluation
+  succeeded, as a backstop independent of the cause. The one case where a missing verdict is
+  honest is preserved: a candidate whose own **evaluation** failed has no rollouts to gate, so
+  `gate_unless_eval_failed` keeps that row in the table carrying its `eval_rc`/`eval_error`
+  instead of killing the round — a real infrastructure failure stays a report rather than
+  becoming a crash.
 - **A live run was reported as `failed` for as long as it was scoring its baseline.** Run
   33492876620's live snapshot showed a red `failed` badge, "no baseline and no candidate was
   ever evaluated" and `0s elapsed` on a smoke-spreadsheetbench job that had been healthy and

--- a/core/tests/test_a_failed_gate_is_not_a_verdict.py
+++ b/core/tests/test_a_failed_gate_is_not_a_verdict.py
@@ -1,0 +1,232 @@
+"""A gate that FAILED must not be written to the round table as a gate that decided nothing.
+
+Observed on run 33492876620 round 3 (spreadsheetbench smoke, agent-optimize). The whole table
+came back with ``reward``/``gate_delta``/``gate_threshold``/``verdict`` null for all three
+candidates AND for the control, ``control_replicates: []`` and ``evidence_bar: null`` — while
+``eval_rc: 0`` and all 100 rollouts were on disk, fully scored. The round was booked anyway.
+
+Three things had to line up, and this file pins all three:
+
+1. ``round.py``'s ``--mode`` had ``default="paired"`` and no ``choices=``, so argparse accepted
+   ``--mode val`` (the agent confused it with ``--split val``, which is the default and a no-op).
+   ``gate_check.py`` DOES validate ``--mode``, so it exited 2 with empty stdout.
+2. ``_gate`` caught the ``json.loads`` failure and returned ``{"error": ...}`` — a dict with no
+   verdict keys. The caller ``.get()``s the keys it wants, so every one came back ``None``.
+3. Nothing downstream checked. A row with no reward read exactly like a row whose candidate had
+   simply not moved.
+
+There is a SECOND path to the same silent table, which is why fixing the flag alone is not
+enough: ``gate_check.py``'s own two ``return 2`` paths (no ``--current`` and no ``best_id``; no
+rollouts for the tag) print valid JSON — ``{"error": "..."}`` — so ``json.loads`` SUCCEEDS and
+``_gate`` never even notices it failed. Both paths must be failures, not verdicts.
+
+The one case where a missing verdict is legitimate: the candidate's own EVALUATION failed, so
+there are no rollouts to gate. That row must still be written, carrying its ``eval_rc`` and
+``eval_error`` — otherwise a real infrastructure failure becomes a crash instead of a report.
+That is the line these tests draw: no reward AND a successful eval is a framework bug; no reward
+AND a failed eval is a result.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPTS = REPO / "skills" / "algorithms" / "agent-optimize" / "scripts"
+
+
+def _load(name: str, modname: str):
+    spec = importlib.util.spec_from_file_location(modname, SCRIPTS / name)
+    mod = importlib.util.module_from_spec(spec)
+    sys.path.insert(0, str(SCRIPTS))
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _round():
+    return _load("round.py", "_ao_round_failed_gate")
+
+
+def _gate_check():
+    return _load("gate_check.py", "_ao_gate_check_failed_gate")
+
+
+class _Proc:
+    """Just enough of subprocess.CompletedProcess for _gate."""
+
+    def __init__(self, returncode, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+# ---------------------------------------------------------------- 1. the flag
+
+
+def test_mode_rejects_a_value_gate_check_cannot_accept():
+    """`--mode val` is what actually happened. It must die at the command line."""
+    rnd = _round()
+    with pytest.raises(SystemExit) as exc:
+        rnd.main(["--run-dir", "/nonexistent", "--project", "/nonexistent",
+                  "--candidates", "cand_1", "--n-trials", "10", "--mode", "val"])
+    assert exc.value.code == 2, (
+        "round.py accepted --mode val and passed it to gate_check.py, which rejected it and "
+        "exited 2 with empty stdout — emptying the entire round table. A value the downstream "
+        "script cannot accept must be refused here, before any rollout is read")
+
+
+def test_round_mode_choices_are_exactly_gate_check_mode_choices():
+    """The two lists must not be able to drift apart again."""
+    rnd, gc = _round(), _gate_check()
+
+    def _choices(mod, flag):
+        p = mod.build_parser() if hasattr(mod, "build_parser") else None
+        assert p is not None, f"{mod.__name__} needs build_parser() so its flags are inspectable"
+        for a in p._actions:
+            if flag in getattr(a, "option_strings", []):
+                return a.choices
+        raise AssertionError(f"{flag} not found in {mod.__name__}")
+
+    assert _choices(rnd, "--mode") == _choices(gc, "--mode"), (
+        "round.py forwards --mode verbatim to gate_check.py, so any value one accepts and the "
+        "other rejects is a silent round-emptying bug. Deriving one list from the other is the "
+        "only thing that keeps them in step")
+
+
+# ---------------------------------------------------------- 2. _gate fails loudly
+
+
+def test_a_crashed_gate_check_raises_instead_of_returning_a_result_shaped_dict(monkeypatch):
+    """The run 33492876620 path: rc=2, empty stdout, json.loads throws."""
+    rnd = _round()
+    monkeypatch.setattr(rnd.subprocess, "run",
+                        lambda *a, **k: _Proc(2, stdout="",
+                                              stderr="round: error: argument --mode: invalid"))
+    with pytest.raises(rnd.GateCheckFailed) as exc:
+        rnd._gate(Path("/nonexistent"), "cand_1", 1.0, "paired", False)
+    assert "cand_1" in str(exc.value) and "invalid" in str(exc.value), (
+        "_gate returned {'error': ...} — a dict shaped like a verdict, with the verdict keys "
+        "missing. The caller .get()s them into None and writes a row that reads as 'no movement'. "
+        "It must raise, naming the tag and carrying gate_check.py's own message")
+
+
+def test_gate_check_error_json_is_a_failure_too_not_a_verdict(monkeypatch):
+    """The second path: gate_check.py's own `return 2` prints VALID JSON, so json.loads succeeds.
+
+    Fixing only the ``--mode`` flag would leave this one wide open.
+    """
+    rnd = _round()
+    payload = json.dumps({"error": "no val rollouts for tag 'cand_1' — run the evaluate phase"})
+    monkeypatch.setattr(rnd.subprocess, "run",
+                        lambda *a, **k: _Proc(2, stdout=payload, stderr=""))
+    with pytest.raises(rnd.GateCheckFailed) as exc:
+        rnd._gate(Path("/nonexistent"), "cand_1", 1.0, "paired", False)
+    assert "no val rollouts" in str(exc.value), (
+        "gate_check.py's two `return 2` paths print well-formed JSON, so json.loads succeeded "
+        "and _gate handed back {'error': ...} without noticing the non-zero rc. A non-zero rc is "
+        "a failure whether or not its stdout happens to parse")
+
+
+def test_a_successful_gate_check_still_returns_its_payload(monkeypatch):
+    """The fix must not turn a working gate into an exception."""
+    rnd = _round()
+    payload = json.dumps({"candidate": {"reward": 0.6}, "gate": {"delta": 0.05},
+                          "verdict": "accept"})
+    monkeypatch.setattr(rnd.subprocess, "run",
+                        lambda *a, **k: _Proc(0, stdout=payload, stderr=""))
+    got = rnd._gate(Path("/nonexistent"), "cand_1", 1.0, "paired", False)
+    assert got["verdict"] == "accept" and got["candidate"]["reward"] == 0.6
+
+
+def test_rc_zero_with_unparseable_stdout_is_also_a_failure(monkeypatch):
+    """A gate that exits 0 but prints nothing usable has still not decided anything."""
+    rnd = _round()
+    monkeypatch.setattr(rnd.subprocess, "run",
+                        lambda *a, **k: _Proc(0, stdout="Traceback (most recent call last):",
+                                              stderr=""))
+    with pytest.raises(rnd.GateCheckFailed):
+        rnd._gate(Path("/nonexistent"), "cand_1", 1.0, "paired", False)
+
+
+# ------------------------------------------------- 3. the table refuses a null row
+
+
+def test_a_null_reward_row_is_refused_when_its_evaluation_succeeded():
+    """The invariant that makes run 33492876620 impossible whatever the cause.
+
+    Independent of the two fixes above: any future path to a reward-less row on a successful
+    eval fails here instead of being written to the table.
+    """
+    rnd = _round()
+    rows = [{"tag": "cand_1", "reward": None, "verdict": None, "eval_rc": 0, "eval_error": None}]
+    with pytest.raises(rnd.GateCheckFailed) as exc:
+        rnd.assert_rows_were_judged(rows)
+    assert "cand_1" in str(exc.value), (
+        "a row with eval_rc 0 and no reward means the rollouts were scored and the GATE failed. "
+        "Writing it as null publishes 'this candidate did not move' for a candidate nothing "
+        "judged")
+
+
+def test_a_null_reward_row_is_allowed_when_the_evaluation_itself_failed():
+    """A real infra failure must stay a REPORT, not become a crash."""
+    rnd = _round()
+    rnd.assert_rows_were_judged([
+        {"tag": "cand_1", "reward": None, "verdict": None, "eval_rc": 1,
+         "eval_error": "runner OOM"},
+    ])
+
+
+def test_a_judged_row_passes():
+    rnd = _round()
+    rnd.assert_rows_were_judged([
+        {"tag": "cand_1", "reward": 0.6, "verdict": "accept", "eval_rc": 0, "eval_error": None},
+    ])
+
+
+# ------------------------------------- 4. the one case that must NOT start failing
+
+
+def test_a_candidate_whose_own_evaluation_failed_does_not_crash_the_round(monkeypatch):
+    """Raising on a failed gate must not turn a real infra failure into a dead round.
+
+    If the eval failed there are no rollouts, so ``gate_check.py`` exits 2 legitimately. That
+    row belongs in the table carrying its ``eval_rc``/``eval_error`` — the round reports the
+    failure and the other candidates are still judged.
+    """
+    rnd = _round()
+    monkeypatch.setattr(rnd.subprocess, "run",
+                        lambda *a, **k: _Proc(2, stdout=json.dumps(
+                            {"error": "no val rollouts for tag 'cand_1'"})))
+    got = rnd.gate_unless_eval_failed({"tag": "cand_1", "rc": 1, "error": "runner OOM"},
+                                      Path("/nonexistent"), "cand_1", 1.0, "paired", False)
+    assert got == {}, (
+        "the evaluation itself failed, so there was never anything to gate. This row must still "
+        "be written — with its eval_rc and eval_error — rather than killing the whole round")
+
+
+def test_a_successful_evaluation_with_a_failed_gate_still_raises(monkeypatch):
+    """The run 33492876620 case, at the call site: eval fine, gate broken -> stop."""
+    rnd = _round()
+    monkeypatch.setattr(rnd.subprocess, "run",
+                        lambda *a, **k: _Proc(2, stdout="", stderr="invalid --mode"))
+    with pytest.raises(rnd.GateCheckFailed):
+        rnd.gate_unless_eval_failed({"tag": "cand_1", "rc": 0, "error": None},
+                                    Path("/nonexistent"), "cand_1", 1.0, "paired", False)
+
+
+def test_the_control_row_is_held_to_the_same_bar():
+    """On run 33492876620 the CONTROL was null too, which is what emptied the evidence bar."""
+    rnd = _round()
+    with pytest.raises(rnd.GateCheckFailed) as exc:
+        rnd.assert_rows_were_judged([
+            {"tag": "ctl_null_i2", "reward": None, "verdict": None, "eval_rc": 0,
+             "eval_error": None},
+        ])
+    assert "ctl_null_i2" in str(exc.value), (
+        "a null control is worse than a null candidate: control_replicates goes empty and "
+        "evidence_bar goes null, so the round loses the noise floor it exists to establish")

--- a/skills/algorithms/agent-optimize/scripts/gate_check.py
+++ b/skills/algorithms/agent-optimize/scripts/gate_check.py
@@ -103,7 +103,15 @@ def regressions(current, candidate) -> list[str]:
     return sorted(t for t in cur if t in cand and _dropped(t))
 
 
-def main(argv=None) -> int:
+# The gate modes THIS script implements, and the single source of truth for them.
+# `round.py` forwards its own --mode here verbatim, so it imports this list rather than
+# repeating it: on run 33492876620 round 3 the two disagreed (round.py had no `choices=` at
+# all), `--mode val` sailed through round.py, was rejected here, and emptied the entire
+# round table while `eval_rc` stayed 0. Two copies of a list is how that happens.
+GATE_MODES = ["paired", "significant", "strict", "threshold"]
+
+
+def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(prog="gate_check")
     p.add_argument("--run-dir", required=True)
     p.add_argument("--candidate", required=True, help="candidate tag (== its dir name)")
@@ -119,8 +127,7 @@ def main(argv=None) -> int:
                         "no-op whenever the edit's surface cannot be determined; see "
                         "cap_evolve.footprint for why the unrestricted vector buries real "
                         "effects in the noise of tasks the edit never touched.")
-    p.add_argument("--mode", default="paired",
-                   choices=["paired", "significant", "strict", "threshold"])
+    p.add_argument("--mode", default="paired", choices=GATE_MODES)
     p.add_argument("--k-se", type=float, default=1.0)
     p.add_argument("--threshold", type=float, default=0.0)
     p.add_argument("--veto-regressions", action="store_true",
@@ -128,7 +135,11 @@ def main(argv=None) -> int:
                         "measured-and-passed. OFF by default — see regressions() for why.")
     p.add_argument("--allow-regression", action="store_true",
                    help="deprecated no-op: regressions no longer veto unless --veto-regressions")
-    args = p.parse_args(argv)
+    return p
+
+
+def main(argv=None) -> int:
+    args = build_parser().parse_args(argv)
 
     run_dir = RunDir.open(Path(args.run_dir))
     cur_tags = [t.strip() for t in (args.current or "").split(",") if t.strip()] \

--- a/skills/algorithms/agent-optimize/scripts/round.py
+++ b/skills/algorithms/agent-optimize/scripts/round.py
@@ -37,6 +37,11 @@ from pathlib import Path
 
 import _bootstrap  # noqa: F401  # side-effect import: seeds sys.path for cap_evolve
 
+# Sibling script, imported for GATE_MODES: --mode is forwarded to it verbatim, so its list of
+# accepted values is the only correct source for ours. Importable on the same terms as
+# _bootstrap above — this directory is already on sys.path or that import would have failed.
+import gate_check
+
 from cap_evolve import RunDir, harness
 
 #: Gate measurement concurrency. The default is deliberately low; the ceiling is where the
@@ -237,6 +242,26 @@ def _evaluate(run_dir: Path, project: Path, tag: str, split: str, n_trials: int,
         return {"tag": tag, "rc": p.returncode, "error": (p.stderr or p.stdout)[-800:]}
 
 
+class GateCheckFailed(RuntimeError):
+    """The gate did not run. That is NOT the same as a gate that decided against a candidate.
+
+    On run 33492876620 round 3 this distinction did not exist. ``_gate`` returned
+    ``{"error": ...}`` — a dict with every verdict key MISSING — and the caller ``.get()``s the
+    keys it wants, so the table was written with ``reward``, ``gate_delta``, ``gate_threshold``
+    and ``verdict`` all ``null`` for all three candidates AND the control, ``eval_rc: 0``,
+    100/100 rollouts scored on disk. A row that reads "this candidate did not move" for a
+    candidate nothing judged is the most expensive kind of wrong this script can be.
+    """
+
+    def __init__(self, tag: str, rc: int, detail: str):
+        self.tag, self.rc, self.detail = tag, rc, detail
+        super().__init__(
+            f"gate_check.py failed for tag {tag!r} (rc={rc}): {detail}\n"
+            "The round is NOT booked. Nothing was written to the round table, because a failed "
+            "gate is not a verdict — fix the cause and re-run this round; the rollouts are "
+            "already on disk, so re-gating costs nothing.")
+
+
 def _gate(run_dir: Path, tag: str, k_se: float, mode: str, veto: bool,
           current: str | None = None) -> dict:
     cmd = [sys.executable, str(HERE / "gate_check.py"), "--run-dir", str(run_dir),
@@ -246,13 +271,57 @@ def _gate(run_dir: Path, tag: str, k_se: float, mode: str, veto: bool,
     if veto:
         cmd.append("--veto-regressions")
     p = subprocess.run(cmd, capture_output=True, text=True)
+    # A non-zero rc is a failure whether or not its stdout parses. gate_check.py's own two
+    # `return 2` paths (no --current and no best_id; no rollouts for the tag) print WELL-FORMED
+    # JSON, so `json.loads` succeeds on them and the old code handed the error dict straight
+    # back as if it were a result. Checking rc first is what closes that second path — fixing
+    # the --mode flag alone would have left it wide open.
+    if p.returncode != 0:
+        raise GateCheckFailed(tag, p.returncode, ((p.stderr or p.stdout) or "").strip()[-800:])
     try:
         return json.loads(p.stdout)
-    except Exception:  # noqa: BLE001
-        return {"error": (p.stderr or p.stdout)[-800:]}
+    except Exception as exc:  # noqa: BLE001
+        raise GateCheckFailed(
+            tag, p.returncode,
+            f"exited 0 but stdout is not JSON: {(p.stdout or '').strip()[-800:]}") from exc
 
 
-def main(argv=None) -> int:
+def gate_unless_eval_failed(ev: dict, run_dir: Path, tag: str, k_se: float, mode: str,
+                            veto: bool, current: str | None = None) -> dict:
+    """Gate a tag, unless its own EVALUATION failed — then there was never anything to gate.
+
+    The distinction the round needs and did not have. A candidate whose eval died has no
+    rollouts, so ``gate_check.py`` exits 2 for a legitimate reason and the row belongs in the
+    table carrying its ``eval_rc``/``eval_error``. A candidate whose eval SUCCEEDED and whose
+    gate still failed is a framework bug, and the round stops.
+    """
+    try:
+        return _gate(run_dir, tag, k_se, mode, veto, current)
+    except GateCheckFailed:
+        if ev.get("rc") or ev.get("error"):
+            return {}
+        raise
+
+
+def assert_rows_were_judged(rows: list[dict]) -> None:
+    """Refuse to publish a round table row that no gate actually decided.
+
+    The backstop for the invariant itself, independent of any particular cause: a row whose
+    ``eval_rc`` is 0 was measured — its rollouts exist and were scored — so a missing reward can
+    only mean the GATE failed. A row whose evaluation genuinely failed keeps its ``None`` and its
+    ``eval_rc``/``eval_error``, because a real infrastructure failure must stay a REPORT rather
+    than becoming a crash: that is the one case where "no verdict" is the honest answer.
+    """
+    unjudged = [r["tag"] for r in rows
+                if r.get("reward") is None and not r.get("eval_rc") and not r.get("eval_error")]
+    if unjudged:
+        raise GateCheckFailed(
+            ", ".join(unjudged), 0,
+            "the evaluation succeeded (eval_rc 0, rollouts scored) but no gate verdict came "
+            "back, so these rows would publish as 'no movement' for candidates nothing judged")
+
+
+def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(prog="round")
     p.add_argument("--run-dir", required=True)
     p.add_argument("--project", required=True)
@@ -260,7 +329,10 @@ def main(argv=None) -> int:
                    help="comma-separated tags that already exist under $R/work/")
     p.add_argument("--n-trials", type=int, required=True)
     p.add_argument("--k-se", type=float, default=1.0)
-    p.add_argument("--mode", default="paired")
+    # choices= imported from gate_check.py, never repeated here: this value is forwarded to it
+    # verbatim, so a value only one side accepts empties the whole round table (run 33492876620
+    # round 3, `--mode val` — the caller meant `--split val`, which is the default anyway).
+    p.add_argument("--mode", default="paired", choices=gate_check.GATE_MODES)
     p.add_argument("--split", default="val")
     p.add_argument("--concurrency", type=int, default=DEFAULT_CONCURRENCY,
                    help="rollout concurrency per eval process (total = this x n_tags). Default "
@@ -297,7 +369,21 @@ def main(argv=None) -> int:
                         "parent always gets fresh ones.")
     p.add_argument("--no-control", action="store_true",
                    help="skip the null control (NOT recommended — you lose the noise floor)")
-    args = p.parse_args(argv)
+    return p
+
+
+def main(argv=None) -> int:
+    try:
+        return _main(argv)
+    except GateCheckFailed as exc:
+        # A traceback would be loud enough, but the driver reads this output to decide what to do
+        # next, so say it in the words the skill uses: the round is not booked, re-gating is free.
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+
+def _main(argv=None) -> int:
+    args = build_parser().parse_args(argv)
 
     # A gate too coarse to resolve its own verdict is refused, not warned about. Measured on
     # run 32861747778: the driver gated at --concurrency 100 after SKILL.md had told it "do not
@@ -430,10 +516,13 @@ def main(argv=None) -> int:
     for ev in evals:
         tag = ev["tag"]
         if tag == CTL:
-            g = _gate(Path(args.run_dir), tag, args.k_se, args.mode, args.veto_regressions)
+            g = gate_unless_eval_failed(ev, Path(args.run_dir), tag, args.k_se, args.mode,
+                                        args.veto_regressions)
         else:
-            g = _gate(Path(args.run_dir), tag, args.k_se, args.mode, args.veto_regressions,
-                      current=gate_ref if args.gate_against == "control" else None)
+            g = gate_unless_eval_failed(ev, Path(args.run_dir), tag, args.k_se, args.mode,
+                                        args.veto_regressions,
+                                        current=gate_ref if args.gate_against == "control"
+                                        else None)
         rows.append({
             "tag": tag,
             "reward": (g.get("candidate") or {}).get("reward"),
@@ -462,6 +551,10 @@ def main(argv=None) -> int:
             # True only for a control replicate this round read back instead of measuring.
             "reused": bool(ev.get("reused")),
         })
+
+    # Nothing derived from these rows — the drift-free re-gate, the evidence bar, the noise
+    # floor, the written table — is meaningful if a row was never judged. Check before any of it.
+    assert_rows_were_judged(rows)
 
     # A parent-gated round has ALREADY measured the drift-free comparison — it just was not
     # reporting it. On run 32871360361 round 4 the table showed cand4 at +0.15 against the seed's


### PR DESCRIPTION
Fixes item 1 of #420. **Do not merge** — for @OsherElhadad to verify.

## The defect

On run [33492876620](https://github.com/skillberry-ai/cap-evolve/actions/runs/33492876620) round 3, `work/round_i2.json` came back like this:

- `reward`, `gate_delta`, `gate_threshold`, `verdict` — `null` for all three candidates **and** for the control
- `control_replicates: []`, `evidence_bar: null`, `null_delta_replicates: 0`
- `eval_rc: 0`, and all 100 rollouts on disk, fully scored

The round was booked anyway. Only the driver noticing by hand — recomputing the verdicts with `gate_check.py` and booking `inconclusive` — kept a garbage verdict out of the ledger.

## Root cause: three things had to line up

1. `round.py`'s `--mode` had `default="paired"` and **no `choices=`**, so argparse accepted `--mode val`. The caller meant `--split val`, which is the default and a no-op.
2. `gate_check.py` **does** validate `--mode`, so it exited 2 with empty stdout.
3. `_gate` caught the `json.loads` failure and returned `{"error": ...}` — a dict with every verdict key **missing**. The caller `.get()`s the keys it wants, so all of them came back `None`.

Every row goes through `_gate`, which is why the candidates, the control, the replicates and the evidence bar were all empty at once while the evaluation itself looked fine. **The evaluation worked. Only the gate died, quietly.**

## There is a second path to the same silent table

Worth calling out, because fixing the flag alone would have left it wide open. `gate_check.py`'s own two `return 2` branches — no `--current` and no `best_id`, and no rollouts for the tag — **print well-formed JSON**:

```python
print(json.dumps({"error": f"no val rollouts for tag {args.candidate!r} — ..."}))
return 2
```

So `json.loads` *succeeds* on them, `_gate` returns the error dict as if it were a result, and `_gate` never notices it failed. Same empty table, different cause.

## The fix, at all three levels

| # | Change | What it stops |
|---|---|---|
| 1 | `--mode`'s `choices=` imported from the new `gate_check.GATE_MODES` constant, never repeated | the two lists drifting apart again — this value is forwarded verbatim, so one list is the only correct number of lists |
| 2 | `_gate` raises `GateCheckFailed` on any non-zero rc, **and** on rc 0 with unparseable stdout | both paths above, since it checks rc *before* trying to parse |
| 3 | `assert_rows_were_judged(rows)` refuses to publish a row with no reward whose eval succeeded | any *future* path to the same silent table, whatever the cause |

Level 3 is the one that matters most for the next unknown bug: it encodes the invariant itself rather than any particular way of violating it.

`main()` catches `GateCheckFailed` and returns 2 with the message in the words the skill uses — *the round is NOT booked; the rollouts are already on disk, so re-gating costs nothing* — rather than a traceback, because the driver reads this output to decide what to do next.

## The one case that must NOT start failing

A candidate whose own **evaluation** failed has no rollouts, so `gate_check.py` exits 2 for a legitimate reason. That row belongs in the table carrying its `eval_rc`/`eval_error`, and the round's other candidates should still be judged. `gate_unless_eval_failed` draws that line:

- eval failed → tolerate the gate failure, write the row, **report** the infrastructure problem
- eval succeeded, gate failed → **stop**, because that is a framework bug

Turning a real infra failure into a dead round would have traded one silent wrong for a loud wrong. Two tests pin both sides.

## A bonus the change buys for free

The two remaining `_gate` call sites — the drift-free `control_relative` re-gate and the `verdict_by_reference` stability check — already skip rows with no reward, so they need no change. But because `_gate` now raises, a gate failure in *those* aborts the round cleanly instead of writing `control_relative: null` and `verdict_by_reference: null`. Run 33492876620's empty `control_replicates` and missing stability check would now be a loud failure too.

## Verification

- **12 new tests** in `core/tests/test_a_failed_gate_is_not_a_verdict.py`. **11 fail against `main` at `373aca57`.** The twelfth, `test_a_successful_gate_check_still_returns_its_payload`, passes both before and after by design — it guards the happy path so the new raising cannot swallow a working gate.
- Full suite: **1176 passed, 12 skipped**.
- `agent-optimize/scripts/check.py` ok, `linkcheck.py` ok.
- Manual CLI check — the bad value now dies at the command line and names the alternatives:
  ```
  round: error: argument --mode: invalid choice: 'val'
         (choose from 'paired', 'significant', 'strict', 'threshold')
  ```

**Two environment notes for whoever re-runs this**, both of which look like branch regressions and are not:
1. Pin `CAPEVOLVE_SKILLS_DIR` to this tree, or a stale installed `~/.claude/skills` manifest fails `test_cli_surface::test_spec_defaults_relative_to_project_not_the_cwd` with `KeyError: "skill 'run-optimizer' not in manifest"`. Confirmed pre-existing by stashing this branch's changes and reproducing it.
2. In a **worktree**, the editable install's `sys.meta_path` finder hard-codes the *main* checkout, so `PYTHONPATH` cannot redirect it and the worktree silently tests main's `cap_evolve`. I ran the suite in a throwaway venv with this tree installed editable.

## Not in scope

The other nine items in #420, including `grow.py` never running (item 3) and subset triage never being used (item 4). Item 1 was picked first because #420 recommends fixing it before the re-run — a re-run against a gate that can silently empty its own table measures nothing.

## Refactors, for review

Two mechanical extractions, no behaviour change, both needed so the flags are inspectable by a test that asserts the two `--mode` lists match:

- `round.py`: `main()` → `build_parser()` + `main()` (which now wraps `_main()` for the error handling)
- `gate_check.py`: `main()` → `build_parser()` + `main()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
