### PR TITLE
feat(parsec): add parsec as a local-only benchmark, plus a v2 tier

### DIFF
--- a/ci/benchmarks/README.md
+++ b/ci/benchmarks/README.md
@@ -27,6 +27,18 @@ not a leaderboard.
 - Results are uploaded as an artifact and posted as a sticky PR comment (metrics table +
   optimized-capability diff).
 
+> **Also in this tree, but not part of the CI suite: [`parsec`](parsec/README.md)**
+> (**local-only / internal-only**). Red Hat's LLM-agentic troubleshooting tool; tiers
+> `smoke` (5) · `pilot` (30 v1 real-trace tasks) · `v2` (10 authored tasks, one isolated
+> simulator each). `run_suite.sh` accepts it as a `<bench>`, so it runs the same code path
+> locally, but it is deliberately absent from `benchmarks.yml`'s `BENCHES` and from every
+> other dispatch list: neither its task trees (internal RH, not in the public
+> `rhpds/parsec`) nor its kaegis simulators (`github.ibm.com/kaegis/simulation-harness`)
+> exist outside IBM/RH, so a dispatched leg could only ever fail for infrastructure
+> reasons. Nothing but per-tier `tasks.json` metadata is committed — the datasets are
+> regenerated locally by `parsec/utils/`. See its README for the setup pipelines and the
+> reasoning.
+
 ## Layout
 
 ```

--- a/ci/benchmarks/lib/run_suite.sh
+++ b/ci/benchmarks/lib/run_suite.sh
@@ -14,7 +14,7 @@
 set -uo pipefail
 LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO="$(cd "$LIB_DIR/../../.." && pwd)"
-BENCH="${1:?bench (tau2|swebench|skillsbench|spreadsheetbench)}"
+BENCH="${1:?bench (tau2|swebench|skillsbench|spreadsheetbench|parsec)}"
 PY="${CAPEVOLVE_PY:-$REPO/.venv-e2e/bin/python}"; [ -x "$PY" ] || PY="python3"
 TIER="${TIER:-smoke}"
 
@@ -286,6 +286,76 @@ ENV
     export HARBOR_AGENT_BASE_URL="${HARBOR_AGENT_BASE_URL:-$ANTHROPIC_BASE_URL}"
     export HARBOR_AGENT_API_KEY="${HARBOR_AGENT_API_KEY:-$ANTHROPIC_AUTH_TOKEN}"
     export ANTHROPIC_API_KEY="$ANTHROPIC_AUTH_TOKEN"
+    : > "$WORK/.env"
+    ;;
+  parsec)
+    # Parsec = Red Hat's LLM-agentic troubleshooting tool. The aap2 sub-agent
+    # is the subject. Harbor is the runner (same template as swebench), BUT
+    # with HARBOR_LOCAL_ASIS=1 because Parsec's task dirs already ship per-task
+    # task.toml + tests/verify.py + expected.json + a ubi9 Dockerfile — the
+    # default package_dataset repacking would blow those away.
+    #
+    # LOCAL-ONLY / INTERNAL-ONLY. Deliberately absent from benchmarks.yml's
+    # BENCHES, so nothing dispatches this in CI. Neither the dataset (RH's
+    # harbor task tree, not in the public rhpds/parsec repo) nor the kaegis
+    # simulators (github.ibm.com/kaegis/simulation-harness) exist outside
+    # IBM/RH, so a GitHub-hosted or public run could only ever fail. See
+    # ci/benchmarks/parsec/README.md.
+    cp "$TPL/harbor/adapter.py" "$PROJ/adapters/"
+    cp -R "$TPL/harbor/seed_capability" "$PROJ/seed_capability"
+    CAPS="[system-prompt]"
+    # HARBOR_DATASET is a per-TIER shadow of the RH task tree, regenerated
+    # locally by the matching utils/patch-harbor-tasks*.sh — never committed
+    # (same convention as skillsbench/spreadsheetbench: local dataset shadows
+    # live under the gitignored e2e/).
+    #
+    #   smoke|pilot (v1) — 30 real-trace aap2 tasks, FOUR SHARED kaegis sim
+    #     endpoints (aap2 :8086, github :8087, babylon :8088,
+    #     provisions_db :8090) across every task. Icinga :8089 is optional
+    #     (no aap2 task uses it; blocked on an api.json fix upstream).
+    #     Producer: utils/patch-harbor-tasks.sh
+    #   v2 — 10 authored bench-aap2-* tasks, ONE ISOLATED kaegis sim per task
+    #     (:9086..:9095) seeded from that task's own seed.json. The tier's
+    #     basis is harbor-tasks-v2.1, the downstream patch that fixes the
+    #     three container-correctness bugs (MCP server name, verify.py prefix
+    #     strip, host.containers.internal). Producers, in order:
+    #       utils/patch-harbor-tasks-v2.sh   → harbor-tasks-v2
+    #       utils/bake-aap2-skill.sh         → the kaegis skill artifacts
+    #       utils/start-sims-v2.sh           → the 10 sims + per-task MCP URLs
+    #       utils/patch-harbor-tasks-v2.1.sh → harbor-tasks-v2.1  (this default)
+    case "${TIER:-smoke}" in
+      v2) export HARBOR_DATASET="${PARSEC_HARBOR_TASKS_V2_DST:-$REPO/e2e/parsec/v2/harbor-tasks-v2.1}" ;;
+      *)  export HARBOR_DATASET="${PARSEC_HARBOR_TASKS_DST:-$REPO/e2e/parsec/harbor-tasks-patched}" ;;
+    esac
+    [ -d "$HARBOR_DATASET" ] || { echo "::error:: parsec shadow tasks not found at $HARBOR_DATASET (set PARSEC_HARBOR_TASKS_V2_DST / PARSEC_HARBOR_TASKS_DST, or run the matching ci/benchmarks/parsec/utils/patch-harbor-tasks*.sh first — see ci/benchmarks/parsec/README.md)"; exit 1; }
+    export HARBOR_LOCAL_ASIS=1
+    export HARBOR_AGENT=claude-code
+    export HARBOR_MODEL="$AGENT_MODEL"
+    case "${TIER:-smoke}" in
+      smoke) _hp_default=2 ;;
+      *)     _hp_default=4 ;;
+    esac
+    export HARBOR_PARALLEL="${HARBOR_PARALLEL:-$_hp_default}"
+    export HARBOR_TIMEOUT="${HARBOR_TIMEOUT:-900}"
+    export HARBOR_TASK_IDS="$IDS_CSV"
+    # Job dir + TMPDIR on the shared cache volume, same rationale as swebench.
+    _hb_jobs_base="${CAPEVOLVE_CI_CACHE:-${HOME}/.cache/capevolve-ci}"
+    if mkdir -p "$_hb_jobs_base/harbor-jobs" 2>/dev/null; then
+      export HARBOR_JOBS_DIR="${HARBOR_JOBS_DIR:-$_hb_jobs_base/harbor-jobs}"
+      export TMPDIR="${TMPDIR:-$_hb_jobs_base/tmp}"; mkdir -p "$TMPDIR" 2>/dev/null || true
+    fi
+    # Route the in-container claude-code at the VPC gateway (same rationale as
+    # swebench). Without HARBOR_AGENT_BASE_URL the adapter falls back to bare
+    # api.anthropic.com which is unreachable from the runner.
+    export HARBOR_AGENT_BASE_URL="${HARBOR_AGENT_BASE_URL:-$ANTHROPIC_BASE_URL}"
+    export HARBOR_AGENT_API_KEY="${HARBOR_AGENT_API_KEY:-$ANTHROPIC_AUTH_TOKEN}"
+    export ANTHROPIC_API_KEY="$ANTHROPIC_AUTH_TOKEN"
+    # BACKEND_MCP_URL retained for compatibility with any lingering ${VAR}
+    # placeholder in task.toml (the v1 shadow patcher replaces most). Points at
+    # the aap2 sim by default. Inert for v2, whose task.toml files carry a
+    # concrete per-task host.containers.internal:908X URL baked in by
+    # start-sims-v2.sh.
+    export BACKEND_MCP_URL="${BACKEND_MCP_URL:-http://host.containers.internal:8086/mcp/sse}"
     : > "$WORK/.env"
     ;;
   skillsbench)

--- a/ci/benchmarks/parsec/README.md
+++ b/ci/benchmarks/parsec/README.md
@@ -1,0 +1,400 @@
+# parsec
+
+**Parsec** ([`rhpds/parsec`](https://github.com/rhpds/parsec)) is Red Hat's
+internal LLM-agentic troubleshooting tool for the Red Hat Demo Platform. It
+routes a user question to one of six sub-agents (`orchestrator`, `icinga`,
+`aap2`, `babylon`, `ocpv`, `cost`), each running an LLM → tool loop over a
+shared pool of ~21 tools until it produces an answer.
+
+This benchmark evaluates cap-evolve's ability to optimize a **single Parsec
+sub-agent's SKILL.md** against a curated set of tasks. Both tiers target the
+**aap2 sub-agent**.
+
+---
+
+## Internal-only, and local-only
+
+Read this before anything else: **this benchmark cannot be run outside
+IBM/Red Hat.** Not "is awkward to run" — cannot. Two of its three inputs do not
+exist publicly:
+
+| Input | Where it lives | Public? |
+|---|---|---|
+| The task trees (v1's `harbor-tasks/`, v2's authored `tasks_v2/`) | internal RH task-extraction output | **no** — not in the public `rhpds/parsec` repo |
+| kaegis, the simulation harness that backs every tool call | `github.ibm.com/kaegis/simulation-harness` | **no** — IBM-internal |
+| The model gateway | the IBM VPC LiteLLM gateway | no — VPC-internal (as for every bench here) |
+
+Consequences, all deliberate:
+
+- **Nothing is committed but metadata.** The task bodies are never checked in;
+  each tier's dataset is regenerated at run time by a patcher in `utils/` from an
+  external checkout you supply by env var. Only the small `<tier>/tasks.json`
+  (ids + tags + provenance agent) is in git. This mirrors how `skillsbench`
+  treats its Anthropic-licensed clone.
+- **Every external input fails loudly when unset.** Anything that points outside
+  this repo — the RH task trees, the aap2 OpenAPI spec, the kaegis checkout — has
+  *no* default, because no default could be right for anyone but the author; the
+  error names the env var to set. Paths *inside* the repo (the `e2e/` shadows one
+  stage hands to the next) do have defaults, chained so each stage's output is the
+  next stage's input with nothing to configure.
+- **parsec is deliberately NOT CI-dispatchable** — see the next section.
+
+### Deliberately not wired into CI
+
+`parsec` is absent from `benchmarks.yml`'s `BENCHES` list and its dispatch
+`options`, from `ALL_BENCHES` in `core/tests/test_benchmarks_plan_legs.py`, from
+`BENCHES` in `core/tests/test_site_live_panel_tiers.py`, from `JOB_RE` in
+`site/benchmarks.js`, and from the `case` block in `ci/benchmarks/lib/ci_setup.sh`.
+
+That is the intended end state for now, not an oversight. Every one of those
+gates CI-dispatchability, and a dispatched parsec leg could only ever fail: the
+self-hosted `ibm-vpc` runner reaches the model gateway, but it has no RH task
+tree, no kaegis checkout, and — for v2 — no way to bring up ten host-bound
+simulator processes as part of a job. A leg that is red for infrastructure
+reasons on every single run teaches people to ignore red legs.
+
+What *is* wired: `run_suite.sh` accepts `parsec` as its `<bench>` argument, so a
+person on a suitably provisioned machine runs the same code path CI would.
+Revisit the wiring if and when the dataset and the sims become reachable from a
+runner.
+
+---
+
+## Tiers
+
+| Tier | Count | Task set | Sims | Held-out test? |
+|---|---:|---|---|---|
+| `smoke` | 5 | subset of v1's 30 | 4 shared kaegis endpoints | no (FIT) |
+| `pilot` | 30 | v1 — extracted from real Parsec traces | 4 shared kaegis endpoints | no (FIT) |
+| `v2` | 10 | v2 — newly authored `bench-aap2-*` | 1 isolated kaegis **per task** | no (FIT) |
+
+**No tier ships a `split_ids.json`, so every tier is a no-holdout FIT tier**
+(`train == val == test ==` all of the tier's tasks). `run_suite.sh` treats the
+presence of `<tier>/split_ids.json` as the opt-in to a genuine held-out split;
+with the file absent it builds the FIT split and the report labels the number as
+a fit metric rather than a generalization claim. Same as `swebench`'s pilot.
+
+> **A committed `pilot/split_ids.json` was withdrawn.** The original intake
+> shipped a seeded 60/20/20 split whose held-out `test` set was
+> `{0005, 0032, 0047, 0048, 0088, 0104}` — and the very optimizer pilot published
+> below had already been tuned directly against `0047` and `0048`. The "held-out"
+> test was contaminated by this benchmark's own experiment before it was ever
+> sealed, so the honest fix was to delete the file rather than regenerate it: the
+> pilot is a FIT tier, which is what the numbers below actually are. A real
+> held-out split can be added later, generated from tasks no published run has
+> touched.
+
+---
+
+## Tier v1 — `smoke` (5) and `pilot` (30)
+
+Tasks were extracted from real Parsec traces by RH's task-extractor pipeline
+into the `harbor-tasks/` format:
+
+```
+harbor-tasks/traces_parsec-aap2-<NNNN>/
+├── task.toml           # docker_image + [[environment.mcp_servers]] pointing at ${BACKEND_MCP_URL}
+├── instruction.md      # the user turn (one line)
+└── tests/
+    ├── expected.json   # gold: expected tool sequence + assertions
+    ├── verify.py       # scorer: reward = gate · (0.5 · trajectory + 0.5 · assertions)
+    └── test.sh         # runs verify.py inside the container
+```
+
+30 aap2 tasks total. `smoke` is a 5-task subset chosen for coverage of the score
+distribution: `perfect-solve` (aap2-0037), `trajectory-match` (aap2-0023, 0074),
+`gate-failed` (aap2-0047, 0048).
+
+### Sims — four SHARED endpoints
+
+| Sim endpoint | Port | Tools |
+|---|---:|---|
+| aap2 | 8086 | `query_aap2` |
+| github | 8087 | `fetch_github_file`, `search_github_repo`, `search_github_code`, `search_agnosticv_prs` |
+| babylon | 8088 | `lookup_catalog_item`, `query_babylon_catalog` |
+| provisions_db | 8090 | `query_provisions_db`, `db_describe_table` |
+
+All 30 tasks share these four. The icinga sim (`:8089`) is optional and unused by
+any aap2 task; its `api.json` currently fails kaegis skill-generation (no
+`components.schemas`) and is tracked for a future upstream fix.
+
+### Setup
+
+```bash
+# 1. the agent base image (once; both tiers need it)
+bash ci/benchmarks/parsec/utils/build-parsec-agent-base.sh
+
+# 2. the task shadow — writes <repo>/e2e/parsec/harbor-tasks-patched/
+PARSEC_HARBOR_TASKS_SRC=/path/to/your/rhpds-parsec/harbor-tasks \
+  bash ci/benchmarks/parsec/utils/patch-harbor-tasks.sh
+
+# 3. bring up the four kaegis sims on 8086/8087/8088/8090 (kaegis's own tooling)
+
+# 4. run
+TIER=smoke bash ci/benchmarks/lib/run_suite.sh parsec
+TIER=pilot bash ci/benchmarks/lib/run_suite.sh parsec
+```
+
+`patch-harbor-tasks.sh` shadow-copies the RH tree and applies three edits the
+pilot needs: swap `docker_image` to `localhost/parsec-agent-base:latest`; replace
+the single `${BACKEND_MCP_URL}` mcp_servers block with the four concrete sim URLs
+(Harbor's docker environment does not interpolate `${VAR}` in `task.toml`); and
+strip the `mcp__<server>__` prefix inside `verify.py`'s `parse_transcript` so
+trajectory-match compares against the bare tool names in `expected.json`. The RH
+original is never modified.
+
+---
+
+## Tier v2 — 10 authored tasks, one simulator each
+
+`v2` is a **second, independent experiment**, not a refinement of v1. It targets
+the same aap2 sub-agent and reuses the same `HARBOR_LOCAL_ASIS` adapter path, but
+differs materially:
+
+| | v1 (`smoke`/`pilot`) | v2 |
+|---|---|---|
+| Tasks | 30, extracted from real Parsec traces | 10, **newly authored** (`bench-aap2-001-single-job-outcome` … `-010-log-does-not-say`) |
+| Per-task files | `task.toml`, `instruction.md`, `tests/{expected.json,verify.py,test.sh}` | the same **plus** `golden.json`, `seed.json`, `provenance.md` |
+| Simulators | **4 shared** endpoints (8086/8087/8088/8090) across all 30 tasks | **1 isolated** kaegis per task (10 processes, 9086–9095), each seeded from that task's own `seed.json` |
+| Tools exercised | `query_aap2` + github/babylon/provisions_db | `query_aap2` only |
+| Setup | patch the shadow, then run | **bake + start 10 sims + a second patch pass** before running |
+| Held-out test | none (FIT) | none (FIT) — the intake's own split file has `test: []`, `test_used: false` |
+
+The isolation is the point: one simulator per task, seeded from that task's own
+`seed.json`, means one task's fixture data cannot leak into another task's
+answers, which four shared endpoints across 30 tasks cannot guarantee.
+
+### The dataset is `harbor-tasks-v2.1`, not `harbor-tasks-v2`
+
+v2's pipeline has two patch passes, and the tier's `HARBOR_DATASET` is the
+**second** one. `v2.1` is a downstream patch of `v2` that fixes three bugs which
+only appear once the tier actually runs inside a Harbor/Podman container:
+
+- **MCP server name** `"backend"` → `"aap2"`. Claude Code namespaces MCP tools as
+  `mcp__<serverName>__<toolName>`, so `name = "backend"` made SKILL.md's bare
+  `query_aap2` resolve to `mcp__backend__query_aap2`, which the agent then invoked
+  as bare `query_aap2` → "No such tool available".
+- **`verify.py` prefix strip.** The scorer compares against bare `query_aap2` in
+  `expected.json`; without the strip, namespaced `tool_use` names never match and
+  `tool_calls` is 0.0 no matter how correct the calls were. (Same class of fix as
+  v1's patcher applies to its own `verify.py`.)
+- **`127.0.0.1` → `host.containers.internal`.** The sims bind to the *host's*
+  loopback. Inside a Podman task container `127.0.0.1` is the container's own
+  loopback, so the MCP SSE handshake fails and the agent runs with no
+  `mcp__aap2__*` tools at all. Podman's host-bridge alias reaches the host sockets
+  through gvproxy/slirp port forwarding.
+
+### Setup — order matters
+
+Five stages, in this order. Stage 3 mutates stage 1's output (writing each task's
+live sim URL into its `task.toml`), and stage 4 reads the result — so rerunning an
+earlier stage means rerunning the later ones.
+
+```bash
+# 0. the agent base image (once; shared with v1)
+bash ci/benchmarks/parsec/utils/build-parsec-agent-base.sh
+
+# 1. shadow the authored tasks  -> <repo>/e2e/parsec/v2/harbor-tasks-v2/
+PARSEC_HARBOR_TASKS_V2_SRC=/path/to/your/parsec/tasks_v2 \
+  bash ci/benchmarks/parsec/utils/patch-harbor-tasks-v2.sh
+
+# 2. bake the aap2 kaegis skill once, offline
+PARSEC_AAP2_SPEC_SRC=/path/to/your/parsec/aap2.json \
+HARNESS_SRC=/path/to/your/kaegis/simulation-harness \
+  bash ci/benchmarks/parsec/utils/bake-aap2-skill.sh
+
+# 3. start the 10 isolated sims (9086..9095) and write each task's MCP URL
+HARNESS_SRC=/path/to/your/kaegis/simulation-harness \
+  bash ci/benchmarks/parsec/utils/start-sims-v2.sh
+
+# 4. container-correctness pass  -> <repo>/e2e/parsec/v2/harbor-tasks-v2.1/
+bash ci/benchmarks/parsec/utils/patch-harbor-tasks-v2.1.sh
+
+# 5. run
+TIER=v2 bash ci/benchmarks/lib/run_suite.sh parsec
+
+# teardown when you're done (kills the sims, removes the manifest)
+bash ci/benchmarks/parsec/utils/stop-sims-v2.sh
+```
+
+`start-sims-v2.sh` refuses to start over a live `sims-v2.manifest.json`; run
+`stop-sims-v2.sh` first. Both need `jq`, `curl`, `lsof` and `uv` on `PATH`; the
+bake and the sims need a kaegis checkout.
+
+### v2 env vars
+
+| Var | Required? | Default | Used by |
+|---|---|---|---|
+| `PARSEC_HARBOR_TASKS_V2_SRC` | **yes** | *(none — fails loudly)* | stage 1 |
+| `PARSEC_AAP2_SPEC_SRC` | **yes** | *(none — fails loudly)* | stage 2 |
+| `HARNESS_SRC` | **yes** | *(none — fails loudly)* | stages 2, 3 |
+| `PARSEC_HARBOR_TASKS_V2_STAGE` | no | `<repo>/e2e/parsec/v2/harbor-tasks-v2` | stages 1, 3, 4 |
+| `PARSEC_HARBOR_TASKS_V2_DST` | no | `<repo>/e2e/parsec/v2/harbor-tasks-v2.1` | stage 4, `run_suite.sh` |
+| `PARSEC_V2_WORK` | no | `<repo>/e2e/parsec/v2` | stages 2, 3, teardown |
+| `KAEGIS_PORT_BASE` | no | `9086` | stage 3 |
+| `KAEGIS_HOST` | no | `127.0.0.1` | stage 3 |
+
+`PARSEC_HARBOR_TASKS_V2_DST`'s default is the same string as `run_suite.sh`'s
+`TIER=v2` `HARBOR_DATASET` default — producer and consumer agree under their own
+documented defaults, which was not true of the intake scripts.
+
+`PARSEC_V2_WORK` is the **runtime scratch root**: the baked kaegis artifacts, the
+generated harness configs, the per-task skills-store shadows, the sims manifest
+and the sim logs all live under it. It defaults under the gitignored `e2e/` and
+deliberately *not* under `ci/benchmarks/parsec/` — a committed source tree must
+not double as a runtime scratch directory.
+
+The intake worktree's `env.sh` is **not** promoted here. It pinned
+`HARBOR_DATASET` at `harbor-tasks-v2` (stale — the tier's dataset is `v2.1`, the
+copy with the three container fixes) and hardcoded one laptop's podman-machine
+`DOCKER_HOST` socket path. Its durable content — the agent config,
+`KAEGIS_PORT_BASE`, and the order of operations — is the table above plus the five
+stages; `run_suite.sh` exports the agent config itself.
+
+---
+
+## Environment (both tiers)
+
+Harbor-based, same runner shape as `swebench` — but with `HARBOR_LOCAL_ASIS=1`,
+because Parsec's task dirs already ship every per-task artifact and Harbor's
+default `package_dataset` repacking would blow them away. `run_suite.sh`'s
+`parsec)` case exports that (and the rest of the Harbor config) unconditionally;
+no tier ships an `overrides.env`.
+
+Both tiers run against `localhost/parsec-agent-base:latest`, a ubi9 image built by
+`utils/build-parsec-agent-base.sh`. It exists because Harbor's claude-code
+installer runs `yum install -y curl procps-ng` inside the task image, and vanilla
+ubi9 ships `curl-minimal`, which conflicts with `curl` — the install fails, the
+container exits, and no trajectory is recorded. The image pre-resolves that with
+`--allowerasing` and bakes in node/npm.
+
+## What's optimized
+
+`capabilities: [system-prompt]` — cap-evolve mutates the aap2 sub-agent's SKILL.md
+only (from
+[`rhpds/parsec:config/prompts/aap2_agent.md`](https://github.com/rhpds/parsec/blob/main/config/prompts/aap2_agent.md)).
+Tools are held fixed at their sim-served implementations. The wrapper architecture
+for tool-code optimization is queued for a later phase.
+
+## Scoring
+
+Each task's `tests/verify.py` (stdlib-only, deterministic) reads the agent's
+transcript from `/logs/agent` and writes `/logs/verifier/reward.json`:
+
+```
+reward = gate · (0.5 · trajectory + 0.5 · assertions)
+```
+
+- **gate** ∈ `{0, 1}` — 0 if the agent didn't complete or produced an empty answer.
+- **trajectory** ∈ `{0, 1}` — subset match against the expected tool sequence. The
+  extractor writes bare tool names to `expected.json` while claude-code emits
+  MCP-prefixed ones (`mcp__aap2__query_aap2`), so both tiers' patchers strip the
+  `mcp__<server>__` prefix in `parse_transcript`. Without that, trajectory-match is
+  0 for every task.
+- **assertions** ∈ `[0, 1]` — fraction of `answer_contains` substrings present in
+  the answer. v1's assertions are all `needs_review: true` (LLM-drafted by the task
+  extractor) — their quality is an open item with RH. v2's are authored alongside
+  each task's `seed.json`, so its assertions and its fixture data are correlated by
+  construction.
+
+## v1 baseline (2026-08-12)
+
+30 aap2 tasks, seed capability unmodified, `aws/claude-sonnet-4-5`, 4 sims live,
+single trial per task:
+
+- **mean 0.240** · stdev 0.281 · min/max 0.000/1.000
+- 5 tasks hit `trajectory=1.0` (the `query_aap2`-only subset) — mean **0.730**
+- 25 multi-tool tasks — mean **0.142**
+- 1 perfect solve: `aap2-0037`
+- 3 tasks scored `assertions=1.0` without trajectory — the 50/50 weighting caps
+  them at 0.5 (honesty check working as designed)
+- 2 gate-failed tasks (`aap2-0047`, `aap2-0048`) — the agent looped
+  combinatorially and never emitted a final answer
+
+## v1 N=30 optimization pilot (2026-08-17)
+
+**Question:** can the optimizer discover a SKILL.md edit that improves reward on
+the two hardest-scoring aap2 tasks (`aap2-0047`, `aap2-0048`)?
+
+**Setup:** those 2 tasks only, both gate-failed at the Aug-12 baseline;
+`train = val = test = {0047, 0048}` (no holdout — a fit metric); `num_trials: 30`
+(chosen to average out per-trial `gate=0/1` stochasticity that N=10 could not
+distinguish from optimizer signal); `hill-climb`, `max_iterations: 5`, `stall: 2`,
+paired-SE gate at `k=1.0`; optimizer `claude-code` / `claude-opus-4-7` at
+`optimizer_max_turns: 60`.
+
+| | val reward | stderr | verdict |
+|---|---:|---:|---|
+| seed | 0.317 | 0.035 | baseline |
+| seed (train) | 0.342 | 0.033 | consistent |
+| cand_0001 | 0.225 | 0.025 | **rejected** (Δ = −0.092, 2.5 · SE) |
+| cand_0002 | 0.157 | 0.029 | **rejected** (Δ = −0.160, 7 · SE) |
+| finalize test (best = `seed`) | 0.326 | 0.050 | `test_delta = 0.000` |
+
+Both proposals regressed. `stall = 2` triggered → halted at iter=2 of 5. Optimizer
+spend: $8.61 of a $40 budget.
+
+**What we learned:**
+
+1. **Parsec's seed `aap2_agent.md` is already at a local optimum** for these 2
+   tasks. Optimizer additions ("always emit final report", "budget your rounds",
+   "no controller sweep") over-constrain the agent and hurt reward; the paired-SE
+   gate correctly caught both regressions.
+2. **N=10 is not enough on gate-stochastic tasks.** An earlier N=10 pilot on the
+   same 2 tasks measured seed val **0.017** → cand_0001 **0.215** (Δ = +0.198).
+   That evaporated on finalize test (`test_delta = −0.003`). At N=30 the seed's
+   true mean is **0.317**; the N=10 measurement was dominated by a window in which
+   95% of trials scored `gate=0`.
+3. **The paired-SE gate produced false-positive accepts at N=10.** At N=30 all
+   stderrs shrink to ~0.03 and it correctly rejects noise-dominated deltas.
+4. **`optimizer_max_turns=30` was too tight** for real edits to a ~24 KB SKILL.md
+   — the optimizer emitted byte-identical candidates on retry. 60 fixed it.
+
+**Framework implications for cap-evolve upstream** (not blocking):
+
+- For `gate`-stochastic tasks, N ≥ 25–30 is needed to separate optimizer signal
+  from measurement noise at reasonable gate `k`.
+- Consider surfacing `completion` (the `gate` term) as a first-class side-metric,
+  so "same capability, higher emit rate" is distinguishable from "genuinely better
+  answers".
+- Consider a longer default `optimizer_max_turns` for capabilities whose seed
+  content exceeds ~15 KB.
+
+## v2 baseline
+
+Not yet published here. v2's intake produced local baselines against the 10
+authored tasks; they are not comparable to v1's 0.240 (different task set,
+different simulator topology, and only `query_aap2` exercised). A v2 number goes in
+this section once it has been measured through
+`TIER=v2 bash ci/benchmarks/lib/run_suite.sh parsec` rather than through the
+intake's own scripts.
+
+---
+
+## Direction of travel
+
+Parsec is turning into a **versioned benchmark family** — v1, v2, and a future v3
+— rather than one benchmark with tiers. v1 and v2 already share only the sub-agent
+under test: different task provenance (extracted vs authored), different simulator
+topology (shared vs per-task), different per-task file shape, and separate setup
+pipelines. Carrying that as `<tier>/tasks.json` under one `ci/benchmarks/parsec/`
+is already a stretch.
+
+The intent is to move parsec's versions out to a **dedicated benchmark repo** —
+locally, and in a dedicated IBM GitHub repo — and treat them the way a
+multi-version family is normally treated (the analogy: "maybe like
+tau1/tau2/tau3"), with cap-evolve consuming them as an external dataset rather
+than vendoring their pipelines here.
+
+Nothing in this PR builds toward that yet; it is recorded so the current shape is
+read as a way-station, not a destination.
+
+## Related
+
+- `templates/adapters/harbor/` — the adapter. `HARBOR_LOCAL_ASIS=1` (the opt-in
+  that lets Harbor use a hand-authored task dir verbatim) is added there
+  separately; `run_suite.sh`'s `parsec)` case exports it.
+- `ci/benchmarks/README.md` — the suite-wide runner/tier/dispatch documentation.
+- `PalmPalm7/parsec#4` — draft PR against `PalmPalm7:migration/full-sdk` adding
+  the `PARSEC_TOOLS_DIR` hook to Parsec's `src/__init__.py` (needed for the later
+  wrapper architecture; harmless today).

