### PR TITLE
Fix report/dashboard transcript crash and abandoned FINAL-eval seal waste

### DIFF
--- a/core/cap_evolve/dashboard.py
+++ b/core/cap_evolve/dashboard.py
@@ -181,9 +181,15 @@ def _read_jsonl(path: Path | None) -> list[dict]:
             line = line.strip()
             if line:
                 try:
-                    out.append(json.loads(line))
+                    rec = json.loads(line)
                 except json.JSONDecodeError:
                     continue
+                # A line that decodes to valid JSON but not an object (e.g. a bare
+                # string) is not a record any caller here can use — every caller
+                # treats each line as a dict (``ev.get(...)``); skip it like a
+                # malformed line rather than handing callers a non-dict to crash on.
+                if isinstance(rec, dict):
+                    out.append(rec)
     return out
 
 

--- a/core/tests/test_agent_optimize_host.py
+++ b/core/tests/test_agent_optimize_host.py
@@ -939,6 +939,60 @@ def test_seal_only_also_reports_an_abandoned_round(tmp_path):
         f"--seal-only sealed the run and said nothing about the abandoned round: {out}")
 
 
+# --- dangling FINAL eval: eval_start with no matching evaluate ----------------
+
+
+def test_a_dangling_final_eval_with_no_matching_evaluate_is_reported(tmp_path):
+    """The optimizer's own driving session can open a sealed-test eval and have its turn
+    or process end before the matching `evaluate` event is ever logged — no crash, no
+    error, just a Bash call that outlived the turn that launched it. Measured on three
+    separate runs: `eval_start(split=test, tag=FINAL)` on disk, no `evaluate` after it, no
+    `final.json`. The abandoned attempt also leaves a partial rollout on disk, which is
+    exactly what makes the host's own seal backstop fail too (`begin_test_attempt` refuses
+    to re-score a test split that already has rollouts on it) — the seal was never
+    consumed, just wasted.
+    """
+    project = _project(tmp_path)
+    run_dir = _run_dir(tmp_path)
+
+    run_dir.log_event("eval_start", split="test", tag="FINAL", n_tasks=1, n_trials=1,
+                      workers=1, rollouts=1)
+    # The partial artifact the abandoned attempt leaves behind — enough to make the
+    # host's own seal backstop refuse to re-score test, same as a real interrupted eval.
+    (run_dir.rollouts / "test").mkdir(parents=True, exist_ok=True)
+    (run_dir.rollouts / "test" / "task0__FINAL__t0.json").write_text("{}", encoding="utf-8")
+
+    out = _host("--run-dir", str(run_dir.root), "--project", str(project), "--seal-only",
+                expect_rc=1)
+
+    assert out["sealed"] is False, (
+        f"the pre-existing partial test rollout should have blocked the seal, not {out}")
+    dangling = out.get("dangling_eval")
+    assert dangling is not None, f"the open eval_start was not detected: {out}"
+    assert dangling["split"] == "test" and dangling["tag"] == "FINAL", dangling
+
+    events = [json.loads(l) for l in
+              (run_dir.root / "events.jsonl").read_text(encoding="utf-8").splitlines() if l]
+    assert any(e.get("kind") == "eval_abandoned" and e.get("split") == "test"
+               and e.get("tag") == "FINAL" for e in events), (
+        f"the abandoned eval was not flagged in events.jsonl: {events}")
+
+
+def test_an_eval_start_followed_by_its_evaluate_is_not_flagged_as_dangling(tmp_path):
+    """The backstop must be silent once the matching close event is on record."""
+    project = _project(tmp_path)
+    run_dir = _run_dir(tmp_path)
+
+    run_dir.log_event("eval_start", split="val", tag="cand_1", n_tasks=1, n_trials=1,
+                      workers=1, rollouts=1)
+    run_dir.log_event("evaluate", split="val", tag="cand_1", reward=0.5, stderr=0.01)
+
+    out = _host("--run-dir", str(run_dir.root), "--project", str(project), "--seal-only")
+
+    assert out.get("dangling_eval") is None, (
+        f"a closed eval_start/evaluate pair was flagged as abandoned: {out}")
+
+
 # --- run 32861747778: round 1 died on the interpreter, then on concurrency ----
 
 

