### PR TITLE
Surface host session transcript and agent-optimize internals in the dashboard

### DIFF
--- a/core/cap_evolve/dashboard.py
+++ b/core/cap_evolve/dashboard.py
@@ -971,6 +971,95 @@ def _read_narrative(root: Path, best_id: str | None) -> dict:
     return {"files": files}
 
 
+#: A real transcript.jsonl can be 1.6MB / 600+ lines (a full Claude Code session for one
+#: agent-optimize run). Never parsed/embedded whole — capped on both bytes (read at all)
+#: and turns (rendered), same "preview + point at the real path" shape as _read_project_files.
+_HOST_PROMPT_MAX_BYTES = 40_000
+_HOST_TRANSCRIPT_MAX_BYTES = 8_000_000
+_HOST_TRANSCRIPT_MAX_TURNS = 300
+
+
+def _transcript_turn(ev: dict) -> dict | None:
+    """One line of ``host/transcript.jsonl`` -> a compact turn, or ``None`` to skip it.
+
+    Only ``assistant`` (text / tool_use / thinking) and ``user`` (tool_result) lines carry
+    anything a human would read here; ``system``/``tool_progress``/``result`` lines are
+    session plumbing and are dropped rather than rendered as empty turns.
+    """
+    t = ev.get("type")
+    msg = ev.get("message") or {}
+    content = msg.get("content")
+    if not isinstance(content, list):
+        return None
+    parts = []
+    if t == "assistant":
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            bt = block.get("type")
+            if bt == "text" and block.get("text"):
+                parts.append(_sanitize_text(block["text"], 500))
+            elif bt == "tool_use":
+                parts.append(f"[tool] {block.get('name')} "
+                             f"{_sanitize_text(json.dumps(block.get('input', {})), 400)}")
+            elif bt == "thinking" and block.get("thinking"):
+                parts.append("[thinking] " + _sanitize_text(block["thinking"], 300))
+    elif t == "user":
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "tool_result":
+                c = block.get("content")
+                if isinstance(c, list):
+                    c = "".join(x.get("text", "") for x in c if isinstance(x, dict))
+                parts.append("[result] " + _sanitize_text(str(c or ""), 500))
+    if not parts:
+        return None
+    return {"role": t, "t": ev.get("timestamp"), "text": "\n".join(parts)}
+
+
+def _read_host_session(root: Path) -> dict:
+    """The agent-optimize host's own record of the run — the ONLY place the full
+    turn-by-turn optimizer session lives (#432). ``events.jsonl`` records coarse
+    accept/reject decisions; this reads what actually produced them.
+
+    Returns ``{}`` when there is no ``host/`` dir (e.g. a deterministic-loop algorithm
+    with no LLM driver session) so the panel hides itself rather than showing empty.
+    """
+    hdir = _safe_subpath(root, "host")
+    if hdir is None or not hdir.is_dir():
+        return {}
+    out: dict = {}
+    pf = _safe_subpath(hdir, "driver_prompt.md")
+    if pf is not None and pf.is_file():
+        try:
+            out["driver_prompt"] = _sanitize_text(
+                pf.read_text(encoding="utf-8"), _HOST_PROMPT_MAX_BYTES)
+        except OSError:
+            pass
+    tf = _safe_subpath(hdir, "transcript.jsonl")
+    if tf is not None and tf.is_file():
+        try:
+            size = tf.stat().st_size
+        except OSError:
+            size = 0
+        out["transcript_path"] = str(tf)
+        out["transcript_bytes"] = size
+        if size > _HOST_TRANSCRIPT_MAX_BYTES:
+            # Too big to safely read+parse into this HTML — point at the real file
+            # instead of embedding a partial/garbled slice of it.
+            out["transcript_too_large"] = True
+        else:
+            lines = _read_jsonl(tf)
+            out["transcript_total_lines"] = len(lines)
+            turns = [turn for ev in lines[:_HOST_TRANSCRIPT_MAX_TURNS]
+                     if (turn := _transcript_turn(ev)) is not None]
+            out["transcript_turns"] = turns
+            out["transcript_truncated"] = len(lines) > _HOST_TRANSCRIPT_MAX_TURNS
+    if not out.get("driver_prompt") and not out.get("transcript_turns") \
+            and not out.get("transcript_too_large"):
+        return {}
+    return out
+
+
 def reduce_run(run_dir) -> dict:
     """Fold the run dir into ``{"graph": ..., "summary": ...}`` (redacted)."""
     root = Path(run_dir.root)
