### PR TITLE
agent-optimize: merge-as-graph-search over disjoint-cluster survivors (#438)

### DIFF
--- a/core/tests/test_merge_search.py
+++ b/core/tests/test_merge_search.py
@@ -1,0 +1,249 @@
+"""merge_search — disjoint-cluster survivors get merged via existing integrate.py machinery,
+and the result is an ordinary candidate directory that round.py's normal gate cascade picks up
+with no special-casing (#438, child of #434/#438's "4. Concurrent multi-issue candidates, then
+graph-search merge").
+
+A fixture capability exposes a `tools/tools.py` with three independent functions. Two survivor
+branches each fix ONE function (disjoint edits); a third branch fixes the SAME function branch A
+does, but differently (an overlapping edit). merge_search.py must:
+  1. identify the (A, B) pair as mergeable and the (A, C) / (B, C)-with-C pairs as NOT (shared
+     function), never attempting a merge across a real edit collision;
+  2. build the (A, B) merge via `integrate.py`/`funcmerge.py` — the SAME merge engine any
+     hand-driven merge in this skill uses, not a bespoke one;
+  3. leave the merged artifact as a plain `$R/work/merge_A_B` directory that `round.py` gates
+     exactly like any other candidate tag, control included.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPTS = REPO / "skills" / "algorithms" / "agent-optimize" / "scripts"
+
+TOOLS_BASE = '''
+def fn_a(x):
+    return x
+
+def fn_b(x):
+    return x
+
+def fn_c(x):
+    return x
+'''
+
+TOOLS_FIX_A = '''
+def fn_a(x):
+    return x + "MARK_A"
+
+def fn_b(x):
+    return x
+
+def fn_c(x):
+    return x
+'''
+
+TOOLS_FIX_B = '''
+def fn_a(x):
+    return x
+
+def fn_b(x):
+    return x + "MARK_B"
+
+def fn_c(x):
+    return x
+'''
+
+# Overlaps branch A: rewrites fn_a DIFFERENTLY — a real edit collision, not a pure insertion.
+TOOLS_FIX_A_DIFFERENTLY = '''
+def fn_a(x):
+    return x + "OTHER_MARK_A"
+
+def fn_b(x):
+    return x
+
+def fn_c(x):
+    return x
+'''
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.path.insert(0, str(path.parent))
+    assert spec and spec.loader
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _write_project(tmp_path: Path) -> Path:
+    """A tiny cap-evolve project whose adapter scores tasks by reading tools/tools.py's
+    text — t0/t1 need MARK_A, t2/t3 need MARK_B, t4/t5 pass unconditionally (stable canaries).
+    """
+    project = tmp_path / "project"
+    (project / "adapters").mkdir(parents=True)
+    (project / "adapters" / "adapter.py").write_text('''
+from pathlib import Path
+from cap_evolve.adapter import CapabilityAdapter
+from cap_evolve.trials import run_trials_pool
+from cap_evolve.types import Task, Rollout, Score
+
+NEEDS = {"t0": "MARK_A", "t1": "MARK_A", "t2": "MARK_B", "t3": "MARK_B"}
+
+class Adapter(CapabilityAdapter):
+    def tasks(self, split):
+        return [Task(id=f"t{i}") for i in range(6)]
+
+    def run_target(self, task, ctx, *, seed=0):
+        src = (Path(ctx) / "tools" / "tools.py").read_text(encoding="utf-8")
+        return Rollout(task_id=task.id, output=src)
+
+    def run_trials(self, tasks, ctx, *, n_trials, base_seed):
+        return run_trials_pool(lambda t, s: self.run_target(t, ctx, seed=s), tasks,
+                               n_trials=n_trials, base_seed=base_seed)
+
+    def score(self, task, rollout):
+        src = rollout.output or ""
+        need = NEEDS.get(task.id)
+        ok = True if need is None else (need in src)
+        return Score(task_id=task.id, reward=1.0 if ok else 0.0,
+                     feedback="ok" if ok else f"needs {need}", trial_rewards=[1.0 if ok else 0.0])
+''', encoding="utf-8")
+    return project
+
+
+def _seed_capability(root: Path, name: str, tools_src: str) -> Path:
+    d = root / name
+    (d / "tools").mkdir(parents=True, exist_ok=True)
+    (d / "tools" / "tools.py").write_text(tools_src, encoding="utf-8")
+    (d / "policy").mkdir(parents=True, exist_ok=True)
+    (d / "policy" / "policy.md").write_text("base policy\n", encoding="utf-8")
+    return d
+
+
+def _run_dir_with_survivors(tmp_path: Path):
+    """A run dir past baseline, with base/A/B/C staged under work/ like a real round would
+    leave them, plus mechanisms.jsonl rows recording each survivor's target tasks."""
+    from cap_evolve import Budget, RunDir, harness
+
+    project = _write_project(tmp_path)
+    adapter = _load("forge_project_adapter", project / "adapters" / "adapter.py").Adapter()
+
+    run_dir = RunDir.create(tmp_path / ".capevolve", ts="ci", budget=Budget(max_iterations=10))
+    seed = _seed_capability(tmp_path, "seed_capability", TOOLS_BASE)
+    harness.ensure_splits(adapter, run_dir, seed=0,
+                          split_ids={"val": [f"t{i}" for i in range(6)], "train": [], "test": []})
+    harness.baseline(adapter, seed, run_dir=run_dir)
+
+    work = run_dir.root / "work"
+    for tag, src in (("A", TOOLS_FIX_A), ("B", TOOLS_FIX_B), ("C", TOOLS_FIX_A_DIFFERENTLY)):
+        _seed_capability(work, tag, src)
+
+    mech = SCRIPTS / "mechanisms.py"
+    for tag, tids in (("A", ["t0", "t1"]), ("B", ["t2", "t3"]), ("C", ["t0", "t1"])):
+        subprocess.run([sys.executable, str(mech), "add", "--run-dir", str(run_dir.root),
+                       "--owner", tag, "--status", "proposed",
+                       "--mechanism", f"fixes {tag}", "--evidence", "screen promoted it",
+                       "--touches", "tools/tools.py",
+                       *[a for t in tids for a in ("--task", t)]],
+                      capture_output=True, text=True, check=True)
+    return run_dir, project, adapter
+
+
+def _run_merge_search(run_dir, project, **extra):
+    cmd = [sys.executable, str(SCRIPTS / "merge_search.py"),
+          "--run-dir", str(run_dir.root), "--project", str(project),
+          "--base", "seed", "--survivors", "A,B,C",
+          "--canary-auto", str(run_dir.root / "baseline.json"),
+          "--n", "2", "--conc", "1"]
+    for k, v in extra.items():
+        if isinstance(v, list):
+            for item in v:
+                cmd += [f"--{k}", item]
+        else:
+            cmd += [f"--{k}", str(v)]
+    p = subprocess.run(cmd, capture_output=True, text=True)
+    assert p.returncode == 0, f"merge_search.py failed: {p.stdout}\n{p.stderr}"
+    return json.loads(p.stdout)
+
+
+def test_disjoint_survivors_are_identified_as_a_merge_pair_and_overlapping_ones_are_not(tmp_path):
+    run_dir, project, _adapter = _run_dir_with_survivors(tmp_path)
+    out = _run_merge_search(run_dir, project)
+
+    assert ["A", "B"] in out["disjoint_pairs"], f"A+B (disjoint edits) not offered: {out}"
+    overlapping = {tuple(o["pair"]) for o in out["overlapping_pairs_skipped"]}
+    assert ("A", "C") in overlapping, f"A+C (both rewrite fn_a) must be flagged overlapping: {out}"
+    assert ("B", "C") not in overlapping and ["B", "C"] in out["disjoint_pairs"], (
+        f"B+C touch different functions and should be offered too: {out}")
+    # C's own overlap reason must name the actually-shared function.
+    a_c = next(o for o in out["overlapping_pairs_skipped"] if tuple(o["pair"]) == ("A", "C"))
+    assert a_c["shared"] == ["fn_a"], f"wrong shared-function attribution: {a_c}"
+
+
+def test_the_merge_is_attempted_via_existing_integrate_py_machinery(tmp_path):
+    run_dir, project, _adapter = _run_dir_with_survivors(tmp_path)
+    out = _run_merge_search(run_dir, project)
+
+    ab = next(m for m in out["merges"] if m["pair"] == ["A", "B"])
+    assert ab["attempted"] and ab["built"], f"A+B merge was not built: {ab}"
+    assert ab["result"].get("final_objective") is not None, (
+        f"integrate.py's own measurement is missing from the result: {ab}")
+    # The written artifact is the union of both branches' fixes — funcmerge.py's per-function
+    # merge, not a hand-written stitch.
+    merged_src = (run_dir.root / "work" / ab["tag"] / "tools" / "tools.py").read_text()
+    assert "MARK_A" in merged_src and "MARK_B" in merged_src, (
+        f"merged artifact does not carry both branches' fixes:\n{merged_src}")
+
+    # A merge that overlaps (A, C) must never even be attempted.
+    ac = [m for m in out["merges"] if m["pair"] == ["A", "C"]]
+    assert not ac, f"an overlapping pair must not appear in merges[] at all: {out['merges']}"
+
+    assert ab["tag"] in out["ready_for_gate"]
+
+    # mechanisms.jsonl records the merge as a first-class finding, same ledger any hand-driven
+    # merge would use (per-task-fanout.md), not a side channel only this script can read.
+    ledger = [json.loads(ln) for ln in
+             (run_dir.root / "mechanisms.jsonl").read_text().splitlines() if ln.strip()]
+    merge_rows = [r for r in ledger if r["owner"] == ab["tag"]]
+    assert merge_rows, "the merge was not recorded in mechanisms.jsonl"
+    assert sorted(merge_rows[0]["tasks"]) == ["t0", "t1", "t2", "t3"]
+
+
+def test_the_merge_result_goes_through_rounds_normal_gate_cascade(tmp_path):
+    """The merged candidate is gated by round.py with NO special-casing: the SAME mandatory
+    screen ladder (#420/#442), null control, and paired significance a hand-authored
+    candidate goes through — a merge is a candidate, not a shortcut past the cascade."""
+    run_dir, project, _adapter = _run_dir_with_survivors(tmp_path)
+    out = _run_merge_search(run_dir, project)
+    ab = next(m for m in out["merges"] if m["pair"] == ["A", "B"])
+    assert ab["built"]
+
+    screen = subprocess.run(
+        [sys.executable, str(SCRIPTS / "screen.py"), "--run-dir", str(run_dir.root),
+         "--project", str(project), "--candidate", str(run_dir.root / "work" / ab["tag"]),
+         "--tag", ab["tag"], "--tier", "1"],
+        capture_output=True, text=True)
+    assert screen.returncode == 0, f"screen.py failed on the merge candidate: {screen.stdout}\n{screen.stderr}"
+    assert json.loads(screen.stdout)["decision"] == "promote", (
+        "the merge should screen as a real improvement, not get killed pre-gate: "
+        f"{screen.stdout}")
+
+    p = subprocess.run(
+        [sys.executable, str(SCRIPTS / "round.py"), "--run-dir", str(run_dir.root),
+         "--project", str(project), "--candidates", ab["tag"], "--n-trials", "2",
+         "--concurrency", "1"],
+        capture_output=True, text=True)
+    assert p.returncode == 0, f"round.py could not gate the merge candidate: {p.stdout}\n{p.stderr}"
+    table = json.loads(p.stdout)
+
+    row = next(c for c in table["candidates"] if c["tag"] == ab["tag"])
+    # t0,t1,t2,t3 now pass (both fixes merged); t4,t5 already passed. Full val = 1.0, seed = 0.0.
+    assert row["reward"] == 1.0, f"merged candidate did not measure the combined fix: {row}"
+    assert row["verdict"] == "accept", f"round.py's ordinary gate did not accept a real gain: {row}"
+    assert row["gate_delta"] is not None and row["gate_threshold"] is not None, (
+        f"the merge did not get the SAME structured gate numbers any candidate gets: {row}")

--- a/skills/algorithms/agent-optimize/scripts/integrate.py
+++ b/skills/algorithms/agent-optimize/scripts/integrate.py
@@ -46,11 +46,19 @@ HERE = Path(__file__).resolve().parent
 
 
 def _measure(pyexe: str, taskeval: Path, cand: Path, tasks: str, canary: str,
-             n: int, conc: int, base_seed: int) -> dict:
-    """Run taskeval on one candidate and return {task: rate} plus the objective."""
+             n: int, conc: int, base_seed: int, project: str) -> dict:
+    """Run taskeval on one candidate and return {task: rate} plus the objective.
+
+    ``base_seed`` is accepted for the caller's own record-keeping (see the ``measurement``
+    block in the final report) but is NOT forwarded to taskeval.py, which has no such flag —
+    it always evaluates at its own internal seed 0. Forwarding it anyway used to make this
+    call fail argparse outright with "unrecognized arguments", right after failing it a
+    second way for the missing ``--project`` this function now supplies: this script had
+    never actually been run end-to-end (see #434/#438), and both defects were latent.
+    """
     out = cand.parent / f".{cand.name}_eval.json"
