### PR TITLE
agent-optimize: heartbeat + external watchdog for a dead host.py process

### DIFF
--- a/core/cap_evolve/dashboard.py
+++ b/core/cap_evolve/dashboard.py
@@ -546,8 +546,27 @@ def _eval_busy(ev: dict) -> str:
     return f"scoring {who} on the {split} split{scale}"
 
 
+def _heartbeat_pid_alive(pid) -> bool:
+    """Same liveness check `watchdog.py` uses, duplicated rather than imported: `core`
+    (this module) must not depend on a `skills/` script, so a 3-line stdlib check is
+    cheaper than a shared util module for it.
+    """
+    if not pid:
+        return False
+    try:
+        os.kill(int(pid), 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
 def _derive_status(*, events: list, now: float, budget, spent, agent_mode: bool,
-                   has_candidates: bool, has_baseline: bool) -> tuple[str, str]:
+                   has_candidates: bool, has_baseline: bool,
+                   heartbeat: dict | None = None) -> tuple[str, str]:
     """``(status, reason)`` for a run — the six outcomes an operator must tell apart.
 
     ``completed`` (finalize sealed the test) · ``budget_exhausted`` (a cap was hit and
@@ -568,6 +587,14 @@ def _derive_status(*, events: list, now: float, budget, spent, agent_mode: bool,
     reports an outcome for a run that has not reached one. So the timestamps are read
     first, and "nothing evaluated" is only a failure once the log has actually stopped
     moving (or a cap/convergence already ended the run).
+
+    ``heartbeat`` (``host/heartbeat.json``, written by `agent-optimize`'s ``host.py`` while
+    an agent invocation is in flight) is a second, independent liveness signal on top of
+    events: an unattended `host.py` that dies mid-turn (machine sleep, closed terminal)
+    leaves events silent with no distinguishing event to explain it, which otherwise reads
+    identically to "still mid-eval" until the wide `EVAL_STALE_AFTER_SECONDS` window also
+    expires. A confirmed-dead heartbeat pid turns that "interrupted" into an explicit
+    "needs relaunch" reason instead of a bare "died, was killed, or ...".
     """
     kinds = [str(e.get("kind") or "") for e in events]
     if not events:
@@ -650,6 +677,14 @@ def _derive_status(*, events: list, now: float, budget, spent, agent_mode: bool,
         return "budget_exhausted", f"{exhausted}; test split never sealed"
     if silent is None:
         return "interrupted", "events carry no timestamps — cannot tell if it is still alive"
+
+    heartbeat_pid = (heartbeat or {}).get("pid")
+    heartbeat_dead = heartbeat is not None and not _heartbeat_pid_alive(heartbeat_pid)
+    if heartbeat_dead:
+        return "interrupted", (
+            f"stalled — no activity in {silent / 60.0:.0f}m and host.py's pid ({heartbeat_pid}) "
+            "is gone: it died mid-turn rather than stopping cleanly. Needs relaunch — re-run "
+            "host.py against this run dir, or point watchdog.py at it")
     return "interrupted", (
         f"no finalize and no event for {silent / 60.0:.0f} min — the run died, was "
         "killed, or is still being written by a process that is no longer logging")
@@ -1906,10 +1941,12 @@ def reduce_run(run_dir) -> dict:
     }
 
     now = _now()
+    heartbeat = _read_json(_safe_subpath(root, "host/heartbeat.json")) or None
     status, status_reason = _derive_status(
         events=events, now=now, budget=(run_dir.budget if sp is not None else None),
         spent=sp, agent_mode=(_orchestration_mode(root) == "agent"),
-        has_candidates=len(nodes) > 1, has_baseline=baseline_val is not None)
+        has_candidates=len(nodes) > 1, has_baseline=baseline_val is not None,
+        heartbeat=heartbeat)
     ts = [float(e["t"]) for e in events if isinstance(e.get("t"), (int, float))]
 
     # Elapsed wall time. For a finished run that is first event → last event. For a run