@@ -1769,6 +1858,7 @@ def reduce_run(run_dir) -> dict:
         algo_extra["evograph"] = evograph
     narrative = _read_narrative(root, best_id)
     config = _read_config(root)
+    host_session = _read_host_session(root)
     par = [e for e in events if e.get("kind") == "parallel"]
     if par:
         algo_extra["parallel"] = [{k: v for k, v in e.items()
@@ -1793,9 +1883,11 @@ def reduce_run(run_dir) -> dict:
         "focus": "focus" in algo_extra,
         "evograph": "evograph" in algo_extra,
         "screens": "screens" in algo_extra,
+        "compliance": "compliance" in algo_extra,
         "parallel": "parallel" in algo_extra,
         "narrative": bool(narrative),
         "config": bool(config),
+        "host_transcript": bool(host_session),
         "controls": bool(controls),
         "screened": any(n.get("screened") is not None for n in nodes.values()),
         # A free-form (agent-driven) run has no deterministic step loop: candidates
@@ -1903,6 +1995,7 @@ def reduce_run(run_dir) -> dict:
         "git_log": _git_log(root),
         "narrative": narrative,
         "config": config,
+        "host_session": host_session,
     }
 
     graph = {"nodes": list(nodes.values()), "root": "seed", "best_id": best_id}
@@ -2886,6 +2979,117 @@ function dsecs(v){v=Math.max(0,Math.round(v||0));if(v<60)return v+'s';
       s.append(det);
     });
   }