-    cmd = [pyexe, str(taskeval), str(cand), tasks, "--n", str(n), "--conc", str(conc),
-           "--base-seed", str(base_seed), "--json", str(out)]
+    cmd = [pyexe, str(taskeval), str(cand), tasks, "--project", project,
+           "--n", str(n), "--conc", str(conc), "--json", str(out)]
     if canary:
         cmd += ["--canary", canary, "--canary-n", str(max(3, n // 2))]
     p = subprocess.run(cmd, capture_output=True, text=True)
@@ -80,6 +88,8 @@ def _objective(rates: dict, tasks: list[str], canary: list[str]) -> float | None
 def main(argv=None) -> int:
     ap = argparse.ArgumentParser(prog="integrate")
     ap.add_argument("--base", required=True, help="starting artifact dir (the current best)")
+    ap.add_argument("--project", required=True,
+                    help="cap-evolve project dir (holds adapters/), forwarded to taskeval.py")
     ap.add_argument("--branches", nargs="+", required=True,
                     help="branch artifact dirs, applied in the order given; put the "
                          "best-evidenced branch first so a later regression is attributable")
@@ -158,7 +168,7 @@ def main(argv=None) -> int:
         shutil.rmtree(junk, ignore_errors=True)
 
     ev = _measure(args.python, taskeval, out, args.tasks, args.canary,
-                  args.n, args.conc, args.base_seed)
+                  args.n, args.conc, args.base_seed, args.project)
     if "error" in ev:
         print(json.dumps({"error": "baseline measurement failed", "detail": ev["error"]}, indent=2))
         return 2
@@ -194,7 +204,7 @@ def main(argv=None) -> int:
                                   "NOT applied; base prose already modified by an earlier step"})
 
         ev = _measure(args.python, taskeval, trial, args.tasks, args.canary,
-                      args.n, args.conc, args.base_seed)
+                      args.n, args.conc, args.base_seed, args.project)
         if "error" in ev:
             steps.append({"step": b.name, "decision": "reject", "reason": "eval failed",
                           "detail": ev["error"]})