--- a/ci/benchmarks/parsec/docker/parsec-agent-base/Dockerfile
+++ b/ci/benchmarks/parsec/docker/parsec-agent-base/Dockerfile
@@ -1,0 +1,38 @@
+# parsec-agent-base:latest — a ubi9-based image ready for Harbor's claude-code CLI.
+#
+# Purpose. Harbor's claude-code agent installer runs `yum install -y curl procps-ng`
+# inside whatever image the task declares. Parsec's harbor-tasks declare bare
+# `registry.access.redhat.com/ubi9/ubi:latest`, and vanilla ubi9 ships `curl-minimal`
+# which conflicts with `curl` from the ubi-baseos repo — the yum install fails, the
+# container exits, no trajectory is recorded. We build this image once, up front,
+# with the conflict pre-resolved via `--allowerasing` and with node/npm baked in so
+# Harbor's per-container `npm install -g @anthropic-ai/claude-code` runs against a
+# warm system.
+#
+# Both tiers use it: the v1 (smoke/pilot) and v2 shadow patchers each rewrite every
+# task.toml's docker_image to `localhost/parsec-agent-base:latest`, so this image must
+# exist locally before either tier can run.
+#
+# Rebuild:  bash ci/benchmarks/parsec/utils/build-parsec-agent-base.sh
+# Docs:     ci/benchmarks/parsec/README.md
+
+FROM registry.access.redhat.com/ubi9/ubi:latest
+
+# 1. Resolve the curl / curl-minimal conflict, then install the tools Harbor's
+#    claude-code installer expects. `--allowerasing` lets curl replace curl-minimal
+#    without requiring the installer to know that trick. `install_weak_deps=False`
+#    keeps the image lean.
+RUN dnf install -y --allowerasing curl bash procps-ng \
+ && dnf install -y --setopt=install_weak_deps=False nodejs npm \
+ && dnf clean all \
+ && rm -rf /var/cache/dnf
+
+# 2. Harbor's Trial code uploads the task's environment/ to /workspace and the agent
+#    runs there. Parsec's task.toml already declares workdir = "/workspace" but a
+#    default here keeps things consistent for direct `podman run` debugging.
+WORKDIR /workspace
+
+# 3. Sanity — surfaces the versions to `podman inspect` so we can tell at a glance
+#    which build of the base image is running.
+LABEL org.parsec.agent-base.built-for="cap-evolve parsec-intake pilot" \
+      org.parsec.agent-base.node-required-by="Harbor claude-code CLI installer"