+})();
+
+/* ---------- 10d. Host session — the optimizer's own turn-by-turn record (#432) ---------- */
+(function(){
+  const HS=S.host_session; if(!HS)return;
+  const s=sec('Host session — optimizer transcript');
+  s.append($('p',{class:'muted',style:'margin:0 0 12px',text:
+    'For an agent-driven run, this is the ONLY full record of what the optimizer actually did — '+
+    'every tool call, bash command, file edit and reasoning turn between the coarse accept/reject '+
+    'events above.'}));
+  const h3t=(t)=>$('h2',{style:'margin:16px 0 6px;text-transform:none;letter-spacing:0;font-size:13px;color:var(--text)',text:t});
+  if(HS.driver_prompt){
+    s.append(h3t('Driver prompt'));
+    s.append($('div',{class:'narrative-box md',style:'margin-bottom:14px',html:mdToHtml(HS.driver_prompt)}));
+  }
+  if(HS.transcript_too_large){
+    s.append($('div',{class:'banner',text:
+      'transcript.jsonl is '+(HS.transcript_bytes/1e6).toFixed(1)+' MB — too large to parse into '+
+      'this dashboard. Read it directly at '+HS.transcript_path}));
+    return;
+  }
+  const turns=HS.transcript_turns||[];
+  if(!turns.length)return;
+  s.append(h3t('Turns ('+turns.length+(HS.transcript_truncated?' of '+HS.transcript_total_lines+', truncated':'')+')'));
+  const list=$('div'); s.append(list);
+  turns.forEach(tn=>{
+    const row=$('div',{class:'logrow',style:'grid-template-columns:100px 90px 1fr'});
+    const clock=tn.t?new Date(tn.t).toLocaleTimeString([],{hour12:false}):'--:--:--';
+    const gist=tn.text.split('\n')[0].slice(0,140);
+    row.append($('span',{class:'muted num',text:clock}),
+      $('span',{class:'k',style:'color:var(--accent)',text:tn.role}),
+      $('span',{class:'muted2',style:'color:var(--muted2);overflow:hidden;text-overflow:ellipsis;white-space:nowrap',
+                text:gist}));
+    list.append(row);
+    const det=$('div',{class:'logdet'});
+    det.textContent=tn.text; // model-authored — never parsed as markup
+    det.style.display='none';
+    list.append(det);
+    row.addEventListener('click',()=>{det.style.display=det.style.display==='block'?'none':'block';});
+  });
+  if(HS.transcript_truncated)s.append($('p',{class:'muted',style:'margin-top:8px',text:
+    'Showing the first '+turns.length+' of '+HS.transcript_total_lines+' turns — full record at '+
+    HS.transcript_path}));
+})();
+
+/* ---------- 10e. agent-optimize internals — screens/compliance/minibatch/gepa/skillopt/parallel (#433) ---------- */
+(function(){
+  const C=S.capabilities||{}, AE=S.algo_extra||{};
+  if(!(C.screens||C.compliance||C.minibatch||C.gepa||C.skillopt||C.parallel))return;
+  const s=sec('agent-optimize internals');
+  s.append($('p',{class:'muted',style:'margin:0 0 12px',text:
+    "Signals the algorithm computed about its own process — which subset of tasks a cheap screen "+
+    "evaluated, whether the discipline of screening before a full-val eval was actually followed, "+
+    "and any minibatch/gepa/skillopt/parallel bookkeeping this run recorded."}));
+  const h3=(t)=>$('h2',{style:'margin:16px 0 6px;text-transform:none;letter-spacing:0;font-size:13px;color:var(--text)',text:t});
+
+  if(C.compliance){
+    s.append(h3('Screen-before-full-val compliance'));
+    const t=$('table');
+    t.append($('tr',{},$('th',{text:'candidate'}),$('th',{class:'r',text:'iteration'}),$('th',{text:'screened before full-val'})));
+    (AE.compliance||[]).forEach(r=>t.append($('tr',{},
+      $('td',{},$('code',{text:r.candidate})),
+      $('td',{class:'r num',text:r.iteration}),
+      $('td',{},$('span',{class:'badge '+(r.screened_before_fullval?'b-accepted':'b-rejected'),
+        text:r.screened_before_fullval?'✓ yes':'✗ no'})))));
+    s.append(t);
+  }
+
+  if(C.screens){
+    s.append(h3('Screens — cheap subset evals'));
+    (AE.screens||[]).forEach(sc=>{
+      const box=$('div',{class:'dead',style:'border-left-color:var(--accent)'});
+      const head=$('div',{style:'display:flex;flex-wrap:wrap;gap:8px;align-items:center'});
+      head.append($('code',{text:sc.candidate}),
+        $('span',{class:'badge '+(sc.decision==='pass'?'b-accepted':sc.decision==='fail'?'b-rejected':'b-indecisive'),
+          text:String(sc.decision||'—')+(sc.inconclusive?' (inconclusive)':'')}));
+      if(sc.tier!=null)head.append($('span',{class:'muted',style:'font-size:11px',text:'tier '+sc.tier}));
+      box.append(head);
+      const bits=[];
+      if((sc.ids||[]).length)bits.push('subset ('+sc.ids.length+'): '+sc.ids.join(', '));
+      if((sc.fixed||[]).length)bits.push('fixed: '+sc.fixed.join(', '));
+      if((sc.regressed||[]).length)bits.push('regressed: '+sc.regressed.join(', '));
+      if(sc.mean_delta!=null)bits.push('Δ='+(+sc.mean_delta).toFixed(3)+(sc.se!=null?' ± '+(+sc.se).toFixed(3):''));
+      if(sc.threshold!=null)bits.push('threshold='+sc.threshold);
+      box.append($('div',{class:'muted num',style:'font-size:11px;margin-top:4px',text:bits.join('  ·  ')}));
+      s.append(box);
+    });
+  }
+
+  [['minibatch','Minibatch'],['gepa','GEPA'],['skillopt','SkillOpt'],['parallel','Parallel']].forEach(([key,label])=>{
+    if(!C[key])return;
+    s.append(h3(label));
+    const rows=AE[key]||[];
+    const t=$('table');
+    if(key==='minibatch'){
+      t.append($('tr',{},$('th',{text:'candidate'}),$('th',{class:'r',text:'reward'}),
+        $('th',{class:'r',text:'n tasks'}),$('th',{text:'tasks'})));
+      rows.forEach(r=>t.append($('tr',{},
+        $('td',{},$('code',{text:r.candidate||'—'})),
+        $('td',{class:'r num',text:fmt(r.reward)}),
+        $('td',{class:'r num',text:r.n_tasks==null?'—':r.n_tasks}),
+        $('td',{class:'muted',text:(r.tasks||[]).join(', ').slice(0,120)}))));
+    }else{
+      t.append($('tr',{},$('th',{text:'kind'}),$('th',{text:'candidate'}),$('th',{text:'detail'})));
+      rows.forEach(r=>t.append($('tr',{},
+        $('td',{},$('code',{text:r.kind||'—'})),
+        $('td',{},r.candidate||'—'),
+        $('td',{class:'muted',style:'font-size:11px',text:JSON.stringify(r.detail||{}).slice(0,200)}))));
+    }
+    s.append(t);
+  });
 })();
 
 /* ---------- 8. Candidate leaderboard + git log ---------- */

