### PR TITLE
memory: make cross-iteration memory pluggable, extract evograph's wiki format

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <img src="https://img.shields.io/badge/python-3.10%2B-blue" alt="python">
   <img src="https://img.shields.io/badge/runtime%20deps-0%20(stdlib)-success" alt="deps">
   <img src="https://img.shields.io/badge/license-Apache--2.0-informational" alt="license">
-  <img src="https://img.shields.io/badge/agent%20skills-21-7c5cff" alt="skills">
+  <img src="https://img.shields.io/badge/agent%20skills-22-7c5cff" alt="skills">
 </p>
 
 **cap-evolve improves an AI agent's prompts, tools, and skills by learning from failed

--- a/core/cap_evolve/cli.py
+++ b/core/cap_evolve/cli.py
@@ -955,6 +955,10 @@ def _cmd_run(argv):
             if not tpf_p.is_absolute() and not tpf_p.exists():
                 tpf_p = Path(project) / str(tpf)
             alg_cmd += ["--target-profile-file", str(tpf_p)]
+        # Cross-iteration memory scheme (md-files default, or wiki). Selectable per
+        # #400/#404 instead of hardcoded LEDGER/JOURNAL in every run.
+        if spec.get("memory_skill"):
+            alg_cmd += ["--memory-skill", str(spec["memory_skill"])]
     # Protected-path seal + graded convergence signal. Both are OPT-IN: absent keys
     # add no flags at all, so an existing spec runs byte-identically.
     if algorithm_name in ("hill-climb", "skillopt", "gepa"):

--- a/core/cap_evolve/dashboard.py
+++ b/core/cap_evolve/dashboard.py
@@ -1087,12 +1087,17 @@ def reduce_run(run_dir) -> dict:
     algorithm_source = "run_config" if cfg_algo else ("events" if algorithm else None)
     wiki_dir = _safe_subpath(root, "wiki")
     has_wiki = wiki_dir is not None and wiki_dir.is_dir()
-    if algorithm is None or has_wiki:
+    # ``wiki/`` used to mean "this is an evograph run" unconditionally — now any
+    # algorithm can write it via ``memory_skill: wiki`` (#400, #404), so it is only a
+    # fallback label for the genuinely-unlabeled case (an old evograph run with no
+    # ``run_config`` event), never an override of an algorithm already known from
+    # ``run_config``/events.
+    if algorithm is None:
         from_spec = _algorithm_from_spec(root)
-        if has_wiki:
-            algorithm, algorithm_source = "evograph", "run-dir wiki/"
-        elif from_spec:
+        if from_spec:
             algorithm, algorithm_source = from_spec, "capevolve.yaml"