--- a/ci/benchmarks/parsec/pilot/tasks.json
+++ b/ci/benchmarks/parsec/pilot/tasks.json
@@ -1,0 +1,152 @@
+[
+  {
+    "id": "traces_parsec-aap2-0004",
+    "tag": "aap2",
+    "agent": "aws/claude-sonnet-4-5"
+  },
+  {
+    "id": "traces_parsec-aap2-0005",
+    "tag": "aap2",
+    "agent": "aws/claude-sonnet-4-5"
+  },
+  {
+    "id": "traces_parsec-aap2-0006",
+    "tag": "aap2",
+    "agent": "aws/claude-sonnet-4-5"
+  },
+  {
+    "id": "traces_parsec-aap2-0016",
+    "tag": "aap2",
+    "agent": "aws/claude-sonnet-4-5"
+  },
+  {
+    "id": "traces_parsec-aap2-0018",
+    "tag": "aap2",
+    "agent": "aws/claude-sonnet-4-5"
+  },
+  {
+    "id": "traces_parsec-aap2-0021",
+    "tag": "aap2",
+    "agent": "aws/claude-sonnet-4-5"
+  },
+  {
+    "id": "traces_parsec-aap2-0023",
+    "tag": "aap2",
+    "agent": "aws/claude-sonnet-4-5"
+  },
+  {
+    "id": "traces_parsec-aap2-0030",
+    "tag": "aap2",
+    "agent": "aws/claude-sonnet-4-5"
+  },
+  {
+    "id": "traces_parsec-aap2-0032",
+    "tag": "aap2",
+    "agent": "aws/claude-sonnet-4-5"
+  },
+  {
+    "id": "traces_parsec-aap2-0036",
+    "tag": "aap2",
+    "agent": "aws/claude-sonnet-4-5"
+  },
+  {
+    "id": "traces_parsec-aap2-0037",
+    "tag": "aap2",
+    "agent": "aws/claude-sonnet-4-5"
+  },
+  {
+    "id": "traces_parsec-aap2-0044",
+    "tag": "aap2",
+    "agent": "aws/claude-sonnet-4-5"
+  },
+  {
+    "id": "traces_parsec-aap2-0047",
+    "tag": "aap2",
+    "agent": "aws/claude-sonnet-4-5"
+  },
+  {
+    "id": "traces_parsec-aap2-0048",
+    "tag": "aap2",
+    "agent": "aws/claude-sonnet-4-5"
+  },
+  {
+    "id": "traces_parsec-aap2-0049",
+    "tag": "aap2",
+    "agent": "aws/claude-sonnet-4-5"
+  },
+  {
+    "id": "traces_parsec-aap2-0052",
+    "tag": "aap2",
+    "agent": "aws/claude-sonnet-4-5"
+  },
+  {
+    "id": "traces_parsec-aap2-0053",
+    "tag": "aap2",
+    "agent": "aws/claude-sonnet-4-5"
+  },
+  {
+    "id": "traces_parsec-aap2-0074",
+    "tag": "aap2",
+    "agent": "aws/claude-sonnet-4-5"
+  },
+  {
+    "id": "traces_parsec-aap2-0080",
+    "tag": "aap2",
+    "agent": "aws/claude-sonnet-4-5"
+  },
+  {
+    "id": "traces_parsec-aap2-0081",
+    "tag": "aap2",
+    "agent": "aws/claude-sonnet-4-5"
+  },
+  {
+    "id": "traces_parsec-aap2-0082",
+    "tag": "aap2",
+    "agent": "aws/claude-sonnet-4-5"
+  },
+  {
+    "id": "traces_parsec-aap2-0084",
+    "tag": "aap2",
+    "agent": "aws/claude-sonnet-4-5"
+  },
+  {
+    "id": "traces_parsec-aap2-0085",
+    "tag": "aap2",
+    "agent": "aws/claude-sonnet-4-5"
+  },
+  {
+    "id": "traces_parsec-aap2-0087",
+    "tag": "aap2",
+    "agent": "aws/claude-sonnet-4-5"
+  },
+  {
+    "id": "traces_parsec-aap2-0088",
+    "tag": "aap2",
+    "agent": "aws/claude-sonnet-4-5"
+  },
+  {
+    "id": "traces_parsec-aap2-0092",
+    "tag": "aap2",
+    "agent": "aws/claude-sonnet-4-5"
+  },
+  {
+    "id": "traces_parsec-aap2-0094",
+    "tag": "aap2",
+    "agent": "aws/claude-sonnet-4-5"
+  },
+  {
+    "id": "traces_parsec-aap2-0104",
+    "tag": "aap2",
+    "agent": "aws/claude-sonnet-4-5"
+  },
+  {
+    "id": "traces_parsec-aap2-0112",
+    "tag": "aap2",
+    "agent": "aws/claude-sonnet-4-5"
+  },
+  {
+    "id": "traces_parsec-aap2-0113",
+    "tag": "aap2",
+    "agent": "aws/claude-sonnet-4-5"
+  }
+]

