### PR TITLE
insights: add skills-to-tasks mapping tables for all 87 SkillsBench tasks

### DIFF
--- a/.github/workflows/notify-pages.yml
+++ b/.github/workflows/notify-pages.yml
@@ -1,0 +1,17 @@
+name: Notify Pages build
+
+on:
+  push:
+    branches: [skillsbench-history]
+
+permissions:
+  actions: write
+
+jobs:
+  trigger-pages:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger pages.yml on main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run pages.yml --repo ${{ github.repository }} --ref main

--- a/insights/SKILLS_TASKS_MAP.md
+++ b/insights/SKILLS_TASKS_MAP.md
@@ -1,0 +1,350 @@
+# SkillsBench: skills ↔ tasks map (87 tasks)
+
+Derived from `insights/SKILLSBENCH_INVENTORY.md`'s per-task "Shipped skills" data (the task-by-task-87 run seeds each task from this same per-task skill set — see "Implications for a task-by-task optimization strategy" §1 in that doc).
+
+- **201 distinct skill names** appear across the 87 tasks' shipped-skill lists. 5 of those are boilerplate filenames, not real skills — `README.md`, `LICENSE`, `INSTALLATION.md`, `TESTING.md`, `reference.md` — carried over from how the source repo lays out its `environment/skills/` directories (e.g. `lean4-proof` ships its real skills `lean4-memories`/`lean4-theorem-proving` alongside a `README.md`/`LICENSE`/etc.). These are marked **B** below rather than given a skill number, so the numbering (1–196) covers only actual skills.
+
+- Task numbers (1–87) follow the category order and task order used in `SKILLSBENCH_INVENTORY.md`. Skill numbers (1–196) follow first-appearance order in that same document.
+
+## Table A — all 87 tasks, by category, with skill numbers
+
+
+### software-engineering (16 tasks)
+
+| # | Task | Difficulty | Skills (by #) |
+|---:|---|---|---|
+| 1 | `azure-bgp-oscillation-route-leak` | medium | 1 |
+| 2 | `data-to-d3` | medium | 2 |
+| 3 | `debug-trl-grpo` | hard | 3, 4, 5 |
+| 4 | `dialogue-parser` | easy | 6 |
+| 5 | `fix-build-agentops` | easy | 7, 8, 9, 10 |
+| 6 | `fix-build-google-auto` | easy | 11, 12, 13 |
+| 7 | `fix-visual-stability` | hard | 14, 15, 16 |
+| 8 | `flink-query` | hard | 17, 18 |
+| 9 | `jax-computing-basics` | medium | 19 |
+| 10 | `llm-prefix-cache-replay` | medium | 20, 21 |
+| 11 | `parallel-tfidf-search` | medium | 22, 23, 24 |
+| 12 | `python-scala-translation` | medium | 25, 26, 27, 28, 29, 30 |
+| 13 | `react-performance-debugging` | hard | 14, 15 |
+| 14 | `simpo-code-reproduction` | hard | 31, 17 |
+| 15 | `spring-boot-jakarta-migration` | hard | 32, 33, 34, 35, 36 |
+| 16 | `tictoc-unnecessary-abort-detection` | hard | 37, 38, 39 |
+
+### industrial-physical-systems (14 tasks)
+
+| # | Task | Difficulty | Skills (by #) |
+|---:|---|---|---|
+| 17 | `3d-scan-calc` | hard | 40 |
+| 18 | `ada-bathroom-plan-repair` | hard | 41, 42, 43 |
+| 19 | `adaptive-cruise-control` | medium | 44, 45, 46, 47, 48 |
+| 20 | `drone-planning-control` | medium | 49, 50, 51, 52, 53, 54 |
+| 21 | `dynamic-object-aware-egomotion` | medium | 55, 56, 57, 58 |
+| 22 | `energy-ac-optimal-power-flow` | medium | 59, 60, 61 |
+| 23 | `energy-market-pricing` | hard | 62, 63, 64, 61 |
+| 24 | `energy-unit-commitment` | hard | 65, 66, 67 |
+| 25 | `grid-dispatch-operator` | medium | 62, 63, 61 |
+| 26 | `hvac-control` | medium | 68, 69, 70, 71, 72 |
+| 27 | `manufacturing-codebook-normalization` | medium | 73, B |
+| 28 | `manufacturing-equipment-maintenance` | medium | B, 74, 75 |
+| 29 | `manufacturing-fjsp-optimization` | medium | 76, B |
+| 30 | `r2r-mpc-control` | medium | 77, 78, 79, 80 |
+
+### office-white-collar (14 tasks)
+
+| # | Task | Difficulty | Skills (by #) |
+|---:|---|---|---|
+| 31 | `citation-check` | medium | 81 |
+| 32 | `court-form-filling` | easy | 17 |
+| 33 | `edit-pdf` | medium | 82, 83 |
+| 34 | `enterprise-information-search` | hard | 84 |
+| 35 | `exceltable-in-ppt` | medium | 85, 86 |
+| 36 | `jpg-ocr-stat` | hard | 87, 88, 17, 89, 86 |
+| 37 | `latex-formula-extraction` | medium | 90, 17 |
+| 38 | `offer-letter-generator` | easy | 91 |
+| 39 | `organize-messy-files` | medium | 91, 92, 17, 93, 85 |
+| 40 | `paper-anonymizer` | medium | 94, 17 |
+| 41 | `pdf-excel-diff` | medium | 17, 86 |
+| 42 | `powerlifting-coef-calc` | easy | 95, 96, 86 |
+| 43 | `pptx-reference-formatting` | medium | 85 |
+| 44 | `sales-pivot-analysis` | medium | 17, 86 |
+
+### natural-science (14 tasks)
+
+| # | Task | Difficulty | Skills (by #) |
+|---:|---|---|---|
+| 45 | `crystallographic-wyckoff-position-analysis` | medium | 97, 98 |
+| 46 | `earthquake-phase-association` | hard | 99, 100, 101, 102, 103 |
+| 47 | `earthquake-plate-calculation` | medium | 104 |
+| 48 | `exoplanet-detection-period` | medium | 105, 106, 107, 108, 109 |
+| 49 | `flood-risk-analysis` | medium | 110, 111, 112 |
+| 50 | `glm-lake-mendota` | hard | 113, 114, 115 |
+| 51 | `gravitational-wave-detection` | medium | 116, 117 |
+| 52 | `lab-unit-harmonization` | medium | 118 |
+| 53 | `lake-warming-attribution` | medium | 119, 120, 121, 122 |
+| 54 | `mars-clouds-clustering` | hard | 123, 124, 125 |
+| 55 | `protein-expression-analysis` | medium | 86 |
+| 56 | `quantum-numerical-simulation` | medium | 126 |
+| 57 | `radar-vital-signs` | medium | 127, 128, 129 |
+| 58 | `seismic-phase-picking` | hard | 100, 101, 130, 102, 103 |
+
+### finance-economics (9 tasks)
+
+| # | Task | Difficulty | Skills (by #) |
+|---:|---|---|---|
+| 59 | `econ-detrending-correlation` | medium | 131 |
+| 60 | `financial-modeling-qa` | hard | 17, 86 |
+| 61 | `invoice-fraud-detection` | hard | 132, 17, 86 |
+| 62 | `reserves-at-risk-calc` | medium | 86 |
+| 63 | `sec-financial-report` | hard | 133, 134 |
+| 64 | `shock-analysis-demand` | medium | 86 |
+| 65 | `shock-analysis-supply` | hard | 86 |
+| 66 | `weighted-gdp-calc` | medium | 86 |
+| 67 | `xlsx-recover-data` | medium | 135, 86 |
+
+### mathematics-or-formal-reasoning (8 tasks)
+
+| # | Task | Difficulty | Skills (by #) |
+|---:|---|---|---|
+| 68 | `bike-rebalance` | medium | 136, 137, 138, 139 |
+| 69 | `civ6-adjacency-optimizer` | hard | 140, 141, 142, 143 |
+| 70 | `exam-block-sequencing` | hard | 144, 145 |
+| 71 | `lean4-proof` | medium | B, B, B, B, 146, 147 |
+| 72 | `paratransit-routing` | hard | 148, 149 |
+| 73 | `pddl-airport-planning` | medium | 150 |
+| 74 | `pddl-tpp-planning` | medium | 150 |
+| 75 | `travel-planning` | medium | 151, 152, 153, 154, 155, 156 |
+
+### cybersecurity (7 tasks)
+
+| # | Task | Difficulty | Skills (by #) |
+|---:|---|---|---|
+| 76 | `dapt-intrusion-detection` | hard | 157, 158 |
+| 77 | `fix-druid-loophole-cve` | hard | 159, 160 |
+| 78 | `fix-erlang-ssh-cve` | hard | 161, 162, 163, 164, 165, 166 |
+| 79 | `setup-fuzzing-py` | medium | 167, 168, 169 |
+| 80 | `software-dependency-audit` | medium | 170, 171, 172 |
+| 81 | `suricata-custom-exfil` | medium | 173, 174, 175 |
+| 82 | `syzkaller-ppdev-syzlang` | medium | 176, 177, 178 |
+
+### media-content-production (5 tasks)
+
+| # | Task | Difficulty | Skills (by #) |
+|---:|---|---|---|
+| 83 | `mario-coin-counting` | medium | 179, 180, 181 |
+| 84 | `multilingual-video-dubbing` | medium | 182, 183, 184, 185, 186, 187 |
+| 85 | `threejs-structure-parser` | medium | 188, 189 |
+| 86 | `threejs-to-obj` | medium | 188, 189 |
+| 87 | `video-silence-remover` | hard | 190, 191, 192, 193, 194, 195, 196 |
+
+## Table B — skills index, with the tasks that use each
+
+Rows = skills, numbered by first appearance in Table A. "Categories" lists every category the skill appears in (most skills are single-category; a few — e.g. `pdf`, `xlsx` — cross several).
+
+| # | Skill | # tasks | Categories | Task #s |
+|---:|---|---:|---|---|
+| 1 | `azure-bgp` | 1 | software-engineering | 1 |
+| 2 | `d3-visualization` | 1 | software-engineering | 2 |
+| 3 | `grpo` | 1 | software-engineering | 3 |
+| 4 | `rl-post-training` | 1 | software-engineering | 3 |
+| 5 | `trl` | 1 | software-engineering | 3 |
+| 6 | `dialogue-graph` | 1 | software-engineering | 4 |
+| 7 | `analyze-ci` | 1 | software-engineering | 5 |
+| 8 | `temporal-python-testing` | 1 | software-engineering | 5 |
+| 9 | `testing-python` | 1 | software-engineering | 5 |
+| 10 | `uv-package-manager` | 1 | software-engineering | 5 |
+| 11 | `maven-build-lifecycle` | 1 | software-engineering | 6 |
+| 12 | `maven-dependency-management` | 1 | software-engineering | 6 |
+| 13 | `maven-plugin-configuration` | 1 | software-engineering | 6 |
+| 14 | `browser-testing` | 2 | software-engineering | 7, 13 |
+| 15 | `react-best-practices` | 2 | software-engineering | 7, 13 |
+| 16 | `web-interface-guidelines` | 1 | software-engineering | 7 |
+| 17 | `pdf` | 11 | finance-economics, office-white-collar, software-engineering | 8, 14, 32, 36, 37, 39, 40, 41, 44, 60, 61 |
+| 18 | `senior-data-engineer` | 1 | software-engineering | 8 |
+| 19 | `jax-skills` | 1 | software-engineering | 9 |
+| 20 | `cache-policy-comparison` | 1 | software-engineering | 10 |
+| 21 | `prefix-cache-replay` | 1 | software-engineering | 10 |
+| 22 | `memory-optimization` | 1 | software-engineering | 11 |
+| 23 | `python-parallelization` | 1 | software-engineering | 11 |
+| 24 | `workload-balancing` | 1 | software-engineering | 11 |
+| 25 | `python-scala-collections` | 1 | software-engineering | 12 |
+| 26 | `python-scala-functional` | 1 | software-engineering | 12 |
+| 27 | `python-scala-idioms` | 1 | software-engineering | 12 |
+| 28 | `python-scala-libraries` | 1 | software-engineering | 12 |
+| 29 | `python-scala-oop` | 1 | software-engineering | 12 |
+| 30 | `python-scala-syntax-mapping` | 1 | software-engineering | 12 |
+| 31 | `nlp-research-repo-package-installment` | 1 | software-engineering | 14 |
+| 32 | `hibernate-upgrade` | 1 | software-engineering | 15 |
+| 33 | `jakarta-namespace` | 1 | software-engineering | 15 |
+| 34 | `restclient-migration` | 1 | software-engineering | 15 |
+| 35 | `spring-boot-migration` | 1 | software-engineering | 15 |
+| 36 | `spring-security-6` | 1 | software-engineering | 15 |
+| 37 | `transaction-concurrency-control-foundations` | 1 | software-engineering | 16 |
+| 38 | `transaction-protocol-reasoning` | 1 | software-engineering | 16 |
+| 39 | `transaction-trace-analysis` | 1 | software-engineering | 16 |
+| 40 | `mesh-analysis` | 1 | industrial-physical-systems | 17 |
+| 41 | `ada-plan-view-accessibility` | 1 | industrial-physical-systems | 18 |
+| 42 | `architectural-dxf-extraction` | 1 | industrial-physical-systems | 18 |
+| 43 | `geometric-layout-repair` | 1 | industrial-physical-systems | 18 |
+| 44 | `csv-processing` | 1 | industrial-physical-systems | 19 |
+| 45 | `pid-controller` | 1 | industrial-physical-systems | 19 |
+| 46 | `simulation-metrics` | 1 | industrial-physical-systems | 19 |
+| 47 | `vehicle-dynamics` | 1 | industrial-physical-systems | 19 |
+| 48 | `yaml-config` | 1 | industrial-physical-systems | 19 |
+| 49 | `attitude-controller-planner` | 1 | industrial-physical-systems | 20 |
+| 50 | `flight-plan-parser` | 1 | industrial-physical-systems | 20 |
+| 51 | `motor-model-dynamics` | 1 | industrial-physical-systems | 20 |
+| 52 | `plot-quadrotor` | 1 | industrial-physical-systems | 20 |
+| 53 | `position-controller-trajectory-planner` | 1 | industrial-physical-systems | 20 |
+| 54 | `stepinfo-3d` | 1 | industrial-physical-systems | 20 |
+| 55 | `dyn-object-masks` | 1 | industrial-physical-systems | 21 |
+| 56 | `egomotion-estimation` | 1 | industrial-physical-systems | 21 |
+| 57 | `output-validation` | 1 | industrial-physical-systems | 21 |
+| 58 | `sampling-and-indexing` | 1 | industrial-physical-systems | 21 |
+| 59 | `ac-branch-pi-model` | 1 | industrial-physical-systems | 22 |
+| 60 | `casadi-ipopt-nlp` | 1 | industrial-physical-systems | 22 |
+| 61 | `power-flow-data` | 3 | industrial-physical-systems | 22, 23, 25 |
+| 62 | `dc-power-flow` | 2 | industrial-physical-systems | 23, 25 |
+| 63 | `economic-dispatch` | 2 | industrial-physical-systems | 23, 25 |
+| 64 | `locational-marginal-prices` | 1 | industrial-physical-systems | 23 |
+| 65 | `milp-solver-workflow` | 1 | industrial-physical-systems | 24 |
+| 66 | `unit-commitment-data-modeling` | 1 | industrial-physical-systems | 24 |
+| 67 | `unit-commitment-operating-rules` | 1 | industrial-physical-systems | 24 |
+| 68 | `excitation-signal-design` | 1 | industrial-physical-systems | 26 |
+| 69 | `first-order-model-fitting` | 1 | industrial-physical-systems | 26 |
+| 70 | `imc-tuning-rules` | 1 | industrial-physical-systems | 26 |
+| 71 | `safety-interlocks` | 1 | industrial-physical-systems | 26 |
+| 72 | `scipy-curve-fit` | 1 | industrial-physical-systems | 26 |
+| 73 | `manufacturing-failure-reason-codebook-normalization` | 1 | industrial-physical-systems | 27 |
+| 74 | `reflow-machine-maintenance-guidance` | 1 | industrial-physical-systems | 28 |
+| 75 | `reflow-profile-compliance-toolkit` | 1 | industrial-physical-systems | 28 |
+| 76 | `fjsp-baseline-repair-with-downtime-and-policy` | 1 | industrial-physical-systems | 29 |
+| 77 | `finite-horizon-lqr` | 1 | industrial-physical-systems | 30 |
+| 78 | `integral-action-design` | 1 | industrial-physical-systems | 30 |
+| 79 | `mpc-horizon-tuning` | 1 | industrial-physical-systems | 30 |
+| 80 | `state-space-linearization` | 1 | industrial-physical-systems | 30 |
+| 81 | `citation-management` | 1 | office-white-collar | 31 |
+| 82 | `pdf-editing` | 1 | office-white-collar | 33 |
+| 83 | `text-parser` | 1 | office-white-collar | 33 |
+| 84 | `enterprise-artifact-search` | 1 | office-white-collar | 34 |
+| 85 | `pptx` | 3 | office-white-collar | 35, 39, 43 |
+| 86 | `xlsx` | 13 | finance-economics, natural-science, office-white-collar | 35, 36, 41, 42, 44, 55, 60, 61, 62, 64, 65, 66, 67 |
+| 87 | `image-ocr` | 1 | office-white-collar | 36 |
+| 88 | `openai-vision` | 1 | office-white-collar | 36 |
+| 89 | `video-frame-extraction` | 1 | office-white-collar | 36 |
+| 90 | `marker` | 1 | office-white-collar | 37 |
+| 91 | `docx` | 2 | office-white-collar | 38, 39 |
+| 92 | `file-organizer` | 1 | office-white-collar | 39 |
+| 93 | `planning-with-files` | 1 | office-white-collar | 39 |
+| 94 | `academic-pdf-redaction` | 1 | office-white-collar | 40 |
+| 95 | `powerlifting` | 1 | office-white-collar | 42 |
+| 96 | `senior-data-scientist` | 1 | office-white-collar | 42 |
+| 97 | `pymatgen` | 1 | natural-science | 45 |
+| 98 | `sympy` | 1 | natural-science | 45 |
+| 99 | `gamma-phase-associator` | 1 | natural-science | 46 |
+| 100 | `licenses` | 2 | natural-science | 46, 58 |
+| 101 | `obspy-data-api` | 2 | natural-science | 46, 58 |
+| 102 | `seisbench-model-api` | 2 | natural-science | 46, 58 |
+| 103 | `seismic-picker-selection` | 2 | natural-science | 46, 58 |
+| 104 | `geospatial-analysis` | 1 | natural-science | 47 |
+| 105 | `box-least-squares` | 1 | natural-science | 48 |
+| 106 | `exoplanet-workflows` | 1 | natural-science | 48 |
+| 107 | `light-curve-preprocessing` | 1 | natural-science | 48 |
+| 108 | `lomb-scargle-periodogram` | 1 | natural-science | 48 |
+| 109 | `transit-least-squares` | 1 | natural-science | 48 |
+| 110 | `flood-detection` | 1 | natural-science | 49 |
+| 111 | `nws-flood-thresholds` | 1 | natural-science | 49 |
+| 112 | `usgs-data-download` | 1 | natural-science | 49 |
+| 113 | `glm-basics` | 1 | natural-science | 50 |
+| 114 | `glm-calibration` | 1 | natural-science | 50 |
+| 115 | `glm-output` | 1 | natural-science | 50 |
+| 116 | `conditioning` | 1 | natural-science | 51 |
+| 117 | `matched-filtering` | 1 | natural-science | 51 |
+| 118 | `lab-unit-harmonization` | 1 | natural-science | 52 |
+| 119 | `contribution-analysis` | 1 | natural-science | 53 |
+| 120 | `meteorology-driver-classification` | 1 | natural-science | 53 |
+| 121 | `pca-decomposition` | 1 | natural-science | 53 |
+| 122 | `trend-analysis` | 1 | natural-science | 53 |
+| 123 | `custom-distance-metrics` | 1 | natural-science | 54 |
+| 124 | `parallel-processing` | 1 | natural-science | 54 |
+| 125 | `pareto-optimization` | 1 | natural-science | 54 |
+| 126 | `qutip` | 1 | natural-science | 56 |
+| 127 | `radar-signal-processing` | 1 | natural-science | 57 |
+| 128 | `radar-vital-signs` | 1 | natural-science | 57 |
+| 129 | `vital-sign-extraction` | 1 | natural-science | 57 |
+| 130 | `obspy-datacenter-client` | 1 | natural-science | 58 |
+| 131 | `timeseries-detrending` | 1 | finance-economics | 59 |
+| 132 | `fuzzy-match` | 1 | finance-economics | 61 |
+| 133 | `13f-analyzer` | 1 | finance-economics | 63 |
+| 134 | `fuzzy-name-search` | 1 | finance-economics | 63 |
+| 135 | `data-reconciliation` | 1 | finance-economics | 67 |
+| 136 | `geospatial-routing-data` | 1 | mathematics-or-formal-reasoning | 68 |
+| 137 | `logistics-rules-to-optimization` | 1 | mathematics-or-formal-reasoning | 68 |
+| 138 | `routing-subtour-elimination` | 1 | mathematics-or-formal-reasoning | 68 |
+| 139 | `scip-opt` | 1 | mathematics-or-formal-reasoning | 68 |
+| 140 | `civ6lib` | 1 | mathematics-or-formal-reasoning | 69 |
+| 141 | `hex-grid-spatial` | 1 | mathematics-or-formal-reasoning | 69 |
+| 142 | `map-optimization-strategy` | 1 | mathematics-or-formal-reasoning | 69 |
+| 143 | `sqlite-map-parser` | 1 | mathematics-or-formal-reasoning | 69 |
+| 144 | `mip-solver-and-solution-audit` | 1 | mathematics-or-formal-reasoning | 70 |
+| 145 | `ordered-window-sequencing-mip` | 1 | mathematics-or-formal-reasoning | 70 |
+| 146 | `lean4-memories` | 1 | mathematics-or-formal-reasoning | 71 |
+| 147 | `lean4-theorem-proving` | 1 | mathematics-or-formal-reasoning | 71 |
+| 148 | `ortools-pickup-delivery-routing` | 1 | mathematics-or-formal-reasoning | 72 |
+| 149 | `ortools-routing-modeling` | 1 | mathematics-or-formal-reasoning | 72 |
+| 150 | `pddl-skills` | 2 | mathematics-or-formal-reasoning | 73, 74 |
+| 151 | `search-accommodations` | 1 | mathematics-or-formal-reasoning | 75 |
+| 152 | `search-attractions` | 1 | mathematics-or-formal-reasoning | 75 |
+| 153 | `search-cities` | 1 | mathematics-or-formal-reasoning | 75 |
+| 154 | `search-driving-distance` | 1 | mathematics-or-formal-reasoning | 75 |
+| 155 | `search-flights` | 1 | mathematics-or-formal-reasoning | 75 |
+| 156 | `search-restaurants` | 1 | mathematics-or-formal-reasoning | 75 |
+| 157 | `pcap-analysis` | 1 | cybersecurity | 76 |
+| 158 | `threat-detection` | 1 | cybersecurity | 76 |
+| 159 | `jackson-security` | 1 | cybersecurity | 77 |
+| 160 | `senior-java` | 1 | cybersecurity | 77 |
+| 161 | `erlang-concurrency` | 1 | cybersecurity | 78 |
+| 162 | `erlang-distribution` | 1 | cybersecurity | 78 |
+| 163 | `erlang-otp-behaviors` | 1 | cybersecurity | 78 |
+| 164 | `find-bugs` | 1 | cybersecurity | 78 |
+| 165 | `senior-security` | 1 | cybersecurity | 78 |
+| 166 | `ssh-penetration-testing` | 1 | cybersecurity | 78 |
+| 167 | `discover-important-function` | 1 | cybersecurity | 79 |
+| 168 | `fuzzing-python` | 1 | cybersecurity | 79 |
+| 169 | `setup-env` | 1 | cybersecurity | 79 |
+| 170 | `cvss-score-extraction` | 1 | cybersecurity | 80 |
+| 171 | `trivy-offline-vulnerability-scanning` | 1 | cybersecurity | 80 |
+| 172 | `vulnerability-csv-reporting` | 1 | cybersecurity | 80 |
+| 173 | `pcap-triage-tshark` | 1 | cybersecurity | 81 |
+| 174 | `suricata-offline-evejson` | 1 | cybersecurity | 81 |
+| 175 | `suricata-rules-basics` | 1 | cybersecurity | 81 |
+| 176 | `syz-extract-constants` | 1 | cybersecurity | 82 |
+| 177 | `syzkaller-build-loop` | 1 | cybersecurity | 82 |
+| 178 | `syzlang-ioctl-basics` | 1 | cybersecurity | 82 |
+| 179 | `ffmpeg-keyframe-extraction` | 1 | media-content-production | 83 |
+| 180 | `image-editing` | 1 | media-content-production | 83 |
+| 181 | `object-counter` | 1 | media-content-production | 83 |
+| 182 | `ffmpeg-audio-processing` | 1 | media-content-production | 84 |
+| 183 | `ffmpeg-format-conversion` | 1 | media-content-production | 84 |
+| 184 | `ffmpeg-media-info` | 1 | media-content-production | 84 |
+| 185 | `ffmpeg-video-editing` | 1 | media-content-production | 84 |
+| 186 | `ffmpeg-video-filters` | 1 | media-content-production | 84 |
+| 187 | `text-to-speech` | 1 | media-content-production | 84 |
+| 188 | `obj-exporter` | 2 | media-content-production | 85, 86 |
+| 189 | `threejs` | 2 | media-content-production | 85, 86 |
+| 190 | `audio-extractor` | 1 | media-content-production | 87 |
+| 191 | `energy-calculator` | 1 | media-content-production | 87 |
+| 192 | `pause-detector` | 1 | media-content-production | 87 |
+| 193 | `report-generator` | 1 | media-content-production | 87 |
+| 194 | `segment-combiner` | 1 | media-content-production | 87 |
+| 195 | `silence-detector` | 1 | media-content-production | 87 |
+| 196 | `video-processor` | 1 | media-content-production | 87 |
+
+## Boilerplate entries (not numbered as skills)
+
+| Filename | # tasks | Task #s |
+|---|---:|---|
+| `reference.md` | 3 | 27, 28, 29 |
+| `INSTALLATION.md` | 1 | 71 |
+| `LICENSE` | 1 | 71 |
+| `README.md` | 1 | 71 |
+| `TESTING.md` | 1 | 71 |

