### PR TITLE
Resolve remaining items in #420 (2, 10)

### DIFF
--- a/ci/benchmarks/lib/run_suite.sh
+++ b/ci/benchmarks/lib/run_suite.sh
@@ -150,15 +150,22 @@ PY
 [ "${#IDS[@]}" -gt 0 ] || { echo "::warning::tasks.json empty for $BENCH/$TIER"; echo "## ${TIER^} suite — $BENCH" > "$OUT/report.md"; echo "(no tasks)" >> "$OUT/report.md"; exit 0; }
 # AGENT_MODEL (env — the workflow's `agent_model` input, or its default) is
 # AUTHORITATIVE: it's what this run actually uses. tasks.json's per-task "agent"
-# field is only consulted to WARN on a mismatch (e.g. a curated task pinned to a
-# different model than requested) — it never silently overrides the caller's choice.
-"$PY" - "$BASE/tasks.json" "$AGENT_MODEL" <<'PY'
+# field is PROVENANCE, not a pin to enforce — it records which model a tier's tasks were
+# curated/measured against (e.g. pilot/tasks.json's "agent" names the one model the whole
+# tier exists to validate — see make_pilot.py's AGENT). Picking a different agent_model on
+# dispatch is a normal, deliberate thing to do (that IS the benchmark), so a mismatch is
+# informational, never a "::warning::" — a same-every-time warning trains people to stop
+# reading warnings (#420 item 10).
+"$PY" - "$BASE/tasks.json" "$AGENT_MODEL" "$BENCH/$TIER" <<'PY'
 import json,sys
 ts=json.load(open(sys.argv[1]))
 agents={t.get("agent") for t in ts if t.get("agent")}
-env_model=sys.argv[2]
+env_model, tier = sys.argv[2], sys.argv[3]
 if agents and agents != {env_model}:
-    sys.stderr.write(f"::warning::tasks.json pins agent(s) {sorted(agents)} but this run uses {env_model!r} (override)\n")
+    sys.stderr.write(f"::notice::tasks.json records {sorted(agents)} as the agent "
+                      f"{tier}'s tasks were curated/measured against; this run uses "
+                      f"{env_model!r} instead, which is expected when deliberately "
+                      f"evaluating a different agent\n")
 PY
 IDS_CSV="$(IFS=,; echo "${IDS[*]}")"
 echo ">>> $BENCH/$TIER — optimizing ${#IDS[@]} tasks together (agent=$AGENT_MODEL, ${ITER} iters)" >&2

--- a/core/tests/test_run_suite_split_hook.py
+++ b/core/tests/test_run_suite_split_hook.py
@@ -160,3 +160,48 @@ def test_spreadsheetbench_tier_defaults(tier, turns, concurrency, dataset):
 def test_max_turns_is_overridable():
     src = RUN_SUITE.read_text(encoding="utf-8")
     assert "SPREADSHEETBENCH_MAX_TURNS=${SPREADSHEETBENCH_MAX_TURNS:-$SB_MAX_TURNS_DEFAULT}" in src
+
+
+def _agent_provenance_block() -> str:
+    """Lift the tasks.json agent-provenance check verbatim out of run_suite.sh."""
+    src = RUN_SUITE.read_text(encoding="utf-8")
+    start = src.index("# AGENT_MODEL (env")
+    end = src.index("IDS_CSV=", start)
+    block = src[start:end]
+    assert '"$PY" - "$BASE/tasks.json" "$AGENT_MODEL" "$BENCH/$TIER"' in block
+    return block
+
+
+def _run_agent_provenance(tmp_path: Path, tasks: list[dict], agent_model: str):
+    base = tmp_path / "base"
+    base.mkdir(parents=True)
+    (base / "tasks.json").write_text(json.dumps(tasks), encoding="utf-8")
+    script = textwrap.dedent(f"""
+        set -euo pipefail
+        PY=python3
+        BASE={base}
+        BENCH=spreadsheetbench
+        TIER=pilot
+        AGENT_MODEL={agent_model}
+    """) + _agent_provenance_block()
+    return subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+
+
+def test_agent_mismatch_annotation(tmp_path):
+    """#420 item 10: the field is provenance (which agent a tier was curated/measured against),
+    not a canonical pin — deliberately running a different agent is expected, so the annotation
+    must not read as "::warning::" (a same-every-run warning teaches people to ignore warnings).
+    """
+    proc = _run_agent_provenance(
+        tmp_path, [{"id": "1", "agent": "azure/gpt-5.5"}], "aws/gpt-oss-120b")
+    assert proc.returncode == 0, proc.stderr
+    assert "::warning::" not in proc.stderr
+    assert "::notice::" in proc.stderr
+    assert "azure/gpt-5.5" in proc.stderr and "aws/gpt-oss-120b" in proc.stderr
+
+
+def test_agent_match_emits_nothing(tmp_path):
+    proc = _run_agent_provenance(
+        tmp_path, [{"id": "1", "agent": "aws/gpt-oss-120b"}], "aws/gpt-oss-120b")
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stderr == ""