--- a/ci/benchmarks/parsec/smoke/tasks.json
+++ b/ci/benchmarks/parsec/smoke/tasks.json
@@ -1,0 +1,27 @@
+[
+  {
+    "id": "traces_parsec-aap2-0037",
+    "tag": "perfect-solve",
+    "agent": "aws/claude-sonnet-4-5"
+  },
+  {
+    "id": "traces_parsec-aap2-0023",
+    "tag": "trajectory-match",
+    "agent": "aws/claude-sonnet-4-5"
+  },
+  {
+    "id": "traces_parsec-aap2-0074",
+    "tag": "high-assert",
+    "agent": "aws/claude-sonnet-4-5"
+  },
+  {
+    "id": "traces_parsec-aap2-0047",
+    "tag": "gate-failed",
+    "agent": "aws/claude-sonnet-4-5"
+  },
+  {
+    "id": "traces_parsec-aap2-0048",
+    "tag": "gate-failed",
+    "agent": "aws/claude-sonnet-4-5"
+  }
+]

--- a/ci/benchmarks/parsec/utils/bake-aap2-skill.sh
+++ b/ci/benchmarks/parsec/utils/bake-aap2-skill.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# STAGE 2 of the parsec v2 tier's local pipeline.
+#
+# Bake the aap2 kaegis "skill" (SKILL.md + api.json + schema.json) once, offline. Every
+# task's per-task skills-store is then a copy of this output with db.json swapped for that
+# task's own seed.json — that swap is what makes v2's 10 simulators independent, and it
+# happens in stage 3 (utils/start-sims-v2.sh).
+#
+# INTERNAL-ONLY. Both inputs are IBM/RH-internal and neither has a default:
+#   * the aap2 OpenAPI spec is not in the public rhpds/parsec repo, and
+#   * kaegis (the simulation harness) lives at github.ibm.com/kaegis/simulation-harness.
+# There is therefore no HARNESS_SRC/SPEC path that is correct for anyone but its author, so
+# both are required env vars and this script fails loudly naming them rather than pointing at
+# somebody's laptop.
+#
+# Overrides (env vars):
+#   PARSEC_AAP2_SPEC_SRC — the aap2 OpenAPI spec JSON (REQUIRED; no default)
+#   HARNESS_SRC          — a github.ibm.com/kaegis/simulation-harness checkout
+#                          (REQUIRED; no default). Needs `uv` on PATH.
+#   PARSEC_V2_WORK       — runtime scratch root for the v2 tier
+#                          (default: <repo>/e2e/parsec/v2 — gitignored). Holds the baked
+#                          artifacts, the generated harness config, the per-task
+#                          skills-store shadows, the sims manifest and the sim logs. This is
+#                          deliberately NOT under ci/benchmarks/parsec/: a committed source
+#                          tree must not double as a runtime scratch directory.
+#
+# Idempotent — wipes any prior bake output first, so stale files from a previous schema
+# variant cannot linger alongside the freshly generated artifacts.
+set -euo pipefail
+
+HERE=$(cd "$(dirname "$0")" && pwd -P)
+REPO=$(cd "$HERE/../../../.." && pwd -P)
+V2WORK=${PARSEC_V2_WORK:-$REPO/e2e/parsec/v2}
+SPEC=${PARSEC_AAP2_SPEC_SRC:?set PARSEC_AAP2_SPEC_SRC to your local parsec aap2 OpenAPI spec (e.g. .../parsec/aap2.json)}
+HARNESS_SRC=${HARNESS_SRC:?set HARNESS_SRC to your github.ibm.com/kaegis/simulation-harness checkout}
+OUT="$V2WORK/harness-src/skills-store"
+
+[ -f "$SPEC" ] || { echo "missing spec: $SPEC (override with PARSEC_AAP2_SPEC_SRC)" >&2; exit 1; }
+[ -d "$HARNESS_SRC" ] || { echo "missing simulation-harness at $HARNESS_SRC (override with HARNESS_SRC)" >&2; exit 1; }
+
+rm -rf "$OUT/aap2"
+mkdir -p "$OUT" "$V2WORK/harness-src" "$V2WORK/logs/sims-v2"
+
+# The setup CLI writes to <skills.folder>/<name>/… — override skills.folder
+# to our v2-local path via a tiny config override.
+cat > "$V2WORK/harness-src/harness.local.yaml" <<YAML
+llm:
+  provider: openai
+  skill_generation_model: azure/gpt-5.4
+  skill_generation_max_tokens: 40000
+  simulation_model: azure/gpt-5.4
+  temperature: 0
+skills:
+  folder: $OUT
+sessions:
+  max_messages: 100
+  idle_timeout_seconds: 3600
+  max_concurrent_queue_depth: 8
+  agent_recursion_limit: 50
+generation:
+  concurrency: 5
+  chunk_threshold: 40
+  stage_timeout_seconds: 420
+  extract: { temperature: 0.0, max_tokens: 20000 }
+  classify: { temperature: 0.0, max_tokens: 10000 }
+  schema_seed: { temperature: 0.0, max_tokens: 20000 }
+  operation: { temperature: 0.2, max_tokens: 10000 }
+  scenarios_enabled: true
+  scenarios_count: 5
+  scenarios: { temperature: 0.4, max_tokens: 3000 }
+mcp:
+  transport: sse
+server:
+  host: 127.0.0.1
+  port: 8086
+logging:
+  level: INFO
+  destination_folder: $V2WORK/logs/sims-v2
+YAML
+
+cd "$HARNESS_SRC"
+uv run python -m simulation_harness.setup_cli "$SPEC" \
+  --name aap2 \
+  --config "$V2WORK/harness-src/harness.local.yaml"
+
+echo "Baked skill artifacts:"
+ls "$OUT/aap2/"
+echo "Next: utils/start-sims-v2.sh"

