### PR TITLE
fix(harness): tell the optimizer when a run is ending (#404 item 2)

### DIFF
--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -1627,6 +1627,49 @@ def seed_framework_memory(target: Path, run_dir: RunDir) -> list[str]:
     return written
 
 
+def _run_ending_signal(run_dir: RunDir) -> str:
+    """Tell the optimizer where this iteration sits against the run's budget.
+
+    ``META_INSIGHTS.md``/``FRAMEWORK_IMPROVEMENTS.md`` are only required "at the end
+    of the run", and with no signal of when that is, the optimizer reasonably ranks
+    them below the REQUIRED ``PROCESS.md`` every iteration (issue #404 item 2: a real
+    run left both empty). Everything below is read straight from ``run_dir.budget``/
+    ``run_dir.spent`` — the same numbers ``spend.py`` reports — never guessed.
+    """
+    b, s = run_dir.budget, run_dir.spent
+    this_iter = s.iterations + 1
+    parts: list[str] = []
+    iters_left = None
+    if b.max_iterations:
+        iters_left = max(b.max_iterations - this_iter, 0)
+        parts.append(f"iteration {this_iter}/{b.max_iterations} ({iters_left} after this one)")
+    if b.max_usd:
+        parts.append(f"${s.total_usd:.2f}/${b.max_usd:.2f} spent "
+                      f"({100 * s.total_usd / b.max_usd:.0f}%)")
+    if b.max_metric_calls:
+        parts.append(f"{s.metric_calls}/{b.max_metric_calls} rollouts used "
+                      f"({100 * s.metric_calls / b.max_metric_calls:.0f}%)")
+    if b.stall:
+        parts.append(f"{s.stall}/{b.stall} consecutive rejects")
+    if not parts:
+        return ""
+
+    is_last = (
+        iters_left == 0
+        or (b.max_usd and s.total_usd / b.max_usd >= 0.85)
+        or (b.max_metric_calls and s.metric_calls / b.max_metric_calls >= 0.85)
+        or (b.stall and s.stall + 1 >= b.stall)
+    )
+    status = "; ".join(parts)
+    if is_last:
+        return (
+            f"## Run budget — THIS MAY BE YOUR LAST ITERATION ({status})\n"
+            "Update `META_INSIGHTS.md` and `FRAMEWORK_IMPROVEMENTS.md` THIS iteration — "
+            "there may be no next one to do it in.\n\n"
+        )
+    return f"## Run budget ({status})\n\n"
+
+
 def _augment_instructions(instructions: str, workdir: Path, run_dir: RunDir) -> str:
     """Give the optimizer its cross-iteration files + a prompt pointer to each.
 
@@ -1642,7 +1685,8 @@ def _augment_instructions(instructions: str, workdir: Path, run_dir: RunDir) -> 
     seed_framework_memory(workdir, run_dir)
 
     pointer = (
-        "## Cross-iteration files in THIS working dir (clean ownership — read all)\n"
+        _run_ending_signal(run_dir)
+        + "## Cross-iteration files in THIS working dir (clean ownership — read all)\n"
         "- `LEDGER.md` — FACTS (framework, read-only): every iteration's outcome + the tasks "
         "it MEASURABLY broke/fixed, plus the ones whose move was under 2·SE and so resolves "
         "nothing. Never re-introduce a change that broke a task; never redesign an edit "

--- a/core/tests/test_run_ending_signal.py
+++ b/core/tests/test_run_ending_signal.py
@@ -1,0 +1,65 @@
+"""Issue #404 item 2: the optimizer must be told when a run is ending.
+
+``_augment_instructions`` threads the run's remaining iteration/spend budget into
+the per-iteration prompt, with an explicit stronger nudge once this is likely the
+last iteration -- so optional accumulators (META_INSIGHTS.md, FRAMEWORK_IMPROVEMENTS.md)
+get a real signal instead of losing out to the required PROCESS.md every time.
+"""
+
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+CORE = REPO / "core"
+sys.path.insert(0, str(CORE))
+
+from cap_evolve import Budget, RunDir, harness  # noqa: E402
+
+
+def test_last_iteration_gets_a_strong_nudge(tmp_path):
+    run_dir = RunDir.create(tmp_path / ".capevolve", ts="low", budget=Budget(max_iterations=2))
+    run_dir.update_spent(iterations=1)  # one done -> this is iteration 2/2, the last one
+
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    augmented = harness._augment_instructions("BASE INSTRUCTIONS", workdir, run_dir)
+
+    assert "iteration 2/2" in augmented
+    assert "LAST ITERATION" in augmented
+    assert "META_INSIGHTS.md" in augmented and "FRAMEWORK_IMPROVEMENTS.md" in augmented
+    assert "BASE INSTRUCTIONS" in augmented
+
+
+def test_early_iteration_gets_a_plain_status_no_false_urgency(tmp_path):
+    run_dir = RunDir.create(tmp_path / ".capevolve", ts="early", budget=Budget(max_iterations=20))
+
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    augmented = harness._augment_instructions("BASE INSTRUCTIONS", workdir, run_dir)
+
+    assert "iteration 1/20 (19 after this one)" in augmented
+    assert "LAST ITERATION" not in augmented
+
+
+def test_near_usd_ceiling_also_triggers_the_last_iteration_nudge(tmp_path):
+    run_dir = RunDir.create(tmp_path / ".capevolve", ts="usd",
+                             budget=Budget(max_iterations=20, max_usd=10.0))
+    run_dir.update_spent(usd=9.0)  # 90% of max_usd spent, well under max_iterations
+
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    augmented = harness._augment_instructions("BASE INSTRUCTIONS", workdir, run_dir)
+
+    assert "LAST ITERATION" in augmented
+    assert "$9.00/$10.00 spent (90%)" in augmented
+
+
+if __name__ == "__main__":
+    import tempfile
+    for fn in (test_last_iteration_gets_a_strong_nudge,
+               test_early_iteration_gets_a_plain_status_no_false_urgency,
+               test_near_usd_ceiling_also_triggers_the_last_iteration_nudge):
+        with tempfile.TemporaryDirectory() as d:
+            fn(Path(d))
+        print(f"ok: {fn.__name__}")
+    print("all ok")


### PR DESCRIPTION
## Summary
- Addresses #404 item 2: the optimizer had no signal telling it a run is on its last iteration, so `META_INSIGHTS.md`/`FRAMEWORK_IMPROVEMENTS.md` (only required "at the end of the run") lost out to the required `PROCESS.md` every time -- confirmed empty in real-run validation for #400.
- `_augment_instructions` in `core/cap_evolve/harness.py` now prepends a "Run budget" status line to the per-iteration instructions, computed straight from `run_dir.budget`/`run_dir.spent` (the same numbers `spend.py` reports): current iteration vs `max_iterations`, $ and rollout-count spend against their ceilings, and the stall count.
- When any of those crosses a last-iteration threshold (iterations exhausted, ≥85% of `max_usd`/`max_metric_calls`, or one more reject away from the stall cap), the line becomes an explicit stronger nudge that names `META_INSIGHTS.md` and `FRAMEWORK_IMPROVEMENTS.md` directly.

Note: item 1 of #404 (real pluggable memory-skill interface, evograph wiki extraction) is being handled separately in the parallel `feat/issue-400-pluggable-memory` effort. This PR touches only `_augment_instructions`'s pointer text in `harness.py`; if that other branch also lands changes near this function, expect a small merge conflict for a human to resolve -- the two changes are logically independent (this one only prepends a string to the existing pointer).

## Test plan
- [x] New `core/tests/test_run_ending_signal.py`: asserts the plain status line on an early iteration, the strong "LAST ITERATION" nudge (naming both accumulator files) when `max_iterations` is exhausted, and the same nudge triggering off a 90%-spent `max_usd` ceiling well before `max_iterations` would fire.
- [x] Ran together with the directly relevant existing suites (`test_store_memory.py`, `test_multi_sibling_journal_reconciliation.py`, `test_optimizer_context.py`, `test_iteration_record_parity.py`) -- 19 passed.
- Note: this sandbox's `cap_evolve` package is pip-installed in editable mode pointing at a different (shared) checkout than this worktree, so a full `core/tests` run is order-dependent and produces spurious failures unrelated to this diff whenever an earlier-collected test does a bare `from cap_evolve import ...` before this worktree's `sys.path` insert takes effect. This is a pre-existing environment quirk, not a regression -- verified by reproducing the same spurious failures with this change stashed out.