--- a/core/tests/test_agent_optimize_watchdog.py
+++ b/core/tests/test_agent_optimize_watchdog.py
@@ -1,0 +1,119 @@
+"""``watchdog.py`` — notices a dead `host.py` process and relaunches it.
+
+Pure logic: no real subprocess is ever spawned here. Every case injects a stub
+`relaunch` callable and asserts what `check()` decided and what it would have run,
+not that a process actually started.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+WATCHDOG_PATH = REPO / "skills" / "algorithms" / "agent-optimize" / "scripts" / "watchdog.py"
+
+_spec = importlib.util.spec_from_file_location("agent_optimize_watchdog", WATCHDOG_PATH)
+watchdog = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(watchdog)
+
+
+def _write(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _relaunch_spy():
+    calls = []
+
+    def _fn(cmd, log_path):
+        calls.append({"cmd": cmd, "log_path": log_path})
+
+    return _fn, calls
+
+
+def test_a_run_with_no_heartbeat_yet_is_left_alone(tmp_path):
+    out = watchdog.check(tmp_path)
+    assert out["action"] == "none"
+    assert "heartbeat" in out["reason"]
+
+
+def test_a_sealed_run_is_never_touched_even_with_a_dead_heartbeat(tmp_path):
+    (tmp_path / "final.json").write_text("{}", encoding="utf-8")
+    _write(tmp_path / "host" / "heartbeat.json", {"pid": 999999, "ts": time.time() - 3600})
+    out = watchdog.check(tmp_path)
+    assert out["action"] == "none"
+    assert "sealed" in out["reason"]
+
+
+def test_a_live_pid_is_not_relaunched_regardless_of_heartbeat_age(tmp_path):
+    _write(tmp_path / "host" / "heartbeat.json", {"pid": os.getpid(), "ts": time.time() - 3600})
+    _write(tmp_path / "host" / "launch_args.json",
+           {"python": sys.executable, "argv": ["--run-dir", str(tmp_path)]})
+    fn, calls = _relaunch_spy()
+    out = watchdog.check(tmp_path, relaunch=fn)
+    assert out["action"] == "none"
+    assert "alive" in out["reason"]
+    assert calls == []
+
+
+def test_a_recently_dead_pid_under_the_threshold_is_not_yet_relaunched(tmp_path):
+    _write(tmp_path / "host" / "heartbeat.json", {"pid": 999999, "ts": time.time() - 30})
+    fn, calls = _relaunch_spy()
+    out = watchdog.check(tmp_path, stale_seconds=600, relaunch=fn)
+    assert out["action"] == "none"
+    assert "threshold" in out["reason"]
+    assert calls == []
+
+
+def test_a_stale_dead_heartbeat_with_no_launch_args_reports_an_error_not_a_guess(tmp_path):
+    _write(tmp_path / "host" / "heartbeat.json", {"pid": 999999, "ts": time.time() - 3600})
+    out = watchdog.check(tmp_path, stale_seconds=600)
+    assert out["action"] == "error"
+    assert "launch_args.json" in out["reason"]
+
+
+def test_a_stale_dead_heartbeat_relaunches_with_the_saved_command_line(tmp_path):
+    _write(tmp_path / "host" / "heartbeat.json", {"pid": 999999, "ts": time.time() - 3600})
+    _write(tmp_path / "host" / "launch_args.json",
+           {"python": "/usr/bin/python3.11",
+            "argv": ["--run-dir", str(tmp_path), "--project", "/p", "--agent", "claude-code"]})
+    fn, calls = _relaunch_spy()
+    out = watchdog.check(tmp_path, stale_seconds=600, relaunch=fn)
+    assert out["action"] == "relaunched"
+    assert len(calls) == 1
+    cmd = calls[0]["cmd"]
+    assert cmd[0] == "/usr/bin/python3.11"
+    assert cmd[1] == str(watchdog.HOST_PY)
+    assert cmd[2:] == ["--run-dir", str(tmp_path), "--project", "/p",
+                       "--agent", "claude-code"]
+    assert calls[0]["log_path"] == tmp_path / "host_launch.log"
+
+
+def test_dry_run_reports_would_relaunch_and_never_calls_relaunch(tmp_path):
+    _write(tmp_path / "host" / "heartbeat.json", {"pid": 999999, "ts": time.time() - 3600})
+    _write(tmp_path / "host" / "launch_args.json",
+           {"python": sys.executable, "argv": ["--run-dir", str(tmp_path)]})
+    fn, calls = _relaunch_spy()
+    out = watchdog.check(tmp_path, stale_seconds=600, relaunch=fn, dry_run=True)
+    assert out["action"] == "would_relaunch"
+    assert calls == []
+
+
+def test_a_missing_run_dir_is_an_error():
+    out = watchdog.check(Path("/no/such/run/dir/xyz"))
+    assert out["action"] == "error"
+
+
+def test_cli_exit_code_is_nonzero_only_on_an_actual_error(tmp_path, capsys):
+    rc = watchdog.main(["--run-dir", str(tmp_path)])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["action"] == "none"
+
+    rc = watchdog.main(["--run-dir", "/no/such/run/dir/xyz"])
+    assert rc == 1

--- a/core/tests/test_dashboard_status_cost_log.py
+++ b/core/tests/test_dashboard_status_cost_log.py
@@ -97,6 +97,45 @@ def test_status_interrupted_when_a_run_died_without_finalizing():
         assert "died" in s["status_reason"] or "killed" in s["status_reason"]
 
 
+def test_status_names_the_relaunch_when_hosts_own_pid_is_confirmed_dead():
+    """A dead `host/heartbeat.json` pid upgrades the generic "died, was killed, or..."
+    guess into an actionable "needs relaunch" reason — the agent-optimize host.py stall
+    this was written for: the process died mid-turn with no distinguishing event at all.
+    """
+    from cap_evolve import dashboard
+    old = NOW - 5 * 24 * 3600
+    with tempfile.TemporaryDirectory() as d:
+        rd = _mk(Path(d), events=_events(t0=old, finalize=False), baseline=_BASELINE)
+        host_dir = rd.root / "host"
+        host_dir.mkdir(exist_ok=True)
+        # A pid that (almost certainly) does not exist on this machine.
+        (host_dir / "heartbeat.json").write_text(
+            json.dumps({"pid": 999999, "ts": old + 4}), encoding="utf-8")
+        s = dashboard.reduce_run(rd)["summary"]
+        assert s["status"] == "interrupted"
+        assert "Needs relaunch" in s["status_reason"]
+        assert "999999" in s["status_reason"]
+
+
+def test_a_live_heartbeat_pid_does_not_get_the_relaunch_wording():
+    """The current process's own pid IS alive, so a heartbeat pointing at it must not be
+    accused of being dead — that would tell an operator to relaunch a run that is fine.
+    """
+    import os
+
+    from cap_evolve import dashboard
+    old = NOW - 5 * 24 * 3600
+    with tempfile.TemporaryDirectory() as d:
+        rd = _mk(Path(d), events=_events(t0=old, finalize=False), baseline=_BASELINE)
+        host_dir = rd.root / "host"
+        host_dir.mkdir(exist_ok=True)
+        (host_dir / "heartbeat.json").write_text(
+            json.dumps({"pid": os.getpid(), "ts": old + 4}), encoding="utf-8")
+        s = dashboard.reduce_run(rd)["summary"]
+        assert s["status"] == "interrupted"
+        assert "Needs relaunch" not in s["status_reason"]
+
+
 def test_status_budget_exhausted_is_distinct_from_running_and_from_completed():
     from cap_evolve import dashboard
     from cap_evolve import Budget

--- a/skills/algorithms/agent-optimize/scripts/host.py
+++ b/skills/algorithms/agent-optimize/scripts/host.py
@@ -63,6 +63,19 @@ It reports rather than books: booking an accept after ``measure.py`` sealed agai
 
 That check runs AFTER the seal on purpose — the abandoned round's evals outlived the agent by
 14 minutes, so a pre-seal check would have found an empty ``work/``.
+
+**A heartbeat, for when THIS process dies rather than the CLI it launches.** Everything above
+covers the hosted CLI stopping short while host.py itself stays alive to notice. Nothing here
+covers host.py's own OS process dying — the machine sleeping, the terminal it ran in closing —
+which is a distinct failure `watchdog.py` (this dir) exists to catch from outside: it reads
+``host/heartbeat.json``, written every ``HEARTBEAT_INTERVAL_SECONDS`` while a CLI invocation is
+in flight, and relaunches host.py against the same run dir when the heartbeat goes stale and no
+process still holds its pid. Re-running host.py is already safe to do by hand (``commit.py``
+refuses to double-book a decided candidate, ``_seal`` is idempotent) — the watchdog only
+automates noticing and doing that, using ``host/launch_args.json`` (written on every launch) to
+reconstruct the original command line. It is a process supervisor, not a resume of a hung
+turn: see the briefing's Unattended section for why a turn that ends with work outstanding can
+never be resumed from inside the conversation.
 """
 
 from __future__ import annotations