--- a/ci/benchmarks/parsec/utils/build-parsec-agent-base.sh
+++ b/ci/benchmarks/parsec/utils/build-parsec-agent-base.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Rebuild the parsec-agent-base:latest container image.
+#
+# Usage:  bash ci/benchmarks/parsec/utils/build-parsec-agent-base.sh
+#
+# What this does. Runs `podman build` against the Dockerfile in
+# ci/benchmarks/parsec/docker/parsec-agent-base/. Produces a local image tagged
+# `localhost/parsec-agent-base:latest` — used by every shadowed parsec task
+# (both tiers: see utils/patch-harbor-tasks.sh for v1 and
+# utils/patch-harbor-tasks-v2.sh for v2, each of which rewrites task.toml's
+# docker_image to this tag) so Harbor can pull it by tag without hitting a
+# network registry.
+#
+# When to rerun.
+#   * The Dockerfile changed.
+#   * `podman image rm localhost/parsec-agent-base:latest` was run for any reason.
+#   * A new Harbor release starts installing something we haven't pre-installed
+#     inside the image, and we want to add it as another `dnf install` line.
+#
+# Docs: ci/benchmarks/parsec/README.md
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")/../docker/parsec-agent-base" && pwd)"
+IMAGE=localhost/parsec-agent-base:latest
+
+if ! command -v podman >/dev/null 2>&1; then
+    echo "podman not on PATH. Install via: brew install podman" >&2
+    exit 1
+fi
+
+if ! podman machine list --format='{{.LastUp}}' 2>/dev/null | grep -q Current; then
+    echo "podman machine is not running. Start it via: podman machine start" >&2
+    exit 1
+fi
+
+echo "→ building $IMAGE from $HERE/Dockerfile"
+podman build --tag "$IMAGE" "$HERE"
+
+echo ""
+echo "→ image summary"
+podman image inspect "$IMAGE" --format \
+  'id: {{.Id}}
+size: {{.Size}} bytes
+labels: {{range $k, $v := .Labels}}
+  {{$k}} = {{$v}}{{end}}'
+
+echo ""
+echo "Done. Verify with: podman run --rm $IMAGE bash -lc 'curl --version | head -1; node --version; npm --version'"

--- a/ci/benchmarks/parsec/utils/patch-harbor-tasks-v2.1.sh
+++ b/ci/benchmarks/parsec/utils/patch-harbor-tasks-v2.1.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# STAGE 4 of the parsec v2 tier's local pipeline — and the tier's actual HARBOR_DATASET.
+#
+# Regenerate <repo>/e2e/parsec/v2/harbor-tasks-v2.1/ as a downstream patch of
+# harbor-tasks-v2/. This is NOT a fresh copy from the authored tasks_v2/ tree; it starts
+# from the stage-1 shadow AFTER stage 3 (start-sims-v2.sh) has baked each task's live
+# kaegis URL (127.0.0.1:9086..9095) into its task.toml, and applies three edits — each one
+# a bug found only by actually running the tier inside a Harbor/Podman container:
+#
+#   Bug A fix — MCP server name: "backend" -> "aap2"  (10 x task.toml)
+#     Claude Code namespaces MCP tools as `mcp__<serverName>__<toolName>`.
+#     With name = "backend", SKILL.md's bare `query_aap2` resolved to
+#     `mcp__backend__query_aap2`, which the agent then invoked as bare
+#     `query_aap2` -> "No such tool available". v1's convention is
+#     name = "aap2" -> `mcp__aap2__query_aap2`.
+#
+#   Bug B fix — verify.py strip: add STRIP_MCP_PREFIX_PATCHED block  (10 x verify.py)
+#     The scorer compares against bare `query_aap2` in expected.json; without the
+#     strip the namespaced tool_use names never match and tool_calls = 0.0
+#     regardless of correct calls. (Same class of fix as v1's patcher applies.)
+#
+#   Bug C fix — MCP URL host: 127.0.0.1 -> host.containers.internal (10 x task.toml)
+#     Sims bind to TCP 127.0.0.1:9086..9095 on the HOST. Inside a Podman task
+#     container, 127.0.0.1 is the container's own loopback (not the host's), so
+#     the MCP SSE handshake to http://127.0.0.1:908X/mcp/sse fails and the agent
+#     runs without any mcp__aap2__* tools exposed. Podman's host-bridge alias
+#     `host.containers.internal` reaches the host's 127.0.0.1 sockets via
+#     slirp/gvproxy port forwarding, matching v1's convention.
+#
+# DST below is byte-identical to run_suite.sh's `parsec)` HARBOR_DATASET default for
+# TIER=v2 — if you change one, change both.
+#
+# Overrides (env vars):
+#   PARSEC_HARBOR_TASKS_V2_STAGE — stage-1 shadow to read
+#                                  (default: <repo>/e2e/parsec/v2/harbor-tasks-v2)
+#   PARSEC_HARBOR_TASKS_V2_DST   — this tier's dataset
+#                                  (default: <repo>/e2e/parsec/v2/harbor-tasks-v2.1)
+#
+# Idempotent — rebuilds v2.1 from v2 on every invocation.
+set -euo pipefail
+
+HERE=$(cd "$(dirname "$0")" && pwd -P)
+REPO=$(cd "$HERE/../../../.." && pwd -P)
+SRC=${PARSEC_HARBOR_TASKS_V2_STAGE:-$REPO/e2e/parsec/v2/harbor-tasks-v2}
+DST=${PARSEC_HARBOR_TASKS_V2_DST:-$REPO/e2e/parsec/v2/harbor-tasks-v2.1}
+
+[ -d "$SRC" ] || { echo "missing v2 shadow: $SRC — run utils/patch-harbor-tasks-v2.sh first" >&2; exit 1; }
+
+rm -rf "$DST"
+mkdir -p "$(dirname "$DST")"
+cp -R "$SRC" "$DST"
+
+# --- Bug A: rename MCP server on each task.toml ---
+for task in "$DST"/bench-aap2-*/; do
+  toml="$task/task.toml"
+  [ -f "$toml" ] || { echo "missing task.toml under $task" >&2; exit 1; }
+  # Only match `name = "backend"` under [[environment.mcp_servers]] — the other
+  # `name = ...` line is the task name which must not change. sed with a fixed
+  # literal match to `name = "backend"` is safe: the substring appears once per
+  # file (the task name lines all read `name = "bench/..."`).
+  sed -i.bak 's|^name = "backend"$|name = "aap2"|' "$toml"
+  rm -f "$toml.bak"
+done
+
+# --- Bug B: port STRIP_MCP_PREFIX_PATCHED into each verify.py ---
+# Uses a python transform (not sed) so a multi-line, whitespace-preserving
+# replacement stays readable and doesn't depend on sed dialect (GNU vs BSD).
+python3 - "$DST" <<'PY'
+import sys
+from pathlib import Path
+
+DST = Path(sys.argv[1])
+
+# Indentation matches the actual verify.py (16-space leading indent).
+OLD = (
+    '                if isinstance(block, dict) and block.get("type") == "tool_use":\n'
+    '                    args = block.get("input")\n'
+    '                    calls.append((\n'
+    '                        block.get("name", ""),\n'
+    '                        args if isinstance(args, dict) else {},\n'
+    '                    ))'
+)
+
+NEW = (
+    '                if isinstance(block, dict) and block.get("type") == "tool_use":\n'
+    '                    args = block.get("input")\n'
+    '                    _name = block.get("name", "")\n'
+    '                    if _name.startswith("mcp__"):\n'
+    '                        _parts = _name.split("__", 2)\n'
+    '                        if len(_parts) == 3:\n'
+    '                            _name = _parts[2]  # STRIP_MCP_PREFIX_PATCHED\n'
+    '                    calls.append((\n'
+    '                        _name,\n'
+    '                        args if isinstance(args, dict) else {},\n'
+    '                    ))'
+)
+
+count = 0
+for verify in sorted(DST.glob("bench-aap2-*/tests/verify.py")):
+    text = verify.read_text()
+    if "STRIP_MCP_PREFIX_PATCHED" in text:
+        count += 1
+        continue
+    if OLD not in text:
+        raise SystemExit(f"patch target not found in {verify}")
+    verify.write_text(text.replace(OLD, NEW))
+    count += 1
+
+print(f"patched verify.py in {count} tasks under {DST}")
+PY
+
+# --- Bug C: rewrite MCP URL host on each task.toml ---
+# Stage 3 already resolved ${BACKEND_MCP_URL} to a literal
+# http://127.0.0.1:908X/mcp/sse per task. There is exactly one such line per
+# task.toml (the mcp_servers block URL); rewrite it to host.containers.internal
+# so the alias resolves to the host loopback from inside the Podman task
+# container.
+for task in "$DST"/bench-aap2-*/; do
+  toml="$task/task.toml"
+  [ -f "$toml" ] || { echo "missing task.toml under $task" >&2; exit 1; }
+  if grep -q '\${BACKEND_MCP_URL}' "$toml"; then
+    echo "::error:: $toml still carries the \${BACKEND_MCP_URL} placeholder — run utils/start-sims-v2.sh (stage 3) before this script" >&2
+    exit 1
+  fi
+  sed -i.bak 's|url = "http://127\.0\.0\.1:|url = "http://host.containers.internal:|g' "$toml"
+  rm -f "$toml.bak"
+done
+
+count=$(find "$DST" -maxdepth 1 -type d -name 'bench-aap2-*' | wc -l | tr -d ' ')
+echo "Regenerated $count tasks in $DST"
+echo "Next: TIER=v2 bash ci/benchmarks/lib/run_suite.sh parsec"

