### PR TITLE
Fix dashboard 500 on a string-typed system message in transcript.jsonl

### DIFF
--- a/core/cap_evolve/dashboard.py
+++ b/core/cap_evolve/dashboard.py
@@ -987,7 +987,11 @@ def _transcript_turn(ev: dict) -> dict | None:
     session plumbing and are dropped rather than rendered as empty turns.
     """
     t = ev.get("type")
-    msg = ev.get("message") or {}
+    msg = ev.get("message")
+    if not isinstance(msg, dict):
+        # e.g. a "system" permission-denial line whose "message" is a plain string,
+        # not the usual {"content": [...]} shape — plumbing either way, drop it.
+        return None
     content = msg.get("content")
     if not isinstance(content, list):
         return None

--- a/core/tests/test_dashboard_host_and_algo_extra.py
+++ b/core/tests/test_dashboard_host_and_algo_extra.py
@@ -65,6 +65,58 @@ def test_driver_prompt_and_transcript_are_read_and_summarized():
     assert hs["transcript_truncated"] is False
 
 
+def test_transcript_turn_skips_system_line_with_string_message():
+    """A "system" line can carry a plain string ``message`` (e.g. a permission-denial
+    notice) instead of the usual ``{"content": [...]}`` dict. ``.get()`` on a string
+    used to raise AttributeError before the type ever got checked."""
+    from cap_evolve import dashboard
+    ev = {"type": "system", "subtype": "permission_denied",
+          "message": "Permission to use Write has been denied."}
+    assert dashboard._transcript_turn(ev) is None
+
+
+def test_transcript_with_string_message_system_line_does_not_crash_reduce_run():
+    """Regression for a real run (host/transcript.jsonl line 239): a system line whose
+    "message" is a plain string used to crash _transcript_turn, which cascaded through
+    reduce_run and 500'd GET /api/runs/{run_id} for the whole run, not just this panel."""
+    rd, dashboard = _make_run()
+    hdir = rd.root / "host"
+    hdir.mkdir()
+    real_permission_denied_line = (
+        '{"type":"system","subtype":"permission_denied","tool_name":"Write",'
+        '"tool_use_id":"toolu_bdrk_01GGCHTW4SctBqUjDWoxYp9t","agent_id":"ad621f6b49843494a",'
+        '"decision_reason_type":"asyncAgent",'
+        '"decision_reason":"Permission prompts are not available in this context",'
+        '"message":"Permission to use Write has been denied. IMPORTANT: You *may* attempt '
+        'to accomplish this action using other tools that might naturally be used to '
+        'accomplish this goal, e.g. using head instead of cat. But you *should not* attempt '
+        'to work around this denial in malicious ways, e.g. do not use your ability to run '
+        'tests to execute non-test actions. You should only try to work around this '
+        'restriction in reasonable ways that do not attempt to bypass the intent behind '
+        'this denial. If you believe this capability is essential to complete the user\'s '
+        'request, STOP and explain to the user what you were trying to do and why you need '
+        'this permission. Let the user decide how to proceed.",'
+        '"uuid":"e141aa19-5db5-4d49-a823-cc29fa0c3d5c","session_id":"a7e94a62-23c9-4200-94ed-'
+        'a8f5b192f7a4"}'
+    )
+    transcript = [
+        {"type": "assistant", "timestamp": "2026-09-03T12:00:00Z",
+         "message": {"content": [{"type": "text", "text": "Before the bad line."}]}},
+        real_permission_denied_line,  # raw text: the fixture line as it appears on disk
+        {"type": "assistant", "timestamp": "2026-09-03T12:00:02Z",
+         "message": {"content": [{"type": "text", "text": "After the bad line."}]}},
+    ]
+    lines = [t if isinstance(t, str) else json.dumps(t) for t in transcript]
+    (hdir / "transcript.jsonl").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    reduced = dashboard.reduce_run(rd)  # must not raise
+    hs = reduced["summary"]["host_session"]
+    assert hs["transcript_total_lines"] == 3
+    assert len(hs["transcript_turns"]) == 2
+    assert "Before the bad line" in hs["transcript_turns"][0]["text"]
+    assert "After the bad line" in hs["transcript_turns"][1]["text"]
+
+
 def test_oversized_transcript_is_not_parsed_just_pointed_at():
     """A multi-megabyte transcript must never be read into memory whole and rendered —
     the section links out to the real path instead."""


### PR DESCRIPTION
## Summary
- `_transcript_turn()` in `core/cap_evolve/dashboard.py` unconditionally called `.get("content")` on `ev["message"]`, but a `system`-type line can carry `message` as a plain string (e.g. a permission-denial notice) rather than the usual dict — raising `AttributeError` before the existing plumbing-skip logic runs.
- That crash propagates through `reduce_run()`, so `GET /api/runs/{run_id}` (and `GET /api/runs`) 500 for any run whose `host/transcript.jsonl` has one of these lines — taking down cost, run config, intake artifacts, and the process-narrative panel too, not just the transcript view.
- Fix: guard with `isinstance(msg, dict)` and drop the line the same way other plumbing/system lines are already dropped.
- Audited the rest of `dashboard.py`'s transcript/turn handling — this was the only spot that calls `.get()` on a transcript-line field that can be a bare string; no other instance of this bug class found.

## Test plan
- Added `test_transcript_turn_skips_system_line_with_string_message` — direct unit test on `_transcript_turn` with a string `message`.
- Added `test_transcript_with_string_message_system_line_does_not_crash_reduce_run` — regression test using the exact real transcript line (a permission-denial notice) that caused the crash in a live run, verifying `reduce_run` no longer raises and surrounding turns are still parsed correctly.
- `python3 -m pytest core/tests/test_dashboard_host_and_algo_extra.py core/tests/test_dashboard.py -q` → 32 passed
- Full `core/tests` suite → 1210 passed, 12 skipped, 2 failed (both in `test_eventstream.py`, unrelated thread-timing flakiness — this PR does not touch that file)