--- a/core/tests/test_dashboard_host_and_algo_extra.py
+++ b/core/tests/test_dashboard_host_and_algo_extra.py
@@ -1,0 +1,118 @@
+"""Coverage for #432 (host/driver_prompt.md + host/transcript.jsonl reach the
+dashboard payload) and #433 (algo_extra's compliance capability flag is actually set,
+so the frontend has something to gate the panel on).
+
+Both gaps were the same shape: the data existed on disk / in ``events.jsonl`` and was
+silently dropped before it reached the JSON the browser renders.
+"""
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO / "core"))
+
+
+def _make_run(events=None):
+    from cap_evolve import Budget, RunDir, dashboard
+    tmp = Path(tempfile.mkdtemp())
+    rd = RunDir.create(tmp, ts="t", budget=Budget())
+    events = events if events is not None else [{"t": 1.0, "kind": "splits",
+                                                  "train": 1, "val": 1, "test": 1, "seed": 0}]
+    rd.events_path.write_text("\n".join(json.dumps(e) for e in events) + "\n", encoding="utf-8")
+    return rd, dashboard
+
+
+def test_no_host_dir_means_no_host_session():
+    """A deterministic-loop run has no ``host/`` dir — the panel must hide, not error."""
+    rd, dashboard = _make_run()
+    reduced = dashboard.reduce_run(rd)
+    assert reduced["summary"]["host_session"] == {}
+    assert reduced["summary"]["capabilities"]["host_transcript"] is False
+
+
+def test_driver_prompt_and_transcript_are_read_and_summarized():
+    rd, dashboard = _make_run()
+    hdir = rd.root / "host"
+    hdir.mkdir()
+    (hdir / "driver_prompt.md").write_text("# Brief\n\nDo the thing.", encoding="utf-8")
+    transcript = [
+        {"type": "system", "subtype": "hook_started"},  # plumbing — must be dropped
+        {"type": "assistant", "timestamp": "2026-09-03T12:00:00Z",
+         "message": {"content": [{"type": "text", "text": "Looking at the run dir first."}]}},
+        {"type": "assistant", "timestamp": "2026-09-03T12:00:01Z",
+         "message": {"content": [{"type": "tool_use", "name": "Bash",
+                                   "input": {"command": "ls -la"}}]}},
+        {"type": "user", "timestamp": "2026-09-03T12:00:02Z",
+         "message": {"content": [{"type": "tool_result", "content": "total 0"}]}},
+    ]
+    (hdir / "transcript.jsonl").write_text(
+        "\n".join(json.dumps(e) for e in transcript) + "\n", encoding="utf-8")
+
+    reduced = dashboard.reduce_run(rd)
+    hs = reduced["summary"]["host_session"]
+    assert reduced["summary"]["capabilities"]["host_transcript"] is True
+    assert "Do the thing" in hs["driver_prompt"]
+    assert hs["transcript_total_lines"] == 4
+    # the plumbing "system" line contributed nothing; the other three did.
+    assert len(hs["transcript_turns"]) == 3
+    assert hs["transcript_turns"][0]["role"] == "assistant"
+    assert "Looking at the run dir" in hs["transcript_turns"][0]["text"]
+    assert "[tool] Bash" in hs["transcript_turns"][1]["text"]
+    assert "[result] total 0" in hs["transcript_turns"][2]["text"]
+    assert hs["transcript_truncated"] is False
+
+
+def test_oversized_transcript_is_not_parsed_just_pointed_at():
+    """A multi-megabyte transcript must never be read into memory whole and rendered —
+    the section links out to the real path instead."""
+    rd, dashboard = _make_run()
+    hdir = rd.root / "host"
+    hdir.mkdir()
+    big_line = json.dumps({"type": "assistant",
+                            "message": {"content": [{"type": "text", "text": "x" * 1000}]}})
+    with (hdir / "transcript.jsonl").open("w", encoding="utf-8") as f:
+        # cheap way to exceed _HOST_TRANSCRIPT_MAX_BYTES without writing real MBs of test data
+        f.write((big_line + "\n") * 1)
+    import cap_evolve.dashboard as dmod
+    orig = dmod._HOST_TRANSCRIPT_MAX_BYTES
+    dmod._HOST_TRANSCRIPT_MAX_BYTES = 10  # force the "too large" branch deterministically
+    try:
+        reduced = dashboard.reduce_run(rd)
+    finally:
+        dmod._HOST_TRANSCRIPT_MAX_BYTES = orig
+    hs = reduced["summary"]["host_session"]
+    assert hs["transcript_too_large"] is True
+    assert "transcript_turns" not in hs
+    assert hs["transcript_path"].endswith("transcript.jsonl")
+
+
+def test_compliance_capability_flag_is_set_when_events_present():
+    """Issue #433: ``algo_extra['compliance']`` was already computed but no
+    ``capabilities.compliance`` flag existed for the frontend to gate a panel on."""
+    events = [
+        {"t": 1.0, "kind": "splits", "train": 1, "val": 1, "test": 1, "seed": 0},
+        {"t": 2.0, "kind": "agent_optimize_compliance", "tag": "cand_a", "iteration": 1,
+         "screened_before_fullval": False},
+    ]
+    rd, dashboard = _make_run(events)
+    reduced = dashboard.reduce_run(rd)
+    assert reduced["summary"]["capabilities"]["compliance"] is True
+    (row,) = reduced["summary"]["algo_extra"]["compliance"]
+    assert row["candidate"] == "cand_a" and row["screened_before_fullval"] is False
+
+
+def test_compliance_capability_flag_absent_by_default():
+    rd, dashboard = _make_run()
+    reduced = dashboard.reduce_run(rd)
+    assert reduced["summary"]["capabilities"]["compliance"] is False
+    assert "compliance" not in reduced["summary"]["algo_extra"]
+
+
+if __name__ == "__main__":  # self-check without pytest
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            fn()
+            print("ok", name)