@@ -72,6 +85,7 @@ import json
 import os
 import subprocess
 import sys
+import threading
 import time
 from pathlib import Path
 
@@ -124,6 +138,43 @@ def _backgrounding_near_misses(permission_denials) -> list[dict]:
 # (spreadsheetbench full: one Docker container per task x trials), while still bounding a
 # genuinely hung command instead of waiting forever.
 BASH_TIMEOUT_MS = 4 * 60 * 60 * 1000
+#: How often, while a CLI invocation is in flight, host.py touches ``host/heartbeat.json``.
+#: ``watchdog.py`` treats anything older than a few multiples of this as evidence the
+#: process died rather than just being between writes.
+HEARTBEAT_INTERVAL_SECONDS = 60
+
+
+def _write_heartbeat(run_dir: Path, *, pid: int) -> None:
+    """Best-effort liveness marker for ``watchdog.py``. Never raises: a missed write is not
+    worth failing an otherwise-healthy run over, and the watchdog already tolerates a
+    heartbeat a few intervals stale.
+    """
+    path = run_dir / "host" / "heartbeat.json"
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(".tmp")
+        tmp.write_text(json.dumps({"pid": pid, "ts": time.time()}), encoding="utf-8")
+        tmp.replace(path)
+    except OSError:
+        pass
+
+
+def _heartbeat_loop(run_dir: Path, pid: int, stop: threading.Event) -> None:
+    while not stop.wait(HEARTBEAT_INTERVAL_SECONDS):
+        _write_heartbeat(run_dir, pid=pid)
+
+
+def _save_launch_args(run_dir: Path, argv: list[str]) -> None:
+    """Persist this invocation's CLI args so ``watchdog.py`` can reconstruct the exact
+    command line on a relaunch, without a human remembering ``--agent``/``--model``/etc.
+    """
+    try:
+        path = run_dir / "host" / "launch_args.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({"argv": argv, "python": sys.executable}, indent=2),
+                        encoding="utf-8")
+    except OSError:
+        pass
 #: Measurement concurrency handed to the agent when the spec names none. Matches ``round.py``'s
 #: own default and its refusal bound; see the concurrency note in the briefing.
 GATE_CONCURRENCY = 8
