### PR TITLE
agent-optimize Phase 1: candidate DAG log (graph.jsonl)

### DIFF
--- a/core/cap_evolve/graph.py
+++ b/core/cap_evolve/graph.py
@@ -1,0 +1,169 @@
+"""graph — append-only candidate DAG log ($R/graph.jsonl).
+
+A VIEW over mechanics that already exist and already gate/accept candidates:
+``events.jsonl`` step records (parent/accept/val), ``round.py``'s persisted gate
+tables under ``work/*.json``, and ``screen.py``'s tier files under ``screens/``.
+Writing a node here changes nothing about how a candidate is measured, screened,
+gated, or accepted — every field but ``id``/``parents``/``status`` is a courtesy
+copy of data reconstructible from those artifacts, which is what makes this a
+view and not a new source of truth (issue #435, parent design #434).
+
+Schema (``CandidateNode``, per #434 section "1. Data structure: a candidate
+DAG"): one JSON object per line —
+
+    id: str                    unique candidate tag
+    parents: [str]             1 for an edit, 2+ for a merge
+    cluster_ids: [str]         which diagnose() cluster(s) this targets (Phase 3+)
+    edit_kind: "prompt" | "code" | "merge"
+    micro_tests: [str]         micro-test ids this was designed to pass (Phase 2+)
+    subset: {task_ids, rationale, tier} | None   screen.py's subset, if any ran
+    status: "accepted" | "rejected"              (Phase 1 only records terminal steps)
+    val_mean: float | None
+    screen: {...} | None       merged screen.py tier records, if any ran
+    gate: {...} | None         the round.py gate-table row, if one exists
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+GRAPH_FILENAME = "graph.jsonl"
+
+
+def _screens_dir(run_dir) -> Path:
+    return run_dir.root / "screens"
+
+
+def collect_screen_info(run_dir, tag: str) -> dict | None:
+    """Merge every ``screens/<tag>__screenN.json`` tier for ``tag`` into one summary.
+
+    Returns ``None`` when no screen ever ran for this candidate — the common
+    case today, since screening stays opt-in until #434 Phase 3 makes it the
+    default on-ramp.
+    """
+    d = _screens_dir(run_dir)
+    if not d.is_dir():
+        return None
+    tiers = []
+    for f in sorted(d.glob(f"{tag}__screen*.json")):
+        try:
+            tiers.append(json.loads(f.read_text(encoding="utf-8")))
+        except (json.JSONDecodeError, OSError):
+            continue
+    if not tiers:
+        return None
+    last = tiers[-1]
+    subset_ids = sorted({i for t in tiers for i in (t.get("subset") or {}).get("ids", [])})
+    return {
+        "tiers": [{"tier": t.get("tier"), "decision": t.get("decision"),
+                   "mean_delta": t.get("mean_delta"), "se": t.get("se")}
+                  for t in tiers],
+        "decision": last.get("decision"),
+        "subset_ids": subset_ids,
+        "last_tier": last.get("tier"),
+    }
+
+
+def gate_row(run_dir, candidate_id: str) -> dict | None:
+    """The verdict row a ``round.py`` gate table recorded for ``candidate_id``.
+
+    Reads the newest ``work/*.json`` table that mentions this tag (same lookup
+    ``commit.py._gate_verdict`` already does), so a candidate never gated
+    through ``round.py`` (e.g. a deterministic hill-climb/gepa/skillopt step,
+    which gates via ``gate.decide`` directly) simply has no row here.
+    """
+    work = run_dir.root / "work"
+    if not work.is_dir():
+        return None
+    for log in sorted(work.iterdir(), key=lambda p: p.stat().st_mtime, reverse=True):
+        if not log.is_file() or log.suffix != ".json":
+            continue
+        try:
+            payload = json.loads(log.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        for row in payload.get("candidates") or []:
+            if isinstance(row, dict) and str(row.get("tag")) == str(candidate_id):
+                return row
+    return None
+
+
+def append_node(run_dir, *, node_id: str, parents: list[str], status: str,
+                 val_mean: float | None = None, edit_kind: str | None = None,
+                 cluster_ids: list[str] | None = None,
+                 micro_tests: list[str] | None = None,
+                 note: str | None = None, gate: dict | None = None,
+                 screen: dict | None = None) -> dict:
+    """Append one candidate node to ``$R/graph.jsonl``.
+
+    ``gate``/``screen`` default to a fresh lookup via :func:`gate_row` /
+    :func:`collect_screen_info` when not supplied — callers with the data
+    already in hand (``round.py``'s in-memory table) may pass it directly to
+    avoid re-reading disk.
+    """
+    if gate is None:
+        gate = gate_row(run_dir, node_id)
+    if screen is None:
+        screen = collect_screen_info(run_dir, node_id)
+    subset = None
+    if screen and screen.get("subset_ids"):
+        subset = {"task_ids": screen["subset_ids"], "rationale": None,
+                  "tier": screen.get("last_tier")}
+    rec = {
+        "id": node_id,
+        "parents": list(parents),
+        "cluster_ids": cluster_ids or [],
+        "edit_kind": edit_kind or ("merge" if len(parents) > 1 else "code"),
+        "micro_tests": micro_tests or [],
+        "subset": subset,
+        "status": status,
+        "val_mean": val_mean,
+        "screen": screen,
+        "gate": gate,
+        "note": note,
+    }
+    path = run_dir.root / GRAPH_FILENAME
+    with path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(rec, default=str) + "\n")
+    return rec
+
+
+def read_nodes(run_dir) -> list[dict]:
+    """Every node record in ``$R/graph.jsonl``, in append order."""
+    path = run_dir.root / GRAPH_FILENAME
+    if not path.exists():
+        return []
+    nodes = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            nodes.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return nodes
+
+
+def build_dag(run_dir) -> dict[str, dict]:
+    """Reconstruct ``{node_id: {**node, "children": [...]}}`` from ``graph.jsonl``.
+
+    Last record wins per id — a candidate is normally committed exactly once
+    (``commit.py`` refuses a second decision for the same tag without
+    ``--force``), but an audit/repair re-commit re-appends, and this is the
+    read-back that should reflect the latest state.
+    """
+    by_id: dict[str, dict] = {}
+    for n in read_nodes(run_dir):
+        nid = n.get("id")
+        if not nid:
+            continue
+        by_id[nid] = {**n, "children": by_id.get(nid, {}).get("children", [])}
+    for nid, n in by_id.items():
+        for parent in n.get("parents") or []:
+            if parent in by_id:
+                by_id[parent].setdefault("children", []).append(nid)
+    return by_id

--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -28,6 +28,7 @@ from typing import Callable
 from . import convergence as convergence_mod
 from . import footprint as footprint_mod
 from . import gate as gate_mod
+from . import graph as graph_mod
 from . import integrity
 from .loop import SplitResult, aggregate_scores, has_valid_trials
 from .rundir import RunDir, _atomic_write
@@ -1472,7 +1473,8 @@ def _reconcile_journal(workdir: Path, run_dir: RunDir, cid: str, *,
 def record_iteration(run_dir: RunDir, workdir: Path, cid: str, *,
                      parent_id: str | None, accepted: bool, reason: str,
                      val: float | None = None, parent_val: float | None = None,
-                     indecisive: bool = False, **extra) -> None:
+                     indecisive: bool = False, parents: list | None = None,
+                     edit_kind: str | None = None, **extra) -> None:
     """THE one place an iteration is recorded. EVERY algorithm ends its iteration here.
 
     Three things must happen exactly once per iteration, and they used to be
@@ -1503,6 +1505,13 @@ def record_iteration(run_dir: RunDir, workdir: Path, cid: str, *,
     algorithm-specific (run_step snapshots every candidate with ``_SNAPSHOT_IGNORE``,
     gepa only accepted ones) and they are not silently-droppable the way the three
     above were.
+
+    A 4th thing happens here too: a ``graph.jsonl`` node (#435) — a pure VIEW over the
+    ``step`` event just written plus whatever gate/screen artifacts already exist on
+    disk for ``cid``, so every candidate this framework ever judges (agent-mode via
+    ``commit.py``, or a deterministic algorithm via ``run_step``) gets exactly one DAG
+    node with no separate plumbing per caller. ``parents`` defaults to ``[parent_id]``
+    (an edit); pass 2+ ids for a merge node (#438's job to populate, not this one's).
     """
     run_dir.update_spent(iterations=1, accepted=None if indecisive else accepted,
                          best_val=val if accepted and val is not None else None)
@@ -1514,6 +1523,14 @@ def record_iteration(run_dir: RunDir, workdir: Path, cid: str, *,
                        reason=reason, indecisive=indecisive)
     for filename, seed, mark in _ACCUMULATORS:
         _fold_accumulator(workdir, run_dir, filename=filename, seed=seed, mark=mark)
+    try:
+        graph_mod.append_node(
+            run_dir, node_id=cid,
+            parents=list(parents) if parents else [parent_id or "seed"],
+            edit_kind=edit_kind, status="accepted" if accepted else "rejected",
+            val_mean=val, note=reason)
+    except Exception as e:  # noqa: BLE001 — a log write must never break a run
+        run_dir.log_event("optimizer_context_warning", what="graph.jsonl", error=str(e)[:300])
 
 
 def _build_runmap(workdir: Path, run_dir: RunDir) -> None:

--- a/core/tests/test_graph_jsonl.py
+++ b/core/tests/test_graph_jsonl.py
@@ -1,0 +1,161 @@
+"""issue #435: ``graph.jsonl`` is a candidate DAG log — a VIEW over the accept/reject
+mechanics ``commit.py``/``round.py``/``screen.py`` already enforce, not a new source of
+truth. This covers a multi-round, multi-sibling, one-merge scenario and checks the
+written nodes against ``events.jsonl`` (the pre-existing audit log) and ``screens/*.json``
+(the pre-existing screen record) independently, so a passing test proves the graph is
+reconstructible from data that already existed before #435 — it adds nothing a reader
+could not already piece together by hand.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPTS = REPO / "skills" / "algorithms" / "agent-optimize" / "scripts"
+
+
+def _run_dir(tmp_path):
+    from cap_evolve import Budget, RunDir, harness
+    from cap_evolve.skillcheck import SyntheticAdapter, seed_capability_dir
+
+    adapter = SyntheticAdapter(n=12)
+    seed = seed_capability_dir(tmp_path, level=3)
+    run_dir = RunDir.create(tmp_path / ".capevolve", ts="ci",
+                            budget=Budget(max_iterations=10, stall=10))
+    harness.ensure_splits(adapter, run_dir, seed=0)
+    harness.baseline(adapter, seed, run_dir=run_dir)
+    return run_dir
+
+
+def _stage(run_dir, cid, from_id="seed"):
+    work = run_dir.root / "work" / cid
+    if work.exists():
+        shutil.rmtree(work)
+    work.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(run_dir.candidate_dir(from_id), work)
+    return work
+
+
+def _commit(run_dir, work, cid, decision, val, *extra):
+    return subprocess.run(
+        [sys.executable, str(SCRIPTS / "commit.py"), "--run-dir", str(run_dir.root),
+         "--candidate-id", cid, "--from-dir", str(work),
+         "--decision", decision, "--val", str(val), "--note", f"test commit {cid}", *extra],
+        capture_output=True, text=True,
+        env={**os.environ, "CAPEVOLVE_CORE": str(REPO / "core")})
+
+
+def _ok(p):
+    assert p.returncode == 0, f"commit.py failed: {p.stdout}\n{p.stderr}"
+    return json.loads(p.stdout)
+
+
+def _graph_nodes(run_dir):
+    from cap_evolve import graph
+    return graph.read_nodes(run_dir)
+
+
+def _step_events(run_dir):
+    """Independently rebuild {candidate: {parent, accept}} from events.jsonl, the
+    audit log that existed before #435 — used to cross-check graph.jsonl, never to
+    build it."""
+    out = {}
+    for line in run_dir.events_path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        rec = json.loads(line)
+        if rec.get("kind") == "step" and rec.get("candidate"):
+            out[str(rec["candidate"])] = {"parent": rec.get("parent"), "accept": rec.get("accept")}
+    return out
+
+
+def test_multi_round_multi_sibling_dag_matches_events_and_screens(tmp_path):
+    from cap_evolve import graph
+
+    run_dir = _run_dir(tmp_path)
+
+    # Round 1: two siblings forked from seed — one rejected, one accepted (new best).
+    work_a = _stage(run_dir, "cand_a", "seed")
+    _ok(_commit(run_dir, work_a, "cand_a", "reject", 0.40))
+
+    work_b = _stage(run_dir, "cand_b", "seed")
+    _ok(_commit(run_dir, work_b, "cand_b", "accept", 0.70))
+    assert run_dir.best_id == "cand_b"
+
+    # Round 2: cand_c forks from the NEW best (cand_b), with a screen record on disk
+    # BEFORE it is committed — proving graph.jsonl picks up screen.py's own artifact
+    # rather than requiring a new input.
+    work_c = _stage(run_dir, "cand_c", "cand_b")
+    screens = run_dir.root / "screens"
+    screens.mkdir(parents=True, exist_ok=True)
+    (screens / "cand_c__screen1.json").write_text(json.dumps({
+        "tag": "cand_c", "screen_tag": "cand_c__screen1", "tier": 1,
+        "subset": {"ids": ["1", "2", "3"]}, "decision": "promote",
+        "mean_delta": 0.05, "se": 0.02,
+    }), encoding="utf-8")
+    _ok(_commit(run_dir, work_c, "cand_c", "accept", 0.80))
+    assert run_dir.best_id == "cand_c"
+
+    # A MERGE candidate combining cand_a and cand_c (2 parents) — the data model #434
+    # asks Phase 1 to support even though #438 owns the merge LOGIC. --parents is the
+    # only thing commit.py cannot infer on its own.
+    work_m = _stage(run_dir, "cand_merge", "cand_c")
+    _ok(_commit(run_dir, work_m, "cand_merge", "accept", 0.85,
+                "--parents", "cand_a,cand_c"))
+
+    nodes = {n["id"]: n for n in _graph_nodes(run_dir)}
+    assert set(nodes) == {"cand_a", "cand_b", "cand_c", "cand_merge"}
+
+    # --- cross-check against events.jsonl (pre-existing, independent of graph.jsonl) ---
+    steps = _step_events(run_dir)
+    for cid, node in nodes.items():
+        assert cid in steps, f"{cid} has a graph node but no step event — not a view"
+        expected_accept = steps[cid]["accept"]
+        assert node["status"] == ("accepted" if expected_accept else "rejected")
+        if cid != "cand_merge":  # single-parent nodes: parent must match the step event
+            assert node["parents"] == [steps[cid]["parent"]]
+
+    # --- edit_kind / parents shape ---
+    assert nodes["cand_a"]["parents"] == ["seed"]
+    assert nodes["cand_a"]["edit_kind"] == "code"
+    assert nodes["cand_b"]["parents"] == ["seed"]
+    assert nodes["cand_c"]["parents"] == ["cand_b"]
+    assert nodes["cand_merge"]["parents"] == ["cand_a", "cand_c"]
+    assert nodes["cand_merge"]["edit_kind"] == "merge"
+
+    # --- cross-check the screen/subset fields against the screen file written above ---
+    assert nodes["cand_c"]["screen"] is not None
+    assert nodes["cand_c"]["screen"]["subset_ids"] == ["1", "2", "3"]
+    assert nodes["cand_c"]["screen"]["decision"] == "promote"
+    assert nodes["cand_c"]["subset"]["task_ids"] == ["1", "2", "3"]
+    # cand_a/cand_b/cand_merge never went through screen.py — no screen artifact exists.
+    assert nodes["cand_a"]["screen"] is None
+    assert nodes["cand_b"]["screen"] is None
+
+    # --- val_mean matches what was committed ---
+    assert nodes["cand_a"]["val_mean"] == 0.40
+    assert nodes["cand_c"]["val_mean"] == 0.80
+
+    # --- build_dag reconstructs the correct children edges ---
+    dag = graph.build_dag(run_dir)
+    assert set(dag["cand_b"]["children"]) == {"cand_c"}
+    assert set(dag["cand_a"]["children"]) == {"cand_merge"}
+    assert set(dag["cand_c"]["children"]) == {"cand_merge"}
+    assert dag["cand_merge"]["children"] == []
+
+
+def test_graph_jsonl_absent_when_never_committed(tmp_path):
+    """No commit -> no graph.jsonl. It is written lazily by the same step that would
+    otherwise write nothing at all — never pre-created, never required to exist."""
+    from cap_evolve import graph
+
+    run_dir = _run_dir(tmp_path)
+    assert not (run_dir.root / graph.GRAPH_FILENAME).exists()
+    assert graph.read_nodes(run_dir) == []

--- a/skills/algorithms/agent-optimize/scripts/commit.py
+++ b/skills/algorithms/agent-optimize/scripts/commit.py
@@ -300,6 +300,16 @@ def main(argv=None) -> int:
                    help="commit even though this candidate id already has a decision "
                         "(audit/repair only — it overwrites the earlier snapshot); also "
                         "overrides the inconclusive-without-growth guard below")
+    # graph.jsonl (#435): a MERGE candidate (integrate.py/funcmerge.py/merge_taskopt.py)
+    # has 2+ parents this script has no other way to learn — those scripts produce a
+    # merged artifact dir, not a commit. An ordinary edit's single parent is already
+    # known (best_id at gate time, below) and needs no flag.
+    p.add_argument("--parents", default=None,
+                   help="comma-separated parent candidate ids, for a MERGE candidate "
+                        "(2+ parents). Omit for an ordinary edit.")
+    p.add_argument("--edit-kind", default=None, choices=["prompt", "code", "merge"],
+                   help="graph.jsonl node kind; defaults to 'merge' when --parents has "
+                        "2+ ids, else 'code'.")
     args = p.parse_args(argv)
 
     run_dir = RunDir.open(Path(args.run_dir))
@@ -388,6 +398,8 @@ def main(argv=None) -> int:
     # The parent this candidate was gated against — ``gate_check --current`` defaults to
     # ``best_id``, so read it BEFORE ``set_best`` moves it.
     parent_id = run_dir.best_id or "seed"
+    parents = ([p.strip() for p in args.parents.split(",") if p.strip()]
+               if args.parents else [parent_id])
     run_dir.snapshot(args.candidate_id, src)
     if accepted:
         run_dir.set_best(args.candidate_id)
@@ -444,6 +456,7 @@ def main(argv=None) -> int:
                                  val=args.val,
                                  parent_val=parent_val,
                                  indecisive=indecisive,
+                                 parents=parents, edit_kind=args.edit_kind,
                                  opt_cost_usd=args.optimizer_usd or None,
                                  opt_tokens=args.optimizer_tokens or None,
                                  optimizer_seconds=args.optimizer_seconds or None,


### PR DESCRIPTION
## Summary

Addresses #435 (Phase 1 of the #434 redesign).

- Adds `core/cap_evolve/graph.py`: an append-only `$R/graph.jsonl` node-per-candidate log — `id`, `parents`, `edit_kind`, `cluster_ids`, `micro_tests`, `subset`, `status`, `val_mean`, `screen`, `gate` — matching #434's `CandidateNode` schema.
- Wires the writer into `harness.record_iteration`, the one shared step every algorithm (agent-mode `commit.py`, hill-climb, gepa, skillopt) already routes through (#216/#224) — every path gets a DAG node with no per-caller plumbing.
- `commit.py` gains `--parents`/`--edit-kind` so a future merge candidate (`integrate.py`/`funcmerge.py`/`merge_taskopt.py` output, #438's job) can record 2+ parents. An ordinary edit needs neither flag; its parent is inferred exactly as before.

**No behavior change.** Nothing about how a candidate is measured, screened, gated, or accepted changes. Every field but `id`/`parents`/`status` is read back from artifacts that already exist:
- `gate` ← `round.py`'s persisted `work/*.json` gate table row (same lookup `commit.py._gate_row` already does).
- `screen` / `subset` ← merged `screens/<tag>__screenN.json` tiers, if any ran.

That's what makes `graph.jsonl` a *view*, not a new source of truth.

## Test plan

- [x] New `core/tests/test_graph_jsonl.py`: a multi-round, multi-sibling scenario (two siblings off `seed`, one rejected/one accepted; a third candidate off the new best; a merge candidate with 2 parents via `--parents`), asserting:
  - every graph node's `parents`/`status` matches the independently-read `events.jsonl` step record for that candidate (proves it's a view, not a new authority);
  - `screen`/`subset` on a node matches a `screens/*.json` file written before commit;
  - `edit_kind` is `"merge"` for the 2-parent node, `"code"` otherwise;
  - `graph.build_dag()` reconstructs the correct parent→children edges;
  - no commit ⇒ no `graph.jsonl` file (lazily written, never required).
- [x] `python -m pytest core/tests` — 1171 passed, 12 skipped (no regressions).
- [x] `python skills/algorithms/agent-optimize/scripts/check.py` — `"ok": true`, no problems.