### PR DESCRIPTION
## Summary

- Fixes #432: the dashboard never read `<run_dir>/host/driver_prompt.md` or `<run_dir>/host/transcript.jsonl`. Adds `_read_host_session()` (mirrors the existing `_safe_subpath`-guarded, size-capped pattern already used for `PROJECT.md`/config files) and a new "Host session — optimizer transcript" section: the driver prompt rendered as markdown, plus a capped, click-to-expand list of turns (assistant text/tool_use/thinking, tool_result), never the raw multi-MB file. Files over 8MB link out to the real path instead of being parsed. Everything flows through the existing `redact()` pass on the whole summary dict.
- Fixes #433: `algo_extra["screens"]`/`["compliance"]`/`["minibatch"]`/`["gepa"]`/`["skillopt"]`/`["parallel"]` were computed and shipped in the JSON payload but the JS frontend only ever read `S.algo_extra.evograph`. Adds an "agent-optimize internals" section rendering all of them (a compliance table, per-screen subset/fixed/regressed detail, and minibatch/gepa/skillopt/parallel tables), gated behind capability flags. Also adds the missing `capabilities.compliance` flag — it was referenced by the issue's evidence but didn't actually exist in `dashboard.py`.

## Verification

Pointed the reducer + renderer at the real fixture `/tmp/cap-evolve-worktrees/run-e2e/.capevolve/run_e2e_run3/` (has `host/driver_prompt.md`, 619-line/1.6MB `host/transcript.jsonl`, and `agent_optimize_compliance` events):

- `reduce_run()` on run3: `capabilities.host_transcript == True`, `capabilities.compliance == True`, `driver_prompt` read (15548 chars), `transcript_total_lines == 619`, 194 turns extracted from the capped first 300 raw lines (system/tool_progress/result plumbing lines correctly dropped), `transcript_truncated == True`.
- `algo_extra.compliance` has 6 rows, all `screened_before_fullval: false` — reproducing the exact run3 evidence from issue #433 (every round-1 candidate skipped the screen-before-full-val discipline).
- Rendered the full `dashboard.html` for run3 and loaded it headlessly in Chrome (`--headless --dump-dom`): no JS errors, and the DOM contains "Host session — optimizer transcript", "Driver prompt", "Turns (194 of 619, truncated)", "agent-optimize internals", and "Screen-before-full-val compliance" with a populated table (121 `.logrow` elements rendered from the log + turns sections combined).
- `node --check` on the extracted inline `<script>` block: syntax OK.
- Added `core/tests/test_dashboard_host_and_algo_extra.py` (5 new tests): no-host-dir hides the panel, driver_prompt+transcript are read and correctly summarized (plumbing lines dropped, tool_use/tool_result previews present), an oversized transcript is pointed at rather than parsed, and the new `capabilities.compliance` flag is set/absent correctly.
- Full existing dashboard test suite (`test_dashboard.py`, `test_dashboard_agent_run.py`, `test_dashboard_status_cost_log.py`, `test_dashboard_path_guard.py`, `test_dashboard_launch.py`, plus the new file): **100 passed, 1 skipped**, no regressions.

## Test plan

- [x] `python3 -m pytest core/tests/test_dashboard*.py -q` → 100 passed, 1 skipped
- [x] Rendered dashboard against real run3 fixture, verified new sections/data via headless Chrome dump + JSON payload inspection
- [x] `node --check` on the generated inline JS