### PR TITLE
agent-optimize: gate_check refuses to accept a subset-evaluated candidate

### DIFF
--- a/core/tests/test_gate_subset_guard.py
+++ b/core/tests/test_gate_subset_guard.py
@@ -1,0 +1,132 @@
+"""A candidate evaluated on a SUBSET of val must never clear the accept gate.
+
+``screen.py --ids`` / ``evaluate.py --ids`` (#469) let the optimizer restrict an eval to
+tasks it chose itself. That is fine for triage and train, and explicitly forbidden by
+SKILL.md for the full-val accept gate — but the prohibition was prose only.
+``harness.split_result_from_rollouts`` reconstructs a ``SplitResult`` purely from whatever
+rollout files exist for a tag, so a subset-evaluated candidate's own ``coverage`` reads
+1.0 (every task it measured, it measured) — invisible to ``gate.decide``'s low-coverage
+guard, which compares coverage against nothing but itself.
+
+``gate_check._frozen_coverage`` fixes this by measuring coverage against the run's actual
+frozen val split instead, so the guard can see a subset for what it is regardless of why
+it exists (a deliberate ``--ids``, or a half-finished eval).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPT = REPO / "skills" / "algorithms" / "agent-optimize" / "scripts" / "gate_check.py"
+
+
+def _load_gate_check():
+    spec = importlib.util.spec_from_file_location("_gc_subset_guard", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    sys.path.insert(0, str(SCRIPT.parent))
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class _Adapter:
+    """5 tasks; a task passes iff the candidate's cfg file contains its id."""
+
+    IDS = ["t0", "t1", "t2", "t3", "t4"]
+
+    def tasks(self, split):
+        from cap_evolve import Task
+        return [Task(id=t) for t in self.IDS]
+
+    def run_target(self, task, ctx, *, seed=0):
+        from cap_evolve import Rollout
+        cfg = Path(ctx) / "cfg.txt"
+        text = cfg.read_text() if cfg.exists() else ""
+        return Rollout(task_id=task.id, output=("pass" if task.id in text else "fail"))
+
+    def score(self, task, rollout):
+        from cap_evolve import Score
+        ok = rollout.output == "pass"
+        return Score(task_id=task.id, reward=1.0 if ok else 0.0,
+                     trial_rewards=[1.0 if ok else 0.0])
+
+    def apply(self, candidate_dir, edits=None):
+        return None
+
+
+def _setup(tmp_path):
+    from cap_evolve import RunDir, harness
+    from cap_evolve.splits import Splits
+
+    adapter = _Adapter()
+    seed = tmp_path / "seed"
+    seed.mkdir()
+    (seed / "cfg.txt").write_text("")  # 0/5
+
+    run_dir = RunDir.create(tmp_path / ".capevolve", ts="gsg")
+    run_dir.write_splits(Splits(train=[], val=list(adapter.IDS), test=[], seed=0))
+    run_dir.snapshot("seed", seed)
+    run_dir.set_best("seed")
+    harness.evaluate_candidate(adapter, run_dir.candidate_dir("seed"), run_dir=run_dir,
+                                split="val", tag="seed")
+
+    cand = tmp_path / "cand"
+    cand.mkdir()
+    (cand / "cfg.txt").write_text(" ".join(adapter.IDS))  # would score 5/5 in full
+    run_dir.snapshot("cand1", cand)
+    return adapter, run_dir
+
+
+def _run_gate(run_dir, **extra):
+    gc = _load_gate_check()
+    args = ["--run-dir", str(run_dir.root), "--candidate", "cand1",
+            "--mode", "paired", "--no-footprint", "--k-se", "1.0"]
+    for k, v in extra.items():
+        args += [f"--{k.replace('_', '-')}", str(v)]
+    return gc, args
+
+
+def test_subset_evaluated_candidate_is_refused_not_accepted(tmp_path, capsys):
+    from cap_evolve import harness
+
+    adapter, run_dir = _setup(tmp_path)
+    # Only 2 of 5 frozen val ids measured — exactly what `evaluate.py --ids`/`screen.py
+    # --ids` produce, and exactly the shape that would otherwise sail through as a
+    # too-good-to-be-true accept.
+    harness.evaluate_candidate(adapter, run_dir.candidate_dir("cand1"), run_dir=run_dir,
+                                split="val", tag="cand1", ids=["t0", "t1"])
+
+    gc, args = _run_gate(run_dir)
+    rc = gc.main(args)
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 0
+
+    assert out["candidate"]["coverage"] == 1.0, (
+        "sanity: the per-attempted-task coverage IS 1.0 -- that is the blind spot")
+    assert out["candidate"]["coverage_of_frozen_val"] < 0.6, out["candidate"]
+    assert set(out["candidate"]["missing_from_frozen_val"]) == {"t2", "t3", "t4"}
+    assert out["gate"]["indecisive"] is True
+    assert out["gate"]["accept"] is False
+    assert out["verdict"] == "indecisive"
+
+
+def test_full_val_candidate_is_unaffected(tmp_path, capsys):
+    """The fix must not turn a genuine full-val eval into a false indecisive."""
+    from cap_evolve import harness
+
+    adapter, run_dir = _setup(tmp_path)
+    harness.evaluate_candidate(adapter, run_dir.candidate_dir("cand1"), run_dir=run_dir,
+                                split="val", tag="cand1")  # full split, no ids=
+
+    gc, args = _run_gate(run_dir)
+    rc = gc.main(args)
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 0
+
+    assert out["candidate"]["coverage_of_frozen_val"] == 1.0
+    assert out["candidate"]["missing_from_frozen_val"] == []
+    assert out["gate"]["indecisive"] is False
+    assert out["gate"]["accept"] is True, out["gate"]

