### PR TITLE
Fix host.py crash misclassification and add bounded retry (#428, #430)

### DIFF
--- a/core/tests/test_agent_optimize_host.py
+++ b/core/tests/test_agent_optimize_host.py
@@ -1172,3 +1172,170 @@ def test_a_fully_staged_run_reports_no_guidance_gap(tmp_path):
 
     assert out["context"].get("guidance_missing") == [], (
         f"a fully-staged run reports a phantom gap: {out['context']}")
+
+
+# --- #428/#430: a crash with subtype=success must not read as a clean success, and a ------
+# --- transient crash gets a bounded retry rather than forfeiting the run's budget. --------
+
+
+def _crash_stub(tmp_path: Path) -> Path:
+    """A stub `run-optimizer` that ALWAYS reports the run_e2e_run3 crash shape.
+
+    `subtype: "success"` in the SAME object as `is_error: true` /
+    `terminal_reason: "api_error"` — exactly issue #428's evidence, so host.py's
+    classification cannot be tricked by `subtype` alone.
+    """
+    stub = tmp_path / "fake_run_optimizer.py"
+    payload = {
+        "optimizer": "claude-code", "cli_present": True, "returncode": 1,
+        "auth_present": [],
+        "stop": {"subtype": "success", "is_error": True, "terminal_reason": "api_error",
+                 "result": "API Error: Can't reach the API server (ENOTFOUND)",
+                 "num_turns": 146},
+    }
+    stub.write_text(
+        f"import json, sys\nprint(json.dumps({payload!r}))\nsys.exit(1)\n",
+        encoding="utf-8")
+    return stub
+
+
+def _host_events(run_dir, kind: str) -> list:
+    events = (run_dir.root / "events.jsonl").read_text(encoding="utf-8")
+    return [json.loads(ln) for ln in events.splitlines() if ln.strip()
+            and json.loads(ln).get("kind") == kind]
+
+
+def test_a_crash_with_subtype_success_is_not_logged_as_clean_success(tmp_path):
+    """#428: `subtype: "success"` + `is_error: true` must be classified as a crash.
+
+    Evidence: run_e2e_run3's `events.jsonl` recorded `stop_reason: "success"` for a run
+    whose CLI payload carried `is_error: true, terminal_reason: "api_error"` in the same
+    object, with 3 of 10 iterations and 2000 of 8000 rollouts spent. host.py must surface
+    the crash, not let `subtype` alone paper over it.
+    """
+    project = _project(tmp_path)
+    run_dir = _run_dir(tmp_path)
+    stub = _crash_stub(tmp_path)
+
+    # --max-retries 0 isolates the classification from #430's retry behavior.
+    out = _host("--run-dir", str(run_dir.root), "--project", str(project),
+                "--agent", "claude-code", "--run-optimizer", str(stub), "--max-retries", "0")
+
+    # The raw fields must reach the host's own output, not just get absorbed into `subtype`.
+    assert out.get("stop_reason") == "success", out
+    host_ev = _host_events(run_dir, "host")
+    assert host_ev, "no host event was logged"
+    assert host_ev[-1]["is_error"] is True, (
+        f"the host event never records is_error, so the crash is indistinguishable from a "
+        f"clean success in the audit trail: {host_ev[-1]}")
+    assert host_ev[-1]["terminal_reason"] == "api_error", host_ev[-1]
+
+    # And the operator-facing diagnosis must name the crash, not read as voluntary/finished.
+    msg = str(out.get("incomplete") or "").lower()
+    assert msg, f"a crashed run with rounds left must not read as complete: {out}"
+    assert "infra failure" in msg or "error termination" in msg, (
+        f"the crash was not called out as its own diagnosis: {msg}")
+    assert "voluntary" not in msg and "sealed the run itself" not in msg, (
+        f"a crash must not be diagnosed as a voluntary/finished stop: {msg}")
+
+
+def test_a_transient_crash_triggers_a_bounded_retry_and_can_recover(tmp_path):
+    """#430: a DNS/network blip gets retried against the SAME run_dir, not forfeited.
+
+    The stub crashes on its first two invocations (api_error) and succeeds on the third —
+    exactly the "transient" case #430 exists for. With --max-retries 2 the host must retry
+    twice and pick up the eventual success rather than sealing on the first crash.
+    """
+    project = _project(tmp_path)
+    run_dir = _run_dir(tmp_path)
+
+    counter = tmp_path / "attempts.txt"
+    stub = tmp_path / "fake_run_optimizer.py"
+    crash_payload = {
+        "optimizer": "claude-code", "cli_present": True, "returncode": 1,
+        "auth_present": [],
+        "stop": {"subtype": "success", "is_error": True, "terminal_reason": "api_error",
+                 "num_turns": 50},
+    }
+    ok_payload = {
+        "optimizer": "claude-code", "cli_present": True, "returncode": 0,
+        "auth_present": [],
+        "stop": {"subtype": "success", "is_error": False, "stop_reason": "end_turn",
+                 "num_turns": 10},
+    }
+    stub.write_text(
+        "import json, sys\n"
+        "from pathlib import Path\n"
+        f"counter = Path(r'{counter}')\n"
+        "n = int(counter.read_text()) if counter.exists() else 0\n"
+        "counter.write_text(str(n + 1))\n"
+        "if n < 2:\n"
+        f"    print(json.dumps({crash_payload!r}))\n"
+        "    sys.exit(1)\n"
+        "else:\n"
+        f"    print(json.dumps({ok_payload!r}))\n",
+        encoding="utf-8")
+
+    out = _host("--run-dir", str(run_dir.root), "--project", str(project),
+                "--agent", "claude-code", "--run-optimizer", str(stub), "--max-retries", "2")
+
+    assert int(counter.read_text()) == 3, (
+        "expected exactly 1 initial attempt + 2 retries (3 CLI invocations), got "
+        f"{counter.read_text()}")
+
+    retry_ev = _host_events(run_dir, "host_retry")
+    assert len(retry_ev) == 2, f"expected 2 retry events, got: {retry_ev}"
+    assert [e["attempt"] for e in retry_ev] == [1, 2], retry_ev
+    assert all(e["terminal_reason"] == "api_error" for e in retry_ev), retry_ev
+
+    # The FINAL attempt succeeded, so the classification must not still call it a crash.
+    msg = str(out.get("incomplete") or "").lower()
+    assert "infra failure" not in msg, (
+        f"the run recovered on its final retry but is still diagnosed as crashed: {msg}")
+
+
+def test_a_permanent_crash_exhausts_retries_and_surfaces_clearly(tmp_path):
+    """#430 acceptance criteria: a bounded retry count, and the final failure is clear.
+
+    The stub NEVER recovers — a persistently broken endpoint. The host must not retry
+    forever (bounded by --max-retries) and must still report the crash plainly rather than
+    quietly sealing on a "success"-shaped payload once it gives up.
+    """
+    project = _project(tmp_path)
+    run_dir = _run_dir(tmp_path)
+
+    counter = tmp_path / "attempts.txt"
+    stub = tmp_path / "fake_run_optimizer.py"
+    crash_payload = {
+        "optimizer": "claude-code", "cli_present": True, "returncode": 1,
+        "auth_present": [],
+        "stop": {"subtype": "success", "is_error": True, "terminal_reason": "api_error",
+                 "num_turns": 50},
+    }
+    stub.write_text(
+        "import json, sys\n"
+        "from pathlib import Path\n"
+        f"counter = Path(r'{counter}')\n"
+        "n = int(counter.read_text()) if counter.exists() else 0\n"
+        "counter.write_text(str(n + 1))\n"
+        f"print(json.dumps({crash_payload!r}))\n"
+        "sys.exit(1)\n",
+        encoding="utf-8")
+
+    out = _host("--run-dir", str(run_dir.root), "--project", str(project),
+                "--agent", "claude-code", "--run-optimizer", str(stub), "--max-retries", "2")
+
+    # Bounded: exactly 1 initial attempt + 2 retries, never an unbounded loop against a
+    # genuinely broken endpoint.
+    assert int(counter.read_text()) == 3, (
+        f"expected exactly 3 CLI invocations (bounded retries), got {counter.read_text()}")
+
+    retry_ev = _host_events(run_dir, "host_retry")
+    assert len(retry_ev) == 2, f"retries were not bounded to --max-retries: {retry_ev}"
+
+    msg = str(out.get("incomplete") or "").lower()
+    assert msg, f"an exhausted-retry crash must still surface, not read as complete: {out}"
+    assert "infra failure" in msg or "error termination" in msg, (
+        f"the exhausted crash is not clearly diagnosed: {msg}")
+    assert "2 retries" in msg or "2 retry" in msg, (
+        f"the diagnosis should say how many retries were already spent: {msg}")

--- a/skills/algorithms/agent-optimize/scripts/host.py
+++ b/skills/algorithms/agent-optimize/scripts/host.py
@@ -83,6 +83,11 @@ SKILLS = SKILL_DIR.parents[1]
 RUN_OPTIMIZER = SKILLS / "optimizers" / "run-optimizer" / "scripts" / "run.py"
 REGISTRY = SKILLS / "optimizers" / "registry.yaml"
 
+#: `terminal_reason` values that name a TRANSIENT infra failure (network/DNS/rate-limit),
+#: not a genuine stop. Deliberately narrow — see #430's non-goal: `error_max_turns` and any
+#: other real stop condition must never be retried, only this small allow-list.
+_RETRYABLE_TERMINAL_REASONS = {"api_error"}
+
 # 4h. Long enough for a full-val eval on the slowest benchmark in this repo
 # (spreadsheetbench full: one Docker container per task x trials), while still bounding a
 # genuinely hung command instead of waiting forever.
@@ -772,6 +777,11 @@ def main(argv=None) -> int:
     p.add_argument("--run-optimizer", default=None,
                    help="path to the run-optimizer script (test seam; defaults to the "
                         "sibling optimizers/run-optimizer)")
+    p.add_argument("--max-retries", type=int, default=2,
+                   help="bounded retries of the optimizer CLI on a transient crash "
+                        "(terminal_reason in %s), so a single DNS/network blip does not "
+                        "forfeit the rest of the run's budget (default: 2)"
+                        % sorted(_RETRYABLE_TERMINAL_REASONS))
     args = p.parse_args(argv)
 
     run_dir = Path(args.run_dir).resolve()
@@ -897,92 +907,128 @@ def main(argv=None) -> int:
     if args.usd_budget:
         cmd += ["--usd-budget", str(float(args.usd_budget))]
 
-    # What the run had already booked as optimizer spend BEFORE this agent started. The agent
-    # books its own proposal cost per round through commit.py --optimizer-usd (the skill asks it
-    # to), and that is the SAME money this subprocess meters — so the host must book the
-    # RESIDUAL, not the total, or a compliant agent makes the run report roughly twice the
-    # optimizer spend it actually used. Snapshotted rather than read at the end because a
-    # `--resume` run carries a PREVIOUS host invocation's spend in the same counter, and that is
-    # not this agent's attribution to net out.
-    booked_before = {"usd": 0.0, "tokens": 0, "seconds": 0.0}
-    try:
-        from cap_evolve import RunDir as _RunDir
-
-        _sp = _RunDir.open(run_dir).spent
-        booked_before = {"usd": float(_sp.optimizer_usd or 0.0),
-                         "tokens": int(_sp.optimizer_tokens or 0),
-                         "seconds": float(_sp.optimizer_seconds or 0.0)}
-    except Exception:  # noqa: BLE001 — a missing snapshot must not stop the run
-        pass
-
-    started = time.time()
-    try:
-        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=args.timeout,
-                              env={**_child_env(), **agent_env})
-        timed_out = False
-    except subprocess.TimeoutExpired:
-        proc = None
-        timed_out = True
-    seconds = time.time() - started
-
-    payload: dict = {}
-    if proc is not None:
+    # Retry loop: one attempt, plus up to --max-retries more when the CLI's OWN payload
+    # says it died on a transient infra error (#430). Each attempt re-invokes the SAME cmd
+    # against the SAME run_dir — commit.py refuses to double-book a candidate that already
+    # has an accept/reject event, so a retry can never re-decide a round the first attempt
+    # already committed; it can only pick up where that attempt died.
+    attempt = 0
+    while True:
+        # What the run had already booked as optimizer spend BEFORE *this* attempt. The agent
+        # books its own proposal cost per round through commit.py --optimizer-usd (the skill
+        # asks it to), and that is the SAME money this subprocess meters — so the host must
+        # book the RESIDUAL, not the total, or a compliant agent makes the run report roughly
+        # twice the optimizer spend it actually used. Snapshotted per attempt because a retried
+        # invocation is its own bracket, same as a `--resume` run's previous host invocation.
+        booked_before = {"usd": 0.0, "tokens": 0, "seconds": 0.0}
         try:
-            payload = json.loads(proc.stdout)
-        except Exception:  # noqa: BLE001 — a non-JSON tail is reported, not fatal
-            payload = {"stdout_tail": (proc.stdout or "")[-1200:]}
+            from cap_evolve import RunDir as _RunDir
 
-    # run-optimizer nests the figure under `cost.total_cost_usd` (see its `result["cost"]`).
-    # Reading a flat `cost_usd`/`usd` booked 0.0 for every run: on run 32733635494 the payload
-    # carried 8.370 USD / 68,432 tokens and the run recorded $0.00, which is indistinguishable
-    # from the genuinely-unmetered case the skill warns about — so the wrong conclusion was
-    # drawn twice. The flat keys stay as fallbacks for any optimizer row that reports that way.
-    cost = payload.get("cost") or {}
-    usd = float(cost.get("total_cost_usd") or payload.get("cost_usd")
-                or payload.get("usd") or 0.0)
-    tokens = int(cost.get("tokens") or payload.get("tokens") or 0)
-    # Why the agent stopped. Reconstructing this from a truncated stdout tail is what the
-    # previous version forced, and the answer (turns exhausted mid-round, with a better
-    # candidate evaluated but never committed) mattered more than anything else in the payload.
-    stop = payload.get("stop") or {}
-    stop_reason = str(stop.get("subtype") or "") or None
-    # Two different fields, and the discriminator is the SECOND one. Claude Code reports the
-    # harness-level outcome in `subtype` and the model's own reason in `stop_reason`; on run
-    # 32814848187 those were "success" and "end_turn". Reading only `subtype` sees a clean
-    # finish and cannot tell a voluntary stop from a completed run.
-    agent_stop = str(stop.get("stop_reason") or "") or None
-    num_turns = stop.get("num_turns")
+            _sp = _RunDir.open(run_dir).spent
+            booked_before = {"usd": float(_sp.optimizer_usd or 0.0),
+                             "tokens": int(_sp.optimizer_tokens or 0),
+                             "seconds": float(_sp.optimizer_seconds or 0.0)}
+        except Exception:  # noqa: BLE001 — a missing snapshot must not stop the run
+            pass
 