--- a/skills/algorithms/agent-optimize/SKILL.md
+++ b/skills/algorithms/agent-optimize/SKILL.md
@@ -294,6 +294,17 @@ for you: **never hand a subset result to `gate_check.py`** — its `coverage` re
 denominator *is* the subset; and **a round that produced no run-dir artifacts is a bug**, so fix it
 rather than driving around the primitives.
 
+**A broken framework file is reported, never hand-worked-around.** `round.py`/`gate_check.py` already
+raise `GateCheckFailed` and write nothing to the round table when a gate fails to run — that specific
+crash can no longer produce a null-filled table to work around. The rule is general and covers every
+other framework output too: if a round-table row, a `screen.py`/`measure.py` result, or any other
+framework artifact comes back malformed (missing keys, unparsable JSON, a non-zero exit), **stop and
+say exactly what is broken** in your report — do not recompute the verdict by hand from raw files and
+keep going, even if your hand-computed number is correct. The rollouts stay on disk, so re-running the
+tool that produced the artifact is free; silently substituting your own arithmetic is the one thing
+that is not, because nothing downstream can then tell the difference between a judged round and one
+you judged yourself. `references/algorithm.md`, "How honesty survives handing the agent the wheel".
+
 ## References
 
 One level deep — each is read on its own, and none points at another.

--- a/skills/algorithms/agent-optimize/SKILL.md
+++ b/skills/algorithms/agent-optimize/SKILL.md
@@ -289,30 +289,19 @@ No finalize, no result.
 ## Honesty invariants that are yours by hand
 
 Core enforces the split seal, the val-only gate and the tamper guard whether you cooperate or not
-(`skills/phases/{evaluate,gate,finalize}` document them). Two are yours, because no script can do them
-for you: **never hand a subset result to `gate_check.py`** — its `coverage` reads 1.0 because its
-denominator *is* the subset; and **a round that produced no run-dir artifacts is a bug**, so fix it
-rather than driving around the primitives.
+(`skills/phases/{evaluate,gate,finalize}` document them). Two are yours: **never hand a subset result
+to `gate_check.py`** — its `coverage` reads 1.0 because its denominator *is* the subset; and **a round
+with no run-dir artifacts is a bug**, so fix it rather than drive around the primitives.
 
-**A broken framework file is reported, never hand-worked-around.** `round.py`/`gate_check.py` already
-raise `GateCheckFailed` and write nothing to the round table when a gate fails to run — that specific
-crash can no longer produce a null-filled table to work around. The rule is general and covers every
-other framework output too: if a round-table row, a `screen.py`/`measure.py` result, or any other
-framework artifact comes back malformed (missing keys, unparsable JSON, a non-zero exit), **stop and
-say exactly what is broken** in your report — do not recompute the verdict by hand from raw files and
-keep going, even if your hand-computed number is correct. The rollouts stay on disk, so re-running the
-tool that produced the artifact is free; silently substituting your own arithmetic is the one thing
-that is not, because nothing downstream can then tell the difference between a judged round and one
-you judged yourself. `references/algorithm.md`, "How honesty survives handing the agent the wheel".
+**Report a broken framework file, don't hand-work around it.** `references/algorithm.md` §honesty.
 
 ## References
 
 One level deep — each is read on its own, and none points at another.
 
-- [`references/algorithm.md`](references/algorithm.md) — why free-form, how the honesty invariants
-  survive full autonomy, the screening break-even (incl. targeted-cluster holdouts), which steps
-  parallelise safely, the constraint surface, provisional candidates. **Load** before relying on a
-  screen, growing a candidate, or skipping a rule.
+- [`references/algorithm.md`](references/algorithm.md) — why free-form, how honesty survives full
+  autonomy, the screening break-even, parallel-safe steps, the constraint surface, provisional
+  candidates. **Load** before relying on a screen, growing a candidate, or skipping a rule.
 - [`references/measured-lessons.md`](references/measured-lessons.md) — every measurement rule with the
   number that bought it: binomial floor, full val vs a hard subset, the load-vs-noise tables, the sign
   test, the across-runs estimator. **Load** before your first gate decision on a new benchmark, or

--- a/skills/algorithms/agent-optimize/references/algorithm.md
+++ b/skills/algorithms/agent-optimize/references/algorithm.md
@@ -54,6 +54,22 @@ agent does:
   applies. It is what diagnose's `kept_good` list exists to protect.
 - **Edits are audited.** Every candidate is snapshotted in the git-backed store and every
   round is appended to `events.jsonl`, so the search is fully reconstructable.
