### PR TITLE
agent-optimize: let the optimizer choose its own screen/train subset

### DIFF
--- a/skills/algorithms/agent-optimize/SKILL.md
+++ b/skills/algorithms/agent-optimize/SKILL.md
@@ -138,8 +138,8 @@ python "$A/screen.py" --run-dir "$R" --project "$P" \
        --candidate "$R/work/$TAG" --tier 1 --k-se 1.0
 ```
 
-Only the candidate pays, and only for the subset. `decision` is `kill` or `promote` — **never accept** — and
-it kills only on proven harm. **Check the arithmetic before trusting a screen:**
+Only the candidate pays, for the subset (`--ids`: your pick). `decision` is `kill` or `promote`
+— **never accept** — kills only on proven harm. **Check the arithmetic before trusting a screen:**
 `savings.breakeven_kill_rate` (`fired / full_val_rollouts`) is the fraction it must kill to pay for itself;
 `savings.net_rollouts` books what it cost. Screen only when that break-even sits below your observed kill
 rate — on a small val the tier-1 floor makes it unreachable, so pay full val directly — and read a screen as

--- a/skills/algorithms/agent-optimize/references/algorithm.md
+++ b/skills/algorithms/agent-optimize/references/algorithm.md
@@ -155,6 +155,30 @@ it checks the untouched surface without having to name it. One `--k`-sized draw 
 either drowns the targeted signal in noise or lets the same tasks stand for both target and
 holdout at once.
 
+### Choosing your own subset
+
+`select_screen_subset`'s broken/informative/holdout heuristic is the DEFAULT selection, not the
+only one you may use. `screen.py --ids <comma-separated task ids>` bypasses it entirely: name the
+val tasks you want screened — from your own read of the candidate's target failure cluster's
+rollouts, grouped by trajectory similarity (same tool misused, same failure site, same violated
+expectation), or by any other method — and the same paired-delta kill/promote decision runs on
+exactly those ids, with the same audit trail under `$R/screens/`. It can still only kill, never
+accept, for the same reason the heuristic path can't: a subset you picked because it targets the
+edit is biased toward that edit, which is excellent triage and an invalid basis for acceptance.
+
+On **train** there is no screen/gate ceremony to bypass at all: `evaluate.py --split train --ids
+<your subset>` (`cap_evolve.harness.evaluate_candidate`'s `ids` parameter, exposed on the CLI)
+runs exactly the ids you name and nothing else, under a tag you control. Iterate on it as many
+times as you find useful — different clustering, different candidate, different cluster size —
+before ever touching val; train carries none of the honesty machinery, so there is nothing to
+protect there.
+
+**Never pass `--ids` to the step 4 full-val gate eval.** That call is the one place the loop's
+freedom stops: `gate_check.py`'s coverage guard (`min_coverage`) exists to catch an
+under-measured candidate, and a deliberately-chosen subset's `coverage` reads 1.0 by construction
+(its denominator IS the subset) — the exact blind spot the guard cannot see through. The full-val
+eval stays the whole split every round, same as the heuristic-screened path always required.
+
 ### `phases/gate` is an inspection front-end, not the round's gate
 
 `phases/gate/scripts/run.py --mode paired` reaches the *same* paired gate off the *same* persisted

--- a/skills/algorithms/agent-optimize/scripts/screen.py
+++ b/skills/algorithms/agent-optimize/scripts/screen.py
@@ -101,6 +101,14 @@ def main(argv=None) -> int:
                    help="kill only when Δ̄ + k·SE < 0 on the subset (default 1.0)")
     p.add_argument("--broken", default="",
                    help="comma-separated task ids a previous edit broke — screened first")
+    p.add_argument("--ids", default="",
+                   help="comma-separated val task ids to screen on, chosen by YOUR OWN method "
+                        "(trajectory-similarity clustering, reading rollouts, anything) — "
+                        "bypasses select_screen_subset's fixed broken/informative/holdout "
+                        "heuristic entirely. --tier/--k/--broken/--holdout-frac are ignored "
+                        "when this is set. The kill/promote decision and audit trail are "
+                        "unchanged — this only changes WHICH tasks are screened, never "
+                        "whether a screen can accept (it still can't).")
     p.add_argument("--n-trials", type=int, default=1,
                    help="trials per screened task (1 is the point; >1 is not a gate)")
     p.add_argument("--workers", type=int, default=None,
@@ -131,13 +139,24 @@ def main(argv=None) -> int:
         }, indent=2))
         return 2
 
-    frac = TIER_FRAC[args.tier]
-    k = args.k or max(MIN_K, int(round(frac * len(val_ids))))
-    seed = args.seed if args.seed is not None else int(run_dir.read_splits().seed) + args.tier
-    broken = [b for b in (args.broken or "").split(",") if b.strip()]
-    sub = select_screen_subset(parent.per_task, k=k, seed=seed,
-                               holdout_frac=args.holdout_frac,
-                               broken_ids=[b.strip() for b in broken])
+    custom_ids = [i.strip() for i in (args.ids or "").split(",") if i.strip()]
+    if custom_ids:
+        val_id_set = {str(i) for i in val_ids}
+        chosen = sorted({i for i in custom_ids if i in val_id_set})
+        sub = {"ids": chosen, "broken": [], "holdout": [], "informative": chosen,
+               "k": len(chosen), "requested_k": len(custom_ids), "seed": None,
+               "holdout_frac": None, "pool_n": len(parent.per_task),
+               "rationale": f"optimizer-chosen subset ({len(chosen)} of {len(custom_ids)} "
+                            "requested ids fell inside the frozen val split), bypassing "
+                            "select_screen_subset's heuristic"}
+    else:
+        frac = TIER_FRAC[args.tier]
+        k = args.k or max(MIN_K, int(round(frac * len(val_ids))))
+        seed = args.seed if args.seed is not None else int(run_dir.read_splits().seed) + args.tier
+        broken = [b for b in (args.broken or "").split(",") if b.strip()]
+        sub = select_screen_subset(parent.per_task, k=k, seed=seed,
+                                   holdout_frac=args.holdout_frac,
+                                   broken_ids=[b.strip() for b in broken])
 
     # Rungs are cumulative: never re-run a task an earlier rung already screened.
     prior_tags = _screen_tags(run_dir, tag)

--- a/skills/phases/evaluate/scripts/run.py
+++ b/skills/phases/evaluate/scripts/run.py
@@ -27,7 +27,18 @@ def main(argv=None) -> int:
     p.add_argument("--ks", default=None,
                    help="comma-separated k values for pass^k/pass@k "
                         "(default: 1..n-trials, so the k you paid for is reported)")
+    p.add_argument("--ids", default=None,
+                   help="comma-separated task ids to restrict this eval to (default: the "
+                        "whole split). For agent-optimize: evaluate on train freely, on any "
+                        "subset you chose yourself — by your own trajectory-similarity "
+                        "clustering, or any other method — cap_evolve.harness.evaluate_candidate "
+                        "already supports it. Use a tag unique to this subset eval (a fresh "
+                        "candidate dir name), never one a full-split eval also writes to. NEVER "
+                        "pass this for the full-val accept gate: a subset result's coverage "
+                        "looks like 1.0 to gate_check.py, exactly the case its coverage guard "
+                        "cannot see through.")
     args = p.parse_args(argv)
+    ids = [i.strip() for i in args.ids.split(",") if i.strip()] if args.ids else None
 
     # ks defaults to every k the trials can support. The harness default is (1, 2),
     # which silently drops pass^3 from a --n-trials 3 run — the exact reliability
@@ -51,7 +62,7 @@ def main(argv=None) -> int:
     cand_dir = cand if cand.exists() else run_dir.candidate_dir(args.candidate)
     result = harness.evaluate_candidate(adapter, cand_dir, run_dir=run_dir,
                                         split=args.split, n_trials=args.n_trials,
-                                        ks=ks, tag=cand_dir.name)
+                                        ks=ks, tag=cand_dir.name, ids=ids)
     print(json.dumps(result.to_dict(), indent=2))
     return 0
 


### PR DESCRIPTION
## Summary

Audit of agent-optimize's orchestration freedom found the algorithm already almost entirely correct on this axis — but one real gap: subset (screen/train) task selection was hard-wired to `select_screen_subset`'s fixed heuristic, with no way for the optimizer to hand in a subset it derived itself (e.g. by clustering failing trajectories).

- `screen.py --ids t1,t7,t12` now screens exactly those val ids, bypassing `select_screen_subset` entirely — same kill/promote decision, same audit trail, still can never accept (protocol integrity unchanged).
- `phases/evaluate/scripts/run.py --ids ...` exposes `harness.evaluate_candidate`'s existing `ids=` restriction on the CLI, so the optimizer can run train evals on any subset it picks, with no gate ceremony.
- SKILL.md + `references/algorithm.md` document the override and warn explicitly against using `--ids` on the step-4 full-val gate eval (a subset's `coverage` reads 1.0 to `gate_check.py`'s coverage guard — the one blind spot that guard can't see through).

## What was already correct (no changes needed)

- `host.py` genuinely just briefs + invokes the CLI subprocess; every screen/merge/evaluate decision happens inside the optimizer's own agent turn via its own tool calls, not in host.py's Python control flow.
- The full-val paired gate (`gate_check.py`, `round.py`'s serial gating) is deliberately fixed/deterministic — that's protocol integrity for the accept/reject decision, not over-constraint, and is left untouched.
- No tau2- or benchmark-specific logic in `core/cap_evolve/subsample.py` or the agent-optimize skill scripts — fully benchmark-agnostic already.
- `--tier`/`--k`/`--broken`/`--holdout-frac` were already overridable knobs on the heuristic, just with no way to replace the heuristic's task-picking logic itself — that's the gap this PR closes.

## Test plan

- [x] `cd core && python -m pytest tests/ -k "screen or subsample or agent_optimize" -q` — 173 passed, 2 skipped
- [x] `cd core && python -m pytest tests/ -q` — 1210 passed, 12 skipped, 2 pre-existing failures in `test_merge_search.py` unrelated to this change (confirmed via `git stash` against origin/main — same 2 failures, a subprocess `PYTHONPATH`/`ModuleNotFoundError` issue in the test sandbox, not caused by this PR)
- [x] SKILL.md body budget test (`test_agent_optimize_host.py::test_host_script_exists_and_is_documented_where_it_belongs`) passes — SKILL.md kept under its 5000-token cap