--- a/core/tests/test_dashboard_host_and_algo_extra.py
+++ b/core/tests/test_dashboard_host_and_algo_extra.py
@@ -117,6 +117,33 @@ def test_transcript_with_string_message_system_line_does_not_crash_reduce_run():
     assert "After the bad line" in hs["transcript_turns"][1]["text"]
 
 
+def test_transcript_line_that_is_a_bare_json_string_does_not_crash():
+    """``_read_jsonl`` parses each line with ``json.loads``, which happily accepts a
+    bare string (e.g. a truncated/garbled write leaving just a JSON-quoted fragment)
+    as valid JSON — but not a dict. Every consumer (``_transcript_turn`` here, and
+    events.jsonl's readers) calls ``.get()`` on each parsed line unconditionally, so a
+    non-dict line used to raise the same 'str' object has no attribute 'get' crash
+    #455 fixed for a string *message*, just one level up: a string *line*."""
+    rd, dashboard = _make_run()
+    hdir = rd.root / "host"
+    hdir.mkdir()
+    lines = [
+        json.dumps({"type": "assistant", "timestamp": "2026-09-03T12:00:00Z",
+                    "message": {"content": [{"type": "text", "text": "Before the bad line."}]}}),
+        json.dumps("just a bare string, not an object"),
+        json.dumps({"type": "assistant", "timestamp": "2026-09-03T12:00:02Z",
+                    "message": {"content": [{"type": "text", "text": "After the bad line."}]}}),
+    ]
+    (hdir / "transcript.jsonl").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    reduced = dashboard.reduce_run(rd)  # must not raise
+    hs = reduced["summary"]["host_session"]
+    assert hs["transcript_total_lines"] == 2  # the bare-string line is not a record
+    assert len(hs["transcript_turns"]) == 2
+    assert "Before the bad line" in hs["transcript_turns"][0]["text"]
+    assert "After the bad line" in hs["transcript_turns"][1]["text"]
+
+
 def test_oversized_transcript_is_not_parsed_just_pointed_at():
     """A multi-megabyte transcript must never be read into memory whole and rendered —
     the section links out to the real path instead."""

--- a/skills/algorithms/agent-optimize/SKILL.md
+++ b/skills/algorithms/agent-optimize/SKILL.md
@@ -267,8 +267,8 @@ mechanism-vs-artifact designs, gating the sum not each addend, the sign test bel
 
 Spend is not a CLI subcommand: **every 2–3 rounds** (and always before a fan-out) run `spend.py`.
 Everything it reports is re-read from the run dir, never a total in your head — which keeps a `$6.00`
-cap from becoming `$6.01`. (The Stop hook re-nudges you until finalized; a `PostToolUse` hook
-re-injects the same predicates on a cadence even if you skip `spend.py` — `goal_reminder.py`.)
+cap from becoming `$6.01`. (The Stop hook re-nudges you until finalized; `goal_reminder.py`
+re-injects the same predicates even if you skip `spend.py`.)
 Stop when `recommendation` is `stop`, then produce the run's one honest table — seed vs best on
 **val**, on **train** when the spec defines one worth reporting, and on the **sealed test** split
 scored once:
@@ -284,7 +284,7 @@ interchangeable with `phases/finalize/scripts/run.py`. Report its four refusals 
 generalisation**, with the overlap counted; a negative `screen_ledger.net_rollouts` says screening was
 pure overhead; `best_id == "seed"` is a **null result with a diagnosed cause**, not a 0.000 gain.
 (Sealing is that phase script, **not a CLI subcommand**; a second finalize raises `TestSealError`.)
