### PR TITLE
fix(agent-optimize): mandatory growth on inconclusive, mandatory screen ladder, recorded parallelism (#420)

### DIFF
--- a/core/tests/test_an_unresolved_gate_is_not_a_rejection.py
+++ b/core/tests/test_an_unresolved_gate_is_not_a_rejection.py
@@ -70,12 +70,16 @@ def _staged(tmp_path, cid="cand_2", table=UNSTABLE_TABLE):
 
 
 def _commit(run_dir, work, *extra, cid="cand_2", decision="inconclusive", val="0.54"):
+    # This file tests the booking MECHANICS of `inconclusive` — issue #420 item 3 (a separate
+    # test file) covers the newer, orthogonal rule that commit.py refuses that decision without
+    # a prior scripts/grow.py run. `--force` here is that override, not a re-test of it.
+    force = ["--force"] if decision == "inconclusive" and "--force" not in extra else []
     return subprocess.run(
         [sys.executable, str(SCRIPTS / "commit.py"), "--run-dir", str(run_dir.root),
          "--candidate-id", cid, "--from-dir", str(work),
          "--decision", decision, "--val", val,
          "--note", "verdict flipped between control replicates; not resolvable this round",
-         *extra],
+         *extra, *force],
         capture_output=True, text=True,
         env={**os.environ, "CAPEVOLVE_CORE": str(REPO / "core")})
 

