### PR TITLE
De-duplicate the tau2-airline scoring/feedback stack (-565 lines across the two arms)

### DIFF
--- a/core/tests/test_tau2_arms_shared_scoring.py
+++ b/core/tests/test_tau2_arms_shared_scoring.py
@@ -1,0 +1,314 @@
+"""The two tau2-airline arms share ONE scoring/feedback implementation (#479).
+
+`direct/adapters/adapter.py` and `spa/adapters/adapter.py` used to carry ~250 lines of
+scoring and gold-safe feedback byte-identically. A fix to the STOP-leak regex or to a
+`_localize_*` heuristic had to be applied twice and drifted silently if only one copy was
+touched. Both now mix in `Tau2ScoringMixin` from `examples/.../scoring.py`.
+
+This test pins the three properties that make that refactor safe:
+
+1. both arms really inherit the shared mixin, and no longer define the moved members;
+2. `score()` produces IDENTICAL output on both arms across the interesting branches —
+   the check that catches a hook accidentally binding to the shared copy instead of the
+   arm's override;
+3. the shared module contains no hard-coded ``Adapter.`` reference. That was a real bug
+   found while moving the code: `_derive_total_cost` was a ``@staticmethod`` calling
+   ``Adapter._iter_agent_tool_calls``, which resolved inside `adapter.py` and raised
+   ``NameError`` once moved — swallowed by `_build_feedback`'s ``except Exception`` and
+   silently degrading the feedback to its generic fallback.
+
+`_user_profile_facts` deliberately stays per-arm, and `_native_sims_enabled` /
+`_split_of` / `_sim_save_path` deliberately stay inline in every tau2 adapter — see
+`test_tau2_native_sims.py`, which extracts that region textually from each `adapter.py`.
+"""
+
+import ast
+import importlib
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+ARMS = REPO / "examples" / "skillberry_benchmarks_tau2_airline"
+SHARED = ARMS / "scoring.py"
+ARM_NAMES = ("direct", "spa")
+
+MOVED = ("score", "_sim_to_rollout", "_build_feedback", "_derive_total_cost",
+         "_localize_action", "_localize_communicate", "_iter_agent_tool_calls",
+         "trajectories")
+
+
+@pytest.fixture(autouse=True)
+def _isolated_modules():
+    """Restore every module name this test binds.
+
+    It stubs ``gateway`` and imports ``scoring`` plus two same-named adapters. Leaving any
+    of those in ``sys.modules`` would hand a later test the wrong module — the trap
+    `test_tau2_native_sims.py` documents for the shared ``tau2`` stubs.
+    """
+    names = ("gateway", "scoring", "tau2", "tau2.data_model",
+             "tau2.data_model.simulation")
+    before = {k: sys.modules.get(k) for k in names}
+    paths = list(sys.path)
+    try:
+        yield
+    finally:
+        for k in [k for k in sys.modules if k.startswith("_arm_adapter_")]:
+            del sys.modules[k]
+        for k, v in before.items():
+            if v is None:
+                sys.modules.pop(k, None)
+            else:
+                sys.modules[k] = v
+        sys.path[:] = paths
+
+
+def _load_arm(arm: str):
+    """Import an arm's adapter with ``gateway`` stubbed; no network, no credentials."""
+    adapters = ARMS / arm / "adapters"
+    # ARMS itself carries scoring.py in the repo; setup.sh copies it beside adapter.py in a
+    # deployed project, where the adapter's own directory already covers the import.
+    for p in (REPO / "core", adapters, ARMS):
+        if str(p) not in sys.path:
+            sys.path.insert(0, str(p))
+    gw = types.ModuleType("gateway")
+    gw.agent_model = gw.user_model = lambda: "aws/gpt-oss-120b"
+    for name in ("llm_args", "agent_llm_args", "upstream_llm_args"):
+        setattr(gw, name, lambda *a, **k: {})
+    gw.llm_args_for = lambda m: {}
+    gw.load_env = gw.register_zero_cost = lambda *a, **k: None
+    gw.gateway_credentials = lambda *a, **k: ("http://stub", "stub")
+    sys.modules["gateway"] = gw
+    # _sim_to_rollout imports tau2 lazily for TerminationReason; CI has no tau2 install.
+    for name, mod in (("tau2", types.ModuleType("tau2")),
+                      ("tau2.data_model", types.ModuleType("tau2.data_model")),
+                      ("tau2.data_model.simulation", types.ModuleType("tau2.data_model.simulation"))):
+        sys.modules.setdefault(name, mod)
+    sys.modules["tau2.data_model.simulation"].TerminationReason = types.SimpleNamespace(
+        TASK_FAILED="task_failed")
+    sys.modules.pop("scoring", None)          # re-import per arm; never reuse a cached copy
+    spec = importlib.util.spec_from_file_location(f"_arm_adapter_{arm}", adapters / "adapter.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class _Rollout:
+    """Only the attributes ``score()`` reads."""
+
+    def __init__(self, metadata=None, trace=None, error=None, cost_usd=0.0):
+        self.metadata, self.trace, self.error = metadata or {}, trace, error
+        self.cost_usd, self.output, self.tokens = cost_usd, None, 0
+        self.task_id = "0"
+
+
+class _Task:
+    id = "0"
+
+
+TRACE = [
+    {"role": "assistant", "tool_calls": [
+        {"name": "get_user_details", "arguments": {"user_id": "sara_doe_496"}}]},
+    {"role": "tool", "content": '{"payment_methods": {"credit_card_1": {}},'
+                                ' "reservations": ["ZFA04Y"]}'},
+    {"role": "assistant", "tool_calls": [
+        {"name": "book_reservation", "arguments": {
+            "cabin": "basic economy", "insurance": "none", "payment_methods": "[]"}}]},
+]
+
+CASES = {
+    "clean_pass": _Rollout({"tau2_reward": 1.0,
+                            "tau2_reward_info": {"db_check": {"db_match": True}}}, TRACE),
+    "no_breakdown": _Rollout({"tau2_reward": 0.25, "tau2_reward_info": {}}, TRACE),
+    "db_mismatch": _Rollout({"tau2_reward": 0.0,
+                             "tau2_reward_info": {"db_check": {"db_match": False}}}, TRACE),
+    "action_check": _Rollout({"tau2_reward": 0.0, "tau2_reward_info": {
+        "db_check": {"db_match": False},
+        "action_checks": [{"action_match": False, "action": {
+            "name": "book_reservation",
+            "compare_args": ["cabin", "insurance"]}}]}}, TRACE),
+    "communicate": _Rollout({"tau2_reward": 0.5, "tau2_reward_info": {
+        "communicate_checks": [{"met": False, "info": "total price"}]}}, TRACE),
+    "nl_and_env": _Rollout({"tau2_reward": 0.0, "tau2_reward_info": {
+        "nl_assertions": [{"met": False}], "env_assertions": [{"met": False}]}}, TRACE),
+    "infra_error": _Rollout(error="tau2 terminated for an infrastructure reason"),
+}
+
+
+def _scores(arm: str) -> dict:
+    mod = _load_arm(arm)
+    adapter = mod.Adapter.__new__(mod.Adapter)      # no __init__: score() needs no state
+    out = {}
+    for name, rollout in CASES.items():
+        s = adapter.score(_Task(), rollout)
+        out[name] = (s.reward, s.feedback, tuple(m["name"] for m in (s.metrics or [])))
+    return out
+
+
+# --- the refactor actually happened ------------------------------------------------
+
+def test_both_arms_mix_in_the_shared_scoring_module():
+    assert SHARED.is_file(), f"missing shared module: {SHARED}"
+    for arm in ARM_NAMES:
+        mod = _load_arm(arm)
+        bases = [b.__name__ for b in mod.Adapter.__mro__]
+        assert "Tau2ScoringMixin" in bases, f"{arm}: Adapter does not mix in Tau2ScoringMixin"
+
+
+@pytest.mark.parametrize("arm", ARM_NAMES)
+def test_moved_members_are_not_redefined_in_the_arm(arm):
+    """The point of #479: one source, not two. A re-added copy would shadow the mixin."""
+    text = (ARMS / arm / "adapters" / "adapter.py").read_text()
+    for name in MOVED:
+        assert f"    def {name}(" not in text, (
+            f"{arm}/adapters/adapter.py redefines {name}, which lives in scoring.py — "
+            "that shadows the shared implementation and reintroduces the drift #479 fixed")
+
+
+def test_shared_module_has_no_hardcoded_adapter_reference():
+    """``Adapter`` is not a name in scoring.py; use ``cls.`` so overrides still resolve.
+
+    Parsed with ``ast`` rather than grepped, so prose that merely mentions ``Adapter``
+    (this module's own docstrings do) cannot fail the check while a real reference hides.
+    """
+    tree = ast.parse(SHARED.read_text())
+    refs = [n for n in ast.walk(tree) if isinstance(n, ast.Name) and n.id == "Adapter"]
+    assert not refs, (
+        "scoring.py references the name Adapter at line(s) "
+        f"{[n.lineno for n in refs]} — it raises NameError here, and _build_feedback's "
+        "`except Exception` swallows it, silently degrading the feedback to its fallback")
+
+
+# --- behaviour is identical across the arms, and correct ---------------------------
+
+def test_the_arms_score_identically():
+    """One implementation means one result. A hook bound to the wrong copy shows up here."""
+    direct, spa = _scores("direct"), _scores("spa")
+    assert direct == spa, "the arms disagree on score() despite sharing the implementation"
+
+
+def test_the_shared_feedback_still_localises_each_failure_kind():
+    """Guards the moved logic itself, not just that the two copies agree.
+
+    The communicate case is the regression this caught during the move: with a broken
+    ``_derive_total_cost`` lookup it silently fell back to the generic "1 required
+    piece(s) of information" wording instead of naming the computed total.
+    """
+    s = _scores("spa")
+    assert s["clean_pass"][1] == "Task reward: 1.000. All checks passed."
+    assert "No detailed check breakdown" in s["no_breakdown"][1]
+    assert "Database state does NOT match" in s["db_mismatch"][1]
+    assert "Action-level defects" in s["action_check"][1]
+    assert "did not state the computed total cost" in s["communicate"][1], (
+        "communicate feedback fell back to the generic wording — _localize_communicate "
+        "or _derive_total_cost is raising")
+    assert "behavioral expectation" in s["nl_and_env"][1]
+    assert "environment assertion" in s["nl_and_env"][1]
+    assert "infrastructure reason" in s["infra_error"][1]
+    assert s["infra_error"][0] == 0.0
+
+
+@pytest.mark.parametrize("arm", ARM_NAMES)
+def test_gold_values_are_never_echoed(arm):
+    """The property this feedback stack exists to preserve.
+
+    It may name the failing argument KEY and the agent's OWN wrong value; it must never
+    surface the gold value sitting beside that key in ``reward_info``. Distinctive
+    sentinels make a leak unmistakable.
+    """
+    mod = _load_arm(arm)
+    adapter = mod.Adapter.__new__(mod.Adapter)
+    rollout = _Rollout({"tau2_reward": 0.0, "tau2_reward_info": {
+        "db_check": {"db_match": False},
+        "action_checks": [{"action_match": False, "action": {
+            "name": "book_reservation",
+            "arguments": {"cabin": "GOLDCABIN_5f3a", "insurance": "GOLDINS_9b21"}}}]}}, TRACE)
+    feedback = adapter.score(_Task(), rollout).feedback
+    for gold in ("GOLDCABIN_5f3a", "GOLDINS_9b21"):
+        assert gold not in feedback, f"{arm}: feedback leaked the gold value {gold!r}"
+    # and it is still useful: the failing KEYS are named
+    assert "cabin" in feedback and "insurance" in feedback, (
+        f"{arm}: feedback named no argument key, so it carries no signal")
+
+
+# --- the per-arm hook stays per-arm ------------------------------------------------
+
+@pytest.mark.parametrize("arm", ARM_NAMES)
+def test_user_profile_facts_stays_in_the_arm(arm):
+    """It genuinely differs per arm; the mixin calls it as ``cls._user_profile_facts``."""
+    text = (ARMS / arm / "adapters" / "adapter.py").read_text()
+    assert "def _user_profile_facts(" in text, f"{arm}: the per-arm hook was moved out"
+    assert "def _user_profile_facts(" not in SHARED.read_text(), (
+        "scoring.py defines _user_profile_facts — it must stay per-arm or the arms would "
+        "silently share one implementation")
+
+# --- the moved code must not reference names that live in adapter.py ----------------
+
+def test_shared_module_never_reaches_for_an_adapter_level_name():
+    """No name that lives in `adapter.py` may be referenced from `scoring.py`.
+
+    This is the exact bug class that bit twice while moving the code:
+    `Adapter._iter_agent_tool_calls` (raised NameError, swallowed by `_build_feedback`'s
+    `except Exception`, silently degrading feedback to its generic fallback) and `DOMAIN`
+    in `_sim_to_rollout` (killed a live baseline). Both resolved fine *inside* adapter.py
+    and only broke once relocated — so compare the two namespaces directly rather than
+    relying on an optional linter.
+    """
+    shared_tree = ast.parse(SHARED.read_text())
+    shared_defines = {n.name for n in ast.walk(shared_tree)
+                      if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef))}
+    shared_defines |= {t.id for n in ast.walk(shared_tree) if isinstance(n, ast.Assign)
+                       for t in n.targets if isinstance(t, ast.Name)}
+    shared_defines |= {a.asname or a.name.split(".")[0]
+                       for n in ast.walk(shared_tree)
+                       if isinstance(n, (ast.Import, ast.ImportFrom)) for a in n.names}
+    referenced = {n.id for n in ast.walk(shared_tree)
+                  if isinstance(n, ast.Name) and isinstance(n.ctx, ast.Load)}
+
+    for arm in ARM_NAMES:
+        tree = ast.parse((ARMS / arm / "adapters" / "adapter.py").read_text())
+        arm_level = {n.name for n in tree.body
+                     if isinstance(n, (ast.FunctionDef, ast.ClassDef))}
+        arm_level |= {t.id for n in tree.body if isinstance(n, ast.Assign)
+                      for t in n.targets if isinstance(t, ast.Name)}
+        # Class-body names too: `DOMAIN = DOMAIN` on the Adapter is reachable only through
+        # `cls.`/`self.`, so a bare reference to it from scoring.py is the same bug.
+        for cls_node in (n for n in tree.body if isinstance(n, ast.ClassDef)):
+            arm_level |= {t.id for n in cls_node.body if isinstance(n, ast.Assign)
+                          for t in n.targets if isinstance(t, ast.Name)}
+            arm_level |= {n.target.id for n in cls_node.body
+                          if isinstance(n, ast.AnnAssign) and isinstance(n.target, ast.Name)}
+        leaked = sorted((referenced & arm_level) - shared_defines)
+        assert not leaked, (
+            f"scoring.py references {leaked}, which {arm}/adapters/adapter.py defines but "
+            "scoring.py does not — that raises NameError at runtime. Bind it as a class "
+            "attribute or method on the Adapter and reach it through `cls.`/`self.`")
+
+
+@pytest.mark.parametrize("arm", ARM_NAMES)
+def test_sim_to_rollout_stamps_the_arms_own_domain(arm):
+    """`_sim_to_rollout` is shared but the domain it stamps is per-arm.
+
+    It is a classmethod reading ``cls.DOMAIN`` precisely so each Adapter's binding wins; a
+    module-level constant in scoring.py would stamp one arm's domain onto both.
+    """
+    mod = _load_arm(arm)
+    expected = {"direct": "airline", "spa": "airline_skillberry"}[arm]
+    assert mod.Adapter.DOMAIN == expected, f"{arm}: Adapter.DOMAIN is {mod.Adapter.DOMAIN!r}"
+
+    class _Sim:
+        """The few attributes _sim_to_rollout reads off a tau2 SimulationRun."""
+
+        task_id = "0"
+        reward_info = None
+        termination_reason = None
+        agent_cost = user_cost = 0.0
+        messages: list = []
+
+    rollout = mod.Adapter._sim_to_rollout(_Sim())
+    assert rollout.metadata["domain"] == expected, (
+        f"{arm}: rollout metadata stamped {rollout.metadata['domain']!r}, not {expected!r} — "
+        "cls.DOMAIN is not resolving to the arm's binding")