--- a/ci/benchmarks/parsec/utils/patch-harbor-tasks-v2.sh
+++ b/ci/benchmarks/parsec/utils/patch-harbor-tasks-v2.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# STAGE 1 of the parsec v2 tier's local pipeline.
+#
+# Shadow-copy the 10 authored bench-aap2-* tasks into <repo>/e2e/parsec/v2/harbor-tasks-v2/
+# and rewrite each task.toml's docker_image to the parsec-agent-base image (same as v1 — the
+# ubi9 base ships nodejs + npm, which the claude-code agent bootstrap needs; build it with
+# utils/build-parsec-agent-base.sh).
+#
+# ${BACKEND_MCP_URL} is left alone here; start-sims-v2.sh replaces it per task with that
+# task's own kaegis URL once the sims are up.
+#
+# The authored task tree is NOT committed to this repo (same deliberate convention as v1's
+# harbor-tasks/): it is regenerated at run time from an external checkout, so the source has
+# no default — see PARSEC_HARBOR_TASKS_V2_SRC below.
+#
+# Order of operations for the whole v2 tier — see ci/benchmarks/parsec/README.md:
+#   1. utils/patch-harbor-tasks-v2.sh    (this script)      → harbor-tasks-v2/
+#   2. utils/bake-aap2-skill.sh          (kaegis artifacts)
+#   3. utils/start-sims-v2.sh            (10 sims + per-task MCP URLs into harbor-tasks-v2/)
+#   4. utils/patch-harbor-tasks-v2.1.sh  (container fixes)  → harbor-tasks-v2.1/
+#   5. TIER=v2 bash ci/benchmarks/lib/run_suite.sh parsec
+#
+# Overrides (env vars):
+#   PARSEC_HARBOR_TASKS_V2_SRC   — the authored tasks_v2/ tree (REQUIRED; no default —
+#                                  it is an internal RH/authored tree, so no path is right
+#                                  for anyone but its author)
+#   PARSEC_HARBOR_TASKS_V2_STAGE — stage-1 destination, which stage 3 mutates and stage 4
+#                                  reads (default: <repo>/e2e/parsec/v2/harbor-tasks-v2).
+#                                  Under the gitignored e2e/, same convention as v1's shadow
+#                                  and skillsbench's e2e/skillsbench-src.
+#
+# Rerun. Idempotent — deletes and recreates the shadow. NB rerunning this discards the
+# concrete per-task MCP URLs stage 3 wrote, so rerun stages 3 and 4 after it.
+set -euo pipefail
+
+HERE=$(cd "$(dirname "$0")" && pwd -P)
+REPO=$(cd "$HERE/../../../.." && pwd -P)
+SRC=${PARSEC_HARBOR_TASKS_V2_SRC:?set PARSEC_HARBOR_TASKS_V2_SRC to your local authored parsec tasks_v2/ checkout}
+DST=${PARSEC_HARBOR_TASKS_V2_STAGE:-$REPO/e2e/parsec/v2/harbor-tasks-v2}
+
+[ -d "$SRC" ] || { echo "missing tasks_v2 source: $SRC (override with PARSEC_HARBOR_TASKS_V2_SRC)" >&2; exit 1; }
+
+echo "→ source: $SRC"
+echo "→ shadow: $DST"
+
+rm -rf "$DST"
+mkdir -p "$DST"
+
+for task in "$SRC"/bench-aap2-*/; do
+  [ -d "$task" ] || continue
+  name=$(basename "$task")
+  cp -R "$task" "$DST/$name"
+  # Rewrite docker_image to the v1 base (has node+npm for claude-code bootstrap).
+  sed -i.bak -E \
+    's|^docker_image = ".*"$|docker_image = "localhost/parsec-agent-base:latest"|' \
+    "$DST/$name/task.toml"
+  rm -f "$DST/$name/task.toml.bak"
+done
+
+count=$(find "$DST" -maxdepth 1 -type d -name 'bench-aap2-*' | wc -l | tr -d ' ')
+[ "$count" -gt 0 ] || { echo "no bench-aap2-* tasks found under $SRC" >&2; exit 1; }
+
+echo "Patched $count tasks in $DST"
+echo "Next: utils/bake-aap2-skill.sh, then utils/start-sims-v2.sh."