--- a/skills/algorithms/agent-optimize/scripts/merge_search.py
+++ b/skills/algorithms/agent-optimize/scripts/merge_search.py
@@ -1,0 +1,314 @@
+"""merge_search — pairwise merge-as-graph-search over a round's disjoint-cluster survivors.
+
+Why this exists. run_agentoptv3/run_agentoptv4 produced 3-6 narrow, single-issue candidates
+per round, each individually gated on full val and rejected, and NEVER combined — no
+integrate.py/funcmerge.py/merge_taskopt.py call appears in either run (#434, #438). The
+merge machinery already exists and already works (see integrate.py/funcmerge.py's own
+docstrings for the measured cases it was built to fix); the missing piece is simply DECIDING
+which survivors are safe to try merging and DOING it, instead of leaving that to a driver
+under time pressure who defaults to the cheapest step (another single candidate).
+
+A round's "survivors" are candidates that got PAST screening (screen.py promote, or a
+grow.py-provisional that ran out of growth rounds) without individually clearing the full-val
+accept gate — see round.py/screen.py/grow.py. Two survivors are a MERGE CANDIDATE when the
+functions/constants they changed, relative to the same base, are DISJOINT: `funcmerge.py`'s
+own docstring is the reason overlapping edits are refused here rather than attempted — a
+same-function collision is a genuine semantic disagreement funcmerge.py already declines to
+auto-resolve, and offering it to a human via a merge conflict is not "graph search", it is
+"ask a human what the graph search could not decide". Disjoint edits are exactly the
+provably-safe case per-task-fanout.md already describes.
+
+This script does NOT invent a new merge engine. Per pair it shells out to `integrate.py`
+(one branch at a time, measured after each — see that file for why a one-shot N-way merge
+does not compose) and forwards `--canary-auto` so the merge's objective is measured against
+canaries drawn from the WHOLE suite, never just the neighbourhood of the two branches'
+targets (per-task-fanout.md's "a canary set that only covers what you aimed at cannot catch
+what you hit by accident" — restated here because a merge is exactly the moment two
+neighbourhoods combine and the blast radius is not either one's alone).
+
+It also does NOT gate anything. A successfully-built merge candidate is written to
+`$R/work/merge_<a>_<b>` — an ordinary candidate directory, indistinguishable from any other
+tag on disk — so `round.py --candidates merge_<a>_<b>,...` gates it through the EXACT SAME
+cascade (null control, paired significance, no-regression veto) as a hand-authored edit. No
+special-casing was added to round.py, deliberately: a merge is a candidate, not a new kind
+of thing the gate has to know about.
+
+Per-survivor target task ids come from `--targets tag:1,2,3` (repeatable) when given, else
+from `mechanisms.jsonl`'s `tasks` field for rows owned by that tag (the ledger's existing
+"who changed what, aimed at which tasks" record — see mechanisms.py). A survivor with
+neither is skipped with a reason, never silently merged on an empty/whole-val objective.
+
+Graph-DAG note (#435): this script currently reads survivor tags + a mechanisms ledger
+directly, because no `graph.jsonl` exists yet on `main` to consume. Once #435 lands, the
+survivor list and each one's `subset.rationale`/target ids should come from the DAG's
+frontier nodes instead of `--survivors`/`--targets`/mechanisms.jsonl — the disjointness
+check and the integrate.py call below do not change.
+
+    python merge_search.py --run-dir R --project P --base BEST \\
+        --survivors t7,t17,u33 --targets t7:1,2 --targets t17:5,9 \\
+        --canary-auto R/baseline.json --n 10 --conc 8 --floor 0.0333
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import io
+import itertools
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import funcmerge
+import mechanisms
+
+HERE = Path(__file__).resolve().parent
+
+
+def _canary_auto_file(path: str) -> str:
+    """Normalize a baseline JSON into the per-task DICT shape `integrate.py --canary-auto`
+    reads (``{tid: {"rate": ...}}``, taskeval.py's own shape).
+
+    The run's own ``$R/baseline.json`` (harness.baseline's output) is the file every run
+    already has, but its ``per_task`` is a LIST of Score dicts (``harness.SplitResult``),
+    one level down under ``"val"``. Reshaping it here — rather than teaching integrate.py a
+    second per_task shape — keeps the merge engine itself unchanged.
+    """
+    raw = json.loads(Path(path).read_text(encoding="utf-8"))
+    per = raw.get("per_task")
+    if per is None and isinstance(raw.get("val"), dict):
+        per = raw["val"].get("per_task")
+    if isinstance(per, list):
+        shaped = {str(row["task_id"]): {"rate": row.get("reward")}
+                 for row in per if isinstance(row, dict) and row.get("task_id") is not None}
+    elif isinstance(per, dict):
+        return path  # already the shape integrate.py expects
+    else:
+        return path  # nothing recognizable — let integrate.py report the same error
+    import tempfile
+    fd, tmp = tempfile.mkstemp(suffix=".json", prefix="merge_search_canary_")
+    Path(tmp).write_text(json.dumps({"per_task": shaped}), encoding="utf-8")
+    return tmp
+
+
+def changed_functions(base_src: str, variant_src: str) -> set[str]:
+    """Names of functions/constants `variant_src` changed or added relative to `base_src`.
+
+    Reuses funcmerge.blocks — the SAME per-function split integrate.py's own merge step
+    runs on — so "disjoint" here means exactly what funcmerge.py would find non-conflicting,
+    not a second, possibly-inconsistent notion of overlap.
+    """
+    _, base_fns = funcmerge.blocks(base_src)
+    _, var_fns = funcmerge.blocks(variant_src)
+    return {name for name, text in var_fns.items()
+            if name not in base_fns or text != base_fns[name]}
+
+
+def _mechanisms_targets(run_dir: Path, tag: str) -> list[str]:
+    """Union of `tasks` from mechanisms.jsonl rows owned by `tag` (see mechanisms.py)."""
+    path = Path(run_dir) / "mechanisms.jsonl"
+    if not path.exists():
+        return []
+    ids: set[str] = set()
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except Exception:  # noqa: BLE001
+            continue
+        if row.get("owner") == tag:
+            ids.update(str(t) for t in (row.get("tasks") or []))
+    return sorted(ids)
+
+
+def find_disjoint_pairs(base_src: str, survivor_srcs: dict[str, str]) -> dict:
+    """Every survivor pair, split into disjoint (mergeable) vs overlapping (skipped).
+
+    Returns {"changed": {tag: sorted[fn...]}, "disjoint_pairs": [[a, b], ...],
+    "overlapping_pairs": [{"pair": [a, b], "shared": [fn...]}]}.
+    """
+    changed = {tag: changed_functions(base_src, src) for tag, src in survivor_srcs.items()}
+    disjoint, overlapping = [], []
+    for a, b in itertools.combinations(sorted(survivor_srcs), 2):
+        shared = changed[a] & changed[b]
+        if shared:
+            overlapping.append({"pair": [a, b], "shared": sorted(shared)})
+        else:
+            disjoint.append([a, b])
+    return {"changed": {t: sorted(v) for t, v in changed.items()},
+            "disjoint_pairs": disjoint, "overlapping_pairs": overlapping}
+
+
+def _integrate(run_dir: Path, project: Path, work: Path, base_dir: Path, a: str, b: str,
+               tasks: list[str], canary: list[str], canary_auto: str, canary_floor: float,
+               n: int, conc: int, base_seed: int, floor: float, file_: str, prose: str,
+               out_tag: str) -> dict:
+    json_out = work / f".{out_tag}_integrate.json"
+    cmd = [sys.executable, str(HERE / "integrate.py"),
+           "--base", str(base_dir), "--project", str(project),
+           "--branches", str(work / a), str(work / b),
+           "--out", str(work / out_tag), "--tasks", ",".join(tasks),
+           "--n", str(n), "--conc", str(conc), "--base-seed", str(base_seed),
+           "--floor", str(floor), "--file", file_, "--prose", prose,
+           "--taskeval", str(HERE / "taskeval.py"), "--json", str(json_out)]
+    if canary_auto:
+        cmd += ["--canary-auto", canary_auto, "--canary-floor", str(canary_floor)]
+    elif canary:
+        cmd += ["--canary", ",".join(canary)]
+    p = subprocess.run(cmd, capture_output=True, text=True)
+    # NOT json.loads(p.stdout): with --canary-auto, integrate.py prints the canary-selection
+    # note as its OWN json.dumps call before the final result — two concatenated JSON
+    # documents on one stream, which `json.loads` cannot parse as one object. `--json`
+    # writes only the final result, so read that back instead.
+    if json_out.exists():
+        try:
+            return json.loads(json_out.read_text(encoding="utf-8"))
+        except Exception:  # noqa: BLE001
+            pass
+    return {"error": (p.stderr or p.stdout)[-1200:], "rc": p.returncode}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    ap = argparse.ArgumentParser(prog="merge_search")
+    ap.add_argument("--run-dir", required=True)
+    ap.add_argument("--project", required=True)
+    ap.add_argument("--base", required=True, help="tag of the round's current parent")
+    ap.add_argument("--survivors", required=True,
+                    help="comma-separated tags under $R/work/ that passed screening but did "
+                         "not individually clear the full-val accept gate")
+    ap.add_argument("--targets", action="append", default=[],
+                    help="tag:comma,separated,task,ids — the tasks this survivor targeted. "
+                         "Repeatable. Falls back to mechanisms.jsonl's `tasks` field for rows "
+                         "owned by that tag when omitted.")
+    ap.add_argument("--file", default="tools/tools.py",
+                    help="the Python file merged per function — see integrate.py --file")
+    ap.add_argument("--prose", default="policy/policy.md")
+    ap.add_argument("--canary-auto", default="",
+                    help="path to a baseline per-task JSON. Canaries are drawn from the "
+                         "WHOLE suite (per-task-fanout.md), not from the merged branches' "
+                         "own neighbourhood — pass the run's baseline.json.")
+    ap.add_argument("--canary", default="", help="explicit canary ids, if not using --canary-auto")
+    ap.add_argument("--canary-floor", type=float, default=0.9)
+    ap.add_argument("--n", type=int, default=10)
+    ap.add_argument("--conc", type=int, default=8)
+    ap.add_argument("--base-seed", type=int, default=0)
+    ap.add_argument("--floor", type=float, default=0.0,
+                    help="measured null delta — see integrate.py --floor")
+    ap.add_argument("--json", dest="json_out", default="")
+    return ap
+
+
+def main(argv=None) -> int:
+    args = build_parser().parse_args(argv)
+
+    run_dir = Path(args.run_dir)
+    project = Path(args.project)
+    work = run_dir / "work"
+    survivors = [t.strip() for t in args.survivors.split(",") if t.strip()]
+    canary_auto = _canary_auto_file(args.canary_auto) if args.canary_auto else ""
+
+    explicit_targets: dict[str, list[str]] = {}
+    for item in args.targets:
+        tag, _, ids = item.partition(":")
+        explicit_targets[tag.strip()] = [i.strip() for i in ids.split(",") if i.strip()]
+
+    base_dir = work / args.base
+    if not base_dir.is_dir():
+        # The round's parent usually lives in candidates/, not work/ — only a branch
+        # actively being merged gets a work/ copy. Fall back to the run's own record of
+        # where that tag's snapshot is, rather than requiring the caller to pre-stage it.
+        import _bootstrap  # noqa: F401
+        from cap_evolve import RunDir
+        base_dir = RunDir.open(run_dir).candidate_dir(args.base)
+    base_file = base_dir / args.file
+    if not base_file.exists():
+        print(json.dumps({"error": f"base file not found: {base_file}"}, indent=2))
+        return 2
+    base_src = base_file.read_text(encoding="utf-8")
+
+    survivor_srcs, missing = {}, []
+    for tag in survivors:
+        f = work / tag / args.file
+        if not f.exists():
+            missing.append(tag)
+            continue
+        survivor_srcs[tag] = f.read_text(encoding="utf-8")
+    if missing:
+        print(json.dumps({"error": f"survivor file(s) missing under {work}: {missing}"},
+                         indent=2))
+        return 2
+
+    disjointness = find_disjoint_pairs(base_src, survivor_srcs)
+
+    targets = {}
+    skipped_no_targets = []
+    for tag in survivors:
+        t = explicit_targets.get(tag) or _mechanisms_targets(run_dir, tag)
+        if t:
+            targets[tag] = t
+        else:
+            skipped_no_targets.append(tag)
+
+    merges = []
+    ready_for_gate = []
+    for a, b in disjointness["disjoint_pairs"]:
+        if a in skipped_no_targets or b in skipped_no_targets:
+            merges.append({"pair": [a, b], "attempted": False,
+                          "reason": "no target task ids for at least one branch "
+                                    "(pass --targets or record them in mechanisms.jsonl)"})
+            continue
+        union_tasks = sorted(set(targets[a]) | set(targets[b]))
+        out_tag = f"merge_{a}_{b}"
+        result = _integrate(run_dir, project, work, base_dir, a, b, union_tasks,
+                            [i.strip() for i in args.canary.split(",") if i.strip()],
+                            canary_auto, args.canary_floor, args.n, args.conc,
+                            args.base_seed, args.floor, args.file, args.prose, out_tag)
+        built = bool(result.get("out")) and (work / out_tag).is_dir() and "error" not in result
+        merges.append({"pair": [a, b], "attempted": True, "tag": out_tag, "built": built,
+                      "targets": union_tasks, "result": result})
+        if built:
+            ready_for_gate.append(out_tag)
+            mechanisms.ledger(run_dir).parent.mkdir(parents=True, exist_ok=True)
+            mechanisms_args = argparse.Namespace(
+                run_dir=run_dir, owner=out_tag, status="proposed",
+                mechanism=f"pairwise merge of disjoint-cluster survivors {a} + {b}",
+                evidence=f"integrate.py accepted: {sorted(result.get('accepted', []))}; "
+                         f"final_objective={result.get('final_objective')}",
+                touches=sorted(disjointness["changed"].get(a, []))
+                        + sorted(disjointness["changed"].get(b, [])),
+                task=union_tasks, supersedes=[])
+            # mechanisms.add() is written as a CLI subcommand and prints its own JSON on
+            # success — fine standalone, but this script has ONE JSON document on stdout
+            # (see main()'s final print) and mixing a second one in breaks any caller
+            # parsing stdout as JSON. Suppress its print; the ledger write itself is
+            # unaffected.
+            with contextlib.redirect_stdout(io.StringIO()):
+                mechanisms.add(mechanisms_args)
+
+    out = {
+        "base": args.base,
+        "survivors": survivors,
+        "changed_functions": disjointness["changed"],
+        "disjoint_pairs": disjointness["disjoint_pairs"],
+        "overlapping_pairs_skipped": disjointness["overlapping_pairs"],
+        "skipped_no_targets": skipped_no_targets,
+        "merges": merges,
+        "ready_for_gate": ready_for_gate,
+        "next": (f"python round.py --run-dir {run_dir} --project {project} "
+                 f"--candidates {','.join(ready_for_gate)} --n-trials {args.n} "
+                 "— gates each merge through the SAME cascade as any candidate"
+                 if ready_for_gate else
+                 "no merge candidate was built — see merges[].reason / merges[].result.error"),
+    }
+    text = json.dumps(out, indent=2)
+    print(text)
+    if args.json_out:
+        Path(args.json_out).write_text(text, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/algorithms/agent-optimize/scripts/taskeval.py
+++ b/skills/algorithms/agent-optimize/scripts/taskeval.py
@@ -132,9 +132,6 @@ def main() -> int:
         print("WARNING: no --canary. A per-task edit that breaks a working task will not be "
               "visible until the full-val gate.", file=sys.stderr)
 
-    adapter.apply(cand)
-    ctx = adapter.materialize(cand) if hasattr(adapter, "materialize") else None
-
     groups = [(want, args.n, "target")]
     if canary:
         groups.append((canary, args.canary_n, "canary"))
@@ -148,37 +145,46 @@ def main() -> int:
         lambda: defaultdict(list))
     t0 = time.time()
 
-    for ids, n, kind in groups:
-        tasks = [by_id[i] for i in ids]
-        for i in ids:
-            role[i] = kind
-        out = adapter.run_trials(tasks, ctx, n_trials=n, base_seed=0)
-        for tid, rolls in sorted(out.items()):
-            for k, roll in enumerate(rolls or []):
-                if roll is None or getattr(roll, "error", None):
-                    infra[tid] += 1          # missing data, NOT a zero
-                    continue
-                s = adapter.score(by_id[tid], roll)
-                rates[tid].append(float(s.reward))
-                for comp, v in component_rates(s, roll).items():
-                    comps[tid][comp].append(v)
-                if s.reward < 1.0:
-                    if s.feedback:
-                        fb[tid].append(s.feedback)
-                    if args.traces:
-                        traces.append({
-                            "task": tid, "trial": k, "reward": s.reward,
-                            "feedback": s.feedback,
-                            "tool_calls": [
-                                {"name": c.get("name"), "arguments": c.get("arguments")}
-                                for c in (getattr(roll, "tool_calls", None) or [])
-                            ],
-                            "trace": [
-                                {"role": m.get("role"),
-                                 "content": str(m.get("content") or "")[:900]}
-                                for m in (getattr(roll, "trace", None) or [])
-                            ],
-                        })
+    # `adapter.live(cand)` is the documented contract `run_target`'s docstring points to
+    # ("ctx is whatever live() yielded (default: the candidate dir Path)") — NOT
+    # `adapter.materialize(cand)`, whose default implementation writes `edits` (there are
+    # none here) and returns None. Calling it directly silently made `ctx` None for every
+    # adapter using the standard materialize/live split, so every rollout below raised
+    # inside run_trials_pool and was counted as an infra drop rather than scored — the
+    # reason this script, like integrate.py which calls it, was measured (#434/#438) to
+    # have never actually produced a per-task result on a real run.
+    with adapter.live(cand) as ctx:
+        for ids, n, kind in groups:
+            tasks = [by_id[i] for i in ids]
+            for i in ids:
+                role[i] = kind
+            out = adapter.run_trials(tasks, ctx, n_trials=n, base_seed=0)
+            for tid, rolls in sorted(out.items()):
+                for k, roll in enumerate(rolls or []):
+                    if roll is None or getattr(roll, "error", None):
+                        infra[tid] += 1          # missing data, NOT a zero
+                        continue
+                    s = adapter.score(by_id[tid], roll)
+                    rates[tid].append(float(s.reward))
+                    for comp, v in component_rates(s, roll).items():
+                        comps[tid][comp].append(v)
+                    if s.reward < 1.0:
+                        if s.feedback:
+                            fb[tid].append(s.feedback)
+                        if args.traces:
+                            traces.append({
+                                "task": tid, "trial": k, "reward": s.reward,
+                                "feedback": s.feedback,
+                                "tool_calls": [
+                                    {"name": c.get("name"), "arguments": c.get("arguments")}
+                                    for c in (getattr(roll, "tool_calls", None) or [])
+                                ],
+                                "trace": [
+                                    {"role": m.get("role"),
+                                     "content": str(m.get("content") or "")[:900]}
+                                    for m in (getattr(roll, "trace", None) or [])
+                                ],
+                            })
 
     per_task = {
         tid: {


### PR DESCRIPTION
Addresses #438 (child of #434 phase 4, depends conceptually on #435).

## What this adds

`skills/algorithms/agent-optimize/scripts/merge_search.py`: given a round's
"survivors" (candidates that passed screening but did not individually clear
the full-val accept gate), it:

1. **Identifies disjoint-cluster merge candidates.** For every pair of
   survivors, computes which functions/constants each changed relative to the
   same parent (reusing `funcmerge.py`'s own per-function split) and offers a
   pair for merging only when the changed sets are disjoint. An overlapping
   pair (both survivors rewrite the same function) is reported and skipped —
   that is a genuine semantic collision `funcmerge.py` already declines to
   auto-resolve, not something a graph search should paper over.
2. **Merges via the existing `integrate.py` machinery**, unmodified in
   approach — one branch at a time, measured after each — and forwards
   `--canary-auto` so the merge's objective includes canaries drawn from the
   **whole suite**, not just the two branches' own targets (per
   `references/per-task-fanout.md`).
3. **Records the attempt in `mechanisms.jsonl`** (owner = merge tag, tasks =
   union of parents' targets, touches = union of changed functions) — the same
   ledger any hand-driven merge already uses.
4. **Leaves the result as an ordinary `work/merge_<a>_<b>` directory.** No
   changes to `round.py`: a merge candidate is gated through the exact same
   cascade as any other candidate, including the mandatory screen ladder
   `round.py` now enforces (#420/#442).

Per-survivor target task ids come from `--targets tag:1,2,3` or, by default,
from `mechanisms.jsonl`'s existing `tasks` field for rows owned by that tag. A
survivor with neither is skipped with a reason, never silently merged on an
implicit whole-val objective.

## Bugs this surfaced and fixed

Investigating why `integrate.py`/`funcmerge.py`/`merge_taskopt.py` are
"essentially never invoked" (#434's finding) turned up two real, pre-existing
defects that made `integrate.py` fail on any actual invocation:

- **`integrate.py` never forwarded `--project`** to the `taskeval.py`
  subprocess it shells out to — `taskeval.py` requires it, so every call
  failed argparse immediately. Added `--project`, forwarded it, and dropped
  the `--base-seed` flag it was also passing to `taskeval.py`, which has no
  such argument.
- **`taskeval.py` used `adapter.materialize(cand)` as the rollout `ctx`**
  instead of `adapter.live(cand)`. The default `materialize()` writes `edits`
  (there are none here) and returns `None` — so for any adapter using the
  standard materialize/live split, every rollout ran with `ctx=None`, raised
  inside `run_trials_pool`, and was silently counted as an infra-dropped
  trial. `per_task` came back empty on every call. Switched to
  `with adapter.live(cand) as ctx:`, matching `run_target`'s own documented
  contract ("ctx is whatever live() yielded").

Both are one-line-scope fixes; without them this PR's own tests could not
pass, and no prior driver invocation of this machinery could have worked
either.

## MVP scope — deliberately deferred

- **One round of pairwise merging**, not full N-way or multi-hop graph
  exploration — per the issue's own steer ("favor a correct, well-tested MVP
  over an elaborate but shaky implementation"). Merging three+ mutually
  disjoint survivors would need a second pass over the merged output; not
  built here.
- **No `graph.jsonl` / candidate DAG (#435)** exists on `main` yet (checked;
  no PR found). `merge_search.py` reads `--survivors` + `mechanisms.jsonl`
  directly instead — the module docstring notes where the DAG's frontier
  nodes and `subset.rationale` should plug in once #435 lands; the
  disjointness check and the `integrate.py` call are unaffected by that
  swap.
- **Micro-tests (#436)** are optional/future-compatible per the brief — not
  wired in, since they don't exist on `main` yet either.
- Canary selection reuses `integrate.py --canary-auto` as-is (floor 0.9,
  lowest-rate-first) rather than adding new selection logic.

## Test evidence

`core/tests/test_merge_search.py` — a self-contained fixture capability
(`tools/tools.py` with three independent functions) and a tiny deterministic
adapter, run through the real scripts (no mocking of `integrate.py`,
`funcmerge.py`, `screen.py`, or `round.py`):

1. `test_disjoint_survivors_are_identified_as_a_merge_pair_and_overlapping_ones_are_not`
   — two survivors editing different functions are offered as a pair; a third
   survivor that rewrites the SAME function as one of them is correctly
   flagged overlapping and excluded, with the shared function named.
2. `test_the_merge_is_attempted_via_existing_integrate_py_machinery` — the
   disjoint pair is actually merged through `integrate.py`, the artifact
   carries both branches' fixes, an overlapping pair never even reaches
   `merges[]`, and the attempt is recorded in `mechanisms.jsonl`.
3. `test_the_merge_result_goes_through_rounds_normal_gate_cascade` — the
   merged candidate is screened (`screen.py --tier 1`, promotes) and then
   gated by `round.py` completely unmodified, producing the same structured
   table (`gate_delta`, `gate_threshold`, `verdict`) any hand-authored
   candidate gets, and correctly accepts the combined fix.

```
$ PYTHONPATH=core python3 -m pytest core/tests/test_merge_search.py -q
...
3 passed
```

Also re-ran the pre-existing agent-optimize round/gate test suite to confirm
no regression from the `integrate.py`/`taskeval.py` fixes:

```
$ PYTHONPATH=core python3 -m pytest core/tests/test_agent_optimize_round_attribution.py core/tests/test_stop_at_reward.py core/tests/test_merge_search.py -q
28 passed
```

(The full `core/tests/` run showed 23 unrelated failures — `Budget.__init__()
got an unexpected keyword argument 'stop_at_reward'` etc. — traced to a stale
editable `cap_evolve` install resolving to a *different*, unrelated worktree
on this machine; not present when `PYTHONPATH` points at this branch's own
`core/`, and unrelated to this change.)

Not merging — flagging for review given the complexity, per the task brief.