### PR TITLE
docs(agent-optimize): clarify JOURNAL.md write target

### DIFF
--- a/skills/algorithms/agent-optimize/SKILL.md
+++ b/skills/algorithms/agent-optimize/SKILL.md
@@ -189,8 +189,8 @@ after which `grow.py` buys trials on the SAME candidate, re-gating at the pooled
 `references/algorithm.md`.
 
 **6. Write the handover before ending this round** — append one `## Iteration <cid>` entry below
-`JOURNAL.md`'s marker: what you tried, why, what the numbers said. The only thing the NEXT round reads,
-and `commit.py` folds in only what you wrote (`references/algorithm.md`).
+`work/$TAG/JOURNAL.md`'s marker (never `$R/JOURNAL.md`, framework-owned): what you tried, why, what
+the numbers said. The only thing the NEXT round reads (`references/algorithm.md`).
 
 ## Parallel round (optional)
 

--- a/skills/algorithms/agent-optimize/references/algorithm.md
+++ b/skills/algorithms/agent-optimize/references/algorithm.md
@@ -300,13 +300,17 @@ cap turns "maybe next round" into a bounded, auditable cost rather than an open-
 the seed candidate before round 1, and re-seeds it onto whichever candidate is `$BEST` after
 every `commit.py` call, so it is always present at the start of a round regardless of how many
 rounds came before. It is YOUR file (append-only, never reset): the run-level copy at
-`$R/JOURNAL.md` accumulates one entry per iteration, accepted and rejected alike.
+`$R/JOURNAL.md` accumulates one entry per iteration, accepted and rejected alike — but that
+accumulation is done BY THE FRAMEWORK (`harness._reconcile_journal`), never by you directly.
+Edit `$R/work/$TAG/JOURNAL.md` only; never append to `$R/JOURNAL.md` yourself (e.g. via a bash
+`cat >>`) — it is rewritten wholesale on the next `_seed_journal`/`_reconcile_journal` pass, so a
+direct edit there is invisible to the parser and gets clobbered.
 
 The write protocol:
 
 1. Read the WHOLE file before proposing — not just the last entry — so you build on every prior
    attempt and never re-test a refuted idea.
-2. Append your new entry BELOW the marker line
+2. Append your new entry BELOW the marker line, in `$R/work/$TAG/JOURNAL.md`
    `<!-- cap-evolve:journal-append-below — add your Iteration entry under this line; do not edit
    anything above it -->`. Never edit or delete anything above the marker.
 3. Use the heading `## Iteration <candidate id> — <one-line headline of what you tried>`,


### PR DESCRIPTION
## Summary
- An agent-optimize session was appending handover entries to the run-root `.capevolve/JOURNAL.md` via `bash cat >>`, instead of editing `work/$TAG/JOURNAL.md` — the per-candidate file `harness._seed_journal` seeds with the append marker and `_journal_tail`/`_reconcile_journal` actually parse.
- The run-root file is framework-owned and gets rewritten on the next `_seed_journal`/`_reconcile_journal` pass, so those entries were invisible to the parser and silently clobbered — surfacing as repeated `optimizer_context_warning` ("empty handover") events even though the optimizer had written real, well-formatted content.
- Made the write target unambiguous in `SKILL.md` step 6 and `references/algorithm.md`'s JOURNAL.md write protocol section. Doc-only change; no harness code touched.

## Test plan
- [x] `python -m pytest core/tests/test_agent_optimize_host.py::test_host_script_exists_and_is_documented_where_it_belongs core/tests/test_skill_authoring_lint.py::test_the_repo_has_no_authoring_violations -q` — passes (had to trim wording twice to stay under the 5000-token SKILL.md body budget).
- [x] Full `core/tests` suite: 1236 passed, 12 skipped, 2 failed (`test_dashboard_stream_reexports_the_shared_helper`, `test_follower_thread_reports_instead_of_dying_silently`). Both failures reproduce identically on a clean `origin/main` checkout run in isolation the same way, and both pass when run individually in this branch — pre-existing full-suite test-order flakiness, unrelated to this doc-only change.