-No finalize, no result.
+Wait for it to exit, or the seal is wasted. No finalize, no result.
 
 ## Honesty invariants that are yours by hand
 

--- a/skills/algorithms/agent-optimize/references/algorithm.md
+++ b/skills/algorithms/agent-optimize/references/algorithm.md
@@ -346,6 +346,33 @@ delta is 0 *by construction* and must be reported as a null result with a diagno
 `--train auto` also declines to pay for a train evaluation whose ids equal val's, because the
 numbers would be a copy.
 
+### Never abandon a running FINAL eval
+
+`measure.py` opens the sealed test split by logging `eval_start(split=test, tag=FINAL)` before
+it starts scoring — the same pairing every eval in the run uses (`harness.py`'s own docstring:
+"an eval_start with no evaluate after it is an evaluation that never returned"). The test seal
+is single-use, so this is the one eval in the whole run where abandoning it mid-flight is not
+just a wasted wait:
+
+- If your turn or process ends while `measure.py`/`finalize.py` is still running, nothing is
+  left to read `final.json` even if the eval finishes on its own a minute later — the same
+  failure mode `host.py`'s Unattended briefing warns about for a round's gate, just at the
+  one point in the run where it also costs the seal.
+- Worse than a mid-round eval: the abandoned attempt's PARTIAL test rollouts are enough to make
+  a retry refuse. `begin_test_attempt` (`rundir.py`) sees test already has rollout files on
+  disk and raises `TestSealError`, because it cannot tell "crashed before scoring" from
+  "crashed after scoring but before the result was read" — the second case must not be
+  silently re-scored, so it isn't, even when the first case is what actually happened.
+- Measured on three separate runs: `eval_start(split=test, tag=FINAL)` on disk, no matching
+  `evaluate`, no `final.json` — the seal was never consumed, just spent on nothing. `host.py`
+  flags this shape as an `eval_abandoned` event and reports it in `dangling_eval` when its own
+  seal backstop (`_seal`) also fails for exactly this reason, so at least the gap is visible
+  instead of silently read as "the run just never finalized."
+
+So: run `measure.py` in the foreground, and do not end your turn — or let a headless session
+exit — until it has printed its result. If you are running low on turns/budget, that is a
+reason to run it SOONER, not to launch it and move on.
+
 ## Gate as evidence, not a verdict
 
 The statistics come from two scripts, and it matters which one prints what: `gate_check.py` prints

--- a/skills/algorithms/agent-optimize/scripts/host.py
+++ b/skills/algorithms/agent-optimize/scripts/host.py
@@ -524,6 +524,15 @@ Three consequences worth being explicit about:
    once) and the report phase, as SKILL.md's "Stop & seal" section shows. A run with no
    finalize has no result. If you are running out of budget, stop optimizing and seal —
    sealing what you have beats one more candidate.
+
+   `measure.py` is the *last* long-running eval you launch — it opens the sealed test split
+   (`eval_start(split=test, tag=FINAL)`), and this seal is single-use. Rule 3 below applies
+   here MOST of all: stay in the foreground until it exits. Ending your turn while it is
+   still running does not just lose the number — the abandoned attempt's partial rollouts
+   then make even a RETRY refuse (`begin_test_attempt` sees test already has rollouts on it),
+   so the seal is wasted, not merely delayed. Measured on three separate runs: an
+   `eval_start(split=test, tag=FINAL)` with no matching `evaluate` and no `final.json` ever
+   written.
 2. **A null result is a valid outcome, honestly reported.** If nothing beat the baseline
    through the gate, say so and seal anyway. Do not lower the gate, gate on a screen
    subset, or present a screen `promote` as an accept to manufacture a gain.
@@ -632,6 +641,60 @@ def _unbooked_rounds(run_dir: Path) -> list[dict]:
                           "parent": (payload.get("parent") or {}).get("tag"),
                           "log": log.name})
     return found