--- a/core/tests/test_inconclusive_requires_growth.py
+++ b/core/tests/test_inconclusive_requires_growth.py
@@ -1,0 +1,99 @@
+"""issue #420 item 3: an inconclusive-booked candidate must trigger ``grow.py``.
+
+Round 3 of run 33492876620 produced exactly the case ``grow.py`` was built for: a candidate
+above zero, below the significance bar, verdict flipping depending on which byte-identical
+control it was compared against. The agent booked it ``inconclusive`` and moved on — the
+transcript shows it had already read ``grow.py --help``, so this was not a discovery gap, it
+was optional, and optional tools that fix an exact recurring failure do not get used.
+
+``commit.py`` now refuses ``--decision inconclusive`` unless a ``work/grow_<candidate>_r*.json``
+table already exists for that candidate — i.e. ``grow.py`` has bought it at least one extra
+round of trials — or the driver passes ``--force`` and says why.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPTS = REPO / "skills" / "algorithms" / "agent-optimize" / "scripts"
+
+UNSTABLE_TABLE = {
+    "parent": {"tag": "seed", "reward": 0.51, "stderr": 0.13, "n_tasks": 10},
+    "gate_reference": {"tag": "ctl_null_i1", "mode": "control", "reward": 0.4966666666666667},
+    "gated_against": {"tag": "ctl_null_i1", "mode": "control"},
+    "null_delta_between_control_replicates": 0.0167,
+    "evidence_bar": {"value": 0.0167, "basis": "gap between byte-identical control replicates"},
+    "candidates": [{
+        "tag": "cand_2", "reward": 0.54, "gate_delta": 0.0433,
+        "gate_threshold": 0.0492, "verdict": "inconclusive",
+        "verdict_by_reference": {"ctl_null_i1": "reject", "ctl_null_i1r1": "accept"},
+        "verdict_stable": False, "regressions": [], "eval_rc": 0, "eval_error": None,
+    }],
+}
+
+
+def _staged(tmp_path, cid="cand_2"):
+    from cap_evolve import Budget, RunDir, harness
+    from cap_evolve.skillcheck import SyntheticAdapter, seed_capability_dir
+
+    adapter = SyntheticAdapter(n=12)
+    seed = seed_capability_dir(tmp_path, level=3)
+    run_dir = RunDir.create(tmp_path / ".capevolve", ts="ci",
+                            budget=Budget(max_iterations=3, stall=3))
+    harness.ensure_splits(adapter, run_dir, seed=0)
+    harness.baseline(adapter, seed, run_dir=run_dir)
+    work = run_dir.root / "work" / cid
+    work.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(run_dir.root / "candidates" / "seed", work)
+    (run_dir.root / "work" / "round_i0.json").write_text(json.dumps(UNSTABLE_TABLE),
+                                                         encoding="utf-8")
+    return run_dir, work
+
+
+def _commit(run_dir, work, *extra, cid="cand_2", decision="inconclusive", val="0.54"):
+    return subprocess.run(
+        [sys.executable, str(SCRIPTS / "commit.py"), "--run-dir", str(run_dir.root),
+         "--candidate-id", cid, "--from-dir", str(work),
+         "--decision", decision, "--val", val, "--note", "test", *extra],
+        capture_output=True, text=True,
+        env={**os.environ, "CAPEVOLVE_CORE": str(REPO / "core")})
+
+
+def test_inconclusive_without_growth_is_refused(tmp_path):
+    run_dir, work = _staged(tmp_path)
+    p = _commit(run_dir, work)
+    assert p.returncode != 0, f"inconclusive was booked without a grow.py run: {p.stdout}"
+    assert "grow.py" in p.stdout
+
+
+def test_inconclusive_with_force_is_still_allowed(tmp_path):
+    run_dir, work = _staged(tmp_path)
+    p = _commit(run_dir, work, "--force")
+    assert p.returncode == 0, f"commit.py --force failed: {p.stdout}\n{p.stderr}"
+    assert json.loads(p.stdout)["decision"] == "inconclusive"
+
+
+def test_inconclusive_after_a_grow_table_exists_is_allowed(tmp_path):
+    run_dir, work = _staged(tmp_path)
+    work_dir = run_dir.root / "work"
+    (work_dir / "grow_cand_2_r1.json").write_text(json.dumps({
+        "grown": "cand_2", "growth_round": 1,
+        "candidates": [{"tag": "cand_2", "reward": 0.55, "verdict": "inconclusive"}],
+    }), encoding="utf-8")
+
+    p = _commit(run_dir, work)
+    assert p.returncode == 0, f"commit.py failed even though grow.py already ran: {p.stdout}"
+    assert json.loads(p.stdout)["decision"] == "inconclusive"
+
+
+def test_round_next_line_points_the_driver_at_grow_py():
+    src = (SCRIPTS / "round.py").read_text(encoding="utf-8")
+    assert "grow.py" in src, (
+        "round.py's inconclusive reading no longer tells the driver to grow the candidate "
+        "before booking it, so the fix is only enforced silently in commit.py")

--- a/core/tests/test_round_requires_screen_ladder.py
+++ b/core/tests/test_round_requires_screen_ladder.py
@@ -1,0 +1,134 @@
+"""issue #420 item 4: full-val evaluation must go through the screen ladder by default.
+
+Run 33492876620 paid a full 100-rollout sweep for every one of 7 candidates, including
+``cand_scope`` (clearly harmful) and ``cand_e2_verifytype`` (flat) — exactly the cases
+``screen.py`` exists to kill for a quarter of the price. It was never used because using it
+was optional. ``round.py`` now refuses a candidate with no ``$R/screens/<tag>__screen*.json``
+record unless the driver passes ``--skip-screen-ladder``.
+
+Also covers issue #420 item 9: ``round.py`` records ``measurement_max_parallel`` alongside
+``measurement_concurrency``, and warns when either drifts from the previous round.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+CORE = REPO / "core"
+SCRIPTS = REPO / "skills" / "algorithms" / "agent-optimize" / "scripts"
+
+sys.path.insert(0, str(CORE))
+sys.path.insert(0, str(SCRIPTS))
+
+
+def _project(tmp: Path, *, n: int) -> Path:
+    project = tmp / "project"
+    (project / "adapters").mkdir(parents=True, exist_ok=True)
+    (project / "adapters" / "adapter.py").write_text(
+        "from cap_evolve.skillcheck import SyntheticAdapter\n\n\n"
+        "class Adapter(SyntheticAdapter):\n"
+        f"    def __init__(self):\n        super().__init__(n={n})\n",
+        encoding="utf-8")
+    (project / "capevolve.yaml").write_text(
+        "num_trials: 1\ngate_mode: paired\ngate_k_se: 1.0\n"
+        'stop_condition: "reach val mean >= 0.9, or stop after $5 or 30 minutes"\n',
+        encoding="utf-8")
+    return project
+
+
+def _run(argv, env=None):
+    e = dict(os.environ, CAPEVOLVE_CORE=str(CORE))
+    if env:
+        e.update(env)
+    return subprocess.run([sys.executable, *argv], capture_output=True, text=True, env=e)
+
+
+def _staged_run_dir(tmp_path, *, n=24):
+    from cap_evolve import RunDir, harness
+    from cap_evolve.skillcheck import SyntheticAdapter, seed_capability_dir
+
+    adapter = SyntheticAdapter(n=n)
+    project = _project(tmp_path, n=n)
+    run_dir = RunDir.create(tmp_path / ".capevolve", ts="chk")
+    harness.ensure_splits(adapter, run_dir, seed=0)
+
+    for i, tid in enumerate(run_dir.read_splits().ids("val")):
+        from cap_evolve.skillcheck import write_val_rollout
+        write_val_rollout(run_dir, tid, tag="cur", reward=float(i % 2), feedback="fb")
+    run_dir.set_best("cur")
+    run_dir.snapshot("cur", seed_capability_dir(tmp_path / "roundcap", level=12))
+
+    work = run_dir.root / "work"
+    work.mkdir(parents=True, exist_ok=True)
+    import shutil
+    shutil.copytree(seed_capability_dir(tmp_path / "_src", level=24), work / "cand_1")
+    return run_dir, project, work
+
+
+def test_round_refuses_an_unscreened_candidate(tmp_path):
+    run_dir, project, work = _staged_run_dir(tmp_path)
+    p = _run([str(SCRIPTS / "round.py"), "--run-dir", str(run_dir.root),
+              "--project", str(project), "--candidates", "cand_1", "--n-trials", "1"])
+    assert p.returncode != 0, f"round.py ran full val on an unscreened candidate: {p.stdout}"
+    assert "screen.py" in p.stdout
+
+
+def test_skip_screen_ladder_records_the_deliberate_override(tmp_path):
+    run_dir, project, work = _staged_run_dir(tmp_path)
+    p = _run([str(SCRIPTS / "round.py"), "--run-dir", str(run_dir.root),
+              "--project", str(project), "--candidates", "cand_1", "--n-trials", "1",
+              "--skip-screen-ladder"])
+    assert p.returncode == 0, f"--skip-screen-ladder did not override the guard: {p.stdout}"
+    out = json.loads(p.stdout)
+    assert [x["tag"] for x in out.get("candidates") or []] == ["cand_1"]
+
+
+def test_round_proceeds_once_the_candidate_has_a_screen_record(tmp_path):
+    run_dir, project, work = _staged_run_dir(tmp_path)
+    screens = run_dir.root / "screens"
+    screens.mkdir(parents=True, exist_ok=True)
+    (screens / "cand_1__screen1.json").write_text(json.dumps({"decision": "promote"}),
+                                                  encoding="utf-8")
+    p = _run([str(SCRIPTS / "round.py"), "--run-dir", str(run_dir.root),
+              "--project", str(project), "--candidates", "cand_1", "--n-trials", "1"])
+    assert p.returncode == 0, f"round.py refused a screened candidate: {p.stdout}"
+
+
+def test_round_records_max_parallel_and_warns_on_drift(tmp_path):
+    run_dir, project, work = _staged_run_dir(tmp_path)
+    screens = run_dir.root / "screens"
+    screens.mkdir(parents=True, exist_ok=True)
+    (screens / "cand_1__screen1.json").write_text(json.dumps({"decision": "promote"}),
+                                                  encoding="utf-8")
+    p1 = _run([str(SCRIPTS / "round.py"), "--run-dir", str(run_dir.root),
+               "--project", str(project), "--candidates", "cand_1", "--n-trials", "1",
+               "--max-parallel", "2"])
+    assert p1.returncode == 0, p1.stdout
+    out1 = json.loads(p1.stdout)
+    assert out1["measurement_max_parallel"] == 2
+    assert out1["parallel_warning"] is None, "the first round has nothing to drift from"
+
+    # Advance to a fresh iteration and re-run with a different --max-parallel.
+    from cap_evolve import RunDir, harness
+    harness.record_iteration(run_dir, work / "cand_1", "cand_1", parent_id="cur",
+                             accepted=False, reason="test", val=0.5, parent_val=0.5)
+
+    import shutil
+    from cap_evolve.skillcheck import seed_capability_dir
+    shutil.copytree(seed_capability_dir(tmp_path / "_src2", level=24), work / "cand_2")
+    (screens / "cand_2__screen1.json").write_text(json.dumps({"decision": "promote"}),
+                                                  encoding="utf-8")
+    p2 = _run([str(SCRIPTS / "round.py"), "--run-dir", str(run_dir.root),
+               "--project", str(project), "--candidates", "cand_2", "--n-trials", "1",
+               "--max-parallel", "4"])
+    assert p2.returncode == 0, p2.stdout
+    out2 = json.loads(p2.stdout)
+    assert out2["measurement_max_parallel"] == 4
+    assert out2["parallel_warning"] is not None, (
+        "round 2 silently doubled --max-parallel from round 1's 2 and nothing warned about it")
+    assert "2" in out2["parallel_warning"] and "4" in out2["parallel_warning"]

