### PR TITLE
Fix sibling-round JOURNAL.md reconciliation discarding real handovers

### DIFF
--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -1197,8 +1197,29 @@ def _journal_tail(workdir: Path) -> str:
     return tail.replace(_JOURNAL_MARK, "").strip()
 
 
-def pending_handover(workdir: Path, run_dir: RunDir) -> str:
-    """The optimizer's handover entry ``_reconcile_journal`` would actually book — "" if none.
+_ITER_HEAD_RE = re.compile(r"(?m)^## Iteration\s+(\S+)")
+
+
+def _split_journal_blocks(tail: str) -> list[str]:
+    """Split a journal tail into its individual ``## ...`` blocks.
+
+    N sibling candidates proposed in one shared session/workdir all start from the SAME
+    workdir, so every sibling's snapshot ``JOURNAL.md`` tail holds ALL N candidates' ``##
+    Iteration`` blocks, not just its own (#429). Splitting on the heading pattern
+    ``_journal_tail``'s own fallback already uses lets callers fold in one candidate's
+    block at a time instead of treating the whole multi-candidate tail as one unit."""
+    if not tail.strip():
+        return []
+    heads = list(re.finditer(r"(?m)^## ", tail))
+    if not heads:
+        return [tail.strip()]
+    return [tail[h.start():(heads[i + 1].start() if i + 1 < len(heads) else len(tail))].strip()
+            for i, h in enumerate(heads)]
+
+
+def pending_handover(workdir: Path, run_dir: RunDir, cid: str | None = None) -> str:
+    """This candidate's own handover block ``_reconcile_journal`` would actually book — ""
+    if none.
 
     Asking "is there a ## block in the workdir journal?" is not the same question: an agent
     whose next working copy is a COPY of the last one carries the previous round's entry along,
@@ -1206,11 +1227,30 @@ def pending_handover(workdir: Path, run_dir: RunDir) -> str:
     that wrote no new handover can hold a stale one. Callers that report the answer back to the
     optimizer (``agent-optimize``'s ``commit.py``) must agree with what was booked, or the
     round most in need of the warning is the one that does not get it.
+
+    ``cid``, when given, picks THIS candidate's block out of a multi-block tail (#429): first
+    by heading id match (the optimizer is asked to head each block ``## Iteration <cid> —
+    ...``), falling back to the first block not yet folded into the run-level journal — so a
+    batch of siblings sharing one tail each get their own distinct block rather than all
+    colliding on "already in base" after the first one is booked.
     """
     tail = _journal_tail(workdir).strip()
+    if not tail:
+        return ""
     run_journal = run_dir.root / "JOURNAL.md"
     base = (run_journal.read_text(encoding="utf-8") if run_journal.exists() else _JOURNAL_SEED)
-    return "" if not tail or tail in base else tail
+    blocks = _split_journal_blocks(tail)
+    if len(blocks) <= 1:
+        return "" if tail in base else tail
+    if cid is not None:
+        for block in blocks:
+            m = _ITER_HEAD_RE.match(block)
+            if m and m.group(1) == cid:
+                return "" if block in base else block
+    for block in blocks:
+        if block not in base:
+            return block
+    return ""
 
 
 def _build_ledger(workdir: Path, run_dir: RunDir) -> None:
@@ -1338,7 +1378,7 @@ def _reconcile_journal(workdir: Path, run_dir: RunDir, cid: str, *,
     # ``pending_handover``, not ``_journal_tail``: ONE place decides whether this round has a
     # bookable handover, so what ``commit.py`` reports back to the optimizer cannot drift from
     # what is actually booked here.
-    tail = pending_handover(workdir, run_dir)
+    tail = pending_handover(workdir, run_dir, cid)
     run_journal = run_dir.root / "JOURNAL.md"
     base = run_journal.read_text(encoding="utf-8") if run_journal.exists() else _JOURNAL_SEED
     # Run-level file is pure accumulated entries — strip any marker before appending.
@@ -1391,12 +1431,19 @@ def _reconcile_journal(workdir: Path, run_dir: RunDir, cid: str, *,
              f"{'unresolved' if indecisive else 'ACCEPTED' if accepted else 'rejected'} "
              f"val={vs} Δ={ds} -->")
     tail = tail.strip()
-    if not tail and _journal_tail(workdir).strip():
-        # Dedup guard: the optimizer dropped the marker without appending (so the tail
-        # fallback returned an entry already recorded in the run-level journal — typically a
-        # working copy CLONED from the last round). Do NOT re-append it — that would
-        # duplicate a prior iteration's entry under this cid. Not the empty-handover
+    raw_tail = _journal_tail(workdir).strip()
+    if not tail and raw_tail:
+        # Dedup guard: this candidate's own block (matched by ``pending_handover`` above) was
+        # already folded into the run-level journal — typically a working copy CLONED from the
+        # last round, still carrying THAT round's entry unchanged. Do NOT re-append it — that
+        # would duplicate a prior iteration's entry under this cid. Not the empty-handover
         # escalation below either: an entry was written, just not by this round.
+        if len(_split_journal_blocks(raw_tail)) > 1:
+            # A multi-block tail (sibling candidates sharing one batch session/workdir, #429)
+            # reaching this guard means every block was already booked by an earlier sibling —
+            # log it so a genuine collision is never silent, even though nothing is discarded
+            # here (pending_handover already gave each sibling its own distinct block).
+            run_dir.log_event("journal_sibling_collision", what="JOURNAL.md", candidate=cid)
         tail = f"## Iteration {cid} — (duplicate handover; optimizer re-appended a prior entry unchanged)"
     elif not tail:
         # Confirmed data-loss bug (#400): the optimizer wrote no handover at all, and

--- a/core/tests/test_multi_sibling_journal_reconciliation.py
+++ b/core/tests/test_multi_sibling_journal_reconciliation.py
@@ -1,0 +1,103 @@
+"""Repro for #429: N sibling candidates proposed in one shared session/workdir all carry
+the SAME multi-block JOURNAL.md tail (every sibling's own real '## Iteration' block).
+Reconciling them one at a time used to fold only the first sibling's block, then discard
+every other sibling's real, distinct entry as a false "duplicate handover" — because the
+whole tail (all N blocks) became a substring of the run-level journal after the first
+fold. Assert all N candidates' real content survives, with no false duplicate stamp, and
+that a genuine collision (nothing left unbooked) is logged rather than silent.
+"""
+
+import json
+
+from cap_evolve import Budget, RunDir, harness
+
+
+def _sibling_workdir(tmp_path, name, entries):
+    """A workdir whose JOURNAL.md tail holds ALL siblings' blocks (as a real batch does)."""
+    workdir = tmp_path / name
+    workdir.mkdir()
+    blocks = "\n\n".join(entries)
+    (workdir / "JOURNAL.md").write_text(
+        harness._JOURNAL_SEED + "\n\n" + harness._JOURNAL_MARK + "\n\n" + blocks + "\n",
+        encoding="utf-8")
+    return workdir
+
+
+def test_three_siblings_each_keep_their_own_real_journal_entry(tmp_path):
+    entries = [
+        "## Iteration i1_tools_netguard — added a network egress allowlist check",
+        "## Iteration i1_prompt_verify_tier — require get_user_details before tier questions",
+        "## Iteration i1_prompt_confirm_final — ask for confirmation before final booking",
+    ]
+    cids = ["i1_tools_netguard", "i1_prompt_verify_tier", "i1_prompt_confirm_final"]
+
+    run_dir = RunDir.create(tmp_path / ".capevolve", ts="sib3", budget=Budget(max_iterations=3))
+
+    for cid in cids:
+        workdir = _sibling_workdir(tmp_path, cid, entries)
+        harness._reconcile_journal(workdir, run_dir, cid, accepted=False, val=0.5, delta=-0.02,
+                                   reason=f"{cid}: rejected")
+
+    journal = (run_dir.root / "JOURNAL.md").read_text(encoding="utf-8")
+
+    # Every sibling's REAL, distinct headline survives.
+    assert "added a network egress allowlist check" in journal
+    assert "require get_user_details before tier questions" in journal
+    assert "ask for confirmation before final booking" in journal
+
+    # None of them were falsely stamped as a duplicate handover.
+    assert "duplicate handover" not in journal
+
+    # Each candidate got exactly one RESULT stamp of its own.
+    for cid in cids:
+        assert journal.count(f"<!-- {cid}:") == 1
+
+
+def test_genuine_stale_carry_forward_is_still_deduped(tmp_path):
+    """Not every same-tail collision is a sibling batch: a workdir cloned from the last
+    round that appends nothing new must still be deduped as before (no re-booking)."""
+    run_dir = RunDir.create(tmp_path / ".capevolve", ts="stale", budget=Budget(max_iterations=2))
+
+    workdir1 = _sibling_workdir(tmp_path, "cand_1", ["## Iteration cand_1 — did the first thing"])
+    harness._reconcile_journal(workdir1, run_dir, "cand_1", accepted=False, val=0.5, delta=-0.02,
+                               reason="cand_1: rejected")
+
+    # cand_2's workdir is a stale clone carrying cand_1's entry forward unchanged (no marker).
+    workdir2 = tmp_path / "cand_2"
+    workdir2.mkdir()
+    journal_so_far = (run_dir.root / "JOURNAL.md").read_text(encoding="utf-8")
+    (workdir2 / "JOURNAL.md").write_text(journal_so_far, encoding="utf-8")
+    harness._reconcile_journal(workdir2, run_dir, "cand_2", accepted=False, val=0.4, delta=-0.1,
+                               reason="cand_2: rejected")
+
+    journal = (run_dir.root / "JOURNAL.md").read_text(encoding="utf-8")
+    assert "## Iteration cand_2 — (duplicate handover; optimizer re-appended a prior entry unchanged)" in journal
+    assert journal.count("did the first thing") == 1
+
+
+def test_sibling_collision_with_no_unbooked_block_left_is_logged(tmp_path):
+    """If every block in a multi-block tail is already booked (a genuine collision, not
+    just one sibling among several still-pending), it must be logged, not silent."""
+    entries = [
+        "## Iteration cand_a — did thing A",
+        "## Iteration cand_b — did thing B",
+    ]
+    run_dir = RunDir.create(tmp_path / ".capevolve", ts="collide", budget=Budget(max_iterations=2))
+
+    workdir_a = _sibling_workdir(tmp_path, "cand_a", entries)
+    harness._reconcile_journal(workdir_a, run_dir, "cand_a", accepted=False, val=0.5, delta=-0.02,
+                               reason="cand_a: rejected")
+    workdir_b = _sibling_workdir(tmp_path, "cand_b", entries)
+    harness._reconcile_journal(workdir_b, run_dir, "cand_b", accepted=False, val=0.4, delta=-0.1,
+                               reason="cand_b: rejected")
+
+    # A third call with the SAME already-fully-booked batch (nothing left unbooked) hits
+    # the dedup guard for real, and must be logged as a collision.
+    workdir_c = _sibling_workdir(tmp_path, "cand_c", entries)
+    harness._reconcile_journal(workdir_c, run_dir, "cand_c", accepted=False, val=0.3, delta=-0.2,
+                               reason="cand_c: rejected")
+
+    events = [json.loads(ln) for ln in run_dir.events_path.read_text(encoding="utf-8").splitlines()
+              if ln.strip()]
+    assert any(e.get("kind") == "journal_sibling_collision" and e.get("candidate") == "cand_c"
+               for e in events)

--- a/skills/algorithms/agent-optimize/scripts/commit.py
+++ b/skills/algorithms/agent-optimize/scripts/commit.py
@@ -389,7 +389,7 @@ def main(argv=None) -> int:
     # still holds THAT round's entry, and _reconcile_journal's dedup guard books the placeholder
     # rather than the same entry twice — so the plain tail reports "recorded" for exactly the
     # round whose handover went missing.
-    handover = bool(harness.pending_handover(src, run_dir))
+    handover = bool(harness.pending_handover(src, run_dir, args.candidate_id))
     reason = args.note or args.decision
     if indecisive:
         reason = f"indecisive (gate): {reason}"


### PR DESCRIPTION
## Fixes #429

## What

`agent-optimize`'s recommended default is N≥3 sibling candidates proposed in one shared session/workdir. Each sibling's snapshot `JOURNAL.md` tail then contains **all N** candidates' `## Iteration` blocks, not just its own. The old reconciliation (`harness._journal_tail` / `pending_handover` / `_reconcile_journal`) treated that whole multi-block tail as one atomic unit per candidate:

- Candidate 1's reconcile call folds all N blocks into the run-level `JOURNAL.md` under its own RESULT stamp.
- Candidates 2..N's identical-looking tail is now a substring of the run-level journal, so it's treated as "no new content" and replaced with a false `(duplicate handover; optimizer re-appended a prior entry unchanged)` placeholder — silently discarding their real, distinct reflections, with zero event logged.

## Fix

- `_split_journal_blocks` splits a tail into its individual `## ...` blocks.
- `pending_handover(workdir, run_dir, cid=None)` now, for a multi-block tail, picks out **this candidate's own** block: first by heading id match (optimizers are already instructed to head each block `## Iteration <cid> — ...`), falling back to the first block not yet folded into the run-level journal (in order) when no heading matches — so N siblings sharing one tail each get their own distinct block instead of all colliding on "already in base" after the first is booked.
- The dedup guard in `_reconcile_journal` still fires for a genuine stale carry-forward (a workdir cloned from the last round, unchanged), and now logs a `journal_sibling_collision` event if a multi-block tail is ever left with no unbooked block at all, so a real collision is never silent.
- `commit.py`'s pre-commit handover check now passes the candidate id through, so what it reports to the optimizer agrees with what `record_iteration` will actually book.

## Scope

Primarily fixes #429. Looked at #420 item 8 ("journal repeats itself" — an exact duplicate entry across rounds, the opposite failure mode) but it needs more repro detail than is on hand to fix safely alongside this without risking a wrong guess, so left it for a separate issue/PR rather than block this fix. Reviewed open PR #425 (`driver_prompt.md` LEDGER/RUNMAP text) — no file or logic overlap with this change.

## Test plan

- Added `core/tests/test_multi_sibling_journal_reconciliation.py`:
  - `test_three_siblings_each_keep_their_own_real_journal_entry`: reproduces the exact issue #429 scenario (3 candidates sharing a session, each with distinct real journal content) — asserts all 3 real headlines survive, no false "duplicate handover" stamp, and each candidate gets exactly one RESULT stamp.
  - `test_genuine_stale_carry_forward_is_still_deduped`: confirms the original dedup behavior (single-block stale carry-forward) is unchanged.
  - `test_sibling_collision_with_no_unbooked_block_left_is_logged`: confirms a genuine collision (no block left unbooked) is logged via `journal_sibling_collision`, not silent.
- Ran the full harness test suite: `1147 passed, 12 skipped`, no regressions.