--- a/skills/algorithms/agent-optimize/scripts/gate_check.py
+++ b/skills/algorithms/agent-optimize/scripts/gate_check.py
@@ -111,6 +111,25 @@ def regressions(current, candidate) -> list[str]:
 GATE_MODES = ["paired", "significant", "strict", "threshold"]
 
 
+def _frozen_coverage(run_dir, per_task, split: str = "val") -> float:
+    """Real coverage against the FROZEN split, not just the tasks a rollout exists for.
+
+    ``SplitResult.coverage`` is ``n_scored / n_tasks`` where ``n_tasks`` counts only
+    tasks that have a rollout file under this tag — reconstructed purely from disk
+    (``harness.split_result_from_rollouts``). A candidate evaluated on a SUBSET of val
+    (deliberately via ``--ids``, or by an eval that died partway through) therefore
+    reads back ``coverage == 1.0``: every task it DID measure, it measured. That is
+    exactly the blind spot ``gate.decide``'s low-coverage guard exists to catch, and it
+    cannot see through it unless coverage is computed against the split cap-evolve
+    actually froze, not against whatever happened to land on disk.
+    """
+    frozen = {str(i) for i in (run_dir.read_splits().ids(split) or [])}
+    if not frozen:
+        return 1.0
+    scored = {str(pt.get("task_id")) for pt in (per_task or []) if has_valid_trials(pt)}
+    return len(scored & frozen) / len(frozen)
+
+
 def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(prog="gate_check")
     p.add_argument("--run-dir", required=True)
@@ -169,6 +188,15 @@ def main(argv=None) -> int:
             tags=[*cur_tags, args.candidate], split="val",
             all_task_ids=[pt.get("task_id") for pt in (cand.per_task or [])])
 
+    # Real coverage against the frozen split (see `_frozen_coverage`), min of both sides —
+    # a candidate OR a reference measured on a subset is equally invalid to gate on.
+    cand_frozen_cov = _frozen_coverage(run_dir, cand.per_task, "val")
+    cur_frozen_cov = _frozen_coverage(run_dir, cur.per_task, "val")
+    frozen_coverage = min(cand_frozen_cov, cur_frozen_cov)
+    frozen_ids = {str(i) for i in (run_dir.read_splits().ids("val") or [])}
+    cand_ids = {str(pt.get("task_id")) for pt in (cand.per_task or []) if has_valid_trials(pt)}
+    missing_from_frozen_val = sorted(frozen_ids - cand_ids)
+
     deltas = harness._paired_deltas(cur, cand, footprint=fp)
     # Only when restricted: on a small footprint the zero-padded vector's cross-task spread
     # understates the real uncertainty, so floor it with per-task trial noise. Unrestricted