@@ -852,6 +903,12 @@ def main(argv=None) -> int:
         }, indent=2))
         return 2
 
+    # So `watchdog.py` can relaunch this exact invocation without a human reconstructing
+    # the flags. Not saved for --prompt-only (a render-and-exit probe, never actually
+    # relaunchable) or --seal-only (handled above, before this line is even reached).
+    if not args.prompt_only:
+        _save_launch_args(run_dir, list(argv if argv is not None else sys.argv[1:]))
+
     # The agent needs write access to BOTH the run dir and the project; their common parent
     # is the natural workdir, and it is where the staged guidance + native skills land.
     workdir = _common_parent(run_dir, project)
@@ -965,6 +1022,11 @@ def main(argv=None) -> int:
             pass
 
         started = time.time()
+        stop_hb = threading.Event()
+        _write_heartbeat(run_dir, pid=os.getpid())
+        hb_thread = threading.Thread(target=_heartbeat_loop, args=(run_dir, os.getpid(), stop_hb),
+                                     daemon=True)
+        hb_thread.start()
         try:
             proc = subprocess.run(cmd, capture_output=True, text=True, timeout=args.timeout,
                                   env={**_child_env(), **agent_env})
@@ -972,6 +1034,8 @@ def main(argv=None) -> int:
         except subprocess.TimeoutExpired:
             proc = None
             timed_out = True
+        finally:
+            stop_hb.set()
         seconds = time.time() - started
 
         payload: dict = {}

