### PR TITLE
agent-optimize: structurally block backgrounded waits, flag near-misses

### DIFF
--- a/core/tests/test_agent_optimize_host.py
+++ b/core/tests/test_agent_optimize_host.py
@@ -1343,3 +1343,88 @@ def test_a_permanent_crash_exhausts_retries_and_surfaces_clearly(tmp_path):
         f"the exhausted crash is not clearly diagnosed: {msg}")
     assert "2 retries" in msg or "2 retry" in msg, (
         f"the diagnosis should say how many retries were already spent: {msg}")
+
+
+def test_claude_code_registry_row_structurally_disallows_monitor():
+    """#431: the Monitor denial on run_e2e_run3 must not depend on luck.
+
+    ``--allowedTools Bash`` alone denies anything not on the list only because ``-p`` has no
+    human to ask — a future row change (a broader allowlist, a different permission mode)
+    could silently make a persistent ``Monitor`` call succeed instead of denied. `Claude
+    Code's own precedence rule is that ``--disallowedTools`` always wins over
+    ``--allowedTools``, so asserting it is present (and that it survives command-building)
+    is what makes the guard structural rather than an accident of what else is allowed.
+    """
+    import yaml
+
+    registry_path = REPO / "skills" / "optimizers" / "registry.yaml"
+    registry = yaml.safe_load(registry_path.read_text(encoding="utf-8"))
+    template = registry["claude-code"]["command_template"]
+    assert "--disallowedTools" in template and "Monitor" in template, (
+        f"claude-code's command_template no longer structurally disallows Monitor: {template}")
+
+    sys.path.insert(0, str(REPO / "skills" / "optimizers" / "run-optimizer" / "scripts"))
+    import run as run_optimizer  # noqa: E402
+
+    cmd = run_optimizer.build_command(
+        template, workdir="/tmp/w", prompt="/tmp/p.md", prompt_text="do the thing",
+        model="claude-sonnet-5", self_dir="/tmp")
+    assert "--disallowedTools" in cmd, f"the flag was dropped during command-building: {cmd}"
+    assert cmd[cmd.index("--disallowedTools") + 1] == "Monitor", (
+        f"Monitor is not the value that ends up on the built command: {cmd}")
+
+
+def _permission_denial_stub(tmp_path: Path, *, denials: list) -> Path:
+    stub = tmp_path / "fake_run_optimizer.py"
+    payload = {
+        "optimizer": "claude-code", "cli_present": True, "returncode": 0,
+        "auth_present": [],
+        "stop": {"subtype": "success", "stop_reason": "end_turn", "num_turns": 5,
+                 "permission_denials": denials},
+    }
+    stub.write_text(f"import json\nprint(json.dumps({payload!r}))\n", encoding="utf-8")
+    return stub
+
+
+def test_a_denied_persistent_monitor_call_is_flagged_as_a_near_miss(tmp_path):
+    """#431's own evidence, replayed: a denied persistent ``Monitor`` must be visible in the
+    run's own report, not only recoverable by hand-reading ``host/transcript.jsonl``.
+    """
+    project = _project(tmp_path)
+    run_dir = _run_dir(tmp_path)
+    stub = _permission_denial_stub(tmp_path, denials=[{
+        "tool_name": "Monitor",
+        "tool_input": {"description": "round.py progress for iteration 1 (3 candidates)",
+                       "timeout_ms": 3600000, "persistent": True,
+                       "command": "tail -f -n +1 /tmp/round1.log"},
+    }])
+
+    p = subprocess.run(
+        [sys.executable, str(HOST), "--run-dir", str(run_dir.root), "--project", str(project),
+         "--agent", "claude-code", "--run-optimizer", str(stub)],
+        capture_output=True, text=True, env=_env())
+    out = json.loads(p.stdout)
+
+    misses = out.get("backgrounding_near_misses")
+    assert misses and len(misses) == 1, f"the Monitor denial was not flagged: {out}"
+    assert misses[0]["tool_name"] == "Monitor", misses
+    assert "backgrounding" in p.stderr.lower() or "detach" in p.stderr.lower(), (
+        f"no near-miss warning reached stderr: {p.stderr}")
+
+
+def test_an_unrelated_permission_denial_is_not_flagged_as_a_backgrounding_attempt(tmp_path):
+    """A denial with no persistent/backgrounding shape must not be misread as this anti-pattern
+    — flagging every denial would bury the real signal in noise the first time an agent is
+    denied something ordinary (e.g. a write outside its workdir).
+    """
+    project = _project(tmp_path)
+    run_dir = _run_dir(tmp_path)
+    stub = _permission_denial_stub(tmp_path, denials=[{
+        "tool_name": "Write", "tool_input": {"file_path": "/etc/passwd", "content": "x"},
+    }])
+
+    out = _host("--run-dir", str(run_dir.root), "--project", str(project),
+                "--agent", "claude-code", "--run-optimizer", str(stub))
+
+    assert out.get("backgrounding_near_misses") == [], (
+        f"an unrelated denial was misclassified as a detach attempt: {out}")