--- a/skills/algorithms/agent-optimize/SKILL.md
+++ b/skills/algorithms/agent-optimize/SKILL.md
@@ -182,9 +182,10 @@ events over ONE set of rollouts. Pass `--optimizer-usd/--optimizer-tokens/--opti
 **your own** proposal cost — the evaluate phase records the runner's, nothing records the proposer's.
 
 **Two decisions that are NOT rejects** (a reject advances **stall**): `--decision inconclusive` for an
-unresolved round (`verdict_stable: false`), re-measured under a FRESH tag; `--decision provisional` for a
-Δ>0 round under the bar (`directionally_positive_but_inconclusive`), after which `grow.py` buys trials on
-the SAME candidate and re-gates at the pooled n, capped at 2 rounds. `references/algorithm.md`.
+unresolved round (`verdict_stable: false`) — run `grow.py` first, required unless forced;
+`--decision provisional` for a Δ>0 round under the bar (`directionally_positive_but_inconclusive`),
+after which `grow.py` buys trials on the SAME candidate, re-gating at the pooled n, capped at 2.
+`references/algorithm.md`.
 
 **6. Write the handover before ending this round** — append one `## Iteration <cid>` entry below
 `JOURNAL.md`'s marker: what you tried, why, what the numbers said. The only thing the NEXT round reads,