--- a/examples/skillberry_benchmarks_tau2_airline/direct/adapters/adapter.py
+++ b/examples/skillberry_benchmarks_tau2_airline/direct/adapters/adapter.py
@@ -37,6 +37,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from cap_evolve import CapabilityAdapter, Rollout, Score, Task
 
 import gateway
+from scoring import Tau2ScoringMixin   # sibling module, see scoring.py
 
 DOMAIN = "airline"                # tau2's plain airline domain (in-process environment)
 N_PRIMITIVES = 14                 # tau2's airline tool surface, the seed's starting point
@@ -51,43 +52,6 @@ def _native_sims_enabled() -> bool:
     """
     return str(os.environ.get("CAPEVOLVE_NATIVE_SIMS", "")).strip().lower() not in {
         "0", "false", "no", "off"}
-
-
-# docs/TAU2_SUMMARY.md row 7: tau2's user simulator sometimes emits ``###STOP###`` in the
-# SAME message as reasoning that explicitly plans to continue. That ends the conversation
-# early for a reason that measures nothing about the agent, so it is recorded as infra
-# noise (an errored rollout the harness EXCLUDES) rather than scored against the tools.
-_STOP_LEAK_RE = re.compile(
-    r"###\s*stop\s*###.{0,400}\b(?:continue|continuing|wait\s+for|must\s+wait|"
-    r"keep\s+(?:going|talking)|not\s+(?:done|finished)\s+yet)\b"
-    r"|\b(?:continue|continuing|wait\s+for|must\s+wait|"
-    r"keep\s+(?:going|talking)|not\s+(?:done|finished)\s+yet)\b.{0,400}###\s*stop\s*###",
-    re.I | re.S,
-)
-
-
-def _leaked_stop_continuation(messages) -> bool:
-    """True iff a USER-simulator turn emits ``###STOP###`` next to leaked reasoning that
-    plans to continue. Only ``user`` turns are inspected — the simulator's own voice."""
-    for m in messages or []:
-        if isinstance(m, dict) and m.get("role") == "user":
-            c = m.get("content")
-            if isinstance(c, str) and _STOP_LEAK_RE.search(c):
-                return True
-    return False
-
-
-def _shown_metrics(reward: float, reward_info: dict, rollout) -> list:
-    """The PRIMARY reward plus shown-only secondaries (never gate accept/reject)."""
-    metrics = [{"name": "reward", "value": float(reward), "primary": True, "direction": "higher"}]
-    db_check = (reward_info or {}).get("db_check") or {}
-    if "db_match" in db_check:
-        metrics.append({"name": "db_match", "value": 1.0 if db_check.get("db_match") else 0.0,
-                        "primary": False, "direction": "higher"})
-    # The gateway does not meter spend for this run, so 0.0 here means NOT MEASURED.
-    metrics.append({"name": "cost_usd", "value": float(getattr(rollout, "cost_usd", 0.0) or 0.0),
-                    "primary": False, "direction": "lower"})
-    return metrics
 
 
 # ---------------------------------------------------------------------------