+        elif has_wiki:
+            algorithm, algorithm_source = "evograph", "run-dir wiki/"
     # Candidates the gate REFUSED TO JUDGE (low coverage, or an integrity tamper).
     # These are neither accepted nor rejected: the edit was never validly measured.
     indecisive_ids = {

--- a/core/cap_evolve/gepa.py
+++ b/core/cap_evolve/gepa.py
@@ -56,7 +56,6 @@ from . import selection
 from .cache import EvalCache, hash_candidate_dir
 from .harness import (
     OptimizerContext,
-    _augment_instructions,
     move_is_resolved,
     _init_memory_store,
     _live,
@@ -602,7 +601,7 @@ def gepa_loop(
                            f"{focus_label}",
             algorithm="gepa", parent_dir=parent_dir,
             extra=_instructions(refl_summary, focus_label, mb))
-        instructions = _augment_instructions(instructions, workdir, run_dir)
+        instructions = ctx.augment_instructions(instructions, workdir, run_dir)
 
         # Seal the eval surface for this child. GEPA runs the optimizer itself rather
         # than via ``harness.run_step``, so it needs the same two calls. None = off.
@@ -636,7 +635,8 @@ def gepa_loop(
                                   report=report.to_dict(), reason=report.reason)
                 _reason = "indecisive (integrity): " + report.reason
                 record_iteration(run_dir, workdir, cid, parent_id=parent["id"],
-                                 accepted=False, reason=_reason, indecisive=True)
+                                 accepted=False, reason=_reason, indecisive=True,
+                                 memory_skill=ctx.memory_skill)
                 run_dir.log_event("step_indecisive", candidate=cid, reason=_reason)
                 steps.append({"candidate_id": cid, "parent_id": parent["id"], "minibatch": mb,
                               "accepted": False, "candidate_val": None,
@@ -667,6 +667,7 @@ def gepa_loop(
             record_iteration(run_dir, workdir, cid, parent_id=parent["id"], accepted=False,
                              reason="local minibatch gate: sum(child) <= sum(parent)",
                              parent_val=parent["result"].reward, focus=focus_label,
+                             memory_skill=ctx.memory_skill,
                              mb_child=child_mb.reward, mb_parent=parent_mb.reward)
             rejected.add(cid, f"candidate {cid} (mb {child_mb.reward:.3f} vs parent "
                               f"{parent_mb.reward:.3f})",
@@ -684,6 +685,7 @@ def gepa_loop(
             adapter, run_dir=run_dir, workdir=workdir, parent_result=parent_result,
             cid=cid, n_trials=n_trials, gate_kwargs=gate_kwargs,
             no_regression=no_regression, parent_id=parent["id"],
+            memory_skill=ctx.memory_skill,
         )
         step["decision"] = decision_dict
         step["candidate_val"] = cand_val.to_dict()
@@ -715,7 +717,7 @@ def gepa_loop(
                 mb_size=minibatch_size, rng=rng, n_trials=n_trials,
                 gate_kwargs=gate_kwargs, no_regression=no_regression,
                 store=store, history=history, rejected=rejected, train_ids=train_ids,
-                idx=step_offset + len(steps), seed=seed,
+                idx=step_offset + len(steps), seed=seed, ctx=ctx,
             )
             if merge_step is not None:
                 steps.append(merge_step)
@@ -753,7 +755,7 @@ def _sample_minibatch(train_ids: list[str], size: int, rng: random.Random) -> li
 def _full_val_gate(
     adapter, *, run_dir: RunDir, workdir: Path, parent_result: SplitResult,
     cid: str, n_trials: int, gate_kwargs: dict, no_regression: bool,
-    parent_id: str | None = None,
+    parent_id: str | None = None, memory_skill: str | None = None,
 ) -> tuple[dict, bool, SplitResult]:
     """Full-val eval + the honest significance gate (the same path ``run_step``
     uses, replicated WITHOUT bypassing gate/seal).
@@ -799,7 +801,7 @@ def _full_val_gate(
     # neither charges the budget itself.
     record_iteration(run_dir, workdir, cid, parent_id=parent_id, accepted=accepted,
                      reason=decision.reason, val=cand_val.reward,
-                     parent_val=parent_result.reward,
+                     parent_val=parent_result.reward, memory_skill=memory_skill,
                      runner_seconds=round(cand_val.seconds, 2),
                      cost_usd=cand_val.cost_usd, tokens=cand_val.tokens)
     return decision.to_dict(), accepted, cand_val
@@ -809,7 +811,7 @@ def _try_merge(
     adapter, *, run_dir: RunDir, pool: list[dict], lineage: dict[str, str | None],
     cache: EvalCache, mb_size: int, rng: random.Random, n_trials: int,
     gate_kwargs: dict, no_regression: bool, store, history, rejected,
-    train_ids: list[str], idx: int, seed: int,
+    train_ids: list[str], idx: int, seed: int, ctx: "OptimizerContext | None" = None,
 ) -> dict | None:
     """Find a complementary frontier pair, build a component-wise merge, minibatch-
     gate it (>= max(parents) on the minibatch), then full-val + standard gate.
@@ -860,7 +862,7 @@ def _try_merge(
     decision_dict, accepted, cand_val = _full_val_gate(
         adapter, run_dir=run_dir, workdir=workdir, parent_result=base_parent["result"],
         cid=mid, n_trials=n_trials, gate_kwargs=gate_kwargs, no_regression=no_regression,
-        parent_id=base_parent["id"],
+        parent_id=base_parent["id"], memory_skill=(ctx.memory_skill if ctx else None),
     )
     step["decision"] = decision_dict
     step["candidate_val"] = cand_val.to_dict()

--- a/core/cap_evolve/harness.py
+++ b/core/cap_evolve/harness.py
@@ -30,6 +30,7 @@ from . import footprint as footprint_mod
 from . import gate as gate_mod
 from . import graph as graph_mod
 from . import integrity
+from .memory import MemorySkill
 from .loop import SplitResult, aggregate_scores, has_valid_trials
 from .rundir import RunDir, _atomic_write
 from .splits import Splits, make_splits
@@ -1474,7 +1475,8 @@ def record_iteration(run_dir: RunDir, workdir: Path, cid: str, *,
                      parent_id: str | None, accepted: bool, reason: str,
                      val: float | None = None, parent_val: float | None = None,
                      indecisive: bool = False, parents: list | None = None,
-                     edit_kind: str | None = None, **extra) -> None:
+                     edit_kind: str | None = None, memory_skill: str | None = None,
+                     **extra) -> None:
     """THE one place an iteration is recorded. EVERY algorithm ends its iteration here.
 
     Three things must happen exactly once per iteration, and they used to be
@@ -1517,12 +1519,9 @@ def record_iteration(run_dir: RunDir, workdir: Path, cid: str, *,
                          best_val=val if accepted and val is not None else None)
     run_dir.log_event("step", candidate=cid, accept=accepted, reason=reason,
                       val=val, parent=parent_id, parent_val=parent_val, **extra)
-    delta = (val - parent_val if isinstance(val, (int, float))
-             and isinstance(parent_val, (int, float)) else None)
-    _reconcile_journal(workdir, run_dir, cid, accepted=accepted, val=val, delta=delta,
-                       reason=reason, indecisive=indecisive)
-    for filename, seed, mark in _ACCUMULATORS:
-        _fold_accumulator(workdir, run_dir, filename=filename, seed=seed, mark=mark)
+    resolve_memory(memory_skill).write_handover(
+        run_dir, workdir, cid, accepted=accepted, val=val, parent_val=parent_val,
+        reason=reason, indecisive=indecisive)
     try:
         graph_mod.append_node(
             run_dir, node_id=cid,
@@ -1736,6 +1735,98 @@ def _augment_instructions(instructions: str, workdir: Path, run_dir: RunDir) -> 
     return f"{instructions}\n\n{pointer}\n"
 
 
+class MdFilesMemory(MemorySkill):
+    """Default memory scheme: LEDGER/JOURNAL/PROCESS/RUNMAP + the three summary
+    accumulators (see the file-header comment near ``_JOURNAL_MARK``) — exactly the
+    behavior every algorithm has always had, now reachable through the plug-in
+    interface instead of only via bare module functions."""
+    name = "md-files"
+
+    def seed(self, workdir: Path, run_dir: RunDir) -> list[str]:
+        return seed_framework_memory(workdir, run_dir)
+
+    def augment_instructions(self, instructions: str, workdir: Path, run_dir: RunDir) -> str:
+        return _augment_instructions(instructions, workdir, run_dir)
+
+    def write_handover(self, run_dir: RunDir, workdir: Path, cid: str, *,
+                       accepted: bool, val=None, parent_val=None, reason: str | None = None,
+                       indecisive: bool = False) -> None:
+        delta = (val - parent_val if isinstance(val, (int, float))
+                 and isinstance(parent_val, (int, float)) else None)
+        _reconcile_journal(workdir, run_dir, cid, accepted=accepted, val=val, delta=delta,
+                           reason=reason, indecisive=indecisive)
+        for filename, seed, mark in _ACCUMULATORS:
+            _fold_accumulator(workdir, run_dir, filename=filename, seed=seed, mark=mark)
+
+
+class WikiMemory(MemorySkill):
+    """Wiki memory: weakness nodes + solution cards, extracted from the deprecated
+    ``evograph`` algorithm's run-dir format per its own maintainer note (a memory
+    FORMAT, not a search strategy — see ``skills/algorithms/evograph/SKILL.md``),
+    now selectable independent of algorithm.
+
+    Unlike ``md-files``, the optimizer writes ``wiki/`` itself at the run root's
+    ABSOLUTE path, not into the per-iteration ``workdir`` — every iteration's working
+    copy sees the same live tree, so nothing needs copying in or folding back, and
+    ``write_handover`` has nothing to do.
+    """
+    name = "wiki"
+
+    def seed(self, workdir: Path, run_dir: RunDir) -> list[str]:
+        written: list[str] = []
+        for sub in ("weaknesses", "solutions", "results"):
+            (run_dir.root / "wiki" / sub).mkdir(parents=True, exist_ok=True)
+        written.append("wiki/")
+        try:
+            _build_ledger(workdir, run_dir)
+            written.append("LEDGER.md")
+        except Exception as e:  # noqa: BLE001
+            run_dir.log_event("optimizer_context_warning", what="LEDGER.md", error=str(e)[:300])
+        # PROCESS.md (per-iteration explainability) is orthogonal to the handover
+        # FORMAT — every memory scheme wants it, so it is seeded here too, not just
+        # by md-files.
+        try:
+            if not (workdir / "PROCESS.md").exists():
+                (workdir / "PROCESS.md").write_text(_PROCESS_SEED, encoding="utf-8")
+            written.append("PROCESS.md")
+        except OSError as e:
+            run_dir.log_event("optimizer_context_warning", what="PROCESS.md", error=str(e)[:300])
+        return written
+
+    def augment_instructions(self, instructions: str, workdir: Path, run_dir: RunDir) -> str:
+        self.seed(workdir, run_dir)
+        wiki_root = run_dir.root / "wiki"
+        pointer = (
+            "## Cross-iteration memory: the WIKI (this run's memory_skill)\n"
+            f"Write directly to the ABSOLUTE path `{wiki_root}` — never a relative copy "
+            "inside this working dir, it must stay visible across every iteration.\n"
+            "- `weaknesses/<slug>.md` — one file per known weakness (front matter: slug, "
+            "status, tags, discovered_in_round, attacked_in_rounds, solved_in_round, "
+            "affected_tasks, related). Read every existing one before proposing, so you "
+            "build on or close a weakness instead of rediscovering it.\n"
+            "- `solutions/<weakness-slug>/<sol-id>/{solution.md,changes.diff}` — a kept "
+            "improvement for that weakness. Write one for any weakness you fix or "
+            "materially improve this iteration.\n"
+            "- `results/round-<N>.json` — this iteration's metrics.\n"
+            "Full format + examples: `./guidance/memory-wiki/SKILL.md`.\n"
+            "- `LEDGER.md` — FACTS (framework, read-only): every iteration's outcome + "
+            "which val tasks it measurably broke/fixed.\n"
+        )
+        return f"{instructions}\n\n{pointer}\n"
+
+    def write_handover(self, run_dir: RunDir, workdir: Path, cid: str, **kwargs) -> None:
+        pass  # the optimizer already wrote directly to wiki/ at the absolute path
+
+
+MEMORY_SKILLS: dict[str, MemorySkill] = {"md-files": MdFilesMemory(), "wiki": WikiMemory()}
+
+
+def resolve_memory(name: str | None) -> MemorySkill:
+    """Look up a ``memory_skill`` name, falling back to the default (``md-files``)
+    for an unset or unknown one — a run must never crash over a bad memory choice."""
+    return MEMORY_SKILLS.get(str(name or "md-files").strip()) or MEMORY_SKILLS["md-files"]
+
+
 def _copy_step_trajectories(adapter, run_dir: RunDir, workdir: Path, split: str,
                             tag: str | None = None) -> None:
     """Copy ONLY the current best/parent candidate's per-tag rollouts for ``split``
@@ -1816,7 +1907,7 @@ def _copy_step_trajectories(adapter, run_dir: RunDir, workdir: Path, split: str,
 def _inject_optimizer_context(adapter, run_dir: RunDir, workdir: Path, *, split: str,
                               capabilities=None, optimizer_name: str | None = None,
                               capability_sources=None, project_dir: Path | None = None,
-                              tag: str | None = None) -> None:
+                              tag: str | None = None, memory_skill: str | None = None) -> None:
     """Give the optimizer everything it needs to read, inside its own working dir.
 
     Copies, VERBATIM and without parsing:
@@ -1917,11 +2008,32 @@ def _inject_optimizer_context(adapter, run_dir: RunDir, workdir: Path, *, split:
     # instructions file. All best-effort: a missing registry / unknown agent just skips
     # native placement (./guidance/ still works).
     if optimizer_name:
-        _inject_native_skills(run_dir, workdir, caps, repo_root, optimizer_name)
+        _inject_native_skills(run_dir, workdir, caps, repo_root, optimizer_name,
+                              memory_skill=memory_skill)
+
+
+def _inject_memory_skill_guidance(run_dir: RunDir, workdir: Path, memory_skill: str) -> None:
+    """Copy the non-default ``memory_skill``'s own skill directory into
+    ``workdir/guidance/memory-<name>/``, the same way capability/diagnose skills are
+    copied — so ``wiki``'s pointer text ("full format: ./guidance/memory-wiki/SKILL.md")
+    resolves to a real file instead of a promise. Best-effort: a missing skill dir
+    just means the inline pointer text is all the optimizer gets."""
+    repo_root = Path(__file__).resolve().parents[2]
+    src = repo_root / "skills" / "memory" / memory_skill
+    if not src.is_dir():
+        return
+    try:
+        dst = workdir / "guidance" / f"memory-{memory_skill}"
+        if dst.exists():
+            shutil.rmtree(dst)
+        shutil.copytree(src, dst, ignore=shutil.ignore_patterns("__pycache__", "scripts", "*.pyc"))
+    except Exception as e:  # noqa: BLE001
+        run_dir.log_event("optimizer_context_warning",
+                          what=f"guidance/memory-{memory_skill}", error=str(e)[:300])
 
 
 def _inject_native_skills(run_dir: RunDir, workdir: Path, caps, repo_root: Path,
-                          optimizer_name: str) -> None:
+                          optimizer_name: str, memory_skill: str | None = None) -> None:
     """Place capability + diagnose skills where ``optimizer_name`` natively discovers
     them, and write a pointer into its always-on instructions file.
 
@@ -1978,7 +2090,8 @@ def _inject_native_skills(run_dir: RunDir, workdir: Path, caps, repo_root: Path,
         if instructions_file:
             try:
                 _write_instructions_pointer(workdir / instructions_file, skills_dir,
-                                            run_dir=run_dir, workdir=workdir)
+                                            run_dir=run_dir, workdir=workdir,
+                                            memory_skill=memory_skill)
             except Exception as e:  # noqa: BLE001
                 run_dir.log_event("optimizer_context_warning",
                                   what=f"instructions/{instructions_file}", error=str(e)[:300])
@@ -2022,21 +2135,23 @@ _POINTER_FILES = (
 
 
 def _write_instructions_pointer(path: Path, skills_dir: str, *, run_dir=None,
-                                workdir: Path | None = None) -> None:
+                                workdir: Path | None = None,
+                                memory_skill: str | None = None) -> None:
     """Write (or append) a short generic pointer block into the agent's instructions
     file, idempotently (keyed on a marker comment so it is not duplicated).
 
     Given ``run_dir`` + ``workdir`` it first CREATES the cross-iteration files it is about
-    to name (``seed_framework_memory``) and then lists only the ones that exist. Both
-    halves matter: the promise used to be unconditional prose, so an agent-driven run was
-    told to read four files and a directory that nothing on its path ever created (see
-    ``seed_framework_memory``). Tying the text to the filesystem means the pointer cannot
-    drift back into promising a file again — if a file stops being created, it stops being
-    named, instead of silently sending the optimizer to a dead path.
+    to name (through the chosen ``memory_skill``, default ``md-files``) and then lists
+    only the ones that exist. Both halves matter: the promise used to be unconditional
+    prose, so an agent-driven run was told to read four files and a directory that
+    nothing on its path ever created. Tying the text to the filesystem means the pointer
+    cannot drift back into promising a file again — if a file stops being created, it
+    stops being named, instead of silently sending the optimizer to a dead path.
     """
     present = set()
+    memory = resolve_memory(memory_skill)
     if run_dir is not None and workdir is not None:
-        present = set(seed_framework_memory(workdir, run_dir))
+        present = set(memory.seed(workdir, run_dir))
     existing = ""
     if path.exists():
         try:
@@ -2047,12 +2162,20 @@ def _write_instructions_pointer(path: Path, skills_dir: str, *, run_dir=None,
         return
     skills_note = (f"the optimization skills are available natively under `{skills_dir}/` and "
                    if skills_dir else "the optimization skills are available under ")
-    listed = [brief for name, brief in _POINTER_FILES if name in present]
     files_note = ""
-    if listed:
-        files_note = ("Cross-iteration files in this directory (clean ownership) — read all of "
-                      "these before you start:\n"
-                      + "".join(f"- {b}\n" for b in listed))
+    if memory.name == "md-files":
+        listed = [brief for name, brief in _POINTER_FILES if name in present]
+        if listed:
+            files_note = ("Cross-iteration files in this directory (clean ownership) — read "
+                          "all of these before you start:\n"
+                          + "".join(f"- {b}\n" for b in listed))
+    else:
+        # Non-default memory scheme (e.g. wiki): its own pointer text fully replaces the
+        # md-files listing above, since it describes a different set of files/paths.
+        memo_note = memory.augment_instructions("", workdir, run_dir).strip() if (
+            run_dir is not None and workdir is not None) else ""
+        if memo_note:
+            files_note = memo_note + "\n"
     # ``rejected.jsonl`` has always existed in the run dir and was never mentioned: it is the
     # run's own record of approaches already refuted, written by every algorithm, and an
     # optimizer that does not know about it re-proposes what the run has already paid to rule
@@ -2086,7 +2209,8 @@ def _tamper_step(run_dir: RunDir, *, cid: str, parent_id, workdir: Path,
                  report, current_val: SplitResult, optimizer_seconds: float,
                  opt_cost_usd: float, opt_tokens: int, optimizer_error,
                  kind: str = "integrity", event: str = "tamper_detected",
-                 detail_key: str = "tamper", rejected=None) -> dict:
+                 detail_key: str = "tamper", rejected=None,
+                 memory_skill: str | None = None) -> dict:
     """An INDECISIVE step for a candidate that was never validly measurable.
 
     Two causes share this path: the candidate edited a protected file (integrity),
@@ -2108,7 +2232,7 @@ def _tamper_step(run_dir: RunDir, *, cid: str, parent_id, workdir: Path,
     run_dir.snapshot(cid, workdir, ignore=_SNAPSHOT_IGNORE)  # forensics only — never best
     record_iteration(run_dir, workdir, cid, parent_id=parent_id, accepted=False,
                      reason=reason, val=None, parent_val=current_val.reward,
-                     indecisive=True,
+                     indecisive=True, memory_skill=memory_skill,
                      optimizer_seconds=round(optimizer_seconds, 2),
                      opt_cost_usd=round(opt_cost_usd, 6), opt_tokens=opt_tokens)
     run_dir.log_event("step_indecisive", candidate=cid, reason=reason)
@@ -2136,7 +2260,8 @@ _MAX_CONSECUTIVE_EVAL_ERRORS = 3  # N raises in a row -> the environment, not th
 
 def _eval_error_step(run_dir: RunDir, *, cid: str, parent_id, workdir: Path, error: str,
                      current_val: SplitResult, optimizer_seconds: float,
-                     opt_cost_usd: float, opt_tokens: int, optimizer_error) -> dict:
+                     opt_cost_usd: float, opt_tokens: int, optimizer_error,
+                     memory_skill: str | None = None) -> dict:
     """An INDECISIVE step for a candidate whose ``evaluate_candidate`` call raised —
     e.g. an adapter's ``live()``/rollout setup blew up (#286). The run keeps going
     (that is the whole point: one candidate's cost, not the run's) but the candidate
@@ -2158,7 +2283,7 @@ def _eval_error_step(run_dir: RunDir, *, cid: str, parent_id, workdir: Path, err
     run_dir.snapshot(cid, workdir, ignore=_SNAPSHOT_IGNORE)  # forensics only — never best
     record_iteration(run_dir, workdir, cid, parent_id=parent_id, accepted=False,
                      reason=reason, val=None, parent_val=current_val.reward,
-                     indecisive=True,
+                     indecisive=True, memory_skill=memory_skill,
                      optimizer_seconds=round(optimizer_seconds, 2),
                      opt_cost_usd=round(opt_cost_usd, 6), opt_tokens=opt_tokens)
     run_dir.log_event("step_indecisive", candidate=cid, reason=reason)
@@ -2240,7 +2365,7 @@ def run_step(
     ctx = ctx or OptimizerContext()
     ctx.inject(adapter, run_dir, workdir, split=eval_split)
 
-    instructions = _augment_instructions(instructions, workdir, run_dir)
+    instructions = ctx.augment_instructions(instructions, workdir, run_dir)
 
     # Seal the eval surface (hash manifest + best-effort read-only bits) AFTER the
     # context injection wrote its scratch files, so nothing we add ourselves reads as
@@ -2290,7 +2415,7 @@ def run_step(
                                 report=report, current_val=current_val,
                                 optimizer_seconds=optimizer_seconds,
                                 opt_cost_usd=opt_cost_usd, opt_tokens=opt_tokens,
-                                optimizer_error=optimizer_error)
+                                optimizer_error=optimizer_error, memory_skill=ctx.memory_skill)
 
     # The capability's OWN validity rules, checked here (still before the gate, and
     # before any rollout is paid for) rather than left to prose the optimizer may skip.
@@ -2309,7 +2434,7 @@ def run_step(
                                 opt_cost_usd=opt_cost_usd, opt_tokens=opt_tokens,
                                 optimizer_error=optimizer_error, kind="validation",
                                 event="capability_invalid", detail_key="validation",
-                                rejected=rejected)
+                                rejected=rejected, memory_skill=ctx.memory_skill)
 
     try:
         cand_val = evaluate_candidate(adapter, workdir, run_dir=run_dir, split="val",
@@ -2335,7 +2460,7 @@ def run_step(
                                 error=eval_error, current_val=current_val,
                                 optimizer_seconds=optimizer_seconds,
                                 opt_cost_usd=opt_cost_usd, opt_tokens=opt_tokens,
-                                optimizer_error=optimizer_error)
+                                optimizer_error=optimizer_error, memory_skill=ctx.memory_skill)
     run_dir._consecutive_eval_errors = 0
 
     # Paired gate is the default when per-task data is available: candidate and
@@ -2423,6 +2548,7 @@ def run_step(
     record_iteration(run_dir, workdir, cid, parent_id=parent_id, accepted=accepted,
                      reason=decision.reason, val=cand_val.reward,
                      parent_val=current_val.reward, indecisive=decision.indecisive,
+                     memory_skill=ctx.memory_skill,
                      optimizer_seconds=round(optimizer_seconds, 2),
                      runner_seconds=round(cand_val.seconds, 2),
                      cost_usd=cand_val.cost_usd, tokens=cand_val.tokens,
@@ -3142,6 +3268,7 @@ class OptimizerContext:
     instructions_file: str | None = None
     bench_repo: str | None = None
     target_reader: str = ""
+    memory_skill: str = "md-files"
 
     # ---- construction from an algorithm run.py --------------------------------
 
@@ -3174,6 +3301,8 @@ class OptimizerContext:
                        help="consuming/runtime model id or tier keyword (frontier|strong|mid|weak)")
         p.add_argument("--target-profile-file", default=None,
                        help="optional project-local brief overriding the tier's built-in brief")
+        p.add_argument("--memory-skill", default=None,
+                       help="cross-iteration memory scheme (md-files|wiki); defaults to md-files")
 
     @classmethod
     def from_args(cls, args, run_dir: RunDir | None = None) -> "OptimizerContext":
@@ -3204,6 +3333,7 @@ class OptimizerContext:
             instructions_file=getattr(args, "instructions_file", None),
             bench_repo=getattr(args, "bench_repo", None),
             target_reader=_tp.reader_block(profile),
+            memory_skill=getattr(args, "memory_skill", None) or "md-files",
         )
 
     @classmethod
@@ -3227,6 +3357,7 @@ class OptimizerContext:
             instructions_file=(str(spec.get("optimizer_instructions_file") or "") or None),
             bench_repo=(str(spec.get("bench_repo") or "") or None),
             target_reader=_tp.reader_block(profile),
+            memory_skill=str(spec.get("memory_skill") or "md-files"),
         )
 
     # ---- reusable prompt blocks ----------------------------------------------
@@ -3315,7 +3446,18 @@ class OptimizerContext:
                                   capabilities=list(self.capabilities),
                                   optimizer_name=self.optimizer_name,
                                   capability_sources=list(self.capability_sources),
-                                  project_dir=self.project_dir, tag=tag)
+                                  project_dir=self.project_dir, tag=tag,
+                                  memory_skill=self.memory_skill)
+        if self.memory_skill and self.memory_skill != "md-files":
+            _inject_memory_skill_guidance(run_dir, workdir, self.memory_skill)
+
+    def augment_instructions(self, instructions: str, workdir: Path, run_dir: RunDir) -> str:
+        """Seed this run's chosen ``memory_skill``'s files and append its pointer text."""
+        return resolve_memory(self.memory_skill).augment_instructions(instructions, workdir, run_dir)
+
+    def write_handover(self, run_dir: RunDir, workdir: Path, cid: str, **kwargs) -> None:
+        """Record this iteration's handover the way the chosen ``memory_skill`` wants it."""
+        resolve_memory(self.memory_skill).write_handover(run_dir, workdir, cid, **kwargs)
 
     def instructions(self, current_val: SplitResult, focus_ids, label: str, *,
                      algorithm: str, parent_dir: Path | None = None,

--- a/core/cap_evolve/memory.py
+++ b/core/cap_evolve/memory.py
@@ -21,6 +21,36 @@ from pathlib import Path
 from typing import Optional
 
 
+class MemorySkill:
+    """Minimal common interface a cross-iteration memory scheme implements, so
+    ``harness.py`` can drive ANY of them the same way it already drives capability/
+    optimizer skills — one selectable component (``memory_skill`` in ``capevolve.yaml``,
+    default ``md-files``), not one hardcoded scheme (#400, #404).
+
+    Three hooks, one per thing the harness needs from memory each iteration:
+
+    - ``seed`` — write/refresh whatever memory artifacts the optimizer reads. May write
+      into ``workdir`` (the per-iteration working copy) and/or elsewhere (e.g. the run
+      root, for a scheme the optimizer must reach from every iteration at one stable
+      absolute path). Returns the names written, for logging.
+    - ``augment_instructions`` — call ``seed`` and return the per-iteration prompt with a
+      pointer to what got written and where to find it.
+    - ``write_handover`` — after the gate decides this iteration's outcome, record
+      whatever this scheme calls a "handover". A scheme whose optimizer writes its own
+      memory directly (no framework-owned accumulator to fold) can leave this a no-op.
+    """
+    name = "base"
+
+    def seed(self, workdir: Path, run_dir) -> list[str]:
+        return []
+
+    def augment_instructions(self, instructions: str, workdir: Path, run_dir) -> str:
+        return instructions
+
+    def write_handover(self, run_dir, workdir: Path, cid: str, **kwargs) -> None:
+        pass
+
+
 class RejectedMemory:
     def __init__(self, path: Path):
         self.path = Path(path)

--- a/core/tests/test_memory_skills.py
+++ b/core/tests/test_memory_skills.py
@@ -1,0 +1,99 @@
+"""The memory_skill plug-in interface (#400, #404): md-files stays the unchanged
+default, and selecting wiki drives a real end-to-end run through the extracted
+weakness-graph format instead of LEDGER/JOURNAL/INSIGHTS."""
+
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+CORE = REPO / "core"
+EXAMPLE = REPO / "examples" / "toy_calc"
+MOCK_RUN = REPO / "skills" / "optimizers" / "run-optimizer" / "scripts" / "run.py"
+sys.path.insert(0, str(CORE))
+sys.path.insert(0, str(EXAMPLE))
+
+
+@pytest.fixture(autouse=True)
+def _env(monkeypatch):
+    monkeypatch.setenv("CAPEVOLVE_CORE", str(CORE))
+    monkeypatch.setenv("CAPEVOLVE_TOY_DATA", str(EXAMPLE))
+    monkeypatch.setenv("CAPEVOLVE_MOCK_SCRIPT", str(EXAMPLE / "mock_script.json"))
+
+
+def _toy_adapter():
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("toy_calc_adapter3", EXAMPLE / "adapter.py")
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m.Adapter()
+
+
+def test_resolve_memory_defaults_and_looks_up_by_name():
+    from cap_evolve import harness
+
+    assert isinstance(harness.resolve_memory(None), harness.MdFilesMemory)
+    assert isinstance(harness.resolve_memory("md-files"), harness.MdFilesMemory)
+    assert isinstance(harness.resolve_memory("wiki"), harness.WikiMemory)
+    # An unknown name must never crash a run — it silently falls back to the default.
+    assert isinstance(harness.resolve_memory("no-such-skill"), harness.MdFilesMemory)
+
+
+def test_wiki_memory_skill_end_to_end(tmp_path):
+    if shutil.which("git") is None:
+        pytest.skip("git not available")
+    from cap_evolve import Budget, RunDir, harness
+
+    adapter = _toy_adapter()
+    seed = tmp_path / "seed"
+    shutil.copytree(EXAMPLE / "capability", seed)
+    run_dir = RunDir.create(tmp_path / ".capevolve", ts="wiki", budget=Budget(max_iterations=3, stall=3))
+    harness.ensure_splits(adapter, run_dir, seed=0)
+    base = harness.baseline(adapter, seed, run_dir=run_dir)
+
+    optimizer = harness.optimizer_from_command(
+        ["python3", str(MOCK_RUN), "--name", "mock", "--workdir", "{workdir}", "--prompt", "{prompt}"])
+    ctx = harness.OptimizerContext(memory_skill="wiki")
+    summary = harness.hill_climb_loop(
+        adapter, run_dir=run_dir, optimizer=optimizer, current_val=base,
+        focus="all", max_iterations=3, gate_kwargs={"mode": "significant", "k_se": 1.0},
+        algorithm="all-at-once", ctx=ctx,
+    )
+    assert summary["iterations"] >= 1
+
+    # The wiki lives at the run root's ABSOLUTE path, not copied into any iteration's
+    # working dir, and framework-owned LEDGER.md still gets built (facts are scheme-
+    # agnostic) — but the md-files append-only journal/accumulators must NOT exist.
+    assert (run_dir.root / "wiki" / "weaknesses").is_dir()
+    assert (run_dir.root / "wiki" / "solutions").is_dir()
+    assert (run_dir.root / "wiki" / "results").is_dir()
+    work = run_dir.root / "work" / run_dir.best_id
+    assert (work / "LEDGER.md").exists()
+    assert not (work / "JOURNAL.md").exists()
+    assert not (work / "INSIGHTS.md").exists()
+    assert not (run_dir.root / "JOURNAL.md").exists()
+
+    # The mock optimizer only appends to JOURNAL.md when the harness seeded one
+    # (see _mock_apply.py) — under wiki it never gets seeded, so no candidate should
+    # ever have been mis-escalated as an "empty handover" (a false positive that the
+    # md-files-only pointer path would have produced before this was memory-aware).
+    events = [e.get("kind") for e in _read_events(run_dir)]
+    warnings = [e for e in _read_events(run_dir)
+               if e.get("kind") == "optimizer_context_warning"
+               and "empty handover" in str(e.get("error") or "")]
+    assert warnings == []
+    assert "step" in events
+
+
+def _read_events(run_dir):
+    import json
+    if not run_dir.events_path.exists():
+        return []
+    out = []
+    for line in run_dir.events_path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line:
+            out.append(json.loads(line))
+    return out

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -86,7 +86,7 @@ heatmap, per-iteration git diffs, the lineage tree, and gate decisions.
 
 ## Skill library
 
-21 skills · 5 algorithms (3 run-executable + 2 agent-mode) · 14 optimizer backends, all over
+22 skills · 5 algorithms (3 run-executable + 2 agent-mode) · 14 optimizer backends, all over
 the core. Extending is one folder or one registry row — see [`EXTENDING.md`](EXTENDING.md).
 
 **How the counts are defined.** A *skill* is one `skills/<component>/<name>/SKILL.md`, i.e.

--- a/llms.txt
+++ b/llms.txt
@@ -31,13 +31,16 @@ except at finalize; gate acceptance on val with a paired significance gate.
 - [CONTRIBUTING.md](CONTRIBUTING.md): dev setup and house rules.
 - [docs/ROADMAP.md](docs/ROADMAP.md): prioritized next work.
 
-## Skills (21)
+## Skills (22)
 Counting rule: one skill = one skills/<component>/<name>/SKILL.md, i.e. every row of
 skills/_registry/manifest.json — phases + capabilities + algorithms + optimizers +
 interventions + orchestrate.
 - phases: intake, implement-and-check, baseline, evaluate, diagnose, gate, finalize, report
 - capabilities: system-prompt, skill-package, tools, mcp-tool
 - interventions: spa (how a candidate is DELIVERED to the model under test, vs what is edited)
+- memory: wiki (which cross-iteration memory scheme, selected via `memory_skill` —
+  md-files is the built-in default and needs no skill dir; wiki is the weakness-graph
+  format extracted from evograph)
 - algorithms (5): 3 run-executable + 2 agent-mode. Run-executable via `cap-evolve run`:
   hill-climb (--focus all|cyclic|hardest-first), gepa, skillopt (gepa & skillopt are the
   sample-efficient flagships). Agent-mode only (orchestration_mode: agent; their

--- a/site/architecture.html
+++ b/site/architecture.html
@@ -276,7 +276,7 @@
       <h2 id="skill-library">Skill library</h2>
 
       <p>
-        21 skills · 5 algorithms (3 run-executable + 2 agent-mode) · 14 optimizer backends,
+        22 skills · 5 algorithms (3 run-executable + 2 agent-mode) · 14 optimizer backends,
         all over the core. Extending is one
         folder or one registry row — see
         <a href="https://github.com/skillberry-ai/cap-evolve/blob/main/docs/EXTENDING.md">EXTENDING.md</a>.

--- a/site/index.html
+++ b/site/index.html
@@ -85,7 +85,7 @@
       <span class="badge">beta (0.x)</span>
       <span class="badge">python 3.10+</span>
       <span class="badge">Apache-2.0</span>
-      <span class="badge badge-accent">21 skills · 5 algorithms (3 run-executable + 2 agent-mode)</span>
+      <span class="badge badge-accent">22 skills · 5 algorithms (3 run-executable + 2 agent-mode)</span>
       <span class="badge badge-amber">14 optimizer backends</span>
     </div>
     <div class="hero-affil">

--- a/skills/_registry/build_manifest.py
+++ b/skills/_registry/build_manifest.py
@@ -26,7 +26,13 @@ from pathlib import Path
 # `intervention` names HOW a candidate is delivered to the model under test, as opposed to
 # WHAT is optimized (`capability`). An intervention skill owns an out-of-process delivery
 # stack rather than a step in the run DAG, so it declares no needs/provides tokens.
-COMPONENTS = {"phase", "capability", "algorithm", "optimizer", "orchestrate", "intervention"}
+#
+# `memory` names WHICH cross-iteration memory scheme the harness drives (#400, #404) —
+# selected via `memory_skill` in capevolve.yaml the same way `capability`/`optimizer` are,
+# but it owns no step in the run DAG either (declares no needs/provides), same as
+# `intervention`.
+COMPONENTS = {"phase", "capability", "algorithm", "optimizer", "orchestrate", "intervention",
+             "memory"}
 
 # The needs/provides token vocabulary. Every needs/provides entry must be one of
 # these; a misspelling ("score" for "scores") fails the build instead of silently

--- a/skills/_registry/manifest.json
+++ b/skills/_registry/manifest.json
@@ -242,6 +242,26 @@
         ]
       }
     },