-    # Book the host's own spend. The agent books per-round costs it knows about through
-    # commit.py --optimizer-usd; it cannot know its own process cost, and the host can.
-    try:
-        from cap_evolve import RunDir
+        started = time.time()
+        try:
+            proc = subprocess.run(cmd, capture_output=True, text=True, timeout=args.timeout,
+                                  env={**_child_env(), **agent_env})
+            timed_out = False
+        except subprocess.TimeoutExpired:
+            proc = None
+            timed_out = True
+        seconds = time.time() - started
 
-        rd = RunDir.open(run_dir)
-        rd.log_event("host", agent=args.agent, model=args.model or "",
-                     usd=usd, tokens=tokens, seconds=round(seconds, 3),
-                     returncode=(None if proc is None else proc.returncode),
-                     timed_out=timed_out, stop_reason=stop_reason, num_turns=num_turns)
-        # Book only what the agent did not already attribute to a round during THIS invocation.
-        # `seconds` is booked too: without it the run recorded `optimizer_seconds: 0.0` for a
-        # loop that ran for hours, so metrics.py's whole-loop total rendered a dash and every
-        # per-hour cost figure was undefined.
-        now = rd.spent
-        book = optimizer_spend_to_book(
-            {"usd": usd, "tokens": tokens, "seconds": seconds},
-            booked_before,
-            {"usd": float(now.optimizer_usd or 0.0), "tokens": int(now.optimizer_tokens or 0),
-             "seconds": float(now.optimizer_seconds or 0.0)})
-        if book["usd"] or book["tokens"] or book["seconds"]:
-            rd.update_spent(optimizer_usd=book["usd"], optimizer_tokens=book["tokens"],
-                            optimizer_seconds=book["seconds"])
-        # The run dir's budget, not the spec's: baseline freezes it there, `--resume` can
-        # extend it, and it is what `budget_exhausted()` actually judges against.
-        rounds_done = int(rd.spent.iterations or 0)
-        rounds_budget = int(rd.budget.max_iterations or 0)
-    except Exception as exc:  # noqa: BLE001 — spend accounting must not lose the run
-        payload.setdefault("warnings", []).append(f"could not book host spend: {exc}")
+        payload: dict = {}
+        if proc is not None:
+            try:
+                payload = json.loads(proc.stdout)
+            except Exception:  # noqa: BLE001 — a non-JSON tail is reported, not fatal
+                payload = {"stdout_tail": (proc.stdout or "")[-1200:]}
+
+        # run-optimizer nests the figure under `cost.total_cost_usd` (see its `result["cost"]`).
+        # Reading a flat `cost_usd`/`usd` booked 0.0 for every run: on run 32733635494 the
+        # payload carried 8.370 USD / 68,432 tokens and the run recorded $0.00, which is
+        # indistinguishable from the genuinely-unmetered case the skill warns about — so the
+        # wrong conclusion was drawn twice. The flat keys stay as fallbacks for any optimizer
+        # row that reports that way.
+        cost = payload.get("cost") or {}
+        usd = float(cost.get("total_cost_usd") or payload.get("cost_usd")
+                    or payload.get("usd") or 0.0)
+        tokens = int(cost.get("tokens") or payload.get("tokens") or 0)
+        # Why the agent stopped. Reconstructing this from a truncated stdout tail is what the
+        # previous version forced, and the answer (turns exhausted mid-round, with a better
+        # candidate evaluated but never committed) mattered more than anything else in the
+        # payload.
+        stop = payload.get("stop") or {}
+        stop_reason = str(stop.get("subtype") or "") or None
+        # Two different fields, and the discriminator is the SECOND one. Claude Code reports
+        # the harness-level outcome in `subtype` and the model's own reason in `stop_reason`;
+        # on run 32814848187 those were "success" and "end_turn". Reading only `subtype` sees
+        # a clean finish and cannot tell a voluntary stop from a completed run.
+        agent_stop = str(stop.get("stop_reason") or "") or None
+        num_turns = stop.get("num_turns")
+        # #428: `subtype` alone is not enough to call a run a clean success — run_e2e_run3's
+        # final payload carried `subtype: "success"` AND `is_error: true` /
+        # `terminal_reason: "api_error"` in the same object. Read those explicitly rather than
+        # trusting `subtype`, and fold a nonzero exit code into the same signal so it can never
+        # be silently absorbed into a "success"-shaped `stop_reason`.
+        is_error = bool(stop.get("is_error"))
+        terminal_reason = stop.get("terminal_reason")
+        permission_denials = stop.get("permission_denials")
+        crashed = (not timed_out) and (is_error or (proc is not None and proc.returncode != 0))
+
+        # Book the host's own spend. The agent books per-round costs it knows about through
+        # commit.py --optimizer-usd; it cannot know its own process cost, and the host can.
         rounds_done, rounds_budget = -1, 0