--- a/skills/algorithms/agent-optimize/scripts/check.py
+++ b/skills/algorithms/agent-optimize/scripts/check.py
@@ -591,7 +591,10 @@ def _round_control(c: Checker, tmp: Path) -> None:
 
     r = _run(c, "round.py (null control + parallel eval + serial gate)",
              [str(HERE / "round.py"), "--run-dir", R, "--project", str(project),
-              "--candidates", "cand_x", "--n-trials", "1", "--k-se", "1.0"])
+              "--candidates", "cand_x", "--n-trials", "1", "--k-se", "1.0",
+              # This check exercises round.py's own gate mechanics, not the screen ladder
+              # (covered separately below) — cand_x never went through screen.py.
+              "--skip-screen-ladder"])
     if r:
         ctl_tag = r.get("control", {}).get("tag") or ""
         c.check(ctl_tag.startswith("ctl_null_i") and (work / ctl_tag).is_dir(),
@@ -626,7 +629,7 @@ def _round_control(c: Checker, tmp: Path) -> None:
     r2 = _run(c, "round.py --gate-against control",
               [str(HERE / "round.py"), "--run-dir", R, "--project", str(project),
                "--candidates", "cand_y", "--n-trials", "1", "--k-se", "1.0",
-               "--gate-against", "control"])
+               "--gate-against", "control", "--skip-screen-ladder"])
     if r2:
         ref = (r2.get("gated_against") or {})
         c.check(str(ref.get("tag", "")).startswith("ctl_null_i")
@@ -637,7 +640,7 @@ def _round_control(c: Checker, tmp: Path) -> None:
     r3 = _run(c, "round.py --gate-against control --no-control (refused)",
               [str(HERE / "round.py"), "--run-dir", R, "--project", str(project),
                "--candidates", "cand_y", "--n-trials", "1", "--gate-against", "control",
-               "--no-control"], expect_rc=2)
+               "--no-control", "--skip-screen-ladder"], expect_rc=2)
     c.check(bool(r3) and "control" in json.dumps(r3),
             f"gating against a control that was skipped must be refused, got {r3}",
             note="asking to gate against a control while disabling it is refused, not ignored")