--- a/ci/benchmarks/parsec/utils/patch-harbor-tasks.sh
+++ b/ci/benchmarks/parsec/utils/patch-harbor-tasks.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# STAGE 2 of the parsec v1 tier's local pipeline (stage 1 is
+# utils/build-parsec-agent-base.sh; stage 3 is bringing up the four kaegis sims;
+# stage 4 is `TIER=smoke|pilot bash ci/benchmarks/lib/run_suite.sh parsec`).
+#
+# Shadow-copy Parsec's harbor-tasks/ with the edits needed for our pilot:
+#
+#   task.toml edits:
+#     1. Swap the docker_image to localhost/parsec-agent-base:latest.
+#     2. Rewrite the single ${BACKEND_MCP_URL} mcp_servers block into FOUR concrete
+#        endpoints — the aap2 kaegis sim on :8086 (which the placeholder stood for),
+#        plus github :8087, babylon :8088 and provisions_db :8090, each a further
+#        kaegis instance. Together they cover the aap2 sub-agent's whole tool set.
+#        Harbor's docker environment does not interpolate ${VAR} placeholders in
+#        task.toml, so we substitute concrete URLs here.
+#
+#   tests/verify.py edits:
+#     3. Strip the MCP name-prefix (mcp__<server>__<tool> → <tool>) inside
+#        parse_transcript, so trajectory-match compares against the bare tool
+#        names in expected.json. Parsec's real runtime uses direct Python
+#        function calls (bare names); Harbor's claude-code uses MCP-prefixed
+#        names. Without this fix, trajectory-match is 0 for every task.
+#
+#   filesystem edits:
+#     4. Ensure an environment/ subdirectory exists (Harbor's TaskModel.is_valid_dir
+#        requires it even for tasks that declare environment inline in task.toml).
+#
+# The original harbor-tasks/ from RH is left UNTOUCHED. The shadow is the tier's
+# HARBOR_DATASET and is NEVER committed: it defaults under the gitignored e2e/,
+# the same convention skillsbench (e2e/skillsbench-src) and spreadsheetbench use
+# for a local dataset shadow. The default below is byte-identical to
+# run_suite.sh's `parsec)` HARBOR_DATASET default for smoke/pilot — if you change
+# one, change both.
+#
+# Overrides (env vars):
+#   PARSEC_HARBOR_TASKS_SRC — RH's original harbor-tasks/ (REQUIRED; no default —
+#                             it is an internal RH tree that is not in the public
+#                             rhpds/parsec repo, so there is no path that is right
+#                             for anyone but its author)
+#   PARSEC_HARBOR_TASKS_DST — shadow destination (default: <repo>/e2e/parsec/harbor-tasks-patched)
+#   BACKEND_MCP_URL_VALUE   — aap2 sim URL   (default: http://host.containers.internal:8086/mcp/sse)
+#   GITHUB_MCP_URL_VALUE    — github sim URL (default: http://host.containers.internal:8087/mcp/sse)
+#
+# Rerun. Idempotent — safe to rerun any time. Deletes and recreates the shadow.
+#
+# Docs: ci/benchmarks/parsec/README.md
+
+set -euo pipefail
+
+REPO=$(cd "$(dirname "$0")/../../../.." && pwd -P)
+SRC=${PARSEC_HARBOR_TASKS_SRC:?set PARSEC_HARBOR_TASKS_SRC to your local rhpds/parsec harbor-tasks/ checkout}
+DST=${PARSEC_HARBOR_TASKS_DST:-$REPO/e2e/parsec/harbor-tasks-patched}
+FILTER=${1:-aap2}   # subdomain to include; default aap2 for the pilot
+BACKEND_MCP_URL_VALUE=${BACKEND_MCP_URL_VALUE:-http://host.containers.internal:8086/mcp/sse}
+GITHUB_MCP_URL_VALUE=${GITHUB_MCP_URL_VALUE:-http://host.containers.internal:8087/mcp/sse}
+BABYLON_MCP_URL_VALUE=${BABYLON_MCP_URL_VALUE:-http://host.containers.internal:8088/mcp/sse}
+PROVISIONS_DB_MCP_URL_VALUE=${PROVISIONS_DB_MCP_URL_VALUE:-http://host.containers.internal:8090/mcp/sse}
+
+if [ ! -d "$SRC" ]; then
+    echo "Source harbor-tasks/ not found at $SRC" >&2
+    echo "Override via PARSEC_HARBOR_TASKS_SRC=/path/to/harbor-tasks" >&2
+    exit 1
+fi
+
+echo "→ source:         $SRC"
+echo "→ shadow:         $DST"
+echo "→ filter:         traces_parsec-${FILTER}-*"
+echo "→ aap2 sim:       $BACKEND_MCP_URL_VALUE"
+echo "→ github sim:     $GITHUB_MCP_URL_VALUE"
+echo "→ babylon sim:    $BABYLON_MCP_URL_VALUE"
+echo "→ provisions sim: $PROVISIONS_DB_MCP_URL_VALUE"
+
+rm -rf "$DST"
+mkdir -p "$DST"
+
+count=0
+for t in "$SRC"/traces_parsec-"$FILTER"-*; do
+    [ -d "$t" ] || continue
+    name=$(basename "$t")
+    cp -r "$t" "$DST/$name"
+
+    # -- task.toml: docker_image + REPLACE single mcp_servers block with FOUR endpoints --
+    python3 - "$DST/$name/task.toml" "$BACKEND_MCP_URL_VALUE" "$GITHUB_MCP_URL_VALUE" "$BABYLON_MCP_URL_VALUE" "$PROVISIONS_DB_MCP_URL_VALUE" <<'PY'
+import sys
+path = sys.argv[1]
+aap2_url, github_url, babylon_url, provisions_url = sys.argv[2], sys.argv[3], sys.argv[4], sys.argv[5]
+text = open(path).read()
+
+# 1. Swap docker_image
+text = text.replace(
+    'docker_image = "registry.access.redhat.com/ubi9/ubi:latest"',
+    'docker_image = "localhost/parsec-agent-base:latest"',
+)
+
+# 2. Replace the single [[environment.mcp_servers]] block that has
+#    name = "backend" + url = "${BACKEND_MCP_URL}" with FOUR blocks:
+#    aap2 (was the placeholder) + github + babylon + provisions_db.
+#    All four cover the aap2 sub-agent's tool set (query_aap2 +
+#    fetch_github_file/search_github_repo/etc + lookup_catalog_item/
+#    query_babylon_catalog + query_provisions_db/db_describe_table).
+import re
+pattern = re.compile(
+    r'\[\[environment\.mcp_servers\]\]\s*\n'
+    r'\s*name\s*=\s*"backend"\s*\n'
+    r'\s*url\s*=\s*"\$\{BACKEND_MCP_URL\}"\s*\n?',
+    re.MULTILINE,
+)
+replacement = (
+    '[[environment.mcp_servers]]\n'
+    f'name = "aap2"\n'
+    f'url = "{aap2_url}"\n'
+    '\n'
+    '[[environment.mcp_servers]]\n'
+    f'name = "github"\n'
+    f'url = "{github_url}"\n'
+    '\n'
+    '[[environment.mcp_servers]]\n'
+    f'name = "babylon"\n'
+    f'url = "{babylon_url}"\n'
+    '\n'
+    '[[environment.mcp_servers]]\n'
+    f'name = "provisions_db"\n'
+    f'url = "{provisions_url}"\n'
+)
+new_text, n = pattern.subn(replacement, text)
+if n != 1:
+    print(f"WARN: mcp_servers block not rewritten in {path} (matched {n} times); check task.toml shape", file=sys.stderr)
+    sys.exit(2)
+open(path, "w").write(new_text)
+PY
+
+    # -- tests/verify.py: strip MCP prefix in parse_transcript --
+    python3 - "$DST/$name/tests/verify.py" <<'PY'
+import sys, re
+path = sys.argv[1]
+text = open(path).read()
+
+# Inject a prefix-stripping call right after the `tool_use` block extracts the name.
+# Idempotent: if already patched, do nothing.
+if "STRIP_MCP_PREFIX_PATCHED" in text:
+    sys.exit(0)
+
+pattern = re.compile(
+    r'(if isinstance\(block, dict\) and block\.get\("type"\) == "tool_use":\s*\n'
+    r'\s+tool_names\.append\(block\.get\("name", ""\)\))'
+)
+replacement = (
+    'if isinstance(block, dict) and block.get("type") == "tool_use":  # STRIP_MCP_PREFIX_PATCHED\n'
+    '                    _n = block.get("name", "")\n'
+    '                    if _n.startswith("mcp__"):\n'
+    '                        _parts = _n.split("__", 2)\n'
+    '                        if len(_parts) == 3:\n'
+    '                            _n = _parts[2]\n'
+    '                    tool_names.append(_n)'
+)
+new_text, n = pattern.subn(replacement, text)
+if n != 1:
+    print(f"WARN: verify.py tool_use pattern not found in {path} (matched {n} times)", file=sys.stderr)
+    sys.exit(2)
+open(path, "w").write(new_text)
+PY
+
+    # -- ensure environment/ subdir exists for Harbor's is_valid_dir check --
+    mkdir -p "$DST/$name/environment"
+    touch "$DST/$name/environment/.keep"
+
+    count=$((count + 1))
+done
+
+# Fail loudly rather than leaving an empty shadow that run_suite.sh would happily
+# accept as an existing HARBOR_DATASET and then run zero tasks against.
+[ "$count" -gt 0 ] || { echo "no traces_parsec-${FILTER}-* tasks found under $SRC" >&2; exit 1; }
+
+echo ""
+echo "Patched $count tasks."
+echo ""
+echo "Next: TIER=smoke bash ci/benchmarks/lib/run_suite.sh parsec"
+echo "(run_suite.sh's parsec case defaults HARBOR_DATASET to this same path; export"
+echo " PARSEC_HARBOR_TASKS_DST=$DST if you wrote the shadow anywhere else.)"

--- a/ci/benchmarks/parsec/utils/start-sims-v2.sh
+++ b/ci/benchmarks/parsec/utils/start-sims-v2.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# STAGE 3 of the parsec v2 tier's local pipeline.
+#
+# Start 10 kaegis processes (one per v2 task), each seeded from that task's own seed.json,
+# each on its own REST port. Then rewrite each task's task.toml so ${BACKEND_MCP_URL} points
+# at that task's kaegis. This per-task isolation is the main thing that distinguishes v2 from
+# v1, where all 30 tasks share four sim endpoints.
+#
+# Idempotent by refusing to start over a live manifest — call stop-sims-v2.sh first.
+#
+# RUNTIME STATE LIVES OUTSIDE THE COMMITTED TREE. The manifest, the sim logs and the per-task
+# skills-store shadows all land under $PARSEC_V2_WORK (default <repo>/e2e/parsec/v2, which is
+# gitignored), NOT under ci/benchmarks/parsec/. The intake-time version of this script derived
+# its root from its own location, which after promotion into ci/benchmarks/parsec/utils/ would
+# have written runtime scratch into a committed source tree.
+#
+# Overrides (env vars):
+#   HARNESS_SRC                  — a github.ibm.com/kaegis/simulation-harness checkout
+#                                  (REQUIRED; no default — IBM-internal, see
+#                                  utils/bake-aap2-skill.sh). Needs `uv` on PATH.
+#   PARSEC_HARBOR_TASKS_V2_STAGE — the stage-1 shadow whose task.toml files get the concrete
+#                                  MCP URLs written into them
+#                                  (default: <repo>/e2e/parsec/v2/harbor-tasks-v2)
+#   PARSEC_V2_WORK               — runtime scratch root (default: <repo>/e2e/parsec/v2)
+#   KAEGIS_PORT_BASE             — first REST port (default 9086; 10 tasks -> 9086..9095)
+#   KAEGIS_HOST                  — bind address (default 127.0.0.1). Stage 4 rewrites this to
+#                                  host.containers.internal in the task.toml URLs so the
+#                                  Podman task container can reach these host-bound sockets.
+#
+# Requires: jq, curl, lsof, uv.
+set -euo pipefail
+
+HERE=$(cd "$(dirname "$0")" && pwd -P)
+REPO=$(cd "$HERE/../../../.." && pwd -P)
+V2WORK=${PARSEC_V2_WORK:-$REPO/e2e/parsec/v2}
+MANIFEST="$V2WORK/sims-v2.manifest.json"
+LOGS="$V2WORK/logs/sims-v2"
+BAKED="$V2WORK/harness-src/skills-store/aap2"
+SHADOWS_ROOT="$V2WORK/harness-src/skills-stores"
+HARBOR_TASKS=${PARSEC_HARBOR_TASKS_V2_STAGE:-$REPO/e2e/parsec/v2/harbor-tasks-v2}
+HARNESS_SRC=${HARNESS_SRC:?set HARNESS_SRC to your github.ibm.com/kaegis/simulation-harness checkout}
+PORT_BASE=${KAEGIS_PORT_BASE:-9086}
+HOST=${KAEGIS_HOST:-127.0.0.1}
+
+if [ -f "$MANIFEST" ]; then
+  echo "manifest exists: $MANIFEST — run stop-sims-v2.sh first" >&2
+  exit 1
+fi
+
+[ -d "$HARNESS_SRC" ] || { echo "missing simulation-harness at $HARNESS_SRC (override with HARNESS_SRC)" >&2; exit 1; }
+[ -d "$BAKED" ] || { echo "missing baked skill at $BAKED — run bake-aap2-skill.sh first" >&2; exit 1; }
+[ -d "$HARBOR_TASKS" ] || { echo "missing patched tasks at $HARBOR_TASKS — run patch-harbor-tasks-v2.sh first" >&2; exit 1; }
+
+mkdir -p "$LOGS" "$SHADOWS_ROOT"
+
+TASKS=()
+for t in "$HARBOR_TASKS"/bench-aap2-*/; do
+  [ -d "$t" ] || continue
+  TASKS+=("$(basename "$t")")
+done
+if [ "${#TASKS[@]}" -eq 0 ]; then
+  echo "no tasks found under $HARBOR_TASKS" >&2; exit 1
+fi
+
+# Build manifest incrementally so a mid-loop failure still stops cleanly.
+tmp=$(mktemp)
+echo '{"started_at":"'"$(date -u +%FT%TZ)"'","kaegis_host":"'"$HOST"'","tasks":[]}' > "$tmp"
+
+# Cleanup on partial start. Kills every `uv run` wrapper spawned so far (which
+# takes their python listener children with them) plus, defensively, any
+# listener pids already recorded in $tmp. Disarmed on the successful mv below.
+WRAPPER_PIDS=()
+cleanup_failed_start() {
+  local rc=$?
+  if [ "${#WRAPPER_PIDS[@]}" -gt 0 ]; then
+    echo "start-sims-v2.sh: cleanup — killing ${#WRAPPER_PIDS[@]} wrapper pid(s): ${WRAPPER_PIDS[*]}" >&2
+    kill "${WRAPPER_PIDS[@]}" 2>/dev/null || true
+  fi
+  local listener_pids
+  listener_pids=$(jq -r '.tasks[].pid' "$tmp" 2>/dev/null || true)
+  if [ -n "$listener_pids" ]; then
+    echo "start-sims-v2.sh: cleanup — killing listener pid(s): $listener_pids" >&2
+    echo "$listener_pids" | xargs kill 2>/dev/null || true
+  fi
+  rm -f "$tmp"
+  return $rc
+}
+trap cleanup_failed_start ERR EXIT
+
+port=$PORT_BASE
+idx=1
+for task_id in "${TASKS[@]}"; do
+  padded=$(printf "%03d" "$idx")
+  task_dir="$HARBOR_TASKS/$task_id"
+  seed="$task_dir/seed.json"
+  [ -f "$seed" ] || { echo "$task_id: missing seed.json" >&2; exit 1; }
+
+  # 1. Per-task skills-store: copy baked, then swap db.json for the task's seed.
+  shadow="$SHADOWS_ROOT/task-$padded/aap2"
+  rm -rf "$SHADOWS_ROOT/task-$padded"
+  mkdir -p "$shadow"
+  cp "$BAKED"/{SKILL.md,api.json,schema.json} "$shadow/"
+  cp "$seed" "$shadow/db.json"
+
+  # 2. Per-task harness config — points skills.folder at the per-task shadow.
+  cfg="$SHADOWS_ROOT/task-$padded/harness.yaml"
+  cat > "$cfg" <<YAML
+llm:
+  provider: openai
+  skill_generation_model: azure/gpt-5.4
+  simulation_model: azure/gpt-5.4
+  temperature: 0
+skills:
+  folder: $SHADOWS_ROOT/task-$padded
+sessions:
+  max_messages: 100
+  idle_timeout_seconds: 3600
+  max_concurrent_queue_depth: 8
+  agent_recursion_limit: 50
+creation:
+  max_duration_seconds: 120
+mcp:
+  transport: sse
+server:
+  host: $HOST
+  port: $port
+logging:
+  level: INFO
+  destination_folder: $LOGS
+startup:
+  autostart_enabled: true
+  autostart_simulation: aap2
+YAML
+
+  # 3. Launch kaegis in background.
+  # NOTE: `python -m simulation_harness` does not parse CLI args; it reads
+  # HARNESS_CONFIG_PATH (see simulation_harness/__main__.py). We set that env
+  # var so kaegis loads our per-task config instead of its default
+  # config/harness.yaml (which would autostart from the wrong skills-store).
+  log="$LOGS/task-$padded.log"
+  (
+    cd "$HARNESS_SRC"
+    HARNESS_CONFIG_PATH="$cfg" \
+    HARNESS_SERVER_PORT=$port \
+    HARNESS_AUTOSTART_ENABLED=true \
+    HARNESS_AUTOSTART_SIMULATION=aap2 \
+    exec uv run python -m simulation_harness --config "$cfg" >"$log" 2>&1
+  ) &
+  pid=$!
+  WRAPPER_PIDS+=("$pid")
+
+  # 4. Wait for /readyz + status=ready (up to 90s).
+  base="http://$HOST:$port"
+  ready=0
+  for _ in $(seq 1 90); do
+    if curl -fsS "$base/readyz" >/dev/null 2>&1; then
+      status=$(curl -fsS "$base/api/v1/simulation" 2>/dev/null | jq -r '.status // "none"')
+      if [ "$status" = "ready" ]; then ready=1; break; fi
+    fi
+    sleep 1
+  done
+  if [ "$ready" -ne 1 ]; then
+    echo "$task_id: kaegis on port $port never became ready — see $log" >&2
+    # No explicit kill here — the ERR/EXIT trap tears down all tracked
+    # wrappers (including this one, which is already in WRAPPER_PIDS) and any
+    # listener pids recorded in $tmp for previously-succeeded tasks.
+    exit 1
+  fi
+
+  mcp_url=$(curl -fsS "$base/api/v1/simulation" | jq -r '.mcp_url')
+
+  # Resolve the actual port-owning python listener pid (child of the `uv run`
+  # wrapper captured as $pid). We record THIS in the manifest — a stop script
+  # can then kill the listener without leaving a wrapper orphan on SIGKILL,
+  # and uv run also exits naturally when its child dies on plain SIGTERM.
+  listener_pid=$(lsof -tiTCP:"$port" -sTCP:LISTEN 2>/dev/null | head -1)
+  if [ -z "$listener_pid" ]; then
+    echo "$task_id: could not resolve listener pid for port $port" >&2
+    exit 1
+  fi
+
+  # 5. Rewrite ${BACKEND_MCP_URL} in that task's task.toml.
+  sed -i.bak "s|\${BACKEND_MCP_URL}|$mcp_url|g" "$task_dir/task.toml"
+  rm -f "$task_dir/task.toml.bak"
+
+  # 6. Append to manifest — pid field holds the listener pid, not the wrapper.
+  jq --arg id "$task_id" --argjson port "$port" \
+     --arg rest "$base" --arg mcp "$mcp_url" \
+     --argjson pid "$listener_pid" --arg sf "$SHADOWS_ROOT/task-$padded" \
+     --arg log "$log" \
+     '.tasks += [{task_id:$id, rest_port:$port, rest_url:$rest, mcp_url:$mcp, pid:$pid, skills_folder:$sf, log:$log}]' \
+     "$tmp" > "$tmp.new" && mv "$tmp.new" "$tmp"
+
+  echo "  $task_id  port=$port  mcp=$mcp_url  wrapper_pid=$pid  listener_pid=$listener_pid"
+  port=$((port + 1))
+  idx=$((idx + 1))
+done
+
+mv "$tmp" "$MANIFEST"
+# Success — disarm the cleanup trap so it doesn't kill our live sims on EXIT.
+trap - ERR EXIT
+echo
+echo "started ${#TASKS[@]} kaegis processes; manifest: $MANIFEST"
+echo "Next: utils/patch-harbor-tasks-v2.1.sh, then TIER=v2 bash ci/benchmarks/lib/run_suite.sh parsec"

--- a/ci/benchmarks/parsec/utils/stop-sims-v2.sh
+++ b/ci/benchmarks/parsec/utils/stop-sims-v2.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Tear down the parsec v2 tier's simulators.
+#
+# Kill every kaegis process recorded in the manifest start-sims-v2.sh wrote, then delete the
+# manifest (which is what re-arms start-sims-v2.sh). Leaves the per-task skills-store shadows
+# and the sim logs in place for inspection.
+#
+# Overrides (env vars):
+#   PARSEC_V2_WORK — runtime scratch root holding the manifest
+#                    (default: <repo>/e2e/parsec/v2 — gitignored; must match the value
+#                    start-sims-v2.sh ran with)
+#
+# Requires: jq.
+set -euo pipefail
+
+HERE=$(cd "$(dirname "$0")" && pwd -P)
+REPO=$(cd "$HERE/../../../.." && pwd -P)
+V2WORK=${PARSEC_V2_WORK:-$REPO/e2e/parsec/v2}
+MANIFEST="$V2WORK/sims-v2.manifest.json"
+
+if [ ! -f "$MANIFEST" ]; then
+  echo "no manifest at $MANIFEST — nothing to stop" >&2
+  exit 0
+fi
+
+killed=0
+while read -r pid task_id; do
+  if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+    kill "$pid" 2>/dev/null || true
+    killed=$((killed + 1))
+    echo "  killed pid=$pid ($task_id)"
+  else
+    echo "  pid=$pid ($task_id) already gone"
+  fi
+done < <(jq -r '.tasks[] | "\(.pid) \(.task_id)"' "$MANIFEST")
+
+# Give kaegis a moment to release ports.
+sleep 2
+
+rm -f "$MANIFEST"
+echo "stopped $killed processes; manifest removed"

--- a/ci/benchmarks/parsec/v2/tasks.json
+++ b/ci/benchmarks/parsec/v2/tasks.json
@@ -1,0 +1,52 @@
+[
+  {
+    "id": "bench-aap2-001-single-job-outcome",
+    "tag": "aap2",
+    "agent": "aws/claude-sonnet-4-5"
+  },
+  {
+    "id": "bench-aap2-002-failed-jobs-on-controller",
+    "tag": "aap2",
+    "agent": "aws/claude-sonnet-4-5"
+  },
+  {
+    "id": "bench-aap2-003-never-started-explanation",
+    "tag": "aap2",
+    "agent": "aws/claude-sonnet-4-5"
+  },
+  {
+    "id": "bench-aap2-004-failing-task-and-host",
+    "tag": "aap2",
+    "agent": "aws/claude-sonnet-4-5"
+  },
+  {
+    "id": "bench-aap2-005-find-then-diagnose",
+    "tag": "aap2",
+    "agent": "aws/claude-sonnet-4-5"
+  },
+  {
+    "id": "bench-aap2-006-log-root-cause",
+    "tag": "aap2",
+    "agent": "aws/claude-sonnet-4-5"
+  },
+  {
+    "id": "bench-aap2-007-count-and-oldest",
+    "tag": "aap2",
+    "agent": "aws/claude-sonnet-4-5"
+  },
+  {
+    "id": "bench-aap2-008-preceding-task",
+    "tag": "aap2",
+    "agent": "aws/claude-sonnet-4-5"
+  },
+  {
+    "id": "bench-aap2-009-nonexistent-job",
+    "tag": "aap2",
+    "agent": "aws/claude-sonnet-4-5"
+  },
+  {
+    "id": "bench-aap2-010-log-does-not-say",
+    "tag": "aap2",
+    "agent": "aws/claude-sonnet-4-5"
+  }
+]

--- a/core/tests/test_benchmarks_plan_legs.py
+++ b/core/tests/test_benchmarks_plan_legs.py
@@ -122,10 +122,21 @@ def test_which_benches_ship_a_pilot_tier():
     four-figure proposition: 50 stratified tasks (every repo represented, proportions
     tracking full) validate the per-trial cost and runtime at 10x smoke's scale before
     anyone commits to full.
+
+    parsec ships one too, and it is the exception that proves the rule: it ships
+    `pilot/tasks.json` so the tier is runnable *locally* (`TIER=pilot bash
+    ci/benchmarks/lib/run_suite.sh parsec`), but it is deliberately absent from
+    `benchmarks.yml`'s `BENCHES`, so the planner never enumerates it and the
+    `benchmark-pilot` / `tier=pilot` fan-out assertions above are unaffected — see
+    `test_pilot_label_reaches_only_the_benchmarks_that_ship_it`, which still lists two
+    benches. It stays out of CI because neither its task trees (internal Red Hat) nor
+    its kaegis simulators (`github.ibm.com/kaegis/simulation-harness`) exist outside
+    IBM/RH; revisit both this list and the fan-out assertions if that ever changes and
+    parsec becomes CI-dispatchable.
     """
     shipped = sorted(p.parent.parent.name
                      for p in (REPO / "ci" / "benchmarks").glob("*/pilot/tasks.json"))
-    assert shipped == ["spreadsheetbench", "swebench"], shipped
+    assert shipped == ["parsec", "spreadsheetbench", "swebench"], shipped
 
 
 # ---- the missing-checkout regression (run 30682558719) -----------------------


### PR DESCRIPTION
## Summary

Splits the parsec-specific half out of #320, which bundled parsec's benchmark
wiring together with a shared harbor-adapter change (that half is PR #464). This
PR is parsec's local-only integration under `ci/benchmarks/parsec/`, addressing
the review feedback on #320:

- **Removes the contamination**: deletes `pilot/split_ids.json`. `run_suite.sh`
  treats the presence of a tier's `split_ids.json` as opt-in to a genuine
  held-out split; parsec's file put `{0005, 0032, 0047, 0048, 0088, 0104}` in
  `test`, but the published N=30 pilot run optimized directly against
  `0047`/`0048` — i.e. against its own claimed held-out set. Deleting the file
  (rather than regenerating it) makes the pilot an honest no-holdout FIT tier,
  matching what `ci/benchmarks/parsec/README.md` already claims it is.
- **Removes the redundant override file**: deletes `pilot/overrides.env` — every
  key it set (`HARBOR_LOCAL_ASIS=1`, `BACKEND_MCP_URL=...`) is already exported
  unconditionally by `run_suite.sh`'s parsec case block with identical values.
- **Fixes two broken defaults** in `utils/patch-harbor-tasks.sh`: `SRC` no longer
  defaults to a personal laptop path (now unset-by-default, fails with a message
  naming `PARSEC_HARBOR_TASKS_SRC`); `DST` now matches what `run_suite.sh`
  actually reads (`$REPO/e2e/parsec/harbor-tasks-patched`) instead of a path
  under `ci/benchmarks/parsec/` that nothing consumes.
- **Adds a v2 tier** — a second, independently-authored parsec dataset (10
  hand-written `bench-aap2-*` tasks, one isolated simulator per task, vs. v1's 4
  shared simulator endpoints across 30 real-trace tasks). Wires a `v2` branch
  into `run_suite.sh`'s parsec case (`HARBOR_DATASET` defaults to
  `harbor-tasks-v2.1`), and promotes that tier's task-patching script
  (`utils/patch-harbor-tasks-v2.1.sh`) the same way v1's patcher is promoted.
- **Promotes two previously-gitignored files** that the README's own commands
  depended on but that shipped nowhere: `docker/parsec-agent-base/Dockerfile` and
  `utils/build-parsec-agent-base.sh` (updated to the new in-repo paths).
- **Rewrites `ci/benchmarks/parsec/README.md`**: fixes the `BENCH`-as-env-var
  error (it's positional — commands are now
  `TIER=<tier> bash ci/benchmarks/lib/run_suite.sh parsec`), adds a prominent
  internal-only section (the dataset and the four kaegis simulators are
  IBM/RH-internal — this benchmark cannot be run externally), states plainly
  that parsec is not CI-dispatchable and why, and explains the pilot is now a
  FIT tier with no committed split.
- **Adds `parsec` to `ci/benchmarks/lib/run_suite.sh`'s usage string** and to
  `ci/benchmarks/README.md`'s inventory (flagged local-only) — but deliberately
  **not** to the per-bench PR-label enumeration in that same file, since no label
  dispatches parsec.
- **Updates the one guard test this touches**:
  `test_which_benches_ship_a_pilot_tier` now includes `parsec` in the benches
  that ship a `pilot/tasks.json`, with an inline rationale: parsec ships a pilot
  tier so it's runnable locally, but stays out of `benchmarks.yml`'s `BENCHES`,
  so the `benchmark-pilot` label / `tier=pilot` fan-out this test otherwise pins
  is unaffected.

### Deliberately not wired (by design, not oversight)

`benchmarks.yml`'s `BENCHES`/dispatch `options`, `ALL_BENCHES` in
`test_benchmarks_plan_legs.py`, `BENCHES` in `test_site_live_panel_tiers.py`,
`JOB_RE` in `site/benchmarks.js`, and the case in `ci/benchmarks/lib/ci_setup.sh`
all describe *CI-dispatchable* benchmarks. parsec's dataset and simulators are
internal-only, so none of these should include it — adding it there would make
`bench=all` CI sweeps hard-exit or make the live "Running now" panel expect a
job that will never appear.

Results and recipes from parsec's actual runs (v1's 30-task pilot, v2's 10-task
run) live on the `parsec-history` branch, not in this PR.

## Test plan

- [x] `python -m pytest core/tests -q` — full suite passes on this branch
- [x] `bash -n` on `run_suite.sh`, `patch-harbor-tasks.sh`,
      `patch-harbor-tasks-v2.1.sh`, `build-parsec-agent-base.sh`
- [x] `patch-harbor-tasks.sh`'s `DST` default matches `run_suite.sh`'s
      `HARBOR_DATASET` default for the `pilot`/`smoke` tiers (grepped both)
- [x] Confirmed this branch does **not** touch
      `templates/adapters/harbor/adapter.py` (`git log --stat` / `git diff
      main...HEAD --stat`)
- [ ] Reviewer: this cannot be run end-to-end outside the IBM/RH network (needs
      the internal dataset + kaegis simulators) — README commands were checked
      far enough to confirm they parse and reach the dataset check, not a full run

🤖 Generated with [Claude Code](https://claude.com/claude-code)