### PR TITLE
agent-optimize: stop telling the agent-mode optimizer to ignore its own real memory

### DIFF
--- a/core/tests/test_agent_optimize_host.py
+++ b/core/tests/test_agent_optimize_host.py
@@ -307,10 +307,14 @@ def test_the_hosted_agent_gets_the_same_optimizer_context_as_every_other_algorit
         "INSTRUCTIONS.md and the run-dir briefing differ — two versions of the brief means "
         "no way to tell which one the agent followed")
 
-    # That same pointer names deterministic-loop artifacts this loop never builds.
-    assert "LEDGER.md" in body and "will not exist here" in body, (
-        "the briefing does not tell the agent that LEDGER.md/RUNMAP.md belong to the other "
-        "loop, so it will hunt for files that are legitimately absent")
+    # seed_framework_memory builds LEDGER.md/RUNMAP.md/prior_iterations for this loop too —
+    # the briefing must say so, not claim they're deterministic-loop-only and absent here.
+    assert "LEDGER.md" in body and "real here too" in body, (
+        "the briefing must tell the agent LEDGER.md/RUNMAP.md/prior_iterations are real and "
+        "populated in agent mode, not a deterministic-loop-only artifact it should ignore")
+    assert "will not exist here" not in body, (
+        "the briefing still tells the agent these files won't exist, contradicting "
+        "seed_framework_memory which builds them for real")
 
 
 def test_the_briefing_carries_the_same_measured_blocks_the_deterministic_prompt_does(tmp_path):

--- a/skills/algorithms/agent-optimize/scripts/host.py
+++ b/skills/algorithms/agent-optimize/scripts/host.py
@@ -446,12 +446,13 @@ accepted or returned inconclusive, because that field is the run's record of wha
 `spend.py` parses that text into checkable predicates; run it before each round and act on
 its single `recommendation` (`stop` | `narrow_scope` | `continue`), as SKILL.md describes.
 
-## Files in your working directory that belong to the OTHER loop
+## `LEDGER.md`, `RUNMAP.md`, `prior_iterations/`
 
-Your always-on instructions mention `LEDGER.md`, `RUNMAP.md` and `prior_iterations/`. Those are
-built by the *deterministic* loop, which calls one optimizer per iteration; you are driving the
-whole search yourself, so they will not exist here and their absence is not a problem — do not
-go looking for them or try to recreate them.
+Your always-on instructions mention these. They are real here too — `seed_framework_memory`
+builds them for this loop the same as for the deterministic one, so read them; do not assume
+they're a deterministic-loop-only artifact. `rejected.jsonl` and `history.jsonl` sit next to
+them and are worth reading as well — they hold every prior candidate's real outcome, not just
+what made it into `JOURNAL.md`'s prose.
 
 `JOURNAL.md` is different, and it has TWO halves — one of them is yours to write.
 


### PR DESCRIPTION
## What

\`driver_prompt.md\` (baked into \`host.py\`'s system prompt for the agent-mode
optimizer) said LEDGER.md, RUNMAP.md and prior_iterations/ "will not exist here"
and told the optimizer not to bother looking for them — true before #419, false
after it.

## Why

PR #419 added \`harness.seed_framework_memory\`, which builds these files with
real content for the agent loop too (wired at \`host.py:669\` and
\`commit.py:430\`), but the driver prompt text was never updated to match. The
optimizer was being actively told to ignore real, working memory.

Confirmed live on a real end-to-end run (\`e2e_run1\`, real \`claude -p\` CLI
optimizer, not simulated): \`candidates/seed/\` had genuinely populated
LEDGER.md/RUNMAP.md/JOURNAL.md/INSIGHTS.md/PROCESS.md by round 1, and the
optimizer read them anyway despite the prompt telling it not to — but that's
luck, not something the framework should rely on. A less exploratory model or
run could skip real data because the prompt says not to bother.

Also: \`rejected.jsonl\` and \`history.jsonl\` exist with real per-candidate
outcome data and were never mentioned to the optimizer at all — added a
pointer to both alongside the corrected LEDGER/RUNMAP text.

## Testing

Updated the one test (\`test_agent_optimize_host.py\`) that pinned the old,
now-incorrect claim in the briefing text, and added an explicit negative
assertion that the stale "will not exist here" phrase is gone. Ran the full
file: 37 passed.

This is purely a driver-prompt text fix — no behavior change to
\`seed_framework_memory\` itself, no benchmark/optimizer/model-specific content.