--- a/core/tests/test_agent_optimize_host.py
+++ b/core/tests/test_agent_optimize_host.py
@@ -1355,10 +1355,10 @@ def test_claude_code_registry_row_structurally_disallows_monitor():
     ``--allowedTools``, so asserting it is present (and that it survives command-building)
     is what makes the guard structural rather than an accident of what else is allowed.
     """
-    import yaml
+    from cap_evolve.specfile import read_yaml
 
     registry_path = REPO / "skills" / "optimizers" / "registry.yaml"
-    registry = yaml.safe_load(registry_path.read_text(encoding="utf-8"))
+    registry = read_yaml(registry_path.read_text(encoding="utf-8"))
     template = registry["claude-code"]["command_template"]
     assert "--disallowedTools" in template and "Monitor" in template, (
         f"claude-code's command_template no longer structurally disallows Monitor: {template}")

--- a/skills/algorithms/agent-optimize/scripts/host.py
+++ b/skills/algorithms/agent-optimize/scripts/host.py
@@ -88,6 +88,38 @@ REGISTRY = SKILLS / "optimizers" / "registry.yaml"
 #: other real stop condition must never be retried, only this small allow-list.
 _RETRYABLE_TERMINAL_REASONS = {"api_error"}
 
+#: #431: ``permission_denials`` entries whose ``tool_input`` shape says the driver tried to
+#: DETACH a wait rather than stay in the foreground — a persistent ``Monitor``, or a
+#: ``tail -f`` / ``nohup`` / backgrounding-shaped Bash command. ``registry.yaml``'s
+#: ``--disallowedTools Monitor`` now makes the Monitor case structurally impossible for
+#: claude-code specifically, but ``permission_denials`` is read from the CLI's own payload
+#: regardless of agent or registry row, so a near-miss on any other tool/CLI is still flagged
+#: instead of only visible in a raw transcript nobody was going to read.
+_DETACH_COMMAND_PATTERNS = ("tail -f", "nohup ", "disown", "setsid ")
+
+
+def _looks_like_a_detach_attempt(denial) -> bool:
+    if not isinstance(denial, dict):
+        return False
+    if str(denial.get("tool_name") or "") == "Monitor":
+        return True
+    tool_input = denial.get("tool_input")
+    if isinstance(tool_input, dict):
+        if tool_input.get("persistent") is True:
+            return True
+        command = str(tool_input.get("command") or "")
+        if any(pat in command for pat in _DETACH_COMMAND_PATTERNS):
+            return True
+    return False
+
+
+def _backgrounding_near_misses(permission_denials) -> list[dict]:
+    """``permission_denials`` entries shaped like a detached-wait attempt, not a plain denial."""
+    if not isinstance(permission_denials, list):
+        return []
+    return [d for d in permission_denials if _looks_like_a_detach_attempt(d)]
+
+
 # 4h. Long enough for a full-val eval on the slowest benchmark in this repo
 # (spreadsheetbench full: one Docker container per task x trials), while still bounding a
 # genuinely hung command instead of waiting forever.
@@ -1138,6 +1170,7 @@ def main(argv=None) -> int:
         "instructions_warning": arm_warning,
         "context": context,
         "optimizer": payload,
+        "backgrounding_near_misses": _backgrounding_near_misses(permission_denials),
         **seal,
     }
     if proc is not None and proc.returncode != 0:
@@ -1145,6 +1178,16 @@ def main(argv=None) -> int:
     print(json.dumps(out, indent=2))
     if incomplete:
         print(f"::warning::agent-optimize: {incomplete}", file=sys.stderr)
+    if out["backgrounding_near_misses"]:
+        # A near-miss, not the incomplete-run diagnosis above: the permission system already
+        # denied it, so the run may have finished cleanly regardless. Reported anyway — #431's
+        # run_e2e_run3 was exactly this shape, and it was only recoverable by hand-reading
+        # host/transcript.jsonl before this.
+        print("::warning::agent-optimize: the driver attempted to background/detach a wait "
+              f"({len(out['backgrounding_near_misses'])} denial(s): "
+              f"{[d.get('tool_name') for d in out['backgrounding_near_misses']]}) and was "
+              "denied by the permission system — see backgrounding_near_misses in this run's "
+              "output and the briefing's Unattended section", file=sys.stderr)
     # The run's worth is its sealed number, so that — not the agent's exit code — decides
     # ours. An agent that ran out of turns after three honest rounds produced a result; one
     # that exited 0 without sealing did not.

--- a/skills/optimizers/registry.yaml
+++ b/skills/optimizers/registry.yaml
@@ -80,7 +80,16 @@ claude-code:
   # text it can't test, so it conservatively avoids shipping scripts/tool code. Verifying edits
   # is core to optimizing skills/tools, so this is on by default. Edits stay auto-approved
   # (acceptEdits); the optimizer runs in an isolated candidate-copy workdir.
-  command_template: "claude -p {prompt_text} --permission-mode acceptEdits --allowedTools Bash --model {model}"
+  #
+  # --disallowedTools Monitor (issue #431): on run_e2e_run3 the driver reached for a persistent
+  # ``Monitor`` (a ``tail -f`` watch on a round's gate) to background the wait instead of
+  # staying in the foreground as the briefing demands, and was saved only by the permission
+  # system happening to deny it — Monitor was never in --allowedTools, so it fell back to
+  # -p's no-human-to-ask auto-deny. That is luck, not a guarantee: it depends on Monitor
+  # staying off an allowlist nobody wrote to protect this. --disallowedTools always takes
+  # precedence over --allowedTools in Claude Code's own permission resolution, so listing
+  # Monitor here makes the denial unconditional instead of an accident of what else is allowed.
+  command_template: "claude -p {prompt_text} --permission-mode acceptEdits --allowedTools Bash --disallowedTools Monitor --model {model}"
   env_keys: "ANTHROPIC_API_KEY"
   install_url: "https://docs.claude.com/claude-code"
   auth_notes: "Logged-in Claude Code session or ANTHROPIC_API_KEY."


### PR DESCRIPTION
Fixes #431.

## Problem
The driver briefing (host.py's Unattended section) forbids ending a turn with a backgrounded/detached wait, citing run 32814848187. On run_e2e_run3 the driver reached for exactly that anti-pattern anyway — a persistent `Monitor` (`tail -f` on a round's gate log) — and was only saved because the permission system happened to deny it. `Monitor` was never in `--allowedTools`, so the deny was an accident of what else was allowed, not a guarantee.

## Changes

1. **Structural** (`skills/optimizers/registry.yaml`): claude-code's `command_template` now adds `--disallowedTools Monitor`. `--disallowedTools` always takes precedence over `--allowedTools` in Claude Code's own permission resolution, so a persistent `Monitor` call is now unconditionally denied for this loop, regardless of any future change to what else is allowed.

2. **Observability** (`skills/algorithms/agent-optimize/scripts/host.py`): `permission_denials` (already captured by run-optimizer per #428) is now scanned for entries shaped like a detach/backgrounding attempt — `tool_name == "Monitor"`, `tool_input.persistent is True`, or a `tail -f`/`nohup`/`setsid`/`disown` command — and surfaced as `backgrounding_near_misses` in the run's JSON output plus a `::warning::` on stderr. A near-miss like run_e2e_run3's is now visible in the run's own report instead of only recoverable by hand-reading `host/transcript.jsonl`.

## Test evidence

```
$ CAPEVOLVE_CORE=.../core CAPEVOLVE_SKILLS_DIR=.../skills python3 -m pytest core/tests/test_agent_optimize_host.py core/tests/test_optimizer_transcript.py -q
...................................................                      [100%]
51 passed in 9.59s
```

New tests added to `core/tests/test_agent_optimize_host.py`:
- `test_claude_code_registry_row_structurally_disallows_monitor` — asserts `--disallowedTools Monitor` is present in the registry row AND survives `run_optimizer.build_command()`.
- `test_a_denied_persistent_monitor_call_is_flagged_as_a_near_miss` — replays #431's own evidence (the exact `tool_input` from the issue) through `host.py` and asserts it lands in `backgrounding_near_misses` plus a stderr warning.
- `test_an_unrelated_permission_denial_is_not_flagged_as_a_backgrounding_attempt` — a plain denial (e.g. `Write` outside the workdir) is NOT misclassified, so the signal stays meaningful.

`skills/optimizers/run-optimizer/scripts/check.py` also still passes (`"ok": true`).