--- a/insights/SKILLS_TASKS_MAP.md
+++ b/insights/SKILLS_TASKS_MAP.md
@@ -4,7 +4,7 @@ Derived from `insights/SKILLSBENCH_INVENTORY.md`'s per-task "Shipped skills" dat
 
 - **201 distinct skill names** appear across the 87 tasks' shipped-skill lists. 5 of those are boilerplate filenames, not real skills — `README.md`, `LICENSE`, `INSTALLATION.md`, `TESTING.md`, `reference.md` — carried over from how the source repo lays out its `environment/skills/` directories (e.g. `lean4-proof` ships its real skills `lean4-memories`/`lean4-theorem-proving` alongside a `README.md`/`LICENSE`/etc.). These are marked **B** below rather than given a skill number, so the numbering (1–196) covers only actual skills.
 
-- Task numbers (1–87) follow the category order and task order used in `SKILLSBENCH_INVENTORY.md`. Skill numbers (1–196) follow first-appearance order in that same document.
+- Task numbers (1–87) follow the category order and task order used in `SKILLSBENCH_INVENTORY.md`. Skill numbers follow first-appearance order in that same document.
 
 ## Table A — all 87 tasks, by category, with skill numbers
 
@@ -338,6 +338,53 @@ Rows = skills, numbered by first appearance in Table A. "Categories" lists every
 | 194 | `segment-combiner` | 1 | media-content-production | 87 |
 | 195 | `silence-detector` | 1 | media-content-production | 87 |
 | 196 | `video-processor` | 1 | media-content-production | 87 |
