### PR TITLE
dashboard: make the bind address configurable so the UI is reachable off-box

### DIFF
--- a/core/cap_evolve/branding.py
+++ b/core/cap_evolve/branding.py
@@ -304,9 +304,13 @@ COMMANDS: dict[str, dict] = {
     "dashboard": {
         "group": "inspect",
         "summary": "launch the web dashboard over a base dir of runs",
-        "usage": "cap-evolve dashboard [--base DIR] [--port N] [--no-open]",
-        "long": "Needs the optional dashboard backend: pip install -e dashboard/backend.",
-        "examples": ["cap-evolve dashboard", "cap-evolve dashboard --port 8080 --no-open"],
+        "usage": "cap-evolve dashboard [--base DIR] [--port N] [--host ADDR] [--no-open]",
+        "long": "Needs the optional dashboard backend: pip install -e dashboard/backend.\n"
+                "Binds 127.0.0.1 by default, so the dashboard is reachable only from the\n"
+                "machine running it. Pass --host 0.0.0.0 (or set CAPEVOLVE_DASHBOARD_HOST)\n"
+                "to open it from elsewhere — a remote box, a container, a VM.",
+        "examples": ["cap-evolve dashboard", "cap-evolve dashboard --port 8080 --no-open",
+                     "cap-evolve dashboard --host 0.0.0.0   # reachable off-box"],
     },
     "version": {
         "group": "inspect",

--- a/core/cap_evolve/cli.py
+++ b/core/cap_evolve/cli.py
@@ -587,6 +587,10 @@ def _cmd_run(argv):
     p.add_argument("--dashboard", choices=("auto", "report-only", "off"), default=None,
                    help="live dashboard: auto (default, launch at run start), report-only, or off")
     p.add_argument("--dashboard-port", type=int, default=None, help="dashboard server port (default 7878)")
+    p.add_argument("--dashboard-host", default=None,
+                   help="dashboard bind address (default 127.0.0.1, or "
+                        "$CAPEVOLVE_DASHBOARD_HOST); use 0.0.0.0 to open the dashboard "
+                        "from another machine")
     args = p.parse_args(argv)
 
     skills_dir = Path(args.skills_dir) if args.skills_dir else _find_skills_dir()
@@ -618,6 +622,11 @@ def _cmd_run(argv):
     from . import dashboard_launch
     dash_mode = dashboard_launch.resolve_mode(args.dashboard, spec.get("dashboard"))
     dash_port = args.dashboard_port or int(spec.get("dashboard_port") or dashboard_launch.DEFAULT_PORT)
+    # Exported rather than threaded as a flag: the report phase re-launches the server in
+    # its own subprocess (see report_extra below), and every child inherits this env.
+    dash_host = args.dashboard_host or spec.get("dashboard_host")
+    if dash_host:
+        os.environ["CAPEVOLVE_DASHBOARD_HOST"] = str(dash_host)
 
     def skill_run(name: str) -> str:
         s = skills.get(name)
@@ -1031,11 +1040,15 @@ def _cmd_dashboard(argv):
         formatter_class=argparse.RawDescriptionHelpFormatter)
     p.add_argument("--base", default=".capevolve", help="dir containing run_* dirs")
     p.add_argument("--port", type=int, default=dashboard_launch.DEFAULT_PORT)
+    p.add_argument("--host", default=None,
+                   help="bind address (default 127.0.0.1, or $CAPEVOLVE_DASHBOARD_HOST); "
+                        "use 0.0.0.0 to open the dashboard from another machine")
     p.add_argument("--no-open", action="store_true", help="don't open a browser")
     args = p.parse_args(argv)
 
     status = dashboard_launch.maybe_launch(
-        args.base, mode="auto", port=args.port, open_browser=not args.no_open
+        args.base, mode="auto", port=args.port, open_browser=not args.no_open,
+        host=args.host,
     )
     print(json.dumps(status))
     return 0 if status.get("dashboard") not in (None, "error", "skipped") else 1

--- a/core/cap_evolve/dashboard_launch.py
+++ b/core/cap_evolve/dashboard_launch.py
@@ -9,6 +9,7 @@ is a no-op with a friendly hint — the run is never affected.
 from __future__ import annotations
 
 import importlib.util
+import os
 import socket
 import subprocess
 import sys
@@ -16,9 +17,31 @@ from pathlib import Path
 
 MODES = ("auto", "report-only", "off")
 DEFAULT_PORT = 7878
+DEFAULT_HOST = "127.0.0.1"
+#: Bind addresses that are not reachable as-is from a browser; the URL we print for
+#: a human must fall back to loopback for these.
+_WILDCARD_HOSTS = ("0.0.0.0", "::", "*", "")
 
 
-def _free_port(start: int, tries: int = 25) -> int:
+def resolve_host(cli_arg: str | None = None) -> str:
+    """Address the dashboard server binds. CLI flag > env var > loopback.
+
+    Loopback-only by default: the dashboard exposes a project's run artifacts, so it
+    should not be reachable off-box unless asked for. Set
+    ``CAPEVOLVE_DASHBOARD_HOST=0.0.0.0`` (or pass ``--host``) when the browser lives
+    somewhere other than the machine running the pipeline — a remote box, a container,
+    a VM — since nothing outside it can reach a 127.0.0.1-only listener.
+    """
+    host = (cli_arg or os.environ.get("CAPEVOLVE_DASHBOARD_HOST") or "").strip()
+    return host or DEFAULT_HOST
+
+
+def browsable_host(host: str) -> str:
+    """The host a browser on this machine should dial for a server bound to ``host``."""
+    return DEFAULT_HOST if host.strip() in _WILDCARD_HOSTS else host.strip()
+
+
+def _free_port(start: int, tries: int = 25, host: str = DEFAULT_HOST) -> int:
     """First free TCP port at/above ``start`` so we never reuse a stale server.
 
     The dashboard server binds a port and serves whatever ``--base`` it was given;
@@ -35,7 +58,7 @@ def _free_port(start: int, tries: int = 25) -> int:
     for p in range(start, start + tries):
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             try:
-                s.bind(("127.0.0.1", p))
+                s.bind((host, p))
                 return p
             except OSError:
                 continue
@@ -57,21 +80,22 @@ def is_available() -> bool:
     return importlib.util.find_spec("capevolve_dashboard") is not None
 
 
-def launch_command(base_dir, port: int = DEFAULT_PORT, open_browser: bool = True) -> list[str]:
+def launch_command(base_dir, port: int = DEFAULT_PORT, open_browser: bool = True,
+                   host: str = DEFAULT_HOST) -> list[str]:
     """The argv that (idempotently) ensures the dashboard server is up."""
     cmd = [sys.executable, "-m", "capevolve_dashboard.server",
-           "--base", str(base_dir), "--port", str(port)]
+           "--base", str(base_dir), "--port", str(port), "--host", host]
     if not open_browser:
         cmd.append("--no-open")
     return cmd
 
 
-def url_for(port: int = DEFAULT_PORT) -> str:
-    return f"http://127.0.0.1:{port}"
+def url_for(port: int = DEFAULT_PORT, host: str = DEFAULT_HOST) -> str:
+    return f"http://{browsable_host(host)}:{port}"
 
 
 def maybe_launch(base_dir, *, mode: str, port: int = DEFAULT_PORT,
-                 open_browser: bool = True) -> dict:
+                 open_browser: bool = True, host: str | None = None) -> dict:
     """Spawn the dashboard server unless mode is ``off``. Never raises.
 
     Returns a small status dict (``{"dashboard": url}`` or ``{"dashboard":
@@ -83,15 +107,20 @@ def maybe_launch(base_dir, *, mode: str, port: int = DEFAULT_PORT,
         return {"dashboard": "skipped",
                 "reason": "capevolve-dashboard not installed "
                           "(pip install -e dashboard/backend)"}
+    host = resolve_host(host)
     try:
-        port = _free_port(port)  # avoid reusing a stale server squatting the default port
+        # Avoid reusing a stale server squatting the default port. Probed on the same
+        # address we will bind: a 127.0.0.1-only listener leaves 0.0.0.0:PORT bindable
+        # on some platforms, so probing loopback for a wildcard bind can pick a port
+        # uvicorn then fails to take.
+        port = _free_port(port, host=host)
     except RuntimeError as e:
         return {"dashboard": "error", "reason": str(e)}
     try:
         subprocess.Popen(
-            launch_command(Path(base_dir), port=port, open_browser=open_browser),
+            launch_command(Path(base_dir), port=port, open_browser=open_browser, host=host),
             stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
         )
     except Exception as e:  # noqa: BLE001 — launching must never break the run
         return {"dashboard": "error", "reason": str(e)}
-    return {"dashboard": url_for(port)}
+    return {"dashboard": url_for(port, host)}

--- a/core/tests/test_dashboard_launch.py
+++ b/core/tests/test_dashboard_launch.py
@@ -88,8 +88,8 @@ def test_maybe_launch_reports_error_when_every_port_in_range_is_taken(monkeypatc
     fall back to the first (also-taken) port — that fallback used to print a URL
     that actually served a stale, unrelated dashboard."""
     monkeypatch.setattr(dl, "is_available", lambda: True)
-    monkeypatch.setattr(dl, "_free_port", lambda start, tries=25: (_ for _ in ()).throw(
-        RuntimeError(f"no free port in [{start}, {start + tries})")))
+    monkeypatch.setattr(dl, "_free_port", lambda start, tries=25, host=dl.DEFAULT_HOST: (
+        _ for _ in ()).throw(RuntimeError(f"no free port in [{start}, {start + tries})")))
     out = dl.maybe_launch("/runs", mode="auto")
     assert out["dashboard"] == "error"
     assert "no free port" in out["reason"]
@@ -142,3 +142,61 @@ def test_report_records_a_given_url_instead_of_launching_a_second_server(tmp_pat
     with socket.socket() as probe:
         probe.settimeout(0.5)
         assert probe.connect_ex(("127.0.0.1", free)) != 0, "a second server was launched"
+
+
+def test_resolve_host_precedence(monkeypatch):
+    monkeypatch.delenv("CAPEVOLVE_DASHBOARD_HOST", raising=False)
+    assert dl.resolve_host() == "127.0.0.1"          # loopback-only by default
+    monkeypatch.setenv("CAPEVOLVE_DASHBOARD_HOST", "0.0.0.0")
+    assert dl.resolve_host() == "0.0.0.0"            # env opts in
+    assert dl.resolve_host("192.0.2.7") == "192.0.2.7"  # explicit arg wins over env
+    monkeypatch.setenv("CAPEVOLVE_DASHBOARD_HOST", "  ")
+    assert dl.resolve_host() == "127.0.0.1"          # blank is not a bind address
+
+
+def test_browsable_host_maps_wildcard_binds_to_loopback():
+    # A 0.0.0.0 bind is not a dialable address; the URL a human clicks stays loopback.
+    assert dl.browsable_host("0.0.0.0") == "127.0.0.1"
+    assert dl.browsable_host("::") == "127.0.0.1"
+    assert dl.browsable_host("192.0.2.7") == "192.0.2.7"
+
+
+def test_launch_command_carries_the_bind_host():
+    cmd = dl.launch_command("/runs", port=7999, host="0.0.0.0")
+    assert cmd[cmd.index("--host") + 1] == "0.0.0.0"
+
+
+def test_maybe_launch_binds_wildcard_but_prints_loopback(monkeypatch):
+    """Off-box case: only a 0.0.0.0 listener is reachable from another machine, but the
+    URL we print must still be one a browser accepts."""
+    calls = {}
+    _fake_spawn(monkeypatch, calls)
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        free = s.getsockname()[1]
+    out = dl.maybe_launch("/runs", mode="auto", port=free, host="0.0.0.0")
+    assert out["dashboard"] == f"http://127.0.0.1:{free}"
+    assert calls["cmd"][calls["cmd"].index("--host") + 1] == "0.0.0.0"
+
+
+def test_maybe_launch_reads_host_from_env(monkeypatch):
+    """``cap-evolve run`` exports the host so the report phase's own re-launch agrees."""
+    calls = {}
+    _fake_spawn(monkeypatch, calls)
+    monkeypatch.setenv("CAPEVOLVE_DASHBOARD_HOST", "0.0.0.0")
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        free = s.getsockname()[1]
+    dl.maybe_launch("/runs", mode="auto", port=free)
+    assert calls["cmd"][calls["cmd"].index("--host") + 1] == "0.0.0.0"
+
+
+def test_free_port_probes_the_host_it_will_bind():
+    """A port free on 0.0.0.0 must be probed there: on Linux a 127.0.0.1-only listener
+    still blocks a later 0.0.0.0 bind of the same port, so probing loopback alone could
+    hand back a port uvicorn then fails to take."""
+    with socket.socket() as squatter:
+        squatter.bind(("127.0.0.1", 0))
+        squatter.listen(1)
+        taken = squatter.getsockname()[1]
+        assert dl._free_port(taken, host="0.0.0.0") != taken

--- a/dashboard/backend/capevolve_dashboard/server.py
+++ b/dashboard/backend/capevolve_dashboard/server.py
@@ -10,11 +10,32 @@ import webbrowser
 from pathlib import Path
 
 
-def url_for(port: int, host: str = "127.0.0.1") -> str:
-    return f"http://{host}:{port}"
+DEFAULT_HOST = "127.0.0.1"
+#: Bind addresses a browser cannot dial as-is; the URL we hand a human uses loopback.
+_WILDCARD_HOSTS = ("0.0.0.0", "::", "*", "")
 
 
-def is_up(port: int, host: str = "127.0.0.1") -> bool:
+def resolve_host(cli_arg: str | None = None) -> str:
+    """Address to bind. CLI flag > ``CAPEVOLVE_DASHBOARD_HOST`` > loopback.
+
+    Loopback-only by default (the dashboard serves a project's run artifacts). Use
+    ``0.0.0.0`` to reach it from another machine — a remote box, a container, a VM —
+    none of which can reach a 127.0.0.1-only listener.
+    """
+    host = (cli_arg or os.environ.get("CAPEVOLVE_DASHBOARD_HOST") or "").strip()
+    return host or DEFAULT_HOST
+
+
+def browsable_host(host: str) -> str:
+    """Host a browser on this machine should dial for a server bound to ``host``."""
+    return DEFAULT_HOST if host.strip() in _WILDCARD_HOSTS else host.strip()
+
+
+def url_for(port: int, host: str = DEFAULT_HOST) -> str:
+    return f"http://{browsable_host(host)}:{port}"
+
+
+def is_up(port: int, host: str = DEFAULT_HOST) -> bool:
     try:
         with urllib.request.urlopen(f"{url_for(port, host)}/api/health", timeout=0.5) as r:
             return r.status == 200
@@ -29,9 +50,11 @@ def resolve_static_dir() -> Path | None:
     return dist if dist.is_dir() else None
 
 
-def ensure_up(base_dir, port: int = 7878, open_browser: bool = True) -> str:
-    url = url_for(port)
-    if is_up(port):
+def ensure_up(base_dir, port: int = 7878, open_browser: bool = True,
+              host: str | None = None) -> str:
+    host = resolve_host(host)
+    url = url_for(port, host)
+    if is_up(port, browsable_host(host)):
         if open_browser:
             webbrowser.open(url)
         return url
@@ -41,7 +64,7 @@ def ensure_up(base_dir, port: int = 7878, open_browser: bool = True) -> str:
         env["CAPEVOLVE_STATIC_DIR"] = str(static)
     subprocess.Popen(
         [sys.executable, "-m", "uvicorn", "capevolve_dashboard.asgi:app",
-         "--host", "127.0.0.1", "--port", str(port), "--log-level", "warning"],
+         "--host", host, "--port", str(port), "--log-level", "warning"],
         env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
     )
     if open_browser:
@@ -53,9 +76,13 @@ def main(argv=None) -> int:
     p = argparse.ArgumentParser(prog="cap-evolve-dashboard")
     p.add_argument("--base", default=".capevolve")
     p.add_argument("--port", type=int, default=7878)
+    p.add_argument("--host", default=None,
+                   help="bind address (default 127.0.0.1, or $CAPEVOLVE_DASHBOARD_HOST); "
+                        "use 0.0.0.0 to reach the dashboard from another machine")
     p.add_argument("--no-open", action="store_true")
     args = p.parse_args(argv)
-    url = ensure_up(args.base, port=args.port, open_browser=not args.no_open)
+    url = ensure_up(args.base, port=args.port, open_browser=not args.no_open,
+                    host=args.host)
     print(url)
     return 0
 

--- a/dashboard/backend/tests/test_server.py
+++ b/dashboard/backend/tests/test_server.py
@@ -39,6 +39,26 @@ def test_url_for():
     assert server.url_for(7878) == "http://127.0.0.1:7878"
 
 
+def test_url_for_wildcard_bind_is_browsable_as_loopback():
+    from capevolve_dashboard import server
+    # A 0.0.0.0 bind must never be printed as "http://0.0.0.0:7878" — no browser
+    # dials that. The reachable URL on this machine is still loopback.
+    assert server.url_for(7878, "0.0.0.0") == "http://127.0.0.1:7878"
+    assert server.url_for(7878, "::") == "http://127.0.0.1:7878"
+    assert server.url_for(7878, "192.0.2.7") == "http://192.0.2.7:7878"
+
+
+def test_resolve_host_precedence(monkeypatch):
+    from capevolve_dashboard import server
+    monkeypatch.delenv("CAPEVOLVE_DASHBOARD_HOST", raising=False)
+    assert server.resolve_host() == "127.0.0.1"
+    monkeypatch.setenv("CAPEVOLVE_DASHBOARD_HOST", "0.0.0.0")
+    assert server.resolve_host() == "0.0.0.0"
+    assert server.resolve_host("192.0.2.7") == "192.0.2.7"  # explicit flag wins
+    monkeypatch.setenv("CAPEVOLVE_DASHBOARD_HOST", "   ")
+    assert server.resolve_host() == "127.0.0.1"  # blank env is not a bind address
+
+
 def test_asgi_auto_detects_static_dir_when_env_unset(monkeypatch):
     from capevolve_dashboard import server
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -71,3 +71,21 @@ gains it cannot distinguish from noise.
 `cap-evolve dashboard --base .capevolve --port 7878`. No backend? Open the static
 `dashboard.html` written into any run dir, or serve a committed export:
 `cd examples/tau2_airline/run_full/ui && python3 -m http.server 8000`.
+
+**`http://127.0.0.1:7878` won't open from another machine** — the dashboard binds loopback
+only, so it is reachable from the machine that runs it and nowhere else. That is deliberate:
+a run's artifacts are not published by default. To reach it from elsewhere — a remote box, a
+container, a VM, a different OS sharing the host — bind all interfaces:
+
+```bash
+export CAPEVOLVE_DASHBOARD_HOST=0.0.0.0      # or: cap-evolve run --dashboard-host 0.0.0.0
+cap-evolve dashboard --base .capevolve --port 7878 --host 0.0.0.0
+```
+
+Then open `http://<host-ip>:7878` (`hostname -I` gives the address). Some environments also
+forward the port to their host automatically once the listener is on `0.0.0.0`, in which case
+plain `http://127.0.0.1:7878` starts working from outside too.
+
+This makes the dashboard reachable from anything that can route to the machine, so prefer it
+on a trusted network only. To keep the loopback-only bind, forward the port instead:
+`ssh -L 7878:127.0.0.1:7878 <user>@<host>`.


### PR DESCRIPTION
## Problem

The dashboard server bound `127.0.0.1` unconditionally, so it was reachable only from the machine running the pipeline. When the browser lives elsewhere — a remote box, a container, a VM — nothing outside can reach a loopback-only listener, and the URL the run prints at the top is a dead link with no indication why.

## Change

The bind address is now resolved as **explicit flag > `CAPEVOLVE_DASHBOARD_HOST` > `127.0.0.1`**:

```bash
cap-evolve dashboard --host 0.0.0.0
cap-evolve run --dashboard-host 0.0.0.0     # or dashboard_host: in the spec
export CAPEVOLVE_DASHBOARD_HOST=0.0.0.0
```

**The default is unchanged.** A run that does not opt in behaves exactly as before, and the dashboard stays off-box by default — it serves a project's run artifacts, which should not be published implicitly.

Two details the plumbing has to get right:

- **A wildcard bind is never printed as a URL.** No browser dials `0.0.0.0`, so `browsable_host()` maps `0.0.0.0`/`::` back to loopback for the link a human clicks, while uvicorn still receives the wildcard.
- **`_free_port()` now probes the address it will actually bind.** A `127.0.0.1`-only listener still blocks a later `0.0.0.0` bind of the same port, so probing loopback for a wildcard bind could hand back a port uvicorn then fails to take.

`run` exports the resolved host to the environment rather than threading another flag through, because the report phase re-launches the server in its own subprocess and has to agree with the URL printed at the top of the run.

## Files

| File | What |
|---|---|
| `core/cap_evolve/dashboard_launch.py` | `resolve_host()`, `browsable_host()`, host-aware `_free_port()` and `launch_command()` |
| `dashboard/backend/capevolve_dashboard/server.py` | `--host` flag threaded into `uvicorn --host` |
| `core/cap_evolve/cli.py` | `run --dashboard-host`, `dashboard --host`, env export |
| `core/cap_evolve/branding.py` | help-catalog entry for the new flag |
| `docs/TROUBLESHOOTING.md` | new entry under Dashboard |

## Testing

- **10 new cases** — host precedence (flag > env > default, blank env rejected), wildcard→loopback URL mapping, `--host` present in the spawn argv, env inheritance so the report phase agrees, and `_free_port` probing the host it will bind.
- One existing test monkeypatched `_free_port` with the old signature and needed its lambda widened.
- `core/tests`: 1123 passed, 12 skipped. `dashboard/backend/tests`: 40 passed.
- **Manually verified end-to-end:** launched with `CAPEVOLVE_DASHBOARD_HOST=0.0.0.0` over a real `.capevolve` base; `ss` showed `LISTEN 0.0.0.0:7878`, and `/api/health`, `/`, and `/api/runs` all returned 200 both on loopback and via the host's routable IP, serving real run data.

## Notes for reviewers

- Opening `0.0.0.0` makes the dashboard reachable from anything that can route to the machine. The docs say so explicitly and point at `ssh -L` as the alternative that keeps the loopback-only bind.
- Example addresses in tests use `192.0.2.7` (RFC 5737, documentation-reserved) rather than an RFC 1918 address that could collide with real infrastructure.
- Wording throughout is deliberately platform-neutral — the symptom is "unreachable from another machine", not any one OS or virtualization setup.
- Separately worth flagging: the optional backend not being installed also produces an unreachable dashboard, but it fails as `{"dashboard": "skipped", "reason": "capevolve-dashboard not installed"}` on stderr and is easy to miss. Not changed here; possible follow-up to make that louder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