+        rd = None
+        try:
+            from cap_evolve import RunDir
+
+            rd = RunDir.open(run_dir)
+            rd.log_event("host", agent=args.agent, model=args.model or "",
+                         usd=usd, tokens=tokens, seconds=round(seconds, 3),
+                         returncode=(None if proc is None else proc.returncode),
+                         timed_out=timed_out, stop_reason=stop_reason, num_turns=num_turns,
+                         is_error=is_error, terminal_reason=terminal_reason,
+                         permission_denials=permission_denials, attempt=attempt)
+            # Book only what the agent did not already attribute to a round during THIS
+            # invocation. `seconds` is booked too: without it the run recorded
+            # `optimizer_seconds: 0.0` for a loop that ran for hours, so metrics.py's
+            # whole-loop total rendered a dash and every per-hour cost figure was undefined.
+            now = rd.spent
+            book = optimizer_spend_to_book(
+                {"usd": usd, "tokens": tokens, "seconds": seconds},
+                booked_before,
+                {"usd": float(now.optimizer_usd or 0.0),
+                 "tokens": int(now.optimizer_tokens or 0),
+                 "seconds": float(now.optimizer_seconds or 0.0)})
+            if book["usd"] or book["tokens"] or book["seconds"]:
+                rd.update_spent(optimizer_usd=book["usd"], optimizer_tokens=book["tokens"],
+                                optimizer_seconds=book["seconds"])
+            # The run dir's budget, not the spec's: baseline freezes it there, `--resume` can
+            # extend it, and it is what `budget_exhausted()` actually judges against.
+            rounds_done = int(rd.spent.iterations or 0)
+            rounds_budget = int(rd.budget.max_iterations or 0)
+        except Exception as exc:  # noqa: BLE001 — spend accounting must not lose the run
+            payload.setdefault("warnings", []).append(f"could not book host spend: {exc}")
+
+        # Retry only a small allow-list of TRANSIENT reasons (#430's non-goal: a real stop
+        # like `error_max_turns` must never be retried — #428's classification above is what
+        # tells the two apart), only while rounds/budget remain, and only up to the bound.
+        exhausted, _ = rd.budget_exhausted() if rd is not None else (True, "")
+        retryable = crashed and terminal_reason in _RETRYABLE_TERMINAL_REASONS
+        if retryable and attempt < args.max_retries and not exhausted:
+            if rd is not None:
+                rd.log_event("host_retry", agent=args.agent, attempt=attempt + 1,
+                             max_retries=args.max_retries, terminal_reason=terminal_reason,
+                             is_error=is_error,
+                             returncode=(None if proc is None else proc.returncode))
+            attempt += 1
+            continue
+        break
 
     seal = _seal(run_dir, project, spec, timeout=args.timeout)
 