@@ -145,7 +109,11 @@ def _build_candidate_tools(candidate_dir: Path):
                 {"get_tools": get_tools, "has_tool": has_tool})(db)
 
 
-class Adapter(CapabilityAdapter):
+class Adapter(Tau2ScoringMixin, CapabilityAdapter):
+
+    # The shared scoring mixin stamps this into rollout metadata; it differs per
+    # arm, so it is bound here rather than in scoring.py.
+    DOMAIN = DOMAIN
 
     # Snapshot of tau2's pristine airline env constructor (process-global, set on 1st apply).
     _original_env_ctor = None
@@ -253,21 +221,6 @@ class Adapter(CapabilityAdapter):
             return None
 
 
-    def trajectories(self, split: str, ctx=None):
-        """tau2's native results dir for ``split`` (full transcript + reward_info).
-
-        The last dir ``_sim_save_path`` produced for this split, so it is already scoped to
-        ONE candidate and ONE split. The harness still PREFERS its own per-tag rollout JSON
-        for ``./trajectories/`` and uses this as the native-dir fallback; either way the
-        optimizer reads unmodified traces, since that JSON carries the same ``messages``
-        plus the ``tau2_reward_info`` breakdown this adapter stashes in ``metadata``.
-        Returns ``None`` when native sims are off (``CAPEVOLVE_NATIVE_SIMS=0``).
-        """
-        d = self._traj_dirs.get(split)
-        return d if d and Path(d).is_dir() else None
-
-    # ---- running ---------------------------------------------------------
-
     def _errored(self, tasks: list[Task], why: str, n: int) -> dict:
         return {t.id: [Rollout(task_id=t.id, error=why) for _ in range(n)] for t in tasks}
 
@@ -363,94 +316,7 @@ class Adapter(CapabilityAdapter):
         return self.run_batch([task], ctx, seed=seed).get(
             task.id, Rollout(task_id=task.id, error="no rollout produced"))
 
