### PR TITLE
agent-optimize: require merging disjoint-cluster accepted candidates before finalize

### DIFF
--- a/core/tests/test_merge_compliance_check.py
+++ b/core/tests/test_merge_compliance_check.py
@@ -1,0 +1,118 @@
+"""merge_search.check_merge_compliance — an audit signal, not an enforcement.
+
+SKILL.md requires the agent-mode optimizer to run merge_search.py on its accepted
+candidates before any end-of-run measurement whenever 2+ of them target disjoint task
+clusters, but nothing in the framework can force that (host.py owns no algorithm
+decisions). This is the code-level compliance CHECK measure.py runs at finalize time —
+same idiom as round.py's existing agent_optimize_compliance event for the screen ladder:
+it never blocks, it only makes an ignored requirement visible in events.jsonl.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPTS = REPO / "skills" / "algorithms" / "agent-optimize" / "scripts"
+
+
+def _load_merge_search():
+    spec = importlib.util.spec_from_file_location("merge_search", SCRIPTS / "merge_search.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.path.insert(0, str(SCRIPTS))
+    assert spec and spec.loader
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _run_dir(tmp_path):
+    from cap_evolve import Budget, RunDir, harness
+    from cap_evolve.skillcheck import SyntheticAdapter, seed_capability_dir
+
+    adapter = SyntheticAdapter(n=8)
+    seed = seed_capability_dir(tmp_path, level=0)
+    run_dir = RunDir.create(tmp_path / ".capevolve", ts="ci",
+                            budget=Budget(max_iterations=10, stall=10))
+    harness.ensure_splits(adapter, run_dir, seed=0)
+    harness.baseline(adapter, seed, run_dir=run_dir)
+    return run_dir
+
+
+def _accept_node(run_dir, tag, *, parents=("seed",), edit_kind="code"):
+    from cap_evolve import graph
+    graph.append_node(run_dir, node_id=tag, parents=list(parents), status="accepted",
+                      val_mean=0.6, edit_kind=edit_kind)
+
+
+def _record_targets(run_dir, tag, task_ids):
+    line = json.dumps({"owner": tag, "status": "proposed", "tasks": list(task_ids)})
+    with (run_dir.root / "mechanisms.jsonl").open("a", encoding="utf-8") as f:
+        f.write(line + "\n")
+
+
+def test_flags_two_accepted_disjoint_clusters_with_no_merge_attempt(tmp_path):
+    ms = _load_merge_search()
+    run_dir = _run_dir(tmp_path)
+
+    _accept_node(run_dir, "cand_a")
+    _record_targets(run_dir, "cand_a", ["t0", "t1"])
+    _accept_node(run_dir, "cand_b")
+    _record_targets(run_dir, "cand_b", ["t2", "t3"])
+
+    warning = ms.check_merge_compliance(run_dir)
+    assert warning is not None
+    assert warning["reason"] == "merge_skipped_with_multiple_clusters"
+    assert warning["accepted_candidates"] == ["cand_a", "cand_b"]
+    assert warning["disjoint_pairs"] == [["cand_a", "cand_b"]]
+
+
+def test_no_warning_when_a_merge_was_already_attempted(tmp_path):
+    ms = _load_merge_search()
+    run_dir = _run_dir(tmp_path)
+
+    _accept_node(run_dir, "cand_a")
+    _record_targets(run_dir, "cand_a", ["t0", "t1"])
+    _accept_node(run_dir, "cand_b")
+    _record_targets(run_dir, "cand_b", ["t2", "t3"])
+    # A merge node exists (built by merge_search.py, committed via commit.py --parents) —
+    # rejected or accepted, it still proves a merge was ATTEMPTED between these clusters.
+    _accept_node(run_dir, "merge_a_b", parents=("cand_a", "cand_b"), edit_kind="merge")
+
+    assert ms.check_merge_compliance(run_dir) is None
+
+
+def test_no_warning_with_fewer_than_two_accepted_candidates(tmp_path):
+    ms = _load_merge_search()
+    run_dir = _run_dir(tmp_path)
+
+    _accept_node(run_dir, "cand_a")
+    _record_targets(run_dir, "cand_a", ["t0", "t1"])
+
+    assert ms.check_merge_compliance(run_dir) is None
+
+
+def test_no_warning_when_accepted_clusters_are_not_disjoint(tmp_path):
+    ms = _load_merge_search()
+    run_dir = _run_dir(tmp_path)
+
+    _accept_node(run_dir, "cand_a")
+    _record_targets(run_dir, "cand_a", ["t0", "t1"])
+    _accept_node(run_dir, "cand_b")
+    _record_targets(run_dir, "cand_b", ["t1", "t2"])  # shares t1 with cand_a
+
+    assert ms.check_merge_compliance(run_dir) is None
+
+
+def test_no_warning_when_accepted_candidates_have_no_recorded_targets(tmp_path):
+    """A candidate with no mechanisms.jsonl row and no cluster_ids is unknowable, not
+    assumed disjoint — the check must never manufacture a cluster out of missing data."""
+    ms = _load_merge_search()
+    run_dir = _run_dir(tmp_path)
+
+    _accept_node(run_dir, "cand_a")
+    _accept_node(run_dir, "cand_b")
+
+    assert ms.check_merge_compliance(run_dir) is None

--- a/skills/algorithms/agent-optimize/SKILL.md
+++ b/skills/algorithms/agent-optimize/SKILL.md
@@ -252,7 +252,7 @@ a syntactic property; composition is an empirical one.
 **Measure step 2's null control twice**: the gap between two byte-identical parents is the round's bar, and a
 bar smaller than that is not a gate. `round.py` does that, and reuses the replicates while `best_id` is
 unchanged (`control_reuse`). Two more rules; the rest — ceiling arithmetic, the binomial floor,
-mechanism-vs-artifact designs, gating the sum not each addend, the sign test below the floor — is in
+mechanism-vs-artifact designs, gating the sum, the sign test — is in
 [`references/measured-lessons.md`](references/measured-lessons.md).
 
 1. **Explore fast, gate slow, gate ALONE.** The load knob is *total in-flight requests* (K processes at
@@ -266,10 +266,10 @@ mechanism-vs-artifact designs, gating the sum not each addend, the sign test bel
 
 ## Stop & seal, then MEASURE (once)
 
-Spend is not a CLI subcommand: **every 2–3 rounds** (and always before a fan-out) run `spend.py`.
+**Before you stop, merge disjoint-cluster `accepted` candidates — required** (`algorithm.md`
+§Merging). Spend is not a CLI subcommand: **every 2–3 rounds** run `spend.py`.
 Everything it reports is re-read from the run dir, never a total in your head — which keeps a `$6.00`
-cap from becoming `$6.01`. (The Stop hook re-nudges you until finalized; `goal_reminder.py`
-re-injects the same predicates even if you skip `spend.py`.)
+cap from becoming `$6.01`. (The Stop hook re-nudges until finalized; `goal_reminder.py` re-injects.)
 Stop when `recommendation` is `stop`, then produce the run's one honest table — seed vs best on
 **val**, on **train** when the spec defines one worth reporting, and on the **sealed test** split
 scored once:

--- a/skills/algorithms/agent-optimize/references/algorithm.md
+++ b/skills/algorithms/agent-optimize/references/algorithm.md
@@ -541,6 +541,32 @@ moved, and the measurement cannot say the edit did it. Do not redesign an edit b
 there, and do not cite one as a regression — re-measure it, or ignore it. At one trial per task every
 per-task SE is 0, the bar collapses to `eps`, and the classification is exactly what it always was.
 
+## Merging accepted candidates before you finalize
+
+`merge_search.py` (#438) exists precisely because run_agentoptv3/run_agentoptv4 produced 3-6
+narrow, single-issue candidates per round and never combined them (see its own module
+docstring). SKILL.md's "Before finalizing" step makes running it, once 2+ accepted candidates
+target disjoint clusters, a REQUIRED step rather than an available tool nobody reaches for under
+time pressure — the same gap that let `screen.py` sit unused for a whole run before its own
+compliance event existed (#420 item 4).
+
+Practically: `--survivors` takes any tag under `$R/work/`, whether or not it individually cleared
+the gate — an `accepted` graph node works exactly like a screening survivor for this purpose, since
+disjointness is a property of what the edits TOUCHED, not of how they were judged. `--targets`
+(or a `mechanisms.jsonl` row per tag) supplies each one's task ids; a tag with neither is skipped,
+never silently merged on an empty objective. The merge itself pays `integrate.py`/`funcmerge.py`,
+same as any hand-driven merge (per-task-fanout.md); a real edit collision (both branches touch the
+same function differently) is refused, never force-merged.
+
+`measure.py` runs `merge_search.check_merge_compliance` at the start of every finalize-time call:
+it reads `graph.jsonl` for `accepted` nodes, their target ids (`cluster_ids` when populated, else
+the same `mechanisms.jsonl` fallback `merge_search.py` itself uses), and whether any node anywhere
+in the graph carries `edit_kind == "merge"`. Two or more accepted candidates with disjoint targets
+and NO merge attempt anywhere in the run logs `merge_compliance_warning` to `events.jsonl` — visible
+in the dashboard's activity log like any other event. It never blocks: host.py owns no algorithm
+decisions (the "orchestration freedom" invariant), so this is an audit signal for the same reason
+`agent_optimize_compliance` is one for the screen ladder, not a second enforcement mechanism.
+
 ## Caveats
 
 - With `train == val` the val gate is a *fit*, not a held-out check — only the sealed test

--- a/skills/algorithms/agent-optimize/scripts/measure.py
+++ b/skills/algorithms/agent-optimize/scripts/measure.py
@@ -43,6 +43,8 @@ from cap_evolve.gate import decide
 from cap_evolve.loop import SplitResult
 from cap_evolve.specfile import spec_for_run
 
+import merge_search
+
 
 def _num(sr: SplitResult | None) -> dict:
     if sr is None:
@@ -172,6 +174,14 @@ def main(argv=None) -> int:
 
     run_dir = RunDir.open(Path(args.run_dir))
     project = Path(args.project)
+
+    # Compliance signal (SKILL.md: merge disjoint-cluster accepted candidates before any
+    # end-of-run measurement) — see merge_search.check_merge_compliance's own docstring.
+    # Never blocks; just makes an ignored requirement visible in events.jsonl/dashboard.
+    merge_warning = merge_search.check_merge_compliance(run_dir)
+    if merge_warning:
+        run_dir.log_event("merge_compliance_warning", **merge_warning)
+
     spec = spec_for_run(run_dir, project)
     n_trials = args.n_trials or int(spec.get("num_trials") or 1)
     k_se = args.k_se if args.k_se is not None else float(spec.get("gate_k_se") or 1.0)

--- a/skills/algorithms/agent-optimize/scripts/merge_search.py
+++ b/skills/algorithms/agent-optimize/scripts/merge_search.py
@@ -171,6 +171,64 @@ def _integrate(run_dir: Path, project: Path, work: Path, base_dir: Path, a: str,
     return {"error": (p.stderr or p.stdout)[-1200:], "rc": p.returncode}
 
 
+def check_merge_compliance(run_dir) -> dict | None:
+    """Audit signal, not an enforcement: did this run merge disjoint-cluster accepted
+    candidates before finalizing?
+
+    SKILL.md requires the optimizer to run this script on its accepted candidates before
+    any end-of-run measurement, whenever 2+ of them target disjoint task clusters — the
+    exact shape this script exists to combine (module docstring above). Nothing in the
+    framework can force the agent to actually do that (host.py owns no algorithm
+    decisions), so this is the same kind of code-level compliance signal
+    ``round.py``'s ``agent_optimize_compliance`` event already logs for the screen
+    ladder: it never blocks, it only makes the omission visible in ``events.jsonl`` and
+    the dashboard's activity log.
+
+    Reads ``graph.jsonl`` for ``status == "accepted"`` nodes and each one's target task
+    ids — its own ``cluster_ids`` if a caller has populated that field, else the same
+    ``mechanisms.jsonl`` fallback this script's own ``main()`` uses to pick merge targets
+    (`_mechanisms_targets`). Two or more accepted candidates whose target sets are
+    pairwise DISJOINT, with no ``edit_kind == "merge"`` node anywhere in the graph, means
+    the run's "best" is whichever single cluster's fix happened to score highest, never a
+    combination of them.
+
+    Returns ``None`` when there is nothing to flag (fewer than 2 accepted candidates with
+    known targets, none of their target sets are disjoint, or a merge was already
+    attempted this run), else a dict of fields for ``RunDir.log_event``.
+    """
+    import _bootstrap  # noqa: F401
+    from cap_evolve import graph as graph_mod
+
+    nodes = graph_mod.read_nodes(run_dir)
+    accepted = [n for n in nodes if n.get("status") == "accepted"]
+
+    targets: dict[str, list[str]] = {}
+    for n in accepted:
+        tag = n.get("id")
+        if not tag:
+            continue
+        ids = n.get("cluster_ids") or _mechanisms_targets(run_dir.root, tag)
+        if ids:
+            targets[tag] = sorted(set(ids))
+    if len(targets) < 2:
+        return None
+
+    disjoint_pairs = [[a, b] for a, b in itertools.combinations(sorted(targets), 2)
+                      if not (set(targets[a]) & set(targets[b]))]
+    if not disjoint_pairs:
+        return None
+
+    if any(n.get("edit_kind") == "merge" for n in nodes):
+        return None  # a merge was attempted this run — nothing to flag
+
+    return {
+        "reason": "merge_skipped_with_multiple_clusters",
+        "accepted_candidates": sorted(targets),
+        "targets": targets,
+        "disjoint_pairs": disjoint_pairs,
+    }
+
+
 def build_parser() -> argparse.ArgumentParser:
     ap = argparse.ArgumentParser(prog="merge_search")
     ap.add_argument("--run-dir", required=True)


### PR DESCRIPTION
## Summary

- `merge_search.py` (#438) already exists to combine disjoint-cluster survivors via `integrate.py`/`funcmerge.py`, but nothing required the optimizer's agent session to actually invoke it before sealing test — so a run's reported "best" could be whichever single-cluster fix happened to score highest, never a genuine combination of accepted candidates that each fixed a different subset of tasks.
- `SKILL.md` / `references/algorithm.md`: makes running `merge_search.py` on 2+ accepted disjoint-cluster candidates (then gating the merge like any candidate) an explicit, **required** step before any end-of-run measurement, not just an available tool nobody reaches for under time pressure.
- `merge_search.check_merge_compliance()`: a new function that reads `graph.jsonl` for accepted candidates with pairwise-disjoint target task ids and checks whether any `edit_kind == "merge"` node exists anywhere in the graph — the same kind of code-level audit signal `round.py`'s existing `agent_optimize_compliance` event provides for the screen ladder. **It never blocks or forces a decision** — this is an agent-driven framework where `host.py` owns no algorithm decisions, so enforcement stays a prompt-level requirement; this is only the observability half.
- `measure.py` runs the check at finalize time and logs a `merge_compliance_warning` event to `events.jsonl` when tripped, so the omission is visible in the dashboard's activity log (every event renders there regardless of kind) exactly like other compliance signals already are.

## Test plan

- [x] `core/tests/test_merge_compliance_check.py` — new unit tests: positive case (2+ accepted disjoint-cluster candidates, no merge attempt anywhere in the graph → flagged), and negative cases (a merge was already attempted; fewer than 2 accepted candidates; accepted clusters overlap; accepted candidates have no recorded target ids at all).
- [x] `python -m pytest core/tests/ -q` — full suite, 1243 passed, 12 skipped, no regressions.
- [x] `python skills/_registry/lint_skills.py skills` — no authoring violations; `agent-optimize`'s `SKILL.md` body stays under the 5000-token budget.