+
+## Table C — per-category train/test split (skill-disjoint-safe)
+
+For each category: a **test** subset of tasks whose skills all also appear in at least one **train** task of the same category — i.e. every skill the test set needs to succeed is still present, unseen-combination, in the train set. Intended use: optimize/tune skills on the train tasks, then evaluate held-out on the test tasks. Target was ~20–30% of each category, found greedily (tasks with the fewest skills tried first, since they're least likely to strand a skill). Where a skill is unique to a single task within its category, that task can never be a test task — this is what caps the achievable split, sometimes to 0%.
+
+| Category | n | Test tasks (n, %) | Train task #s | Test task #s |
+|---|---:|---|---|---|
+| software-engineering | 16 | 1 (6.2%) | 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 14, 15, 16 | 13 |
+| industrial-physical-systems | 14 | 1 (7.1%) | 17, 18, 19, 20, 21, 22, 23, 24, 26, 27, 28, 29, 30 | 25 |
+| office-white-collar | 14 | 4 (28.6%) | 31, 33, 34, 36, 37, 39, 40, 41, 42, 44 | 32, 35, 38, 43 |
+| natural-science | 14 | 0 (0.0%) | 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58 | — |
+| finance-economics | 9 | 3 (33.3%) | 59, 60, 61, 63, 66, 67 | 62, 64, 65 |
+| mathematics-or-formal-reasoning | 8 | 1 (12.5%) | 68, 69, 70, 71, 72, 74, 75 | 73 |
+| cybersecurity | 7 | 0 (0.0%) | 76, 77, 78, 79, 80, 81, 82 | — |
+| media-content-production | 5 | 1 (20.0%) | 83, 84, 86, 87 | 85 |
+
+### Table C detail — test task names by category
+
+
+**software-engineering** — 1/16 (6.2%)
+- `react-performance-debugging` (#13, skills 14, 15)
+
+**industrial-physical-systems** — 1/14 (7.1%)
+- `grid-dispatch-operator` (#25, skills 62, 63, 61)
+
+**office-white-collar** — 4/14 (28.6%)
+- `court-form-filling` (#32, skills 17)
+- `exceltable-in-ppt` (#35, skills 85, 86)
+- `offer-letter-generator` (#38, skills 91)
+- `pptx-reference-formatting` (#43, skills 85)
+
+**natural-science** — 0/14 (0.0%)
+- _No valid split found — every task in this category has at least one skill unique to it within the category._
+
+**finance-economics** — 3/9 (33.3%)
+- `reserves-at-risk-calc` (#62, skills 86)
+- `shock-analysis-demand` (#64, skills 86)
+- `shock-analysis-supply` (#65, skills 86)
+
+**mathematics-or-formal-reasoning** — 1/8 (12.5%)
+- `pddl-airport-planning` (#73, skills 150)
+
+**cybersecurity** — 0/7 (0.0%)
+- _No valid split found — every task in this category has at least one skill unique to it within the category._
+
+**media-content-production** — 1/5 (20.0%)
+- `threejs-structure-parser` (#85, skills 188, 189)
 
 ## Boilerplate entries (not numbered as skills)
 

--- a/insights/skills_tasks_map.html
+++ b/insights/skills_tasks_map.html
@@ -18,6 +18,9 @@
   #toc a { margin-right: 1rem; }
   tr:hover { background: #fafafa; }
   .boilerplate-tag { color: #b45309; font-weight: 600; }
+  .test-tag { color: #0a7d2f; font-weight: 600; }
+  .no-split { color: #888; font-style: italic; }
+  ul.testlist { margin: .3rem 0 1rem; }
 </style>
 </head>
 <body>
@@ -30,14 +33,12 @@
 5 of those are boilerplate filenames, not real skills &mdash; <code>README.md</code>,
 <code>LICENSE</code>, <code>INSTALLATION.md</code>, <code>TESTING.md</code>, <code>reference.md</code>
 &mdash; carried over from how the source repo lays out its <code>environment/skills/</code>
-directories (e.g. <code>lean4-proof</code> ships its real skills <code>lean4-memories</code> /
-<code>lean4-theorem-proving</code> alongside a <code>README.md</code>/<code>LICENSE</code>/etc.).
-These are marked <span class="boilerplate-tag">B</span> below rather than given a skill number,
-so the numbering (1&ndash;196) covers only actual skills. Task numbers (1&ndash;87) and skill
-numbers follow the order used in <code>SKILLSBENCH_INVENTORY.md</code> (category order, then
-first-appearance order).
+directories. These are marked <span class="boilerplate-tag">B</span> below rather than given a
+skill number, so the numbering (1&ndash;196) covers only actual skills. Task numbers (1&ndash;87)
+and skill numbers follow the order used in <code>SKILLSBENCH_INVENTORY.md</code> (category order,
+then first-appearance order).
 </div>
-<div id="toc"><a href="#table-a">Table A: tasks &rarr; skills</a> <a href="#table-b">Table B: skills &rarr; tasks</a> <a href="#boilerplate">Boilerplate entries</a></div>
+<div id="toc"><a href="#table-a">Table A: tasks &rarr; skills</a> <a href="#table-b">Table B: skills &rarr; tasks</a> <a href="#table-c">Table C: train/test split</a> <a href="#boilerplate">Boilerplate entries</a></div>
 
 <h2 id="table-a">Table A &mdash; all 87 tasks, by category, with skill numbers</h2>
 <h3>software-engineering (16 tasks)</h3>
@@ -351,6 +352,52 @@ first-appearance order).
 <tr><td class='num'>195</td><td><code>silence-detector</code></td><td class='num'>1</td><td><span class='cat-badge'>media-content-production</span></td><td>87</td></tr>
 <tr><td class='num'>196</td><td><code>video-processor</code></td><td class='num'>1</td><td><span class='cat-badge'>media-content-production</span></td><td>87</td></tr>
 </tbody></table>
+<h2 id="table-c">Table C &mdash; per-category train/test split (skill-disjoint-safe)</h2>
+<p>For each category: a <strong>test</strong> subset of tasks whose skills all also appear in at least one <strong>train</strong> task of the same category &mdash; every skill the test set needs is still available, unseen-combination, in the train set. Intended use: optimize/tune skills on the train tasks, then evaluate held-out on the test tasks. Target was ~20&ndash;30% of each category, found greedily. Where a skill is unique to a single task within its category, that task can never be a test task &mdash; this caps the achievable split, sometimes to 0%.</p>
+<table><thead><tr><th>Category</th><th class='num'>n</th><th class='num'>Test (n, %)</th><th>Train task #s</th><th>Test task #s</th></tr></thead><tbody>
+<tr><td>software-engineering</td><td class='num'>16</td><td class='num'>1 (6.2%)</td><td>1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 14, 15, 16</td><td>13</td></tr>
+<tr><td>industrial-physical-systems</td><td class='num'>14</td><td class='num'>1 (7.1%)</td><td>17, 18, 19, 20, 21, 22, 23, 24, 26, 27, 28, 29, 30</td><td>25</td></tr>
+<tr><td>office-white-collar</td><td class='num'>14</td><td class='num'>4 (28.6%)</td><td>31, 33, 34, 36, 37, 39, 40, 41, 42, 44</td><td>32, 35, 38, 43</td></tr>
+<tr class='no-split'><td>natural-science</td><td class='num'>14</td><td class='num'>0 (0.0%)</td><td>45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58</td><td>&mdash;</td></tr>
+<tr><td>finance-economics</td><td class='num'>9</td><td class='num'>3 (33.3%)</td><td>59, 60, 61, 63, 66, 67</td><td>62, 64, 65</td></tr>
+<tr><td>mathematics-or-formal-reasoning</td><td class='num'>8</td><td class='num'>1 (12.5%)</td><td>68, 69, 70, 71, 72, 74, 75</td><td>73</td></tr>
+<tr class='no-split'><td>cybersecurity</td><td class='num'>7</td><td class='num'>0 (0.0%)</td><td>76, 77, 78, 79, 80, 81, 82</td><td>&mdash;</td></tr>
+<tr><td>media-content-production</td><td class='num'>5</td><td class='num'>1 (20.0%)</td><td>83, 84, 86, 87</td><td>85</td></tr>
+</tbody></table>
+<h3>Table C detail &mdash; test task names by category</h3>
+<p><strong>software-engineering</strong> &mdash; <span class='test-tag'>1/16 (6.2%)</span></p>
+<ul class='testlist'>
+<li><code>react-performance-debugging</code> (#13, skills 14, 15)</li>
+</ul>
+<p><strong>industrial-physical-systems</strong> &mdash; <span class='test-tag'>1/14 (7.1%)</span></p>
+<ul class='testlist'>
+<li><code>grid-dispatch-operator</code> (#25, skills 62, 63, 61)</li>
+</ul>
+<p><strong>office-white-collar</strong> &mdash; <span class='test-tag'>4/14 (28.6%)</span></p>
+<ul class='testlist'>
+<li><code>court-form-filling</code> (#32, skills 17)</li>
+<li><code>exceltable-in-ppt</code> (#35, skills 85, 86)</li>
+<li><code>offer-letter-generator</code> (#38, skills 91)</li>
+<li><code>pptx-reference-formatting</code> (#43, skills 85)</li>
+</ul>
+<p><strong>natural-science</strong> &mdash; <span class='test-tag'>0/14 (0.0%)</span></p>
+<p class='no-split'>No valid split found &mdash; every task in this category has at least one skill unique to it within the category.</p>
+<p><strong>finance-economics</strong> &mdash; <span class='test-tag'>3/9 (33.3%)</span></p>
+<ul class='testlist'>
+<li><code>reserves-at-risk-calc</code> (#62, skills 86)</li>
+<li><code>shock-analysis-demand</code> (#64, skills 86)</li>
+<li><code>shock-analysis-supply</code> (#65, skills 86)</li>
+</ul>
+<p><strong>mathematics-or-formal-reasoning</strong> &mdash; <span class='test-tag'>1/8 (12.5%)</span></p>
+<ul class='testlist'>
+<li><code>pddl-airport-planning</code> (#73, skills 150)</li>
+</ul>
+<p><strong>cybersecurity</strong> &mdash; <span class='test-tag'>0/7 (0.0%)</span></p>
+<p class='no-split'>No valid split found &mdash; every task in this category has at least one skill unique to it within the category.</p>
+<p><strong>media-content-production</strong> &mdash; <span class='test-tag'>1/5 (20.0%)</span></p>
+<ul class='testlist'>
+<li><code>threejs-structure-parser</code> (#85, skills 188, 189)</li>
+</ul>
 <h2 id="boilerplate">Boilerplate entries (not numbered as skills)</h2>
 <table><thead><tr><th>Filename</th><th class='num'># tasks</th><th>Task #s</th></tr></thead><tbody>
 <tr><td><code>reference.md</code></td><td class='num'>3</td><td>27, 28, 29</td></tr>

--- a/insights/skills_tasks_map.html
+++ b/insights/skills_tasks_map.html
@@ -1,0 +1,362 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>SkillsBench: skills to tasks map</title>
+<style>
+  body { font-family: -apple-system, Segoe UI, Helvetica, Arial, sans-serif; margin: 2rem auto; max-width: 1100px; padding: 0 1rem; color: #1a1a1a; }
+  h1 { font-size: 1.6rem; }
+  h2 { margin-top: 2.5rem; border-bottom: 2px solid #ddd; padding-bottom: .3rem; }
+  h3 { margin-top: 1.8rem; color: #333; }
+  table { border-collapse: collapse; width: 100%; margin: .8rem 0 1.6rem; font-size: .88rem; }
+  th, td { border: 1px solid #ccc; padding: .3rem .5rem; text-align: left; vertical-align: top; }
+  th { background: #f2f2f2; position: sticky; top: 0; }
+  td.num, th.num { text-align: right; white-space: nowrap; }
+  code { background: #f5f5f5; padding: 0 .25rem; border-radius: 3px; font-size: .85em; }
+  .note { background: #fff8e1; border: 1px solid #f0d97a; border-radius: 6px; padding: .7rem 1rem; margin: 1rem 0; font-size: .92rem; }
+  .cat-badge { display: inline-block; background: #eef; border-radius: 4px; padding: 0 .4rem; margin-right: .2rem; font-size: .8em; }
+  #toc a { margin-right: 1rem; }
+  tr:hover { background: #fafafa; }
+  .boilerplate-tag { color: #b45309; font-weight: 600; }
+</style>
+</head>
+<body>
+<h1>SkillsBench: skills &harr; tasks map (87 tasks)</h1>
+<p>Derived from <code>insights/SKILLSBENCH_INVENTORY.md</code>'s per-task "Shipped skills" data
+(the task-by-task-87 run seeds each task from this same per-task skill set &mdash; see
+"Implications for a task-by-task optimization strategy" &sect;1 in that doc).</p>
+<div class="note">
+<strong>201 distinct skill names</strong> appear across the 87 tasks' shipped-skill lists.
+5 of those are boilerplate filenames, not real skills &mdash; <code>README.md</code>,
+<code>LICENSE</code>, <code>INSTALLATION.md</code>, <code>TESTING.md</code>, <code>reference.md</code>
+&mdash; carried over from how the source repo lays out its <code>environment/skills/</code>
+directories (e.g. <code>lean4-proof</code> ships its real skills <code>lean4-memories</code> /
+<code>lean4-theorem-proving</code> alongside a <code>README.md</code>/<code>LICENSE</code>/etc.).
+These are marked <span class="boilerplate-tag">B</span> below rather than given a skill number,
+so the numbering (1&ndash;196) covers only actual skills. Task numbers (1&ndash;87) and skill
+numbers follow the order used in <code>SKILLSBENCH_INVENTORY.md</code> (category order, then
+first-appearance order).
+</div>
+<div id="toc"><a href="#table-a">Table A: tasks &rarr; skills</a> <a href="#table-b">Table B: skills &rarr; tasks</a> <a href="#boilerplate">Boilerplate entries</a></div>
+
+<h2 id="table-a">Table A &mdash; all 87 tasks, by category, with skill numbers</h2>
+<h3>software-engineering (16 tasks)</h3>
+<table><thead><tr><th class='num'>#</th><th>Task</th><th>Difficulty</th><th>Skills (by #)</th></tr></thead><tbody>
+<tr><td class='num'>1</td><td><code>azure-bgp-oscillation-route-leak</code></td><td>medium</td><td>1</td></tr>
+<tr><td class='num'>2</td><td><code>data-to-d3</code></td><td>medium</td><td>2</td></tr>
+<tr><td class='num'>3</td><td><code>debug-trl-grpo</code></td><td>hard</td><td>3, 4, 5</td></tr>
+<tr><td class='num'>4</td><td><code>dialogue-parser</code></td><td>easy</td><td>6</td></tr>
+<tr><td class='num'>5</td><td><code>fix-build-agentops</code></td><td>easy</td><td>7, 8, 9, 10</td></tr>
+<tr><td class='num'>6</td><td><code>fix-build-google-auto</code></td><td>easy</td><td>11, 12, 13</td></tr>
+<tr><td class='num'>7</td><td><code>fix-visual-stability</code></td><td>hard</td><td>14, 15, 16</td></tr>
+<tr><td class='num'>8</td><td><code>flink-query</code></td><td>hard</td><td>17, 18</td></tr>
+<tr><td class='num'>9</td><td><code>jax-computing-basics</code></td><td>medium</td><td>19</td></tr>
+<tr><td class='num'>10</td><td><code>llm-prefix-cache-replay</code></td><td>medium</td><td>20, 21</td></tr>
+<tr><td class='num'>11</td><td><code>parallel-tfidf-search</code></td><td>medium</td><td>22, 23, 24</td></tr>
+<tr><td class='num'>12</td><td><code>python-scala-translation</code></td><td>medium</td><td>25, 26, 27, 28, 29, 30</td></tr>
+<tr><td class='num'>13</td><td><code>react-performance-debugging</code></td><td>hard</td><td>14, 15</td></tr>
+<tr><td class='num'>14</td><td><code>simpo-code-reproduction</code></td><td>hard</td><td>31, 17</td></tr>
+<tr><td class='num'>15</td><td><code>spring-boot-jakarta-migration</code></td><td>hard</td><td>32, 33, 34, 35, 36</td></tr>
+<tr><td class='num'>16</td><td><code>tictoc-unnecessary-abort-detection</code></td><td>hard</td><td>37, 38, 39</td></tr>
+</tbody></table>
+<h3>industrial-physical-systems (14 tasks)</h3>
+<table><thead><tr><th class='num'>#</th><th>Task</th><th>Difficulty</th><th>Skills (by #)</th></tr></thead><tbody>
+<tr><td class='num'>17</td><td><code>3d-scan-calc</code></td><td>hard</td><td>40</td></tr>
+<tr><td class='num'>18</td><td><code>ada-bathroom-plan-repair</code></td><td>hard</td><td>41, 42, 43</td></tr>
+<tr><td class='num'>19</td><td><code>adaptive-cruise-control</code></td><td>medium</td><td>44, 45, 46, 47, 48</td></tr>
+<tr><td class='num'>20</td><td><code>drone-planning-control</code></td><td>medium</td><td>49, 50, 51, 52, 53, 54</td></tr>
+<tr><td class='num'>21</td><td><code>dynamic-object-aware-egomotion</code></td><td>medium</td><td>55, 56, 57, 58</td></tr>
+<tr><td class='num'>22</td><td><code>energy-ac-optimal-power-flow</code></td><td>medium</td><td>59, 60, 61</td></tr>
+<tr><td class='num'>23</td><td><code>energy-market-pricing</code></td><td>hard</td><td>62, 63, 64, 61</td></tr>
+<tr><td class='num'>24</td><td><code>energy-unit-commitment</code></td><td>hard</td><td>65, 66, 67</td></tr>
+<tr><td class='num'>25</td><td><code>grid-dispatch-operator</code></td><td>medium</td><td>62, 63, 61</td></tr>
+<tr><td class='num'>26</td><td><code>hvac-control</code></td><td>medium</td><td>68, 69, 70, 71, 72</td></tr>
+<tr><td class='num'>27</td><td><code>manufacturing-codebook-normalization</code></td><td>medium</td><td>73, B</td></tr>
+<tr><td class='num'>28</td><td><code>manufacturing-equipment-maintenance</code></td><td>medium</td><td>B, 74, 75</td></tr>
+<tr><td class='num'>29</td><td><code>manufacturing-fjsp-optimization</code></td><td>medium</td><td>76, B</td></tr>
+<tr><td class='num'>30</td><td><code>r2r-mpc-control</code></td><td>medium</td><td>77, 78, 79, 80</td></tr>
+</tbody></table>
+<h3>office-white-collar (14 tasks)</h3>
+<table><thead><tr><th class='num'>#</th><th>Task</th><th>Difficulty</th><th>Skills (by #)</th></tr></thead><tbody>
+<tr><td class='num'>31</td><td><code>citation-check</code></td><td>medium</td><td>81</td></tr>
+<tr><td class='num'>32</td><td><code>court-form-filling</code></td><td>easy</td><td>17</td></tr>
+<tr><td class='num'>33</td><td><code>edit-pdf</code></td><td>medium</td><td>82, 83</td></tr>
+<tr><td class='num'>34</td><td><code>enterprise-information-search</code></td><td>hard</td><td>84</td></tr>
+<tr><td class='num'>35</td><td><code>exceltable-in-ppt</code></td><td>medium</td><td>85, 86</td></tr>
+<tr><td class='num'>36</td><td><code>jpg-ocr-stat</code></td><td>hard</td><td>87, 88, 17, 89, 86</td></tr>
+<tr><td class='num'>37</td><td><code>latex-formula-extraction</code></td><td>medium</td><td>90, 17</td></tr>
+<tr><td class='num'>38</td><td><code>offer-letter-generator</code></td><td>easy</td><td>91</td></tr>
+<tr><td class='num'>39</td><td><code>organize-messy-files</code></td><td>medium</td><td>91, 92, 17, 93, 85</td></tr>
+<tr><td class='num'>40</td><td><code>paper-anonymizer</code></td><td>medium</td><td>94, 17</td></tr>
+<tr><td class='num'>41</td><td><code>pdf-excel-diff</code></td><td>medium</td><td>17, 86</td></tr>
+<tr><td class='num'>42</td><td><code>powerlifting-coef-calc</code></td><td>easy</td><td>95, 96, 86</td></tr>
+<tr><td class='num'>43</td><td><code>pptx-reference-formatting</code></td><td>medium</td><td>85</td></tr>
+<tr><td class='num'>44</td><td><code>sales-pivot-analysis</code></td><td>medium</td><td>17, 86</td></tr>
+</tbody></table>
+<h3>natural-science (14 tasks)</h3>
+<table><thead><tr><th class='num'>#</th><th>Task</th><th>Difficulty</th><th>Skills (by #)</th></tr></thead><tbody>
+<tr><td class='num'>45</td><td><code>crystallographic-wyckoff-position-analysis</code></td><td>medium</td><td>97, 98</td></tr>
+<tr><td class='num'>46</td><td><code>earthquake-phase-association</code></td><td>hard</td><td>99, 100, 101, 102, 103</td></tr>
+<tr><td class='num'>47</td><td><code>earthquake-plate-calculation</code></td><td>medium</td><td>104</td></tr>
+<tr><td class='num'>48</td><td><code>exoplanet-detection-period</code></td><td>medium</td><td>105, 106, 107, 108, 109</td></tr>
+<tr><td class='num'>49</td><td><code>flood-risk-analysis</code></td><td>medium</td><td>110, 111, 112</td></tr>
+<tr><td class='num'>50</td><td><code>glm-lake-mendota</code></td><td>hard</td><td>113, 114, 115</td></tr>
+<tr><td class='num'>51</td><td><code>gravitational-wave-detection</code></td><td>medium</td><td>116, 117</td></tr>
+<tr><td class='num'>52</td><td><code>lab-unit-harmonization</code></td><td>medium</td><td>118</td></tr>
+<tr><td class='num'>53</td><td><code>lake-warming-attribution</code></td><td>medium</td><td>119, 120, 121, 122</td></tr>
+<tr><td class='num'>54</td><td><code>mars-clouds-clustering</code></td><td>hard</td><td>123, 124, 125</td></tr>
+<tr><td class='num'>55</td><td><code>protein-expression-analysis</code></td><td>medium</td><td>86</td></tr>
+<tr><td class='num'>56</td><td><code>quantum-numerical-simulation</code></td><td>medium</td><td>126</td></tr>
+<tr><td class='num'>57</td><td><code>radar-vital-signs</code></td><td>medium</td><td>127, 128, 129</td></tr>
+<tr><td class='num'>58</td><td><code>seismic-phase-picking</code></td><td>hard</td><td>100, 101, 130, 102, 103</td></tr>
+</tbody></table>
+<h3>finance-economics (9 tasks)</h3>
+<table><thead><tr><th class='num'>#</th><th>Task</th><th>Difficulty</th><th>Skills (by #)</th></tr></thead><tbody>
+<tr><td class='num'>59</td><td><code>econ-detrending-correlation</code></td><td>medium</td><td>131</td></tr>
+<tr><td class='num'>60</td><td><code>financial-modeling-qa</code></td><td>hard</td><td>17, 86</td></tr>
+<tr><td class='num'>61</td><td><code>invoice-fraud-detection</code></td><td>hard</td><td>132, 17, 86</td></tr>
+<tr><td class='num'>62</td><td><code>reserves-at-risk-calc</code></td><td>medium</td><td>86</td></tr>
+<tr><td class='num'>63</td><td><code>sec-financial-report</code></td><td>hard</td><td>133, 134</td></tr>
+<tr><td class='num'>64</td><td><code>shock-analysis-demand</code></td><td>medium</td><td>86</td></tr>
+<tr><td class='num'>65</td><td><code>shock-analysis-supply</code></td><td>hard</td><td>86</td></tr>
+<tr><td class='num'>66</td><td><code>weighted-gdp-calc</code></td><td>medium</td><td>86</td></tr>
+<tr><td class='num'>67</td><td><code>xlsx-recover-data</code></td><td>medium</td><td>135, 86</td></tr>
+</tbody></table>
+<h3>mathematics-or-formal-reasoning (8 tasks)</h3>
+<table><thead><tr><th class='num'>#</th><th>Task</th><th>Difficulty</th><th>Skills (by #)</th></tr></thead><tbody>
+<tr><td class='num'>68</td><td><code>bike-rebalance</code></td><td>medium</td><td>136, 137, 138, 139</td></tr>
+<tr><td class='num'>69</td><td><code>civ6-adjacency-optimizer</code></td><td>hard</td><td>140, 141, 142, 143</td></tr>
+<tr><td class='num'>70</td><td><code>exam-block-sequencing</code></td><td>hard</td><td>144, 145</td></tr>
+<tr><td class='num'>71</td><td><code>lean4-proof</code></td><td>medium</td><td>B, B, B, B, 146, 147</td></tr>
+<tr><td class='num'>72</td><td><code>paratransit-routing</code></td><td>hard</td><td>148, 149</td></tr>
+<tr><td class='num'>73</td><td><code>pddl-airport-planning</code></td><td>medium</td><td>150</td></tr>
+<tr><td class='num'>74</td><td><code>pddl-tpp-planning</code></td><td>medium</td><td>150</td></tr>
+<tr><td class='num'>75</td><td><code>travel-planning</code></td><td>medium</td><td>151, 152, 153, 154, 155, 156</td></tr>
+</tbody></table>
+<h3>cybersecurity (7 tasks)</h3>
+<table><thead><tr><th class='num'>#</th><th>Task</th><th>Difficulty</th><th>Skills (by #)</th></tr></thead><tbody>
+<tr><td class='num'>76</td><td><code>dapt-intrusion-detection</code></td><td>hard</td><td>157, 158</td></tr>
+<tr><td class='num'>77</td><td><code>fix-druid-loophole-cve</code></td><td>hard</td><td>159, 160</td></tr>
+<tr><td class='num'>78</td><td><code>fix-erlang-ssh-cve</code></td><td>hard</td><td>161, 162, 163, 164, 165, 166</td></tr>
+<tr><td class='num'>79</td><td><code>setup-fuzzing-py</code></td><td>medium</td><td>167, 168, 169</td></tr>
+<tr><td class='num'>80</td><td><code>software-dependency-audit</code></td><td>medium</td><td>170, 171, 172</td></tr>
+<tr><td class='num'>81</td><td><code>suricata-custom-exfil</code></td><td>medium</td><td>173, 174, 175</td></tr>
+<tr><td class='num'>82</td><td><code>syzkaller-ppdev-syzlang</code></td><td>medium</td><td>176, 177, 178</td></tr>
+</tbody></table>
+<h3>media-content-production (5 tasks)</h3>
+<table><thead><tr><th class='num'>#</th><th>Task</th><th>Difficulty</th><th>Skills (by #)</th></tr></thead><tbody>
+<tr><td class='num'>83</td><td><code>mario-coin-counting</code></td><td>medium</td><td>179, 180, 181</td></tr>
+<tr><td class='num'>84</td><td><code>multilingual-video-dubbing</code></td><td>medium</td><td>182, 183, 184, 185, 186, 187</td></tr>
+<tr><td class='num'>85</td><td><code>threejs-structure-parser</code></td><td>medium</td><td>188, 189</td></tr>
+<tr><td class='num'>86</td><td><code>threejs-to-obj</code></td><td>medium</td><td>188, 189</td></tr>
+<tr><td class='num'>87</td><td><code>video-silence-remover</code></td><td>hard</td><td>190, 191, 192, 193, 194, 195, 196</td></tr>
+</tbody></table>
+<h2 id="table-b">Table B &mdash; skills index, with the tasks that use each</h2>
+<p>Rows = skills, numbered by first appearance in Table A. "Categories" lists every category the skill appears in (most skills are single-category; a few &mdash; e.g. <code>pdf</code>, <code>xlsx</code> &mdash; cross several).</p>
+<table><thead><tr><th class='num'>#</th><th>Skill</th><th class='num'># tasks</th><th>Categories</th><th>Task #s</th></tr></thead><tbody>
+<tr><td class='num'>1</td><td><code>azure-bgp</code></td><td class='num'>1</td><td><span class='cat-badge'>software-engineering</span></td><td>1</td></tr>
+<tr><td class='num'>2</td><td><code>d3-visualization</code></td><td class='num'>1</td><td><span class='cat-badge'>software-engineering</span></td><td>2</td></tr>
+<tr><td class='num'>3</td><td><code>grpo</code></td><td class='num'>1</td><td><span class='cat-badge'>software-engineering</span></td><td>3</td></tr>
+<tr><td class='num'>4</td><td><code>rl-post-training</code></td><td class='num'>1</td><td><span class='cat-badge'>software-engineering</span></td><td>3</td></tr>
+<tr><td class='num'>5</td><td><code>trl</code></td><td class='num'>1</td><td><span class='cat-badge'>software-engineering</span></td><td>3</td></tr>
+<tr><td class='num'>6</td><td><code>dialogue-graph</code></td><td class='num'>1</td><td><span class='cat-badge'>software-engineering</span></td><td>4</td></tr>
+<tr><td class='num'>7</td><td><code>analyze-ci</code></td><td class='num'>1</td><td><span class='cat-badge'>software-engineering</span></td><td>5</td></tr>
+<tr><td class='num'>8</td><td><code>temporal-python-testing</code></td><td class='num'>1</td><td><span class='cat-badge'>software-engineering</span></td><td>5</td></tr>
+<tr><td class='num'>9</td><td><code>testing-python</code></td><td class='num'>1</td><td><span class='cat-badge'>software-engineering</span></td><td>5</td></tr>
+<tr><td class='num'>10</td><td><code>uv-package-manager</code></td><td class='num'>1</td><td><span class='cat-badge'>software-engineering</span></td><td>5</td></tr>
+<tr><td class='num'>11</td><td><code>maven-build-lifecycle</code></td><td class='num'>1</td><td><span class='cat-badge'>software-engineering</span></td><td>6</td></tr>
+<tr><td class='num'>12</td><td><code>maven-dependency-management</code></td><td class='num'>1</td><td><span class='cat-badge'>software-engineering</span></td><td>6</td></tr>
+<tr><td class='num'>13</td><td><code>maven-plugin-configuration</code></td><td class='num'>1</td><td><span class='cat-badge'>software-engineering</span></td><td>6</td></tr>
+<tr><td class='num'>14</td><td><code>browser-testing</code></td><td class='num'>2</td><td><span class='cat-badge'>software-engineering</span></td><td>7, 13</td></tr>
+<tr><td class='num'>15</td><td><code>react-best-practices</code></td><td class='num'>2</td><td><span class='cat-badge'>software-engineering</span></td><td>7, 13</td></tr>
+<tr><td class='num'>16</td><td><code>web-interface-guidelines</code></td><td class='num'>1</td><td><span class='cat-badge'>software-engineering</span></td><td>7</td></tr>
+<tr><td class='num'>17</td><td><code>pdf</code></td><td class='num'>11</td><td><span class='cat-badge'>finance-economics</span><span class='cat-badge'>office-white-collar</span><span class='cat-badge'>software-engineering</span></td><td>8, 14, 32, 36, 37, 39, 40, 41, 44, 60, 61</td></tr>
+<tr><td class='num'>18</td><td><code>senior-data-engineer</code></td><td class='num'>1</td><td><span class='cat-badge'>software-engineering</span></td><td>8</td></tr>
+<tr><td class='num'>19</td><td><code>jax-skills</code></td><td class='num'>1</td><td><span class='cat-badge'>software-engineering</span></td><td>9</td></tr>
+<tr><td class='num'>20</td><td><code>cache-policy-comparison</code></td><td class='num'>1</td><td><span class='cat-badge'>software-engineering</span></td><td>10</td></tr>
+<tr><td class='num'>21</td><td><code>prefix-cache-replay</code></td><td class='num'>1</td><td><span class='cat-badge'>software-engineering</span></td><td>10</td></tr>
+<tr><td class='num'>22</td><td><code>memory-optimization</code></td><td class='num'>1</td><td><span class='cat-badge'>software-engineering</span></td><td>11</td></tr>
+<tr><td class='num'>23</td><td><code>python-parallelization</code></td><td class='num'>1</td><td><span class='cat-badge'>software-engineering</span></td><td>11</td></tr>
+<tr><td class='num'>24</td><td><code>workload-balancing</code></td><td class='num'>1</td><td><span class='cat-badge'>software-engineering</span></td><td>11</td></tr>
+<tr><td class='num'>25</td><td><code>python-scala-collections</code></td><td class='num'>1</td><td><span class='cat-badge'>software-engineering</span></td><td>12</td></tr>
+<tr><td class='num'>26</td><td><code>python-scala-functional</code></td><td class='num'>1</td><td><span class='cat-badge'>software-engineering</span></td><td>12</td></tr>
+<tr><td class='num'>27</td><td><code>python-scala-idioms</code></td><td class='num'>1</td><td><span class='cat-badge'>software-engineering</span></td><td>12</td></tr>
+<tr><td class='num'>28</td><td><code>python-scala-libraries</code></td><td class='num'>1</td><td><span class='cat-badge'>software-engineering</span></td><td>12</td></tr>
+<tr><td class='num'>29</td><td><code>python-scala-oop</code></td><td class='num'>1</td><td><span class='cat-badge'>software-engineering</span></td><td>12</td></tr>
+<tr><td class='num'>30</td><td><code>python-scala-syntax-mapping</code></td><td class='num'>1</td><td><span class='cat-badge'>software-engineering</span></td><td>12</td></tr>
+<tr><td class='num'>31</td><td><code>nlp-research-repo-package-installment</code></td><td class='num'>1</td><td><span class='cat-badge'>software-engineering</span></td><td>14</td></tr>
+<tr><td class='num'>32</td><td><code>hibernate-upgrade</code></td><td class='num'>1</td><td><span class='cat-badge'>software-engineering</span></td><td>15</td></tr>
+<tr><td class='num'>33</td><td><code>jakarta-namespace</code></td><td class='num'>1</td><td><span class='cat-badge'>software-engineering</span></td><td>15</td></tr>
+<tr><td class='num'>34</td><td><code>restclient-migration</code></td><td class='num'>1</td><td><span class='cat-badge'>software-engineering</span></td><td>15</td></tr>
+<tr><td class='num'>35</td><td><code>spring-boot-migration</code></td><td class='num'>1</td><td><span class='cat-badge'>software-engineering</span></td><td>15</td></tr>
+<tr><td class='num'>36</td><td><code>spring-security-6</code></td><td class='num'>1</td><td><span class='cat-badge'>software-engineering</span></td><td>15</td></tr>
+<tr><td class='num'>37</td><td><code>transaction-concurrency-control-foundations</code></td><td class='num'>1</td><td><span class='cat-badge'>software-engineering</span></td><td>16</td></tr>
+<tr><td class='num'>38</td><td><code>transaction-protocol-reasoning</code></td><td class='num'>1</td><td><span class='cat-badge'>software-engineering</span></td><td>16</td></tr>
+<tr><td class='num'>39</td><td><code>transaction-trace-analysis</code></td><td class='num'>1</td><td><span class='cat-badge'>software-engineering</span></td><td>16</td></tr>
+<tr><td class='num'>40</td><td><code>mesh-analysis</code></td><td class='num'>1</td><td><span class='cat-badge'>industrial-physical-systems</span></td><td>17</td></tr>
+<tr><td class='num'>41</td><td><code>ada-plan-view-accessibility</code></td><td class='num'>1</td><td><span class='cat-badge'>industrial-physical-systems</span></td><td>18</td></tr>
+<tr><td class='num'>42</td><td><code>architectural-dxf-extraction</code></td><td class='num'>1</td><td><span class='cat-badge'>industrial-physical-systems</span></td><td>18</td></tr>
+<tr><td class='num'>43</td><td><code>geometric-layout-repair</code></td><td class='num'>1</td><td><span class='cat-badge'>industrial-physical-systems</span></td><td>18</td></tr>
+<tr><td class='num'>44</td><td><code>csv-processing</code></td><td class='num'>1</td><td><span class='cat-badge'>industrial-physical-systems</span></td><td>19</td></tr>
+<tr><td class='num'>45</td><td><code>pid-controller</code></td><td class='num'>1</td><td><span class='cat-badge'>industrial-physical-systems</span></td><td>19</td></tr>
+<tr><td class='num'>46</td><td><code>simulation-metrics</code></td><td class='num'>1</td><td><span class='cat-badge'>industrial-physical-systems</span></td><td>19</td></tr>
+<tr><td class='num'>47</td><td><code>vehicle-dynamics</code></td><td class='num'>1</td><td><span class='cat-badge'>industrial-physical-systems</span></td><td>19</td></tr>
+<tr><td class='num'>48</td><td><code>yaml-config</code></td><td class='num'>1</td><td><span class='cat-badge'>industrial-physical-systems</span></td><td>19</td></tr>
+<tr><td class='num'>49</td><td><code>attitude-controller-planner</code></td><td class='num'>1</td><td><span class='cat-badge'>industrial-physical-systems</span></td><td>20</td></tr>
+<tr><td class='num'>50</td><td><code>flight-plan-parser</code></td><td class='num'>1</td><td><span class='cat-badge'>industrial-physical-systems</span></td><td>20</td></tr>
+<tr><td class='num'>51</td><td><code>motor-model-dynamics</code></td><td class='num'>1</td><td><span class='cat-badge'>industrial-physical-systems</span></td><td>20</td></tr>
+<tr><td class='num'>52</td><td><code>plot-quadrotor</code></td><td class='num'>1</td><td><span class='cat-badge'>industrial-physical-systems</span></td><td>20</td></tr>
+<tr><td class='num'>53</td><td><code>position-controller-trajectory-planner</code></td><td class='num'>1</td><td><span class='cat-badge'>industrial-physical-systems</span></td><td>20</td></tr>
+<tr><td class='num'>54</td><td><code>stepinfo-3d</code></td><td class='num'>1</td><td><span class='cat-badge'>industrial-physical-systems</span></td><td>20</td></tr>
+<tr><td class='num'>55</td><td><code>dyn-object-masks</code></td><td class='num'>1</td><td><span class='cat-badge'>industrial-physical-systems</span></td><td>21</td></tr>
+<tr><td class='num'>56</td><td><code>egomotion-estimation</code></td><td class='num'>1</td><td><span class='cat-badge'>industrial-physical-systems</span></td><td>21</td></tr>
+<tr><td class='num'>57</td><td><code>output-validation</code></td><td class='num'>1</td><td><span class='cat-badge'>industrial-physical-systems</span></td><td>21</td></tr>
+<tr><td class='num'>58</td><td><code>sampling-and-indexing</code></td><td class='num'>1</td><td><span class='cat-badge'>industrial-physical-systems</span></td><td>21</td></tr>
+<tr><td class='num'>59</td><td><code>ac-branch-pi-model</code></td><td class='num'>1</td><td><span class='cat-badge'>industrial-physical-systems</span></td><td>22</td></tr>
+<tr><td class='num'>60</td><td><code>casadi-ipopt-nlp</code></td><td class='num'>1</td><td><span class='cat-badge'>industrial-physical-systems</span></td><td>22</td></tr>
+<tr><td class='num'>61</td><td><code>power-flow-data</code></td><td class='num'>3</td><td><span class='cat-badge'>industrial-physical-systems</span></td><td>22, 23, 25</td></tr>
+<tr><td class='num'>62</td><td><code>dc-power-flow</code></td><td class='num'>2</td><td><span class='cat-badge'>industrial-physical-systems</span></td><td>23, 25</td></tr>
+<tr><td class='num'>63</td><td><code>economic-dispatch</code></td><td class='num'>2</td><td><span class='cat-badge'>industrial-physical-systems</span></td><td>23, 25</td></tr>
+<tr><td class='num'>64</td><td><code>locational-marginal-prices</code></td><td class='num'>1</td><td><span class='cat-badge'>industrial-physical-systems</span></td><td>23</td></tr>
+<tr><td class='num'>65</td><td><code>milp-solver-workflow</code></td><td class='num'>1</td><td><span class='cat-badge'>industrial-physical-systems</span></td><td>24</td></tr>
+<tr><td class='num'>66</td><td><code>unit-commitment-data-modeling</code></td><td class='num'>1</td><td><span class='cat-badge'>industrial-physical-systems</span></td><td>24</td></tr>
+<tr><td class='num'>67</td><td><code>unit-commitment-operating-rules</code></td><td class='num'>1</td><td><span class='cat-badge'>industrial-physical-systems</span></td><td>24</td></tr>
+<tr><td class='num'>68</td><td><code>excitation-signal-design</code></td><td class='num'>1</td><td><span class='cat-badge'>industrial-physical-systems</span></td><td>26</td></tr>
+<tr><td class='num'>69</td><td><code>first-order-model-fitting</code></td><td class='num'>1</td><td><span class='cat-badge'>industrial-physical-systems</span></td><td>26</td></tr>
+<tr><td class='num'>70</td><td><code>imc-tuning-rules</code></td><td class='num'>1</td><td><span class='cat-badge'>industrial-physical-systems</span></td><td>26</td></tr>
+<tr><td class='num'>71</td><td><code>safety-interlocks</code></td><td class='num'>1</td><td><span class='cat-badge'>industrial-physical-systems</span></td><td>26</td></tr>
+<tr><td class='num'>72</td><td><code>scipy-curve-fit</code></td><td class='num'>1</td><td><span class='cat-badge'>industrial-physical-systems</span></td><td>26</td></tr>
+<tr><td class='num'>73</td><td><code>manufacturing-failure-reason-codebook-normalization</code></td><td class='num'>1</td><td><span class='cat-badge'>industrial-physical-systems</span></td><td>27</td></tr>
+<tr><td class='num'>74</td><td><code>reflow-machine-maintenance-guidance</code></td><td class='num'>1</td><td><span class='cat-badge'>industrial-physical-systems</span></td><td>28</td></tr>
+<tr><td class='num'>75</td><td><code>reflow-profile-compliance-toolkit</code></td><td class='num'>1</td><td><span class='cat-badge'>industrial-physical-systems</span></td><td>28</td></tr>
+<tr><td class='num'>76</td><td><code>fjsp-baseline-repair-with-downtime-and-policy</code></td><td class='num'>1</td><td><span class='cat-badge'>industrial-physical-systems</span></td><td>29</td></tr>
+<tr><td class='num'>77</td><td><code>finite-horizon-lqr</code></td><td class='num'>1</td><td><span class='cat-badge'>industrial-physical-systems</span></td><td>30</td></tr>
+<tr><td class='num'>78</td><td><code>integral-action-design</code></td><td class='num'>1</td><td><span class='cat-badge'>industrial-physical-systems</span></td><td>30</td></tr>
+<tr><td class='num'>79</td><td><code>mpc-horizon-tuning</code></td><td class='num'>1</td><td><span class='cat-badge'>industrial-physical-systems</span></td><td>30</td></tr>
+<tr><td class='num'>80</td><td><code>state-space-linearization</code></td><td class='num'>1</td><td><span class='cat-badge'>industrial-physical-systems</span></td><td>30</td></tr>
+<tr><td class='num'>81</td><td><code>citation-management</code></td><td class='num'>1</td><td><span class='cat-badge'>office-white-collar</span></td><td>31</td></tr>
+<tr><td class='num'>82</td><td><code>pdf-editing</code></td><td class='num'>1</td><td><span class='cat-badge'>office-white-collar</span></td><td>33</td></tr>
+<tr><td class='num'>83</td><td><code>text-parser</code></td><td class='num'>1</td><td><span class='cat-badge'>office-white-collar</span></td><td>33</td></tr>
+<tr><td class='num'>84</td><td><code>enterprise-artifact-search</code></td><td class='num'>1</td><td><span class='cat-badge'>office-white-collar</span></td><td>34</td></tr>
+<tr><td class='num'>85</td><td><code>pptx</code></td><td class='num'>3</td><td><span class='cat-badge'>office-white-collar</span></td><td>35, 39, 43</td></tr>
+<tr><td class='num'>86</td><td><code>xlsx</code></td><td class='num'>13</td><td><span class='cat-badge'>finance-economics</span><span class='cat-badge'>natural-science</span><span class='cat-badge'>office-white-collar</span></td><td>35, 36, 41, 42, 44, 55, 60, 61, 62, 64, 65, 66, 67</td></tr>
+<tr><td class='num'>87</td><td><code>image-ocr</code></td><td class='num'>1</td><td><span class='cat-badge'>office-white-collar</span></td><td>36</td></tr>
+<tr><td class='num'>88</td><td><code>openai-vision</code></td><td class='num'>1</td><td><span class='cat-badge'>office-white-collar</span></td><td>36</td></tr>
+<tr><td class='num'>89</td><td><code>video-frame-extraction</code></td><td class='num'>1</td><td><span class='cat-badge'>office-white-collar</span></td><td>36</td></tr>
+<tr><td class='num'>90</td><td><code>marker</code></td><td class='num'>1</td><td><span class='cat-badge'>office-white-collar</span></td><td>37</td></tr>
+<tr><td class='num'>91</td><td><code>docx</code></td><td class='num'>2</td><td><span class='cat-badge'>office-white-collar</span></td><td>38, 39</td></tr>
+<tr><td class='num'>92</td><td><code>file-organizer</code></td><td class='num'>1</td><td><span class='cat-badge'>office-white-collar</span></td><td>39</td></tr>
+<tr><td class='num'>93</td><td><code>planning-with-files</code></td><td class='num'>1</td><td><span class='cat-badge'>office-white-collar</span></td><td>39</td></tr>
+<tr><td class='num'>94</td><td><code>academic-pdf-redaction</code></td><td class='num'>1</td><td><span class='cat-badge'>office-white-collar</span></td><td>40</td></tr>
+<tr><td class='num'>95</td><td><code>powerlifting</code></td><td class='num'>1</td><td><span class='cat-badge'>office-white-collar</span></td><td>42</td></tr>
+<tr><td class='num'>96</td><td><code>senior-data-scientist</code></td><td class='num'>1</td><td><span class='cat-badge'>office-white-collar</span></td><td>42</td></tr>
+<tr><td class='num'>97</td><td><code>pymatgen</code></td><td class='num'>1</td><td><span class='cat-badge'>natural-science</span></td><td>45</td></tr>
+<tr><td class='num'>98</td><td><code>sympy</code></td><td class='num'>1</td><td><span class='cat-badge'>natural-science</span></td><td>45</td></tr>
+<tr><td class='num'>99</td><td><code>gamma-phase-associator</code></td><td class='num'>1</td><td><span class='cat-badge'>natural-science</span></td><td>46</td></tr>
+<tr><td class='num'>100</td><td><code>licenses</code></td><td class='num'>2</td><td><span class='cat-badge'>natural-science</span></td><td>46, 58</td></tr>
+<tr><td class='num'>101</td><td><code>obspy-data-api</code></td><td class='num'>2</td><td><span class='cat-badge'>natural-science</span></td><td>46, 58</td></tr>
+<tr><td class='num'>102</td><td><code>seisbench-model-api</code></td><td class='num'>2</td><td><span class='cat-badge'>natural-science</span></td><td>46, 58</td></tr>
+<tr><td class='num'>103</td><td><code>seismic-picker-selection</code></td><td class='num'>2</td><td><span class='cat-badge'>natural-science</span></td><td>46, 58</td></tr>
+<tr><td class='num'>104</td><td><code>geospatial-analysis</code></td><td class='num'>1</td><td><span class='cat-badge'>natural-science</span></td><td>47</td></tr>
+<tr><td class='num'>105</td><td><code>box-least-squares</code></td><td class='num'>1</td><td><span class='cat-badge'>natural-science</span></td><td>48</td></tr>
+<tr><td class='num'>106</td><td><code>exoplanet-workflows</code></td><td class='num'>1</td><td><span class='cat-badge'>natural-science</span></td><td>48</td></tr>
+<tr><td class='num'>107</td><td><code>light-curve-preprocessing</code></td><td class='num'>1</td><td><span class='cat-badge'>natural-science</span></td><td>48</td></tr>
+<tr><td class='num'>108</td><td><code>lomb-scargle-periodogram</code></td><td class='num'>1</td><td><span class='cat-badge'>natural-science</span></td><td>48</td></tr>
+<tr><td class='num'>109</td><td><code>transit-least-squares</code></td><td class='num'>1</td><td><span class='cat-badge'>natural-science</span></td><td>48</td></tr>
+<tr><td class='num'>110</td><td><code>flood-detection</code></td><td class='num'>1</td><td><span class='cat-badge'>natural-science</span></td><td>49</td></tr>
+<tr><td class='num'>111</td><td><code>nws-flood-thresholds</code></td><td class='num'>1</td><td><span class='cat-badge'>natural-science</span></td><td>49</td></tr>
+<tr><td class='num'>112</td><td><code>usgs-data-download</code></td><td class='num'>1</td><td><span class='cat-badge'>natural-science</span></td><td>49</td></tr>
+<tr><td class='num'>113</td><td><code>glm-basics</code></td><td class='num'>1</td><td><span class='cat-badge'>natural-science</span></td><td>50</td></tr>
+<tr><td class='num'>114</td><td><code>glm-calibration</code></td><td class='num'>1</td><td><span class='cat-badge'>natural-science</span></td><td>50</td></tr>
+<tr><td class='num'>115</td><td><code>glm-output</code></td><td class='num'>1</td><td><span class='cat-badge'>natural-science</span></td><td>50</td></tr>
+<tr><td class='num'>116</td><td><code>conditioning</code></td><td class='num'>1</td><td><span class='cat-badge'>natural-science</span></td><td>51</td></tr>
+<tr><td class='num'>117</td><td><code>matched-filtering</code></td><td class='num'>1</td><td><span class='cat-badge'>natural-science</span></td><td>51</td></tr>
+<tr><td class='num'>118</td><td><code>lab-unit-harmonization</code></td><td class='num'>1</td><td><span class='cat-badge'>natural-science</span></td><td>52</td></tr>
+<tr><td class='num'>119</td><td><code>contribution-analysis</code></td><td class='num'>1</td><td><span class='cat-badge'>natural-science</span></td><td>53</td></tr>
+<tr><td class='num'>120</td><td><code>meteorology-driver-classification</code></td><td class='num'>1</td><td><span class='cat-badge'>natural-science</span></td><td>53</td></tr>
+<tr><td class='num'>121</td><td><code>pca-decomposition</code></td><td class='num'>1</td><td><span class='cat-badge'>natural-science</span></td><td>53</td></tr>
+<tr><td class='num'>122</td><td><code>trend-analysis</code></td><td class='num'>1</td><td><span class='cat-badge'>natural-science</span></td><td>53</td></tr>
+<tr><td class='num'>123</td><td><code>custom-distance-metrics</code></td><td class='num'>1</td><td><span class='cat-badge'>natural-science</span></td><td>54</td></tr>
+<tr><td class='num'>124</td><td><code>parallel-processing</code></td><td class='num'>1</td><td><span class='cat-badge'>natural-science</span></td><td>54</td></tr>
+<tr><td class='num'>125</td><td><code>pareto-optimization</code></td><td class='num'>1</td><td><span class='cat-badge'>natural-science</span></td><td>54</td></tr>
+<tr><td class='num'>126</td><td><code>qutip</code></td><td class='num'>1</td><td><span class='cat-badge'>natural-science</span></td><td>56</td></tr>
+<tr><td class='num'>127</td><td><code>radar-signal-processing</code></td><td class='num'>1</td><td><span class='cat-badge'>natural-science</span></td><td>57</td></tr>
+<tr><td class='num'>128</td><td><code>radar-vital-signs</code></td><td class='num'>1</td><td><span class='cat-badge'>natural-science</span></td><td>57</td></tr>
+<tr><td class='num'>129</td><td><code>vital-sign-extraction</code></td><td class='num'>1</td><td><span class='cat-badge'>natural-science</span></td><td>57</td></tr>
+<tr><td class='num'>130</td><td><code>obspy-datacenter-client</code></td><td class='num'>1</td><td><span class='cat-badge'>natural-science</span></td><td>58</td></tr>
+<tr><td class='num'>131</td><td><code>timeseries-detrending</code></td><td class='num'>1</td><td><span class='cat-badge'>finance-economics</span></td><td>59</td></tr>
+<tr><td class='num'>132</td><td><code>fuzzy-match</code></td><td class='num'>1</td><td><span class='cat-badge'>finance-economics</span></td><td>61</td></tr>
+<tr><td class='num'>133</td><td><code>13f-analyzer</code></td><td class='num'>1</td><td><span class='cat-badge'>finance-economics</span></td><td>63</td></tr>
+<tr><td class='num'>134</td><td><code>fuzzy-name-search</code></td><td class='num'>1</td><td><span class='cat-badge'>finance-economics</span></td><td>63</td></tr>
+<tr><td class='num'>135</td><td><code>data-reconciliation</code></td><td class='num'>1</td><td><span class='cat-badge'>finance-economics</span></td><td>67</td></tr>
+<tr><td class='num'>136</td><td><code>geospatial-routing-data</code></td><td class='num'>1</td><td><span class='cat-badge'>mathematics-or-formal-reasoning</span></td><td>68</td></tr>
+<tr><td class='num'>137</td><td><code>logistics-rules-to-optimization</code></td><td class='num'>1</td><td><span class='cat-badge'>mathematics-or-formal-reasoning</span></td><td>68</td></tr>
+<tr><td class='num'>138</td><td><code>routing-subtour-elimination</code></td><td class='num'>1</td><td><span class='cat-badge'>mathematics-or-formal-reasoning</span></td><td>68</td></tr>
+<tr><td class='num'>139</td><td><code>scip-opt</code></td><td class='num'>1</td><td><span class='cat-badge'>mathematics-or-formal-reasoning</span></td><td>68</td></tr>
+<tr><td class='num'>140</td><td><code>civ6lib</code></td><td class='num'>1</td><td><span class='cat-badge'>mathematics-or-formal-reasoning</span></td><td>69</td></tr>
+<tr><td class='num'>141</td><td><code>hex-grid-spatial</code></td><td class='num'>1</td><td><span class='cat-badge'>mathematics-or-formal-reasoning</span></td><td>69</td></tr>
+<tr><td class='num'>142</td><td><code>map-optimization-strategy</code></td><td class='num'>1</td><td><span class='cat-badge'>mathematics-or-formal-reasoning</span></td><td>69</td></tr>
+<tr><td class='num'>143</td><td><code>sqlite-map-parser</code></td><td class='num'>1</td><td><span class='cat-badge'>mathematics-or-formal-reasoning</span></td><td>69</td></tr>
+<tr><td class='num'>144</td><td><code>mip-solver-and-solution-audit</code></td><td class='num'>1</td><td><span class='cat-badge'>mathematics-or-formal-reasoning</span></td><td>70</td></tr>
+<tr><td class='num'>145</td><td><code>ordered-window-sequencing-mip</code></td><td class='num'>1</td><td><span class='cat-badge'>mathematics-or-formal-reasoning</span></td><td>70</td></tr>
+<tr><td class='num'>146</td><td><code>lean4-memories</code></td><td class='num'>1</td><td><span class='cat-badge'>mathematics-or-formal-reasoning</span></td><td>71</td></tr>
+<tr><td class='num'>147</td><td><code>lean4-theorem-proving</code></td><td class='num'>1</td><td><span class='cat-badge'>mathematics-or-formal-reasoning</span></td><td>71</td></tr>
+<tr><td class='num'>148</td><td><code>ortools-pickup-delivery-routing</code></td><td class='num'>1</td><td><span class='cat-badge'>mathematics-or-formal-reasoning</span></td><td>72</td></tr>
+<tr><td class='num'>149</td><td><code>ortools-routing-modeling</code></td><td class='num'>1</td><td><span class='cat-badge'>mathematics-or-formal-reasoning</span></td><td>72</td></tr>
+<tr><td class='num'>150</td><td><code>pddl-skills</code></td><td class='num'>2</td><td><span class='cat-badge'>mathematics-or-formal-reasoning</span></td><td>73, 74</td></tr>
+<tr><td class='num'>151</td><td><code>search-accommodations</code></td><td class='num'>1</td><td><span class='cat-badge'>mathematics-or-formal-reasoning</span></td><td>75</td></tr>
+<tr><td class='num'>152</td><td><code>search-attractions</code></td><td class='num'>1</td><td><span class='cat-badge'>mathematics-or-formal-reasoning</span></td><td>75</td></tr>
+<tr><td class='num'>153</td><td><code>search-cities</code></td><td class='num'>1</td><td><span class='cat-badge'>mathematics-or-formal-reasoning</span></td><td>75</td></tr>
+<tr><td class='num'>154</td><td><code>search-driving-distance</code></td><td class='num'>1</td><td><span class='cat-badge'>mathematics-or-formal-reasoning</span></td><td>75</td></tr>
+<tr><td class='num'>155</td><td><code>search-flights</code></td><td class='num'>1</td><td><span class='cat-badge'>mathematics-or-formal-reasoning</span></td><td>75</td></tr>
+<tr><td class='num'>156</td><td><code>search-restaurants</code></td><td class='num'>1</td><td><span class='cat-badge'>mathematics-or-formal-reasoning</span></td><td>75</td></tr>
+<tr><td class='num'>157</td><td><code>pcap-analysis</code></td><td class='num'>1</td><td><span class='cat-badge'>cybersecurity</span></td><td>76</td></tr>
+<tr><td class='num'>158</td><td><code>threat-detection</code></td><td class='num'>1</td><td><span class='cat-badge'>cybersecurity</span></td><td>76</td></tr>
+<tr><td class='num'>159</td><td><code>jackson-security</code></td><td class='num'>1</td><td><span class='cat-badge'>cybersecurity</span></td><td>77</td></tr>
+<tr><td class='num'>160</td><td><code>senior-java</code></td><td class='num'>1</td><td><span class='cat-badge'>cybersecurity</span></td><td>77</td></tr>
+<tr><td class='num'>161</td><td><code>erlang-concurrency</code></td><td class='num'>1</td><td><span class='cat-badge'>cybersecurity</span></td><td>78</td></tr>
+<tr><td class='num'>162</td><td><code>erlang-distribution</code></td><td class='num'>1</td><td><span class='cat-badge'>cybersecurity</span></td><td>78</td></tr>
+<tr><td class='num'>163</td><td><code>erlang-otp-behaviors</code></td><td class='num'>1</td><td><span class='cat-badge'>cybersecurity</span></td><td>78</td></tr>
+<tr><td class='num'>164</td><td><code>find-bugs</code></td><td class='num'>1</td><td><span class='cat-badge'>cybersecurity</span></td><td>78</td></tr>
+<tr><td class='num'>165</td><td><code>senior-security</code></td><td class='num'>1</td><td><span class='cat-badge'>cybersecurity</span></td><td>78</td></tr>
+<tr><td class='num'>166</td><td><code>ssh-penetration-testing</code></td><td class='num'>1</td><td><span class='cat-badge'>cybersecurity</span></td><td>78</td></tr>
+<tr><td class='num'>167</td><td><code>discover-important-function</code></td><td class='num'>1</td><td><span class='cat-badge'>cybersecurity</span></td><td>79</td></tr>
+<tr><td class='num'>168</td><td><code>fuzzing-python</code></td><td class='num'>1</td><td><span class='cat-badge'>cybersecurity</span></td><td>79</td></tr>
+<tr><td class='num'>169</td><td><code>setup-env</code></td><td class='num'>1</td><td><span class='cat-badge'>cybersecurity</span></td><td>79</td></tr>
+<tr><td class='num'>170</td><td><code>cvss-score-extraction</code></td><td class='num'>1</td><td><span class='cat-badge'>cybersecurity</span></td><td>80</td></tr>
+<tr><td class='num'>171</td><td><code>trivy-offline-vulnerability-scanning</code></td><td class='num'>1</td><td><span class='cat-badge'>cybersecurity</span></td><td>80</td></tr>
+<tr><td class='num'>172</td><td><code>vulnerability-csv-reporting</code></td><td class='num'>1</td><td><span class='cat-badge'>cybersecurity</span></td><td>80</td></tr>
+<tr><td class='num'>173</td><td><code>pcap-triage-tshark</code></td><td class='num'>1</td><td><span class='cat-badge'>cybersecurity</span></td><td>81</td></tr>
+<tr><td class='num'>174</td><td><code>suricata-offline-evejson</code></td><td class='num'>1</td><td><span class='cat-badge'>cybersecurity</span></td><td>81</td></tr>
+<tr><td class='num'>175</td><td><code>suricata-rules-basics</code></td><td class='num'>1</td><td><span class='cat-badge'>cybersecurity</span></td><td>81</td></tr>
+<tr><td class='num'>176</td><td><code>syz-extract-constants</code></td><td class='num'>1</td><td><span class='cat-badge'>cybersecurity</span></td><td>82</td></tr>
+<tr><td class='num'>177</td><td><code>syzkaller-build-loop</code></td><td class='num'>1</td><td><span class='cat-badge'>cybersecurity</span></td><td>82</td></tr>
+<tr><td class='num'>178</td><td><code>syzlang-ioctl-basics</code></td><td class='num'>1</td><td><span class='cat-badge'>cybersecurity</span></td><td>82</td></tr>
+<tr><td class='num'>179</td><td><code>ffmpeg-keyframe-extraction</code></td><td class='num'>1</td><td><span class='cat-badge'>media-content-production</span></td><td>83</td></tr>
+<tr><td class='num'>180</td><td><code>image-editing</code></td><td class='num'>1</td><td><span class='cat-badge'>media-content-production</span></td><td>83</td></tr>
+<tr><td class='num'>181</td><td><code>object-counter</code></td><td class='num'>1</td><td><span class='cat-badge'>media-content-production</span></td><td>83</td></tr>
+<tr><td class='num'>182</td><td><code>ffmpeg-audio-processing</code></td><td class='num'>1</td><td><span class='cat-badge'>media-content-production</span></td><td>84</td></tr>
+<tr><td class='num'>183</td><td><code>ffmpeg-format-conversion</code></td><td class='num'>1</td><td><span class='cat-badge'>media-content-production</span></td><td>84</td></tr>
+<tr><td class='num'>184</td><td><code>ffmpeg-media-info</code></td><td class='num'>1</td><td><span class='cat-badge'>media-content-production</span></td><td>84</td></tr>
+<tr><td class='num'>185</td><td><code>ffmpeg-video-editing</code></td><td class='num'>1</td><td><span class='cat-badge'>media-content-production</span></td><td>84</td></tr>
+<tr><td class='num'>186</td><td><code>ffmpeg-video-filters</code></td><td class='num'>1</td><td><span class='cat-badge'>media-content-production</span></td><td>84</td></tr>
+<tr><td class='num'>187</td><td><code>text-to-speech</code></td><td class='num'>1</td><td><span class='cat-badge'>media-content-production</span></td><td>84</td></tr>
+<tr><td class='num'>188</td><td><code>obj-exporter</code></td><td class='num'>2</td><td><span class='cat-badge'>media-content-production</span></td><td>85, 86</td></tr>
+<tr><td class='num'>189</td><td><code>threejs</code></td><td class='num'>2</td><td><span class='cat-badge'>media-content-production</span></td><td>85, 86</td></tr>
+<tr><td class='num'>190</td><td><code>audio-extractor</code></td><td class='num'>1</td><td><span class='cat-badge'>media-content-production</span></td><td>87</td></tr>
+<tr><td class='num'>191</td><td><code>energy-calculator</code></td><td class='num'>1</td><td><span class='cat-badge'>media-content-production</span></td><td>87</td></tr>
+<tr><td class='num'>192</td><td><code>pause-detector</code></td><td class='num'>1</td><td><span class='cat-badge'>media-content-production</span></td><td>87</td></tr>
+<tr><td class='num'>193</td><td><code>report-generator</code></td><td class='num'>1</td><td><span class='cat-badge'>media-content-production</span></td><td>87</td></tr>
+<tr><td class='num'>194</td><td><code>segment-combiner</code></td><td class='num'>1</td><td><span class='cat-badge'>media-content-production</span></td><td>87</td></tr>
+<tr><td class='num'>195</td><td><code>silence-detector</code></td><td class='num'>1</td><td><span class='cat-badge'>media-content-production</span></td><td>87</td></tr>
+<tr><td class='num'>196</td><td><code>video-processor</code></td><td class='num'>1</td><td><span class='cat-badge'>media-content-production</span></td><td>87</td></tr>
+</tbody></table>
+<h2 id="boilerplate">Boilerplate entries (not numbered as skills)</h2>
+<table><thead><tr><th>Filename</th><th class='num'># tasks</th><th>Task #s</th></tr></thead><tbody>
+<tr><td><code>reference.md</code></td><td class='num'>3</td><td>27, 28, 29</td></tr>
+<tr><td><code>INSTALLATION.md</code></td><td class='num'>1</td><td>71</td></tr>
+<tr><td><code>LICENSE</code></td><td class='num'>1</td><td>71</td></tr>
+<tr><td><code>README.md</code></td><td class='num'>1</td><td>71</td></tr>
+<tr><td><code>TESTING.md</code></td><td class='num'>1</td><td>71</td></tr>
+</tbody></table>
+</body></html>


### PR DESCRIPTION
## Summary
- Assigns a number (1-196) to every distinct skill shipped across the 87 SkillsBench tasks' `environment/skills/` directories, per `insights/SKILLSBENCH_INVENTORY.md`.
- 5 non-skill boilerplate filenames (`README.md`, `LICENSE`, `INSTALLATION.md`, `TESTING.md`, `reference.md`) are excluded from numbering and called out separately as `B`, rather than counted as skills.
- **Table A**: all 87 tasks, grouped by category (matching the inventory doc's 8 categories), each row showing the task's skill number(s).
- **Table B**: the reverse — one row per skill (named + numbered), listing which task numbers use it and which categories it spans.
- Delivered as both `insights/SKILLS_TASKS_MAP.md` (renders on GitHub) and `insights/skills_tasks_map.html` (standalone, open directly in a browser).
- Generated programmatically from the inventory doc's markdown tables (not hand-transcribed), so the 87-task / 201-skill counts are self-checked against the source.

## Test plan
- [x] Verified all 8 categories sum to 87 tasks (assertion in generation script)
- [x] Verified 201 total distinct skill names, 196 real + 5 boilerplate
- [x] Secret-scanned both new files (`sk-` matches are false positives inside task names like `task-by-task-87`)
- [ ] Reviewer eyeballs `insights/skills_tasks_map.html` in a browser for rendering