+
+
+def _dangling_eval(run_dir: Path) -> dict | None:
+    """The last ``eval_start`` with no matching ``evaluate`` for the same (split, tag).
+
+    ``harness.py``'s own docstring names the invariant: "an eval_start with no evaluate
+    after it is an evaluation that never returned." Measured on three separate runs: the
+    driver issued ``eval_start(split=test, tag=FINAL)`` (the sealed test eval `measure.py`/
+    `finalize.py` opens with — see ``harness.finalize``) near the end of its turns and the
+    process exited before the matching ``evaluate`` was ever logged — no ``final.json``, no
+    error, just a Bash call that outlived the turn that launched it. Reported here so the
+    host's run summary (and the `incomplete` diagnosis) can say which eval was abandoned
+    instead of the operator diffing rollout files by hand.
+
+    Not benchmark-specific: split/tag are read straight off the events, whatever adapter or
+    algorithm wrote them.
+    """
+    starts: dict[tuple, dict] = {}
+    try:
+        with (run_dir / "events.jsonl").open(encoding="utf-8") as f:
+            for line in f:
+                try:
+                    ev = json.loads(line)
+                except Exception:  # noqa: BLE001 — a torn line carries no eval state
+                    continue
+                if not isinstance(ev, dict):
+                    continue
+                kind = ev.get("kind")
+                key = (ev.get("split"), ev.get("tag"))
+                if kind == "eval_start":
+                    starts[key] = ev
+                elif kind == "evaluate":
+                    starts.pop(key, None)
+    except OSError:
+        return None
+    if not starts:
+        return None
+    # Last one issued, by event time — an earlier dangling start that a later retry of the
+    # SAME (split, tag) resolved is not itself abandoned; only the most recent open one is.
+    last = max(starts.values(), key=lambda e: e.get("t") or 0)
+    return last
+
+
+def _log_eval_abandoned(run_dir: Path, dangling_eval: dict) -> None:
+    """Flag a dangling ``eval_start`` in ``events.jsonl`` so the run's audit log names it
+    instead of leaving it discoverable only by hand-diffing eval_start/evaluate pairs."""
+    try:
+        from cap_evolve import RunDir as _RunDir
+
+        _RunDir.open(run_dir).log_event(
+            "eval_abandoned", split=dangling_eval.get("split"),
+            tag=dangling_eval.get("tag"), started_at=dangling_eval.get("t"))
+    except Exception:  # noqa: BLE001 — flagging the gap must not crash a run report
+        pass
 
 
 def _seal(run_dir: Path, project: Path, spec: dict, *, timeout: float | None) -> dict:
@@ -837,6 +900,9 @@ def main(argv=None) -> int:
         # is the path most likely to be sitting on an abandoned round. Reporting it only on
         # the full host path would hide it from exactly the reader who came looking.
         out["unbooked_rounds"] = _unbooked_rounds(run_dir)
+        out["dangling_eval"] = _dangling_eval(run_dir) if not out["sealed"] else None
+        if out["dangling_eval"] is not None:
+            _log_eval_abandoned(run_dir, out["dangling_eval"])
         print(json.dumps({"run_dir": str(run_dir), "seal_only": True, **out}, indent=2))
         return 0 if out["sealed"] else 1
 
@@ -1070,6 +1136,13 @@ def main(argv=None) -> int:
     # check made before sealing would have found an empty work/ and reported nothing.
     unbooked = _unbooked_rounds(run_dir)
 
+    # Also after the seal: `_seal` may itself have just closed the open eval (e.g. the agent's
+    # FINAL attempt was still running and finished during measure.py, same as an unbooked
+    # round above). Only an eval still open AFTER the seal attempt is genuinely abandoned.
+    dangling_eval = _dangling_eval(run_dir) if not seal.get("sealed") else None
+    if dangling_eval is not None:
+        _log_eval_abandoned(run_dir, dangling_eval)
+
     # An agent that stopped with rounds left is a DEFECT, not a finished run — and it must not
     # read as completion. Measured: one run booked 1 of 3 rounds with a higher-scoring
     # candidate already evaluated but never committed, and reported success. The host cannot