@@ -178,7 +206,7 @@ def main(argv=None) -> int:
     d = decide(cur.reward, cand.reward, split="val", mode=args.mode, k_se=args.k_se,
                candidate_stderr=cand.stderr, current_stderr=cur.stderr,
                threshold=args.threshold, paired_deltas=deltas,
-               paired_se_floor=se_floor, coverage=cand.coverage, run_dir=run_dir)
+               paired_se_floor=se_floor, coverage=frozen_coverage, run_dir=run_dir)
 
     regs = regressions(cur, cand)
     accept = bool(d.accept) and not (regs and args.veto_regressions)
@@ -200,7 +228,9 @@ def main(argv=None) -> int:
         "current": {"tag": cur_tag, "reward": cur.reward, "stderr": cur.stderr,
                     "pooled_tags": cur_tags if len(cur_tags) > 1 else None},
         "candidate": {"tag": args.candidate, "reward": cand.reward,
-                      "stderr": cand.stderr, "coverage": cand.coverage},
+                      "stderr": cand.stderr, "coverage": cand.coverage,
+                      "coverage_of_frozen_val": round(frozen_coverage, 4),
+                      "missing_from_frozen_val": missing_from_frozen_val},
         "gate": d.to_dict(),
         "paired_n": len(deltas or []),
         # What the delta was measured over. `restricted: false` means the edit's surface could


### PR DESCRIPTION
## Summary

#469 added `--ids` to `screen.py`/`evaluate.py` so the agent-optimize optimizer can restrict an eval to a subset of tasks it chose itself. That PR documented (in SKILL.md / references/algorithm.md) that `--ids` must never be used for the step-4 full-val accept gate, because a subset's `coverage` reads 1.0 to `gate_check.py`'s coverage guard — a prose-only warning against a footgun that would only surface hours into an unattended run, with nobody watching.

This hardens it in code:

- `harness.split_result_from_rollouts` reconstructs a `SplitResult` purely from whatever rollout files exist for a tag, so `SplitResult.coverage` is `n_scored / n_tasks_attempted` — tautologically ~1.0 for anything actually measured, blind to how much of the *frozen* split was skipped.
- New `gate_check._frozen_coverage()` computes coverage against the run's real frozen val split (`run_dir.read_splits().ids("val")`) instead. `gate_check.py` now passes `min(candidate_frozen_coverage, reference_frozen_coverage)` to `gate.decide()`, which already refuses to judge below `min_coverage` (0.6 default) — that machinery existed and worked correctly; it was just being fed the wrong number.
- A subset-gated candidate now comes back `verdict: indecisive` (not a false accept, not a false reject charged against stall) with `coverage_of_frozen_val` and `missing_from_frozen_val` in the JSON output for audit, regardless of *why* the subset happened (a deliberate `--ids`, or an eval that died partway through — the guard doesn't need to know which).
- A genuine full-val eval is unaffected: `coverage_of_frozen_val` is `1.0` exactly when it always was.

## Test plan

- [x] New `core/tests/test_gate_subset_guard.py`: a candidate evaluated on 2 of 5 frozen val ids comes back `indecisive`/`accept: false` even though its per-attempted-task `coverage` is `1.0` and its subset mean would otherwise clear the gate; a full-val eval of the same candidate is unaffected and accepts normally.
- [x] `cd core && python -m pytest tests/ -k "gate or coverage" -q` — 123 passed, 2 skipped
- [x] `cd core && python -m pytest tests/ -q` (full suite) — 1214 passed, 12 skipped, no failures
- [x] `test_agent_optimize_skill.py` (which executes every SKILL.md gate_check command against a real run dir via `check.py`) still passes — the full-val gate path is unchanged