@@ -1017,7 +1063,20 @@ def main(argv=None) -> int:
         # for is how a warning stops being read.
         finished_itself = (seal.get("seal") == "agent" and not unbooked)
 
-        if turn_limited:
+        # #428: a crash (`is_error`/nonzero exit) takes priority over every other diagnosis —
+        # `subtype: "success"` on the SAME payload as `is_error: true` must never read as a
+        # voluntary stop or a finished run. Checked first, so it cannot be shadowed by
+        # `turn_limited`/`voluntary`/`finished_itself` matching on `subtype` text alone.
+        if crashed:
+            retried_note = (f" after {attempt} retr{'y' if attempt == 1 else 'ies'}"
+                            if attempt else "")
+            fix = (f"the optimizer CLI hit an error termination (terminal_reason="
+                   f"{terminal_reason!r}, is_error={is_error}, returncode="
+                   f"{proc.returncode if proc is not None else None}){retried_note} and "
+                   "exited before finishing its budget — this is an INFRA FAILURE, not a "
+                   "completed search; re-run host.py against the same run_dir rather than "
+                   "trusting this as a completed search")
+        elif turn_limited:
             fix = ("raise the turn budget (optimizer_max_turns) or lower the round count")
         elif finished_itself:
             fix = ("it sealed the run itself and left nothing unbooked, so this is UNSPENT "


### PR DESCRIPTION
## Summary
- `host.py` classified a run's completion using only `stop.subtype`/`stop.stop_reason`. A real crash (`terminal_reason: "api_error"`, `is_error: true`, ENOTFOUND) with `subtype: "success"` in the same object was logged to `events.jsonl` as a clean success (evidence: `run_e2e_run3`, 3 of 10 iterations / 2000 of 8000 rollouts spent). Fixes #428 by reading `is_error`/`terminal_reason`/`permission_denials` (already extracted by `run.py`) and giving a crash its own diagnosis, distinct from `turn_limited`/`voluntary`/`finished_itself`. A nonzero exit code is folded into the same check.
- Adds a bounded retry of the optimizer CLI against the same `run_dir` when the crash's `terminal_reason` is in a small transient allow-list (`api_error`) and remaining budget/rounds permit it. Bounded by `--max-retries` (default 2); each attempt logs a `host_retry` event so the retry is auditable. Fixes #430. Non-goal preserved: `error_max_turns` and other genuine stops are never retried, since they aren't in the allow-list.

## Test plan
Added to `core/tests/test_agent_optimize_host.py`:
- `test_a_crash_with_subtype_success_is_not_logged_as_clean_success` — a crash with `subtype: "success"` is classified as a crash, not voluntary/finished, and `is_error`/`terminal_reason` reach the `host` event.
- `test_a_transient_crash_triggers_a_bounded_retry_and_can_recover` — a stub that crashes twice then succeeds is retried exactly twice (3 total invocations) and the final success is not misreported as a crash.
- `test_a_permanent_crash_exhausts_retries_and_surfaces_clearly` — a stub that never recovers is retried exactly `--max-retries` times (bounded, no infinite loop) and the exhausted failure is clearly diagnosed.

```
$ python -m pytest core/tests/test_agent_optimize_host.py -q
........................................                                 [100%]
40 passed in 7.31s
```

Full suite unaffected (pre-existing, unrelated collection error in `test_intervention.py` from a stale editable install pointing at a different worktree — confirmed unrelated to this change):
```
$ python -m pytest core/tests -q -k "host or run_optimizer or spend" --ignore=core/tests/test_intervention.py
..........................................................               [100%]
58 passed, 2 skipped, 1089 deselected in 8.12s
```