@@ -1147,6 +1220,13 @@ def main(argv=None) -> int:
                       + (f" after {num_turns} turns" if num_turns else "")
                       + evidence + " — " + fix)
 
+    if dangling_eval is not None:
+        note = (f"the agent opened an eval (split={dangling_eval.get('split')!r}, "
+                f"tag={dangling_eval.get('tag')!r}) and its turn/process ended before the "
+                "matching evaluate ever logged — that eval was abandoned mid-flight, not "
+                "backgrounded successfully; logged as eval_abandoned in events.jsonl")
+        incomplete = f"{incomplete}; {note}" if incomplete else note
+
     out = {
         "run_dir": str(run_dir),
         "agent": args.agent,
@@ -1160,6 +1240,7 @@ def main(argv=None) -> int:
         "rounds_booked": rounds_done,
         "rounds_budget": rounds_budget,
         "unbooked_rounds": unbooked,
+        "dangling_eval": dangling_eval,
         "incomplete": incomplete,
         "seconds": round(seconds, 3),
         "usd": usd,


### PR DESCRIPTION
## Summary

Two previously-flagged, unfixed bugs (both general — not tau2-specific):

**Bug A — report.py `dashboard_error`.** `cap-evolve report` on a real run dir could hit `"dashboard_error": "'str' object has no attribute 'get'"`. Root cause: `dashboard._read_jsonl()` (shared by `host/transcript.jsonl` and `events.jsonl`) parses each line with `json.loads()`, which happily accepts a bare JSON string as valid JSON — not just malformed lines. Every caller then does unconditional `.get()` on each parsed line. Same bug class as #455 (a string-typed `message` *field*), one level up (a string *line*). Fixed once in `_read_jsonl`, the shared choke point for every jsonl consumer in `dashboard.py`.

**Bug B — dangling FINAL eval with no matching result.** Measured on three separate runs: the optimizer's own driving CLI session opened the sealed test eval (`eval_start(split=test, tag=FINAL)`) near the end of its turns, then the turn/process ended before the matching `evaluate` event was logged. No `final.json`, no error. Worse than an abandoned mid-round gate: the abandoned attempt's partial test rollouts then make even `host.py`'s own guaranteed-seal backstop refuse (`begin_test_attempt` sees test already has rollouts and raises `TestSealError`), so the run ends unsealed and the one-time seal is wasted, not delayed.

  - Added explicit "wait for it to exit before ending your turn" guidance in `SKILL.md`'s Stop & seal section, `host.py`'s Unattended briefing, and a new subsection in `references/algorithm.md` explaining why (single-use seal + no honest retry once partial rollouts exist).
  - Added a code-level backstop: `host.py._dangling_eval()` scans `events.jsonl` for the last `eval_start` with no matching `evaluate` (keyed generically by split/tag). When the run ends unsealed with one still open, `host.py` logs an `eval_abandoned` event and surfaces it in both the full host path and `--seal-only`'s operator-facing output.

## Test plan

- [x] `core/tests/test_dashboard_host_and_algo_extra.py` — new regression test for a bare-string transcript.jsonl line (reproduced the exact crash before the fix).
- [x] `core/tests/test_agent_optimize_host.py` — new tests for `_dangling_eval` detection + `eval_abandoned` logging, and that a closed eval_start/evaluate pair is not flagged.
- [x] `python -m pytest core/tests/ -q` — 1208 passed, 12 skipped, 7 pre-existing failures unrelated to this change (confirmed present on a clean `origin/main` checkout too: `test_eventstream.py` x2, `test_run_ending_signal.py` x3, `test_subsample.py` x2).
- [x] `core/tests/test_skill_authoring_lint.py` passes (SKILL.md kept within the repo's 5000-token body budget after the added guidance).