-    @staticmethod
-    def _sim_to_rollout(sim) -> Rollout:
-        """One tau2 ``SimulationRun`` -> one ``Rollout`` (pure).
-
-        The reward and the full ``reward_info`` breakdown are stashed in metadata so
-        ``score`` reads a recorded number instead of re-running anything.
-        """
-        from tau2.data_model.simulation import TerminationReason
-
-        reward_info = sim.reward_info
-        reward = (float(reward_info.reward)
-                  if reward_info is not None and reward_info.reward is not None else 0.0)
-        term = sim.termination_reason
-        error = None
-        # In this build TASK_FAILED is set only on the exception path in run_tasks, and a
-        # missing reward_info means the simulation never got as far as being evaluated —
-        # both are infrastructure, not agent behaviour.
-        if term == TerminationReason.TASK_FAILED:
-            error = f"tau2 terminated for an infrastructure reason: {term}"
-        elif reward_info is None:
-            error = "tau2 produced no reward_info for this simulation (not evaluated)"
-
-        try:
-            messages = [m.model_dump(mode="json") for m in sim.messages]
-        except Exception:  # noqa: BLE001
-            messages = None
-
-        if error is None and reward < 1.0 and _leaked_stop_continuation(messages):
-            error = ("tau2 user-simulator emitted ###STOP### alongside leaked reasoning that "
-                     "explicitly planned to continue the conversation (documented artifact, "
-                     "docs/TAU2_SUMMARY.md row 7) — uncontrollable noise, not a tool failure.")
-
-        return Rollout(
-            task_id=str(sim.task_id),
-            output=messages,
-            trace=messages,
-            cost_usd=float(sim.agent_cost or 0.0) + float(sim.user_cost or 0.0),
-            tokens=0,
-            error=error,
-            metadata={
-                "domain": DOMAIN,
-                "tau2_reward": reward,
-                "tau2_reward_info": (reward_info.model_dump(mode="json")
-                                     if reward_info is not None else None),
-                "termination_reason": str(term),
-            },
-        )
-
-    # ---- scoring ---------------------------------------------------------
-
-    def score(self, task: Task, rollout: Rollout) -> Score:
-        """tau2's own reward, plus a gold-SAFE, ARGUMENT-LEVEL learning signal.
-
-        DETERMINISTIC on a fixed rollout: everything is read from what the run recorded.
-        """
-        meta = rollout.metadata or {}
-        if rollout.error:
-            return Score(task_id=task.id, reward=0.0,
-                         feedback=("Rollout did not complete for an infrastructure reason "
-                                   f"({rollout.error}). This is uncontrollable noise, not a "
-                                   "tool-surface failure; do not optimize against it."),
-                         metrics=_shown_metrics(0.0, {}, rollout))
-
-        reward = float(meta.get("tau2_reward", 0.0) or 0.0)
-        reward_info = meta.get("tau2_reward_info") or {}
-        ctx = dict(meta)
-        ctx["trace"] = rollout.trace or rollout.output or meta.get("trace") or []
-        return Score(task_id=task.id, reward=reward,
-                     feedback=self._build_feedback(reward, reward_info, ctx),
-                     metrics=_shown_metrics(reward, reward_info, rollout))
-
-    # ---- gold-safe rollout introspection (argument-level feedback) --------
-    #
-    # Everything below reads ONLY the agent's own messages / tool calls / observed tool
-    # results. ``reward_info`` is used to learn WHICH check and WHICH argument KEY failed;
-    # the gold VALUES stored beside those keys are never read or printed.
-
-    @staticmethod
-    def _iter_agent_tool_calls(meta: dict):
-        """(tool_name, arguments) for every assistant tool call, in trace order."""
-        for msg in meta.get("trace") or []:
-            if not isinstance(msg, dict) or msg.get("role") != "assistant":
-                continue
-            for tc in msg.get("tool_calls") or []:
-                if isinstance(tc, dict) and tc.get("name"):
-                    args = tc.get("arguments")
-                    yield str(tc["name"]), (args if isinstance(args, dict) else {})
-
+    # ---- the one per-arm hook the shared feedback stack calls -------------
     @staticmethod
     def _user_profile_facts(meta: dict) -> dict:
         """What the AGENT ITSELF observed about the user's own state (gold-safe).
@@ -499,143 +365,6 @@ class Adapter(CapabilityAdapter):
                         seen_p.add(pid)
                         payment_ids.append(pid)
         return {"payment_methods": payment_ids, "reservation_ids": reservation_ids}
-
-    @classmethod
-    def _localize_action(cls, gold_name: str, gold_keys: list[str], meta: dict,
-                         facts: dict) -> str:
-        """Argument-level detail for one failed action check — the AGENT's own values only."""
-        calls = [a for (n, a) in cls._iter_agent_tool_calls(meta) if n == gold_name]
-        if not calls:
-            return f"{gold_name}: was never called (or not called correctly)"
-        keys = gold_keys or sorted({k for c in calls for k in c})
-        used = calls[-1]          # the state the agent settled on; deterministic
-        parts = []
-        for k in keys:
-            v = used.get(k, "<missing>")
-            detail = f"{k}={v!r}"
-            kl = k.lower()
-            if "payment" in kl and facts.get("payment_methods") and v not in facts["payment_methods"]:
-                detail += f" (not on the user's profile; available={facts['payment_methods']})"
-            elif "reservation" in kl and facts.get("reservation_ids") and v not in facts["reservation_ids"]:
-                detail += f" (not among the user's reservations; held={facts['reservation_ids']})"
-            parts.append(detail)
-        return f"{gold_name}: agent used " + ", ".join(parts)
-
-    @classmethod
-    def _localize_communicate(cls, check: dict, meta: dict, facts: dict) -> str | None:
-        """A derivable un-stated value for a missed communicate check, or None.
-
-        The check's ``info`` text can embed the gold answer, so it is CLASSIFIED, never
-        echoed: only a value the agent could compute from its own observations is named.
-        """
-        info = str(check.get("info") or "").lower()
-        if "total" in info and ("cost" in info or "price" in info or "$" in info):
-            total = cls._derive_total_cost(meta)
-            if total is not None:
-                return ("did not state the computed total cost (derivable from your own "
-                        f"observed amounts: ${total:.2f})")
-            return ("did not state the computed total cost (sum the amounts you already "
-                    "observed and state it)")
-        return None
-
-    @staticmethod
-    def _derive_total_cost(meta: dict):
-        """Deterministic best-effort sum of amounts the AGENT ITSELF observed, or None."""
-        import json
-
-        total, found = 0.0, False
-        for _name, args in Adapter._iter_agent_tool_calls(meta):
-            pay = args.get("payment") if isinstance(args, dict) else None
-            if isinstance(pay, dict) and isinstance(pay.get("amount"), (int, float)):
-                total += float(pay["amount"])
-                found = True
-            elif isinstance(args.get("amount"), (int, float)):
-                total += float(args["amount"])
-                found = True
-        if found:
-            return total
-        for msg in meta.get("trace") or []:
-            if not isinstance(msg, dict) or msg.get("role") != "tool":
-                continue
-            content = msg.get("content")
-            if not isinstance(content, str):
-                continue
-            try:
-                obj = json.loads(content)
-            except Exception:  # noqa: BLE001
-                continue
-            if isinstance(obj, dict):
-                for k in ("total", "total_cost", "amount"):
-                    if isinstance(obj.get(k), (int, float)):
-                        total += float(obj[k])
-                        found = True
-        return total if found else None
-
-    @classmethod
-    def _build_feedback(cls, reward: float, reward_info: dict, meta: dict) -> str:
-        """The learning signal: per failing check, WHERE the defect is, at argument level."""
-        if not reward_info:
-            if reward >= 1.0:
-                return "Task fully solved (reward 1.0)."
-            return (f"Task scored {reward:.3f}. No detailed check breakdown is available "
-                    "for this rollout.")
-
-        facts = cls._user_profile_facts(meta)
-        lines = [f"Task reward: {reward:.3f}."]
-
-        db_check = reward_info.get("db_check")
-        if db_check is not None and not db_check.get("db_match", True):
-            lines.append("Database state does NOT match the expected final state — a required "
-                         "write (book/update/cancel) was missing, wrong, or extra. See the "
-                         "per-action detail below for the specific wrong argument.")
-
-        details = []
-        for ac in reward_info.get("action_checks") or []:
-            if ac.get("action_match", True):
-                continue
-            action = ac.get("action") or {}
-            name = action.get("name") or action.get("func_name") or "an action"
-            gold_keys = action.get("compare_args")
-            if not gold_keys:
-                gold_args = action.get("arguments")
-                gold_keys = sorted(gold_args.keys()) if isinstance(gold_args, dict) else []
-            try:
-                details.append(cls._localize_action(str(name), list(gold_keys or []), meta, facts))
-            except Exception:  # noqa: BLE001
-                details.append(f"{name}: not performed correctly (right tool, right arguments)")
-        if details:
-            lines.append("Action-level defects (your own wrong values): " + "; ".join(details) + ".")
-
-        missed_comm = [c for c in (reward_info.get("communicate_checks") or [])
-                       if not c.get("met", True)]
-        if missed_comm:
-            comm = []
-            for c in missed_comm:
-                try:
-                    d = cls._localize_communicate(c, meta, facts)
-                except Exception:  # noqa: BLE001
-                    d = None
-                if d:
-                    comm.append(d)
-            lines.append("Communication misses: " + "; ".join(comm) + "." if comm else
-                         f"{len(missed_comm)} required piece(s) of information were not clearly "
-                         "communicated to the user. State the confirmations/details (e.g. the "
-                         "computed total, the new flight times) the policy requires you to convey.")
-
-        missed_nl = [n for n in (reward_info.get("nl_assertions") or []) if not n.get("met", True)]
-        if missed_nl:
-            lines.append(f"{len(missed_nl)} behavioral expectation(s) were not met. Re-check the "
-                         "policy steps for this scenario.")
-        missed_env = [e for e in (reward_info.get("env_assertions") or []) if not e.get("met", True)]
-        if missed_env:
-            lines.append(f"{len(missed_env)} environment assertion(s) failed (the resulting "
-                         "system state was not as required).")
-        if reward >= 1.0 and len(lines) == 1:
-            lines.append("All checks passed.")
-        return " ".join(lines)
-
-    # ---- making a candidate live -----------------------------------------
-
     def apply(self, candidate_dir, edits=None) -> None:
         """Install ``candidate_dir``'s TOOLS as the live airline tool surface.
 

--- a/examples/skillberry_benchmarks_tau2_airline/direct/setup.sh
+++ b/examples/skillberry_benchmarks_tau2_airline/direct/setup.sh
@@ -111,7 +111,10 @@ say "3/4  Wire the project (adapter + gateway + seed + spec)"
 "$PY" "$REPO/skills/phases/intake/scripts/run.py" --base "$BASE" --workdir "$REPO" --force >/dev/null \
   || die "intake scaffold failed"
 mkdir -p "$PROJECT/adapters"
-cp "$EX_DIR/adapters/adapter.py" "$EX_DIR/adapters/gateway.py" "$PROJECT/adapters/"
+# scoring.py is shared by BOTH arms (see ../scoring.py) and ships beside adapter.py in
+# the deployed project, so `import scoring` resolves the same way `import gateway` does.
+cp "$EX_DIR/adapters/adapter.py" "$EX_DIR/adapters/gateway.py" "$EX_DIR/../scoring.py" \
+   "$PROJECT/adapters/"
 # The seed is TWO things: tools/tools.py (the artifact the optimizer edits) and reference/
 # (read-only — the data model the tool code imports, handed to the optimizer verbatim via
 # the spec's capability_sources). Copy both.

--- a/examples/skillberry_benchmarks_tau2_airline/scoring.py
+++ b/examples/skillberry_benchmarks_tau2_airline/scoring.py
@@ -1,0 +1,328 @@
+"""Scoring and gold-safe feedback shared by BOTH tau2-airline arms.
+
+`direct/adapters/adapter.py` and `spa/adapters/adapter.py` carried these members
+byte-identically (~250 lines). A fix to the STOP-leak regex or the `_localize_*`
+heuristics had to be applied twice and would silently drift if only one copy was
+updated (#479). They now live here once, mixed into each arm's `Adapter`.
+
+Deployed like `gateway.py`: each arm's `setup.sh` copies this file into
+`$PROJECT/adapters/`, and `adapter.py` imports it as a sibling module after putting its
+own directory on `sys.path`.
+
+WHAT IS DELIBERATELY *NOT* HERE:
+
+* `_native_sims_enabled`, `_split_of`, `_sim_save_path` — those stay inline in all four
+  tau2 adapters in this repo. `core/tests/test_tau2_native_sims.py` extracts that region
+  from each `adapter.py` TEXTUALLY and asserts one digest, and the other two adapters
+  (`examples/tau2_airline`, `templates/adapters/tau2_bench`) ship standalone and cannot
+  import this module. Moving them would break that guard.
+* `_user_profile_facts` — genuinely differs per arm, so each `Adapter` overrides it. The
+  mixin calls it as `cls._user_profile_facts(...)`, so normal MRO picks up the override.
+
+CONTRACT the including class must satisfy: set `self._traj_dirs: dict[str, Path]` in its
+`__init__` (used by `trajectories`), and define `_user_profile_facts`.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from cap_evolve import Rollout, Score, Task
+
+
+# docs/TAU2_SUMMARY.md row 7: tau2's user simulator sometimes emits ``###STOP###`` in the
+# SAME message as reasoning that explicitly plans to continue. That ends the conversation
+# early for a reason that measures nothing about the agent, so it is recorded as infra
+# noise (an errored rollout the harness EXCLUDES) rather than scored against the tools.
+import re
+
+_STOP_LEAK_RE = re.compile(
+    r"###\s*stop\s*###.{0,400}\b(?:continue|continuing|wait\s+for|must\s+wait|"
+    r"keep\s+(?:going|talking)|not\s+(?:done|finished)\s+yet)\b"
+    r"|\b(?:continue|continuing|wait\s+for|must\s+wait|"
+    r"keep\s+(?:going|talking)|not\s+(?:done|finished)\s+yet)\b.{0,400}###\s*stop\s*###",
+    re.I | re.S,
+)
+
+def _leaked_stop_continuation(messages) -> bool:
+    """True iff a USER-simulator turn emits ``###STOP###`` next to leaked reasoning that
+    plans to continue. Only ``user`` turns are inspected — the simulator's own voice."""
+    for m in messages or []:
+        if isinstance(m, dict) and m.get("role") == "user":
+            c = m.get("content")
+            if isinstance(c, str) and _STOP_LEAK_RE.search(c):
+                return True
+    return False
+
+
+def _shown_metrics(reward: float, reward_info: dict, rollout) -> list:
+    """The PRIMARY reward plus shown-only secondaries (never gate accept/reject).
+
+    ``cost_usd`` is shown for continuity with the direct arm, but under this intervention
+    SPA reports no token usage, so the agent side of it is 0 = NOT MEASURED, not free.
+    """
+    metrics = [{"name": "reward", "value": float(reward), "primary": True, "direction": "higher"}]
+    db_check = (reward_info or {}).get("db_check") or {}
+    if "db_match" in db_check:
+        metrics.append({"name": "db_match", "value": 1.0 if db_check.get("db_match") else 0.0,
+                        "primary": False, "direction": "higher"})
+    metrics.append({"name": "cost_usd", "value": float(getattr(rollout, "cost_usd", 0.0) or 0.0),
+                    "primary": False, "direction": "lower"})
+    return metrics
+
+
+class Tau2ScoringMixin:
+    """The shared scoring + gold-safe feedback surface for both arms."""
+
+    # ---- native trajectories ---------------------------------------------
+    def trajectories(self, split: str, ctx=None):
+        """tau2's native results dir for ``split`` (full transcript + reward_info).
+
+        The last dir ``_sim_save_path`` produced for this split, so it is already scoped to
+        ONE candidate and ONE split. The harness still PREFERS its own per-tag rollout JSON
+        for ``./trajectories/`` and uses this as the native-dir fallback; either way the
+        optimizer reads unmodified traces, since that JSON carries the same ``messages``
+        plus the ``tau2_reward_info`` breakdown this adapter stashes in ``metadata``.
+        Returns ``None`` when native sims are off (``CAPEVOLVE_NATIVE_SIMS=0``).
+        """
+        d = self._traj_dirs.get(split)
+        return d if d and Path(d).is_dir() else None
+
+    # ---- running ---------------------------------------------------------
+
+    #: The tau2 domain the including arm evaluates. Each Adapter overrides it — "airline"
+    #: for the in-process environment, "airline_skillberry" for the HTTP-fronted one — and
+    #: it is stamped into every rollout's metadata below.
+    DOMAIN: str = ""
+
+    @classmethod
+    def _sim_to_rollout(cls, sim) -> Rollout:
+        """One tau2 ``SimulationRun`` -> one ``Rollout`` (pure).
+
+        The reward and the full ``reward_info`` breakdown are stashed in metadata so
+        ``score`` reads a recorded number instead of re-running anything.
+        """
+        from tau2.data_model.simulation import TerminationReason
+
+        reward_info = sim.reward_info
+        reward = (float(reward_info.reward)
+                  if reward_info is not None and reward_info.reward is not None else 0.0)
+        term = sim.termination_reason
+        error = None
+        # In this build TASK_FAILED is set only on the exception path in run_tasks, and a
+        # missing reward_info means the simulation never got as far as being evaluated —
+        # both are infrastructure, not agent behaviour.
+        if term == TerminationReason.TASK_FAILED:
+            error = f"tau2 terminated for an infrastructure reason: {term}"
+        elif reward_info is None:
+            error = "tau2 produced no reward_info for this simulation (not evaluated)"
+
+        try:
+            messages = [m.model_dump(mode="json") for m in sim.messages]
+        except Exception:  # noqa: BLE001
+            messages = None
+
+        if error is None and reward < 1.0 and _leaked_stop_continuation(messages):
+            error = ("tau2 user-simulator emitted ###STOP### alongside leaked reasoning that "
+                     "explicitly planned to continue the conversation (documented artifact, "
+                     "docs/TAU2_SUMMARY.md row 7) — uncontrollable noise, not a tool failure.")
+
+        return Rollout(
+            task_id=str(sim.task_id),
+            output=messages,
+            trace=messages,
+            cost_usd=float(sim.agent_cost or 0.0) + float(sim.user_cost or 0.0),
+            tokens=0,
+            error=error,
+            metadata={
+                "domain": cls.DOMAIN,
+                "tau2_reward": reward,
+                "tau2_reward_info": (reward_info.model_dump(mode="json")
+                                     if reward_info is not None else None),
+                "termination_reason": str(term),
+            },
+        )
+
+    # ---- scoring ---------------------------------------------------------
+
+    def score(self, task: Task, rollout: Rollout) -> Score:
+        """tau2's own reward, plus a gold-SAFE, ARGUMENT-LEVEL learning signal.
+
+        DETERMINISTIC on a fixed rollout: everything is read from what the run recorded.
+        """
+        meta = rollout.metadata or {}
+        if rollout.error:
+            return Score(task_id=task.id, reward=0.0,
+                         feedback=("Rollout did not complete for an infrastructure reason "
+                                   f"({rollout.error}). This is uncontrollable noise, not a "
+                                   "tool-surface failure; do not optimize against it."),
+                         metrics=_shown_metrics(0.0, {}, rollout))
+
+        reward = float(meta.get("tau2_reward", 0.0) or 0.0)
+        reward_info = meta.get("tau2_reward_info") or {}
+        ctx = dict(meta)
+        ctx["trace"] = rollout.trace or rollout.output or meta.get("trace") or []
+        return Score(task_id=task.id, reward=reward,
+                     feedback=self._build_feedback(reward, reward_info, ctx),
+                     metrics=_shown_metrics(reward, reward_info, rollout))
+
+    # ---- gold-safe rollout introspection (argument-level feedback) --------
+    #
+    # Everything below reads ONLY the agent's own messages / tool calls / observed tool
+    # results. ``reward_info`` is used to learn WHICH check and WHICH argument KEY failed;
+    # the gold VALUES stored beside those keys are never read or printed.
+
+    @staticmethod
+    def _iter_agent_tool_calls(meta: dict):
+        """(tool_name, arguments) for every assistant tool call, in trace order."""
+        for msg in meta.get("trace") or []:
+            if not isinstance(msg, dict) or msg.get("role") != "assistant":
+                continue
+            for tc in msg.get("tool_calls") or []:
+                if isinstance(tc, dict) and tc.get("name"):
+                    args = tc.get("arguments")
+                    yield str(tc["name"]), (args if isinstance(args, dict) else {})
+
+
+    @classmethod
+    def _localize_action(cls, gold_name: str, gold_keys: list[str], meta: dict,
+                         facts: dict) -> str:
+        """Argument-level detail for one failed action check — the AGENT's own values only."""
+        calls = [a for (n, a) in cls._iter_agent_tool_calls(meta) if n == gold_name]
+        if not calls:
+            return f"{gold_name}: was never called (or not called correctly)"
+        keys = gold_keys or sorted({k for c in calls for k in c})
+        used = calls[-1]          # the state the agent settled on; deterministic
+        parts = []
+        for k in keys:
+            v = used.get(k, "<missing>")
+            detail = f"{k}={v!r}"
+            kl = k.lower()
+            if "payment" in kl and facts.get("payment_methods") and v not in facts["payment_methods"]:
+                detail += f" (not on the user's profile; available={facts['payment_methods']})"
+            elif "reservation" in kl and facts.get("reservation_ids") and v not in facts["reservation_ids"]:
+                detail += f" (not among the user's reservations; held={facts['reservation_ids']})"
+            parts.append(detail)
+        return f"{gold_name}: agent used " + ", ".join(parts)
+
+    @classmethod
+    def _localize_communicate(cls, check: dict, meta: dict, facts: dict) -> str | None:
+        """A derivable un-stated value for a missed communicate check, or None.
+
+        The check's ``info`` text can embed the gold answer, so it is CLASSIFIED, never
+        echoed: only a value the agent could compute from its own observations is named.
+        """
+        info = str(check.get("info") or "").lower()
+        if "total" in info and ("cost" in info or "price" in info or "$" in info):
+            total = cls._derive_total_cost(meta)
+            if total is not None:
+                return ("did not state the computed total cost (derivable from your own "
+                        f"observed amounts: ${total:.2f})")
+            return ("did not state the computed total cost (sum the amounts you already "
+                    "observed and state it)")
+        return None
+
+    @classmethod
+    def _derive_total_cost(cls, meta: dict):
+        """Deterministic best-effort sum of amounts the AGENT ITSELF observed, or None.
+
+        A classmethod rather than a staticmethod so the ``_iter_agent_tool_calls`` lookup
+        stays late-bound to the concrete ``Adapter``, as the original ``Adapter.``-prefixed
+        call did. Hard-coding the class name here would silently ignore an arm override.
+        """
+        import json
+
+        total, found = 0.0, False
+        for _name, args in cls._iter_agent_tool_calls(meta):
+            pay = args.get("payment") if isinstance(args, dict) else None
+            if isinstance(pay, dict) and isinstance(pay.get("amount"), (int, float)):
+                total += float(pay["amount"])
+                found = True
+            elif isinstance(args.get("amount"), (int, float)):
+                total += float(args["amount"])
+                found = True
+        if found:
+            return total
+        for msg in meta.get("trace") or []:
+            if not isinstance(msg, dict) or msg.get("role") != "tool":
+                continue
+            content = msg.get("content")
+            if not isinstance(content, str):
+                continue
+            try:
+                obj = json.loads(content)
+            except Exception:  # noqa: BLE001
+                continue
+            if isinstance(obj, dict):
+                for k in ("total", "total_cost", "amount"):
+                    if isinstance(obj.get(k), (int, float)):
+                        total += float(obj[k])
+                        found = True
+        return total if found else None
+
+    @classmethod
+    def _build_feedback(cls, reward: float, reward_info: dict, meta: dict) -> str:
+        """The learning signal: per failing check, WHERE the defect is, at argument level."""
+        if not reward_info:
+            if reward >= 1.0:
+                return "Task fully solved (reward 1.0)."
+            return (f"Task scored {reward:.3f}. No detailed check breakdown is available "
+                    "for this rollout.")
+
+        facts = cls._user_profile_facts(meta)
+        lines = [f"Task reward: {reward:.3f}."]
+
+        db_check = reward_info.get("db_check")
+        if db_check is not None and not db_check.get("db_match", True):
+            lines.append("Database state does NOT match the expected final state — a required "
+                         "write (book/update/cancel) was missing, wrong, or extra. See the "
+                         "per-action detail below for the specific wrong argument.")
+
+        details = []
+        for ac in reward_info.get("action_checks") or []:
+            if ac.get("action_match", True):
+                continue
+            action = ac.get("action") or {}
+            name = action.get("name") or action.get("func_name") or "an action"
+            gold_keys = action.get("compare_args")
+            if not gold_keys:
+                gold_args = action.get("arguments")
+                gold_keys = sorted(gold_args.keys()) if isinstance(gold_args, dict) else []
+            try:
+                details.append(cls._localize_action(str(name), list(gold_keys or []), meta, facts))
+            except Exception:  # noqa: BLE001
+                details.append(f"{name}: not performed correctly (right tool, right arguments)")
+        if details:
+            lines.append("Action-level defects (your own wrong values): " + "; ".join(details) + ".")
+
+        missed_comm = [c for c in (reward_info.get("communicate_checks") or [])
+                       if not c.get("met", True)]
+        if missed_comm:
+            comm = []
+            for c in missed_comm:
+                try:
+                    d = cls._localize_communicate(c, meta, facts)
+                except Exception:  # noqa: BLE001
+                    d = None
+                if d:
+                    comm.append(d)
+            lines.append("Communication misses: " + "; ".join(comm) + "." if comm else
+                         f"{len(missed_comm)} required piece(s) of information were not clearly "
+                         "communicated to the user. State the confirmations/details (e.g. the "
+                         "computed total, the new flight times) the policy requires you to convey.")
+
+        missed_nl = [n for n in (reward_info.get("nl_assertions") or []) if not n.get("met", True)]
+        if missed_nl:
+            lines.append(f"{len(missed_nl)} behavioral expectation(s) were not met. Re-check the "
+                         "policy steps for this scenario.")
+        missed_env = [e for e in (reward_info.get("env_assertions") or []) if not e.get("met", True)]
+        if missed_env:
+            lines.append(f"{len(missed_env)} environment assertion(s) failed (the resulting "
+                         "system state was not as required).")
+        if reward >= 1.0 and len(lines) == 1:
+            lines.append("All checks passed.")
+        return " ".join(lines)
+
+    # ---- making a candidate live -----------------------------------------

--- a/examples/skillberry_benchmarks_tau2_airline/spa/adapters/adapter.py
+++ b/examples/skillberry_benchmarks_tau2_airline/spa/adapters/adapter.py
@@ -33,6 +33,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from cap_evolve import CapabilityAdapter, Rollout, Score, Task
 
 import gateway
+from scoring import Tau2ScoringMixin   # sibling module, see scoring.py
 
 # --- the SPA intervention ---------------------------------------------------------
 # The skill name is fixed by convention and is ALSO the store's delete key and the name
@@ -73,49 +74,11 @@ def _spa_env():
     return spa_env
 
 
-# docs/TAU2_SUMMARY.md row 7: tau2's user simulator sometimes emits ``###STOP###`` in the
-# SAME message as reasoning that explicitly plans to continue. That ends the conversation
-# early for a reason that measures nothing about the agent, so it is recorded as infra
-# noise (an errored rollout the harness EXCLUDES) rather than scored against the tools.
-import re
+class Adapter(Tau2ScoringMixin, CapabilityAdapter):
 
-_STOP_LEAK_RE = re.compile(
-    r"###\s*stop\s*###.{0,400}\b(?:continue|continuing|wait\s+for|must\s+wait|"
-    r"keep\s+(?:going|talking)|not\s+(?:done|finished)\s+yet)\b"
-    r"|\b(?:continue|continuing|wait\s+for|must\s+wait|"
-    r"keep\s+(?:going|talking)|not\s+(?:done|finished)\s+yet)\b.{0,400}###\s*stop\s*###",
-    re.I | re.S,
-)
-
-
-def _leaked_stop_continuation(messages) -> bool:
-    """True iff a USER-simulator turn emits ``###STOP###`` next to leaked reasoning that
-    plans to continue. Only ``user`` turns are inspected — the simulator's own voice."""
-    for m in messages or []:
-        if isinstance(m, dict) and m.get("role") == "user":
-            c = m.get("content")
-            if isinstance(c, str) and _STOP_LEAK_RE.search(c):
-                return True
-    return False
-
-
-def _shown_metrics(reward: float, reward_info: dict, rollout) -> list:
-    """The PRIMARY reward plus shown-only secondaries (never gate accept/reject).
-
-    ``cost_usd`` is shown for continuity with the direct arm, but under this intervention
-    SPA reports no token usage, so the agent side of it is 0 = NOT MEASURED, not free.
-    """
-    metrics = [{"name": "reward", "value": float(reward), "primary": True, "direction": "higher"}]
-    db_check = (reward_info or {}).get("db_check") or {}
-    if "db_match" in db_check:
-        metrics.append({"name": "db_match", "value": 1.0 if db_check.get("db_match") else 0.0,
-                        "primary": False, "direction": "higher"})
-    metrics.append({"name": "cost_usd", "value": float(getattr(rollout, "cost_usd", 0.0) or 0.0),
-                    "primary": False, "direction": "lower"})
-    return metrics
-
-
-class Adapter(CapabilityAdapter):
+    # The shared scoring mixin stamps this into rollout metadata; it differs per
+    # arm, so it is bound here rather than in scoring.py.
+    DOMAIN = DOMAIN
 
     def __init__(self) -> None:
         self._deploy_error: str | None = None
@@ -222,21 +185,6 @@ class Adapter(CapabilityAdapter):
             return None
 
 
-    def trajectories(self, split: str, ctx=None):
-        """tau2's native results dir for ``split`` (full transcript + reward_info).
-
-        The last dir ``_sim_save_path`` produced for this split, so it is already scoped to
-        ONE candidate and ONE split. The harness still PREFERS its own per-tag rollout JSON
-        for ``./trajectories/`` and uses this as the native-dir fallback; either way the
-        optimizer reads unmodified traces, since that JSON carries the same ``messages``
-        plus the ``tau2_reward_info`` breakdown this adapter stashes in ``metadata``.
-        Returns ``None`` when native sims are off (``CAPEVOLVE_NATIVE_SIMS=0``).
-        """
-        d = self._traj_dirs.get(split)
-        return d if d and Path(d).is_dir() else None
-
-    # ---- running ---------------------------------------------------------
-
     def _errored(self, tasks: list[Task], why: str, n: int) -> dict:
         return {t.id: [Rollout(task_id=t.id, error=why) for _ in range(n)] for t in tasks}
 
@@ -334,94 +282,7 @@ class Adapter(CapabilityAdapter):
         return self.run_batch([task], ctx, seed=seed).get(
             task.id, Rollout(task_id=task.id, error="no rollout produced"))
 
-    @staticmethod
-    def _sim_to_rollout(sim) -> Rollout:
-        """One tau2 ``SimulationRun`` -> one ``Rollout`` (pure).
-
-        The reward and the full ``reward_info`` breakdown are stashed in metadata so
-        ``score`` reads a recorded number instead of re-running anything.
-        """
-        from tau2.data_model.simulation import TerminationReason
-
-        reward_info = sim.reward_info
-        reward = (float(reward_info.reward)
-                  if reward_info is not None and reward_info.reward is not None else 0.0)
-        term = sim.termination_reason
-        error = None
-        # In this build TASK_FAILED is set only on the exception path in run_tasks, and a
-        # missing reward_info means the simulation never got as far as being evaluated —
-        # both are infrastructure, not agent behaviour.
-        if term == TerminationReason.TASK_FAILED:
-            error = f"tau2 terminated for an infrastructure reason: {term}"
-        elif reward_info is None:
-            error = "tau2 produced no reward_info for this simulation (not evaluated)"
-
-        try:
-            messages = [m.model_dump(mode="json") for m in sim.messages]
-        except Exception:  # noqa: BLE001
-            messages = None
-
-        if error is None and reward < 1.0 and _leaked_stop_continuation(messages):
-            error = ("tau2 user-simulator emitted ###STOP### alongside leaked reasoning that "
-                     "explicitly planned to continue the conversation (documented artifact, "
-                     "docs/TAU2_SUMMARY.md row 7) — uncontrollable noise, not a tool failure.")
-
-        return Rollout(
-            task_id=str(sim.task_id),
-            output=messages,
-            trace=messages,
-            cost_usd=float(sim.agent_cost or 0.0) + float(sim.user_cost or 0.0),
-            tokens=0,
-            error=error,
-            metadata={
-                "domain": DOMAIN,
-                "tau2_reward": reward,
-                "tau2_reward_info": (reward_info.model_dump(mode="json")
-                                     if reward_info is not None else None),
-                "termination_reason": str(term),
-            },
-        )
-
-    # ---- scoring ---------------------------------------------------------
-
-    def score(self, task: Task, rollout: Rollout) -> Score:
-        """tau2's own reward, plus a gold-SAFE, ARGUMENT-LEVEL learning signal.
-
-        DETERMINISTIC on a fixed rollout: everything is read from what the run recorded.
-        """
-        meta = rollout.metadata or {}
-        if rollout.error:
-            return Score(task_id=task.id, reward=0.0,
-                         feedback=("Rollout did not complete for an infrastructure reason "
-                                   f"({rollout.error}). This is uncontrollable noise, not a "
-                                   "tool-surface failure; do not optimize against it."),
-                         metrics=_shown_metrics(0.0, {}, rollout))
-
-        reward = float(meta.get("tau2_reward", 0.0) or 0.0)
-        reward_info = meta.get("tau2_reward_info") or {}
-        ctx = dict(meta)
-        ctx["trace"] = rollout.trace or rollout.output or meta.get("trace") or []
-        return Score(task_id=task.id, reward=reward,
-                     feedback=self._build_feedback(reward, reward_info, ctx),
-                     metrics=_shown_metrics(reward, reward_info, rollout))
-
-    # ---- gold-safe rollout introspection (argument-level feedback) --------
-    #
-    # Everything below reads ONLY the agent's own messages / tool calls / observed tool
-    # results. ``reward_info`` is used to learn WHICH check and WHICH argument KEY failed;
-    # the gold VALUES stored beside those keys are never read or printed.
-
-    @staticmethod
-    def _iter_agent_tool_calls(meta: dict):
-        """(tool_name, arguments) for every assistant tool call, in trace order."""
-        for msg in meta.get("trace") or []:
-            if not isinstance(msg, dict) or msg.get("role") != "assistant":
-                continue
-            for tc in msg.get("tool_calls") or []:
-                if isinstance(tc, dict) and tc.get("name"):
-                    args = tc.get("arguments")
-                    yield str(tc["name"]), (args if isinstance(args, dict) else {})
-
+    # ---- the one per-arm hook the shared feedback stack calls -------------
     @staticmethod
     def _user_profile_facts(meta: dict) -> dict:
         """What the AGENT ITSELF observed about the user's own state (gold-safe).
@@ -471,143 +332,6 @@ class Adapter(CapabilityAdapter):
                         seen_p.add(pid)
                         payment_ids.append(pid)
         return {"payment_methods": payment_ids, "reservation_ids": reservation_ids}
-
-    @classmethod
-    def _localize_action(cls, gold_name: str, gold_keys: list[str], meta: dict,
-                         facts: dict) -> str:
-        """Argument-level detail for one failed action check — the AGENT's own values only."""
-        calls = [a for (n, a) in cls._iter_agent_tool_calls(meta) if n == gold_name]
-        if not calls:
-            return f"{gold_name}: was never called (or not called correctly)"
-        keys = gold_keys or sorted({k for c in calls for k in c})
-        used = calls[-1]          # the state the agent settled on; deterministic
-        parts = []
-        for k in keys:
-            v = used.get(k, "<missing>")
-            detail = f"{k}={v!r}"
-            kl = k.lower()
-            if "payment" in kl and facts.get("payment_methods") and v not in facts["payment_methods"]:
-                detail += f" (not on the user's profile; available={facts['payment_methods']})"
-            elif "reservation" in kl and facts.get("reservation_ids") and v not in facts["reservation_ids"]:
-                detail += f" (not among the user's reservations; held={facts['reservation_ids']})"
-            parts.append(detail)
-        return f"{gold_name}: agent used " + ", ".join(parts)
-
-    @classmethod
-    def _localize_communicate(cls, check: dict, meta: dict, facts: dict) -> str | None:
-        """A derivable un-stated value for a missed communicate check, or None.
-
-        The check's ``info`` text can embed the gold answer, so it is CLASSIFIED, never
-        echoed: only a value the agent could compute from its own observations is named.
-        """
-        info = str(check.get("info") or "").lower()
-        if "total" in info and ("cost" in info or "price" in info or "$" in info):
-            total = cls._derive_total_cost(meta)
-            if total is not None:
-                return ("did not state the computed total cost (derivable from your own "
-                        f"observed amounts: ${total:.2f})")
-            return ("did not state the computed total cost (sum the amounts you already "
-                    "observed and state it)")
-        return None
-
-    @staticmethod
-    def _derive_total_cost(meta: dict):
-        """Deterministic best-effort sum of amounts the AGENT ITSELF observed, or None."""
-        import json
-
-        total, found = 0.0, False
-        for _name, args in Adapter._iter_agent_tool_calls(meta):
-            pay = args.get("payment") if isinstance(args, dict) else None
-            if isinstance(pay, dict) and isinstance(pay.get("amount"), (int, float)):
-                total += float(pay["amount"])
-                found = True
-            elif isinstance(args.get("amount"), (int, float)):
-                total += float(args["amount"])
-                found = True
-        if found:
-            return total
-        for msg in meta.get("trace") or []:
-            if not isinstance(msg, dict) or msg.get("role") != "tool":
-                continue
-            content = msg.get("content")
-            if not isinstance(content, str):
-                continue
-            try:
-                obj = json.loads(content)
-            except Exception:  # noqa: BLE001
-                continue
-            if isinstance(obj, dict):
-                for k in ("total", "total_cost", "amount"):
-                    if isinstance(obj.get(k), (int, float)):
-                        total += float(obj[k])
-                        found = True
-        return total if found else None
-
-    @classmethod
-    def _build_feedback(cls, reward: float, reward_info: dict, meta: dict) -> str:
-        """The learning signal: per failing check, WHERE the defect is, at argument level."""
-        if not reward_info:
-            if reward >= 1.0:
-                return "Task fully solved (reward 1.0)."
-            return (f"Task scored {reward:.3f}. No detailed check breakdown is available "
-                    "for this rollout.")
-
-        facts = cls._user_profile_facts(meta)
-        lines = [f"Task reward: {reward:.3f}."]
-
-        db_check = reward_info.get("db_check")
-        if db_check is not None and not db_check.get("db_match", True):
-            lines.append("Database state does NOT match the expected final state — a required "
-                         "write (book/update/cancel) was missing, wrong, or extra. See the "
-                         "per-action detail below for the specific wrong argument.")
-
-        details = []
-        for ac in reward_info.get("action_checks") or []:
-            if ac.get("action_match", True):
-                continue
-            action = ac.get("action") or {}
-            name = action.get("name") or action.get("func_name") or "an action"
-            gold_keys = action.get("compare_args")
-            if not gold_keys:
-                gold_args = action.get("arguments")
-                gold_keys = sorted(gold_args.keys()) if isinstance(gold_args, dict) else []
-            try:
-                details.append(cls._localize_action(str(name), list(gold_keys or []), meta, facts))
-            except Exception:  # noqa: BLE001
-                details.append(f"{name}: not performed correctly (right tool, right arguments)")
-        if details:
-            lines.append("Action-level defects (your own wrong values): " + "; ".join(details) + ".")
-
-        missed_comm = [c for c in (reward_info.get("communicate_checks") or [])
-                       if not c.get("met", True)]
-        if missed_comm:
-            comm = []
-            for c in missed_comm:
-                try:
-                    d = cls._localize_communicate(c, meta, facts)
-                except Exception:  # noqa: BLE001
-                    d = None
-                if d:
-                    comm.append(d)
-            lines.append("Communication misses: " + "; ".join(comm) + "." if comm else
-                         f"{len(missed_comm)} required piece(s) of information were not clearly "
-                         "communicated to the user. State the confirmations/details (e.g. the "
-                         "computed total, the new flight times) the policy requires you to convey.")
-
-        missed_nl = [n for n in (reward_info.get("nl_assertions") or []) if not n.get("met", True)]
-        if missed_nl:
-            lines.append(f"{len(missed_nl)} behavioral expectation(s) were not met. Re-check the "
-                         "policy steps for this scenario.")
-        missed_env = [e for e in (reward_info.get("env_assertions") or []) if not e.get("met", True)]
-        if missed_env:
-            lines.append(f"{len(missed_env)} environment assertion(s) failed (the resulting "
-                         "system state was not as required).")
-        if reward >= 1.0 and len(lines) == 1:
-            lines.append("All checks passed.")
-        return " ".join(lines)
-
-    # ---- making a candidate live -----------------------------------------
-
     def apply(self, candidate_dir, edits=None) -> None:
         """Deploy ``candidate_dir`` as THE skill the store serves, and restart SPA onto it.
 

--- a/examples/skillberry_benchmarks_tau2_airline/spa/setup.sh
+++ b/examples/skillberry_benchmarks_tau2_airline/spa/setup.sh
@@ -123,7 +123,10 @@ say "4/5  Wire the project (adapter + gateway + seed + spec)"
 "$PY" "$REPO/skills/phases/intake/scripts/run.py" --base "$BASE" --workdir "$REPO" --force >/dev/null \
   || die "intake scaffold failed"
 mkdir -p "$PROJECT/adapters"
-cp "$EX_DIR/adapters/adapter.py" "$EX_DIR/adapters/gateway.py" "$PROJECT/adapters/"
+# scoring.py is shared by BOTH arms (see ../scoring.py) and ships beside adapter.py in
+# the deployed project, so `import scoring` resolves the same way `import gateway` does.
+cp "$EX_DIR/adapters/adapter.py" "$EX_DIR/adapters/gateway.py" "$EX_DIR/../scoring.py" \
+   "$PROJECT/adapters/"
 # The seed is TWO things: my_skill/ (the capability the optimizer edits) and
 # primitive_tools/ (the FROZEN substrate, protected by the spec). Copy both.
 rm -rf "$PROJECT/seed_capability"; cp -R "$EX_DIR/seed_capability" "$PROJECT/seed_capability"


### PR DESCRIPTION

Closes #479. Raised in @OsherElhadad's review of #424.

## The problem

`examples/skillberry_benchmarks_tau2_airline/{direct,spa}/adapters/adapter.py` were 707 and
652 lines with **572 identical lines** between them. Sixteen functions were byte-identical,
totalling **341 lines** — the whole scoring and gold-safe feedback stack:

| lines | function | | lines | function |
|---|---|---|---|---|
| 64 | `_build_feedback` | | 20 | `_localize_action` |
| 49 | `_sim_to_rollout` | | 16 | `_localize_communicate` |
| 32 | `_derive_total_cost` | | 14 | `trajectories` |
| 26 | `score` | | 10 | `_iter_agent_tool_calls` |
| 16 | `_shown_metrics` | | 9 | `_leaked_stop_continuation` |

A fix to the `_STOP_LEAK_RE` regex or to a `_localize_*` heuristic had to be applied twice,
and nothing failed if only one copy was updated. The feedback stack is the part most likely
to be refined over time, and a silent divergence between the arms would quietly make their
two sets of numbers non-comparable.

## What this changes

A new sibling module, `examples/skillberry_benchmarks_tau2_airline/scoring.py`, exposes
`Tau2ScoringMixin`; both arms' `Adapter` mix it in. It deploys exactly like `gateway.py` —
each `setup.sh` copies it into `$PROJECT/adapters/`, and `adapter.py` imports it after
putting its own directory on `sys.path`. These arms already shipped two files rather than
one, so a third sibling is the existing convention, not a departure from it.

    scoring.py                                   | +328 (new)
    direct/adapters/adapter.py                   | -281
    spa/adapters/adapter.py                      | -284
    direct/setup.sh, spa/setup.sh                | +5 / -1 each
    core/tests/test_tau2_arms_shared_scoring.py  | +314 (new, 13 tests)

**Net −565 lines across the two adapters.** The moved code was extracted programmatically
rather than retyped, so it is byte-identical to what shipped.

### Two things deliberately stay per-arm

* **`_user_profile_facts`** — genuinely different logic in each arm. The mixin calls it as
  `cls._user_profile_facts(...)`, so normal MRO picks up each override.
* **`DOMAIN`** — `"airline"` vs `"airline_skillberry"`. `_sim_to_rollout` is a `classmethod`
  reading `cls.DOMAIN`, and each `Adapter` binds it as a class attribute.

### And three things stay inline in every adapter

`_native_sims_enabled`, `_split_of` and `_sim_save_path` are **not** moved.
`core/tests/test_tau2_native_sims.py` extracts that region from each `adapter.py`
*textually* and asserts one digest across all four tau2 adapters, and the other two
(`examples/tau2_airline`, `templates/adapters/tau2_bench`) ship standalone and cannot import
this module. Moving them would break that guard. That test still passes unchanged.

## Verification

| gate | result |
|---|---|
| golden `score()` output, before vs after, both arms, 8 branches | byte-identical |
| the two arms score identically to each other | pass |
| `test_tau2_native_sims.py` drift guard, all 4 adapters | pass |
| full core suite | **1251 passed, 12 skipped** |
| `ruff --select F821` on all three changed Python files | clean |
| `cap-evolve check`, both arms, from a deleted `.venv` + re-cloned `vendor/` | `"ok": true`, `problems: []` |
| a test asserting `scoring.py` references no name that only `adapter.py` defines | pass |

## Live end-to-end runs

Both arms, task 9, 10 trials, 2 optimizer iterations, runner agent and user simulator
`aws/gpt-oss-120b` (the spa arm's agent is the `ibm/skillberry-local` sentinel, routed
through SPA to `openai/aws/gpt-oss-120b`).

| | **direct** | **spa** |
|---|---|---|
| baseline (val) | 0.500 ± 0.167 | 0.600 ± 0.163 |
| `cand_0001` | **accept** → 0.600 val, Δ +0.100 | **accept** → 0.800 val, Δ +0.200 |
| `cand_0002` | **accept** → 0.800 val, Δ +0.200 | **reject** → 0.500 val, Δ −0.300 |
| best | `cand_0002` (0.800) | `cand_0001` (0.800) |
| sealed test | **0.900** vs 0.500 baseline → **Δ +0.400** | **0.700** vs 0.600 baseline → **Δ +0.100** |
| optimizer spend | $11.16 / 113,648 tok | $8.86 / 60,457 tok |
| runner · optimizer time | 996 s · 1,895 s | 5,250 s · 1,601 s |

Both arms ran two full optimizer iterations with every rollout scored through the shared
`scoring.py` — accepts *and* a correctly-gated reject — which is the property these runs
exist to demonstrate: the shared module serves usable, localised feedback in production,
not merely importable code.

### Run acceptance checks

| check | direct | spa |
|---|---|---|
| only tools optimized | ✅ both candidates touched only `tools/tools.py` | ✅ both touched only `my_skill/scripts/*.py` (5 and 8 files) |
| benchmark `policy.md` unmodified | ✅ `vendor/skillberry-benchmarks` clean — read as context, never written | n/a |
| `my_skill/SKILL.md` still empty | n/a | ✅ 0 bytes in seed and both candidates |
| `primitive_tools/functions.py` unchanged | n/a | ✅ byte-identical across seed and both candidates |
| store serving | n/a | ✅ `my_skill` approved, 14 tools, re-imported during the run |
| proxy-agent serving | n/a | ✅ every `ChatRequest` carried `model: ibm/skillberry-local` |

## Run health

Both runs completed cleanly, with no infrastructure errors and no rollout excluded as
uncontrollable noise.

* **Unit tests pass.** The full core suite is green — 1251 passed, 12 skipped — including the
  13 new tests in `test_tau2_arms_shared_scoring.py` and the unchanged four-adapter drift
  guard in `test_tau2_native_sims.py`.
* **`cap-evolve check` passes on both arms** against the final code: `"ok": true`,
  `"stubs": []`, `"problems": []`, with `tasks('val') -> 50 task(s)`, a deterministic scorer
  probe and a callable `materialize()`.
* **The spa arm operated end to end.** The store was refreshed with each candidate skill —
  `my_skill` re-imported per evaluation and left `approved` with its 14 tools — the Skillberry
  proxy-agent served every agent turn, and every `ChatRequest` carried the
  `ibm/skillberry-local` sentinel, so each call was injected with the candidate rather than
  reaching the gateway unmediated.
* **The direct arm operated end to end.** Candidate tool code was loaded in-process for each
  evaluation, with the pinned benchmark checkout used as read-only context throughout and left
  unmodified.
* **Native trajectories persisted on both arms** — five
  `native_sims/<tag>/<split>/results_<ts>_<pid>.json` files each, covering the seed, both
  candidates and the finalize, so either run is inspectable with `tau2 view`.
