### PR TITLE
fix(tau2_airline): stop reporting real evaluate spend as $0.00

### DIFF
--- a/core/tests/test_tau2_airline_eval_cost.py
+++ b/core/tests/test_tau2_airline_eval_cost.py
@@ -1,0 +1,182 @@
+"""The production tau2_airline adapter (examples/tau2_airline/adapters/adapter.py — the one
+actually run by capevolve.yaml with the RITS/proxy-routed ``aws/gpt-oss-120b`` target model
+and ``run_trials``) hardcoded ``cost_usd=agent_cost + user_cost`` and ``tokens=0``, so every
+evaluate/optimization/intake event reported $0.00 despite real token counts and real elapsed
+time — exactly the bug already fixed in ``templates/adapters/tau2_bench/adapter.py`` (see
+``test_tau2_eval_cost.py``) but never ported to the example that production runs actually use.
+
+This mirrors that fix's tests against the production adapter to prove the port landed.
+"""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+ADAPTER = REPO / "examples" / "tau2_airline" / "adapters" / "adapter.py"
+
+
+def _load_adapter_module():
+    for p in (REPO / "core", ADAPTER.parent, ADAPTER.parent.parent):
+        if str(p) not in sys.path:
+            sys.path.insert(0, str(p))
+
+    llm_utils = types.ModuleType("tau2.utils.llm_utils")
+
+    def get_token_usage(messages):
+        usage = {"completion_tokens": 0, "prompt_tokens": 0}
+        for m in messages:
+            u = getattr(m, "usage", None)
+            if u is None:
+                continue
+            usage["completion_tokens"] += u["completion_tokens"]
+            usage["prompt_tokens"] += u["prompt_tokens"]
+        return usage
+
+    llm_utils.get_token_usage = get_token_usage
+    for name, mod in (
+        ("tau2", types.ModuleType("tau2")),
+        ("tau2.utils", types.ModuleType("tau2.utils")),
+        ("tau2.utils.llm_utils", llm_utils),
+    ):
+        sys.modules.setdefault(name, mod)
+
+    spec = importlib.util.spec_from_file_location("_tau2_airline_adapter_cost", ADAPTER)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class _Msg:
+    def __init__(self, cost=None, usage=None):
+        self.cost = cost
+        self.usage = usage
+
+
+class _Sim:
+    def __init__(self, agent_cost, user_cost, messages):
+        self.agent_cost = agent_cost
+        self.user_cost = user_cost
+        self._messages = messages
+
+    def get_messages(self):
+        return self._messages
+
+
+_USAGE = {"prompt_tokens": 100, "completion_tokens": 20}
+
+
+def test_priced_run_is_reported_as_before():
+    mod = _load_adapter_module()
+    sim = _Sim(1.25, 0.75, [_Msg(cost=1.0, usage=_USAGE), _Msg(cost=1.0, usage=_USAGE)])
+    cost, tokens, meta = mod._cost_and_tokens(sim)
+    assert cost == 2.0
+    assert meta["cost_source"] == "tau2"
+    assert tokens == 240, "tokens must be recovered, not hardcoded to 0"
+
+
+def test_unpriced_run_reports_tokens_and_says_it_is_unpriced():
+    """The bug: RITS/proxy target models (aws/gpt-oss-120b) go unpriced and this used to
+    be indistinguishable from a genuinely free run — cost_usd read 0.0 either way."""
+    mod = _load_adapter_module()
+    sim = _Sim(None, None, [_Msg(cost=None, usage=_USAGE), _Msg(cost=None, usage=_USAGE)])
+    cost, tokens, meta = mod._cost_and_tokens(sim)
+    assert cost == 0.0
+    assert meta["cost_source"] == "unpriced"
+    assert meta["messages_missing_cost"] == 2
+    assert tokens == 240, "tokens are the honest fallback unit and must survive"
+
+
+def test_no_cost_is_ever_invented_from_a_rate_table():
+    mod = _load_adapter_module()
+    sim = _Sim(None, None, [_Msg(cost=None, usage={"prompt_tokens": 10**6,
+                                                   "completion_tokens": 10**6})])
+    cost, tokens, meta = mod._cost_and_tokens(sim)
+    assert cost == 0.0
+    assert tokens == 2_000_000
+    src = ADAPTER.read_text(encoding="utf-8")
+    for banned in ("completion_cost", "cost_per_token", "model_cost", "litellm.model_prices"):
+        assert banned not in src, f"{banned} would synthesize a price"
+
+
+def test_cost_metadata_reaches_the_rollout():
+    src = ADAPTER.read_text(encoding="utf-8")
+    assert "cost_usd=cost_usd" in src and "tokens=tokens" in src
+    assert "**cost_meta," in src, "cost_source must land in Rollout.metadata"
+    assert "tokens=0," not in src, "the hardcoded zero must be gone"
+    assert "float(agent_cost) + float(user_cost)" not in src, "the unguarded sum must be gone"
+
+
+def test_a_sim_whose_messages_explode_still_yields_a_rollout():
+    mod = _load_adapter_module()
+
+    class _Bad(_Sim):
+        def get_messages(self):
+            raise RuntimeError("tau2 internals changed")
+
+    cost, tokens, meta = mod._cost_and_tokens(_Bad(None, None, []))
+    assert (cost, tokens) == (0.0, 0)
+    assert meta["cost_source"] == "unpriced"
+
+
+class _TermReason:
+    INFRASTRUCTURE_ERROR = "infrastructure_error"
+    UNEXPECTED_ERROR = "unexpected_error"
+    USER_STOP = "user_stop"
+
+
+class _RewardInfo:
+    def __init__(self, reward):
+        self.reward = reward
+
+    def model_dump(self, mode="json"):
+        return {"reward": self.reward}
+
+
+class _RollMsg:
+    def __init__(self, role, content, cost=None, usage=None):
+        self.role = role
+        self.content = content
+        self.cost = cost
+        self.usage = usage
+
+    def model_dump(self):
+        return {"role": self.role, "content": self.content}
+
+
+class _RollSim:
+    def __init__(self, messages, reward=0.0, term=_TermReason.USER_STOP,
+                 agent_cost=None, user_cost=None):
+        self.task_id = "7"
+        self.reward_info = _RewardInfo(reward)
+        self.agent_cost = agent_cost
+        self.user_cost = user_cost
+        self.termination_reason = term
+        self._messages = messages
+
+    def get_messages(self):
+        return self._messages
+
+
+def _load_adapter_module_with_termination_reason():
+    sim_mod = types.ModuleType("tau2.data_model.simulation")
+    sim_mod.TerminationReason = _TermReason
+    sys.modules["tau2.data_model.simulation"] = sim_mod
+    return _load_adapter_module()
+
+
+def test_sim_to_rollout_reports_real_tokens_and_unpriced_cost_for_gptoss():
+    """End-to-end: a real-token, unpriced (RITS/proxy) simulation must NOT collapse to a
+    Rollout that reads exactly like a genuinely free/zero-usage run."""
+    mod = _load_adapter_module_with_termination_reason()
+    messages = [
+        _RollMsg("assistant", "booking your flight", usage={"prompt_tokens": 500_000,
+                                                             "completion_tokens": 300_000}),
+    ]
+    sim = _RollSim(messages, reward=1.0, agent_cost=None, user_cost=None)
+    rollout = mod.Adapter._sim_to_rollout(sim)
+    assert rollout.cost_usd == 0.0
+    assert rollout.tokens == 800_000, "real token usage must reach the Rollout"
+    assert rollout.metadata["cost_source"] == "unpriced"

