### PR TITLE
agent-optimize: require and surface subset.rationale on every screen

### DIFF
--- a/core/cap_evolve/dashboard.py
+++ b/core/cap_evolve/dashboard.py
@@ -1836,6 +1836,7 @@ def reduce_run(run_dir) -> dict:
             "fixed": [str(x) for x in (paired.get("fixed") or [])],
             "regressed": [str(x) for x in (paired.get("regressed") or [])],
             "pool_n": sub.get("pool_n"),
+            "rationale": e.get("rationale") or sub.get("rationale"),
             "t": e.get("t"),
         })
     if screens:
@@ -3064,6 +3065,7 @@ function dsecs(v){v=Math.max(0,Math.round(v||0));if(v<60)return v+'s';
       if(sc.mean_delta!=null)bits.push('Δ='+(+sc.mean_delta).toFixed(3)+(sc.se!=null?' ± '+(+sc.se).toFixed(3):''));
       if(sc.threshold!=null)bits.push('threshold='+sc.threshold);
       box.append($('div',{class:'muted num',style:'font-size:11px;margin-top:4px',text:bits.join('  ·  ')}));
+      if(sc.rationale)box.append($('div',{class:'muted',style:'font-size:11px;margin-top:4px',text:'why this subset: '+sc.rationale}));
       s.append(box);
     });
   }

--- a/core/cap_evolve/subsample.py
+++ b/core/cap_evolve/subsample.py
@@ -152,7 +152,30 @@ def select_screen_subset(
         "seed": int(seed),
         "holdout_frac": float(holdout_frac),
         "pool_n": len(pool),
+        "rationale": _subset_rationale(broken=broken, informative=informative, holdout=holdout,
+                                       seed=seed),
     }
+
+
+def _subset_rationale(*, broken: list, informative: list, holdout: list, seed: int) -> str:
+    """One sentence explaining WHICH tasks are in the subset and WHY — issue #437's
+
+    ``subset.rationale``: a screen must say why its subset looks the way it does, not
+    just what the ids are.
+    """
+    parts = []
+    if broken:
+        parts.append(f"{len(broken)} previously-broken task(s) {broken} (a prior edit's "
+                     "known regression, highest-value to re-check)")
+    if informative:
+        parts.append(f"{len(informative)} most-informative failing/high-variance task(s) "
+                     f"{informative}")
+    if holdout:
+        parts.append(f"{len(holdout)} random regression-canary task(s) {holdout} drawn "
+                     f"(seed {seed}) from tasks the parent currently passes")
+    if not parts:
+        return "empty subset — no valid parent measurements to screen against"
+    return "; ".join(parts)
 
 
 def paired_deltas_on(parent_per_task: list, cand_per_task: list, ids: list) -> dict:

--- a/core/tests/test_dashboard_agent_run.py
+++ b/core/tests/test_dashboard_agent_run.py
@@ -34,7 +34,10 @@ _EVENTS = [
     {"t": 3.0, "kind": "baseline", "val": 0.5, "stderr": 0.25, "n_scored": 2},
     {"t": 4.0, "kind": "screen", "tag": "cand_a", "tier": 1, "ids": ["t1", "t2"],
      "fired": 2, "decision": "promote", "mean_delta": 0.5, "se": 0.5, "n": 2,
-     "inconclusive": True, "net_rollouts": -2},
+     "inconclusive": True, "net_rollouts": -2,
+     "rationale": "1 most-informative failing/high-variance task(s) ['t2']; 1 random "
+                  "regression-canary task(s) ['t1'] drawn (seed 1) from tasks the parent "
+                  "currently passes"},
     {"t": 5.0, "kind": "evaluate", "split": "val", "tag": "cand_a", "reward": 0.5,
      "stderr": 0.25, "cost_usd": 1.25, "tokens": 20, "seconds": 30.0, "n_scored": 2},
     {"t": 6.0, "kind": "reject", "candidate": "cand_a", "val": 0.5,
@@ -160,6 +163,7 @@ def test_screens_expose_the_subset_and_its_movement():
     assert sc["holdout"] == ["t1"] and sc["informative"] == ["t2"]
     assert sc["fixed"] == ["t2"] and sc["regressed"] == ["t1"]
     assert sc["pool_n"] == 2
+    assert "t2" in sc["rationale"] and "t1" in sc["rationale"]
 
 
 def test_no_screens_means_no_screens_capability():

--- a/core/tests/test_subsample.py
+++ b/core/tests/test_subsample.py
@@ -48,6 +48,22 @@ def test_broken_tasks_are_screened_first():
     assert "t0" in s["ids"] and s["broken"] == ["t0"]
 
 
+# ---- rationale (issue #437) -----------------------------------------------
+
+def test_rationale_names_broken_informative_and_holdout_tasks():
+    s = select_screen_subset(PARENT, k=6, seed=1, holdout_frac=0.5, broken_ids=["t0"])
+    assert "t0" in s["rationale"]
+    for tid in s["informative"]:
+        assert tid in s["rationale"]
+    for tid in s["holdout"]:
+        assert tid in s["rationale"]
+
+
+def test_rationale_is_never_empty_for_a_nonempty_subset():
+    s = select_screen_subset(PARENT, k=4, seed=1)
+    assert s["rationale"]
+
+
 def test_unmeasured_tasks_are_never_screened():
     """A task with no valid trial is missing data, not a 0.0 to go re-measure."""
     parent = PARENT + [_pt("ghost", 0.0, valid=0)]

--- a/skills/algorithms/agent-optimize/scripts/screen.py
+++ b/skills/algorithms/agent-optimize/scripts/screen.py
@@ -208,7 +208,7 @@ def main(argv=None) -> int:
                       fired=fired, decision=decision["decision"],
                       mean_delta=decision["mean_delta"], se=decision["se"],
                       n=decision["n"], inconclusive=decision["inconclusive"],
-                      net_rollouts=savings["net_rollouts"])
+                      net_rollouts=savings["net_rollouts"], rationale=sub["rationale"])
     print(json.dumps(payload, indent=2))
     return 0
 


### PR DESCRIPTION
Addresses #437.

## Overlap check with PR #442 (issue #420 item 4)

#442 makes `screen.py` mandatory before a full-val eval: `round.py` now
refuses a candidate with no `$R/screens/<tag>__screen*.json` record unless
the driver passes `--skip-screen-ladder`. That covers #437's "make subset
screening the default step every candidate goes through" ask and the
"subset: null reaching the gate must be a visible gap" ask (it goes from a
logged fact to a hard refusal). I did not duplicate that enforcement here.

What #442 does **not** cover, and what #434/#437 additionally ask for:
every candidate node recording `subset.rationale` — which tasks, and why —
visibly, not just inferable by re-deriving it from `screens/*.json`.
`select_screen_subset()` already computes broken/informative/holdout task
lists but never phrased *why* into a field.

## What this PR does

- `core/cap_evolve/subsample.py`: `select_screen_subset()` now always
  returns a `rationale` sentence naming the broken tasks (prior
  regressions), the most-informative failing/high-variance tasks, and the
  random holdout tasks + seed — built from data already computed, not an
  extra call.
- `skills/algorithms/agent-optimize/scripts/screen.py`: logs `rationale`
  into `events.jsonl` (was already written verbatim into
  `screens/<tag>.json` via the `subset` dict).
- `core/cap_evolve/dashboard.py`: the screens panel renders "why this
  subset: ..." under each screen box, gated by the existing `screens`
  capability (no new capability flag needed).
- Tests: `test_subsample.py` (rationale composition), and
  `test_dashboard_agent_run.py` (rationale flows through to the reduced
  summary).

## Out of scope (left for #434 Phase 4 / a future issue)

#434's broader ask — the optimizer choosing an *adaptive*, non-fixed-tier
subset per candidate, with that strategy choice itself surfaced — is
explicitly Phase 4 ("merge-as-graph-search") in #434's phased plan, not
Phase 3. `screen.py` already accepts driver-supplied `--broken` ids to
bias a subset toward a diagnosed cluster; making that a first-class,
graph-aware choice is a larger change than this issue's stated scope
("make subset screening the default on-ramp" + "subset.rationale
visible") and would duplicate #442's in-flight work on the enforcement
side.

## Testing

- `pytest core/tests/test_subsample.py core/tests/test_dashboard_agent_run.py core/tests/test_agent_optimize_constraints.py core/tests/test_dashboard_host_and_algo_extra.py` — all pass
- Full `pytest core/tests` — 1157 passed, 12 skipped