+- **A broken framework file stops the round, it does not get hand-worked-around.** On run
+  33492876620 round 3, `_gate()` swallowed a `gate_check.py` crash into `{"error": ...}` and
+  the caller `.get()`'d the missing verdict keys into `null`s in the round table; the agent
+  noticed, recomputed the verdicts itself from `gate_check.py`'s raw output, booked the round
+  `inconclusive` by hand, and said so in `JOURNAL.md`. That specific case is now closed by
+  code: `_gate()` raises `GateCheckFailed` on a non-zero exit or unparsable stdout,
+  `assert_rows_were_judged` refuses to publish any row whose reward is `null` when its own
+  eval succeeded, and `round.py` exits non-zero with nothing written to the table — so there
+  is no broken table left standing to work around. The **general** rule survives that fix and
+  covers every other framework artifact (a malformed `screen.py`/`measure.py`/`diagnose`
+  output, a torn JSON file on disk): treat it the same way `GateCheckFailed` is treated,
+  never the way the old `_gate()` did. Stop, report the malformed file and what it should have
+  contained, and let the caller re-run it — the underlying rollouts are already on disk, so
+  re-deriving the verdict is free. Do **not** recompute a substitute number by hand and keep
+  going, even when the hand-computed number turns out right, because the run is no longer
+  telling anyone when this happens.
 
 So the "free" in free-form is freedom of *strategy*, not freedom to fake a result. The
 headline number is still produced once, on data the search never saw.


### PR DESCRIPTION
## Summary

Resolves remaining items in #420 (items 2 and 10 — everything else closed by #442/#443).

**Item 2 — policy decision: stop and report, never hand-work-around a broken framework file.**

Decision made by the reporting team: the host must halt loudly on a broken/malformed
framework artifact, not silently substitute its own hand-computed numbers.

Investigated whether #442's `GateCheckFailed` fix (`round.py`/`gate_check.py` now raise
instead of returning a result-shaped `{"error": ...}` dict, and `assert_rows_were_judged`
refuses to publish any row with a null reward when its own eval succeeded) already closes
this. **It does, for the specific mechanism the report describes**: a null-filled round
table can no longer be silently produced, so there is no broken table left standing to
work around in that path — no redundant code guard added there.

What was still missing was the **general driver-facing rule**, since other framework
artifacts (a malformed `screen.py`/`measure.py` output, a torn JSON file) could still hand
the agent something broken. Added to:
- `skills/algorithms/agent-optimize/SKILL.md` ("Honesty invariants that are yours by hand")
- `skills/algorithms/agent-optimize/references/algorithm.md` ("How honesty survives handing
  the agent the wheel")

Both point at the correct recovery path: report the malformed file and what it should have
contained, then re-run the tool that produced it (the rollouts are already on disk, so this
is free) — never recompute a substitute verdict by hand and keep going, even when the
hand-computed number turns out correct.

**Item 10 — investigated, not blind-edited: the "agent" field is provenance, not a stale pin.**

Grepped every consumer of `tasks.json`'s `agent` field and read the git history of the code
that reads it:
- `ci/benchmarks/lib/run_suite.sh` (`#162`, `77697eca`) already documents the intended
  precedence explicitly in a comment: `AGENT_MODEL` (the workflow input) is
  **authoritative**; `tasks.json`'s `agent` field is "only consulted to WARN on a mismatch
  (e.g. a curated task pinned to a different model than requested) — it never silently
  overrides the caller's choice."
- `ci/benchmarks/spreadsheetbench/utils/make_pilot.py` confirms the field is per-tier
  **curation/measurement provenance**: `pilot`'s tasks are stamped with `azure/gpt-5.5`
  because that pilot tier's entire purpose is validating that specific model — a
  deliberately different value from `full`/`smoke`'s `aws/gpt-oss-120b`, exactly what a
  prior teammate flagged as "already-different value" that must not be overwritten.
- `ci/benchmarks/lib/sync_models.py`'s own docstring: "`ci/benchmarks/*/<tier>/tasks.json`
  `agent` pins are checked and reported. They are **advisory** ... so a stale pin is noise,
  not breakage."
- The workflow's own default `agent_model` (`aws/gpt-oss-120b`) already matches every
  current `tasks.json` pin, so the flagged warning only fires when a run **deliberately**
  dispatches with a different agent — exactly the case #420's own run did
  (`Azure/gpt-5-mini-2025-08-07`). That is expected, correct behaviour, not staleness.

So this is **provenance metadata, not a canonical pin** — bulk find-replacing ~900 tasks
would have destroyed real curation information (which model each tier/task set was
selected or measured against) for no reason. Fixed the warning instead: reworded and
downgraded `ci/benchmarks/lib/run_suite.sh`'s annotation from `::warning::` to `::notice::`,
and made the message say explicitly that a mismatch is expected when deliberately
evaluating a different agent than a tier was curated against — "a warning that fires every
time teaches people to ignore warnings" is exactly what a same-every-run `::warning::` was
doing.

## Test plan

- [x] `python3 -m pytest core/tests/test_run_suite_split_hook.py` — 15 passed (includes two
  new tests: the mismatch case emits `::notice::` and not `::warning::`; the matching case
  emits nothing)
- [x] `python3 -m pytest core/tests/test_a_failed_gate_is_not_a_verdict.py
  ci/benchmarks/lib/test_sync_models.py` — 33 passed (unaffected, confirms no regression)
- [x] `python3 skills/algorithms/agent-optimize/scripts/check.py` — `ok: true`, no problems
  (SKILL.md still 336/500 lines)
- [x] `bash -n ci/benchmarks/lib/run_suite.sh` — syntax OK