--- a/examples/tau2_airline/adapters/adapter.py
+++ b/examples/tau2_airline/adapters/adapter.py
@@ -63,6 +63,79 @@ def _leaked_stop_continuation(messages) -> bool:
     return False
 
 
+_cost_unpriced_warned = False
+
+
+def _cost_and_tokens(sim) -> tuple[float, int, dict]:
+    """Cost and token usage for one simulation, plus metadata saying how solid the cost is.
+
+    ``sim.agent_cost``/``sim.user_cost`` come from tau2's ``get_cost``, which is
+    ALL-OR-NOTHING: it returns ``None`` the moment ANY non-tool message lacks a
+    per-message ``cost``. The previous ``sim.agent_cost or 0.0`` therefore collapsed
+    "the provider did not price this" into "$0.00" — every RITS/proxy run (the
+    ``aws/gpt-oss-120b`` target model included) reported $0.0000 of eval spend despite
+    real rollouts, so a genuinely free run was indistinguishable from an unpriced one.
+
+    What this does about it:
+      * TOKENS are always recovered via tau2's ``get_token_usage`` (skips messages
+        without usage instead of nulling the whole run) rather than hardcoding
+        ``tokens=0`` and discarding real usage.
+      * COST falls back to summing the per-message ``cost`` values that ARE present,
+        which beats zero when only a few messages are unpriced.
+      * It deliberately does NOT price tokens from a public rate table here — the
+        proxy/RITS endpoint's real rates are not knowable from this adapter, and a
+        fabricated dollar figure next to measured ones is worse than an absent one.
+      * ``cost_source``/``messages_missing_cost`` record which case happened, so a
+        0.0 reads as "unpriced" rather than "free" (``Rollout.cost_usd`` is a
+        non-optional float that coerces ``None`` to ``0.0``).
+    """
+    global _cost_unpriced_warned
+
+    agent_cost, user_cost = sim.agent_cost, sim.user_cost
+    try:
+        messages = list(sim.get_messages())
+    except Exception:  # noqa: BLE001
+        messages = []
+
+    try:
+        from tau2.utils.llm_utils import get_token_usage
+
+        usage = get_token_usage(messages) or {}
+        tokens = int(usage.get("prompt_tokens", 0)) + int(usage.get("completion_tokens", 0))
+    except Exception:  # noqa: BLE001
+        tokens = 0
+    missing_usage = sum(1 for m in messages if getattr(m, "usage", None) is None)
+
+    if agent_cost is not None or user_cost is not None:
+        return (
+            float(agent_cost or 0.0) + float(user_cost or 0.0),
+            tokens,
+            {"cost_source": "tau2", "messages_missing_cost": 0, "messages_missing_usage": missing_usage},
+        )
+
+    # tau2 gave up on the whole run: salvage whatever the provider did price.
+    priced = [m for m in messages if getattr(m, "cost", None) is not None]
+    missing = len(messages) - len(priced)
+    partial = float(sum(m.cost for m in priced))
+    if priced:
+        source = "partial_messages"
+    else:
+        source = "unpriced"
+        if not _cost_unpriced_warned:
+            _cost_unpriced_warned = True
+            print(
+                "tau2: the provider returned no per-message cost for this target model, "
+                "so eval spend cannot be measured for this run; reporting tokens instead. "
+                "Rollout cost_usd will read 0.0 with metadata cost_source='unpriced'.",
+                file=sys.stderr,
+            )
+    return partial, tokens, {
+        "cost_source": source,
+        "messages_missing_cost": missing,
+        "messages_missing_usage": missing_usage,
+    }
+
+
 def _shown_metrics(reward: float, reward_info: dict, rollout) -> list:
     """Shown-only secondary metrics for display; the GATE still uses reward (primary).
 
@@ -292,8 +365,7 @@ class Adapter(CapabilityAdapter):
             if reward_info is not None and reward_info.reward is not None
             else 0.0
         )
-        agent_cost = sim.agent_cost or 0.0
-        user_cost = sim.user_cost or 0.0
+        cost_usd, tokens, cost_meta = _cost_and_tokens(sim)
         term = sim.termination_reason
         error = None
         if term in infra_reasons:
@@ -320,14 +392,15 @@ class Adapter(CapabilityAdapter):
             task_id=task_id,
             output=messages,
             trace=messages,
-            cost_usd=float(agent_cost) + float(user_cost),
-            tokens=0,
+            cost_usd=cost_usd,
+            tokens=tokens,
             error=error,
             metadata={
                 "domain": DOMAIN,
                 "tau2_reward": reward,
                 "tau2_reward_info": reward_info_dump,
                 "termination_reason": str(term),
+                **cost_meta,
             },
         )
 


### PR DESCRIPTION
## Summary

- `evaluate`/`optimization`/`intake` events showed `cost_usd: 0.0` for real runs despite multi-million real token counts and real elapsed time (confirmed in a run-e2e `events.jsonl` on target model `aws/gpt-oss-120b`).
- Root cause: `examples/tau2_airline/adapters/adapter.py` — the adapter production runs actually use (`capevolve.yaml` → `orchestration_mode: agent`, `run_trials`, RITS/litellm-proxy routing via `rits.py`) — still had `cost_usd=float(agent_cost) + float(user_cost)` and a hardcoded `tokens=0`.
  - `sim.agent_cost`/`sim.user_cost` come from tau2's `get_cost`, which is **all-or-nothing**: it returns `None` the moment any message lacks a per-message cost. That's exactly what happens on a RITS/litellm-proxy target model like `aws/gpt-oss-120b`. `agent_cost or 0.0` collapsed "unpriced" into "$0.00".
  - Tokens were hardcoded to `0` and thrown away even though tau2 reports them per-message.
- `dashboard.py` reads `events.jsonl`'s `cost_usd` verbatim (confirmed at `core/cap_evolve/dashboard.py` lines 736/1274/1477 etc.) — the bug is upstream in event emission, not a dashboard display bug.
- The "host" (optimizer CLI) cost path was already correct — it reads the agent CLI's real reported `total_cost_usd` directly, a different code path from the target-model rollout side that was broken.

Interestingly, `templates/adapters/tau2_bench/adapter.py` **already has this exact fix** (a `_cost_and_tokens()` helper, tested by `core/tests/test_tau2_eval_cost.py`) — but it was never ported to `examples/tau2_airline/adapters/adapter.py`, the adapter production runs actually use. This PR ports that fix.

## What changed

- `examples/tau2_airline/adapters/adapter.py`: added `_cost_and_tokens(sim)`, used by `_sim_to_rollout` (shared by `run_batch` and `run_trials`):
  - Tokens are always recovered via tau2's `get_token_usage` instead of being discarded.
  - Cost falls back to summing whatever per-message cost the provider DID report when tau2's own all-or-nothing total is `None`.
  - A `cost_source` metadata flag (`"tau2"` | `"partial_messages"` | `"unpriced"`) lets a genuinely-unpriced RITS/proxy run (e.g. `aws/gpt-oss-120b`) be told apart from a genuinely-free run, instead of both reading as an indistinguishable `$0.00`.
  - No price is ever fabricated from a rate table (checked by test).

## Test plan

- [x] Added `core/tests/test_tau2_airline_eval_cost.py`, mirroring the existing `core/tests/test_tau2_eval_cost.py` coverage against the production adapter: priced/unpriced/partially-priced simulations, no-rate-table-fabrication, exception safety, and an end-to-end `_sim_to_rollout` check that real tokens (800k) survive while unpriced cost stays honestly `0.0` with `cost_source=unpriced`.
- [x] `python3 -m pytest core/tests/test_tau2_airline_eval_cost.py core/tests/test_tau2_eval_cost.py -q` → 17 passed.
- [x] `python3 -m pytest core/tests/ -q --ignore=core/tests/test_intervention.py` → 188 passed, 3 skipped, 5 failed. The 5 failures (`test_dashboard_launch.py`, `test_eventstream.py` x2, `test_stop_at_reward.py` x2) are pre-existing and unrelated to this change — they touch dashboard port-binding, a stale editable-install module identity mismatch, and a `Budget`/`Spent` API mismatch, none of which this diff touches. `test_intervention.py` fails to collect due to an unrelated stale editable `cap_evolve` install pointing at a different worktree path in this environment.