### PR TITLE
test_merge_search: pin subprocess env to this checkout's cap_evolve

### DIFF
--- a/core/tests/test_merge_search.py
+++ b/core/tests/test_merge_search.py
@@ -18,12 +18,26 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[2]
 SCRIPTS = REPO / "skills" / "algorithms" / "agent-optimize" / "scripts"
+
+
+def _env() -> dict:
+    """Pin every subprocess this file spawns to THIS checkout's own cap_evolve, the same
+    way every other subprocess-spawning test here does (e.g.
+    ``test_round_requires_screen_ladder.py``). ``merge_search.py``, ``screen.py`` and
+    ``round.py`` each ``import _bootstrap`` to resolve ``cap_evolve``; without an explicit
+    ``CAPEVOLVE_CORE``, that falls back to walking up from the script's own path OR
+    whatever checkout happens to hold the ambient editable install — usually fine, but a
+    test should not depend on "usually".
+    """
+    return dict(os.environ, CAPEVOLVE_CORE=str(REPO / "core"),
+                CAPEVOLVE_SKILLS_DIR=str(REPO / "skills"))
 
 TOOLS_BASE = '''
 def fn_a(x):
@@ -150,7 +164,7 @@ def _run_dir_with_survivors(tmp_path: Path):
                        "--mechanism", f"fixes {tag}", "--evidence", "screen promoted it",
                        "--touches", "tools/tools.py",
                        *[a for t in tids for a in ("--task", t)]],
-                      capture_output=True, text=True, check=True)
+                      capture_output=True, text=True, check=True, env=_env())
     return run_dir, project, adapter
 
 
@@ -166,7 +180,7 @@ def _run_merge_search(run_dir, project, **extra):
                 cmd += [f"--{k}", item]
         else:
             cmd += [f"--{k}", str(v)]
-    p = subprocess.run(cmd, capture_output=True, text=True)
+    p = subprocess.run(cmd, capture_output=True, text=True, env=_env())
     assert p.returncode == 0, f"merge_search.py failed: {p.stdout}\n{p.stderr}"
     return json.loads(p.stdout)
 
@@ -227,7 +241,7 @@ def test_the_merge_result_goes_through_rounds_normal_gate_cascade(tmp_path):
         [sys.executable, str(SCRIPTS / "screen.py"), "--run-dir", str(run_dir.root),
          "--project", str(project), "--candidate", str(run_dir.root / "work" / ab["tag"]),
          "--tag", ab["tag"], "--tier", "1"],
-        capture_output=True, text=True)
+        capture_output=True, text=True, env=_env())
     assert screen.returncode == 0, f"screen.py failed on the merge candidate: {screen.stdout}\n{screen.stderr}"
     assert json.loads(screen.stdout)["decision"] == "promote", (
         "the merge should screen as a real improvement, not get killed pre-gate: "
@@ -237,7 +251,7 @@ def test_the_merge_result_goes_through_rounds_normal_gate_cascade(tmp_path):
         [sys.executable, str(SCRIPTS / "round.py"), "--run-dir", str(run_dir.root),
          "--project", str(project), "--candidates", ab["tag"], "--n-trials", "2",
          "--concurrency", "1"],
-        capture_output=True, text=True)
+        capture_output=True, text=True, env=_env())
     assert p.returncode == 0, f"round.py could not gate the merge candidate: {p.stdout}\n{p.stderr}"
     table = json.loads(p.stdout)
 


### PR DESCRIPTION
## Summary

audit-freedom flagged an intermittent `ModuleNotFoundError: cap_evolve` from a subprocess spawned by `core/tests/test_merge_search.py`. Confirmed pre-existing on clean `origin/main`.

Root cause: `merge_search.py`, `screen.py` and `round.py` each `import _bootstrap` to resolve `cap_evolve` (see `skills/algorithms/agent-optimize/scripts/_bootstrap.py`). Without an explicit `CAPEVOLVE_CORE` env var, that resolution falls back to walking up from the script's own path or to whatever checkout the machine's *ambient* editable install happens to point at — which is not guaranteed to be the checkout the test is running from, and (per `_bootstrap.py`'s own docstring) is exactly the class of bug that's bitten this before ("a checkout's own core outranks an ambient install... the only symptom was missing modules").

Every other subprocess-spawning test in this repo already pins this explicitly (`env=dict(os.environ, CAPEVOLVE_CORE=str(REPO / "core"), CAPEVOLVE_SKILLS_DIR=str(REPO / "skills"))` — see `test_round_requires_screen_ladder.py`, `test_agent_optimize_host.py`, 24+ others). `test_merge_search.py`'s three `subprocess.run` calls (staging `mechanisms.py` rows, invoking `merge_search.py`, and the `screen.py`/`round.py` gate cascade) were the one gap.

## Fix

Added the same `_env()` helper `test_merge_search.py`'s siblings use, and passed it to all three `subprocess.run` call sites.

## Test plan

- [x] `pytest core/tests/test_merge_search.py -v` — 3/3 pass.
- [x] Reproduced the class of failure by pointing the shared venv's editable `cap_evolve` install at a *different* checkout and rerunning without the fix (passed anyway in this environment — the ambient/self-heal fallback happened to still resolve correctly here — but the fix removes the dependency on that fallback entirely by pinning the env explicitly, matching the established pattern).
- [x] Full `core/tests/` suite: 1216 passed, 12 skipped, 7 failed — all 7 confirmed pre-existing on a clean `origin/main` checkout via `git stash` (in `test_eventstream.py`, `test_run_ending_signal.py`, `test_subsample.py`), unrelated to `test_merge_search.py` and out of scope for this fix.