--- a/skills/algorithms/agent-optimize/scripts/watchdog.py
+++ b/skills/algorithms/agent-optimize/scripts/watchdog.py
@@ -1,0 +1,143 @@
+"""watchdog.py — notice when ``host.py`` itself died, and relaunch it.
+
+``host.py``'s own docstring covers every way the AGENT it launches can stop short —
+turn budget, a backgrounded wait, a transient CLI crash — because in each of those cases
+host.py is still alive to diagnose and (for a transient crash) retry. None of that helps
+when host.py's OS process dies: the machine sleeps, the terminal running it closes, the
+CI runner is preempted. The process just stops, mid tool-call, with no exit code anyone
+sees and no ``final.json``. Re-running host.py against the same run dir is already safe
+(``commit.py`` refuses to double-book a decided candidate; ``_seal`` is idempotent) — this
+script only automates *noticing* that it needs to happen and doing it, so a run does not
+sit silently stalled until a human happens to look.
+
+Run it periodically (cron, a loop, CI) alongside host.py, once per run dir being watched.
+It does ONE check per invocation and exits — no internal sleep loop, no daemon.
+
+What it is not: a way to resume a hung turn inside the agent's own conversation. host.py's
+briefing already states that invariant (delegate the work, never the waiting) because
+ending a turn with work outstanding ends the process with nothing left to resume from
+the inside. This script only restarts the OUTER process from the outside, which then
+starts a fresh turn against the same run dir.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+HOST_PY = HERE / "host.py"
+
+#: Heartbeat age past which host.py is presumed dead if its pid is also gone. Several
+#: multiples of `host.py`'s HEARTBEAT_INTERVAL_SECONDS (60s), so one missed write from a
+#: slow disk or a GC pause never reads as a crash.
+DEFAULT_STALE_SECONDS = 10 * 60
+
+
+def _read_json(path: Path) -> dict | None:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _pid_alive(pid: int | None) -> bool:
+    if not pid:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True  # exists, just owned by someone else — still alive
+    except OSError:
+        return False
+    return True
+
+
+def _default_relaunch(cmd: list[str], log_path: Path) -> None:
+    """Detached, output redirected to `log_path` — the file this run's launch was missing,
+    which is what made the original stall so hard to see after the fact.
+    """
+    with log_path.open("a", encoding="utf-8") as log:
+        subprocess.Popen(cmd, stdout=log, stderr=subprocess.STDOUT, start_new_session=True)
+
+
+def check(run_dir: Path, *, stale_seconds: int = DEFAULT_STALE_SECONDS,
+          host_py: Path = HOST_PY, relaunch=_default_relaunch, dry_run: bool = False) -> dict:
+    """One staleness check + (maybe) relaunch. Returns a JSON-serializable report.
+
+    ``relaunch`` is a seam for tests: a callable ``(cmd, log_path) -> None``, never invoked
+    for real when ``dry_run`` is set.
+    """
+    run_dir = Path(run_dir).resolve()
+    if not run_dir.is_dir():
+        return {"run_dir": str(run_dir), "action": "error", "reason": "run dir not found"}
+
+    if (run_dir / "final.json").exists():
+        return {"run_dir": str(run_dir), "action": "none",
+                 "reason": "already sealed (final.json present)"}
+
+    heartbeat = _read_json(run_dir / "host" / "heartbeat.json")
+    if heartbeat is None:
+        return {"run_dir": str(run_dir), "action": "none",
+                 "reason": "no host/heartbeat.json — host.py has not started an agent "
+                           "invocation yet, or this run predates the heartbeat"}
+
+    age = time.time() - float(heartbeat.get("ts") or 0.0)
+    pid = heartbeat.get("pid")
+    if _pid_alive(pid):
+        return {"run_dir": str(run_dir), "action": "none",
+                 "reason": f"pid {pid} is alive", "age_seconds": round(age, 1)}
+
+    if age < stale_seconds:
+        return {"run_dir": str(run_dir), "action": "none",
+                 "reason": f"heartbeat is {age:.0f}s old, under the {stale_seconds}s "
+                           "threshold — pid is gone but may just be between attempts",
+                 "age_seconds": round(age, 1)}
+
+    launch = _read_json(run_dir / "host" / "launch_args.json")
+    if launch is None:
+        return {"run_dir": str(run_dir), "action": "error",
+                 "reason": "heartbeat is stale and its pid is gone, but "
+                           "host/launch_args.json is missing — cannot reconstruct the "
+                           "original command line to relaunch it",
+                 "age_seconds": round(age, 1)}
+
+    cmd = [str(launch.get("python") or sys.executable), str(host_py),
+           *[str(a) for a in (launch.get("argv") or [])]]
+    log_path = run_dir / "host_launch.log"
+    report = {"run_dir": str(run_dir), "cmd": cmd, "age_seconds": round(age, 1),
+              "log": str(log_path)}
+    if dry_run:
+        report["action"] = "would_relaunch"
+        return report
+    relaunch(cmd, log_path)
+    report["action"] = "relaunched"
+    return report
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(
+        prog="watchdog.py",
+        description="Check a cap-evolve run dir's host.py heartbeat; relaunch it if stale.")
+    p.add_argument("--run-dir", required=True, help="run dir host.py was launched against")
+    p.add_argument("--stale-minutes", type=float, default=DEFAULT_STALE_SECONDS / 60,
+                   help=f"heartbeat age, in minutes, before host.py is presumed dead "
+                        f"(default {DEFAULT_STALE_SECONDS / 60:g})")
+    p.add_argument("--dry-run", action="store_true",
+                   help="report what would happen without actually relaunching")
+    args = p.parse_args(argv)
+
+    out = check(Path(args.run_dir), stale_seconds=args.stale_minutes * 60, dry_run=args.dry_run)
+    print(json.dumps(out, indent=2))
+    return 1 if out["action"] == "error" else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Diagnosed a stalled run (`run_v2`, val=0.587 seed baseline, 0 iterations): host.py's own OS process died mid-turn — the machine slept while it was running unattended — leaving no `final.json`, no error, and no way to tell "still working" from "dead" except a human noticing.

host.py already handles the CLI subprocess it launches stopping short (turn budget, backgrounded wait, transient crash retry) — none of that helps when host.py itself dies, since the retry/diagnosis logic lives inside that same process. Re-running host.py against the same run dir is already safe (`commit.py` refuses to double-book, `_seal` is idempotent), so the fix is to automate *noticing* it needs to happen.

- `host.py` now writes `host/heartbeat.json` (`{pid, ts}`) every 60s while an agent invocation is in flight, via a background thread wrapped around the existing blocking `subprocess.run` call.
- `host.py` persists the CLI args it was launched with to `host/launch_args.json` (skipped for `--seal-only`/`--prompt-only` probes) so a relaunch never needs a human to reconstruct flags.
- New `skills/algorithms/agent-optimize/scripts/watchdog.py`: a single-shot check (meant to be run via cron/a loop alongside host.py) that relaunches host.py with the saved args — output redirected to `host_launch.log`, fixing the exact observability gap this stall exposed — when the heartbeat is stale, its pid is confirmed dead, and the run isn't already sealed. It never resumes a hung *turn*; it only restarts the outer process, consistent with host.py's existing "delegate the work, never the waiting" invariant.
- `dashboard.py`'s status reducer now reads the same heartbeat to turn a bare "interrupted, died/killed/still-writing" guess into an explicit "stalled — no activity in Xm ... Needs relaunch" reason once host.py's pid is confirmed dead.

## Test plan

- [x] `pytest core/tests/test_agent_optimize_watchdog.py` — 9 new pure-logic tests (staleness thresholds, dead/alive pid, missing launch_args, dry-run, CLI exit codes) — all pass, no real subprocess spawned.
- [x] `pytest core/tests/test_dashboard_status_cost_log.py` — 44 pass, incl. 2 new tests for the heartbeat-aware status reason (dead pid → "Needs relaunch"; live pid → unchanged wording); no regression to the existing "interrupted" test.
- [x] `pytest core/tests/test_agent_optimize_host.py` — 43 pass; verified via a real subprocess invocation that `heartbeat.json`/`launch_args.json` are written on a normal run and correctly skipped on `--prompt-only`/`--seal-only`.
- [x] `pytest core/tests/` (full suite) — 1223 passed, 12 skipped (pre-existing skips), no regressions.
- [x] Manual end-to-end: ran host.py against a real run dir, backdated the heartbeat + swapped in a dead pid to simulate the original stall, confirmed `watchdog.py --dry-run` reconstructs the exact relaunch command from `launch_args.json`.