+    "wiki": {
+      "component": "memory",
+      "path": "memory/wiki",
+      "summary": "Cross-iteration memory as a weakness graph (weakness nodes + solution cards), extracted from the deprecated evograph algorithm. Select via memory_skill: wiki in capevolve.yaml.",
+      "entry": "scripts/run.py",
+      "abstract": null,
+      "check": "scripts/check.py",
+      "prompt": null,
+      "inputs": null,
+      "needs": [],
+      "provides": [],
+      "compatible_with": {
+        "optimizers": [
+          "*"
+        ],
+        "algorithms": [
+          "*"
+        ]
+      }
+    },
     "run-optimizer": {
       "component": "optimizer",
       "path": "optimizers/run-optimizer",

--- a/skills/algorithms/agent-optimize/scripts/commit.py
+++ b/skills/algorithms/agent-optimize/scripts/commit.py
@@ -48,6 +48,28 @@ import _bootstrap  # noqa: F401  # side-effect import, see above
 from cap_evolve import RunDir, harness
 
 
+def _memory_skill_from_spec(run_dir: RunDir) -> str | None:
+    """``memory_skill`` from the sibling project spec, or ``None``.
+
+    Agent mode invokes this script standalone with only ``--run-dir`` — no ``--project``,
+    no spec object — so the choice has to be read off disk the same zero-dependency way
+    ``dashboard.py``'s ``_algorithm_from_spec`` reads ``algorithm_skill``: flat ``key: value``
+    lines only, from ``<base>/project/capevolve.yaml`` next to the run dir. Best-effort — a
+    missing/unreadable spec just means the default (``md-files``) applies, same as today.
+    """
+    spec_path = run_dir.root.parent / "project" / "capevolve.yaml"
+    if not spec_path.is_file():
+        return None
+    try:
+        for line in spec_path.read_text(encoding="utf-8").splitlines():
+            if line.startswith("memory_skill:"):
+                val = line.split(":", 1)[1].split("#", 1)[0].strip().strip("'\"")
+                return val or None
+    except OSError:
+        pass
+    return None
+
+
 def _round_gate_numbers(run_dir: RunDir, candidate_id: str) -> dict:
     """The gate's NUMBERS for ``candidate_id``, read back from ``round.py``'s own table.
 
@@ -450,6 +472,7 @@ def main(argv=None) -> int:
     # bookkeeping on a decision that has not actually been made yet. It files no memory record
     # either, for the same reason `inconclusive` does not: nothing has been refuted.
     if not provisional:
+        memory_skill = _memory_skill_from_spec(run_dir)
         # The shared iteration step: charges iterations/stall, writes the canonical ``step``
         # record, reconciles the run-level JOURNAL.md. The gate's numbers ride along so the
         # dashboard's ``gate_decisions[]`` does not have to regex them out of an agent's prose.
@@ -457,7 +480,7 @@ def main(argv=None) -> int:
                                  accepted=accepted, reason=reason,
                                  val=args.val,
                                  parent_val=parent_val,
-                                 indecisive=indecisive,
+                                 indecisive=indecisive, memory_skill=memory_skill,
                                  parents=parents, edit_kind=args.edit_kind,
                                  opt_cost_usd=args.optimizer_usd or None,
                                  opt_tokens=args.optimizer_tokens or None,
@@ -477,7 +500,7 @@ def main(argv=None) -> int:
         # (a run with no baseline) — that dir always exists (``run_dir.snapshot`` above just
         # created it) — and is best-effort: losing the re-seed must not fail the commit.
         try:
-            harness.seed_framework_memory(
+            harness.resolve_memory(memory_skill).seed(
                 run_dir.candidate_dir(run_dir.best_id or args.candidate_id), run_dir)
         except Exception as exc:  # noqa: BLE001
             run_dir.log_event("optimizer_context_warning", what="framework_memory",

--- a/skills/algorithms/agent-optimize/scripts/host.py
+++ b/skills/algorithms/agent-optimize/scripts/host.py
@@ -704,7 +704,7 @@ def _stage_context(*, run_dir: Path, project: Path, workdir: Path, spec: dict,
         # prior_iterations/ are named by the staged CLAUDE.md pointer AND by JOURNAL.md's own
         # seed text, and seeding only the journal is what left them absent for a whole run.
         try:
-            harness.seed_framework_memory(rd.candidate_dir(rd.best_id or "seed"), rd)
+            harness.resolve_memory(ctx.memory_skill).seed(rd.candidate_dir(rd.best_id or "seed"), rd)
         except Exception as exc:  # noqa: BLE001
             rd.log_event("optimizer_context_warning", what="framework_memory",
                          error=str(exc)[:300])

--- a/skills/algorithms/evograph/SKILL.md
+++ b/skills/algorithms/evograph/SKILL.md
@@ -21,8 +21,8 @@ sources: [evo-graph]
 # evograph — DEPRECATED
 
 **Do not select `algorithm_skill: evograph` for a new run.** Use `agent-optimize` (agent mode) or
-`hill-climb` / `gepa` / `skillopt` (deterministic). This file stays so an existing evograph run dir
-is still readable and so the wiki file-format contract has an owner until it moves.
+`hill-climb` / `gepa` / `skillopt` (deterministic) with `memory_skill: wiki` if you want THIS run's
+weakness-graph format. This file stays so an existing evograph run dir is still readable.
 
 ## Why it is deprecated
 
@@ -44,7 +44,9 @@ that capability is not distinctive and the part that *was* distinctive was a def
 - **What remains unique is an output format, not a search strategy.** The run-dir `wiki/` is
   genuinely useful, but the dashboard renders the Weakness-graph tab from `wiki/` presence alone,
   for any algorithm that writes the format (`core/cap_evolve/dashboard.py`). An output contract
-  does not earn a second agent-mode algorithm that users must choose between.
+  does not earn a second agent-mode algorithm that users must choose between — it has since moved
+  to `skills/memory/wiki/SKILL.md`, a standalone `memory_skill` any algorithm can select (#400,
+  #404), so it no longer needs evograph to stay alive.
 
 ## There is no deterministic engine
 
@@ -69,13 +71,16 @@ used by anything writing the wiki.
 
 ## Removal is a separate decision
 
-Deprecation is reversible; removal is not. Still to decide (maintainer): move the wiki format
-contract into `agent-optimize` as an optional output, stop `dashboard.py` inferring
-`algorithm = "evograph"` from `wiki/` presence, then delete this directory.
+Deprecation is reversible; removal is not. The wiki format contract now has a real owner
+(`skills/memory/wiki/SKILL.md`), so what's left to decide (maintainer): stop `dashboard.py`
+inferring `algorithm = "evograph"` from `wiki/` presence alone (any `memory_skill: wiki` run now
+writes it too), then delete this directory.
 
 ## References
-- [references/dashboard.md](references/dashboard.md) — the wiki file formats the dashboard tab
-  reads. Load it to write or parse `<run_dir>/wiki/`.
+- [skills/memory/wiki/SKILL.md](../../memory/wiki/SKILL.md) — the wiki format contract's current
+  home: weakness-node/solution-card schemas, generalized for any algorithm via `memory_skill: wiki`.
+- [references/dashboard.md](references/dashboard.md) — the same file formats, kept here for reading
+  an existing evograph run dir's branch/round-revert specifics the generalized skill dropped.
 - [references/clustering.md](references/clustering.md) — weakness-node schema and the
   `affected_tasks` freeze rule, kept for reading historical run dirs.
 - [references/graph.md](references/graph.md) — solution-card schema, branch layout, whole-round

--- a/skills/memory/wiki/SKILL.md
+++ b/skills/memory/wiki/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: wiki
+description: >-
+  Cross-iteration memory as a weakness graph (weakness nodes + solution cards), extracted
+  from the deprecated `evograph` algorithm's run-dir format per its own maintainer note.
+  Select via `memory_skill: wiki` in capevolve.yaml (default is `md-files`). Copied into
+  every iteration's working dir as `./guidance/memory-wiki/` when selected; read this
+  before writing anything under the run dir's `wiki/`.
+component: memory
+argument-hint: "no direct invocation — selected via memory_skill: wiki in capevolve.yaml"
+allowed-tools: Read, Write, Edit
+sources: [evo-graph, evograph]
+---
+
+# memory-wiki — the weakness graph memory format
+
+This is a memory FORMAT, not a search strategy: any algorithm (hill-climb, gepa, skillopt,
+agent-optimize) can select `memory_skill: wiki` and get this instead of the default
+`md-files` (LEDGER/JOURNAL/PROCESS/INSIGHTS). It replaces per-iteration append-only prose
+with a **persistent graph of known weaknesses**, each carrying its own history of what was
+tried and what worked — read once, re-read every iteration, useful across the whole run
+instead of scrolling a growing journal.
+
+## Absolute path (most important rule)
+
+Write to `<run_dir>/wiki/` — the **absolute path**, never a relative copy inside your
+per-iteration working dir. Every iteration gets a fresh working copy; the wiki does not
+live inside it and is never copied in or folded back. Writing to the absolute path is what
+makes it visible to the next iteration (and to the dashboard's Weakness-graph tab, which
+reads `wiki/` straight out of the run dir).
+
+## The two graphs
+
+- **Weaknesses** (`wiki/weaknesses/<slug>.md`) — what's broken. Persistent across
+  iterations; a weakness's `related` neighbors are the graph's edges.
+- **Solutions** (`wiki/solutions/<weakness-slug>/<sol-id>/`) — a kept improvement for one
+  weakness. Every solution `[[wikilink]]`s back to its weakness.
+
+### Weakness node — `wiki/weaknesses/<slug>.md`
+
+```markdown
+---
+slug: tool-call-arg-mismatch
+status: in-progress            # open | in-progress | completed | solved | reverted
+tags: [tool-calling, type-error]
+discovered_in_iteration: cand_0003
+attacked_in_iterations: [cand_0003, cand_0007]
+solved_in_iteration: null
+affected_tasks: [task_007, task_011, task_023]   # FROZEN after discovery — see below
+related:
+  - slug: schema-drift-after-retry
+    why: both corrupt the tool-call payload; candidates to merge
+solutions:
+  - "[[tool-call-arg-mismatch-cand_0007]]"
+---
+
+# Tool call arg mismatch
+
+## What fails
+The agent's tool-call planner passes a dict where the tool expects a string.
+
+## Tasks (found on)
+- task_007 — search query sent as JSON object
+
+## References
+- `agent/planner.py:88` — builds the args dict; no type coercion before dispatch.
+
+## Rejected Store Memory (RSM)
+(Empty at discovery; append dead-end attempts here so a later iteration does not retry them.)
+```
+
+**Freeze rule**: `affected_tasks` may only grow in the weakness's discovery iteration —
+after that it is frozen, because solutions are scored against that exact task set and
+changing it invalidates the comparison. Only `status` may change afterward.
+
+**RSM entry** (append-only, inside the weakness md, one per rejected attempt):
+```markdown
+### <iteration id> · <rejected-direction-slug>
+- **Thesis**: one line
+- **Change**: files touched, summarized
+- **Metrics (weakness tasks)**: <primary metric> <value>
+- **Why rejected**: dead end (no gain) · or reverted (broke another task)
+```
+
+### Solution card — `wiki/solutions/<weakness-slug>/<sol-id>/{solution.md,changes.diff}`
+
+`sol-id` is the candidate id that produced it (e.g. `cand_0007`).
+
+```markdown
+---
+weakness: "[[tool-call-arg-mismatch]]"
+iteration: cand_0007
+outcome: kept               # pending -> kept once the gate confirms it improved
+timestamp: 2026-06-28T14:03:00+03:00   # python scripts/now.py — never hand-written
+primary_metric: { name: reward, value: 0.74 }
+new_record: true            # true if this beat the weakness's previous best on its tasks
+---
+
+# Validate tool-call arg types in the planner
+
+## Thesis
+One line: the idea for resolving the weakness.
+
+## Change list
+- `agent/planner.py` — coerce arg types against the tool schema before dispatch.
+
+## Per-task metric delta (weakness tasks)
+| task    | before | after | Δ    |
+|---------|--------|-------|------|
+| task_007| 0.0    | 1.0   | +1.0 |
+
+See also [[tool-call-arg-mismatch]].
+```
+
+`changes.diff` — the capability diff for this candidate vs its parent (the framework's own
+`diff.patch`/LEDGER already have this; keep `changes.diff` as a wiki-local copy so a reader
+of the weakness graph never has to leave it).
+
+**Acceptance is never self-reported here.** `outcome`/`new_record` reflect the SAME honest
+val-significance gate every memory scheme reports through (`LEDGER.md`, framework-owned,
+also written under this scheme) — write the solution card once the candidate is actually
+accepted, not before.
+
+### Per-iteration metrics → `wiki/results/round-<N>.json`
+
+```json
+{
+  "round": 1,
+  "split": "val",
+  "started_at": "2026-06-28T14:00:00+03:00",
+  "completed_at": "2026-06-28T14:04:12+03:00",
+  "metrics": { "reward": { "value": 0.62, "primary": true, "direction": "higher" } },
+  "per_task": [ { "task_id": "0", "reward": 1.0 } ]
+}
+```
+
+Every metric is the wrapped object `{ value, primary, direction }`, never a flat number —
+the dashboard's timeline reads `.value`. Stamp `started_at`/`completed_at` from
+`python scripts/now.py` so every file agrees on the clock.
+
+## What the dashboard renders
+
+The dashboard's Weakness-graph tab reads `wiki/` directly out of the run dir: one row per
+weakness (`status`, `tags`, `related` edges, solution count), the primary metric over
+`wiki/results/round-<N>.json`, and each solution's diff. No registration, no API — write
+the files in this format and the viewer reflects them within a couple of seconds. Everything
+in these files the dashboard doesn't recognize is preserved and ignored, so extra keys are
+always safe.
+
+## What this format does NOT give you
+
+Whole-round revert, branches/worktrees-per-weakness, and multi-builder distribution were
+`evograph`'s ALGORITHM (its search strategy, now deprecated — see
+`skills/algorithms/evograph/SKILL.md`), not this FORMAT. Selecting `memory_skill: wiki` with
+any algorithm gets you the graph and its file contract; the val-significance gate, git
+history and accept/reject mechanics stay whatever that algorithm already does.

--- a/skills/memory/wiki/meta.yaml
+++ b/skills/memory/wiki/meta.yaml
@@ -1,0 +1,10 @@
+component: memory
+name: wiki
+summary: Cross-iteration memory as a weakness graph (weakness nodes + solution cards), extracted from the deprecated evograph algorithm. Select via memory_skill: wiki in capevolve.yaml.
+entry: scripts/run.py
+check: scripts/check.py
+needs: []
+provides: []
+compatible_with:
+  optimizers: ["*"]
+  algorithms: ["*"]

--- a/skills/memory/wiki/scripts/check.py
+++ b/skills/memory/wiki/scripts/check.py
@@ -1,0 +1,26 @@
+"""Self-check for memory/wiki: the format contract SKILL.md still documents the file
+paths ``harness.WikiMemory`` and its pointer text promise the optimizer."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_REQUIRED_MENTIONS = ("wiki/weaknesses", "wiki/solutions", "wiki/results")
+
+
+def main() -> int:
+    skill_md = Path(__file__).resolve().parents[1] / "SKILL.md"
+    text = skill_md.read_text(encoding="utf-8")
+    missing = [m for m in _REQUIRED_MENTIONS if m not in text]
+    if missing:
+        print(f"check failed: {skill_md} no longer documents {missing}")
+        return 1
+    print("ok")
+    return 0
+
+
+if __name__ == "__main__":
+    if "--self-check" in sys.argv:
+        sys.exit(main())
+    sys.exit(main())

--- a/skills/memory/wiki/scripts/run.py
+++ b/skills/memory/wiki/scripts/run.py
@@ -1,0 +1,20 @@
+"""memory/wiki has no executable step of its own — the format is applied by the optimizer
+writing files directly under <run_dir>/wiki/ (see SKILL.md), and the copy-into-guidance
+step lives in harness.py's `_inject_memory_skill_guidance`. This entry just points there,
+so `entry:` in meta.yaml resolves to real, working code rather than a stub."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    print("memory/wiki is a format contract, not a run step — read "
+          f"{Path(__file__).resolve().parents[1] / 'SKILL.md'} and write to "
+          "<run_dir>/wiki/ directly.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/phases/intake/SKILL.md
+++ b/skills/phases/intake/SKILL.md
@@ -53,10 +53,13 @@ gate will correctly reject marginal gains"), so the cost is visible at report ti
    value pre-filled as a default plus a free-text escape — including the ones only a
    human can answer: which metric gates accept/reject and each shown metric's
    direction, GitHub mirroring, deterministic vs agent orchestration (plus
-   `stop_condition` in agent mode), splits, trials, budget. `inputs/INPUTS.md` →
-   RECOMMENDED is the authority on each key; SKILL.md only fixes *when* to ask. Define
-   jargon in a clause before using it ("pass^k — how often it succeeds on all k
-   tries"); the user may be a domain expert, not an ML one.
+   `stop_condition` in agent mode), splits, trials, budget, and `memory_skill`
+   (default `md-files`; offer `wiki` — the weakness-graph format, see
+   `inputs/INPUTS.md` — when the user wants weaknesses tracked as a persistent graph
+   rather than an append-only journal). `inputs/INPUTS.md` → RECOMMENDED is the
+   authority on each key; SKILL.md only fixes *when* to ask. Define jargon in a
+   clause before using it ("pass^k — how often it succeeds on all k tries"); the user
+   may be a domain expert, not an ML one.
 5. **Confirm before scaffolding.** Echo the resolved spec back as one block —
    capability, optimizer, algorithm, dataset, splits, budget, every RECOMMENDED input
    you are defaulting — and get a yes. A misread is cheapest to fix here.

--- a/skills/phases/intake/inputs/INPUTS.md
+++ b/skills/phases/intake/inputs/INPUTS.md
@@ -105,13 +105,20 @@ path, how to obtain it, and the alternatives. Never invent a NEEDED input.
   `run-optimizer` skill against `optimizers/registry.yaml` (run `run-optimizer --list`
   to see the available names); `optimizer_model` is the backend-specific model id.
 
-- **memory_skill** (default `md-files`): which cross-iteration memory scheme the
-  optimizer reads/writes. `md-files` is `harness.py`'s built-in LEDGER/JOURNAL/
-  INSIGHTS/META_INSIGHTS/FRAMEWORK_IMPROVEMENTS scheme (always on today — every run
-  gets it regardless of this key) and is the only fully-wired option; note the choice
-  in `PROJECT.md` either way. The deprecated `evograph` algorithm's `wiki/` weakness-
-  graph format is a candidate SECOND option once it is extracted into a standalone
-  memory skill (tracked separately — not selectable yet).
+- **memory_skill** (default `md-files`, ask alongside algorithm/optimizer): which
+  cross-iteration memory scheme the optimizer reads/writes, selected the same way as
+  `algorithm_skill`/`optimizer_skill` (`harness.OptimizerContext` threads it through
+  every algorithm's `run.py` via `--memory-skill`; resolved off `MEMORY_SKILLS` in
+  `core/cap_evolve/harness.py`). Two options today:
+  - `md-files` (default) — `harness.py`'s built-in LEDGER/JOURNAL/PROCESS/INSIGHTS/
+    META_INSIGHTS/FRAMEWORK_IMPROVEMENTS scheme, append-only prose read fresh each
+    iteration.
+  - `wiki` — the weakness-graph format extracted from the deprecated `evograph`
+    algorithm (`skills/memory/wiki/SKILL.md`): persistent weakness nodes + solution
+    cards under `<run_dir>/wiki/`, rendered by the dashboard's Weakness-graph tab.
+    Offer this when the user wants to inspect known weaknesses across iterations as a
+    graph rather than scroll a journal, or is migrating off `evograph`.
+  Note the choice in `PROJECT.md` either way.
 
 - **target_model** (default `""` = profile-agnostic): the runtime/CONSUMING LLM the
   agent reads these capabilities with — DISTINCT from `optimizer_model`, which proposes

--- a/templates/project/capevolve.yaml
+++ b/templates/project/capevolve.yaml
@@ -35,6 +35,7 @@ target_profile_file: ""
 algorithm_skill: hill-climb              # algorithms/<skill>: hill-climb | gepa | skillopt | agent-optimize (REQUIRES orchestration_mode: agent). evograph is deprecated -- use agent-optimize.
 algorithm_focus: all                     # hill-climb schedule: all | cyclic | hardest-first
 orchestration_mode: deterministic        # deterministic (cap-evolve sequences the loop) | agent (the coding agent drives the loop via cap-evolve primitives, sealing with the finalize phase script)
+memory_skill: md-files                   # cross-iteration memory: md-files (LEDGER/JOURNAL/PROCESS/INSIGHTS, default) | wiki (weakness-graph format, skills/memory/wiki/SKILL.md)
 
 # --- what context the optimizer gets (hill-climb | gepa | skillopt) ---------
 # The per-iteration optimizer prompt is RENDERED from this template (intake authors it,


### PR DESCRIPTION
## Addresses #400, #404

### What was already done (prior merges, before this PR)
- #405 (merged as part of #400's own scope) already shipped: the confirmed empty-JOURNAL escalation fix, `INSIGHTS.md`/`META_INSIGHTS.md`/`FRAMEWORK_IMPROVEMENTS.md` as new per-run summary accumulators, and a default-on process narrative (`PROCESS.md`).
- #440/#429 already fixed multi-sibling JOURNAL.md reconciliation.
- #441/#433 already added a dashboard "Process narrative" tab reading `PROCESS.md`/host-session data — item (e) from the original #400 scope is covered there, not touched by this PR.
- `memory_skill` was already **documented** as an intake input (`skills/phases/intake/inputs/INPUTS.md`) and **shown** in the dashboard's config tab (`dashboard.py`'s `_CONFIG_KEY_GROUPS`) — but nothing in `harness.py` read it, `intake`'s interview never asked for it, and no `capevolve.yaml` template had a slot for it. Every run got the md-files scheme regardless of the key. This matches #404's framing exactly: "memory is NOT yet actually pluggable."

### What this PR adds (the genuinely-missing scope, per #404)
1. **A minimal `MemorySkill` interface** (`core/cap_evolve/memory.py`): `seed` / `augment_instructions` / `write_handover`.
2. **Two implementations, registered in `harness.py`**:
   - `MdFilesMemory` — today's LEDGER/JOURNAL/PROCESS/INSIGHTS/META_INSIGHTS/FRAMEWORK_IMPROVEMENTS scheme, now reachable through the interface instead of only via bare module functions. Default; byte-identical behavior to before this PR.
   - `WikiMemory` — the weakness-graph format (weakness nodes + solution cards + per-round results) extracted from the deprecated `evograph` algorithm into a standalone `skills/memory/wiki/` skill, per evograph's own maintainer note ("move the wiki format contract... then delete this directory"). Selectable by ANY algorithm now, not just evograph. Writes directly to `<run_dir>/wiki/` at the absolute path — no copy-in/fold-back needed, so `write_handover` is a no-op for it.
3. **`OptimizerContext.memory_skill`**, threaded through:
   - `--memory-skill` on every deterministic algorithm's `run.py` (hill-climb, gepa, skillopt) via the existing `add_arguments`/`from_args` generic plumbing.
   - `OptimizerContext.from_spec` for agent-mode (`agent-optimize`'s `host.py`), plus `commit.py` (which has no spec object — reads `memory_skill` off the sibling `capevolve.yaml` the same zero-dependency way `dashboard.py` reads `algorithm_skill`).
   - `cli.py`'s spec → CLI-flags translation (`--memory-skill` alongside the other optimizer-context flags).
4. **Intake wiring**: the interview batch (`skills/phases/intake/SKILL.md`) now actually asks for `memory_skill` alongside algorithm/optimizer, and `templates/project/capevolve.yaml` has a real slot for it.
5. **A real bug this surfaced and fixes**: `dashboard.py` inferred `algorithm = "evograph"` from `wiki/` presence *unconditionally* — which would have mislabeled any non-evograph run selecting `memory_skill: wiki`. Now it's only the fallback label for a genuinely-unlabeled run (no `run_config` event and no spec — an old evograph run), never an override of an already-known algorithm.

### Non-goals (unchanged from #400)
No new memory backends beyond md-files + the extracted wiki skill. Verified skill-usage telemetry (item d) and the process-narrative report (item e) are out of scope here — (e) is already covered by #441/#433; (d) is a separate, unrelated concern from memory pluggability.

## Test plan
- [x] New `core/tests/test_memory_skills.py`: unit test for `resolve_memory`'s registry/fallback behavior, and a real end-to-end `hill_climb_loop` run (toy_calc + the mock optimizer) with `memory_skill="wiki"` — asserts `wiki/{weaknesses,solutions,results}` exist at the run root, `JOURNAL.md`/`INSIGHTS.md` are never seeded into any iteration's workdir under wiki mode, and no candidate is ever mis-escalated as an "empty handover" (the false-positive that would fire if the pointer/fold logic weren't memory-aware).
- [x] Full `core/tests/` suite: 1169 passed, 12 skipped, 0 failed (2 unrelated flaky thread-timing failures in `test_eventstream.py` reproduced clean in isolation — pre-existing, unrelated to this change).
- [x] `skills/_registry/build_manifest.py` + the skill-authoring lint suite pass with the new `memory` component and `skills/memory/wiki` skill registered; `README.md`/`llms.txt`/`docs/ARCHITECTURE.md`/`site/*.html` advertised-skill-count claims updated (21 → 22) and pass `test_advertised_counts.py`.