--- a/skills/algorithms/agent-optimize/scripts/commit.py
+++ b/skills/algorithms/agent-optimize/scripts/commit.py
@@ -237,6 +237,19 @@ def _gate_verdict(run_dir: RunDir, candidate_id: str) -> str | None:
     return row.get("verdict") if row else None
 
 
+def _has_grown(run_dir: RunDir, candidate_id: str) -> bool:
+    """Has ``scripts/grow.py`` already bought this candidate at least one extra round of
+    trials? True iff a ``work/grow_<candidate_id>_r*.json`` table exists.
+
+    On run 33492876620 round 3 a candidate landed exactly on ``grow.py``'s reason for
+    existing — Δ>0, below the significance bar, verdict flipping between control
+    replicates — and was booked ``inconclusive`` and left there. The transcript shows the
+    agent had read ``grow.py --help``, so this was not a discovery gap: the tool was
+    optional, so it went unused. See ``main``'s guard below.
+    """
+    return any((run_dir.root / "work").glob(f"grow_{candidate_id}_r*.json"))
+
+
 def main(argv=None) -> int:
     p = argparse.ArgumentParser(prog="commit")
     p.add_argument("--run-dir", required=True)
@@ -285,7 +298,8 @@ def main(argv=None) -> int:
     p.add_argument("--optimizer-seconds", type=float, default=0.0)
     p.add_argument("--force", action="store_true",
                    help="commit even though this candidate id already has a decision "
-                        "(audit/repair only — it overwrites the earlier snapshot)")
+                        "(audit/repair only — it overwrites the earlier snapshot); also "
+                        "overrides the inconclusive-without-growth guard below")
     args = p.parse_args(argv)
 
     run_dir = RunDir.open(Path(args.run_dir))
@@ -314,6 +328,27 @@ def main(argv=None) -> int:
     accepted = args.decision == "accept"
     indecisive = args.decision == "inconclusive"
     provisional = args.decision == "provisional"
+
+    # An inconclusive round is UNRESOLVED, not refuted — ``grow.py`` exists precisely to
+    # resolve it by buying more trials on this same candidate, and issue #420 item 3 found
+    # it had never run once across two real runs that hit this exact case. Making it
+    # optional is why: the fix is a guard here, not a third restatement in SKILL.md prose
+    # (the same argument round.py's own concurrency guard already makes). ``--force`` is
+    # the deliberate override, for a candidate growth genuinely cannot help (e.g. Δ<=0).
+    if indecisive and not args.force and not _has_grown(run_dir, args.candidate_id):
+        print(json.dumps({
+            "error": f"--decision inconclusive for {args.candidate_id!r}, but scripts/grow.py "
+                     "has not bought it any extra trials yet",
+            "why": "an inconclusive verdict means the measurement could not resolve the edit, "
+                   "not that the edit was refuted. grow.py exists to buy more trials on this "
+                   "SAME candidate and re-gate at the pooled n before it is left unresolved.",
+            "fix": f"run scripts/grow.py --candidate {args.candidate_id} --growth-round 1 "
+                   "--add-trials <n> first (it recommends promote/grow_again/abandon), then "
+                   "commit its recommendation; or pass --force here if growth genuinely "
+                   "cannot help this candidate (e.g. its delta is <= 0) and say why in --note.",
+        }, indent=2))
+        return 2
+
     if args.decision != "reject" and args.reject_basis:
         print(json.dumps({
             "error": f"--reject-basis is meaningless on an {args.decision}",

--- a/skills/algorithms/agent-optimize/scripts/round.py
+++ b/skills/algorithms/agent-optimize/scripts/round.py
@@ -160,6 +160,45 @@ def measurement_context(split: str, n_trials: int, concurrency: int | None) -> d
     return {"split": split, "n_trials": int(n_trials), "concurrency": concurrency}
 
 
+def prior_round_settings(run_dir) -> dict | None:
+    """The most recent EARLIER iteration's ``--concurrency``/``--max-parallel``, or ``None``.
+
+    Issue #420 item 9: round 3 of a real run got ``--max-parallel`` 4 (the default) after
+    rounds 1-2 both explicitly passed 2, doubling how many candidate evals ran concurrently
+    against the same target — a load change that makes the round's own noise floor
+    incomparable with the rounds before it, and nobody noticed because nothing was recorded
+    to notice it from.
+    """
+    it = int(run_dir.spent.iterations)
+    for i, _att, path in reversed(_all_tables(run_dir)):
+        if i >= it:
+            continue
+        try:
+            table = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        return {"concurrency": table.get("measurement_concurrency"),
+                "max_parallel": table.get("measurement_max_parallel")}
+    return None
+
+
+def parallel_drift_warning(prior: dict | None, concurrency: int | None,
+                           max_parallel: int) -> str | None:
+    """Did this round's load settings drift from the previous round's, unannounced?
+
+    ``None`` on a prior round that never recorded ``max_parallel`` (a table written before
+    this field existed) — a missing measurement is not evidence of drift.
+    """
+    if not prior:
+        return None
+    if prior["concurrency"] in (None, concurrency) and prior["max_parallel"] in (None, max_parallel):
+        return None
+    return (f"this round used --concurrency {concurrency} --max-parallel {max_parallel}, but "
+            f"the previous round used --concurrency {prior['concurrency']} --max-parallel "
+            f"{prior['max_parallel']}. Gate settings that drift between rounds make the "
+            "rounds' noise floors incomparable — confirm this was a deliberate change.")
+
+
 def _rollouts_present(run_dir, tag: str, split: str, n_trials: int) -> bool:
     """Are ``tag``'s persisted rollouts still on disk at the trial depth this round needs?
 
@@ -369,6 +408,10 @@ def build_parser() -> argparse.ArgumentParser:
                         "parent always gets fresh ones.")
     p.add_argument("--no-control", action="store_true",
                    help="skip the null control (NOT recommended — you lose the noise floor)")
+    p.add_argument("--skip-screen-ladder", action="store_true",
+                   help="run full-val on a candidate with no screen.py record for it (NOT "
+                        "recommended — see the compliance check above). An explicit, recorded "
+                        "choice, the same idiom as --allow-high-concurrency.")
     return p
 
 
@@ -429,11 +472,36 @@ def _main(argv=None) -> int:
     # `<run_dir>/screens/<tag>__screenN.json`; its absence means this candidate skipped
     # straight to full-val, which the dashboard can now show as its own event kind.
     screens_dir = run_dir.root / "screens"
+    unscreened = []
     for t in tags:
         screened = screens_dir.is_dir() and any(screens_dir.glob(f"{t}__screen*.json"))
         run_dir.log_event("agent_optimize_compliance", tag=t,
                           screened_before_fullval=screened,
                           iteration=int(run_dir.spent.iterations))
+        if not screened:
+            unscreened.append(t)
+
+    # Made a hard refusal, not a logged fact: issue #420 item 4 found that EVERY candidate
+    # in a whole run skipped screen.py, even the ones (`cand_scope`, harmful;
+    # `cand_e2_verifytype`, flat) it exists to kill for a quarter of the price — because
+    # using it was optional, so a real, working, cheap tool never ran once. The compliance
+    # event above already proved this cannot be caught after the fact by inference; making
+    # it a warning would just be a third restatement of the same prose SKILL.md already
+    # carried. `--skip-screen-ladder` is the deliberate, recorded override (e.g. a
+    # candidate whose val is small enough that screening buys nothing).
+    if unscreened and not args.skip_screen_ladder:
+        print(json.dumps({
+            "error": f"candidate(s) {unscreened} went straight to a full-val eval without a "
+                     "screen.py record under $R/screens/",
+            "why": "screen.py triages a candidate on a cheap val SUBSET before this full-val "
+                   "eval is paid — see its own docstring. Skipping it because it is optional "
+                   "is the exact failure issue #420 item 4 found: every candidate paid full "
+                   "val, including ones a quarter-price screen would have killed.",
+            "fix": "run screen.py --tier 1 (then --tier 2 if it promotes) on each of these "
+                   "tags first, or pass --skip-screen-ladder to record the deliberate choice "
+                   "to skip it.",
+        }, indent=2))
+        return 2
 
     # The null control is built here, not by the driver, so it cannot silently be skipped
     # or accidentally differ from the parent.
@@ -663,6 +731,9 @@ def _main(argv=None) -> int:
             "and ~0.03 at conc 8. A verdict from this round can therefore not resolve an effect "
             "smaller than roughly 0.08. Re-run the gate at --concurrency 8 before believing an "
             "accept.")
+
+    prior_settings = prior_round_settings(run_dir)
+    parallel_warning = parallel_drift_warning(prior_settings, args.concurrency, args.max_parallel)
     out = {
         # Which gate of this iteration this is. On the live run nothing in the output
         # distinguished "second opinion on iteration 1" from "iteration 1", so an operator
@@ -721,6 +792,8 @@ def _main(argv=None) -> int:
                                       "established noise floor, so it must be measured")}),
         "measurement_concurrency": args.concurrency,
         "concurrency_warning": conc_warning,
+        "measurement_max_parallel": args.max_parallel,
+        "parallel_warning": parallel_warning,
         "null_delta_between_control_replicates": null_delta,
         "null_delta_replicates": len(pooled_rows),
         "null_delta_reading": (
@@ -766,16 +839,22 @@ def _main(argv=None) -> int:
             "A candidate marked `verdict_stable: false` has an UNSTABLE verdict and is "
             "INCONCLUSIVE, never accepted: its "
             "verdict changed depending on which byte-identical control replicate happened to be "
-            "the reference, so the round cannot tell its edit from re-measurement. Book it as "
-            "`commit.py --decision inconclusive` — that charges the iteration but NOT the stall "
-            "counter, because a measurement that could not resolve is no evidence you have run "
-            "out of ideas, and it keeps the edit out of `rejected.jsonl` so a later round is not "
-            "taught to avoid a change nothing ever judged. To resolve it, re-measure under a "
-            "FRESH tag (e.g. `cand_2b`) or ask for the higher `--trials` in ONE evaluation: "
+            "the reference, so the round cannot tell its edit from re-measurement. Run "
+            "`scripts/grow.py --candidate <tag> --growth-round 1 --add-trials <n>` on it BEFORE "
+            "booking anything — commit.py refuses `--decision inconclusive` until grow.py has "
+            "bought this candidate at least one extra round of trials (issue #420 item 3: this "
+            "exact case was read-and-skipped, never run, across two prior runs). grow.py pools "
+            "the new trials onto the SAME candidate and re-gates at the pooled n; commit its "
+            "recommendation (promote/grow_again/abandon) once it has one. Only if growth "
+            "genuinely cannot help (e.g. delta <= 0) book `commit.py --decision inconclusive "
+            "--force` and say why in --note — that still charges the iteration but NOT the "
+            "stall counter, because a measurement that could not resolve is no evidence you "
+            "have run out of ideas, and it keeps the edit out of `rejected.jsonl` so a later "
+            "round is not taught to avoid a change nothing ever judged. "
             "rollouts are written `<task>__<tag>__t{k}.json` for k in range(n_trials), so "
             "re-running the SAME tag REPLACES t0..t9 rather than adding t10..t19 — it swaps a "
-            "reading for another reading and buys no extra evidence. That applies to the "
-            "CANDIDATE tags you pass; the control side is handled for you — a re-gate of the "
+            "reading for another reading and buys no extra evidence; grow.py's own throwaway "
+            "tag avoids that. The control side is handled for you — a re-gate of the "
             "same iteration gets its own `ctl_null_i<N>a<k>` replicates and POOLS the earlier "
             "attempt's into `null_delta_between_control_replicates`, so re-running this script "
             "adds control evidence instead of replacing it. Do not re-use a candidate tag to "


### PR DESCRIPTION
Addresses #420.

## Triage table

| # | Item | Status | Evidence |
|---|---|---|---|
| 1 | bad `--mode` value empties round table | **already fixed** | `round.py`'s `--mode` has `choices=gate_check.GATE_MODES`; `_gate()` raises `GateCheckFailed` on non-zero rc instead of returning an error dict; `assert_rows_were_judged` refuses to publish a null row. Pinned by `test_a_failed_gate_is_not_a_verdict.py`. |
| 2 | may the host work around a broken framework file? | **policy decision** | Not a code bug. No code changed. Needs a maintainer decision, then a rule in the skill. |
| 3 | `grow.py` never runs on an inconclusive candidate | **fixed here** | `commit.py` now refuses `--decision inconclusive` unless `grow.py` already bought the candidate a growth round (`--force` to override). `round.py`'s inconclusive `reading` and SKILL.md now name `grow.py` directly. |
| 4 | screen ladder optional, so unused | **fixed here** | `round.py` refuses a full-val eval on a candidate with no `screen.py` record under `$R/screens/`, unless `--skip-screen-ladder`. |
| 5 | `gate_decisions` empty in state | **already fixed** | `commit.py` logs full structured gate numbers per decision event; `dashboard.reduce_run` builds a row per candidate from them (#407, #414, #418). |
| 6 | pointer file names files that don't exist | **already fixed** | `harness.seed_framework_memory` writes `LEDGER.md`/`RUNMAP.md`/`JOURNAL.md`/`prior_iterations/`, called from both `commit.py` and `host.py`'s `_stage_context` (#419's defect 4). Confirmed by reading the code, not assumed. |
| 7 | infra error flagged on the wrong side | **already fixed** | `ci/benchmarks/lib/metrics.py`: `infra = _infra_task(o) or _infra_task(b)` checks both sides (#407). |
| 8 | journal repeats itself | **already fixed** | `harness._reconcile_journal` has an explicit "already recorded — do not duplicate" guard, hardened further by #429/#440's sibling-round fix. |
| 9 | round 3 silently lost its parallelism settings | **fixed here** | `round.py` now records `measurement_max_parallel` alongside `measurement_concurrency`, and emits `parallel_warning` when either drifts from the previous round. |
| 10 | `tasks.json` pins an agent nobody uses | **needs a decision** | Left unfixed — see below. |

**Lettered items:**
- A, C, D — need a live re-run, not answerable from static analysis.
- B — needs a live re-run against #419's footprint narrowing.
- E — audited `commit.py`/`measure.py`/`spend.py`: none of them subprocess out at all (direct in-process `cap_evolve` calls), so item 1's swallowed-failure pattern doesn't exist there. `host.py`'s two `subprocess.run` sites and `merge_taskopt.py`/`funcmerge.py`'s git subprocess calls all handle failure explicitly (raise, or distinguish parse failure, or return a checked boolean) rather than treating an error dict as a verdict.
- F — `round.py`'s and `taskeval.py`'s own `--split` lack `choices=["train","val"]` (the evaluate phase's `run.py --split` does have it), unlike every other forwarded flag (`--mode`, `--decision`, `--reject-basis`, `--gate-against`, `--tier`), which all match their downstream `choices=`. Lower risk than item 1's `--mode` bug — an invalid `--split` already surfaces as a non-zero `eval_rc` that `assert_rows_were_judged` reports rather than swallows. Not patched here since the ask was to audit F, not fix it.

## Item 10 — why left unfixed

`tasks.json`'s `"agent"` field records **provenance** (which model produced/verified a task's reference trace), not a "canonical model for this benchmark tier". Bulk-replacing `aws/gpt-oss-120b` → `Azure/gpt-5-mini-2025-08-07` across ~900 tasks to silence a warning risks corrupting curation data if that assumption about the field's meaning is wrong. Flagging for a maintainer decision rather than guessing at data semantics.

## Tests

- `core/tests/test_inconclusive_requires_growth.py` (new) — item 3.
- `core/tests/test_round_requires_screen_ladder.py` (new) — items 4 and 9.
- `core/tests/test_an_unresolved_gate_is_not_a_rejection.py`'s shared `_commit()` helper updated to pass `--force` for the inconclusive-booking-mechanics tests that predate the new growth requirement (unrelated to what those tests assert).
- `skills/algorithms/agent-optimize/scripts/check.py` updated: two `round.py` self-checks now pass `--skip-screen-ladder`, since they exercise gate mechanics, not the screen ladder.

Full `core/tests` suite: **1163 passed, 12 skipped, 0 failed.**

Not merged.